### PR TITLE
fix(worktree): stop branches tracking their base, heal those that do

### DIFF
--- a/electron/ipc/handlers/__tests__/git-write.pushDestination.test.ts
+++ b/electron/ipc/handlers/__tests__/git-write.pushDestination.test.ts
@@ -78,8 +78,12 @@ const FOR_EACH_REF_UPSTREAM = `refs/heads/${LOCAL_BRANCH}\u0000${UPSTREAM_REMOTE
 function rawResponder(forEachRef: string, forEachRefUpstream: string) {
   return async (args: string[]): Promise<string> => {
     if (args[0] === "for-each-ref") {
+      // Discriminate on `push:remotename`, the field only the push resolver
+      // asks for. Testing for "upstream" alone misreads the push resolver the
+      // moment its format mentions `%(upstream)` at all — which it does, to
+      // tell a differently-named upstream from no upstream.
       const format = args[1] ?? "";
-      return `${format.includes("upstream") ? forEachRefUpstream : forEachRef}\n`;
+      return `${format.includes("push:remotename") ? forEachRef : forEachRefUpstream}\n`;
     }
     if (args[0] === "rev-list") return "7\n";
     return "";
@@ -168,6 +172,28 @@ describe("git push — resolved destination", () => {
     ]);
   });
 
+  it("repairs the tracking config in the same push when the upstream names another branch", async () => {
+    // `worktree add -b topic --track origin/develop` state: git reports a push
+    // remote with no push ref, so a plain push fails on the name mismatch —
+    // and fails with a message the "no upstream branch" recovery below does
+    // not match. The explicit form both lands the push and rewrites the config.
+    const mistracked = `refs/heads/${LOCAL_BRANCH}\u0000origin\u0000\u0000refs/remotes/origin/develop`;
+    const git = makeGit(
+      { getRemotes: vi.fn(async () => [{ name: "origin", refs: { fetch: "", push: "" } }]) },
+      mistracked
+    );
+    createAuthenticatedGitMock.mockResolvedValue(git);
+
+    await getHandler("git:push")(FAKE_EVENT, { cwd: CWD });
+
+    expect(git.push).not.toHaveBeenCalledWith();
+    expect(git.push).toHaveBeenCalledWith([
+      "--set-upstream",
+      "origin",
+      `${LOCAL_BRANCH}:${LOCAL_BRANCH}`,
+    ]);
+  });
+
   it("propagates a non-upstream push failure without retrying", async () => {
     const push = vi.fn(async () => {
       throw new Error("fatal: Authentication failed");
@@ -224,6 +250,51 @@ describe("git force-push-with-lease — resolved destination", () => {
       `--force-with-lease=${REMOTE_BRANCH}:${LEASE}`,
       "--force-if-includes",
     ]);
+  });
+});
+
+describe("git force-push-with-lease — upstream repair", () => {
+  it("repairs the tracking config on the force-push too", async () => {
+    // The reachable path: the repair-form push is rejected as non-fast-forward,
+    // the lease is captured, the user force-pushes. Without --set-upstream the
+    // push lands and the broken tracking survives its own recovery.
+    const mistracked = `refs/heads/${LOCAL_BRANCH}\u0000origin\u0000\u0000refs/remotes/origin/develop`;
+    const git = makeGit(
+      { getRemotes: vi.fn(async () => [{ name: "origin", refs: { fetch: "", push: "" } }]) },
+      mistracked
+    );
+    createAuthenticatedGitMock.mockResolvedValue(git);
+
+    await getHandler("git:force-push-with-lease")(FAKE_EVENT, {
+      cwd: CWD,
+      branchName: LOCAL_BRANCH,
+      leaseSha: LEASE,
+    });
+
+    expect(git.push).toHaveBeenCalledWith("origin", `${LOCAL_BRANCH}:${LOCAL_BRANCH}`, [
+      `--force-with-lease=${LOCAL_BRANCH}:${LEASE}`,
+      "--force-if-includes",
+      "--set-upstream",
+    ]);
+  });
+
+  it("leaves an ordinarily-resolved force-push argv untouched", async () => {
+    // The flag must not leak into the common path: a force-push that never
+    // needed repair must not silently rewrite tracking config.
+    const git = makeGit();
+    createAuthenticatedGitMock.mockResolvedValue(git);
+
+    await getHandler("git:force-push-with-lease")(FAKE_EVENT, {
+      cwd: CWD,
+      branchName: LOCAL_BRANCH,
+      leaseSha: LEASE,
+    });
+
+    expect(git.push).toHaveBeenCalledWith(
+      REMOTE,
+      `${LOCAL_BRANCH}:${REMOTE_BRANCH}`,
+      expect.not.arrayContaining(["--set-upstream"]) as unknown as string[]
+    );
   });
 });
 

--- a/electron/ipc/handlers/git-write.ts
+++ b/electron/ipc/handlers/git-write.ts
@@ -649,7 +649,13 @@ export function registerGitWriteHandlers(_deps: HandlerDependencies): () => void
       // push to `release/topic`.
       const refspec = `${branchName}:${destination.branch}`;
 
-      if (payload.setUpstream) {
+      // `requiresUpstreamRepair` forces the explicit form too. That branch's
+      // upstream names a different branch, so a plain `git push` fails on the
+      // name mismatch rather than on a missing upstream — the recovery in the
+      // catch below would never see the message it looks for. Pushing with
+      // `--set-upstream` to the destination the confirm already showed both
+      // completes the push and rewrites the tracking config that broke it.
+      if (payload.setUpstream || destination.requiresUpstreamRepair) {
         await authGit.push(["--set-upstream", destination.remote, refspec]);
       } else {
         try {
@@ -793,6 +799,12 @@ export function registerGitWriteHandlers(_deps: HandlerDependencies): () => void
       await git.push(destination.remote, `${branchName}:${destination.branch}`, [
         `--force-with-lease=${destination.branch}:${payload.leaseSha}`,
         "--force-if-includes",
+        // A force-push is a normal way to reach this destination — the plain
+        // push is rejected as non-fast-forward, the lease is captured, and the
+        // user force-pushes. Without this the push lands but the tracking
+        // config that made the destination unresolvable in the first place
+        // survives the recovery, so the next push is broken again.
+        ...(destination.requiresUpstreamRepair ? ["--set-upstream"] : []),
       ]);
       if (store.get("notificationSettings").uiFeedbackSoundEnabled) {
         playSoundFireAndForget("git-push");

--- a/electron/services/GitService.ts
+++ b/electron/services/GitService.ts
@@ -152,6 +152,14 @@ export class GitService {
           remoteBranch: baseBranch,
         });
 
+        // `--no-track` even from a remote base: tracking is only the truth
+        // when the new branch is that base's own local counterpart
+        // (`-b topic --track origin/topic`), and this path has no remote
+        // table to decide that with. `-b bugfix/x --track origin/develop`
+        // would point a fresh topic branch at the base — the mis-tracking
+        // WorkspaceService.createWorktree exists to avoid. Not tracking is
+        // the recoverable direction; `git push -u` sets the right upstream.
+        //
         // `--end-of-options` after the subcommand flags so any leading-dash
         // ref or path that slipped past validation is treated as positional.
         await git.raw([
@@ -159,7 +167,7 @@ export class GitService {
           "add",
           "-b",
           newBranch,
-          "--track",
+          "--no-track",
           "--end-of-options",
           path,
           baseBranch,

--- a/electron/services/__tests__/GitService.test.ts
+++ b/electron/services/__tests__/GitService.test.ts
@@ -553,7 +553,7 @@ index 1a2b3c4..5d6e7f8 100644
       expect(eooIdx).toBeLessThan(baseIdx);
     });
 
-    it("places --end-of-options after --track for fromRemote worktrees", async () => {
+    it("places --end-of-options after the tracking flag for fromRemote worktrees", async () => {
       const service = new GitService(tempDir);
       const target = path.join(tempDir, "new-wt-remote");
 
@@ -565,8 +565,8 @@ index 1a2b3c4..5d6e7f8 100644
       });
 
       const args = gitClientMock.raw.mock.calls[0][0] as string[];
-      expect(args).toContain("--track");
-      const trackIdx = args.indexOf("--track");
+      expect(args).toContain("--no-track");
+      const trackIdx = args.indexOf("--no-track");
       const eooIdx = args.indexOf("--end-of-options");
       const pathIdx = args.indexOf(target);
       expect(trackIdx).toBeLessThan(eooIdx);

--- a/electron/utils/__tests__/gitPushDestination.test.ts
+++ b/electron/utils/__tests__/gitPushDestination.test.ts
@@ -52,8 +52,55 @@ function makeRepo(): string {
   return dir;
 }
 
+/**
+ * A simple-git client in the same hermetic environment the fixture commands
+ * get. The resolver reads `push.default`, so without this a developer's own
+ * global config decides these results.
+ *
+ * Built from scratch rather than by filtering `process.env`: simple-git
+ * rejects a client environment carrying `GIT_EDITOR` or `PAGER` outright, and
+ * subtracting whatever its blocklist happens to hold today is a worse contract
+ * than naming the four variables git actually needs here. `PATH` is one of
+ * them — the executable is resolved by name.
+ */
+function hermeticClient(repo: string) {
+  // simple-git blocks `GIT_CONFIG_*` on a client environment by default, which
+  // is right for the app and exactly backwards for a fixture whose whole point
+  // is to be isolated from the developer's config. Opted out here only.
+  return simpleGit(repo, { unsafe: { allowUnsafeConfigPaths: true } }).env({
+    PATH: process.env.PATH ?? "",
+    GIT_CONFIG_GLOBAL: "/dev/null",
+    GIT_CONFIG_SYSTEM: "/dev/null",
+    GIT_TERMINAL_PROMPT: "0",
+  });
+}
+
 function resolve(repo: string, branch = "topic") {
-  return resolveGitPushDestination(simpleGit(repo), branch);
+  return resolveGitPushDestination(hermeticClient(repo), branch);
+}
+
+/**
+ * A git double for the guards git itself cannot be made to produce — a
+ * same-name upstream that still yields no push ref, and a config read that
+ * fails rather than reporting an empty config.
+ */
+function stubGit(fields: { record: string; remotes: readonly string[]; config: string | Error }) {
+  return {
+    raw: async (args: readonly string[]): Promise<string> => {
+      if (args[0] === "for-each-ref") return `${fields.record}\n`;
+      if (args[0] === "config") {
+        if (fields.config instanceof Error) throw fields.config;
+        return fields.config;
+      }
+      return "";
+    },
+    getRemotes: async () => fields.remotes.map((name) => ({ name, refs: { fetch: "", push: "" } })),
+  } as unknown as Parameters<typeof resolveGitPushDestination>[0];
+}
+
+/** `%(refname)`, `%(push:remotename)`, `%(push)`, `%(upstream)`, NUL-joined. */
+function refRecord(remote: string, pushRef: string, upstreamRef: string, branch = "topic") {
+  return [`refs/heads/${branch}`, remote, pushRef, upstreamRef].join("\u0000");
 }
 
 beforeAll(() => {
@@ -414,6 +461,117 @@ describe("resolveGitPushDestination — argv hardening", () => {
   });
 });
 
+describe("resolveGitPushDestination — upstream name mismatch", () => {
+  /** A repo whose `topic` branch tracks a differently-named branch on its only remote. */
+  function makeMistrackedRepo(): string {
+    const repo = makeRepo();
+    git(repo, ["remote", "add", "origin", makeBare()]);
+    git(repo, ["config", "branch.topic.remote", "origin"]);
+    git(repo, ["config", "branch.topic.merge", "refs/heads/develop"]);
+    return repo;
+  }
+
+  it("recovers the same-name destination git's simple rule refuses to name", async () => {
+    // `worktree add -b topic --track origin/develop` leaves this config. git
+    // reports a push remote with an empty push ref, which used to be refused —
+    // while the same branch with NO tracking at all pushed fine.
+    const repo = makeMistrackedRepo();
+
+    const result = await resolve(repo);
+
+    expect(result.status === "resolved" && result.destination).toEqual({
+      remote: "origin",
+      branch: "topic",
+      remoteTrackingRef: "refs/remotes/origin/topic",
+      requiresUpstreamRepair: true,
+    });
+  });
+
+  it("does not mark an ordinarily-resolved destination as needing repair", async () => {
+    // The flag drives an argv change, so it must never ride along on a branch
+    // git could already place on its own.
+    const repo = makeRepo();
+    git(repo, ["remote", "add", "origin", makeBare()]);
+    git(repo, ["config", "branch.topic.remote", "origin"]);
+    git(repo, ["config", "branch.topic.merge", "refs/heads/topic"]);
+
+    const result = await resolve(repo);
+
+    expect(
+      result.status === "resolved" && result.destination.requiresUpstreamRepair
+    ).toBeUndefined();
+  });
+
+  it("leaves an untracked branch to the single-remote fallback, unmarked", async () => {
+    const repo = makeRepo();
+    git(repo, ["remote", "add", "origin", makeBare()]);
+
+    const result = await resolve(repo);
+
+    expect(
+      result.status === "resolved" && result.destination.requiresUpstreamRepair
+    ).toBeUndefined();
+  });
+
+  it("refuses when several remotes exist, because the mismatch names no winner", async () => {
+    const repo = makeMistrackedRepo();
+    git(repo, ["remote", "add", "fork", makeBare()]);
+
+    const result = await resolve(repo);
+
+    expect(result).toEqual({ status: "unresolved", reason: "not-configured" });
+  });
+
+  it("refuses under push.default=nothing, which sanctions no destination at all", async () => {
+    const repo = makeMistrackedRepo();
+    git(repo, ["config", "push.default", "nothing"]);
+
+    const result = await resolve(repo);
+
+    expect(result).toEqual({ status: "unresolved", reason: "not-configured" });
+  });
+
+  it("refuses when a push refspec exists that does not cover this branch", async () => {
+    // The refspec is the user saying what gets pushed where; a branch it omits
+    // is one they chose not to push, not one to invent a destination for.
+    const repo = makeMistrackedRepo();
+    git(repo, ["config", "remote.origin.push", "refs/heads/main:refs/heads/main"]);
+
+    const result = await resolve(repo);
+
+    expect(result).toEqual({ status: "unresolved", reason: "not-configured" });
+  });
+
+  it("recovers under an explicitly configured push.default=simple", async () => {
+    // The unset default and an explicit `simple` are the same rule; only the
+    // explicit form exercises the value comparison.
+    const repo = makeMistrackedRepo();
+    git(repo, ["config", "push.default", "simple"]);
+
+    const result = await resolve(repo);
+
+    expect(result.status === "resolved" && result.destination.requiresUpstreamRepair).toBe(true);
+  });
+
+  it("splits the upstream at a slash-bearing remote's real boundary", async () => {
+    // `team/fork/develop` must read as develop on `team/fork`, so the mismatch
+    // against `topic` is detected rather than missed by a first-slash split.
+    const repo = makeRepo();
+    git(repo, ["remote", "add", "team/fork", makeBare()]);
+    git(repo, ["config", "branch.topic.remote", "team/fork"]);
+    git(repo, ["config", "branch.topic.merge", "refs/heads/develop"]);
+
+    const result = await resolve(repo);
+
+    expect(result.status === "resolved" && result.destination).toEqual({
+      remote: "team/fork",
+      branch: "topic",
+      remoteTrackingRef: "refs/remotes/team/fork/topic",
+      requiresUpstreamRepair: true,
+    });
+  });
+});
+
 describe("formatGitPushDestination", () => {
   it("joins remote and branch, preserving slashes on both sides", () => {
     expect(formatGitPushDestination({ remote: "team/fork", branch: "release/topic" })).toBe(
@@ -448,5 +606,94 @@ describe("describeUnresolvedUpstream", () => {
         "config-missing"
       );
     }
+  });
+});
+
+describe("resolveGitPushDestination — guards git cannot be made to produce", () => {
+  const MISMATCHED = refRecord("origin", "", "refs/remotes/origin/develop");
+
+  it("refuses a same-name upstream that still yields no push ref", async () => {
+    // Names agree, so whatever emptied the push ref is a different fault and
+    // the same-name inference is not the answer to it. Nothing else in this
+    // fixture refuses, so dropping the name comparison would resolve it.
+    const result = await resolveGitPushDestination(
+      stubGit({
+        record: refRecord("origin", "", "refs/remotes/origin/topic"),
+        remotes: ["origin"],
+        config: "",
+      }),
+      "topic"
+    );
+
+    expect(result).toEqual({ status: "unresolved", reason: "not-configured" });
+  });
+
+  it("resolves the same fixture once the upstream names a different branch", async () => {
+    // The control for the test above: same shape, only the upstream name
+    // differs, so the refusal there is attributable to that comparison alone.
+    const result = await resolveGitPushDestination(
+      stubGit({ record: MISMATCHED, remotes: ["origin"], config: "" }),
+      "topic"
+    );
+
+    expect(result.status === "resolved" && result.destination.requiresUpstreamRepair).toBe(true);
+  });
+
+  it("fails closed when the config read errors rather than reporting an empty config", async () => {
+    // A push destination inferred from config we could not read is a push to
+    // wherever an unread override pointed.
+    const result = await resolveGitPushDestination(
+      stubGit({
+        record: MISMATCHED,
+        remotes: ["origin"],
+        config: new Error("fatal: unable to read config file"),
+      }),
+      "topic"
+    );
+
+    expect(result).toEqual({ status: "unresolved", reason: "not-configured" });
+  });
+
+  it("lets a local push.default override an inherited one, as git does", async () => {
+    // git resolves later entries over earlier ones; deciding on the first
+    // `push.default` seen would refuse a repo that explicitly opted back in.
+    const result = await resolveGitPushDestination(
+      stubGit({
+        record: MISMATCHED,
+        remotes: ["origin"],
+        config: "push.default\ncurrent\u0000push.default\nsimple\u0000",
+      }),
+      "topic"
+    );
+
+    expect(result.status === "resolved" && result.destination.requiresUpstreamRepair).toBe(true);
+  });
+
+  it("refuses when the effective push.default is not simple", async () => {
+    const result = await resolveGitPushDestination(
+      stubGit({
+        record: MISMATCHED,
+        remotes: ["origin"],
+        config: "push.default\nsimple\u0000push.default\nmatching\u0000",
+      }),
+      "topic"
+    );
+
+    expect(result).toEqual({ status: "unresolved", reason: "not-configured" });
+  });
+
+  it("reads a push refspec whose value contains a newline", async () => {
+    // Multi-valued refspecs are why the scan is NUL-delimited rather than
+    // line-delimited; a line scan would see the second refspec as a key.
+    const result = await resolveGitPushDestination(
+      stubGit({
+        record: MISMATCHED,
+        remotes: ["origin"],
+        config: "remote.origin.push\nrefs/heads/main:refs/heads/main\u0000",
+      }),
+      "topic"
+    );
+
+    expect(result).toEqual({ status: "unresolved", reason: "not-configured" });
   });
 });

--- a/electron/utils/gitPushDestination.ts
+++ b/electron/utils/gitPushDestination.ts
@@ -10,6 +10,18 @@ import type { GitPushDestination } from "../../shared/types/git.js";
 export interface ResolvedGitPushDestination extends GitPushDestination {
   /** Full ref, e.g. `refs/remotes/fork/release/topic`. */
   remoteTrackingRef: string;
+  /**
+   * The branch's upstream names a DIFFERENT branch on the one remote this repo
+   * has, so `push.default=simple` refuses the push outright and git offers no
+   * push ref of its own. The destination above is the same-name branch on that
+   * remote — the only one this branch could mean — and the caller must issue
+   * the push with an explicit `--set-upstream <remote> <local>:<local>`, which
+   * both performs the push and repairs the tracking config that broke it.
+   *
+   * Main-process-only, like {@link remoteTrackingRef}: it changes how the push
+   * is invoked, not what the renderer renders.
+   */
+  requiresUpstreamRepair?: boolean;
 }
 
 export type GitPushDestinationResolution =
@@ -113,7 +125,10 @@ export async function resolveGitPushDestination(
 
   const raw = await git.raw([
     "for-each-ref",
-    "--format=%(refname)%00%(push:remotename)%00%(push)",
+    // `%(upstream)` rides along for free and is what separates "this branch
+    // tracks something differently named" from "this branch tracks nothing" —
+    // the two states that both surface as an empty `%(push)`.
+    "--format=%(refname)%00%(push:remotename)%00%(push)%00%(upstream)",
     `refs/heads/${branchName}`,
   ]);
 
@@ -136,6 +151,7 @@ export async function resolveGitPushDestination(
   // The guard below rejects such names outright instead.
   const remote = record[1] ?? "";
   const pushRef = record[2] ?? "";
+  const upstreamRef = record[3] ?? "";
 
   if (!remote) {
     return resolveUnconfigured(remotes, branchName);
@@ -158,7 +174,7 @@ export async function resolveGitPushDestination(
   //     same-name push.
   // Refuse rather than invent a branch name — the remote alone isn't enough.
   if (!pushRef) {
-    return { status: "unresolved", reason: "not-configured" };
+    return await resolveNameMismatchRepair(git, branchName, remote, remotes, upstreamRef);
   }
 
   const remoteBranch = stripRemotePrefix(pushRef, remotes);
@@ -181,6 +197,114 @@ export async function resolveGitPushDestination(
       remoteTrackingRef: `${REMOTE_TRACKING_PREFIX}${remote}/${remoteBranch}`,
     },
   };
+}
+
+/** The one `push.default` value under which the recovery below is git's own intent. */
+const SIMPLE_PUSH_DEFAULT = "simple";
+
+/**
+ * Recover the destination of a branch whose upstream names a different branch.
+ *
+ * This is the state `git worktree add -b topic --track origin/develop` leaves
+ * behind: `branch.topic.merge` points at `develop`, so under `push.default=simple`
+ * git refuses the push ("the upstream branch of your current branch does not
+ * match the name of your current branch") and reports a push REMOTE with an
+ * empty push REF. Before this, that empty ref fell into `not-configured` and the
+ * push button was dead — while the same branch created without any tracking at
+ * all pushed happily through {@link resolveUnconfigured}. The more-configured
+ * branch was the broken one.
+ *
+ * Narrow on purpose. Every one of these must hold, or it falls back to refusing:
+ *
+ *   - the branch really does track something, and that something is a
+ *     remote-tracking ref under a known remote carrying a DIFFERENT branch name
+ *     (a same-name upstream with an empty push ref is a different fault, and an
+ *     untracked branch is {@link resolveUnconfigured}'s case, not this one);
+ *   - the repository has exactly one remote and git named that same one, so
+ *     "which repository" has a single answer rather than a preferred one;
+ *   - `push.default` is unset or `simple`, so the refusal we are recovering
+ *     from is the name-mismatch rule and not `nothing`, `matching`, or a
+ *     triangular setup;
+ *   - no per-remote push refspec exists to map the branch somewhere else.
+ *
+ * What it infers is only what `simple` itself would have pushed had the names
+ * agreed: the same branch name on that remote. The caller still shows the
+ * destination in the D2 confirm before anything is written.
+ */
+async function resolveNameMismatchRepair(
+  git: Pick<SimpleGit, "raw">,
+  branchName: string,
+  remote: string,
+  remotes: readonly string[],
+  upstreamRef: string
+): Promise<GitPushDestinationResolution> {
+  const unresolved: GitPushDestinationResolution = {
+    status: "unresolved",
+    reason: "not-configured",
+  };
+
+  if (!upstreamRef) return unresolved;
+  if (remotes.length !== 1 || remote !== remotes[0]) return unresolved;
+
+  const upstreamBranch = stripRemotePrefix(upstreamRef, remotes);
+  if (!upstreamBranch || upstreamBranch === branchName) return unresolved;
+
+  if (!(await hasDefaultSimplePushConfig(git))) return unresolved;
+
+  return {
+    status: "resolved",
+    destination: {
+      remote,
+      branch: branchName,
+      remoteTrackingRef: `${REMOTE_TRACKING_PREFIX}${remote}/${branchName}`,
+      requiresUpstreamRepair: true,
+    },
+  };
+}
+
+/**
+ * True when nothing in the effective config redirects a push away from the
+ * plain same-name destination — no `push.default` other than `simple`, and no
+ * `remote.<name>.push` refspec.
+ *
+ * `--list -z` rather than `--get-regexp`: the latter exits non-zero both when
+ * nothing matched (the ordinary case) and when the read genuinely failed, and
+ * simple-git surfaces the two identically. Reading a real failure as "no
+ * overrides" would authorize a push the config had redirected. `--list` exits
+ * zero for an empty configuration, so a rejection here is unambiguously a read
+ * failure and this fails CLOSED on it: a refused push is a visible prompt to
+ * fix the config, a misdirected one is not recoverable.
+ *
+ * The whole effective config is read, not just the local file, because a
+ * global `push.default` governs this push exactly as a local one would.
+ */
+async function hasDefaultSimplePushConfig(git: Pick<SimpleGit, "raw">): Promise<boolean> {
+  let out: string;
+  try {
+    out = await git.raw(["config", "--list", "-z"]);
+  } catch {
+    return false;
+  }
+
+  // `-z` because a refspec is whitespace-adjacent and a value may span lines:
+  // entries are NUL-separated and the key ends at the first newline.
+  //
+  // Later entries win, exactly as git resolves them, so `push.default` is
+  // carried to the end rather than decided on first sight — a repo-local
+  // `simple` must be allowed to override a global `current`.
+  let pushDefault: string | null = null;
+  for (const entry of out.split("\u0000")) {
+    if (!entry) continue;
+    const newline = entry.indexOf("\n");
+    const key = (newline === -1 ? entry : entry.slice(0, newline)).toLowerCase();
+    const value = newline === -1 ? "" : entry.slice(newline + 1);
+    if (key === "push.default") {
+      pushDefault = value.trim();
+    } else if (key.startsWith("remote.") && key.endsWith(".push")) {
+      return false;
+    }
+  }
+  return pushDefault === null || pushDefault === SIMPLE_PUSH_DEFAULT;
 }
 
 /**

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -2874,10 +2874,13 @@ export class WorkspaceService {
             listFailed = true;
           }
 
-          // For fromRemote (PR mode) we never reuse a stale local branch:
-          // the local ref is at the previous tip, and dropping --track would
-          // strip @{u} that ahead/behind badges depend on. Suffix instead so
-          // a fresh tracking branch is created.
+          // For fromRemote (PR mode) we never reuse a stale local branch: the
+          // local ref sits at the previous tip, so reuse would check the
+          // worktree out at old code instead of the remote base's current
+          // tip. Suffix instead — the retry branches from `baseBranch`, so it
+          // starts at the right commit. That retry emits `--no-track`: a
+          // suffixed name is by definition not the remote base's counterpart,
+          // and shouldTrackBase is recomputed against the name being created.
           const canReuse = !listFailed && !fromRemote && !checkedOut.has(newBranch);
 
           this.topologyWatcher.markPendingCreate(pendingCreateKey);

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -55,7 +55,10 @@ import { WorktreeMonitor } from "./WorktreeMonitor.js";
 import { WorktreeListService } from "./WorktreeListService.js";
 import { PRIntegrationService, type PRIntegrationCallbacks } from "./PRIntegrationService.js";
 import { RepoFetchCoordinator } from "./RepoFetchCoordinator.js";
-import { planFetchRemotes } from "../../shared/utils/baseRemoteSelection.js";
+import {
+  parseKnownRemoteBranch,
+  planFetchRemotes,
+} from "../../shared/utils/baseRemoteSelection.js";
 
 /**
  * The remote a worktree's displayed counts depend on. Derived through the same
@@ -2766,22 +2769,63 @@ export class WorkspaceService {
       // or path that slipped past validation is treated as positional.
       const addReusingBranch = () =>
         git.raw(["worktree", "add", "--end-of-options", path, newBranch]);
-      // --no-track: local-base branches shouldn't auto-track a local ref even
-      // when the user has branch.autoSetupMerge=always. Skipping tracking also
-      // avoids a .git/config.lock acquisition, cutting contention under bulk
-      // creation. PR-mode (fromRemote) keeps --track — ahead/behind badges
-      // at WorktreeMonitor.ts:1092 depend on @{u} resolving.
-      const addNewBranch = () =>
-        git.raw([
+      // Remote names, read once and only when a remote base is actually in
+      // play. The tracking decision below is the only thing that needs them,
+      // and the local-base path — the overwhelming majority, and the one that
+      // runs in bulk — must not pay a spawn for a question it never asks.
+      let remoteNames: string[] | null = null;
+      const knownRemotes = async (): Promise<string[]> => {
+        if (remoteNames === null) {
+          try {
+            remoteNames = (await git.getRemotes()).map((r) => r.name).filter((n) => n.length > 0);
+          } catch {
+            remoteNames = [];
+          }
+        }
+        return remoteNames;
+      };
+
+      /**
+       * `--track` only when the new branch is the local counterpart of the
+       * remote base — `-b topic --track origin/topic`, which is the PR-mode
+       * shape and the only one where tracking is the truth.
+       *
+       * `-b bugfix/x --track origin/develop` is the shape that broke: git
+       * writes `branch.bugfix/x.merge = refs/heads/develop`, so a brand new
+       * topic branch tracks the BASE. Everything downstream reads `@{u}` as
+       * the branch's own remote counterpart, so `git status` reports
+       * ahead/behind of develop with nothing naming develop, the base
+       * divergence line then suppresses itself as a duplicate, and
+       * `push.default=simple` refuses to push a branch whose upstream carries
+       * a different name.
+       *
+       * `--no-track` is also what keeps a local base from auto-tracking a
+       * local ref under `branch.autoSetupMerge=always`, and skipping the
+       * tracking write avoids a `.git/config.lock` acquisition — real
+       * contention relief under bulk creation.
+       *
+       * Recomputed per call: collision recovery can suffix `newBranch` to
+       * `topic-2`, and `origin/topic` is not that branch's counterpart.
+       */
+      const shouldTrackBase = async (branchName: string): Promise<boolean> => {
+        if (!fromRemote) return false;
+        const parsed = parseKnownRemoteBranch(baseBranch, await knownRemotes());
+        return parsed !== null && parsed.branch === branchName;
+      };
+
+      const addNewBranch = async () => {
+        const tracking = (await shouldTrackBase(newBranch)) ? "--track" : "--no-track";
+        return git.raw([
           "worktree",
           "add",
           "-b",
           newBranch,
-          fromRemote ? "--track" : "--no-track",
+          tracking,
           "--end-of-options",
           path,
           baseBranch,
         ]);
+      };
 
       markHostPerformance("wtcreate.git-add:start", { branch: newBranch });
       if (useExistingBranch) {

--- a/electron/workspace-host/__tests__/WorkspaceService.createWorktree.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.createWorktree.test.ts
@@ -8,6 +8,9 @@ const mockSimpleGit = {
   checkIsRepo: vi.fn().mockResolvedValue(true),
   branch: vi.fn().mockResolvedValue({ current: "main" }),
   branchLocal: vi.fn().mockResolvedValue({ all: [], current: "", branches: {}, detached: false }),
+  // The tracking decision needs the real remote names to know where
+  // `origin/main` splits; a repo with one remote is the ordinary case.
+  getRemotes: vi.fn().mockResolvedValue([{ name: "origin", refs: { fetch: "url", push: "url" } }]),
 };
 
 vi.mock("simple-git", () => ({
@@ -375,7 +378,11 @@ describe("WorkspaceService.createWorktree", () => {
     );
   });
 
-  it("preserves --track (not --no-track) for fromRemote so @{u} resolves for ahead/behind counts", async () => {
+  it("tracks a remote base only when the new branch is its counterpart", async () => {
+    // `-b feature/remote --track origin/main` would write
+    // `branch.feature/remote.merge = refs/heads/main`, pointing a brand new
+    // topic branch at the BASE. Everything downstream then reads that as the
+    // branch's own remote counterpart.
     const requestId = "test-request-789";
     const options = {
       baseBranch: "origin/main",
@@ -391,7 +398,7 @@ describe("WorkspaceService.createWorktree", () => {
       "add",
       "-b",
       "feature/remote",
-      "--track",
+      "--no-track",
       "--end-of-options",
       "/test/worktree3",
       "origin/main",
@@ -769,6 +776,92 @@ describe("WorkspaceService.createWorktree", () => {
     ]);
   });
 
+  it("keeps --track when the new branch IS the remote base's counterpart", async () => {
+    // The PR-mode shape, and the only one where tracking states a truth:
+    // `topic` tracking `origin/topic` is what ahead/behind counts are for.
+    await service.createWorktree("req-track-counterpart", "/test/root", {
+      baseBranch: "origin/feature/login",
+      newBranch: "feature/login",
+      path: "/test/worktree-track",
+      fromRemote: true,
+    });
+
+    expect(lastWorktreeAddCall(mockSimpleGit.raw)).toEqual([
+      "worktree",
+      "add",
+      "-b",
+      "feature/login",
+      "--track",
+      "--end-of-options",
+      "/test/worktree-track",
+      "origin/feature/login",
+    ]);
+  });
+
+  it("splits the base at a slash-bearing remote's real boundary", async () => {
+    // `team/fork/topic` is `topic` on the remote `team/fork`. Splitting at the
+    // first slash would read it as `fork/topic` and refuse to track a branch
+    // that genuinely is its counterpart.
+    mockSimpleGit.getRemotes.mockResolvedValueOnce([
+      { name: "team/fork", refs: { fetch: "url", push: "url" } },
+    ]);
+
+    await service.createWorktree("req-slash-remote", "/test/root", {
+      baseBranch: "team/fork/topic",
+      newBranch: "topic",
+      path: "/test/worktree-slash",
+      fromRemote: true,
+    });
+
+    expect(lastWorktreeAddCall(mockSimpleGit.raw)![4]).toBe("--track");
+  });
+
+  it("does not track a local base branch even when fromRemote is set", async () => {
+    // `fromRemote` is the caller's claim, not a fact. A base that no remote
+    // prefixes is a local ref, and `--track` against a local ref is exactly
+    // what `--no-track` exists to prevent under branch.autoSetupMerge=always.
+    await service.createWorktree("req-local-base-fromremote", "/test/root", {
+      baseBranch: "main",
+      newBranch: "topic",
+      path: "/test/worktree-localbase",
+      fromRemote: true,
+    });
+
+    expect(lastWorktreeAddCall(mockSimpleGit.raw)![4]).toBe("--no-track");
+  });
+
+  it("does not track when the repository has no remotes at all", async () => {
+    // With no remote table, `origin/topic` cannot be a remote ref — so the
+    // base is a local branch literally named `origin/topic`.
+    mockSimpleGit.getRemotes.mockResolvedValueOnce([]);
+
+    await service.createWorktree("req-no-remotes", "/test/root", {
+      baseBranch: "origin/topic",
+      newBranch: "topic",
+      path: "/test/worktree-noremotes-repo",
+      fromRemote: true,
+    });
+
+    expect(lastWorktreeAddCall(mockSimpleGit.raw)![4]).toBe("--no-track");
+  });
+
+  it("degrades to --no-track when the remote table cannot be read", async () => {
+    // Without remote names the ref cannot be split at a boundary git agrees
+    // with, so the counterpart question has no answer. Not tracking is the
+    // recoverable direction — `git push -u` sets the right upstream later,
+    // whereas a wrong one has to be noticed first.
+    mockSimpleGit.getRemotes.mockRejectedValueOnce(new Error("git remote failed"));
+
+    await service.createWorktree("req-remotes-unreadable", "/test/root", {
+      baseBranch: "origin/feature/login",
+      newBranch: "feature/login",
+      path: "/test/worktree-noremotes",
+      fromRemote: true,
+    });
+
+    expect(lastWorktreeAddCall(mockSimpleGit.raw)![4]).toBe("--no-track");
+  });
+
   it("suffixes (not reuses) when fromRemote=true and the local branch already exists", async () => {
     // PR-mode creates need --track to give @{u} for ahead/behind badges
     // (WorktreeMonitor.ts:1092). Reusing a stale local branch would drop the
@@ -796,18 +889,22 @@ describe("WorkspaceService.createWorktree", () => {
       fromRemote: true,
     });
 
-    // Failure-driven: the optimistic --track add for the original name runs
-    // first; the suffixed retry keeps --track.
+    // Failure-driven: the optimistic add for the original name runs first and
+    // tracks, because `pr-9999-feature` IS `origin/pr-9999-feature`'s local
+    // counterpart. The suffixed retry is not — `pr-9999-feature-2` tracking
+    // `origin/pr-9999-feature` is the same mis-tracking by another route — so
+    // the decision is recomputed against the name actually being created.
     const addCalls = mockSimpleGit.raw.mock.calls.filter(
       (call) => call[0][0] === "worktree" && call[0][1] === "add"
     );
     expect(addCalls[0]![0][3]).toBe("pr-9999-feature");
+    expect(addCalls[0]![0][4]).toBe("--track");
     expect(lastWorktreeAddCall(mockSimpleGit.raw)).toEqual([
       "worktree",
       "add",
       "-b",
       "pr-9999-feature-2",
-      "--track",
+      "--no-track",
       "--end-of-options",
       "/test/worktree-pr",
       "origin/pr-9999-feature",

--- a/electron/workspace-host/__tests__/WorkspaceService.createWorktree.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.createWorktree.test.ts
@@ -863,10 +863,10 @@ describe("WorkspaceService.createWorktree", () => {
   });
 
   it("suffixes (not reuses) when fromRemote=true and the local branch already exists", async () => {
-    // PR-mode creates need --track to give @{u} for ahead/behind badges
-    // (WorktreeMonitor.ts:1092). Reusing a stale local branch would drop the
-    // tracking ref AND pin the worktree to whatever commit the stale branch
-    // was at, instead of origin's current tip. Always suffix in PR mode.
+    // Reusing a stale local branch would pin the worktree to whatever commit
+    // that branch was left at instead of origin's current tip, so PR mode
+    // always suffixes. The suffixed name is not `origin/pr-9999-feature`'s
+    // counterpart, so the retry drops to --no-track (asserted below).
     mockSimpleGit.branchLocal.mockResolvedValueOnce({
       all: ["main", "pr-9999-feature"],
       current: "main",

--- a/shared/utils/__tests__/baseRemoteSelection.test.ts
+++ b/shared/utils/__tests__/baseRemoteSelection.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { resolveBaseCompareRef, planFetchRemotes } from "../baseRemoteSelection.js";
+import {
+  resolveBaseCompareRef,
+  planFetchRemotes,
+  parseKnownRemoteBranch,
+} from "../baseRemoteSelection.js";
 
 describe("resolveBaseCompareRef", () => {
   it("resolves nothing when the repo has no remotes", () => {
@@ -190,5 +194,46 @@ describe("planFetchRemotes", () => {
       availableRemotes: ["origin", "heroku", "dokku"],
     });
     expect(plan.remotes).toEqual(["origin"]);
+  });
+});
+
+describe("parseKnownRemoteBranch", () => {
+  it("splits at the remote boundary rather than the first slash", () => {
+    expect(parseKnownRemoteBranch("origin/release/1.x", ["origin"])).toEqual({
+      remote: "origin",
+      branch: "release/1.x",
+    });
+  });
+
+  it("prefers the longer remote when one name prefixes another", () => {
+    // `team` and `team/fork` both prefix this ref; only the longer one leaves a
+    // branch the remote actually carries.
+    expect(parseKnownRemoteBranch("team/fork/topic", ["team", "team/fork"])).toEqual({
+      remote: "team/fork",
+      branch: "topic",
+    });
+  });
+
+  it("returns null for a local branch that merely looks remote-shaped", () => {
+    // `origin/develop` is a legal local branch name in a repo with no `origin`.
+    expect(parseKnownRemoteBranch("origin/develop", ["upstream"])).toBeNull();
+  });
+
+  it("returns null for a bare remote name with no branch after it", () => {
+    expect(parseKnownRemoteBranch("origin/", ["origin"])).toBeNull();
+    expect(parseKnownRemoteBranch("origin", ["origin"])).toBeNull();
+  });
+
+  it("ignores the local pseudo-remote", () => {
+    // `branch.<n>.remote = .` tracks a local branch; there is no remote ref.
+    expect(parseKnownRemoteBranch("./develop", ["."])).toBeNull();
+  });
+
+  it("matches case-sensitively, as git ref names are", () => {
+    expect(parseKnownRemoteBranch("Origin/develop", ["origin"])).toBeNull();
+  });
+
+  it("returns null when the repository has no remotes at all", () => {
+    expect(parseKnownRemoteBranch("origin/develop", [])).toBeNull();
   });
 });

--- a/shared/utils/baseRemoteSelection.ts
+++ b/shared/utils/baseRemoteSelection.ts
@@ -127,6 +127,45 @@ export function planFetchRemotes(inputs: FetchRemotePlanInputs): FetchRemotePlan
 /** git's conventional default remote, and the pre-#11747 hardcoded one. */
 const DEFAULT_REMOTE = "origin";
 
+/** A short remote ref (`origin/develop`) split at a remote boundary git agrees with. */
+export interface KnownRemoteBranch {
+  /** Remote name, which may itself contain slashes. */
+  remote: string;
+  /** Branch name on the remote side — everything after the remote's own name. */
+  branch: string;
+}
+
+/**
+ * Split a short ref like `origin/develop` into its remote and branch parts,
+ * using only remote names the repository actually has.
+ *
+ * Positional splitting cannot do this: `team/fork/topic` is `topic` on the
+ * remote `team/fork` in one repo and `fork/topic` on `team` in another, and
+ * only the remote table says which. Candidates are tested longest-name-first
+ * so the more specific remote wins, and matching is case-sensitive because git
+ * ref names are.
+ *
+ * Returns `null` when no known remote prefixes the ref — which is the correct
+ * answer for a local branch that merely looks remote-shaped (`origin/develop`
+ * is a legal local branch name in a repo with no `origin`).
+ */
+export function parseKnownRemoteBranch(
+  shortRef: string | null | undefined,
+  availableRemotes: readonly string[]
+): KnownRemoteBranch | null {
+  if (!shortRef) return null;
+
+  const byLongestName = [...availableRemotes].sort((a, b) => b.length - a.length);
+  for (const remote of byLongestName) {
+    if (remote === LOCAL_PSEUDO_REMOTE) continue;
+    const prefix = `${remote}/`;
+    if (shortRef.startsWith(prefix) && shortRef.length > prefix.length) {
+      return { remote, branch: shortRef.slice(prefix.length) };
+    }
+  }
+  return null;
+}
+
 /**
  * Split `refs/remotes/<remote>/<branch>` into its remote and short-ref parts.
  *
@@ -140,17 +179,9 @@ function parseRemoteRef(
   availableRemotes: readonly string[]
 ): BaseCompareRefSelection | null {
   if (!fullRef || !fullRef.startsWith(REMOTE_REF_PREFIX)) return null;
-  const shortRef = fullRef.slice(REMOTE_REF_PREFIX.length);
-  if (!shortRef) return null;
-
-  const byLongestName = [...availableRemotes].sort((a, b) => b.length - a.length);
-  for (const remote of byLongestName) {
-    if (remote === LOCAL_PSEUDO_REMOTE) continue;
-    if (shortRef.startsWith(`${remote}/`) && shortRef.length > remote.length + 1) {
-      return { compareRef: shortRef, remote };
-    }
-  }
-  return null;
+  const parsed = parseKnownRemoteBranch(fullRef.slice(REMOTE_REF_PREFIX.length), availableRemotes);
+  if (!parsed) return null;
+  return { compareRef: `${parsed.remote}/${parsed.branch}`, remote: parsed.remote };
 }
 
 /**

--- a/src/components/Worktree/WorktreeCard/NonMainSecondaryRow.tsx
+++ b/src/components/Worktree/WorktreeCard/NonMainSecondaryRow.tsx
@@ -75,6 +75,7 @@ export function NonMainSecondaryRow({
   const upstreamTier = computeAlarmTier({
     authFailed: hasAuthFailedSignIn,
     behindCount: worktree.behindCount,
+    baseBehindCount: worktree.baseBehindCount,
   }).tier;
   const upstreamFirst = upstreamTier > prTier;
 

--- a/src/components/Worktree/WorktreeCard/UpstreamSyncBadge.tsx
+++ b/src/components/Worktree/WorktreeCard/UpstreamSyncBadge.tsx
@@ -54,15 +54,33 @@ export function UpstreamSyncBadge({
 
   const showBaseDivergence =
     baseBranchName != null &&
-    !baseMatchesUpstream &&
     ((baseAheadCount != null && baseAheadCount > 0) ||
       (baseBehindCount != null && baseBehindCount > 0));
 
+  // A branch can end up tracking its own base — `git worktree add -b topic
+  // --track origin/develop` writes `branch.topic.merge = refs/heads/develop`,
+  // and any branch may be pointed at an integration branch by hand. Then
+  // `@{u}` and the base compare ref are the same commit, both pairs carry the
+  // same number, and only one of them says what the number is counted against.
+  //
+  // Drop the unlabelled pair, never the label. The old rule did the reverse,
+  // so two worktrees on the same commit off the same base rendered as
+  // `Δ develop ↓4` and a bare `↓4` purely on how their tracking config
+  // happened to be written — and a bare `↓4` beside a labelled one reads as a
+  // different measurement, not the same one.
+  //
+  // Gated on the base pair actually being non-zero so an inter-pass race that
+  // zeroes the base counts while upstream still reports drift falls back to
+  // the upstream form rather than rendering nothing.
+  const dedupeToBase = baseMatchesUpstream === true && showBaseDivergence;
+  const showUpstreamDelta = (hasAhead || hasBehind) && !dedupeToBase;
+
   // Flash only on changes the user can actually see — track display-gated
   // values so a null→0 transition on hidden base counts doesn't flash, and
