### PR TITLE
fix(forge): put the pending CI dot back and stop it blinking on refresh

### DIFF
--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -655,10 +655,20 @@ class PullRequestService {
             : new Error(`CI status for PR #${prNumber} omitted from getCIStatuses batch`)
         );
       }
-      // CI status is best-effort: a transient failure resolves to null rather
-      // than rejecting, so it never invalidates an already-detected PR.
+      // Same contract on the fallback: a resolved value (null included) is a
+      // confirmed answer, a thrown one is a transient miss and rejects. Landing
+      // a failure here as `null` would read downstream as "no checks" and clear
+      // a status the provider never actually contradicted — and a cleared entry
+      // is neither pending nor terminal, so nothing re-polls it afterwards.
       return Promise.all(
-        list.map((prNumber) => bridge.getCIStatus(providerId, repo, prNumber).catch(() => null))
+        list.map((prNumber) =>
+          bridge
+            .getCIStatus(providerId, repo, prNumber)
+            .catch(
+              (cause: unknown) =>
+                new Error(`CI status lookup failed for PR #${prNumber}`, { cause })
+            )
+        )
       );
     });
   }
@@ -1518,6 +1528,15 @@ class PullRequestService {
             detectedPR.title !== pr.title ||
             detectedPR.url !== pr.url;
 
+          // The probe's fresh REST markers, read before the emit rather than
+          // after: a title edit and a push can land in the same tick, and the
+          // rollup we hold describes the head we last saw, not the new one.
+          const snap = changedSnapshotByNumber.get(prNumber);
+          const headMoved =
+            snap?.headSha != null &&
+            detectedPR.headSha !== undefined &&
+            snap.headSha !== detectedPR.headSha;
+
           if (prChanged) {
             const oldState = detectedPR.state;
             detectedPR.state = newState;
@@ -1538,7 +1557,17 @@ class PullRequestService {
               prNumber: pr.number,
               prUrl: pr.url,
               prState: newState,
-              prCiStatus: detectedPR.ciStatus,
+              // Both CI fields or neither. The host rebuilds `linked.pr` from
+              // the rich `ciStatus` on every detection event and full-replaces
+              // it, so an emit carrying only the flat rollup blanks the mark
+              // every badge actually reads until the enrichment below lands a
+              // round trip later — the blink this branch used to produce on any
+              // title or state edit. A metadata change on the same head says
+              // nothing about CI, so the last known status rides along; a change
+              // that came with a new head says the opposite, and holding the old
+              // head's green over the new one would be worse than a blank.
+              prCiStatus: headMoved ? undefined : detectedPR.ciStatus,
+              ciStatus: headMoved ? undefined : detectedPR._ciStatus,
               prTitle: pr.title,
               issueNumber: this.candidates.get(worktreeId)?.issueNumber,
               branchName: lookupBranchByWorktreeId.get(worktreeId),
@@ -1556,7 +1585,6 @@ class PullRequestService {
           // does not), so seeding from anywhere else is impossible. This runs on
           // the success path only — a transient error skips it above, leaving
           // the stale snapshot so the next probe re-flags the PR (self-healing).
-          const snap = changedSnapshotByNumber.get(prNumber);
           if (snap) {
             detectedPR.headSha = snap.headSha ?? undefined;
             detectedPR.updatedAt = snap.updatedAt ?? undefined;
@@ -2073,13 +2101,12 @@ class PullRequestService {
             ? ciStatus.state
             : undefined;
         pr._ciStatus = ciStatus ?? undefined;
-        // Only a positive result settles the blur-sweep backfill debt. A `null`
-        // is not trustworthy here: when the batch call itself fails, the
-        // loader's per-PR fallback converts a transient error into a resolved
-        // `null`, so clearing on null would strand a swept badge on a network
-        // blip — and a swept entry was `pending`, so it demonstrably had checks.
-        // Worst case we retry it once per tick until the provider answers or a
-        // re-detection replaces the entry.
+        // Only a positive result settles the blur-sweep backfill debt. A swept
+        // entry was `pending`, so it demonstrably had checks — a `null` says
+        // they have since vanished, which happens, but rarely enough that
+        // holding the debt and asking again is the cheaper mistake than
+        // stranding the badge. Worst case we retry it once per tick until the
+        // provider answers or a re-detection replaces the entry.
         if (ciStatus) {
           pr.needsCiBackfill = undefined;
         }
@@ -2090,6 +2117,13 @@ class PullRequestService {
         // confirmed "no checks" case so a preserved phase-1 dot is cleared.
         for (const [worktreeId, detected] of this.detectedPRs) {
           if (detected.number === pr.number) {
+            // Sibling worktrees on the same branch share one entry, but two
+            // worktrees can also hold distinct entries for the same PR. Only
+            // one of them is enriched per tick, so carry the result onto the
+            // others too — otherwise a later metadata emit from an unenriched
+            // entry re-publishes the rollup this one just replaced.
+            detected.ciStatus = pr.ciStatus;
+            detected._ciStatus = pr._ciStatus;
             events.emit("sys:pr:detected", {
               worktreeId,
               prNumber: pr.number,

--- a/electron/services/__tests__/PullRequestService.test.ts
+++ b/electron/services/__tests__/PullRequestService.test.ts
@@ -200,6 +200,19 @@ function makeMockCIStatus(): CIStatus {
   return { state: "success", total: 1, passed: 1, failed: 0, pending: 0, rawData: null };
 }
 
+// A rollup carrying counts as well as a state, so a test can tell "the same
+// object travelled" apart from "something rebuilt a state out of the flat field".
+function ciStatusFixture(state: CIStatus["state"]): CIStatus {
+  return {
+    state,
+    total: 3,
+    passed: state === "success" ? 3 : 1,
+    failed: state === "failure" ? 2 : 0,
+    pending: state === "pending" ? 2 : 0,
+    rawData: null,
+  };
+}
+
 // Drain microtasks + process.nextTick so the host-side BatchLoader's
 // fire-and-forget CI enrichment dispatches under fake timers (which fake
 // setTimeout but not nextTick/microtasks).
@@ -1143,6 +1156,139 @@ describe("PullRequestService", () => {
     expect(findPRsByNumbers).toHaveBeenCalledWith(expect.anything(), [1]);
 
     pullRequestService.destroy();
+  });
+
+  // The badge every worktree card renders reads `linked.pr.ciStatus`, which the
+  // workspace host rebuilds from the rich `ciStatus` field of each detection
+  // event and full-replaces. An emit that carries only the flat rollup blanks
+  // the mark until enrichment re-emits a round trip later — the blink this
+  // group pins shut.
+  describe("CI status across a metadata-change re-emit", () => {
+    // One revalidation cycle where the PR is renamed. `headSha` decides whether
+    // the rollup we hold still describes the PR's head; the caller drives it.
+    async function renameAndCapture(options: {
+      ci: CIStatus | null;
+      detectedHeadSha: string;
+      probeHeadSha: string;
+    }) {
+      const batchSpy = vi.fn(async (_repo: RepoRef, branches: string[]) => {
+        const map = new Map<string, ForgePR | null>();
+        for (const branch of branches) {
+          map.set(branch, makeMockForgePR({ number: 1, headRef: branch }));
+        }
+        return map;
+      });
+      const mockImpl = mockForgeProviderResolved(undefined, batchSpy);
+
+      const getCIStatuses = vi.fn(async (_repo: RepoRef, prNumbers: number[]) => {
+        const map = new Map<number, CIStatus | null>();
+        for (const n of prNumbers) map.set(n, options.ci);
+        return map;
+      });
+      // Cycle 1 seeds the head marker with the PR unchanged; cycle 2 is the
+      // rename under test. A PR whose head we have never seen cannot tell us
+      // whether it moved, so the comparison needs both.
+      let cycle = 0;
+      const probeOpenPRList = vi.fn(async () => {
+        cycle++;
+        return {
+          kind: "changed" as const,
+          changed: [
+            {
+              number: 1,
+              headSha: cycle === 1 ? options.detectedHeadSha : options.probeHeadSha,
+              updatedAt: "2024-02-02T00:00:00Z",
+              state: "open" as const,
+              title: cycle === 1 ? "Add new feature" : "Renamed",
+            },
+          ],
+        };
+      });
+      const findPRsByNumbers = vi.fn(async (_repo: RepoRef, prNumbers: number[]) => {
+        const map = new Map<number, ForgePR | null>();
+        for (const n of prNumbers) {
+          map.set(n, makeMockForgePR({ number: n, title: cycle === 1 ? undefined : "Renamed" }));
+        }
+        return map;
+      });
+      mockImpl.batchLookups = { findPRsByNumbers, getCIStatuses, probeOpenPRList };
+
+      const { pullRequestService } = await import("../PullRequestService.js");
+      const { events } = await import("../events.js");
+
+      pullRequestService.initialize("/repo", "test-project-id");
+      events.emit(
+        "sys:worktree:update",
+        makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/a" })
+      );
+
+      await pullRequestService.refresh();
+      await flushLoaders();
+      // Seed the head marker so the cycle under test has a baseline to compare.
+      await (
+        pullRequestService as unknown as { revalidateResolvedPRs: () => Promise<void> }
+      ).revalidateResolvedPRs();
+      await flushLoaders();
+
+      const detected: DaintreeEventMap["sys:pr:detected"][] = [];
+      const unsubscribe = events.on("sys:pr:detected", (payload) => detected.push(payload));
+
+      await (
+        pullRequestService as unknown as { revalidateResolvedPRs: () => Promise<void> }
+      ).revalidateResolvedPRs();
+
+      unsubscribe();
+      pullRequestService.destroy();
+      // The metadata emit lands synchronously inside the revalidation loop; the
+      // CI re-enrichment is a fire-and-forget tail, so the first payload here is
+      // always the one under test.
+      return detected[0];
+    }
+
+    it("carries the rich rollup through, not just the flat one", async () => {
+      const ci = ciStatusFixture("pending");
+      const emit = await renameAndCapture({
+        ci,
+        detectedHeadSha: "sha1",
+        probeHeadSha: "sha1",
+      });
+
+      expect(emit?.prTitle).toBe("Renamed");
+      // Object identity, not a shape match: a regression that rebuilds `{ state }`
+      // from the flat rollup would lose the counts the tooltip renders.
+      expect(emit?.ciStatus).toBe(ci);
+      expect(emit?.prCiStatus).toBe("pending");
+    });
+
+    it("carries a state the flat rollup cannot express", async () => {
+      // `neutral` has no flat representation — it maps to undefined — so a fix
+      // that carried the rich field only when the flat one was set would blank
+      // a neutral mark and still pass the pending case above.
+      const ci = ciStatusFixture("neutral");
+      const emit = await renameAndCapture({
+        ci,
+        detectedHeadSha: "sha1",
+        probeHeadSha: "sha1",
+      });
+
+      expect(emit?.ciStatus).toBe(ci);
+      expect(emit?.prCiStatus).toBeUndefined();
+    });
+
+    it("drops the rollup when the rename rode in on a new head", async () => {
+      // A push and a title edit in the same tick: the green we hold belongs to
+      // the previous commit, and publishing it over the new one reads as "this
+      // head passed" before anything has run against it.
+      const emit = await renameAndCapture({
+        ci: ciStatusFixture("success"),
+        detectedHeadSha: "sha1",
+        probeHeadSha: "sha2",
+      });
+
+      expect(emit?.prTitle).toBe("Renamed");
+      expect(emit?.ciStatus).toBeUndefined();
+      expect(emit?.prCiStatus).toBeUndefined();
+    });
   });
 
   it("seeds headSha/updatedAt from a changed probe so the next tick's snapshot is in sync", async () => {
@@ -3024,7 +3170,7 @@ describe("PullRequestService", () => {
       const probeOpenPRList = vi.fn(async () => ({ kind: "unchanged" as const }));
       mockImpl.batchLookups = { findPRsByNumbers, getCIStatuses, probeOpenPRList };
 
-      return { getCIStatuses, findPRsByNumbers, probeOpenPRList };
+      return { getCIStatuses, findPRsByNumbers, probeOpenPRList, mockImpl };
     }
 
     function ciState(state: "success" | "failure" | "pending"): CIStatus {
@@ -3370,6 +3516,42 @@ describe("PullRequestService", () => {
       await revalidate(pullRequestService);
       expect(getCIStatuses).not.toHaveBeenCalled();
 
+      pullRequestService.destroy();
+    });
+
+    it("keeps the last known CI status when every CI lookup fails", async () => {
+      const { getCIStatuses, mockImpl } = makeUnchangedProbeHarness(
+        new Map([[1, ciState("success")]])
+      );
+
+      const { pullRequestService, events } = await detectAndSettle(["feature/a"]);
+      const svc = pullRequestService as unknown as {
+        detectedPRs: Map<string, { ciStatus?: string }>;
+      };
+      expect(svc.detectedPRs.get("wt-1")?.ciStatus).toBe("success");
+      getCIStatuses.mockClear();
+
+      // The provider goes down between ticks: the batch throws, and so does the
+      // per-PR call the loader drops to. Neither is an answer about this PR.
+      getCIStatuses.mockRejectedValue(new Error("provider unreachable"));
+      vi.mocked(mockImpl.getCIStatus).mockRejectedValue(new Error("provider unreachable"));
+
+      const detected: DaintreeEventMap["sys:pr:detected"][] = [];
+      const unsubscribe = events.on("sys:pr:detected", (payload) => detected.push(payload));
+
+      for (let elapsed = 0; elapsed < 60 && getCIStatuses.mock.calls.length === 0; elapsed++) {
+        jump(MINUTE);
+        await revalidate(pullRequestService);
+      }
+      expect(getCIStatuses).toHaveBeenCalled();
+
+      // Laundering the failure into a resolved `null` would read downstream as a
+      // confirmed "no checks": the mark blanks, and the cleared entry is then
+      // neither pending nor terminal, so nothing ever re-polls it.
+      expect(svc.detectedPRs.get("wt-1")?.ciStatus).toBe("success");
+      expect(detected).toHaveLength(0);
+
+      unsubscribe();
       pullRequestService.destroy();
     });
 

--- a/electron/workspace-host/__tests__/WorkspaceService.adversarial.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.adversarial.test.ts
@@ -863,6 +863,23 @@ describe("WorkspaceService adversarial", () => {
 
   describe("onPRDetected CI-status preservation (#9551)", () => {
     type OnPRDetected = (worktreeId: string, data: Record<string, unknown>) => void;
+    type LinkedCi = { linked?: { pr?: { ciStatus?: { state?: string } } } };
+    type PrDetectedSent = WorkspaceHostEvent & { prCiStatus?: string } & LinkedCi;
+    type WorktreeUpdateSent = WorkspaceHostEvent & {
+      worktree: { prCiStatus?: string } & LinkedCi;
+    };
+
+    // The flat rollup is a legacy compatibility field; `linked.pr.ciStatus` is
+    // what every badge actually reads, and the host rebuilds it from scratch on
+    // each detection event. Preserving one without the other is the same blink
+    // moved into a different field, so both are asserted throughout.
+    function sentPrDetected(): PrDetectedSent | undefined {
+      return sentEvents.find((e) => e.type === "pr-detected") as PrDetectedSent | undefined;
+    }
+
+    function sentWorktreeUpdate(): WorktreeUpdateSent | undefined {
+      return sentEvents.find((e) => e.type === "worktree-update") as WorktreeUpdateSent | undefined;
+    }
 
     function getOnPRDetected(): OnPRDetected {
       return (service as unknown as { prService: { callbacks: { onPRDetected: OnPRDetected } } })
@@ -941,12 +958,12 @@ describe("WorkspaceService adversarial", () => {
 
       // The monitor write and both outbound events keep success — no blink.
       expect(setPRInfo).toHaveBeenCalledWith(expect.objectContaining({ prCiStatus: "success" }));
-      const prDetected = sentEvents.find((e) => e.type === "pr-detected") as
-        (WorkspaceHostEvent & { prCiStatus?: string }) | undefined;
+      const prDetected = sentPrDetected();
       expect(prDetected?.prCiStatus).toBe("success");
-      const wtUpdate = sentEvents.find((e) => e.type === "worktree-update") as
-        (WorkspaceHostEvent & { worktree: { prCiStatus?: string } }) | undefined;
+      expect(prDetected?.linked?.pr?.ciStatus).toEqual({ state: "success" });
+      const wtUpdate = sentWorktreeUpdate();
       expect(wtUpdate?.worktree.prCiStatus).toBe("success");
+      expect(wtUpdate?.worktree.linked?.pr?.ciStatus).toEqual({ state: "success" });
     });
 
     it("full-replaces to undefined when no loading flag is set (checks genuinely gone)", () => {
@@ -960,9 +977,9 @@ describe("WorkspaceService adversarial", () => {
       getOnPRDetected()("/repo/wt", baseEvent({ prCiStatus: undefined }));
 
       expect(setPRInfo).toHaveBeenCalledWith(expect.objectContaining({ prCiStatus: undefined }));
-      const prDetected = sentEvents.find((e) => e.type === "pr-detected") as
-        (WorkspaceHostEvent & { prCiStatus?: string }) | undefined;
+      const prDetected = sentPrDetected();
       expect(prDetected?.prCiStatus).toBeUndefined();
+      expect(prDetected?.linked?.pr?.ciStatus).toBeUndefined();
     });
 
     it("does not preserve across a PR reassignment even when loading", () => {
@@ -980,6 +997,7 @@ describe("WorkspaceService adversarial", () => {
       );
 
       expect(setPRInfo).toHaveBeenCalledWith(expect.objectContaining({ prCiStatus: undefined }));
+      expect(sentPrDetected()?.linked?.pr?.ciStatus).toBeUndefined();
     });
   });
 

--- a/plugins/builtin/github/renderer/__tests__/GitHubListItem.test.tsx
+++ b/plugins/builtin/github/renderer/__tests__/GitHubListItem.test.tsx
@@ -276,7 +276,12 @@ describe("GitHubListItem", () => {
     render(<GitHubListItem item={prWithCI} type="pr" />);
     const indicator = screen.getByLabelText("Checks pending");
     expect(indicator.querySelector("svg")).toBeNull();
-    expect(indicator.querySelector(".bg-status-warning")).not.toBeNull();
+    const dot = indicator.querySelector(".bg-status-warning");
+    expect(dot).not.toBeNull();
+    // The disc is a background, which forced colors strips to nothing; the
+    // shared hook src/index.css repaints is the only thing keeping this row
+    // marked at all for those users.
+    expect(dot?.classList.contains("status-mark")).toBe(true);
   });
 
   it("renders no CI indicator for an unknown roll-up", () => {

--- a/plugins/builtin/github/renderer/components/GitHubListItem.tsx
+++ b/plugins/builtin/github/renderer/components/GitHubListItem.tsx
@@ -418,7 +418,10 @@ export function GitHubListItem({
                             <ciVisual.Icon className={cn("w-3.5 h-3.5", ciVisual.colorClass)} />
                           ) : (
                             <span
-                              className={cn("block w-2 h-2 rounded-full", ciVisual.colorClass)}
+                              className={cn(
+                                "status-mark block w-2 h-2 rounded-full",
+                                ciVisual.colorClass
+                              )}
                             />
                           )}
                         </span>

--- a/src/components/Worktree/ReviewHub/PrStatusChip.tsx
+++ b/src/components/Worktree/ReviewHub/PrStatusChip.tsx
@@ -68,9 +68,19 @@ export function PrStatusChip({ hasRemote, worktreePR, onOpenExternal }: PrStatus
                   className="inline-flex items-center justify-center w-3 h-3 shrink-0"
                   aria-hidden="true"
                 >
-                  <ciVisual.Icon className={cn("w-3 h-3", ciVisual.colorClass)} />
+                  {ciVisual.kind === "icon" ? (
+                    <ciVisual.Icon className={cn("w-3 h-3", ciVisual.colorClass)} />
+                  ) : (
+                    <span
+                      className={cn("status-mark block w-2 h-2 rounded-full", ciVisual.colorClass)}
+                    />
+                  )}
                 </span>
-                <span className={ciVisual.colorClass}>{ciVisual.shortLabel}</span>
+                <span
+                  className={ciVisual.kind === "icon" ? ciVisual.colorClass : ciVisual.labelClass}
+                >
+                  {ciVisual.shortLabel}
+                </span>
               </span>
             </>
           )}

--- a/src/components/Worktree/ReviewHub/__tests__/ReviewHub.prStateAndReviewThreads.test.tsx
+++ b/src/components/Worktree/ReviewHub/__tests__/ReviewHub.prStateAndReviewThreads.test.tsx
@@ -568,6 +568,29 @@ describe("ReviewHub", () => {
       });
     });
 
+    it("renders an in-flight run as a dot with its label on a text channel", async () => {
+      setWorktreePR({
+        prNumber: 42,
+        prUrl: "https://github.com/test/repo/pull/42",
+        prState: "open",
+        prCiStatus: "pending",
+      });
+      getStagingStatusMock.mockResolvedValue(makeStatus({ hasRemote: true }));
+
+      const { container } = render(
+        <ReviewHubContent isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />
+      );
+
+      const label = await waitFor(() => screen.getByText("pending"));
+      // The mark is a painted disc carrying the forced-colors rescue hook…
+      const dot = container.querySelector(".status-mark");
+      expect(dot).toBeTruthy();
+      expect(dot?.className).toContain("bg-status-warning");
+      // …and the words beside it take a text colour, not the disc's background
+      // class, which would paint nothing on the label at all.
+      expect(label.className).toContain("text-status-warning");
+    });
+
     it("omits CI status when prCiStatus is undefined", async () => {
       setWorktreePR({
         prNumber: 42,

--- a/src/components/Worktree/WorktreeCard/PRBadge.tsx
+++ b/src/components/Worktree/WorktreeCard/PRBadge.tsx
@@ -186,7 +186,13 @@ export function PRBadge({
               className="inline-flex items-center justify-center w-3 h-3 shrink-0"
               aria-hidden="true"
             >
-              <ciVisual.Icon className={cn("w-3 h-3", ciVisual.colorClass)} />
+              {ciVisual.kind === "icon" ? (
+                <ciVisual.Icon className={cn("w-3 h-3", ciVisual.colorClass)} />
+              ) : (
+                <span
+                  className={cn("status-mark block w-2 h-2 rounded-full", ciVisual.colorClass)}
+                />
+              )}
             </span>
           )}
           {showPausedGlyph && (

--- a/src/components/Worktree/WorktreeCard/__tests__/PRBadge.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/PRBadge.test.tsx
@@ -44,6 +44,16 @@ vi.mock("../hooks/useForgeBadgeFreshness", () => ({
 }));
 
 import { PRBadge } from "../PRBadge";
+import type { CIStatus, CIStatusState } from "@shared/types/forge";
+
+const ciStatus = (state: CIStatusState): CIStatus => ({
+  state,
+  total: 1,
+  passed: state === "success" ? 1 : 0,
+  failed: state === "failure" ? 1 : 0,
+  pending: state === "pending" ? 1 : 0,
+  rawData: null,
+});
 
 function renderBadge(extra: Partial<Parameters<typeof PRBadge>[0]> = {}) {
   return render(
@@ -169,5 +179,35 @@ describe("PRBadge freshness glyphs", () => {
 
     const button = screen.getByRole("button");
     expect(button.getAttribute("aria-label")).toContain("PR detection paused");
+  });
+});
+
+describe("PRBadge CI rollup mark", () => {
+  beforeEach(() => {
+    mockMissingCredential = false;
+    mockFreshnessCause = undefined;
+  });
+
+  it("marks a run still in flight with a dot, not a glyph", () => {
+    renderBadge({ prCiStatus: ciStatus("pending") });
+
+    const button = screen.getByRole("button");
+    expect(button.getAttribute("aria-label")).toContain("CI pending");
+    // No stroked glyph — the dot is the whole mark, as it is on GitHub.
+    expect(button.querySelector(".lucide-clock")).toBeNull();
+    const dot = button.querySelector(".status-mark");
+    expect(dot).toBeTruthy();
+    // Painted as a background, which forced colors strips; `.status-mark` is
+    // what src/index.css repaints, so the class is the mark's survival.
+    expect(dot?.className).toContain("bg-status-warning");
+  });
+
+  it("marks a settled run with a glyph that carries its own shape", () => {
+    renderBadge({ prCiStatus: ciStatus("success") });
+
+    const button = screen.getByRole("button");
+    expect(button.getAttribute("aria-label")).toContain("CI passing");
+    expect(button.querySelector(".lucide-check")).toBeTruthy();
+    expect(button.querySelector(".status-mark")).toBeNull();
   });
 });

--- a/src/lib/__tests__/worktreeCIStatus.test.ts
+++ b/src/lib/__tests__/worktreeCIStatus.test.ts
@@ -3,33 +3,51 @@ import { getCIStatusVisual } from "@/lib/worktreeCIStatus";
 import type { CIStatus } from "@shared/types/forge";
 
 const status = (state: CIStatus["state"]): CIStatus => ({ state }) as CIStatus;
+const REPORTABLE = ["success", "failure", "pending", "neutral"] as const;
 
 describe("getCIStatusVisual", () => {
-  it("gives every reportable state a glyph, not a background-painted dot", () => {
-    // The point of #12000: a `bg-*` disc is erased by forced-colors, so a state
-    // that only had one communicated nothing. Every state that reports at all
-    // has to hand back something that strokes.
-    for (const state of ["success", "failure", "pending", "neutral"] as const) {
-      const visual = getCIStatusVisual(status(state));
-      expect(visual).not.toBeNull();
-      expect(visual!.Icon).toBeTruthy();
-      expect(visual!.colorClass.startsWith("text-")).toBe(true);
-    }
+  it("marks a run still in flight with a dot and a settled one with a glyph", () => {
+    // GitHub's own vocabulary, and the one the forge dropdown rows speak. A
+    // change here silently puts two views of the same PR out of step.
+    expect(getCIStatusVisual(status("pending"))?.kind).toBe("dot");
+    expect(getCIStatusVisual(status("success"))?.kind).toBe("icon");
+    expect(getCIStatusVisual(status("failure"))?.kind).toBe("icon");
   });
 
-  it("keeps the four states visually distinct by shape", () => {
-    const icons = (["success", "failure", "pending", "neutral"] as const).map(
-      (state) => getCIStatusVisual(status(state))!.Icon
-    );
+  it("keeps only one state on the dot, so shape survives forced colors", () => {
+    // Every dot collapses to the same system-coloured disc under
+    // `forced-colors: active` — a second one would be indistinguishable from
+    // pending for the users that override the strongest.
+    const dots = REPORTABLE.filter((state) => getCIStatusVisual(status(state))?.kind === "dot");
+    expect(dots).toEqual(["pending"]);
+  });
+
+  it("keeps the glyph states distinguishable by shape alone", () => {
+    const icons = REPORTABLE.map((state) => getCIStatusVisual(status(state))!)
+      .filter((visual) => visual.kind === "icon")
+      .map((visual) => visual.Icon);
     expect(new Set(icons).size).toBe(icons.length);
   });
 
-  it("labels every state it renders", () => {
-    for (const state of ["success", "failure", "pending", "neutral"] as const) {
+  it("paints the dot as a background and its label as text", () => {
+    // The two halves diverge on purpose: a background is what the shared
+    // `.status-mark` hook rescues under forced colors, and text alongside it
+    // needs a colour the same override leaves alone.
+    for (const state of REPORTABLE) {
       const visual = getCIStatusVisual(status(state))!;
-      expect(visual.shortLabel).toBeTruthy();
-      expect(visual.ariaLabel).toBeTruthy();
+      if (visual.kind === "dot") {
+        expect(visual.colorClass.startsWith("bg-")).toBe(true);
+        expect(visual.labelClass.startsWith("text-")).toBe(true);
+      } else {
+        expect(visual.colorClass.startsWith("text-")).toBe(true);
+      }
     }
+  });
+
+  it("gives every state it renders its own wording", () => {
+    const labels = REPORTABLE.map((state) => getCIStatusVisual(status(state))!);
+    expect(new Set(labels.map((visual) => visual.shortLabel)).size).toBe(labels.length);
+    expect(new Set(labels.map((visual) => visual.ariaLabel)).size).toBe(labels.length);
   });
 
   it("renders nothing for an absent or unknown status", () => {

--- a/src/lib/worktreeCIStatus.ts
+++ b/src/lib/worktreeCIStatus.ts
@@ -1,26 +1,28 @@
-import { Check, CircleMinus, Clock, X } from "lucide-react";
+import { Check, CircleMinus, X } from "lucide-react";
 import type { CIStatus } from "@shared/types/forge";
 
 /**
- * Every state gets a glyph, terminal or not (#12000). The non-terminal states
- * used to render a disc painted with a status background, which
- * `forced-colors: active` strips to nothing — pending and neutral simply
- * disappeared while passing and failing
- * stayed. A stroked icon inherits `currentColor`, which the UA repaints, so the
- * shape carries the state where the palette no longer can.
+ * A run still in flight is a dot; a settled one is a glyph. That is GitHub's own
+ * vocabulary, and the one the forge dropdown rows already speak
+ * (`plugins/builtin/github/renderer/utils/prCIStatus.ts`) — a clock for pending
+ * read as a duration rather than a state and put the two out of step.
+ *
+ * The dot is painted as a background, which `forced-colors: active` strips to
+ * nothing, so every consumer renders it with the shared `.status-mark` hook
+ * `src/index.css` repaints to CanvasText (#12000). Neutral keeps the glyph it
+ * got there: a second dot would collapse onto pending's under that override,
+ * where hue is gone and only shape is left to tell them apart.
  */
-export type CIStatusVisual = {
-  Icon: typeof Check;
-  colorClass: string;
-  shortLabel: string;
-  ariaLabel: string;
-};
+export type CIStatusVisual =
+  | { kind: "icon"; Icon: typeof Check; colorClass: string; shortLabel: string; ariaLabel: string }
+  | { kind: "dot"; colorClass: string; labelClass: string; shortLabel: string; ariaLabel: string };
 
 export function getCIStatusVisual(status: CIStatus | undefined | null): CIStatusVisual | null {
   if (!status) return null;
   switch (status.state) {
     case "success":
       return {
+        kind: "icon",
         Icon: Check,
         colorClass: "text-status-success",
         shortLabel: "passing",
@@ -28,6 +30,7 @@ export function getCIStatusVisual(status: CIStatus | undefined | null): CIStatus
       };
     case "failure":
       return {
+        kind: "icon",
         Icon: X,
         colorClass: "text-status-error",
         shortLabel: "failing",
@@ -35,16 +38,18 @@ export function getCIStatusVisual(status: CIStatus | undefined | null): CIStatus
       };
     case "pending":
       return {
-        Icon: Clock,
-        colorClass: "text-status-warning",
+        kind: "dot",
+        colorClass: "bg-status-warning",
+        labelClass: "text-status-warning",
         shortLabel: "pending",
         ariaLabel: "CI pending",
       };
     case "neutral":
-      // `text-secondary` rather than the old dot's `text-muted`: as a lone glyph
-      // it owes the 3:1 non-text floor, which `text-muted` only clears on light
-      // themes (`shared/theme/contrast.ts`).
+      // Secondary rather than the old dot's muted token: as a lone mark it owes
+      // the 3:1 non-text floor, which muted only clears on light themes
+      // (`shared/theme/contrast.ts`).
       return {
+        kind: "icon",
         Icon: CircleMinus,
         colorClass: "text-text-secondary",
         shortLabel: "neutral",


### PR DESCRIPTION
This PR does two things to the PR badge in the worktree sidebar.

## Put the pending dot back

A while ago we swapped the CI mark for a pending check run from a dot to a clock glyph. This changes it back. The dot is what GitHub uses, and what the forge dropdown rows were still rendering, so the two surfaces had drifted apart. A clock also reads as a duration rather than a state.

The clock went in to survive Windows High Contrast, where a disc painted with a background colour gets stripped to nothing. That guarantee stays: every dot now carries the shared `.status-mark` class that `src/index.css` repaints under `forced-colors: active`. Neutral keeps its glyph, because a second dot would collapse onto pending's under that override, where hue is gone and only shape is left to tell them apart.

## Stop the mark blinking on refresh

The mark disappears and comes back while data refreshes. The cause is `revalidateResolvedPRs` in `electron/services/PullRequestService.ts`. When PR metadata changes it re-emits `sys:pr:detected` with the flat `prCiStatus` but not the rich `ciStatus` object. The workspace host rebuilds `linked.pr.ciStatus` from that rich field and full-replaces it, so the mark every badge actually reads went blank until the CI enrichment re-emitted a round trip later. Passing the rich object through fixes it.

A Codex review turned up three more holes, all fixed here:

- Carrying the rollup when the metadata change arrives with a **new head SHA** would paint the previous commit's green over a commit nothing had run against. That case drops the rollup instead.
- A transient CI lookup failure was laundered into a resolved `null`, which reads downstream as a confirmed "no checks". The cleared entry is then neither pending nor terminal, so nothing ever re-polls it. The per-PR fallback now rejects, matching the batch path's contract.
- Two worktrees can hold separate detection entries for one PR while only one is enriched per tick, so a later metadata emit from the unenriched one re-published a superseded rollup. Enrichment now syncs the siblings.

## Known gaps

Two left open, both pre-existing:

- A workspace-host restart still blanks the mark for one round trip. The fresh monitor has no prior PR number to match on, so its first loading detection fails the same-PR check. Fixing it needs the loading contract extended across the host/renderer boundary.
- The deliberate blur sweep still clears pending marks when the window loses focus, and restores them on focus.

## Tests

Covered end to end, and I checked each new test fails without its fix:

- The host's phase-1 preservation tests asserted only the flat `prCiStatus`, never `linked.pr.ciStatus`, which is the blind spot that let this bug exist in the first place. Both are asserted now.
- The emit test asserts object identity of the rich rollup, plus a `neutral` case (which has no flat representation at all) and a moved-head case.
- Runtime assertions on all three surfaces that render the dot, replacing a weaker source-text contract test.

Full unit suite green, typecheck clean, lint ratchet down 15.
