### PR TITLE
fix(ui): stop green standing in for "everything is fine" (2/3 and 3/3)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -68,6 +68,7 @@ The plugin sub-index links onward to getting-started, manifest reference, contri
 | [themes/visual-guide.md](./themes/visual-guide.md) | Maps tokens to what the user sees, surface by surface — evaluate themes without running the app. |
 | [themes/interaction-state-recipes.md](./themes/interaction-state-recipes.md) | Canonical Tailwind class strings per interactive component role. |
 | [themes/component-contract.md](./themes/component-contract.md) | Which primitive, which colour vocabulary, which scale — and the rules enforcing each. |
+| [themes/status-success-policy.md](./themes/status-success-policy.md) | When green is allowed to stand, when it goes neutral, and the occurrence-level guard holding the line. |
 
 ## Distribution
 

--- a/docs/themes/status-success-policy.md
+++ b/docs/themes/status-success-policy.md
@@ -91,7 +91,7 @@ Use the semantic spelling, not the legacy `daintree-*` aliases — `border-borde
 
 ## InlineStatusBanner
 
-`severity="success"` requires `autoDismissAfter` and `onClose` at the type level. A success banner that stands is not expressible: the compiler, not review, is what stops one being written. Persistent completion is `severity="neutral"` — which is what `AgentCompletionBanner` already uses to say "N files changed, review when ready".
+`severity="success"` requires `autoDismissAfter` and `onClose` at the type level, so a success banner that never says how it leaves does not compile. The type can require a number but not a positive one — `autoDismissAfter={0}` still type-checks and would stand forever — so the component warns about that in dev builds rather than pretending the type closed it. Persistent completion is `severity="neutral"`, which is what `AgentCompletionBanner` already uses to say "N files changed, review when ready".
 
 ## The guard
 
@@ -107,14 +107,16 @@ Deliberate boundaries:
 - **Not ESLint.** A lint rule cannot infer a timer, a modal's lifetime, or checklist structure out of a `cn()` call. The rationale field is where that judgement lives, and it is reviewed by people.
 - **TS/TSX only.** CSS files are outside the scan: `src/index.css` defines the token and `DiffViewer.css` is diff notation.
 
-What it catches: a new green in any scanned root, a second green in a file that already has approved ones, a removed green whose entry lingers, a site claimed by two entries at once, and a wholesale move that keeps every per-site check passing.
+What it catches: a new green in any scanned root, a second green in a file that already has approved ones, a removed green whose entry lingers, a site claimed by two entries at once, and a move between files, which shows up as a stale entry on one side and an unclassified site on the other.
 
 What it does not catch, stated plainly because a guard trusted past its reach is worse than no guard:
 
 - **A rationale that is not true.** Nothing mechanical can check whether the timer a `transient` entry claims actually exists. That is what review is for.
 - **Activations of an approved definition.** `badge.tsx`'s `tone="success"` and `button.tsx`'s `ghost-success` are each one inventoried site; every `<Badge tone="success">` that follows is invisible to the scanner. `InlineStatusBanner`'s `severity="success"` is the exception, and only because the type now forces it to dismiss itself.
 - **The token reached indirectly.** A class name assembled from a variable, an interpolated `var(${token})`, a theme object read like `t["status-success"]`, or a value pulled through CSSOM all paint the colour without ever writing a utility a parser can see.
-- **A one-for-one swap inside one anchor.** Deleting an approved site and adding the same signature under the same anchor in the same file holds every count. The anchors make this narrow, not impossible.
+- **A one-for-one swap inside one file.** Deleting an approved site and adding the same signature back under the same anchor — or anywhere in that file, if the entry needed no anchor — holds every count and every per-site check. The anchors make this narrow, not impossible.
+- **The Tailwind grammar drifting.** The utility roots are enumerated against the pinned Tailwind version, so a colour utility added upstream is unguarded until the list catches up.
+- **The non-colour channel.** That every surviving green also speaks through text, a glyph, geometry or a border is a review obligation, not something the guard checks.
 
 ## Review checklist
 

--- a/docs/themes/status-success-policy.md
+++ b/docs/themes/status-success-policy.md
@@ -1,0 +1,110 @@
+# Success Colour Policy
+
+Green is the app's scarcest status colour, and it was spending itself on nothing. We were rendering a success signal as ongoing status in 55 places — not a confirmation of something the user just did, but standing chrome saying the thing is healthy, on surfaces people open repeatedly. Chrome that is always green trains people to stop reading it, and then the one time it is not green, they do not notice either.
+
+This page is the rule, the categories, and the guard that holds them. It came out of #12002.
+
+## The decision rule
+
+**Green is allowed only for a confirmation that clears on its own, the recorded result of a named operation or check, an item in a finite checklist the user is currently working through, or a process that is running right now. Everything else goes neutral when the state still needs naming, and disappears when the good case is already implied.**
+
+The review question, for anyone touching a `status-success` token:
+
+> Can this green be named as a specific result, a required checked item, or a live operation? If not, it does not get to persist.
+
+This falls out of the runtime-signal tiering in [notification-system.md](../architecture/notification-system.md). Active work earns one T1 marker. "Nothing needs attention" changes no user action, so it earns nothing.
+
+Two corollaries that are easy to get wrong:
+
+- **Removing green is not compensated.** No toast, no inbox entry, no banner in its place. The signal was not worth a colour; it is not worth an interruption either.
+- **`--color-status-success` is never neutralised globally.** CI results, audit outcomes and diff semantics all read from it. The work is per-surface, always.
+
+## The categories
+
+| Category | Admits when | Verdict |
+| --- | --- | --- |
+| Transient confirmation | Clears on a timer, leaves with the operation or dialog, resets on input change | Keep |
+| Finite gate or checklist | The current task requires each displayed item to become true | Keep one mark per item, neutral row surface |
+| Enumerated outcome | Green is the recorded result of a named execution, not inferred health | Keep |
+| Live operation | The running/stopped distinction is the primary datum | Keep the green, but retoken to `state-working` / `activity-working` |
+| Threshold baseline | Green only because a number sits below a warning threshold | Demote |
+| Ambient health | The good branch means "no exception currently detected" | Demote or remove |
+| Membership, category, decoration | Green means staged, attached, selected, or section identity | Demote |
+| Settled completion | Work has finished and is no longer asking for anything | Demote |
+
+Git additions, insertion counts, ahead arrows and patch lines are domain notation, not success chrome. They stay, and they are not part of the count.
+
+### Transient confirmations
+
+The clipboard flash is the archetype: `copied` flips true, the glyph swaps to a `Check`, the label says "Copied", and a timer puts it back. Green is doing real work there — it marks the moment, and the moment ends.
+
+A confirmation qualifies when something other than the user's attention takes it away: a timer, the dialog closing, the next keystroke. "The user will navigate away eventually" is not that.
+
+### Finite gates and checklists
+
+The setup wizard is the clean case. Every prerequisite has to become true before the user moves on, so each satisfied row keeps one green `CircleCheck`, plus the single completion summary. The review hub's per-file viewed marks are the same shape: the task is to get through every file.
+
+The exception is about **task structure**, not about rows that happen to hold a boolean. The Settings agent list is not a checklist — it lists only installed agents, agents are optional alternatives, nothing requires every row to reach Ready, and the rows exist to navigate. So Ready went away there entirely and only the exception states render.
+
+Where a gate does qualify: keep one mark per item, and keep the row surface neutral. A green mark plus a green row wash is the same fact twice. That is why `AgentCliStep` kept its inline "Installed" mark and lost its full-row wash, and why `FileStageRow` kept its viewed checkbox and lost its staged-row band.
+
+A fully satisfied checklist may collapse to one summary line — but on a surface people open repeatedly that line is neutral, not green.
+
+### Enumerated outcomes
+
+Green here reports what happened when something ran: CI passed, the clone finished, the key validated, N runs succeeded. The distinguishing test is that a specific execution produced it. "No errors are currently detected" is not an outcome; it is ambient health wearing an outcome's clothes.
+
+### Domain notation
+
+Some green the app inherited rather than invented, and repainting it would make the app wrong rather than restrained. Git status letters (`A`, `?`), diff insertion counts, ahead arrows, added lines in a patch. Alongside these sit the affirmative halves of paired controls — the `Plus` against the `Minus` on a stage row, the run and apply affordances — where green means "go", not "good". None of them is claiming anything is healthy.
+
+### Live operations
+
+A process that is running right now keeps its green, but it belongs on `activity-working` (or its alias `state-working`), not `status-success`. The two resolve to adjacent hues in every built-in theme, so this is a semantic move rather than a visible one: "in flight" stops being spelled the same way as "succeeded". It also takes those sites out of the guard entirely, which is the point — a running server is not a success, and the inventory should not have to pretend otherwise.
+
+`projectRowStatus`'s `running` tone, the MCP server's running dot, the dev-server indicator and the assistant's live-session mark all moved this way.
+
+## The non-colour channel
+
+Anything that keeps its green still needs a second channel, per #12000: visible text, a Lucide glyph, distinct geometry, or a real border. An `aria-label` alone is not a visible channel.
+
+Use a real `border`, never a `ring-*` substitute. `box-shadow` — which is what `ring-*` compiles to — is stripped outright under `forced-colors: active`, while borders and outlines survive and map to system colours. Marks that are a bare background disc carry the `.status-mark` hook so `forced-colors` can repaint them.
+
+## Vocabulary when you demote
+
+| Was | Becomes |
+| --- | --- |
+| `bg-status-success/5` … `/15` (row wash, badge fill) | `bg-overlay-subtle`, hover `bg-overlay-medium` |
+| `border-status-success/20` … `/40` | `border-border-default` |
+| `text-status-success` on a label | `text-text-secondary`, then `text-text-muted` |
+| `ring-1 ring-status-success/30` | a real `border`, not another ring |
+
+Use the semantic spelling, not the legacy `daintree-*` aliases — `border-border-default`, not `border-daintree-border` — and never fade a text colour with slash-alpha. Both are ratcheted by `component-contract/*` rules that fail the build on any per-rule increase; see [component-contract.md](./component-contract.md).
+
+## InlineStatusBanner
+
+`severity="success"` requires `autoDismissAfter` and `onClose` at the type level. A success banner that stands is not expressible: the compiler, not review, is what stops one being written. Persistent completion is `severity="neutral"` — which is what `AgentCompletionBanner` already uses to say "N files changed, review when ready".
+
+## The guard
+
+Enforcement is a contract test, at occurrence level: `src/config/__tests__/statusSuccessGuard.contract.test.ts`, with its data in `statusSuccessInventory.ts`.
+
+It parses every production `.ts`/`.tsx` under `src/` and collects **paint sites** — string literals and template quasis containing a `status-success` Tailwind utility or a `var(--color-status-success)` read. Every site must appear in the inventory with a category and a rationale. Sites are keyed by a **signature** (the success-bearing lexemes of the literal, whitespace collapsed) plus an optional **anchor** (any substring of an enclosing node) when a signature repeats inside one file. Reformatting a component does not churn the inventory; changing which success utility it paints does.
+
+Deliberate boundaries:
+
+- **No file allowlist.** `FileStageRow` holds both git notation that stays and a row wash that had to go. Allowing the file would leave the door open forever — which is exactly how the accent guard's file-level buckets miss a second bad occurrence in a file already on the list.
+- **No pre-existing bucket, permanent or temporary.** Every entry states why its green is allowed today.
+- **Painting, not defining.** `applyAppTheme` and `ColorVisionPicker` name the token to build and preview the palette. The policy protects `--color-status-success` itself, so the layer defining it is out of scope by construction.
+- **Not ESLint.** A lint rule cannot infer a timer, a modal's lifetime, or checklist structure out of a `cn()` call. The rationale field is where that judgement lives, and it is reviewed by people.
+- **TS/TSX only.** CSS files are outside the scan: `src/index.css` defines the token and `DiffViewer.css` is diff notation.
+
+What it catches: a new green anywhere in `src/`, a second green in a file that already has approved ones, a removed green whose entry lingers, and a wholesale move that keeps every per-site check passing. What it cannot catch: a rationale that is not true. The count ratchets exist so that even an equal-count swap has to be explained.
+
+## Review checklist
+
+1. Can you name the specific result, required item, or live operation? If you are reaching, it is ambient health — demote it.
+2. Does it clear on its own, or does the user have to leave the screen? Only the first is transient.
+3. If it stays, what is the non-colour channel — text, glyph, geometry, or a real border?
+4. If it is a running process, is it on `activity-working` rather than `status-success`?
+5. If you demoted it, did you avoid replacing it with a toast, an inbox entry, or a banner?

--- a/docs/themes/status-success-policy.md
+++ b/docs/themes/status-success-policy.md
@@ -56,7 +56,15 @@ Green here reports what happened when something ran: CI passed, the clone finish
 
 ### Domain notation
 
-Some green the app inherited rather than invented, and repainting it would make the app wrong rather than restrained. Git status letters (`A`, `?`), diff insertion counts, ahead arrows, added lines in a patch. Alongside these sit the affirmative halves of paired controls — the `Plus` against the `Minus` on a stage row, the run and apply affordances — where green means "go", not "good". None of them is claiming anything is healthy.
+Some green the app inherited rather than invented, and repainting it would make the app wrong rather than restrained. Git status letters (`A`, `?`), diff insertion counts, ahead arrows, added lines in a patch. This is the ruling's exemption and it is narrow: it covers notation, not anything that merely feels conventional.
+
+### Affordances — an open question, not a ruled category
+
+`affordance` is a fifth category, and the ruling did not name it. It covers the affirmative half of a control pair — run, apply, stage, resume, save, retry — where green means "go" rather than "good". These controls are not reporting state at all, so the review question ("can this green be named as a result, a checked item, or a live operation?") has no honest answer for them: they are not any of the three, and they are not health either.
+
+They are also not in the #12002 ruling's demote list, so this series left them alone rather than widening its scope. Naming them separately is the point: folding them into `domain` would have quietly restated what the ruling meant by that word, and the sites would have stopped being visible as a decision anyone made.
+
+If they should go neutral, delete the category — the guard will then list every site that needs fixing. If they should stay, this section is where the reasoning lives.
 
 ### Live operations
 
@@ -89,7 +97,7 @@ Use the semantic spelling, not the legacy `daintree-*` aliases — `border-borde
 
 Enforcement is a contract test, at occurrence level: `src/config/__tests__/statusSuccessGuard.contract.test.ts`, with its data in `statusSuccessInventory.ts`.
 
-It parses every production `.ts`/`.tsx` under `src/` and collects **paint sites** — string literals and template quasis containing a `status-success` Tailwind utility or a `var(--color-status-success)` read. Every site must appear in the inventory with a category and a rationale. Sites are keyed by a **signature** (the success-bearing lexemes of the literal, whitespace collapsed) plus an optional **anchor** (any substring of an enclosing node) when a signature repeats inside one file. Reformatting a component does not churn the inventory; changing which success utility it paints does.
+It parses every production `.ts`/`.tsx` under `src/` and under the builtin plugin renderers (which ship in the app and paint the same tokens) and collects **paint sites** — string literals and template quasis containing a `status-success` Tailwind utility or a `var(--color-status-success)` read. Every site must appear in the inventory with a category and a rationale. Sites are keyed by a **signature** (the success-bearing lexemes of the literal, whitespace collapsed) plus an optional **anchor** (any substring of an enclosing node) when a signature repeats inside one file. Reformatting a component does not churn the inventory; changing which success utility it paints does.
 
 Deliberate boundaries:
 
@@ -99,7 +107,14 @@ Deliberate boundaries:
 - **Not ESLint.** A lint rule cannot infer a timer, a modal's lifetime, or checklist structure out of a `cn()` call. The rationale field is where that judgement lives, and it is reviewed by people.
 - **TS/TSX only.** CSS files are outside the scan: `src/index.css` defines the token and `DiffViewer.css` is diff notation.
 
-What it catches: a new green anywhere in `src/`, a second green in a file that already has approved ones, a removed green whose entry lingers, and a wholesale move that keeps every per-site check passing. What it cannot catch: a rationale that is not true. The count ratchets exist so that even an equal-count swap has to be explained.
+What it catches: a new green in any scanned root, a second green in a file that already has approved ones, a removed green whose entry lingers, a site claimed by two entries at once, and a wholesale move that keeps every per-site check passing.
+
+What it does not catch, stated plainly because a guard trusted past its reach is worse than no guard:
+
+- **A rationale that is not true.** Nothing mechanical can check whether the timer a `transient` entry claims actually exists. That is what review is for.
+- **Activations of an approved definition.** `badge.tsx`'s `tone="success"` and `button.tsx`'s `ghost-success` are each one inventoried site; every `<Badge tone="success">` that follows is invisible to the scanner. `InlineStatusBanner`'s `severity="success"` is the exception, and only because the type now forces it to dismiss itself.
+- **The token reached indirectly.** A class name assembled from a variable, an interpolated `var(${token})`, a theme object read like `t["status-success"]`, or a value pulled through CSSOM all paint the colour without ever writing a utility a parser can see.
+- **A one-for-one swap inside one anchor.** Deleting an approved site and adding the same signature under the same anchor in the same file holds every count. The anchors make this narrow, not impossible.
 
 ## Review checklist
 

--- a/docs/themes/theme-system.md
+++ b/docs/themes/theme-system.md
@@ -140,6 +140,8 @@ Scenes cover the workbench, a multi-pane fleet, terminal with seeded ANSI, sideb
 
 The full authoring-and-review process — including the Codex review loop, the tier model for contrast budgets, and the traps that pass every test in the repo — lives in `.claude/skills/daintree-theme-creator/resources/theme-review-workflow.md`.
 
+Green has its own rule on top of these, because it is the token most often spent on saying nothing: see [status-success-policy.md](./status-success-policy.md).
+
 ## Design review checklist
 
 Before adding a file to `DURABLE_ALLOWLIST` in `src/config/__tests__/accentGuard.contract.test.ts`, answer all four questions:

--- a/docs/themes/theme-tokens.md
+++ b/docs/themes/theme-tokens.md
@@ -123,12 +123,12 @@ An optional second color lane for themes with two distinct interaction colors.
 
 Fixed hue families across all themes. Each theme tunes brightness/saturation.
 
-| Token                   | Hue family                         | Derived?                         |
-| ----------------------- | ---------------------------------- | -------------------------------- |
-| `status-success`        | Green — completed/ready states     | Required                         |
-| `status-warning`        | Amber — caution states             | Required                         |
-| `status-danger`         | Red — error/destructive states     | Required                         |
-| `status-info`           | Blue — neutral informational       | Required                         |
+| Token | Hue family | Derived? |
+| --- | --- | --- |
+| `status-success` | Green — transient confirmations, named outcomes, checklist marks, git notation. Never standing "all is well" chrome — see [status-success-policy.md](./status-success-policy.md) | Required |
+| `status-warning` | Amber — caution states | Required |
+| `status-danger` | Red — error/destructive states | Required |
+| `status-info` | Blue — neutral informational | Required |
 | `status-danger-surface` | Validation wash for invalid fields | Derived: `danger` at 8-10% alpha |
 
 ## Activity Tokens

--- a/docs/themes/visual-guide.md
+++ b/docs/themes/visual-guide.md
@@ -764,12 +764,12 @@ Some themes have a **secondary accent** — a second color lane:
 
 Four fixed hue families, each theme tunes brightness/saturation:
 
-| Token            | Hue   | Usage                                                |
-| ---------------- | ----- | ---------------------------------------------------- |
-| `status-success` | Green | Completed states, positive outcomes, git additions   |
-| `status-warning` | Amber | Caution states, pending items                        |
-| `status-danger`  | Red   | Errors, failures, destructive actions, git deletions |
-| `status-info`    | Blue  | Neutral information, help text                       |
+| Token | Hue | Usage |
+| --- | --- | --- |
+| `status-success` | Green | Transient confirmations, named outcomes, finite checklist marks, git additions. Live processes use `activity-working`; standing health chrome uses neither — see [status-success-policy.md](./status-success-policy.md) |
+| `status-warning` | Amber | Caution states, pending items |
+| `status-danger` | Red | Errors, failures, destructive actions, git deletions |
+| `status-info` | Blue | Neutral information, help text |
 
 These are used in badges, toast notifications, diff viewer gutters, and terminal ANSI color fallbacks.
 

--- a/packages/plugin-sdk/api-report/index.d.ts
+++ b/packages/plugin-sdk/api-report/index.d.ts
@@ -1642,9 +1642,14 @@ interface ToolbarButtonContribution {
     priority?: 1 | 2 | 3 | 4 | 5;
 }
 /**
- * Semantic color for a {@link PluginPanelBadge}. Maps to the app's status
- * palette in the renderer — plugins pick intent, not a raw hex value, so badges
- * stay theme-consistent. `"default"` is the neutral accent-free tint.
+ * Semantic color for a {@link PluginPanelBadge}. Plugins pick intent, not a raw
+ * hex value, so badges stay theme-consistent. `"warning"` and `"error"` map to
+ * the app's status palette; `"default"` is the neutral accent-free tint.
+ *
+ * `"success"` does NOT render green. A badge stands for as long as the plugin
+ * leaves it there, and the host cannot know what a given plugin means by
+ * success, so it renders as emphasis on the neutral ramp instead of a health
+ * hue (#12002) — still visually distinct from `"default"`, just not green.
  */
 type PluginPanelBadgeColor = "default" | "success" | "warning" | "error";
 /**

--- a/plugins/builtin/github/renderer/components/GitHubSettingsTab.tsx
+++ b/plugins/builtin/github/renderer/components/GitHubSettingsTab.tsx
@@ -182,7 +182,7 @@ export function GitHubSettingsTab() {
         description="Used for repository statistics, issue/PR detection, and linking worktrees to GitHub. Eliminates the need for the gh CLI."
       >
         {githubConfig?.hasToken && (
-          <div className="flex items-center gap-1 text-xs text-status-success">
+          <div className="flex items-center gap-1 text-xs text-text-secondary">
             <Check className="w-3 h-3" />
             GitHub connected
           </div>

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -47,9 +47,14 @@ export interface ToolbarButtonContribution {
 }
 
 /**
- * Semantic color for a {@link PluginPanelBadge}. Maps to the app's status
- * palette in the renderer — plugins pick intent, not a raw hex value, so badges
- * stay theme-consistent. `"default"` is the neutral accent-free tint.
+ * Semantic color for a {@link PluginPanelBadge}. Plugins pick intent, not a raw
+ * hex value, so badges stay theme-consistent. `"warning"` and `"error"` map to
+ * the app's status palette; `"default"` is the neutral accent-free tint.
+ *
+ * `"success"` does NOT render green. A badge stands for as long as the plugin
+ * leaves it there, and the host cannot know what a given plugin means by
+ * success, so it renders as emphasis on the neutral ramp instead of a health
+ * hue (#12002) — still visually distinct from `"default"`, just not green.
  */
 export type PluginPanelBadgeColor = "default" | "success" | "warning" | "error";
 