-  // a baseMatchesUpstream flip that reveals existing counts does.
-  const displayedAhead = hasAhead ? aheadCount : null;
-  const displayedBehind = hasBehind ? behindCount : null;
+  // a baseMatchesUpstream flip that moves the counts between the two forms
+  // does.
+  const displayedAhead = showUpstreamDelta && hasAhead ? aheadCount : null;
+  const displayedBehind = showUpstreamDelta && hasBehind ? behindCount : null;
   const displayedBaseAhead =
     showBaseDivergence && baseAheadCount != null && baseAheadCount > 0 ? baseAheadCount : null;
   const displayedBaseBehind =
@@ -136,9 +154,16 @@ export function UpstreamSyncBadge({
             aria-label="Forge authentication failed — click to reconnect"
           >
             <span className="flex items-center gap-1.5 text-text-muted">
-              {hasAhead && <span>↑{aheadCount}</span>}
-              {hasBehind && <span>↓{behindCount}</span>}
-              {!hasAhead && !hasBehind && <span>—</span>}
+              {showUpstreamDelta && hasAhead && <span>↑{aheadCount}</span>}
+              {showUpstreamDelta && hasBehind && <span>↓{behindCount}</span>}
+              {showBaseDivergence && (
+                <>
+                  <span>&Delta; {baseBranchName}</span>
+                  {displayedBaseAhead != null && <span>↑{displayedBaseAhead}</span>}
+                  {displayedBaseBehind != null && <span>↓{displayedBaseBehind}</span>}
+                </>
+              )}
+              {!showUpstreamDelta && !showBaseDivergence && <span>—</span>}
             </span>
           </button>
         </TooltipTrigger>
@@ -153,7 +178,7 @@ export function UpstreamSyncBadge({
     );
   }
 
-  if (!hasAhead && !hasBehind && !showBaseDivergence) return null;
+  if (!showUpstreamDelta && !showBaseDivergence) return null;
 
   return (
     <Tooltip>
@@ -172,8 +197,12 @@ export function UpstreamSyncBadge({
           data-stale={isStale ? "true" : undefined}
           onAnimationEnd={() => setIsFlashing(false)}
         >
-          {hasAhead && <span className="text-status-success">↑{aheadCount}</span>}
-          {hasBehind && <span className="text-status-warning">↓{behindCount}</span>}
+          {showUpstreamDelta && hasAhead && (
+            <span className="text-status-success">↑{aheadCount}</span>
+          )}
+          {showUpstreamDelta && hasBehind && (
+            <span className="text-status-warning">↓{behindCount}</span>
+          )}
           {showBaseDivergence && (
             <>
               {/* `text-secondary`, not `text-muted/60`: this names the branch
@@ -197,20 +226,22 @@ export function UpstreamSyncBadge({
         </span>
       </TooltipTrigger>
       <TooltipContent side="right" className="text-xs">
-        <div>
-          {hasAhead && (
-            <span>
-              {aheadCount} commit{aheadCount !== 1 ? "s" : ""} ahead
-            </span>
-          )}
-          {hasAhead && hasBehind && <span>, </span>}
-          {hasBehind && (
-            <span>
-              {behindCount} commit{behindCount !== 1 ? "s" : ""} behind
-            </span>
-          )}
-          <span> upstream</span>
-        </div>
+        {showUpstreamDelta && (
+          <div>
+            {hasAhead && (
+              <span>
+                {aheadCount} commit{aheadCount !== 1 ? "s" : ""} ahead
+              </span>
+            )}
+            {hasAhead && hasBehind && <span>, </span>}
+            {hasBehind && (
+              <span>
+                {behindCount} commit{behindCount !== 1 ? "s" : ""} behind
+              </span>
+            )}
+            <span> upstream</span>
+          </div>
+        )}
         {showBaseDivergence && baseBranchName && (
           <div className="text-text-muted/70">
             {baseAheadCount != null && baseAheadCount > 0 && (

--- a/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
@@ -207,15 +207,18 @@ export function WorktreeHeader({
   const hasFreshnessPill = !!(lastGitStatusCheckedAt && lastGitStatusCheckedAt > 0);
   const hasDevServerSignal = !!devServerSession && isLiveDevServerStatus(devServerSession.status);
   const underlineOnHover = variant !== "sidebar" || isActive;
+  // Two rules, both load-bearing. No `!baseMatchesUpstream` term: when the two
+  // agree the badge now renders the labelled base form rather than nothing, so
+  // gating the mount on the disagreement would hide the very line that names
+  // what the counts mean. And the base terms require `baseBranchName`, because
+  // that is what the badge itself requires to draw them — mounting the row for
+  // counts the badge will decline to render leaves an empty secondary row.
+  const hasBaseName = worktree.baseBranchName != null;
   const hasUpstreamDelta =
-    (worktree.aheadCount !== undefined && worktree.aheadCount > 0) ||
-    (worktree.behindCount !== undefined && worktree.behindCount > 0) ||
-    (worktree.baseAheadCount != null &&
-      worktree.baseAheadCount > 0 &&
-      !worktree.baseMatchesUpstream) ||
-    (worktree.baseBehindCount != null &&
-      worktree.baseBehindCount > 0 &&
-      !worktree.baseMatchesUpstream);
+    (worktree.aheadCount ?? 0) > 0 ||
+    (worktree.behindCount ?? 0) > 0 ||
+    (hasBaseName && (worktree.baseAheadCount ?? 0) > 0) ||
+    (hasBaseName && (worktree.baseBehindCount ?? 0) > 0);
   const hasAuthFailedSignIn = Boolean(
     worktree.fetchAuthFailed &&
     (worktree.matchedForgeProviderId != null || worktree.linked?.providerId != null)
@@ -232,8 +235,9 @@ export function WorktreeHeader({
         ciState,
         authFailed: hasAuthFailedSignIn,
         behindCount: worktree.behindCount,
+        baseBehindCount: worktree.baseBehindCount,
       }),
-    [ciState, hasAuthFailedSignIn, worktree.behindCount]
+    [ciState, hasAuthFailedSignIn, worktree.behindCount, worktree.baseBehindCount]
   );
 
   const { visibleStates, sessionAriaLabel } = useMemo(() => {

--- a/src/components/Worktree/WorktreeCard/__tests__/UpstreamSyncBadge.compareRef.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/UpstreamSyncBadge.compareRef.test.tsx
@@ -91,3 +91,109 @@ describe("UpstreamSyncBadge — base compare ref (#11747)", () => {
     expect(warning.textContent).not.toContain("origin");
   });
 });
+
+describe("UpstreamSyncBadge — a branch tracking its own base", () => {
+  /**
+   * `git worktree add -b topic --track origin/develop` leaves `@{u}` pointing
+   * at the base, so `git status` and the base-divergence pass measure the same
+   * distance. Both pairs then carry the same number and only one of them says
+   * what it is counted against.
+   */
+  const mistracked: Partial<Props> = {
+    aheadCount: 0,
+    behindCount: 4,
+    baseBranchName: "develop",
+    baseAheadCount: 0,
+    baseBehindCount: 4,
+    baseMatchesUpstream: true,
+    baseCompareRef: "origin/develop",
+  };
+
+  it("shows the count once, and shows it labelled", () => {
+    renderBadge(mistracked);
+
+    const pill = screen.getByTestId("upstream-sync-indicator");
+    expect(pill.textContent).toContain("Δ develop");
+    expect(pill.textContent?.match(/↓4/g)).toHaveLength(1);
+  });
+
+  it("renders identically whether or not the branch happens to track its base", () => {
+    // The bug this fixes: two worktrees on the same commit off the same base
+    // read as different measurements purely on how their tracking config was
+    // written.
+    renderBadge(mistracked);
+    const tracked = screen.getByTestId("upstream-sync-indicator").textContent;
+    cleanup();
+
+    renderBadge({
+      ...mistracked,
+      aheadCount: undefined,
+      behindCount: undefined,
+      baseMatchesUpstream: false,
+    });
+    const untracked = screen.getByTestId("upstream-sync-indicator").textContent;
+
+    expect(tracked).toBe(untracked);
+  });
+
+  it("keeps the unlabelled pair when the base counts have not caught up", () => {
+    // Inter-pass race: base divergence reports zero while upstream already
+    // sees drift. Suppressing the only non-zero pair would render nothing.
+    renderBadge({
+      ...mistracked,
+      baseAheadCount: 0,
+      baseBehindCount: 0,
+    });
+
+    const pill = screen.getByTestId("upstream-sync-indicator");
+    expect(pill.textContent).toContain("↓4");
+    expect(pill.textContent).not.toContain("Δ");
+  });
+
+  it("names the compare ref in the tooltip while the pill stays on the branch", () => {
+    renderBadge(mistracked);
+
+    expect(screen.getByTestId("upstream-sync-indicator").textContent).not.toContain("origin/");
+    expect(document.body.textContent).toContain("4 behind origin/develop");
+  });
+
+  it("drops the upstream tooltip line rather than leaving a bare 'upstream'", () => {
+    renderBadge(mistracked);
+
+    // The line is built as counts followed by the word; with the counts gone
+    // the word must go too, not survive on its own. `origin/develop` in the
+    // base line is the only occurrence the tooltip should have left.
+    const occurrences = document.body.textContent?.match(/upstream/g) ?? [];
+    expect(occurrences).toHaveLength(0);
+  });
+
+  it("still renders both pairs when they measure different things", () => {
+    // Pushed branch, 2 ahead of its own remote, 4 behind the base: two real
+    // numbers, and neither is redundant.
+    renderBadge({
+      aheadCount: 2,
+      behindCount: 0,
+      baseBranchName: "develop",
+      baseAheadCount: 0,
+      baseBehindCount: 4,
+      baseMatchesUpstream: false,
+    });
+
+    const pill = screen.getByTestId("upstream-sync-indicator");
+    expect(pill.textContent).toContain("↑2");
+    expect(pill.textContent).toContain("Δ develop");
+    expect(pill.textContent).toContain("↓4");
+  });
+
+  it("labels the counts on the auth-failed pill too", () => {
+    renderBadge({
+      ...mistracked,
+      fetchAuthFailed: true,
+      hasAuthFailedSignIn: true,
+    });
+
+    const pill = screen.getByTestId("upstream-sync-indicator");
+    expect(pill.textContent).toContain("Δ develop");
+    expect(pill.textContent?.match(/↓4/g)).toHaveLength(1);
+  });
+});

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
@@ -1414,6 +1414,78 @@ describe("WorktreeHeader upstream sync indicator", () => {
     expect(indicator.getAttribute("data-fetch-in-flight")).toBeNull();
   });
 
+  it("mounts the badge for base-only drift and labels the branch it drifted from", () => {
+    // A worktree branch created without tracking reports no upstream counts at
+    // all; if the mount gate ignored base drift the whole line would vanish.
+    renderHeader({
+      worktree: {
+        ...baseWorktree,
+        aheadCount: undefined,
+        behindCount: undefined,
+        baseBranchName: "develop",
+        baseAheadCount: 0,
+        baseBehindCount: 4,
+        baseMatchesUpstream: false,
+      },
+    });
+    const indicator = screen.getByTestId("upstream-sync-indicator");
+    expect(indicator.textContent).toContain("Δ develop");
+    expect(indicator.textContent).toContain("↓4");
+  });
+
+  it("mounts the badge when the branch tracks its own base, and shows the count once", () => {
+    // `baseMatchesUpstream` used to suppress the base line AND was subtracted
+    // from the mount gate, so this pair rendered a bare unlabelled number.
+    renderHeader({
+      worktree: {
+        ...baseWorktree,
+        aheadCount: 0,
+        behindCount: 4,
+        baseBranchName: "develop",
+        baseAheadCount: 0,
+        baseBehindCount: 4,
+        baseMatchesUpstream: true,
+      },
+    });
+    const indicator = screen.getByTestId("upstream-sync-indicator");
+    expect(indicator.textContent).toContain("Δ develop");
+    expect(indicator.textContent?.match(/↓4/g)).toHaveLength(1);
+  });
+
+  it("keeps the unlabelled pair when base counts have not caught up", () => {
+    renderHeader({
+      worktree: {
+        ...baseWorktree,
+        aheadCount: 0,
+        behindCount: 4,
+        baseBranchName: "develop",
+        baseAheadCount: 0,
+        baseBehindCount: 0,
+        baseMatchesUpstream: true,
+      },
+    });
+    const indicator = screen.getByTestId("upstream-sync-indicator");
+    expect(indicator.textContent).toContain("↓4");
+    expect(indicator.textContent).not.toContain("Δ");
+  });
+
+  it("does not mount a row for base counts the badge would decline to draw", () => {
+    // The badge needs a base branch name to render base counts. Mounting on
+    // the counts alone would leave an empty secondary row behind.
+    renderHeader({
+      worktree: {
+        ...baseWorktree,
+        aheadCount: undefined,
+        behindCount: undefined,
+        baseBranchName: undefined,
+        baseAheadCount: 0,
+        baseBehindCount: 4,
+        baseMatchesUpstream: false,
+      },
+    });
+    expect(screen.queryByTestId("upstream-sync-indicator")).toBeNull();
+  });
+
   it("hides the indicator entirely when there are no counts and no auth failure", () => {
     renderHeader({
       worktree: { ...baseWorktree, aheadCount: 0, behindCount: 0 },

--- a/src/lib/__tests__/worktreeAlarmTier.test.ts
+++ b/src/lib/__tests__/worktreeAlarmTier.test.ts
@@ -101,3 +101,23 @@ describe("computeAlarmTier", () => {
     });
   });
 });
+
+describe("computeAlarmTier — base-branch drift", () => {
+  it("raises the behind alarm for a branch whose only drift signal is the base", () => {
+    // A worktree branch created without tracking has no upstream count at all;
+    // its distance from the base is the only "behind" it will ever report.
+    expect(computeAlarmTier({ baseBehindCount: 4 }).kind).toBe("behind");
+  });
+
+  it("stays quiet when neither distance is behind", () => {
+    expect(computeAlarmTier({ behindCount: 0, baseBehindCount: 0 }).tier).toBe(0);
+  });
+
+  it("keeps CI failure above base drift", () => {
+    expect(computeAlarmTier({ ciState: "failure", baseBehindCount: 9 }).kind).toBe("ci-failed");
+  });
+
+  it("keeps an auth failure above base drift", () => {
+    expect(computeAlarmTier({ authFailed: true, baseBehindCount: 9 }).kind).toBe("auth-failed");
+  });
+});

--- a/src/lib/worktreeAlarmTier.ts
+++ b/src/lib/worktreeAlarmTier.ts
@@ -25,7 +25,16 @@ export interface AlarmTierInput {
    * have applied any provider gate (e.g. GitHub-only) before passing this in.
    */
   authFailed?: boolean;
+  /** Commits behind the branch's own upstream, when it has one. */
   behindCount?: number;
+  /**
+   * Commits behind the base branch. Read alongside {@link behindCount} because
+   * the two are alternatives, not a pair: a worktree branch created without
+   * tracking has no upstream count at all, and its drift from the base is the
+   * only "behind" signal it will ever produce. Gating the pill on
+   * `behindCount` alone left every such branch silently un-alarmed.
+   */
+  baseBehindCount?: number | null;
 }
 
 const NONE: AlarmDescriptor = { tier: 0, kind: "none", label: "", tone: "none" };
@@ -45,7 +54,7 @@ export function computeAlarmTier(input: AlarmTierInput): AlarmDescriptor {
   if (input.authFailed === true) {
     return { tier: 2, kind: "auth-failed", label: "Auth failed", tone: "warning" };
   }
-  if ((input.behindCount ?? 0) > 0) {
+  if ((input.behindCount ?? 0) > 0 || (input.baseBehindCount ?? 0) > 0) {
     return { tier: 1, kind: "behind", label: "Behind", tone: "warning" };
   }
   return NONE;


### PR DESCRIPTION
Three worktrees branched off `develop`, all sitting on the same commit, all four commits behind it. Each one rendered something different in the worktree card:

* `bugfix/notification-row-alignment` showed `Δ develop ↓4`
* `bugfix/forge-dropdown-row-model` showed a bare, unlabelled `↓4`
* `bugfix/review-hub-file-list-expanded-default` showed nothing (correct, it was at the tip)

Same commit, same base, two different readings of the same number.

## What was going on

Worktree creation passed `--track` whenever the `fromRemote` flag was set, so `git worktree add -b bugfix/x --track origin/develop` wrote `branch.bugfix/x.merge = refs/heads/develop`. A brand new topic branch ended up tracking the base rather than its own counterpart on the remote, and `git status -sb` reported it plainly:

```
* bugfix/forge-dropdown-row-model...origin/develop [behind 4]
```

The badge then made it worse. When `@{u}` and the base compare ref are the same commit, `baseMatchesUpstream` is true and the labelled `Δ develop` line suppressed itself as a duplicate. That is the right instinct applied to the wrong half: the number is the duplicate, the label is the only thing that says what the number is counted against.

The same config broke pushing. Under `push.default=simple` git refuses a branch whose upstream carries a different name, and `%(push)` comes back empty, so `resolveGitPushDestination` failed closed. The branch with no tracking at all fell through to `resolveUnconfigured()` and pushed fine. The more configured branch was the one that could not push.

## The fix

**Creation.** `--track` only when the new branch is the remote base's counterpart, which is the PR-mode shape (`-b topic --track origin/topic`) and the only one where tracking states a truth. `-b bugfix/x --track origin/develop` now gets `--no-track`. The decision is recomputed after collision suffixing, because `topic-2` tracking `origin/topic` is the same mis-tracking by another route. Splitting `origin/develop` needs the repo's actual remote table (remote names can contain slashes), so there is a new pure `parseKnownRemoteBranch()` in `shared/utils/baseRemoteSelection.ts` and one lazy `git remote` read on the `fromRemote` path only.

**Display.** The badge now renders the labelled form and drops the duplicate unlabelled pair. Two worktrees on the same commit off the same base read identically regardless of how their tracking config happened to be written. If the base counts have not caught up yet, the unlabelled pair is kept rather than rendering nothing. `WorktreeHeader`'s mount gate matches the badge's own rule, and the Behind alarm now fires on base drift too, since that is the only behind signal a branch created without tracking ever produces.

**Push.** `resolveNameMismatchRepair()` recovers the same-name destination under narrow conditions: the branch tracks something differently named, the repo has exactly one remote and git named that same one, `push.default` is unset or `simple`, and no per-remote push refspec exists. Everything else still refuses. The push is then issued as `--set-upstream <remote> <local>:<local>`, which lands it and repairs the tracking config that broke it, on both the normal and the force-push paths.

That last part is the heal: existing worktrees in the bad state fix themselves on their next approved push, and the badge is honest immediately.

## Deliberately not fixed

* A suffixed PR checkout (`topic` collides, so you get `topic-2`) now pushes to `origin/topic-2` instead of being refused. It was refused *and* mis-tracked before. The D2 confirm names the destination, which is the safeguard that exists for this.
* Dropping `@{u}` removes Review Hub's "unpushed commits" signal for these branches. That signal was previously wrong (it measured against `develop`), and this converges on the `--no-track` path nearly every Daintree worktree already takes. A destination-relative push count is the durable answer and is its own piece of work.
* A branch deliberately configured to pull from `origin/develop` in a single-remote repo would have its upstream rewritten by a repair push. Disclosing that in the confirm means threading the flag to the renderer, and the destination itself is already shown.

## Testing

Full suite passes (52258 tests) and `npm run check` is clean. Two Codex review passes caught a fail-open in the config read, a force-push that skipped the repair, a mount gate that disagreed with the badge, and a fixture that was not actually isolated from the developer's global git config. All four are fixed here.