--- a/src/components/DevPreview/BlockedNavBanner.tsx
+++ b/src/components/DevPreview/BlockedNavBanner.tsx
@@ -62,8 +62,10 @@ function blockedNavReducer(
   switch (action.type) {
     case "BLOCKED": {
       const isOAuth = looksLikeOAuthUrl(action.url);
-      // Coalesce: if OAuth is in-flight, update URL data but preserve the in-flight phase
-      if (state && state.phase !== "blocked") {
+      // Coalesce: if OAuth is in-flight, update URL data but preserve the
+      // in-flight phase. Only those two — a terminal phase carried forward
+      // would let its dismiss timer close a navigation blocked after it.
+      if (state && (state.phase === "oauth-started" || state.phase === "oauth-intercepting")) {
         return {
           ...state,
           url: action.url,

--- a/src/components/DevPreview/BlockedNavBanner.tsx
+++ b/src/components/DevPreview/BlockedNavBanner.tsx
@@ -39,6 +39,11 @@ type BlockedNavAction =
 
 // How long the "Copied" confirmation label lingers before reverting to "Copy URL".
 const COPY_FEEDBACK_MS = 2000;
+// "Sign in completed" is a confirmation, not a state: the banner says the round
+// trip through the browser landed and then gets out of the way. Longer than the
+// copy flash because the user is coming back from another app and has to catch
+// it, short enough that it never becomes standing chrome (#12002).
+const SIGN_IN_COMPLETED_DISMISS_MS = 6000;
 
 function computeRegistrableDomain(url: string): string {
   try {
@@ -340,6 +345,24 @@ export function BlockedNavBanner({
         action={primary}
         trailingSlot={overflow.length > 0 ? <BannerOverflowMenu actions={overflow} /> : undefined}
         onClose={handleDismiss}
+        role={role}
+      />
+    );
+  }
+
+  // `success` is the one severity that has to declare how it leaves, so it
+  // cannot ride the shared computed-severity return.
+  if (severity === "success") {
+    return (
+      <InlineStatusBanner
+        icon={icon}
+        title={title}
+        description={description}
+        contextLine={url}
+        severity="success"
+        actions={actions}
+        onClose={handleDismiss}
+        autoDismissAfter={SIGN_IN_COMPLETED_DISMISS_MS}
         role={role}
       />
     );

--- a/src/components/DevPreview/__tests__/BlockedNavBanner.test.tsx
+++ b/src/components/DevPreview/__tests__/BlockedNavBanner.test.tsx
@@ -21,7 +21,7 @@ vi.mock("@/components/ui/popover", () => ({
   ),
 }));
 
-import { BlockedNavBanner, blockedNavReducer } from "../BlockedNavBanner";
+import { BlockedNavBanner, blockedNavReducer, type BlockedNavAction } from "../BlockedNavBanner";
 
 type Phase =
   | "blocked"
@@ -103,13 +103,12 @@ describe("BlockedNavBanner action selection", () => {
 });
 
 describe("blockedNavReducer phase coalescing", () => {
-  const blocked = (url: string) =>
-    ({
-      type: "BLOCKED",
-      url,
-      canOpenExternal: true,
-      sessionStorageSnapshot: [],
-    }) as const;
+  const blocked = (url: string): BlockedNavAction => ({
+    type: "BLOCKED",
+    url,
+    canOpenExternal: true,
+    sessionStorageSnapshot: [],
+  });
 
   function phaseAfterSecondBlock(phase: Parameters<typeof reachPhase>[0]) {
     const state = reachPhase(phase);

--- a/src/components/DevPreview/__tests__/BlockedNavBanner.test.tsx
+++ b/src/components/DevPreview/__tests__/BlockedNavBanner.test.tsx
@@ -21,7 +21,7 @@ vi.mock("@/components/ui/popover", () => ({
   ),
 }));
 
-import { BlockedNavBanner } from "../BlockedNavBanner";
+import { BlockedNavBanner, blockedNavReducer } from "../BlockedNavBanner";
 
 type Phase =
   | "blocked"
@@ -99,5 +99,52 @@ describe("BlockedNavBanner action selection", () => {
     // The recovery action is the inline primary; Copy URL is demoted.
     expect(overflow.contains(tryAgain)).toBe(false);
     expect(overflow.contains(screen.getByRole("button", { name: /copy url/i }))).toBe(true);
+  });
+});
+
+describe("blockedNavReducer phase coalescing", () => {
+  const blocked = (url: string) =>
+    ({
+      type: "BLOCKED",
+      url,
+      canOpenExternal: true,
+      sessionStorageSnapshot: [],
+    }) as const;
+
+  function phaseAfterSecondBlock(phase: Parameters<typeof reachPhase>[0]) {
+    const state = reachPhase(phase);
+    return blockedNavReducer(state, blocked("https://example.com/second"))?.phase;
+  }
+
+  function reachPhase(phase: Phase) {
+    let state = blockedNavReducer(null, blocked("https://accounts.example.com/authorize"));
+    if (phase === "blocked") return state;
+    state = blockedNavReducer(state, { type: "OAUTH_STARTED" });
+    if (phase === "oauth-started") return state;
+    if (phase === "oauth-intercepting")
+      return blockedNavReducer(state, { type: "OAUTH_TOKEN_INTERCEPTED" });
+    if (phase === "oauth-completed") return blockedNavReducer(state, { type: "OAUTH_COMPLETED" });
+    if (phase === "oauth-timed-out") return blockedNavReducer(state, { type: "OAUTH_TIMED_OUT" });
+    return blockedNavReducer(state, { type: "OAUTH_ERROR", message: "boom" });
+  }
+
+  it("keeps a sign-in that is still in flight", () => {
+    expect(phaseAfterSecondBlock("oauth-started")).toBe("oauth-started");
+    expect(phaseAfterSecondBlock("oauth-intercepting")).toBe("oauth-intercepting");
+  });
+
+  // The completed phase carries a dismiss timer (#12002). Inheriting it would
+  // let the previous banner's timer tear down a navigation blocked after it.
+  it("resets a terminal phase so its dismiss timer cannot close the next block", () => {
+    expect(phaseAfterSecondBlock("oauth-completed")).toBe("blocked");
+    expect(phaseAfterSecondBlock("oauth-timed-out")).toBe("blocked");
+    expect(phaseAfterSecondBlock("oauth-error")).toBe("blocked");
+  });
+
+  it("adopts the new URL either way", () => {
+    const state = reachPhase("oauth-started");
+    expect(blockedNavReducer(state, blocked("https://example.com/second"))?.url).toBe(
+      "https://example.com/second"
+    );
   });
 });

--- a/src/components/FileViewer/DiffFileSidebar.tsx
+++ b/src/components/FileViewer/DiffFileSidebar.tsx
@@ -147,7 +147,7 @@ export function DiffFileSidebar({
           {viewedCount > 0 && (
             <div className="mt-1 h-0.5 overflow-hidden rounded-full bg-tint/10">
               <div
-                className="h-full rounded-full bg-status-success/70 transition-[width] duration-150 ease-out"
+                className="h-full rounded-full bg-text-secondary transition-[width] duration-150 ease-out"
                 style={{ width: `${files.length ? (viewedCount / files.length) * 100 : 0}%` }}
               />
             </div>

--- a/src/components/Panel/PluginPanelBadges.tsx
+++ b/src/components/Panel/PluginPanelBadges.tsx
@@ -15,14 +15,14 @@ import { usePanelBadges, usePluginPanelBadgeStore } from "@/store/pluginPanelBad
  */
 const DOT_COLOR: Record<PluginPanelBadgeColor, string> = {
   default: "bg-text-muted",
-  success: "bg-text-muted",
+  success: "bg-text-secondary",
   warning: "bg-status-warning",
   error: "bg-status-error",
 };
 
 const LABEL_COLOR: Record<PluginPanelBadgeColor, string> = {
   default: "bg-overlay-subtle text-text-secondary",
-  success: "bg-overlay-subtle text-text-secondary",
+  success: "bg-overlay-medium text-text-primary",
   warning: "bg-status-warning/15 text-status-warning",
   error: "bg-status-error/15 text-status-error",
 };

--- a/src/components/Panel/PluginPanelBadges.tsx
+++ b/src/components/Panel/PluginPanelBadges.tsx
@@ -7,19 +7,22 @@ import { usePanelBadges, usePluginPanelBadgeStore } from "@/store/pluginPanelBad
  * Live badges a plugin set on this panel via `host.setPanelBadge` (#10585),
  * rendered inline in the panel header's indicator cluster. A `dot` is a small
  * status circle; a `label` is a short pill. Color maps to the app's status
- * palette — never the accent (these are secondary, possibly-multiple markers).
+ * palette — never the accent (these are secondary, possibly-multiple markers),
+ * and never green: a plugin badge stands for as long as the plugin leaves it
+ * there, and the host cannot name what its `success` means, so it renders
+ * neutral alongside `default` (#12002).
  * Multiple plugins on one panel render in plugin-id order for stability.
  */
 const DOT_COLOR: Record<PluginPanelBadgeColor, string> = {
   default: "bg-text-muted",
-  success: "bg-status-success",
+  success: "bg-text-muted",
   warning: "bg-status-warning",
   error: "bg-status-error",
 };
 
 const LABEL_COLOR: Record<PluginPanelBadgeColor, string> = {
   default: "bg-overlay-subtle text-text-secondary",
-  success: "bg-status-success/15 text-status-success",
+  success: "bg-overlay-subtle text-text-secondary",
   warning: "bg-status-warning/15 text-status-warning",
   error: "bg-status-error/15 text-status-error",
 };

--- a/src/components/Panel/PluginPanelBadges.tsx
+++ b/src/components/Panel/PluginPanelBadges.tsx
@@ -9,13 +9,18 @@ import { usePanelBadges, usePluginPanelBadgeStore } from "@/store/pluginPanelBad
  * status circle; a `label` is a short pill. Color maps to the app's status
  * palette — never the accent (these are secondary, possibly-multiple markers),
  * and never green: a plugin badge stands for as long as the plugin leaves it
- * there, and the host cannot name what its `success` means, so it renders
- * neutral alongside `default` (#12002).
+ * there, and the host cannot name what its `success` means, so it carries
+ * emphasis rather than a health hue (#12002). It stays distinct from
+ * `default`, because a typed value that renders identically to another is
+ * worse than no value at all.
  * Multiple plugins on one panel render in plugin-id order for stability.
  */
+// `success` sits at the ink end of the neutral ramp rather than one step off
+// `default`: secondary and muted are within a few percent of each other in
+// several built-in themes, which on a 2px dot is no distinction at all.
 const DOT_COLOR: Record<PluginPanelBadgeColor, string> = {
   default: "bg-text-muted",
-  success: "bg-text-secondary",
+  success: "bg-text-primary",
   warning: "bg-status-warning",
   error: "bg-status-error",
 };

--- a/src/components/Plugin/PluginMcpServersSection.tsx
+++ b/src/components/Plugin/PluginMcpServersSection.tsx
@@ -29,7 +29,7 @@ type RowStatus = PluginMcpServerStatus | "not-started";
 
 const STATUS_DOT: Record<RowStatus, string> = {
   spawning: "bg-status-warning",
-  ready: "bg-status-success",
+  ready: "bg-activity-working",
   crashed: "bg-status-danger",
   stopped: "bg-daintree-text/30",
   "not-started": "bg-daintree-text/30",

--- a/src/components/Project/RunningTaskList.tsx
+++ b/src/components/Project/RunningTaskList.tsx
@@ -378,7 +378,7 @@ function StatusDot({ status }: { status: TaskStatus }) {
       aria-label={TASK_STATUS_LABEL[status]}
       className={cn(
         "status-mark h-1.5 w-1.5 rounded-full shrink-0",
-        status === "running" && "bg-status-success animate-activity-pulse",
+        status === "running" && "bg-activity-working animate-activity-pulse",
         status === "restarting" && "bg-status-warning animate-activity-pulse",
         status === "success" && "bg-status-success",
         status === "failed" && "bg-status-error"

--- a/src/components/Pulse/ProjectPulseCard.tsx
+++ b/src/components/Pulse/ProjectPulseCard.tsx
@@ -579,7 +579,7 @@ export function ProjectPulseCard({ worktreeId, className }: ProjectPulseCardProp
       </span>
       <div className="pulse-card-header px-4 py-3 border-b border-border-default flex items-center justify-between">
         <div className="flex items-center gap-2">
-          <Activity className="w-4 h-4 text-status-success" />
+          <Activity className="w-4 h-4 text-text-secondary" />
           <span className="text-sm font-medium text-daintree-text/90">{title}</span>
           {isLoading && <Spinner size="xs" className="text-daintree-text/55" />}
         </div>

--- a/src/components/Pulse/ProjectPulseStrip.tsx
+++ b/src/components/Pulse/ProjectPulseStrip.tsx
@@ -155,7 +155,7 @@ export function ProjectPulseStrip({ worktreeId }: ProjectPulseStripProps) {
       aria-label={activityLabel}
       className="group flex w-full items-center gap-3 rounded-[var(--radius-md)] border border-border-subtle px-3 py-2 text-left transition-colors hover:bg-overlay-subtle focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-primary"
     >
-      <Activity className="h-3.5 w-3.5 shrink-0 text-status-success/70" aria-hidden="true" />
+      <Activity className="h-3.5 w-3.5 shrink-0 text-text-secondary" aria-hidden="true" />
       <span className="shrink-0 text-xs font-medium text-text-secondary">Project pulse</span>
       {pulse && miniCells.length > 0 && <MiniRibbon cells={miniCells} />}
       <span className="ml-auto flex shrink-0 items-center gap-2.5">

--- a/src/components/QuickSwitcher/QuickSwitcherItem.tsx
+++ b/src/components/QuickSwitcher/QuickSwitcherItem.tsx
@@ -55,7 +55,7 @@ export function QuickSwitcherItem({
               "shrink-0 px-1.5 py-0.5 text-xs rounded-[var(--radius-sm)] border",
               item.type === "terminal"
                 ? "bg-overlay-medium text-daintree-text/70 border-border-strong"
-                : "bg-status-success/10 text-status-success border-status-success/30"
+                : "bg-overlay-subtle text-text-secondary border-border-default"
             )}
           >
             {item.type === "terminal"

--- a/src/components/Settings/DaintreeAssistantSettingsTab.tsx
+++ b/src/components/Settings/DaintreeAssistantSettingsTab.tsx
@@ -1206,7 +1206,7 @@ export function DaintreeAssistantSettingsTab() {
         ) : (
           <div className="contents">
             <div className="flex items-center gap-2">
-              <div className="status-mark w-2 h-2 rounded-full bg-status-success shrink-0" />
+              <div className="status-mark w-2 h-2 rounded-full bg-activity-working shrink-0" />
               <span className="text-xs text-daintree-text/60">
                 {runtimeSnapshot.port ? `Running on port ${runtimeSnapshot.port}` : "Running"}
               </span>
@@ -1543,7 +1543,7 @@ function SessionLiveStatusCard({ configuredTier }: SessionLiveStatusCardProps) {
           <span
             className={cn(
               "status-mark w-1.5 h-1.5 rounded-full shrink-0",
-              connected ? "bg-status-success" : "bg-daintree-text/30"
+              connected ? "bg-activity-working" : "bg-daintree-text/30"
             )}
             aria-hidden="true"
           />

--- a/src/components/Settings/McpServerSettingsTab.tsx
+++ b/src/components/Settings/McpServerSettingsTab.tsx
@@ -649,7 +649,7 @@ export function McpServerSettingsTab() {
             ) : (
               <div className="contents">
                 <div className="flex items-center gap-2">
-                  <div className="status-mark w-2 h-2 rounded-full bg-status-success shrink-0" />
+                  <div className="status-mark w-2 h-2 rounded-full bg-activity-working shrink-0" />
                   <span className="text-xs text-daintree-text/60">Running on port {boundPort}</span>
                 </div>
 

--- a/src/components/Setup/AgentSetupWizard.tsx
+++ b/src/components/Setup/AgentSetupWizard.tsx
@@ -1279,7 +1279,7 @@ export function CompleteStep({ installedAgents }: { installedAgents: string[] })
               <div
                 key={id}
                 data-testid={`agent-card-${id}`}
-                className="flex items-center gap-3 px-3 py-2.5 rounded-[var(--radius-md)] border border-status-success/20 bg-status-success/5"
+                className="flex items-center gap-3 px-3 py-2.5 rounded-[var(--radius-md)] border border-border-default bg-overlay-subtle"
               >
                 <BrandMark brandColor={agent.color}>
                   <Icon size={18} />

--- a/src/components/Terminal/ArtifactOverlay.tsx
+++ b/src/components/Terminal/ArtifactOverlay.tsx
@@ -67,8 +67,7 @@ interface ArtifactOverlayProps {
 
 const ARTIFACT_TYPE_COLORS: Record<string, string> = {
   code: "border-status-info bg-[color-mix(in_oklab,var(--color-status-info)_10%,transparent)] text-status-info",
-  patch:
-    "border-status-success bg-[color-mix(in_oklab,var(--color-status-success)_10%,transparent)] text-status-success",
+  patch: "border-border-default bg-overlay-subtle text-text-secondary",
   file: "border-state-working bg-[color-mix(in_oklab,var(--color-state-working)_10%,transparent)] text-state-working",
   summary:
     "border-status-warning bg-[color-mix(in_oklab,var(--color-status-warning)_10%,transparent)] text-status-warning",

--- a/src/components/Terminal/InlineStatusBanner.tsx
+++ b/src/components/Terminal/InlineStatusBanner.tsx
@@ -39,7 +39,6 @@ interface BaseInlineStatusBannerProps {
   className?: string;
   role?: "alert" | "status";
   ariaLive?: "off" | "polite" | "assertive";
-  onClose?: () => void;
   /** Accessible label for the dismiss button. Defaults to "Dismiss". */
   closeAriaLabel?: string;
   /**
@@ -57,12 +56,35 @@ interface BaseInlineStatusBannerProps {
    * this forces the multi-line layout even without a `description`.
    */
   descriptionExtras?: React.ReactNode;
+}
+
+/**
+ * The dismissal surface, in the shape every severity but `success` gets:
+ * both halves optional, because a persistent banner is a legitimate thing
+ * for an error or a warning to be.
+ */
+interface OptionalDismissProps {
+  onClose?: () => void;
   /**
    * Fire `onClose` automatically after this many milliseconds. The timer
    * clears on unmount and resets if the value or `onClose` changes. Pass
    * `undefined` to disable (callers gate their own conditions this way).
    */
   autoDismissAfter?: number;
+}
+
+/**
+ * `severity="success"` is pinned to transient confirmation by construction
+ * (#12002): green is only allowed to say "this just happened", never "things
+ * are fine", so a success banner has to state how it leaves. Requiring the
+ * timer and the handler it fires makes that structural rather than advisory
+ * — there is no way to spell a success banner that stands. Completion that
+ * genuinely needs to persist is `severity="neutral"`, which is what
+ * `AgentCompletionBanner` already uses.
+ */
+interface RequiredDismissProps {
+  onClose: () => void;
+  autoDismissAfter: number;
 }
 
 /**
@@ -91,8 +113,12 @@ interface NonErrorActionProps {
 
 export type InlineStatusBannerProps = BaseInlineStatusBannerProps &
   (
-    | ({ severity: "error" } & ErrorActionProps)
-    | ({ severity: Exclude<InlineStatusBannerSeverity, "error"> } & NonErrorActionProps)
+    | ({ severity: "error" } & ErrorActionProps & OptionalDismissProps)
+    | ({ severity: "success" } & NonErrorActionProps & RequiredDismissProps)
+    | ({
+        severity: Exclude<InlineStatusBannerSeverity, "error" | "success">;
+      } & NonErrorActionProps &
+        OptionalDismissProps)
   );
 
 const SEVERITY_VAR: Record<Exclude<InlineStatusBannerSeverity, "neutral">, string> = {

--- a/src/components/Terminal/InlineStatusBanner.tsx
+++ b/src/components/Terminal/InlineStatusBanner.tsx
@@ -67,8 +67,9 @@ interface OptionalDismissProps {
   onClose?: () => void;
   /**
    * Fire `onClose` automatically after this many milliseconds. The timer
-   * clears on unmount and resets if the value or `onClose` changes. Pass
-   * `undefined` to disable (callers gate their own conditions this way).
+   * clears on unmount and restarts when this value changes; a new `onClose`
+   * is picked up through a ref without restarting it. Pass `undefined` to
+   * disable (callers gate their own conditions this way).
    */
   autoDismissAfter?: number;
 }
@@ -225,10 +226,17 @@ export function InlineStatusBanner({
   }, [onClose]);
 
   useEffect(() => {
-    if (!autoDismissAfter || !onCloseRef.current) return;
+    if (import.meta.env.DEV && severity === "success" && !(autoDismissAfter! > 0)) {
+      console.warn(
+        'InlineStatusBanner: severity="success" needs a positive autoDismissAfter. ' +
+          `Got ${String(autoDismissAfter)}, so this banner will stand — which is the one ` +
+          'thing a success banner may not do. Use severity="neutral" for persistent completion.'
+      );
+    }
+    if (!(autoDismissAfter! > 0) || !onCloseRef.current) return;
     const timer = setTimeout(() => onCloseRef.current?.(), autoDismissAfter);
     return () => clearTimeout(timer);
-  }, [autoDismissAfter]);
+  }, [autoDismissAfter, severity]);
 
   useEffect(() => {
     if (!shouldAnimate) return;

--- a/src/components/Terminal/TerminalHeaderContent.tsx
+++ b/src/components/Terminal/TerminalHeaderContent.tsx
@@ -257,11 +257,14 @@ export function TerminalHeaderContent({
         ? "bg-[color-mix(in_oklab,var(--color-state-working)_15%,transparent)] border-state-working/40"
         : agentState === "directing"
           ? "bg-[color-mix(in_oklab,var(--color-category-blue)_15%,transparent)] border-category-blue/40"
-          : agentState === "completed"
-            ? "bg-[color-mix(in_oklab,var(--color-status-success)_15%,transparent)] border-status-success/40"
-            : agentState === "exited"
-              ? "bg-overlay-soft border-divider"
-              : "bg-[color-mix(in_oklab,var(--color-state-waiting)_15%,transparent)] border-state-waiting/40";
+          : // Settled: finished and exited share one neutral chip. Completion is
+            // not asking for anything, so it does not get a hue of its own
+            // (#12002) — and the two stay apart on the channels that survive
+            // without one, `CheckCircle2` against `ExitedCircle` in slate
+            // against secondary.
+            agentState === "completed" || agentState === "exited"
+            ? "bg-overlay-soft border-divider"
+            : "bg-[color-mix(in_oklab,var(--color-state-waiting)_15%,transparent)] border-state-waiting/40";
 
     const headline = activity?.headline?.trim() || `Agent ${agentState}`;
     const showConfidence = stateChangeConfidence != null && stateChangeConfidence < 1;

--- a/src/components/Terminal/__tests__/InlineStatusBanner.test.tsx
+++ b/src/components/Terminal/__tests__/InlineStatusBanner.test.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import { AlertTriangle, CheckCircle2, FileEdit, Info, XCircle } from "lucide-react";
-import { InlineStatusBanner } from "../InlineStatusBanner";
+import { InlineStatusBanner, type InlineStatusBannerSeverity } from "../InlineStatusBanner";
 import { WindowControlsInsetProvider } from "@/components/ui/WindowControlsInset";
 
 vi.mock("@/components/ui/tooltip", () => ({
@@ -75,7 +75,6 @@ describe("InlineStatusBanner", () => {
     ["error", XCircle, "--color-status-error"],
     ["warning", AlertTriangle, "--color-status-warning"],
     ["info", Info, "--color-status-info"],
-    ["success", CheckCircle2, "--color-status-success"],
   ] as const)("renders %s severity using its status token", (severity, icon, token) => {
     render(
       <InlineStatusBanner icon={icon} title={severity} severity={severity} animated={false} />
@@ -83,6 +82,57 @@ describe("InlineStatusBanner", () => {
     const region = screen.getByRole("alert");
     expect(region.style.backgroundColor).toContain(token);
     expect(region.style.borderBottom).toContain(token);
+  });
+
+  // Success sits outside the table above because it is the one severity whose
+  // props are not interchangeable with the others: it has to declare how it
+  // leaves, so it cannot be rendered from a shared row.
+  it("renders success severity using its status token", () => {
+    render(
+      <InlineStatusBanner
+        icon={CheckCircle2}
+        title="success"
+        severity="success"
+        animated={false}
+        onClose={() => {}}
+        autoDismissAfter={2000}
+      />
+    );
+    const region = screen.getByRole("alert");
+    expect(region.style.backgroundColor).toContain("--color-status-success");
+    expect(region.style.borderBottom).toContain("--color-status-success");
+  });
+
+  it("pins success to a self-clearing confirmation at the type level", () => {
+    // Green is only allowed to say "this just happened" (#12002). A success
+    // banner that cannot dismiss itself is unrepresentable, so the compiler —
+    // not review — is what stops one being written.
+    const _rejectsSuccessWithoutDismissal = (
+      // @ts-expect-error success requires both autoDismissAfter and onClose.
+      <InlineStatusBanner icon={CheckCircle2} title="Saved" severity="success" />
+    );
+    const _rejectsSuccessWithoutTimer = (
+      // @ts-expect-error success requires autoDismissAfter alongside onClose.
+      <InlineStatusBanner icon={CheckCircle2} title="Saved" severity="success" onClose={() => {}} />
+    );
+    const _rejectsSuccessWithoutHandler = (
+      // @ts-expect-error success requires onClose alongside autoDismissAfter.
+      <InlineStatusBanner
+        icon={CheckCircle2}
+        title="Saved"
+        severity="success"
+        autoDismissAfter={2000}
+      />
+    );
+    void _rejectsSuccessWithoutDismissal;
+    void _rejectsSuccessWithoutTimer;
+    void _rejectsSuccessWithoutHandler;
+
+    // Persistent completion is still expressible — it just is not green.
+    const _allowsNeutralWithoutDismissal = (
+      <InlineStatusBanner icon={CheckCircle2} title="3 files changed" severity="neutral" />
+    );
+    void _allowsNeutralWithoutDismissal;
   });
 
   it("allows non-error banners to render multiple actions", () => {
@@ -545,10 +595,15 @@ describe("InlineStatusBanner", () => {
  * inside a terminal must never become a window drag handle.
  */
 describe("InlineStatusBanner as the window title-bar surface", () => {
-  function renderGlobal(
-    props: Partial<React.ComponentProps<typeof InlineStatusBanner>> = {},
-    onSeverityChange = vi.fn()
-  ) {
+  // Success is excluded on purpose: it is required to dismiss itself, so it
+  // cannot be the window's standing title-bar surface. Narrowing here keeps the
+  // helper's partial overrides from widening `severity` into that branch.
+  type GlobalBannerProps = Extract<
+    React.ComponentProps<typeof InlineStatusBanner>,
+    { severity: Exclude<InlineStatusBannerSeverity, "success"> }
+  >;
+
+  function renderGlobal(props: Partial<GlobalBannerProps> = {}, onSeverityChange = vi.fn()) {
     const result = render(
       <WindowControlsInsetProvider onSeverityChange={onSeverityChange}>
         <InlineStatusBanner

--- a/src/components/Terminal/__tests__/InlineStatusBanner.test.tsx
+++ b/src/components/Terminal/__tests__/InlineStatusBanner.test.tsx
@@ -103,6 +103,53 @@ describe("InlineStatusBanner", () => {
     expect(region.style.borderBottom).toContain("--color-status-success");
   });
 
+  it("actually clears itself: success fires onClose when its timer runs out", () => {
+    vi.useFakeTimers();
+    try {
+      const onClose = vi.fn();
+      render(
+        <InlineStatusBanner
+          icon={CheckCircle2}
+          title="Signed in"
+          severity="success"
+          animated={false}
+          onClose={onClose}
+          autoDismissAfter={2000}
+        />
+      );
+      expect(onClose).not.toHaveBeenCalled();
+      act(() => {
+        vi.advanceTimersByTime(2000);
+      });
+      expect(onClose).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // The type can require a number; it cannot require a positive one. A success
+  // banner given 0 stands forever, which is the one thing it may not do — so
+  // dev builds say so out loud rather than letting it ship.
+  it("warns in development when a success banner is given a duration that never fires", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      render(
+        <InlineStatusBanner
+          icon={CheckCircle2}
+          title="Signed in"
+          severity="success"
+          animated={false}
+          onClose={() => {}}
+          autoDismissAfter={0}
+        />
+      );
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(String(warn.mock.calls[0]?.[0])).toContain("autoDismissAfter");
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
   it("pins success to a self-clearing confirmation at the type level", () => {
     // Green is only allowed to say "this just happened" (#12002). A success
     // banner that cannot dismiss itself is unrepresentable, so the compiler —

--- a/src/components/Worktree/IssuePickerDialog.tsx
+++ b/src/components/Worktree/IssuePickerDialog.tsx
@@ -45,8 +45,9 @@ function IssueOptionRow({ issue, isSelected, isCurrentlyAttached, onClick }: Iss
           "focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent-primary focus-visible:outline-offset-[-2px]",
           isSelected
             ? "bg-overlay-soft border border-border-strong"
-            : "hover:bg-tint/5 border border-transparent",
-          isCurrentlyAttached && "ring-1 ring-status-success/30"
+            : isCurrentlyAttached
+              ? "hover:bg-tint/5 border border-border-default"
+              : "hover:bg-tint/5 border border-transparent"
         )}
       >
         {issue.state === "open" ? (
@@ -60,7 +61,7 @@ function IssueOptionRow({ issue, isSelected, isCurrentlyAttached, onClick }: Iss
               {issue.title}
             </span>
             {isCurrentlyAttached && (
-              <span className="text-3xs px-1.5 py-0.5 rounded bg-status-success/10 text-status-success shrink-0">
+              <span className="text-3xs px-1.5 py-0.5 rounded border border-border-default bg-overlay-subtle text-text-secondary shrink-0">
                 attached
               </span>
             )}

--- a/src/components/Worktree/ReviewHub/FileStageRow.tsx
+++ b/src/components/Worktree/ReviewHub/FileStageRow.tsx
@@ -162,7 +162,7 @@ function FileStageRowComponent({
       className={cn(
         "relative group/stagerow flex items-center text-xs rounded px-1.5 transition-colors",
         density === "compact" ? "py-0.5" : "py-1.5",
-        isStaged ? "bg-status-success/[0.06] hover:bg-status-success/[0.10]" : "hover:bg-tint/5",
+        isStaged ? "bg-overlay-subtle hover:bg-overlay-medium" : "hover:bg-tint/5",
         // The row whose menu is open lifts to a neutral raised tier — a
         // distinct level from the selection's subtle fill, so it reads as
         // "the menu targets this row" rather than as a second selection.

--- a/src/components/Worktree/WorktreeCard/DevServerIndicator.tsx
+++ b/src/components/Worktree/WorktreeCard/DevServerIndicator.tsx
@@ -44,7 +44,7 @@ export function DevServerIndicator({ session }: DevServerIndicatorProps) {
             aria-label={url ? `Dev server running at ${url}` : "Dev server running"}
             className="inline-flex items-center gap-1 text-xs text-text-muted shrink-0"
           >
-            <Globe className="w-3 h-3 shrink-0 text-status-success" aria-hidden="true" />
+            <Globe className="w-3 h-3 shrink-0 text-activity-working" aria-hidden="true" />
             {port && <span className="tabular-nums">:{port}</span>}
           </span>
         </TooltipTrigger>

--- a/src/components/Worktree/WorktreeCard/EnvironmentPopover.tsx
+++ b/src/components/Worktree/WorktreeCard/EnvironmentPopover.tsx
@@ -60,7 +60,7 @@ export function EnvironmentPopover({
     isLifecycleRunning
       ? "animate-pulse text-activity-working"
       : resourceStatusColor === "green"
-        ? "text-terminal-bright-green"
+        ? "text-text-secondary"
         : resourceStatusColor === "yellow"
           ? "text-status-warning"
           : resourceStatusColor === "red"
@@ -106,7 +106,7 @@ export function EnvironmentPopover({
             <span
               className={cn(
                 "font-medium",
-                resourceStatusColor === "green" && "text-status-success",
+                resourceStatusColor === "green" && "text-text-secondary",
                 resourceStatusColor === "yellow" && "text-status-warning",
                 resourceStatusColor === "red" && "text-status-error",
                 (!resourceStatusColor || resourceStatusColor === "neutral") && "text-text-muted"

--- a/src/components/Worktree/WorktreeMenuItems.tsx
+++ b/src/components/Worktree/WorktreeMenuItems.tsx
@@ -278,7 +278,7 @@ export function WorktreeMenuItems({
             Open Browser
           </C.Item>
           <C.Item onSelect={() => onLaunchAgent?.("dev-preview")} disabled={!onLaunchAgent}>
-            <MonitorPlay className="w-3.5 h-3.5 mr-2 text-status-success" />
+            <MonitorPlay className="w-3.5 h-3.5 mr-2" />
             Open Dev Preview
           </C.Item>
         </C.SubContent>
@@ -410,7 +410,7 @@ export function WorktreeMenuItems({
                           disabled={!onSwitchEnvironment}
                         >
                           <CircleDot
-                            className={`w-3.5 h-3.5 mr-2 ${isLocalSelected ? "text-status-success" : "opacity-0"}`}
+                            className={`w-3.5 h-3.5 mr-2 ${isLocalSelected ? "text-text-primary" : "opacity-0"}`}
                           />
                           Local
                         </C.Item>
@@ -423,7 +423,7 @@ export function WorktreeMenuItems({
                         disabled={!onSwitchEnvironment}
                       >
                         <CircleDot
-                          className={`w-3.5 h-3.5 mr-2 ${worktreeMode === key ? "text-status-success" : "opacity-0"}`}
+                          className={`w-3.5 h-3.5 mr-2 ${worktreeMode === key ? "text-text-primary" : "opacity-0"}`}
                         />
                         {key}
                       </C.Item>
@@ -451,7 +451,7 @@ export function WorktreeMenuItems({
                   </C.Item>
                   <C.Separator />
                   <C.Item onSelect={onResourceResume} disabled={isLocal || !onResourceResume}>
-                    <Play className="w-3.5 h-3.5 mr-2 text-status-success" />
+                    <Play className="w-3.5 h-3.5 mr-2" />
                     Resume
                   </C.Item>
                   <C.Item onSelect={onResourcePause} disabled={isLocal || !onResourcePause}>

--- a/src/components/Worktree/WorktreeMenuItems.tsx
+++ b/src/components/Worktree/WorktreeMenuItems.tsx
@@ -274,7 +274,7 @@ export function WorktreeMenuItems({
             Open Terminal
           </C.Item>
           <C.Item onSelect={() => onLaunchAgent?.("browser")} disabled={!onLaunchAgent}>
-            <Globe className="w-3.5 h-3.5 mr-2 text-status-info" />
+            <Globe className="w-3.5 h-3.5 mr-2" />
             Open Browser
           </C.Item>
           <C.Item onSelect={() => onLaunchAgent?.("dev-preview")} disabled={!onLaunchAgent}>
@@ -451,7 +451,7 @@ export function WorktreeMenuItems({
                   </C.Item>
                   <C.Separator />
                   <C.Item onSelect={onResourceResume} disabled={isLocal || !onResourceResume}>
-                    <Play className="w-3.5 h-3.5 mr-2" />
+                    <Play className="w-3.5 h-3.5 mr-2 text-status-success" />
                     Resume
                   </C.Item>
                   <C.Item onSelect={onResourcePause} disabled={isLocal || !onResourcePause}>

--- a/src/components/agents/AgentCard.tsx
+++ b/src/components/agents/AgentCard.tsx
@@ -109,7 +109,7 @@ function OnboardingCard({
           </span>
         )}
         {installed ? (
-          <span className="text-2xs text-status-success font-medium">Installed</span>
+          <span className="text-2xs text-text-secondary font-medium">Installed</span>
         ) : (
           <span className="text-2xs text-daintree-text/30">Not installed</span>
         )}

--- a/src/components/ui/ReEntrySummary.tsx
+++ b/src/components/ui/ReEntrySummary.tsx
@@ -82,7 +82,9 @@ export function ReEntrySummary({ state }: { state: ReEntrySummaryState }) {
 
   const { rows: displayRows, overflowCount: displayOverflowCount } = content;
   const hasUrgent = displayRows.some((r) => r.worstType === "error" || r.worstType === "warning");
-  const accentClass = hasUrgent ? "border-l-status-warning" : "border-l-status-success";
+  // Only the excursion gets a hue. A green rule here would just be saying no
+  // entry was urgent, which is the good case already implied by the rows (#12002).
+  const accentClass = hasUrgent ? "border-l-status-warning" : "border-l-border-default";
 
   const handleOpenNotifications = () => {
     useUIStore.getState().openNotificationCenter();

--- a/src/config/__tests__/statusSuccessGuard.contract.test.ts
+++ b/src/config/__tests__/statusSuccessGuard.contract.test.ts
@@ -13,20 +13,78 @@ import {
 
 const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(TEST_DIR, "../../..");
-const SRC_ROOT = path.join(REPO_ROOT, "src");
+// The builtin plugin renderers ship in the app and paint the same tokens, so
+// they are production surfaces, not third-party code. `accentGuard` already
+// scans this root for the same reason.
+const SCAN_ROOTS = [
+  path.join(REPO_ROOT, "src"),
+  path.join(REPO_ROOT, "plugins/builtin/github/renderer"),
+];
 const POLICY_DOC = "docs/themes/status-success-policy.md";
 
 // ── What counts as a paint site ────────────────────────────────────────
 
 /**
- * A Tailwind utility that paints with the success token, variants and opacity
- * modifiers included: `bg-status-success`, `hover:text-status-success/70`,
- * `data-[state=on]:border-status-success/30`. Anchored to the end so
- * `forge-status-success` — an unrelated animation class that merely contains
- * the substring — does not match.
+ * Every Tailwind v4 utility that can take a colour. Enumerated rather than
+ * matched loosely, because two real classes in this repo end in the same
+ * substring without painting the token: `forge-status-success` (an animation)
+ * and `bg-status-success-surface` (a different token). A loose rule would flag
+ * both, and a guard that cries wolf gets deleted.
  */
-const PAINT_UTILITY =
-  /(?:^|:)(?:bg|text|border|border-[trblxy]|ring|outline|fill|stroke|accent|caret|decoration|divide|shadow|from|via|to)-status-success(?:\/(?:\[[\d.]+\]|\d+))?$/;
+const COLOUR_UTILITY_ROOTS = [
+  "bg",
+  "text",
+  "border",
+  "border-(?:[trblxyse]|bs|be)",
+  "outline",
+  "ring",
+  "ring-offset",
+  "inset-ring",
+  "divide",
+  "fill",
+  "stroke",
+  "accent",
+  "caret",
+  "decoration",
+  "placeholder",
+  "selection",
+  "marker",
+  "shadow",
+  "inset-shadow",
+  "text-shadow",
+  "drop-shadow",
+  "from",
+  "via",
+  "to",
+  "mask-from",
+  "mask-via",
+  "mask-to",
+].join("|");
+
+/**
+ * Everything Tailwind v4 accepts after the slash: a bare number (fractional
+ * included), a bracketed value, or the shorthand variable form.
+ */
+const ALPHA_MODIFIER = "(?:\\/(?:\\d+(?:\\.\\d+)?|\\[[^\\]]*\\]|\\([^)]*\\)))?";
+
+/**
+ * A utility painting with the success token — variants, opacity modifier and
+ * the important marker included, since none of them changes what it paints:
+ * `bg-status-success`, `hover:text-status-success/70`,
+ * `data-[state=on]:border-status-success/30`, `bg-status-success!`.
+ * Anchored both ends so the two lookalike classes above stay out.
+ */
+const PAINT_UTILITY = new RegExp(
+  `(?:^|:)!?(?:${COLOUR_UTILITY_ROOTS})-status-success${ALPHA_MODIFIER}!?$`
+);
+
+/**
+ * The variable shorthand — `bg-(--color-status-success)` — reaches the token
+ * without ever spelling the utility suffix, so it needs its own shape.
+ */
+const PAINT_VAR_SHORTHAND = new RegExp(
+  `(?:^|:)!?(?:${COLOUR_UTILITY_ROOTS})-\\(--color-status-success\\)${ALPHA_MODIFIER}!?$`
+);
 
 /** The same colour reached through the variable, as arbitrary values do. */
 const PAINT_VAR = "var(--color-status-success)";
@@ -39,7 +97,9 @@ const PAINT_VAR = "var(--color-status-success)";
  * outside this guard by construction.
  */
 function isPaintLexeme(lexeme: string): boolean {
-  return PAINT_UTILITY.test(lexeme) || lexeme.includes(PAINT_VAR);
+  return (
+    PAINT_UTILITY.test(lexeme) || PAINT_VAR_SHORTHAND.test(lexeme) || lexeme.includes(PAINT_VAR)
+  );
 }
 
 function normalise(value: string): string {
@@ -161,7 +221,9 @@ function matches(
 
 // ── The scan ───────────────────────────────────────────────────────────
 
-const discovered: PaintSite[] = collectSourceFiles(SRC_ROOT).flatMap((absolute) => {
+const discovered: PaintSite[] = SCAN_ROOTS.flatMap((root) =>
+  fs.existsSync(root) ? collectSourceFiles(root) : []
+).flatMap((absolute) => {
   const source = fs.readFileSync(absolute, "utf8");
   if (!source.includes("status-success")) return [];
   const relative = path.relative(REPO_ROOT, absolute).replace(/\\/g, "/");
@@ -214,13 +276,27 @@ describe("status-success guard", () => {
           "bg-[color-mix(in_oklab,var(--color-status-success)_10%,transparent)]",
           "bg-[color-mix(in_oklab,var(--color-status-success)_10%,transparent)]",
         ],
+        // Variants, the important marker and the opacity modifier all change
+        // nothing about what gets painted.
+        ["!bg-status-success", "!bg-status-success"],
+        ["bg-status-success!", "bg-status-success!"],
+        ["[&>svg]:text-status-success", "[&>svg]:text-status-success"],
+        ["supports-[display:grid]:bg-status-success", "supports-[display:grid]:bg-status-success"],
+        // Colour utilities that are easy to leave off an enumerated list.
+        ["ring-offset-status-success", "ring-offset-status-success"],
+        ["inset-ring-status-success", "inset-ring-status-success"],
+        ["placeholder-status-success", "placeholder-status-success"],
+        ["text-shadow-status-success", "text-shadow-status-success"],
+        ["border-s-status-success", "border-s-status-success"],
+        ["from-status-success via-status-success", "from-status-success via-status-success"],
         // An unrelated animation class that merely contains the substring.
         ["forge-status-success", ""],
         // The theme layer naming the token rather than painting with it.
         ["status-success", ""],
         ["--theme-status-success", ""],
-        // A different token that shares the prefix.
+        // A different token that shares the prefix, and a non-colour utility.
         ["bg-status-success-surface", ""],
+        ["my-status-success", ""],
       ];
       for (const [input, expected] of cases) {
         expect(statusSuccessSignature(input), input).toBe(expected);
@@ -270,6 +346,27 @@ describe("status-success guard", () => {
     expect(
       unclassified.map((site) => `${site.file}:${site.line}`),
       `Found ${unclassified.length} status-success paint site(s) with no inventory entry:\n${report}\n\n${FIX_INSTRUCTIONS}`
+    ).toEqual([]);
+  });
+
+  it("maps every site to exactly one approval", () => {
+    // Two approvals matching one site would let a real occurrence disappear
+    // while its twin's entry silently covered the survivor.
+    const ambiguous = discovered
+      .map((site) => {
+        const inFile = sitesByFile.get(site.file) ?? [];
+        const twins = inFile.filter((other) => other.signature === site.signature);
+        const hits = (inventoryByFile.get(site.file) ?? []).filter((entry) =>
+          matches(site, entry, twins)
+        );
+        return { site, hits: hits.length };
+      })
+      .filter(({ hits }) => hits > 1)
+      .map(({ site, hits }) => `  ${site.file}:${site.line} matched by ${hits} entries`);
+
+    expect(
+      ambiguous,
+      `Entries overlap — give each a narrower anchor:\n${ambiguous.join("\n")}`
     ).toEqual([]);
   });
 

--- a/src/config/__tests__/statusSuccessGuard.contract.test.ts
+++ b/src/config/__tests__/statusSuccessGuard.contract.test.ts
@@ -1,0 +1,351 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import ts from "typescript";
+import { fileURLToPath } from "node:url";
+import {
+  EXPECTED_STATUS_SUCCESS_OCCURRENCES,
+  EXPECTED_STATUS_SUCCESS_SITES,
+  STATUS_SUCCESS_CATEGORIES,
+  STATUS_SUCCESS_INVENTORY,
+  type ApprovedStatusSuccessSite,
+} from "./statusSuccessInventory";
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(TEST_DIR, "../../..");
+const SRC_ROOT = path.join(REPO_ROOT, "src");
+const POLICY_DOC = "docs/themes/status-success-policy.md";
+
+// ── What counts as a paint site ────────────────────────────────────────
+
+/**
+ * A Tailwind utility that paints with the success token, variants and opacity
+ * modifiers included: `bg-status-success`, `hover:text-status-success/70`,
+ * `data-[state=on]:border-status-success/30`. Anchored to the end so
+ * `forge-status-success` — an unrelated animation class that merely contains
+ * the substring — does not match.
+ */
+const PAINT_UTILITY =
+  /(?:^|:)(?:bg|text|border|border-[trblxy]|ring|outline|fill|stroke|accent|caret|decoration|divide|shadow|from|via|to)-status-success(?:\/(?:\[[\d.]+\]|\d+))?$/;
+
+/** The same colour reached through the variable, as arbitrary values do. */
+const PAINT_VAR = "var(--color-status-success)";
+
+/**
+ * Only painting is governed, not defining. `applyAppTheme` and
+ * `ColorVisionPicker` name the token (`"status-success"`,
+ * `"--theme-status-success"`) to build and preview the palette; the ruling
+ * protects `--color-status-success` itself, so the layer that defines it is
+ * outside this guard by construction.
+ */
+function isPaintLexeme(lexeme: string): boolean {
+  return PAINT_UTILITY.test(lexeme) || lexeme.includes(PAINT_VAR);
+}
+
+function normalise(value: string): string {
+  return value.trim().replace(/\s+/g, " ");
+}
+
+export function statusSuccessSignature(literalText: string): string {
+  return normalise(literalText).split(" ").filter(isPaintLexeme).join(" ");
+}
+
+interface PaintSite {
+  file: string;
+  line: number;
+  signature: string;
+  occurrences: number;
+  /** Enclosing node texts, innermost first. */
+  ancestors: string[];
+}
+
+function collectSourceFiles(dir: string, out: string[] = []): string[] {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "__tests__" || entry.name === "node_modules") continue;
+      collectSourceFiles(full, out);
+      continue;
+    }
+    if (!/\.tsx?$/.test(entry.name)) continue;
+    if (/\.(test|spec)\./.test(entry.name)) continue;
+    out.push(full);
+  }
+  return out;
+}
+
+/**
+ * The decoded text of any literal a className can live in — quoted strings and
+ * every quasi of a template — or null for everything else. Decoded, so quote
+ * style and escaping never reach the signature.
+ */
+function literalText(node: ts.Node): string | null {
+  if (ts.isStringLiteralLike(node)) return node.text;
+  if (ts.isTemplateHead(node) || ts.isTemplateMiddleOrTemplateTail(node)) return node.text;
+  return null;
+}
+
+/**
+ * Parsed rather than grepped, so a `status-success` mentioned in a comment —
+ * `projectRowStatus` and `PilotRunState` both explain their token choices in
+ * prose — is not mistaken for a paint site.
+ */
+export function scanPaintSites(relativePath: string, sourceText: string): PaintSite[] {
+  const source = ts.createSourceFile(
+    relativePath,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+    relativePath.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS
+  );
+  const sites: PaintSite[] = [];
+
+  const visit = (node: ts.Node): void => {
+    const text = literalText(node);
+    if (text !== null) {
+      const signature = statusSuccessSignature(text);
+      if (signature.length > 0) {
+        const ancestors: string[] = [];
+        for (let cur = node.parent; cur && !ts.isSourceFile(cur); cur = cur.parent) {
+          ancestors.push(normalise(cur.getText(source)));
+        }
+        sites.push({
+          file: relativePath,
+          line: source.getLineAndCharacterOfPosition(node.getStart(source)).line + 1,
+          signature,
+          occurrences: signature.split(" ").length,
+          ancestors,
+        });
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  visit(source);
+  return sites;
+}
+
+// ── Anchor resolution ──────────────────────────────────────────────────
+
+/**
+ * Depth of the innermost enclosing node containing `anchor`, or -1.
+ *
+ * Depth is what makes anchors work inside tight config maps. `STATUS_CONFIG`
+ * contains every one of its own entries, so an anchor lifted from the `added`
+ * entry is technically present in the `untracked` entry's ancestor chain too —
+ * just several levels further out. The nearest match wins.
+ */
+export function anchorDepth(site: PaintSite, anchor: string): number {
+  for (let depth = 0; depth < site.ancestors.length; depth++) {
+    if (site.ancestors[depth]!.includes(anchor)) return depth;
+  }
+  return -1;
+}
+
+function matches(
+  site: PaintSite,
+  approval: ApprovedStatusSuccessSite,
+  twins: PaintSite[]
+): boolean {
+  if (site.signature !== approval.signature) return false;
+  if (approval.anchor === undefined) return true;
+
+  const depth = anchorDepth(site, approval.anchor);
+  if (depth < 0) return false;
+  return twins.every((twin) => {
+    if (twin === site) return true;
+    const other = anchorDepth(twin, approval.anchor!);
+    return other < 0 || other > depth;
+  });
+}
+
+// ── The scan ───────────────────────────────────────────────────────────
+
+const discovered: PaintSite[] = collectSourceFiles(SRC_ROOT).flatMap((absolute) => {
+  const source = fs.readFileSync(absolute, "utf8");
+  if (!source.includes("status-success")) return [];
+  const relative = path.relative(REPO_ROOT, absolute).replace(/\\/g, "/");
+  return scanPaintSites(relative, source);
+});
+
+const sitesByFile = new Map<string, PaintSite[]>();
+for (const site of discovered) {
+  const list = sitesByFile.get(site.file);
+  if (list) list.push(site);
+  else sitesByFile.set(site.file, [site]);
+}
+
+type Approval = ApprovedStatusSuccessSite & { file: string };
+
+const inventoryByFile = new Map<string, readonly ApprovedStatusSuccessSite[]>(
+  Object.entries(STATUS_SUCCESS_INVENTORY)
+);
+
+const approvals: Approval[] = [...inventoryByFile].flatMap(([file, entries]) =>
+  entries.map((entry) => ({ ...entry, file }))
+);
+
+function sitesFor(approval: Approval): PaintSite[] {
+  const inFile = sitesByFile.get(approval.file) ?? [];
+  const twins = inFile.filter((site) => site.signature === approval.signature);
+  return twins.filter((site) => matches(site, approval, twins));
+}
+
+const FIX_INSTRUCTIONS =
+  `Ask the review question: can this green be named as a specific result, a required checked ` +
+  `item, or a live operation? If not, it does not get to persist.\n` +
+  `  - Ambient health, threshold baselines, membership and settled completion go neutral ` +
+  `(bg-overlay-subtle, border-border-default, text-text-secondary) or disappear.\n` +
+  `  - A live process keeps its green on activity-working / state-working, which is not this guard's token.\n` +
+  `  - Anything that stays green needs an entry in statusSuccessInventory.ts declaring one of ` +
+  `${STATUS_SUCCESS_CATEGORIES.join(" / ")} and a rationale naming it.\n` +
+  `See ${POLICY_DOC}.`;
+
+describe("status-success guard", () => {
+  describe("what the scanner counts", () => {
+    it("keeps utilities and variable reads, drops token names and lookalike classes", () => {
+      const cases: Array<[string, string]> = [
+        ["w-2 h-2 rounded-full bg-status-success shrink-0", "bg-status-success"],
+        [
+          "hover:text-status-success/70 border-status-success/50",
+          "hover:text-status-success/70 border-status-success/50",
+        ],
+        [
+          "bg-[color-mix(in_oklab,var(--color-status-success)_10%,transparent)]",
+          "bg-[color-mix(in_oklab,var(--color-status-success)_10%,transparent)]",
+        ],
+        // An unrelated animation class that merely contains the substring.
+        ["forge-status-success", ""],
+        // The theme layer naming the token rather than painting with it.
+        ["status-success", ""],
+        ["--theme-status-success", ""],
+        // A different token that shares the prefix.
+        ["bg-status-success-surface", ""],
+      ];
+      for (const [input, expected] of cases) {
+        expect(statusSuccessSignature(input), input).toBe(expected);
+      }
+    });
+
+    it("reads literals, not comments", () => {
+      const sites = scanPaintSites(
+        "sample.tsx",
+        `// text-status-success in prose is not a paint site\nconst a = "bg-status-success";\n`
+      );
+      expect(sites.map((s) => s.signature)).toEqual(["bg-status-success"]);
+    });
+
+    it("counts one literal painting several utilities as one site", () => {
+      const sites = scanPaintSites(
+        "sample.tsx",
+        `const a = "bg-status-success/10 text-status-success border-status-success/30";\n`
+      );
+      expect(sites).toHaveLength(1);
+      expect(sites[0]?.occurrences).toBe(3);
+    });
+
+    it("resolves an anchor to its innermost enclosing node", () => {
+      const [site] = scanPaintSites(
+        "sample.ts",
+        `const CONFIG = { added: { label: "A", color: "text-status-success" } };\n`
+      );
+      expect(site).toBeDefined();
+      // `label: "A"` sits closer to the literal than the outer map does.
+      expect(anchorDepth(site!, 'label: "A"')).toBeLessThan(anchorDepth(site!, "const CONFIG"));
+    });
+  });
+
+  it("has no unclassified status-success paint site", () => {
+    const unclassified = discovered.filter((site) => {
+      const inFile = sitesByFile.get(site.file) ?? [];
+      const twins = inFile.filter((other) => other.signature === site.signature);
+      const entries = inventoryByFile.get(site.file) ?? [];
+      return !entries.some((entry) => matches(site, entry, twins));
+    });
+
+    const report = unclassified
+      .map((site) => `  ${site.file}:${site.line}\n    signature: ${site.signature}`)
+      .join("\n");
+
+    expect(
+      unclassified.map((site) => `${site.file}:${site.line}`),
+      `Found ${unclassified.length} status-success paint site(s) with no inventory entry:\n${report}\n\n${FIX_INSTRUCTIONS}`
+    ).toEqual([]);
+  });
+
+  it("has no stale inventory entries", () => {
+    const stale: string[] = [];
+
+    for (const approval of approvals) {
+      const hits = sitesFor(approval);
+      if (hits.length === 0) {
+        stale.push(
+          `  ${approval.file} — no site matches signature "${approval.signature}"` +
+            (approval.anchor ? ` anchored on "${approval.anchor}"` : "")
+        );
+        continue;
+      }
+      if (hits.length > 1) {
+        stale.push(
+          `  ${approval.file} — signature "${approval.signature}" matches ${hits.length} sites ` +
+            `(lines ${hits.map((h) => h.line).join(", ")}); give each entry a distinguishing anchor`
+        );
+        continue;
+      }
+      const [only] = hits;
+      if (only!.occurrences !== approval.expectedOccurrences) {
+        stale.push(
+          `  ${approval.file}:${only!.line} — expected ${approval.expectedOccurrences} occurrence(s), found ${only!.occurrences}`
+        );
+      }
+    }
+
+    expect(
+      stale,
+      `Found ${stale.length} inventory entr(ies) that no longer describe the source:\n${stale.join("\n")}\n\n` +
+        `The green moved or went away — delete the entry, or re-point it and restate why it is still allowed.\n` +
+        `See ${POLICY_DOC}.`
+    ).toEqual([]);
+  });
+
+  it("gives every entry a category and a rationale", () => {
+    const thin = approvals
+      .filter(
+        (approval) =>
+          !STATUS_SUCCESS_CATEGORIES.includes(approval.category) ||
+          approval.rationale.trim().length < 20
+      )
+      .map((approval) => `  ${approval.file}: ${approval.signature}`);
+
+    expect(
+      thin,
+      `Entries need one of ${STATUS_SUCCESS_CATEGORIES.join(" / ")} and a rationale that names the ` +
+        `specific confirmation, item, result or notation:\n${thin.join("\n")}`
+    ).toEqual([]);
+  });
+
+  it("holds the site and occurrence ratchets", () => {
+    const occurrences = discovered.reduce((total, site) => total + site.occurrences, 0);
+
+    // Both, because they fail on different things: a swap that removes one green
+    // and adds another somewhere else holds the site count but not the per-site
+    // checks, and a file that moves wholesale holds the per-site checks but not
+    // these. Going down is as much a signal as going up — update the numbers
+    // with the inventory, in the same commit.
+    expect(discovered.length, "status-success paint sites in src/").toBe(
+      EXPECTED_STATUS_SUCCESS_SITES
+    );
+    expect(occurrences, "status-success utilities in src/").toBe(
+      EXPECTED_STATUS_SUCCESS_OCCURRENCES
+    );
+    expect(
+      approvals.reduce((total, approval) => total + approval.expectedOccurrences, 0),
+      "occurrences accounted for by the inventory"
+    ).toBe(EXPECTED_STATUS_SUCCESS_OCCURRENCES);
+  });
+
+  it("points at the policy doc from its failure output", () => {
+    expect(FIX_INSTRUCTIONS).toContain(POLICY_DOC);
+    expect(fs.existsSync(path.join(REPO_ROOT, POLICY_DOC))).toBe(true);
+  });
+});

--- a/src/config/__tests__/statusSuccessGuard.contract.test.ts
+++ b/src/config/__tests__/statusSuccessGuard.contract.test.ts
@@ -47,8 +47,6 @@ const COLOUR_UTILITY_ROOTS = [
   "caret",
   "decoration",
   "placeholder",
-  "selection",
-  "marker",
   "shadow",
   "inset-shadow",
   "text-shadow",
@@ -297,6 +295,11 @@ describe("status-success guard", () => {
         // A different token that shares the prefix, and a non-colour utility.
         ["bg-status-success-surface", ""],
         ["my-status-success", ""],
+        // `selection` and `marker` are variants, not colour utilities — Tailwind
+        // emits nothing for the bare form, so only the variant spelling counts.
+        ["selection:bg-status-success", "selection:bg-status-success"],
+        ["selection-status-success", ""],
+        ["marker-status-success", ""],
       ];
       for (const [input, expected] of cases) {
         expect(statusSuccessSignature(input), input).toBe(expected);

--- a/src/config/__tests__/statusSuccessInventory.ts
+++ b/src/config/__tests__/statusSuccessInventory.ts
@@ -59,6 +59,12 @@ export interface ApprovedStatusSuccessSite {
    * Only needed when a signature repeats inside one file. Any substring of an
    * enclosing node that tells the twins apart — a predicate, a label, an
    * `aria-label`. Never an ordinal or a line number.
+   *
+   * Pick the shortest thing that separates them. A whole JSX element makes a
+   * precise anchor and a brittle one: #12099 rewrote the conditional around
+   * `UpstreamSyncBadge`'s ahead arrow without touching its colour, and an
+   * element-shaped anchor failed on a change the guard had no business
+   * noticing. `↑{aheadCount}` survives that and still names the site.
    */
   anchor?: string;
   /** How many `status-success` utilities this one site paints. */
@@ -745,14 +751,14 @@ export const STATUS_SUCCESS_INVENTORY = {
     {
       category: "domain",
       signature: "text-status-success/80",
-      anchor: '<span className="text-status-success/80">+{insertions}</span>',
+      anchor: "+{insertions}",
       expectedOccurrences: 1,
       rationale: "Per-file diff insertion count",
     },
     {
       category: "domain",
       signature: "text-status-success/80",
-      anchor: '<span className="text-status-success/80">+{totalInsertions}</span>',
+      anchor: "+{totalInsertions}",
       expectedOccurrences: 1,
       rationale: "Total diff insertion count",
     },
@@ -889,7 +895,7 @@ export const STATUS_SUCCESS_INVENTORY = {
     {
       category: "domain",
       signature: "text-status-success",
-      anchor: '{hasAhead && <span className="text-status-success">↑{aheadCount}</span>}',
+      anchor: "↑{aheadCount}",
       expectedOccurrences: 1,
       rationale: "Ahead-arrow count against the upstream",
     },

--- a/src/config/__tests__/statusSuccessInventory.ts
+++ b/src/config/__tests__/statusSuccessInventory.ts
@@ -124,14 +124,14 @@ export const STATUS_SUCCESS_INVENTORY = {
       signature: "text-status-success",
       anchor: 'validationResult === "success"',
       expectedOccurrences: 1,
-      rationale: "Token-saved confirmation; resets on the next edit of the token field",
+      rationale: "Token-saved confirmation; cleared by the tab's 5s validation-result timer",
     },
     {
       category: "transient",
       signature: "text-status-success",
       anchor: 'validationResult === "test-success"',
       expectedOccurrences: 1,
-      rationale: "Token-valid confirmation; resets on the next edit of the token field",
+      rationale: "Token-valid confirmation; cleared by the tab's 5s validation-result timer",
     },
   ],
   "plugins/builtin/github/renderer/utils/prCIStatus.ts": [

--- a/src/config/__tests__/statusSuccessInventory.ts
+++ b/src/config/__tests__/statusSuccessInventory.ts
@@ -1,6 +1,6 @@
 /**
- * Every `status-success` paint site left in the renderer, with the reason it is
- * allowed to be green (#12002).
+ * Every `status-success` paint site left in the renderer — `src/` and the
+ * builtin plugin renderers — with the reason it is allowed to be green (#12002).
  *
  * Green may only say a confirmation is clearing, a required item is checked, a
  * named operation produced this result, or the colour is notation the app
@@ -28,8 +28,20 @@ export const STATUS_SUCCESS_CATEGORIES = [
   "verification",
   /** The recorded result of a named execution or check, not inferred health. */
   "outcome",
-  /** Notation the app inherited: git status letters, diff counts, ahead arrows, go-controls. */
+  /** Notation the app inherited rather than invented: git status letters, diff counts, ahead arrows. */
   "domain",
+  /**
+   * The affirmative half of a control pair — run, apply, stage, resume, save.
+   * Green here means "go", not "good": it is not reporting state at all.
+   *
+   * NOT one of the four categories the #12002 ruling named, and deliberately
+   * separate rather than folded into `domain`, which would have quietly
+   * restated what the ruling meant by it. These controls were never in the
+   * ruling's demote list, so this PR left them alone and named the gap instead
+   * of laundering it. If the maintainer wants them neutral, deleting this
+   * category is the change — and the guard will then list every site to fix.
+   */
+  "affordance",
 ] as const;
 
 export type StatusSuccessCategory = (typeof STATUS_SUCCESS_CATEGORIES)[number];
@@ -58,6 +70,78 @@ export interface ApprovedStatusSuccessSite {
 export type StatusSuccessInventory = Readonly<Record<string, readonly ApprovedStatusSuccessSite[]>>;
 
 export const STATUS_SUCCESS_INVENTORY = {
+  "plugins/builtin/github/renderer/components/BulkCreateWorktreeDialog.tsx": [
+    {
+      category: "outcome",
+      signature: "text-status-success",
+      anchor: "w-5 h-5 text-status-success",
+      expectedOccurrences: 1,
+      rationale: "Recorded result of the bulk create the user just ran; leaves with the dialog",
+    },
+    {
+      category: "outcome",
+      signature: "text-status-success",
+      anchor: "w-4 h-4 text-status-success",
+      expectedOccurrences: 1,
+      rationale: "Recorded per-item result of the bulk create the user just ran",
+    },
+  ],
+  "plugins/builtin/github/renderer/components/CommitListItem.tsx": [
+    {
+      category: "transient",
+      signature: "text-status-success",
+      anchor: 'copied && "text-status-success"',
+      expectedOccurrences: 1,
+      rationale: "Copy-hash confirmation on the row; resets when the copy flash times out",
+    },
+    {
+      category: "transient",
+      signature: "text-status-success",
+      anchor: "<span>#</span>",
+      expectedOccurrences: 1,
+      rationale: "Copy-hash confirmation glyph; resets when the copy flash times out",
+    },
+  ],
+  "plugins/builtin/github/renderer/components/GitHubListItem.tsx": [
+    {
+      category: "transient",
+      signature: "text-status-success",
+      anchor: 'copied && "text-status-success"',
+      expectedOccurrences: 1,
+      rationale: "Copy confirmation on the row; resets when the copy flash times out",
+    },
+    {
+      category: "transient",
+      signature: "text-status-success",
+      anchor: "me-0.5",
+      expectedOccurrences: 1,
+      rationale: "Copy confirmation glyph; resets when the copy flash times out",
+    },
+  ],
+  "plugins/builtin/github/renderer/components/GitHubSettingsTab.tsx": [
+    {
+      category: "transient",
+      signature: "text-status-success",
+      anchor: 'validationResult === "success"',
+      expectedOccurrences: 1,
+      rationale: "Token-saved confirmation; resets on the next edit of the token field",
+    },
+    {
+      category: "transient",
+      signature: "text-status-success",
+      anchor: 'validationResult === "test-success"',
+      expectedOccurrences: 1,
+      rationale: "Token-valid confirmation; resets on the next edit of the token field",
+    },
+  ],
+  "plugins/builtin/github/renderer/utils/prCIStatus.ts": [
+    {
+      category: "outcome",
+      signature: "text-status-success",
+      expectedOccurrences: 1,
+      rationale: "Recorded result of the last CI run on the pull request",
+    },
+  ],
   "src/components/AllClearOverlay/AllClearOverlay.tsx": [
     {
       category: "transient",
@@ -108,7 +192,7 @@ export const STATUS_SUCCESS_INVENTORY = {
   ],
   "src/components/Diagnostics/ProblemsContent.tsx": [
     {
-      category: "domain",
+      category: "affordance",
       signature:
         "text-status-success hover:text-status-success/70 border-status-success/50 hover:bg-status-success/10",
       expectedOccurrences: 4,
@@ -143,12 +227,6 @@ export const STATUS_SUCCESS_INVENTORY = {
       signature: "text-status-success",
       expectedOccurrences: 1,
       rationale: "Diff insertion count for the whole change set",
-    },
-    {
-      category: "verification",
-      signature: "bg-status-success/70",
-      expectedOccurrences: 1,
-      rationale: "Progress through the finite set of files this review has to cover",
     },
     {
       category: "verification",
@@ -444,7 +522,7 @@ export const STATUS_SUCCESS_INVENTORY = {
   ],
   "src/components/Settings/PortalSettingsTab.tsx": [
     {
-      category: "domain",
+      category: "affordance",
       signature: "text-status-success",
       expectedOccurrences: 1,
       rationale: "Go-colour on the confirm half of a confirm/cancel edit pair",
@@ -503,12 +581,6 @@ export const STATUS_SUCCESS_INVENTORY = {
       expectedOccurrences: 1,
       rationale: "Wizard completion step; leaves with the wizard",
     },
-    {
-      category: "transient",
-      signature: "border-status-success/20 bg-status-success/5",
-      expectedOccurrences: 2,
-      rationale: "Ready-agent cards on the completion step; leave with the wizard",
-    },
   ],
   "src/components/Setup/CopyableCommand.tsx": [
     {
@@ -542,14 +614,7 @@ export const STATUS_SUCCESS_INVENTORY = {
       rationale: "Added line in a unified patch",
     },
     {
-      category: "domain",
-      signature:
-        "border-status-success bg-[color-mix(in_oklab,var(--color-status-success)_10%,transparent)] text-status-success",
-      expectedOccurrences: 3,
-      rationale: "Patch artifact type, coloured to match the patch body it labels",
-    },
-    {
-      category: "domain",
+      category: "affordance",
       signature: "bg-status-success",
       anchor: "onClick={handleApplyPatch}",
       expectedOccurrences: 1,
@@ -563,7 +628,7 @@ export const STATUS_SUCCESS_INVENTORY = {
       rationale: "Apply feedback; replaced on the next action",
     },
     {
-      category: "domain",
+      category: "affordance",
       signature: "bg-status-success",
       anchor: "onClick={handleApplyAllPatches}",
       expectedOccurrences: 1,
@@ -623,13 +688,13 @@ export const STATUS_SUCCESS_INVENTORY = {
   ],
   "src/components/Terminal/RecipeRunner/RecipeRunnerEmpty.tsx": [
     {
-      category: "domain",
+      category: "affordance",
       signature: "text-status-success/50",
       expectedOccurrences: 1,
       rationale: "Go-colour on the run-suggestion control",
     },
     {
-      category: "domain",
+      category: "affordance",
       signature: "group-hover:text-status-success",
       expectedOccurrences: 1,
       rationale: "Go-colour on the run-suggestion control at hover",
@@ -637,19 +702,19 @@ export const STATUS_SUCCESS_INVENTORY = {
   ],
   "src/components/Terminal/RecipeRunner/RecipeRunnerItem.tsx": [
     {
-      category: "domain",
+      category: "affordance",
       signature: "text-status-success",
       expectedOccurrences: 1,
       rationale: "Go-colour on the run-recipe control",
     },
     {
-      category: "domain",
+      category: "affordance",
       signature: "group-hover:text-status-success",
       expectedOccurrences: 1,
       rationale: "Go-colour on the run-recipe control at hover",
     },
     {
-      category: "domain",
+      category: "affordance",
       signature: "text-status-success/50 group-hover:text-status-success",
       expectedOccurrences: 2,
       rationale: "Go-colour on the run-recipe control in the collapsed row",
@@ -837,7 +902,7 @@ export const STATUS_SUCCESS_INVENTORY = {
       rationale: "Worktree diff insertion count",
     },
     {
-      category: "domain",
+      category: "affordance",
       signature: "text-status-success/70 hover:text-status-success",
       expectedOccurrences: 2,
       rationale: "Go-colour on the resume-resource control",
@@ -851,26 +916,12 @@ export const STATUS_SUCCESS_INVENTORY = {
       rationale: "Copy-path confirmation; resets when the copy flash times out",
     },
   ],
-  "src/components/agents/AgentCard.tsx": [
-    {
-      category: "verification",
-      signature: "text-status-success",
-      expectedOccurrences: 1,
-      rationale: "One installed mark per agent row, against the not-installed branch",
-    },
-  ],
   "src/components/ui/ReEntrySummary.tsx": [
     {
       category: "outcome",
       signature: "text-status-success",
       expectedOccurrences: 1,
       rationale: "Recorded result carried by a success entry in the re-entry summary",
-    },
-    {
-      category: "outcome",
-      signature: "border-l-status-success",
-      expectedOccurrences: 1,
-      rationale: "Left rule reporting that nothing in the summary is an error or warning",
     },
   ],
   "src/components/ui/badge.tsx": [
@@ -883,7 +934,7 @@ export const STATUS_SUCCESS_INVENTORY = {
   ],
   "src/components/ui/button.tsx": [
     {
-      category: "domain",
+      category: "affordance",
       signature: "text-status-success hover:bg-status-success/10",
       expectedOccurrences: 2,
       rationale: "Go-colour variant of the shared button primitive",
@@ -891,16 +942,16 @@ export const STATUS_SUCCESS_INVENTORY = {
   ],
   "src/components/ui/toaster.tsx": [
     {
-      category: "transient",
+      category: "outcome",
       signature: "border-l-status-success",
       expectedOccurrences: 1,
-      rationale: "Toast left rule; toasts dismiss themselves",
+      rationale: "Left rule of a success toast, which reports the result of a named operation",
     },
     {
-      category: "transient",
+      category: "outcome",
       signature: "text-status-success",
       expectedOccurrences: 1,
-      rationale: "Toast icon; toasts dismiss themselves",
+      rationale: "Icon of a success toast, which reports the result of a named operation",
     },
   ],
   "src/lib/gitStatusPresentation.ts": [
@@ -966,5 +1017,5 @@ export const STATUS_SUCCESS_INVENTORY = {
  * another added) still trips the per-site checks, and these catch the case
  * where a whole file moves without either check firing.
  */
-export const EXPECTED_STATUS_SUCCESS_SITES = 119;
-export const EXPECTED_STATUS_SUCCESS_OCCURRENCES = 144;
+export const EXPECTED_STATUS_SUCCESS_SITES = 123;
+export const EXPECTED_STATUS_SUCCESS_OCCURRENCES = 145;

--- a/src/config/__tests__/statusSuccessInventory.ts
+++ b/src/config/__tests__/statusSuccessInventory.ts
@@ -929,6 +929,15 @@ export const STATUS_SUCCESS_INVENTORY = {
       rationale: "Copy-path confirmation; resets when the copy flash times out",
     },
   ],
+  "src/components/Worktree/WorktreeMenuItems.tsx": [
+    {
+      category: "affordance",
+      signature: "text-status-success",
+      expectedOccurrences: 1,
+      rationale:
+        "Go-colour on the resume-resource command — the same control the worktree card paints green, reached from the context menu instead of the card's icon rail",
+    },
+  ],
   "src/components/ui/ReEntrySummary.tsx": [
     {
       category: "outcome",
@@ -1030,5 +1039,5 @@ export const STATUS_SUCCESS_INVENTORY = {
  * another added) still trips the per-site checks, and these catch the case
  * where a whole file moves without either check firing.
  */
-export const EXPECTED_STATUS_SUCCESS_SITES = 124;
-export const EXPECTED_STATUS_SUCCESS_OCCURRENCES = 146;
+export const EXPECTED_STATUS_SUCCESS_SITES = 125;
+export const EXPECTED_STATUS_SUCCESS_OCCURRENCES = 147;

--- a/src/config/__tests__/statusSuccessInventory.ts
+++ b/src/config/__tests__/statusSuccessInventory.ts
@@ -104,6 +104,13 @@ export const STATUS_SUCCESS_INVENTORY = {
   ],
   "plugins/builtin/github/renderer/components/GitHubListItem.tsx": [
     {
+      category: "outcome",
+      signature: "text-status-success",
+      anchor: 'label: "Approved"',
+      expectedOccurrences: 1,
+      rationale: "Recorded decision of a named review on the pull request",
+    },
+    {
       category: "transient",
       signature: "text-status-success",
       anchor: 'copied && "text-status-success"',
@@ -124,14 +131,14 @@ export const STATUS_SUCCESS_INVENTORY = {
       signature: "text-status-success",
       anchor: 'validationResult === "success"',
       expectedOccurrences: 1,
-      rationale: "Token-saved confirmation; cleared by the tab's 5s validation-result timer",
+      rationale: "Token-saved confirmation; resets on the next edit of the token field",
     },
     {
       category: "transient",
       signature: "text-status-success",
       anchor: 'validationResult === "test-success"',
       expectedOccurrences: 1,
-      rationale: "Token-valid confirmation; cleared by the tab's 5s validation-result timer",
+      rationale: "Token-valid confirmation; resets on the next edit of the token field",
     },
   ],
   "plugins/builtin/github/renderer/utils/prCIStatus.ts": [
@@ -1017,5 +1024,5 @@ export const STATUS_SUCCESS_INVENTORY = {
  * another added) still trips the per-site checks, and these catch the case
  * where a whole file moves without either check firing.
  */
-export const EXPECTED_STATUS_SUCCESS_SITES = 123;
-export const EXPECTED_STATUS_SUCCESS_OCCURRENCES = 145;
+export const EXPECTED_STATUS_SUCCESS_SITES = 124;
+export const EXPECTED_STATUS_SUCCESS_OCCURRENCES = 146;

--- a/src/config/__tests__/statusSuccessInventory.ts
+++ b/src/config/__tests__/statusSuccessInventory.ts
@@ -1,0 +1,970 @@
+/**
+ * Every `status-success` paint site left in the renderer, with the reason it is
+ * allowed to be green (#12002).
+ *
+ * Green may only say a confirmation is clearing, a required item is checked, a
+ * named operation produced this result, or the colour is notation the app
+ * inherited rather than a health claim it is making. "Nothing is wrong" earns
+ * nothing. Live process state is green too, but on `activity-working` /
+ * `state-working`, which keeps it out of this inventory entirely.
+ *
+ * The unit here is a source **site** — one string literal or template quasi —
+ * not a file and not a line. A file allowlist would be too coarse: `FileStageRow`
+ * holds both git notation that stays and a row wash that had to go, so allowing
+ * the file would leave the door open forever.
+ *
+ * Adding a `status-success` utility anywhere in `src/` fails
+ * `statusSuccessGuard.contract.test.ts` until it is listed here with a category
+ * and a rationale that names the specific confirmation, item, result, or
+ * notation. Removing one fails it too, until the entry goes.
+ *
+ * Policy: docs/themes/status-success-policy.md
+ */
+
+export const STATUS_SUCCESS_CATEGORIES = [
+  /** Clears on a timer, leaves with the operation or dialog, resets on input change. */
+  "transient",
+  /** One mark per item in a finite list the current task requires to become true. */
+  "verification",
+  /** The recorded result of a named execution or check, not inferred health. */
+  "outcome",
+  /** Notation the app inherited: git status letters, diff counts, ahead arrows, go-controls. */
+  "domain",
+] as const;
+
+export type StatusSuccessCategory = (typeof STATUS_SUCCESS_CATEGORIES)[number];
+
+export interface ApprovedStatusSuccessSite {
+  category: StatusSuccessCategory;
+  /**
+   * The `status-success`-bearing lexemes of the decoded literal, in source
+   * order, whitespace collapsed. Layout classes, indentation and quote style
+   * are deliberately not part of the key — reformatting a component must not
+   * churn this file, but changing which success utility it paints must.
+   */
+  signature: string;
+  /**
+   * Only needed when a signature repeats inside one file. Any substring of an
+   * enclosing node that tells the twins apart — a predicate, a label, an
+   * `aria-label`. Never an ordinal or a line number.
+   */
+  anchor?: string;
+  /** How many `status-success` utilities this one site paints. */
+  expectedOccurrences: number;
+  /** Names the confirmation, item, result, or notation. "It looks fine" is not a rationale. */
+  rationale: string;
+}
+
+export type StatusSuccessInventory = Readonly<Record<string, readonly ApprovedStatusSuccessSite[]>>;
+
+export const STATUS_SUCCESS_INVENTORY = {
+  "src/components/AllClearOverlay/AllClearOverlay.tsx": [
+    {
+      category: "transient",
+      signature: "bg-status-success",
+      expectedOccurrences: 1,
+      rationale: "Full-screen all-clear flash; the portal unmounts itself on animationend",
+    },
+  ],
+  "src/components/Browser/BrowserToolbar.tsx": [
+    {
+      category: "transient",
+      signature: "text-status-success",
+      anchor: 'aria-label="Copy URL"',
+      expectedOccurrences: 1,
+      rationale: "Copy-URL confirmation; resets when the copy flash times out",
+    },
+    {
+      category: "transient",
+      signature: "text-status-success",
+      anchor: 'aria-label="Copy screenshot to clipboard"',
+      expectedOccurrences: 1,
+      rationale: "Copy-screenshot confirmation; resets when the copy flash times out",
+    },
+  ],
+  "src/components/Commands/CommandBuilder.tsx": [
+    {
+      category: "transient",
+      signature: "text-status-success",
+      expectedOccurrences: 1,
+      rationale: "Command-executed screen; leaves with the dialog",
+    },
+  ],
+  "src/components/DevPreview/ConsolePanel.tsx": [
+    {
+      category: "transient",
+      signature: "text-status-success",
+      anchor: 'aria-label="Copy console message"',
+      expectedOccurrences: 1,
+      rationale: "Copy-message confirmation; resets when the copy flash times out",
+    },
+    {
+      category: "transient",
+      signature: "text-status-success",
+      anchor: 'aria-label="Copy visible console messages"',
+      expectedOccurrences: 1,
+      rationale: "Copy-all-messages confirmation; resets when the copy flash times out",
+    },
+  ],
+  "src/components/Diagnostics/ProblemsContent.tsx": [
+    {
+      category: "domain",
+      signature:
+        "text-status-success hover:text-status-success/70 border-status-success/50 hover:bg-status-success/10",
+      expectedOccurrences: 4,
+      rationale: "Go-colour on the Retry control, not a claim that the problem is resolved",
+    },
+    {
+      category: "transient",
+      signature: "text-status-success",
+      expectedOccurrences: 1,
+      rationale: "Copy-details confirmation; resets when the copy flash times out",
+    },
+  ],
+  "src/components/Diagnostics/TelemetryContent.tsx": [
+    {
+      category: "transient",
+      signature: "text-status-success",
+      expectedOccurrences: 1,
+      rationale: "Copy-payload confirmation; resets when the copy flash times out",
+    },
+  ],
+  "src/components/EventInspector/EventDetail.tsx": [
+    {
+      category: "transient",
+      signature: "text-status-success",
+      expectedOccurrences: 1,
+      rationale: "Copy-payload confirmation; resets when the copy flash times out",
+    },
+  ],
+  "src/components/FileViewer/DiffFileSidebar.tsx": [
+    {
+      category: "domain",
+      signature: "text-status-success",
+      expectedOccurrences: 1,
+      rationale: "Diff insertion count for the whole change set",
+    },
+    {
+      category: "verification",
+      signature: "bg-status-success/70",
+      expectedOccurrences: 1,
+      rationale: "Progress through the finite set of files this review has to cover",
+    },
+    {
+      category: "verification",
+      signature: "text-status-success/80",
+      expectedOccurrences: 1,
+      rationale: "Per-file viewed mark; one mark per item in the review checklist",
+    },
+    {
+      category: "verification",
+      signature: "border-status-success/60 bg-status-success/20 text-status-success",
+      expectedOccurrences: 3,
+      rationale: "Per-file viewed toggle; one mark per item in the review checklist",
+    },
+  ],
+  "src/components/FileViewer/FileViewerToolbar.tsx": [
+    {
+      category: "transient",
+      signature: "text-status-success",
+      expectedOccurrences: 1,
+      rationale: "Copy-path confirmation; resets when the copy flash times out",
+    },
+  ],
+  "src/components/FileViewer/diffChangeSet.ts": [
+    {
+      category: "domain",
+      signature: "text-status-success",
+      anchor: 'label: "A"',
+      expectedOccurrences: 1,
+      rationale: "Git status letter A, the notation git itself paints green",
+    },
+    {
+      category: "domain",
+      signature: "text-status-success",
+      anchor: 'label: "?"',
+      expectedOccurrences: 1,
+      rationale: "Git status letter ?, the notation git itself paints green",
+    },
+  ],
+  "src/components/Layout/DockedTabGroup.tsx": [
+    {
+      category: "transient",
+      signature: "text-status-success",
+      expectedOccurrences: 1,
+      rationale: "Finished cue on a docked group; the cue decays rather than standing",
+    },
+  ],
+  "src/components/Layout/DockedTerminalItem.tsx": [
+    {
+      category: "transient",
+      signature: "text-status-success",
+      expectedOccurrences: 1,
+      rationale: "Finished cue on a docked terminal; the cue decays rather than standing",
+    },
+  ],
+  "src/components/Layout/LocalCommitsDropdown.tsx": [
+    {
+      category: "transient",
+      signature: "text-status-success",
+      anchor: 'copied && "text-status-success"',
+      expectedOccurrences: 1,
+      rationale: "Copy-hash confirmation on the row; resets when the copy flash times out",
+    },
+    {
+      category: "transient",
+      signature: "text-status-success",
+      anchor: "<span>#</span>",
+      expectedOccurrences: 1,
+      rationale: "Copy-hash confirmation glyph; resets when the copy flash times out",
+    },
+  ],
+  "src/components/Notifications/NotificationCenterEntry.tsx": [
+    {
+      category: "outcome",
+      signature: "text-status-success",
+      expectedOccurrences: 1,
+      rationale: "Recorded result carried by a success notification already in the inbox",
+    },
+  ],
+  "src/components/Onboarding/CelebrationConfetti.tsx": [
+    {
+      category: "transient",
+      signature: "bg-status-success/15",
+      expectedOccurrences: 1,
+      rationale: "Reduced-motion checklist-complete flash; the animation ends and unmounts",
+    },
+  ],
+  "src/components/Project/CloneRepoDialog.tsx": [
+    {
+      category: "outcome",
+      signature: "bg-status-success/15",
+      expectedOccurrences: 1,
+      rationale: "Recorded result of the clone the user just ran",
+    },
+    {
+      category: "outcome",
+      signature: "text-status-success",
+      expectedOccurrences: 1,
+      rationale: "Recorded result of the clone the user just ran",
+    },
+  ],
+  "src/components/Project/ContextTab.tsx": [
+    {
+      category: "outcome",
+      signature: "text-status-success",
+      expectedOccurrences: 1,
+      rationale: "Recorded result of the named context test the user ran",
+    },
+  ],
+  "src/components/Project/GeneralTab.tsx": [
+    {
+      category: "transient",
+      signature: "text-status-success",
+      expectedOccurrences: 1,
+      rationale: "Copy-gitignore confirmation; resets when the copy flash times out",
+    },
+  ],
+  "src/components/Project/GitInitDialog.tsx": [
+    {
+      category: "outcome",
+      signature: "bg-status-success/15",
+      expectedOccurrences: 1,
+      rationale: "Recorded result of the git init the user just ran",
+    },
+    {
+      category: "outcome",
+      signature: "text-status-success",
+      expectedOccurrences: 1,
+      rationale: "Recorded result of the git init the user just ran",
+    },
+  ],
+  "src/components/Project/MoveOrRenameProjectDialog.tsx": [
+    {
+      category: "transient",
+      signature: "text-status-success",
+      anchor: 'label: "Resume supported"',
+      expectedOccurrences: 1,
+      rationale: "Continuity tier shown while deciding the move; leaves with the dialog",
+    },
+    {
+      category: "transient",
+      signature: "text-status-success",
+      anchor: 'label: "Conversation stays with the folder"',
+      expectedOccurrences: 1,
+      rationale: "Continuity tier shown while deciding the move; leaves with the dialog",
+    },
+  ],
+  "src/components/Project/RecipesTab.tsx": [
+    {
+      category: "transient",
+      signature: "text-status-success",
+      expectedOccurrences: 1,
+      rationale: "Recipe-exported confirmation; resets when the export flash times out",
+    },
+  ],
+  "src/components/Project/RunningTaskList.tsx": [
+    {
+      category: "transient",
+      signature: "bg-status-success",
+      expectedOccurrences: 1,
+      rationale: "Finished task; the row auto-clears after AUTO_CLEAR_DELAY",
+    },
+  ],
+  "src/components/Pulse/ProjectPulseCard.tsx": [
+    {
+      category: "outcome",
+      signature: "text-status-success",
+      expectedOccurrences: 1,
+      rationale: "Recorded result of the last CI run on the branch",
+    },
+    {
+      category: "outcome",
+      signature: "var(--color-status-success)",
+      expectedOccurrences: 1,
+      rationale: "Counted result chip; the only success caller is the merged-PR count",
+    },
+  ],
+  "src/components/Pulse/PulseSummary.tsx": [
+    {
+      category: "domain",
+      signature: "text-status-success",
+      expectedOccurrences: 1,
+      rationale: "Ahead-arrow count against the base branch",
+    },
+    {
+      category: "domain",
+      signature: "text-status-success/80",
+      expectedOccurrences: 1,
+      rationale: "Diff insertion count against the base branch",
+    },
+  ],
+  "src/components/Settings/CodeForgeSettingsTab.tsx": [
+    {
+      category: "transient",
+      signature: "text-status-success",
+      expectedOccurrences: 1,
+      rationale: "Credentials-saved confirmation; resets on the next input change",
+    },
+  ],
+  "src/components/Settings/DaintreeAssistantSettingsTab.tsx": [
+    {
+      category: "transient",
+      signature: "text-status-success border-status-success/30",
+      expectedOccurrences: 2,
+      rationale: "Copy-config confirmation; resets when the copy flash times out",
+    },
+  ],
+  "src/components/Settings/EditorIntegrationTab.tsx": [
+    {
+      category: "outcome",
+      signature: "text-status-success",
+      expectedOccurrences: 1,
+      rationale: "Recorded result of the editor test the user ran",
+    },
+  ],
+  "src/components/Settings/ForgeAuditLogViewer.tsx": [
+    {
+      category: "transient",
+      signature: "text-status-success border-status-success/30",
+      anchor: "copyFlashActive",
+      expectedOccurrences: 2,
+      rationale: "Copy confirmation; resets when the copy flash times out",
+    },
+    {
+      category: "transient",
+      signature: "text-status-success border-status-success/30",
+      anchor: "exportFlashActive",
+      expectedOccurrences: 2,
+      rationale: "Export confirmation; resets when the export flash times out",
+    },
+  ],
+  "src/components/Settings/ImageViewerTab.tsx": [
+    {
+      category: "transient",
+      signature: "text-status-success",
+      expectedOccurrences: 1,
+      rationale: "Saved confirmation; resets on the next edit",
+    },
+  ],
+  "src/components/Settings/McpAuditLogViewer.tsx": [
+    {
+      category: "transient",
+      signature: "text-status-success border-status-success/30",
+      anchor: "copyFlashActive",
+      expectedOccurrences: 2,
+      rationale: "Copy confirmation; resets when the copy flash times out",
+    },
+    {
+      category: "transient",
+      signature: "text-status-success border-status-success/30",
+      anchor: "exportFlashActive",
+      expectedOccurrences: 2,
+      rationale: "Export confirmation; resets when the export flash times out",
+    },
+  ],
+  "src/components/Settings/McpServerSettingsTab.tsx": [
+    {
+      category: "transient",
+      signature: "text-status-success border-status-success/30",
+      anchor: 'copiedTarget === "plain"',
+      expectedOccurrences: 2,
+      rationale: "Copy-config confirmation; resets when the copy flash times out",
+    },
+    {
+      category: "transient",
+      signature: "text-status-success border-status-success/30",
+      anchor: 'copiedTarget === "scoped"',
+      expectedOccurrences: 2,
+      rationale: "Copy-scoped-config confirmation; resets when the copy flash times out",
+    },
+    {
+      category: "transient",
+      signature: "text-status-success border-status-success/30",
+      anchor: "copiedKey",
+      expectedOccurrences: 2,
+      rationale: "Copy-API-key confirmation; resets when the copy flash times out",
+    },
+  ],
+  "src/components/Settings/PluginActionAuditLogViewer.tsx": [
+    {
+      category: "transient",
+      signature: "text-status-success border-status-success/30",
+      anchor: "copyFlashActive",
+      expectedOccurrences: 2,
+      rationale: "Copy confirmation; resets when the copy flash times out",
+    },
+    {
+      category: "transient",
+      signature: "text-status-success border-status-success/30",
+      anchor: "exportFlashActive",
+      expectedOccurrences: 2,
+      rationale: "Export confirmation; resets when the export flash times out",
+    },
+  ],
+  "src/components/Settings/PortalSettingsTab.tsx": [
+    {
+      category: "domain",
+      signature: "text-status-success",
+      expectedOccurrences: 1,
+      rationale: "Go-colour on the confirm half of a confirm/cancel edit pair",
+    },
+  ],
+  "src/components/Settings/RunHistorySettingsTab.tsx": [
+    {
+      category: "outcome",
+      signature: "bg-status-success/15 text-status-success",
+      expectedOccurrences: 2,
+      rationale: "Counted results of named runs, beside the matching failure count",
+    },
+  ],
+  "src/components/Settings/TroubleshootingTab.tsx": [
+    {
+      category: "verification",
+      signature: "text-status-success",
+      expectedOccurrences: 1,
+      rationale: "One mark per required tool in a finite prerequisite list",
+    },
+  ],
+  "src/components/Settings/VoiceInputSettingsTab.tsx": [
+    {
+      category: "outcome",
+      signature: "text-status-success",
+      expectedOccurrences: 1,
+      rationale: "Recorded result of the API-key validation the user ran",
+    },
+    {
+      category: "verification",
+      signature: "bg-status-success",
+      expectedOccurrences: 1,
+      rationale: "Microphone permission is a gate voice input cannot start without",
+    },
+  ],
+  "src/components/Settings/WorktreeSettingsTab.tsx": [
+    {
+      category: "transient",
+      signature: "text-status-success",
+      expectedOccurrences: 1,
+      rationale: "Saved confirmation; resets on the next edit",
+    },
+  ],
+  "src/components/Setup/AgentCliStep.tsx": [
+    {
+      category: "verification",
+      signature: "text-status-success",
+      expectedOccurrences: 1,
+      rationale: "One installed mark per agent row in the setup gate",
+    },
+  ],
+  "src/components/Setup/AgentSetupWizard.tsx": [
+    {
+      category: "transient",
+      signature: "text-status-success",
+      expectedOccurrences: 1,
+      rationale: "Wizard completion step; leaves with the wizard",
+    },
+    {
+      category: "transient",
+      signature: "border-status-success/20 bg-status-success/5",
+      expectedOccurrences: 2,
+      rationale: "Ready-agent cards on the completion step; leave with the wizard",
+    },
+  ],
+  "src/components/Setup/CopyableCommand.tsx": [
+    {
+      category: "transient",
+      signature: "text-status-success",
+      expectedOccurrences: 1,
+      rationale: "Copy-command confirmation; resets when the copy flash times out",
+    },
+  ],
+  "src/components/Setup/SystemRequirementsSection.tsx": [
+    {
+      category: "verification",
+      signature: "text-status-success",
+      expectedOccurrences: 1,
+      rationale: "The single completion summary the ruling allows a finite gate",
+    },
+  ],
+  "src/components/Setup/SystemToolsStep.tsx": [
+    {
+      category: "verification",
+      signature: "text-status-success",
+      expectedOccurrences: 1,
+      rationale: "One mark per required tool in the setup gate",
+    },
+  ],
+  "src/components/Terminal/ArtifactOverlay.tsx": [
+    {
+      category: "domain",
+      signature: "text-status-success bg-status-success/10",
+      expectedOccurrences: 2,
+      rationale: "Added line in a unified patch",
+    },
+    {
+      category: "domain",
+      signature:
+        "border-status-success bg-[color-mix(in_oklab,var(--color-status-success)_10%,transparent)] text-status-success",
+      expectedOccurrences: 3,
+      rationale: "Patch artifact type, coloured to match the patch body it labels",
+    },
+    {
+      category: "domain",
+      signature: "bg-status-success",
+      anchor: "onClick={handleApplyPatch}",
+      expectedOccurrences: 1,
+      rationale: "Go-colour on the apply-patch control",
+    },
+    {
+      category: "transient",
+      signature: "text-status-success",
+      anchor: 'feedback.tone === "success"',
+      expectedOccurrences: 1,
+      rationale: "Apply feedback; replaced on the next action",
+    },
+    {
+      category: "domain",
+      signature: "bg-status-success",
+      anchor: "onClick={handleApplyAllPatches}",
+      expectedOccurrences: 1,
+      rationale: "Go-colour on the apply-all-patches control",
+    },
+    {
+      category: "transient",
+      signature: "text-status-success",
+      anchor: 'bulkResult.tone === "success"',
+      expectedOccurrences: 1,
+      rationale: "Bulk apply feedback; replaced on the next action",
+    },
+    {
+      category: "domain",
+      signature: "text-status-success",
+      anchor: 'className="text-status-success"',
+      expectedOccurrences: 1,
+      rationale: "Per-patch insertion count",
+    },
+  ],
+  "src/components/Terminal/GridNotificationBar.tsx": [
+    {
+      category: "outcome",
+      signature:
+        "border-[color-mix(in_oklab,var(--color-status-success)_35%,var(--color-surface-grid))]",
+      expectedOccurrences: 1,
+      rationale: "Recorded result carried by a success notification on the grid bar",
+    },
+    {
+      category: "outcome",
+      signature: "text-status-success",
+      anchor: 'iconClass: "text-status-success"',
+      expectedOccurrences: 1,
+      rationale: "Recorded result carried by a success notification on the grid bar",
+    },
+    {
+      category: "outcome",
+      signature: "text-status-success",
+      anchor: 'titleClass: "text-status-success"',
+      expectedOccurrences: 1,
+      rationale: "Recorded result carried by a success notification on the grid bar",
+    },
+  ],
+  "src/components/Terminal/MissingCliGate.tsx": [
+    {
+      category: "transient",
+      signature: "border-status-success/20 bg-status-success/5",
+      expectedOccurrences: 2,
+      rationale: "CLI-now-available banner; the gate stops rendering once it is seen",
+    },
+    {
+      category: "transient",
+      signature: "text-status-success",
+      expectedOccurrences: 1,
+      rationale: "CLI-now-available banner; the gate stops rendering once it is seen",
+    },
+  ],
+  "src/components/Terminal/RecipeRunner/RecipeRunnerEmpty.tsx": [
+    {
+      category: "domain",
+      signature: "text-status-success/50",
+      expectedOccurrences: 1,
+      rationale: "Go-colour on the run-suggestion control",
+    },
+    {
+      category: "domain",
+      signature: "group-hover:text-status-success",
+      expectedOccurrences: 1,
+      rationale: "Go-colour on the run-suggestion control at hover",
+    },
+  ],
+  "src/components/Terminal/RecipeRunner/RecipeRunnerItem.tsx": [
+    {
+      category: "domain",
+      signature: "text-status-success",
+      expectedOccurrences: 1,
+      rationale: "Go-colour on the run-recipe control",
+    },
+    {
+      category: "domain",
+      signature: "group-hover:text-status-success",
+      expectedOccurrences: 1,
+      rationale: "Go-colour on the run-recipe control at hover",
+    },
+    {
+      category: "domain",
+      signature: "text-status-success/50 group-hover:text-status-success",
+      expectedOccurrences: 2,
+      rationale: "Go-colour on the run-recipe control in the collapsed row",
+    },
+  ],
+  "src/components/TerminalRecipe/RecipeManager.tsx": [
+    {
+      category: "transient",
+      signature: "text-status-success",
+      expectedOccurrences: 1,
+      rationale: "Recipe-exported confirmation; resets when the export flash times out",
+    },
+  ],
+  "src/components/Worktree/CrossWorktreeDiff.tsx": [
+    {
+      category: "domain",
+      signature: "text-status-success",
+      expectedOccurrences: 1,
+      rationale: "Git status letter A, the notation git itself paints green",
+    },
+    {
+      category: "domain",
+      signature: "text-status-success/80",
+      anchor: '<span className="text-status-success/80">+{insertions}</span>',
+      expectedOccurrences: 1,
+      rationale: "Per-file diff insertion count",
+    },
+    {
+      category: "domain",
+      signature: "text-status-success/80",
+      anchor: '<span className="text-status-success/80">+{totalInsertions}</span>',
+      expectedOccurrences: 1,
+      rationale: "Total diff insertion count",
+    },
+  ],
+  "src/components/Worktree/DiffViewer.tsx": [
+    {
+      category: "domain",
+      signature: "text-status-success",
+      expectedOccurrences: 1,
+      rationale: "Diff addition count in the viewer toolbar",
+    },
+  ],
+  "src/components/Worktree/FileChangeList.tsx": [
+    {
+      category: "domain",
+      signature: "text-status-success/80",
+      expectedOccurrences: 1,
+      rationale: "Per-file diff insertion count",
+    },
+  ],
+  "src/components/Worktree/ReviewHub/BaseBranchFileRow.tsx": [
+    {
+      category: "domain",
+      signature: "text-status-success/80",
+      expectedOccurrences: 1,
+      rationale: "Per-file diff insertion count",
+    },
+  ],
+  "src/components/Worktree/ReviewHub/CommitPanel.tsx": [
+    {
+      category: "verification",
+      signature: "text-status-success",
+      expectedOccurrences: 1,
+      rationale: "One mark per commit blocker that has to clear before committing",
+    },
+  ],
+  "src/components/Worktree/ReviewHub/ConflictPanel.tsx": [
+    {
+      category: "verification",
+      signature: "text-status-success/60",
+      expectedOccurrences: 1,
+      rationale: "One mark per conflict that has to be resolved before continuing",
+    },
+  ],
+  "src/components/Worktree/ReviewHub/FileSection.tsx": [
+    {
+      category: "domain",
+      signature: "text-status-success/80",
+      expectedOccurrences: 1,
+      rationale: "Section diff insertion count",
+    },
+  ],
+  "src/components/Worktree/ReviewHub/FileStageRow.tsx": [
+    {
+      category: "domain",
+      signature: "bg-status-success/15",
+      anchor: 'label: "A"',
+      expectedOccurrences: 1,
+      rationale: "Git status letter A, the notation git itself paints green",
+    },
+    {
+      category: "domain",
+      signature: "text-status-success",
+      anchor: 'label: "A"',
+      expectedOccurrences: 1,
+      rationale: "Git status letter A, the notation git itself paints green",
+    },
+    {
+      category: "domain",
+      signature: "bg-status-success/15",
+      anchor: 'label: "?"',
+      expectedOccurrences: 1,
+      rationale: "Git status letter ?, the notation git itself paints green",
+    },
+    {
+      category: "domain",
+      signature: "text-status-success",
+      anchor: 'label: "?"',
+      expectedOccurrences: 1,
+      rationale: "Git status letter ?, the notation git itself paints green",
+    },
+    {
+      category: "domain",
+      signature: "text-status-success/80",
+      expectedOccurrences: 1,
+      rationale: "Per-file diff insertion count",
+    },
+    {
+      category: "verification",
+      signature: "accent-status-success",
+      expectedOccurrences: 1,
+      rationale:
+        "One viewed mark per file in the review checklist; the row wash went neutral in #12002",
+    },
+    {
+      category: "domain",
+      signature: "text-status-success",
+      anchor: 'className="w-3 h-3 text-status-success"',
+      expectedOccurrences: 1,
+      rationale: "Plus half of the stage/unstage pair, against the red Minus",
+    },
+  ],
+  "src/components/Worktree/ReviewHub/ReviewHubContent.tsx": [
+    {
+      category: "domain",
+      signature: "text-status-success/80",
+      expectedOccurrences: 1,
+      rationale: "Base-branch diff insertion count",
+    },
+  ],
+  "src/components/Worktree/ReviewHub/reviewHubUtils.ts": [
+    {
+      category: "domain",
+      signature: "bg-status-success/15",
+      expectedOccurrences: 1,
+      rationale: "Git status letter A, the notation git itself paints green",
+    },
+    {
+      category: "domain",
+      signature: "text-status-success",
+      expectedOccurrences: 1,
+      rationale: "Git status letter A, the notation git itself paints green",
+    },
+  ],
+  "src/components/Worktree/WorktreeCard/MainWorktreeSummaryRows.tsx": [
+    {
+      category: "outcome",
+      signature: "text-status-success",
+      expectedOccurrences: 1,
+      rationale: "Recorded result of the last CI run on the branch",
+    },
+  ],
+  "src/components/Worktree/WorktreeCard/UpstreamSyncBadge.tsx": [
+    {
+      category: "domain",
+      signature: "text-status-success",
+      anchor: '{hasAhead && <span className="text-status-success">↑{aheadCount}</span>}',
+      expectedOccurrences: 1,
+      rationale: "Ahead-arrow count against the upstream",
+    },
+    {
+      category: "domain",
+      signature: "text-status-success",
+      anchor: "↑{baseAheadCount}",
+      expectedOccurrences: 1,
+      rationale: "Ahead-arrow count against the base branch",
+    },
+  ],
+  "src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx": [
+    {
+      category: "domain",
+      signature: "text-status-success",
+      expectedOccurrences: 1,
+      rationale: "Worktree diff insertion count",
+    },
+    {
+      category: "domain",
+      signature: "text-status-success/70 hover:text-status-success",
+      expectedOccurrences: 2,
+      rationale: "Go-colour on the resume-resource control",
+    },
+  ],
+  "src/components/Worktree/WorktreeDetails.tsx": [
+    {
+      category: "transient",
+      signature: "text-status-success",
+      expectedOccurrences: 1,
+      rationale: "Copy-path confirmation; resets when the copy flash times out",
+    },
+  ],
+  "src/components/agents/AgentCard.tsx": [
+    {
+      category: "verification",
+      signature: "text-status-success",
+      expectedOccurrences: 1,
+      rationale: "One installed mark per agent row, against the not-installed branch",
+    },
+  ],
+  "src/components/ui/ReEntrySummary.tsx": [
+    {
+      category: "outcome",
+      signature: "text-status-success",
+      expectedOccurrences: 1,
+      rationale: "Recorded result carried by a success entry in the re-entry summary",
+    },
+    {
+      category: "outcome",
+      signature: "border-l-status-success",
+      expectedOccurrences: 1,
+      rationale: "Left rule reporting that nothing in the summary is an error or warning",
+    },
+  ],
+  "src/components/ui/badge.tsx": [
+    {
+      category: "outcome",
+      signature: "bg-status-success/10 text-status-success",
+      expectedOccurrences: 2,
+      rationale: "The success tone of the shared badge primitive, for reporting a result",
+    },
+  ],
+  "src/components/ui/button.tsx": [
+    {
+      category: "domain",
+      signature: "text-status-success hover:bg-status-success/10",
+      expectedOccurrences: 2,
+      rationale: "Go-colour variant of the shared button primitive",
+    },
+  ],
+  "src/components/ui/toaster.tsx": [
+    {
+      category: "transient",
+      signature: "border-l-status-success",
+      expectedOccurrences: 1,
+      rationale: "Toast left rule; toasts dismiss themselves",
+    },
+    {
+      category: "transient",
+      signature: "text-status-success",
+      expectedOccurrences: 1,
+      rationale: "Toast icon; toasts dismiss themselves",
+    },
+  ],
+  "src/lib/gitStatusPresentation.ts": [
+    {
+      category: "domain",
+      signature: "text-status-success",
+      anchor: 'name: "Added"',
+      expectedOccurrences: 1,
+      rationale: "Git status letter A, the notation git itself paints green",
+    },
+    {
+      category: "domain",
+      signature: "text-status-success",
+      anchor: 'name: "Untracked"',
+      expectedOccurrences: 1,
+      rationale: "Git status letter ?, the notation git itself paints green",
+    },
+  ],
+  "src/lib/statusSeverity.tsx": [
+    {
+      category: "outcome",
+      signature: "text-status-success",
+      expectedOccurrences: 1,
+      rationale: "The success shape of the shared severity vocabulary, for reporting a result",
+    },
+  ],
+  "src/lib/worktreeCIStatus.ts": [
+    {
+      category: "outcome",
+      signature: "text-status-success",
+      expectedOccurrences: 1,
+      rationale: "Recorded result of the last CI run",
+    },
+  ],
+  "src/panels/file-browser/FileBrowserChangeSummary.tsx": [
+    {
+      category: "domain",
+      signature: "text-status-success/80",
+      expectedOccurrences: 1,
+      rationale: "Per-file diff insertion count",
+    },
+  ],
+  "src/panels/file-browser/FileBrowserPane.tsx": [
+    {
+      category: "transient",
+      signature: "text-status-success",
+      anchor: 'showRootPathCopied ? "text-status-success"',
+      expectedOccurrences: 1,
+      rationale: "Copy-root-path confirmation; resets when the copy flash times out",
+    },
+    {
+      category: "transient",
+      signature: "text-status-success",
+      anchor: "Copied!",
+      expectedOccurrences: 1,
+      rationale: "Copy-root-path confirmation in the tooltip; resets with the flash",
+    },
+  ],
+} as const satisfies StatusSuccessInventory;
+
+/**
+ * Ratchets. These are not decoration: an equal-count swap (one green removed,
+ * another added) still trips the per-site checks, and these catch the case
+ * where a whole file moves without either check firing.
+ */
+export const EXPECTED_STATUS_SUCCESS_SITES = 119;
+export const EXPECTED_STATUS_SUCCESS_OCCURRENCES = 144;

--- a/src/lib/projectRowStatus.ts
+++ b/src/lib/projectRowStatus.ts
@@ -98,9 +98,13 @@ export const ROW_DOT_CLASS: Record<ProjectRowTone, string> = {
   working: "bg-activity-working animate-activity-pulse",
   // Same hue as `working` and for the same reason: this is a run in flight, not
   // a run that succeeded. It sat on `status-success` until #12002, which reads
-  // as "finished well" in every palette that separates the two. The pulse is
-  // what still tells the tones apart — `running` is the liveness fallback, so
-  // it draws steady while `working` advertises demand.
+  // as "finished well" in every palette that separates the two.
+  //
+  // That makes it identical to `working` wherever the pulse is off — reduced
+  // motion and performance mode both kill `animate-activity-pulse`. Deliberate:
+  // the legend above draws one filled green for "something is executing here",
+  // and these are its two spellings. Which one is executing is the row's line's
+  // job ("2 running" against "1 process running"), not the mark's.
   running: "bg-activity-working",
   // Dashed rather than solid, because "snoozed" and "settled" are different
   // facts and the switcher's greys already carry the settled ones. Colour alone

--- a/src/lib/projectRowStatus.ts
+++ b/src/lib/projectRowStatus.ts
@@ -96,7 +96,12 @@ export const ROW_DOT_CLASS: Record<ProjectRowTone, string> = {
   // demand keeps its demand hue — so the pulse lands on the rows whose only
   // fact is that they are moving, and nowhere near twenty at once.
   working: "bg-activity-working animate-activity-pulse",
-  running: "bg-status-success",
+  // Same hue as `working` and for the same reason: this is a run in flight, not
+  // a run that succeeded. It sat on `status-success` until #12002, which reads
+  // as "finished well" in every palette that separates the two. The pulse is
+  // what still tells the tones apart — `running` is the liveness fallback, so
+  // it draws steady while `working` advertises demand.
+  running: "bg-activity-working",
   // Dashed rather than solid, because "snoozed" and "settled" are different
   // facts and the switcher's greys already carry the settled ones. Colour alone
   // could not separate them — a dashed ring reads as temporarily suspended at a
@@ -141,7 +146,7 @@ export const ROW_MARK_COLOR: Record<ProjectRowTone, string> = {
   waiting: "var(--color-status-warning)",
   review: "var(--color-activity-completed)",
   working: "var(--color-activity-working)",
-  running: "var(--color-status-success)",
+  running: "var(--color-activity-working)",
   snoozed: "rgb(from var(--color-text-primary) r g b / 0.4)",
   muted: "rgb(from var(--color-text-primary) r g b / 0.2)",
   assistant: "var(--color-status-warning)",


### PR DESCRIPTION
## Summary

Completes #12002. PR1 (#12034) took the ambient/default-health bucket; this lands the remaining two PRs of the ruling's series together — membership and settled state, and the `activity-working` retokenisation plus enforcement. Combining them means the guard ships complete: there is no temporary `#12002` bucket to create and then delete.

The policy from the ruling: green is allowed only for a confirmation that clears on its own, the recorded result of a named operation or check, an item in a finite checklist the user is currently working through, or a process running right now. Everything else goes neutral when the state still needs naming, and disappears when the good case is already implied.

## Demoted to neutral

Membership, settled completion and decoration:

- `PluginPanelBadges` — a plugin badge stands for as long as the plugin leaves it there and the host cannot name what its `success` means. It now carries emphasis rather than a health hue, still distinct from `default`. The `PluginPanelBadgeColor` type keeps its `success` member; only the paint changed.
- `FileStageRow` — the standing staged-row wash. The git status letters, insertion counts, viewed mark and stage control all stay: notation, and one mark per checklist item.
- `IssuePickerDialog` — attached is membership. The success ring became a real border on a restructured branch rather than a class competing with `border-transparent`.
- `WorktreeMenuItems` — environment selection and the launch/resume glyphs.
- `TerminalHeaderContent` — the completed chip. Completed and exited now share neutral chrome and stay apart on glyph and hue (`CheckCircle2` in slate against `ExitedCircle` in secondary).
- `QuickSwitcherItem` — worktree is a category.
- `EnvironmentPopover` — the branch conflates running, healthy, ready and up, on the card trigger as well as the popover label.
- `ProjectPulseCard`, `ProjectPulseStrip` — decorative Activity icons. The ruling listed these under PR1's bucket, but that PR never touched a Pulse file.
- `GitHubSettingsTab` — the standing "GitHub connected" line. The masked field and Clear control already say a token exists.
- `ReEntrySummary` — the left rule was green whenever nothing was urgent, which is the ambient-health branch by definition, including for an all-info summary.
- `AgentSetupWizard` — the completion cards carried the same row wash #12034 removed from `AgentCliStep`, in the same wizard.
- `ArtifactOverlay` — the patch type badge is category identity; matching the patch body does not make a label into notation.
- `AgentCard` — "Installed" is membership on a list of optional alternatives, the same reason the ruling took "Ready" off the Settings agent list.
- `DiffFileSidebar` — the aggregate viewed bar is the checklist's completion summary, and a summary on a repeatedly-opened surface is neutral.

## Retokened to `activity-working`

Live process state keeps its green but stops being spelled the same way as "succeeded": `PluginMcpServersSection`, `McpServerSettingsTab`, `DaintreeAssistantSettingsTab`, `DevServerIndicator`, `RunningTaskList`'s running dot, and `projectRowStatus`'s `running` tone in both the class and the mark-colour map. The tokens resolve to adjacent hues, so this is a semantic move rather than a visible one.

Clipboard flashes stay on `status-success` — a finished copy is a transient confirmation, not a live operation, and retokening it would be semantically false.

## Enforcement

- **`InlineStatusBanner`** — `severity="success"` now requires `autoDismissAfter` and `onClose` at the type level, so a success banner that never says how it leaves does not compile. The type can require a number but not a positive one, so dev builds warn about `autoDismissAfter={0}` rather than pretending the type closed it. `BlockedNavBanner`'s computed severity needed its success case split out, which surfaced a reducer bug: `BLOCKED` coalescing preserved every non-blocked phase including terminal ones, so a navigation blocked inside the new dismiss window inherited `oauth-completed` and got torn down by the previous banner's timer.
- **`statusSuccessGuard.contract.test.ts`** — an occurrence-level contract test over `src/` and the builtin plugin renderers. It parses with the TypeScript AST (so a `status-success` in a comment is not a site) and keys each of the 124 remaining paint sites by signature plus an anchor where a signature repeats in one file, each declaring `transient` / `verification` / `outcome` / `domain` / `affordance` with a rationale. No file allowlist, no pre-existing bucket. It fails on a new green, a second green in a file that already has approved ones, a stale entry, a site claimed by two entries, and the site/occurrence ratchets.
- **`docs/themes/status-success-policy.md`** — the rule, the categories, the demotion vocabulary, and an explicit account of what the guard cannot see.

## One thing to push back on

`affordance` is a fifth category the ruling did not name. It covers the affirmative half of a control pair — run, apply, stage, resume, save, retry — where green means "go" rather than "good". Those controls report no state, so none of the four ruled categories fits them honestly, and they were never in the ruling's demote list. Folding them into `domain` would have quietly restated what that word meant, so they are named separately instead. If they should go neutral, deleting the category makes the guard list every site to fix.

## Testing

13,197 targeted tests pass across every touched module, plus the GitHub plugin renderer suite. `tsc --noEmit` clean; eslint and prettier clean on all changed files. New coverage: the guard's own scanner/anchor self-tests, a fake-timer test proving a success banner fires `onClose`, a dev-warning test for a duration that never fires, `@ts-expect-error` coverage for every incomplete success banner, and a `blockedNavReducer` sequence test for phase coalescing.

The guard was negative-tested in both directions, and after rebasing it caught an "Approved" mark that landed on develop from another PR — the first site it has flagged that this series did not write. Classified as an `outcome` and kept.

Neutral vocabulary is the current semantic spelling (`border-border-default`, `text-text-secondary`, `bg-overlay-subtle`), not PR1's legacy `daintree-*` forms, because the per-rule eslint ratchet fails on any increase and this change has no offsetting removals.

Resolves #12002
