### PR TITLE
Reorganize the worktree card menu into intent-based submenus

### DIFF
--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -132,7 +132,7 @@ Default keyboard shortcuts shipped with Daintree. This page lists defaults only 
 | Action | macOS | Windows/Linux |
 | --- | --- | --- |
 | Dock all sessions in active worktree | `⌘+K ⌘+M` | `Ctrl+K Ctrl+M` |
-| Maximize all sessions in active worktree | `⌘+K ⌘+X` | `Ctrl+K Ctrl+X` |
+| Move all sessions to grid in active worktree | `⌘+K ⌘+X` | `Ctrl+K Ctrl+X` |
 | Reset renderers for all sessions in active worktree | `⌘+K ⌘+V` | `Ctrl+K Ctrl+V` |
 
 ## Panels

--- a/e2e/full/panels/core-review-hub-conflicts.spec.ts
+++ b/e2e/full/panels/core-review-hub-conflicts.spec.ts
@@ -31,13 +31,22 @@ async function openConflictReviewHub(ctx: AppContext) {
   // The card's inline "Open Review & Commit" button is gated on hasChanges,
   // which is 0 while a merge/rebase is in progress: WorktreeMonitor skips the
   // git status poll during an operation to avoid competing for index.lock
-  // (WorktreeMonitor.ts:1421). The actions-menu "Review & Commit" item is only
-  // gated on the handler being wired, so it's the reliable entry point here.
+  // (WorktreeMonitor.ts:1421). The actions-menu Review ▸ "Review worktree" item
+  // is only gated on the handler being wired, so it's the reliable entry point.
   const card = window.locator(SEL.worktree.mainCard);
   await expect(card).toBeVisible({ timeout: T_LONG });
   await card.locator(SEL.worktree.actionsMenu).click();
 
-  const reviewItem = window.getByRole("menuitem", { name: "Review & Commit" });
+  const reviewTrigger = window.getByRole("menuitem", { name: "Review", exact: true });
+  await expect(reviewTrigger).toBeVisible({ timeout: T_MEDIUM });
+  // Radix SubTriggers open on hover, but a hover dropped by Linux CI never
+  // mounts the child — click is the reliable fallback the rest of the suite
+  // uses too.
+  await reviewTrigger.hover();
+  const reviewItem = window.getByRole("menuitem", { name: "Review worktree", exact: true });
+  if (!(await reviewItem.isVisible().catch(() => false))) {
+    await reviewTrigger.click();
+  }
   await expect(reviewItem).toBeVisible({ timeout: T_MEDIUM });
   await reviewItem.click();
 

--- a/e2e/full/platform/oauth-loopback-flow.spec.ts
+++ b/e2e/full/platform/oauth-loopback-flow.spec.ts
@@ -518,12 +518,16 @@ test.describe.serial("E2E: OAuth Loopback Flow in Dev Preview", () => {
       // Verify we're on the project view
       await expect(worktreeCards().first()).toBeVisible({ timeout: T_LONG });
 
-      // Open dev-preview via worktree context menu → Launch → Open Dev Preview
+      // Open dev-preview via worktree context menu → Launch → Dev preview
       await worktreeCards().first().click({ button: "right" });
       const launchTrigger = w().locator('[role="menuitem"]', { hasText: /^Launch$/ });
       await expect(launchTrigger).toBeVisible({ timeout: T_SHORT });
       await launchTrigger.hover();
-      const devPreviewItem = w().locator('[role="menuitem"]', { hasText: "Open Dev Preview" });
+      const devPreviewItem = w().locator('[role="menuitem"]', { hasText: /^Dev preview$/ });
+      // A hover dropped by CI never mounts the submenu child; click reopens it.
+      if (!(await devPreviewItem.isVisible().catch(() => false))) {
+        await launchTrigger.click();
+      }
       await expect(devPreviewItem).toBeVisible({ timeout: T_SHORT });
       await devPreviewItem.click();
 

--- a/e2e/full/worktree/core-worktree-cards.spec.ts
+++ b/e2e/full/worktree/core-worktree-cards.spec.ts
@@ -139,7 +139,8 @@ test.describe.serial("Core: Worktree Cards", () => {
           await expect(window.getByRole("menuitem", { name })).toBeVisible({ timeout: T_SHORT });
         }
 
-        // Feature-only rows (absent on the main worktree card)
+        // Organize also renders on the sidebar main card (it can collapse);
+        // Delete is the genuinely feature-only row.
         await expect(window.getByRole("menuitem", { name: "Organize" })).toBeVisible();
         await expect(window.getByRole("menuitem", { name: /Delete worktree/i })).toBeVisible();
       });

--- a/e2e/full/worktree/core-worktree-cards.spec.ts
+++ b/e2e/full/worktree/core-worktree-cards.spec.ts
@@ -132,20 +132,44 @@ test.describe.serial("Core: Worktree Cards", () => {
         await actionsBtn.click();
       });
 
-      await test.step("Verify expected menu items are visible", async () => {
-        await expect(window.getByRole("menuitem", { name: "Launch" })).toBeVisible({
+      await test.step("Verify the intent-based root hierarchy is visible", async () => {
+        // The root is submenu triggers plus the destructive row — filesystem,
+        // session and card-organization commands live one level down now.
+        for (const name of ["Launch", "Open", "Sessions", "Copy"]) {
+          await expect(window.getByRole("menuitem", { name })).toBeVisible({ timeout: T_SHORT });
+        }
+
+        // Feature-only rows (absent on the main worktree card)
+        await expect(window.getByRole("menuitem", { name: "Organize" })).toBeVisible();
+        await expect(window.getByRole("menuitem", { name: /Delete worktree/i })).toBeVisible();
+      });
+
+      await test.step("Filesystem destinations live under Open", async () => {
+        const openTrigger = window.getByRole("menuitem", { name: "Open", exact: true });
+        // Hover doesn't reliably open Radix submenus on Linux CI; click does.
+        await openTrigger.click();
+        await expect(window.getByRole("menuitem", { name: "Open in editor" })).toBeVisible({
           timeout: T_SHORT,
         });
-        await expect(window.getByRole("menuitem", { name: "Sessions" })).toBeVisible();
-        await expect(window.getByRole("menuitem", { name: "Open in Editor" })).toBeVisible();
-        await expect(window.getByRole("menuitem", { name: "Reveal in Finder" })).toBeVisible();
 
-        // Feature-only items (not shown on main worktree card)
-        await expect(window.getByRole("menuitem", { name: "Pin to Top" })).toBeVisible();
-        await expect(window.getByRole("menuitem", { name: /Delete Worktree/i })).toBeVisible();
+        // The exact label for THIS platform, not any of the three: accepting
+        // all of them everywhere would pass on "Show in Explorer" under macOS,
+        // which is the only failure the row can actually have.
+        const expectedRevealLabel =
+          process.platform === "darwin"
+            ? "Show in Finder"
+            : process.platform === "win32"
+              ? "Show in Explorer"
+              : "Show in file manager";
+        await expect(
+          window.getByRole("menuitem", { name: expectedRevealLabel, exact: true })
+        ).toBeVisible({ timeout: T_SHORT });
       });
 
       await test.step("Close the menu via Escape", async () => {
+        // One press, from inside the open submenu: Radix menus dismiss the
+        // whole stack on Escape (ArrowLeft is what closes just a submenu). A
+        // second press would fall through to the app's global Escape handler.
         await window.keyboard.press("Escape");
         await expect(window.locator('[role="menu"]')).toHaveCount(0, { timeout: T_SHORT });
       });
@@ -153,7 +177,7 @@ test.describe.serial("Core: Worktree Cards", () => {
 
     // The card's two menu surfaces are one item list rendered through two sets
     // of primitives, so they must present the same top-level menu. They drifted
-    // once (Browse Files was wired into the dropdown only), which no test caught
+    // once (Browse files was wired into the dropdown only), which no test caught
     // because both specs assert item labels one surface at a time. This compares
     // the surfaces to each other instead of to hardcoded expectations.
     test("right-click menu and actions dropdown present the same items", async () => {
@@ -221,7 +245,7 @@ test.describe.serial("Core: Worktree Cards", () => {
       ).toEqual([]);
     });
 
-    test("Launch submenu opens on hover and Open Terminal creates a panel", async () => {
+    test("Launch submenu opens on hover and Terminal creates a panel", async () => {
       const { window } = ctx;
       let panelsBefore = 0;
       const featureCard = window.locator(SEL.worktree.card(FEATURE));
@@ -233,12 +257,12 @@ test.describe.serial("Core: Worktree Cards", () => {
         await actionsBtn.click();
       });
 
-      await test.step("Hover Launch submenu and click Open Terminal", async () => {
+      await test.step("Hover Launch submenu and click Terminal", async () => {
         const launchTrigger = window.getByRole("menuitem", { name: "Launch" });
         await expect(launchTrigger).toBeVisible({ timeout: T_SHORT });
         await launchTrigger.hover();
 
-        const openTerminal = window.getByRole("menuitem", { name: "Open Terminal" });
+        const openTerminal = window.getByRole("menuitem", { name: "Terminal", exact: true });
         await expect(openTerminal).toBeVisible({ timeout: T_SHORT });
         await openTerminal.click();
       });
@@ -283,7 +307,7 @@ test.describe.serial("Core: Worktree Cards", () => {
       const mainCard = window.locator(SEL.worktree.mainCard);
 
       await test.step("Select feature worktree and confirm panels are present", async () => {
-        // Feature card should have at least 1 panel from the Open Terminal test
+        // Feature card should have at least 1 panel from the Launch ▸ Terminal test
         await featureCard.click({ position: { x: 10, y: 10 } });
         await expect(window.locator(SEL.worktree.row(FEATURE))).toHaveAttribute(
           "aria-current",

--- a/e2e/full/worktree/core-worktree-session-bulk.spec.ts
+++ b/e2e/full/worktree/core-worktree-session-bulk.spec.ts
@@ -55,17 +55,21 @@ test.describe.serial("Core: Worktree Session Bulk", () => {
       .toContain(`${count}active`);
   }
 
-  async function expectSessionsItemCount(name: string | RegExp, count: number) {
+  // Two assertions because there are two channels: the count reaches assistive
+  // tech through the item's accessible name, and a sighted user through the
+  // aria-hidden trailing slot. `exact` is load-bearing — Playwright string
+  // names match as substrings, so a bare ", 3" would also accept ", 30".
+  async function expectSessionsItemCount(label: string, count: number) {
     const { window } = ctx;
-    const item = window.getByRole("menuitem", { name });
-    await expect(item).toBeVisible({ timeout: T_SHORT });
-    await expect(item).toContainText(`(${count})`, { timeout: T_LONG });
+    const item = window.getByRole("menuitem", { name: `${label}, ${count}`, exact: true });
+    await expect(item).toBeVisible({ timeout: T_LONG });
     await expect(item).not.toHaveAttribute("aria-disabled", "true", { timeout: T_LONG });
+    await expect(item).toContainText(String(count));
   }
 
-  async function clickSessionsItem(name: string | RegExp) {
+  async function clickSessionsItem(name: string) {
     const { window } = ctx;
-    const item = window.getByRole("menuitem", { name });
+    const item = window.getByRole("menuitem", { name, exact: true });
     await expect(item).toBeVisible({ timeout: T_SHORT });
     await expect(item).not.toHaveAttribute("aria-disabled", "true", { timeout: T_LONG });
     await item.click();
@@ -96,23 +100,23 @@ test.describe.serial("Core: Worktree Session Bulk", () => {
 
     await expectWorktreeSessionSummary(3);
     await openSessionsSubmenu();
-    await expectSessionsItemCount(/Dock All/, 3);
-    await clickSessionsItem(/Dock All/);
+    await expectSessionsItemCount("Dock all panels", 3);
+    await clickSessionsItem("Dock all panels, 3");
 
     await expect.poll(() => getGridPanelCount(window), { timeout: T_LONG }).toBe(0);
     await expect.poll(() => getDockPanelCount(window), { timeout: T_LONG }).toBe(3);
     await expectWorktreeSessionSummary(3);
   });
 
-  test("maximize all sessions", async () => {
+  test("move all sessions back to the grid", async () => {
     const { window } = ctx;
 
     await window.waitForTimeout(T_SETTLE);
 
     await expectWorktreeSessionSummary(3);
     await openSessionsSubmenu();
-    await expectSessionsItemCount(/Maximize All/, 3);
-    await clickSessionsItem(/Maximize All/);
+    await expectSessionsItemCount("Move all to grid", 3);
+    await clickSessionsItem("Move all to grid, 3");
 
     await expect.poll(() => getGridPanelCount(window), { timeout: T_LONG }).toBe(3);
     await expect.poll(() => getDockPanelCount(window), { timeout: T_LONG }).toBe(0);

--- a/e2e/screenshots/review-hub-states-review.spec.ts
+++ b/e2e/screenshots/review-hub-states-review.spec.ts
@@ -437,10 +437,14 @@ test("review hub states review — the states around the populated review flow",
       } else {
         await featureCard.click({ button: "right" });
         await page.locator('[role="menu"]').waitFor({ state: "visible", timeout: T_MEDIUM });
-        await page
-          .getByRole("menuitem", { name: /Review & Commit/i })
-          .first()
-          .click();
+        const reviewTrigger = page.getByRole("menuitem", { name: /^Review$/ }).first();
+        const reviewItem = page.getByRole("menuitem", { name: /^Review worktree$/ }).first();
+        // Hover opens the submenu, but a dropped hover never mounts the child.
+        await reviewTrigger.hover();
+        if (!(await reviewItem.isVisible().catch(() => false))) {
+          await reviewTrigger.click();
+        }
+        await reviewItem.click();
       }
       await hub.waitFor({ state: "visible", timeout: T_MEDIUM });
       await page.locator(CONTENT).waitFor({ state: "visible", timeout: T_MEDIUM });

--- a/e2e/screenshots/worktree-delete-dialog-review.spec.ts
+++ b/e2e/screenshots/worktree-delete-dialog-review.spec.ts
@@ -376,7 +376,7 @@ test("worktree-delete dialog review — every consequence tier", async () => {
     //    what the dialog actually counts.
     await step("terminals", async () => {
       for (let i = 0; i < 2; i++) {
-        await launchFromMenu(page, WT_CLEAN, /^Open Terminal$/);
+        await launchFromMenu(page, WT_CLEAN, /^Terminal$/);
         await settle(page, 2500);
         await dismissBlockingPalette(page);
       }
@@ -476,7 +476,7 @@ test("worktree-delete dialog review — every consequence tier", async () => {
     // LAST. Dev preview running — the other cascade the dialog discloses. Opened
     //     through the same Launch submenu so the real IPC session exists.
     await step("dev-preview", async () => {
-      await launchFromMenu(page, WT_CLEAN, /^Open Dev Preview$/);
+      await launchFromMenu(page, WT_CLEAN, /^Dev preview$/);
       await settle(page, 5000);
       await dismissBlockingPalette(page);
       await openDialog(page, WT_CLEAN);

--- a/electron/ipc/handlers/__tests__/systemShell.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/systemShell.handlers.test.ts
@@ -400,7 +400,7 @@ describe("system path-allowlist: tracked worktree roots", () => {
     cleanup();
   });
 
-  it("opens a worktree root that git reports (Reveal in Finder on worktree card)", async () => {
+  it("opens a worktree root that git reports (the worktree card menu's Open ▸ Show in Finder/Explorer/file manager)", async () => {
     gitServiceMock.listWorktrees.mockResolvedValue([
       worktreeRecord(PROJECT_ROOT, { isMainWorktree: true, branch: "develop" }),
       worktreeRecord(UNPREDICTED_WORKTREE),

--- a/shared/config/defaultKeybindings.ts
+++ b/shared/config/defaultKeybindings.ts
@@ -1121,7 +1121,7 @@ const CORE_KEYBINDINGS: KeybindingConfig[] = [
     combo: "Cmd+K Cmd+X",
     scope: "global",
     priority: 0,
-    description: "Maximize all sessions in active worktree",
+    description: "Move all sessions to grid in active worktree",
     category: "Worktree Sessions",
   },
   {

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -60,12 +60,14 @@ import {
   WorktreeMenuItems,
   type WorktreeMenuActions,
 } from "./WorktreeMenuItems";
+import type { MenuActionSourceValue } from "@/components/ui/menu-source";
 import { usePluginContextMenuItems } from "@/hooks/usePluginContextMenuItems";
 import type { WhenClauseContext } from "@shared/utils/whenClause";
 import { isAgentFleetActionEligible, isFleetArmEligible } from "@/store/fleetArmingStore";
 import { useWorktreeStatus } from "./WorktreeCard/hooks/useWorktreeStatus";
 import { useWorktreeDevServerSession } from "@/hooks/app/useWorktreeDevServerSession";
 import { computeChipState } from "./utils/computeChipState";
+import { devServerMenuState } from "./utils/devServerMenuState";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
 import { CHIP_LABELS, WorktreeStatusTick } from "./WorktreeCard/WorktreeStatusTick";
 
@@ -244,6 +246,15 @@ export function WorktreeCard({
   } = useWorktreeTerminals(worktree.id);
 
   const devServerSession = useWorktreeDevServerSession(worktree.id);
+
+  // `stopped` is ambiguous — a session the main process has already deleted
+  // broadcasts it too, and the renderer cache retains that snapshot. The
+  // panel's continued existence is the discriminator; see devServerMenuState.
+  const devServerPanelId = devServerSession?.panelId;
+  const devServerPanelExists = usePanelStore((state) =>
+    devServerPanelId ? state.panelsById[devServerPanelId] !== undefined : false
+  );
+  const devServerState = devServerMenuState(devServerSession, devServerPanelExists);
 
   const pluginMenuContext = useMemo<WhenClauseContext>(
     () => ({ worktreeId: worktree.id }),
@@ -434,6 +445,15 @@ export function WorktreeCard({
   const handleRestartDevServer = useCallback((worktreeId: string) => {
     safeFireAndForget(window.electron.devPreview.restartByWorktree({ worktreeId }), {
       context: "Restart dev server for worktree",
+    });
+  }, []);
+
+  // Same IPC as restart, different promise to the user. A stopped session still
+  // has its panel and manifest, so reviving it is a start — the menu says so
+  // rather than offering a "Restart" that starts and a "Stop" that no-ops.
+  const handleStartDevServer = useCallback((worktreeId: string) => {
+    safeFireAndForget(window.electron.devPreview.restartByWorktree({ worktreeId }), {
+      context: "Start dev server for worktree",
     });
   }, []);
 
@@ -744,12 +764,16 @@ export function WorktreeCard({
     };
   }, []);
 
-  const handleOpenPanelPalette = () => {
+  // Selecting first is load-bearing: whatever the launcher creates lands in the
+  // active worktree's bucket, so without it a pick from an inactive card's menu
+  // would spawn against the previously active worktree.
+  //
+  // The source is resolved by `WorktreeMenuItems` (which IS inside the menu
+  // Root) and handed back here, so the dropdown dispatches as `menu` and the
+  // right-click surface as `context-menu` instead of both claiming the latter.
+  const handleOpenPanelPalette = (source: MenuActionSourceValue) => {
     useWorktreeSelectionStore.getState().setActiveWorktree(worktree.id);
-    void actionService.dispatch("panel.palette", undefined, {
-      // eslint-disable-next-line no-restricted-syntax -- context-menu-source: hardcoded because callback lives outside the ContextMenu Root (see #8322)
-      source: "context-menu",
-    });
+    void actionService.dispatch("panel.palette", undefined, { source });
   };
 
   // One action set drives both menu surfaces — the card's right-click menu and
@@ -777,6 +801,7 @@ export function WorktreeCard({
     onOpenIssueExternal: worktree.issueNumber ? handleOpenIssueExternal : undefined,
     onOpenPRExternal: worktree.linked?.pr?.url ? handleOpenPRExternal : undefined,
     onAttachIssue: () => setShowIssuePicker(true),
+    onUnlinkIssue: worktree.issueNumber ? handleDetachIssue : undefined,
     onViewPlan: openPlanFileForThisWorktree,
     // Gated on the change list, not `hasChanges` (a `changedFileCount` read):
     // an external git provider may report a count with no per-file entries, and
@@ -818,6 +843,8 @@ export function WorktreeCard({
     onResourceConnect: worktree.resourceConnectCommand ? handleResourceConnect : undefined,
     onResourceStatus: hasStatusCommand ? handleResourceStatus : undefined,
     onResourceTeardown: hasTeardownCommand ? handleResourceTeardown : undefined,
+    devServerState,
+    onStartDevServer: handleStartDevServer,
     onStopDevServer: handleStopDevServer,
     onRestartDevServer: handleRestartDevServer,
     pluginItems,
@@ -1250,7 +1277,7 @@ export function WorktreeCard({
                   <WorktreeTerminalSection
                     variant={variant}
                     worktreeId={worktree.id}
-                    onStartSession={handleOpenPanelPalette}
+                    onStartSession={() => handleOpenPanelPalette("user")}
                     isExpanded={isTerminalsExpanded}
                     counts={terminalCounts}
                     terminals={worktreeTerminals}

--- a/src/components/Worktree/WorktreeCard/WorktreeActionsToolbar.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeActionsToolbar.tsx
@@ -11,6 +11,9 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuLabel,
+  DropdownMenuMeta,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuSeparator,
   DropdownMenuShortcut,
   DropdownMenuSub,
@@ -20,14 +23,18 @@ import {
 } from "../../ui/dropdown-menu";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../../ui/tooltip";
 
-const DROPDOWN_COMPONENTS: WorktreeMenuComponents = {
+/** Exported so a test can mount the menu through the real dropdown primitives. */
+export const DROPDOWN_COMPONENTS: WorktreeMenuComponents = {
   Item: DropdownMenuItem,
   Label: DropdownMenuLabel,
   Separator: DropdownMenuSeparator,
   Shortcut: DropdownMenuShortcut,
+  Meta: DropdownMenuMeta,
   Sub: DropdownMenuSub,
   SubTrigger: DropdownMenuSubTrigger,
   SubContent: DropdownMenuSubContent,
+  RadioGroup: DropdownMenuRadioGroup,
+  RadioItem: DropdownMenuRadioItem,
 };
 
 interface WorktreeActionsToolbarProps {

--- a/src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx
@@ -25,6 +25,7 @@ import {
 import { actionService } from "@/services/ActionService";
 import type { ComputedSubtitle, WorktreeReviewState } from "./hooks/useWorktreeStatus";
 import { SECTION_LABEL, CARD_DENSITY } from "./sectionChrome";
+import { resourceLifecycleVisibility } from "../utils/resourceLifecycle";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import {
   ContextMenu,
@@ -184,17 +185,13 @@ export function WorktreeDetailsSection(props: WorktreeDetailsSectionProps) {
     }
   };
 
-  const rsLower = resourceStatus?.toLowerCase();
-  const showResourceResume =
-    hasResourceConfig &&
-    (!rsLower ||
-      rsLower === "paused" ||
-      rsLower === "stopped" ||
-      rsLower === "unknown" ||
-      rsLower === "terminated" ||
-      rsLower === "down");
-  const showResourcePause = hasResourceConfig && (rsLower === "running" || rsLower === "starting");
-  const showResourceConnect = hasResourceConfig && !!onResourceConnect && rsLower === "running";
+  // Same rule the worktree menu's Runtime ▸ Environment section applies, so the
+  // inline controls and the menu can never disagree about whether this
+  // environment is resumable or pausable.
+  const lifecycle = resourceLifecycleVisibility(resourceStatus);
+  const showResourceResume = hasResourceConfig && lifecycle.showResume;
+  const showResourcePause = hasResourceConfig && lifecycle.showPause;
+  const showResourceConnect = hasResourceConfig && !!onResourceConnect && lifecycle.showConnect;
 
   const isSidebar = variant === "sidebar";
   const density = CARD_DENSITY[isSidebar ? "sidebar" : "grid"];

--- a/src/components/Worktree/WorktreeCard/hooks/__tests__/useWorktreeActions.test.tsx
+++ b/src/components/Worktree/WorktreeCard/hooks/__tests__/useWorktreeActions.test.tsx
@@ -91,6 +91,53 @@ describe("useWorktreeActions — confirmed call-site dispatch (#11345)", () => {
     );
   });
 
+  it("dispatches trashAll with confirmed:true only after the local dialog is confirmed", () => {
+    // The reversible half of the destructive pair. Its own confirm gate lives
+    // in the action body too, so a call site that forgot `confirmed` would
+    // route through the app-level pending dialog and prompt a second time.
+    const { result } = renderActions();
+
+    act(() => {
+      result.current.handleCloseAll();
+    });
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(result.current.confirmDialog.isOpen).toBe(true);
+
+    act(() => {
+      if (result.current.confirmDialog.isOpen) result.current.confirmDialog.onConfirm();
+    });
+
+    expect(dispatch).toHaveBeenCalledWith(
+      "worktree.sessions.trashAll",
+      { worktreeId: "wt-1", confirmed: true },
+      { source: "user" }
+    );
+  });
+
+  it("keeps trashing and terminating on separate actions, so the reversible one stays reversible", () => {
+    // Swapping the two callbacks would leave every label and every count
+    // correct while turning "Trash all sessions" into permanent termination.
+    const { result } = renderActions();
+
+    act(() => {
+      result.current.handleCloseAll();
+    });
+    act(() => {
+      if (result.current.confirmDialog.isOpen) result.current.confirmDialog.onConfirm();
+    });
+    act(() => {
+      result.current.handleTerminateAll();
+    });
+    act(() => {
+      if (result.current.confirmDialog.isOpen) result.current.confirmDialog.onConfirm();
+    });
+
+    expect(dispatch.mock.calls.map((call) => call[0])).toEqual([
+      "worktree.sessions.trashAll",
+      "worktree.sessions.endAll",
+    ]);
+  });
+
   it("dispatches clearHistory with confirmed:true only after the local dialog is confirmed", () => {
     const { result } = renderActions();
 

--- a/src/components/Worktree/WorktreeMenuItems.tsx
+++ b/src/components/Worktree/WorktreeMenuItems.tsx
@@ -657,7 +657,7 @@ export function WorktreeMenuItems({
       ].filter(Boolean)
     : [];
 
-  const teardownRow = !isLocalEnvironment && onResourceTeardown && (
+  const teardownRow = hasResourceConfig && !isLocalEnvironment && onResourceTeardown && (
     <C.Item key="teardown" onSelect={onResourceTeardown} destructive>
       <Trash2 className={ICON} />
       Tear down environment…

--- a/src/components/Worktree/WorktreeMenuItems.tsx
+++ b/src/components/Worktree/WorktreeMenuItems.tsx
@@ -1,8 +1,12 @@
+import { Fragment } from "react";
 import type * as React from "react";
 import type { WorktreeState } from "../../types";
 import {
   ContextMenuItem,
   ContextMenuLabel,
+  ContextMenuMeta,
+  ContextMenuRadioGroup,
+  ContextMenuRadioItem,
   ContextMenuSeparator,
   ContextMenuShortcut,
   ContextMenuSub,
@@ -13,14 +17,12 @@ import {
   Activity,
   ArrowDown,
   ArrowUp,
-  CircleDot,
+  CheckSquare,
   Clock,
   Code,
   Copy,
   FileDiff,
   FileText,
-  Folder,
-  FolderTree,
   GitBranch,
   GitCommitHorizontal,
   GitCompare,
@@ -28,14 +30,13 @@ import {
   Globe,
   History,
   LayoutGrid,
-  Layers,
   Link,
   MonitorPlay,
   OctagonX,
-  CheckSquare,
-  Maximize2,
+  PanelBottomClose,
   PanelTopClose,
   PanelTopOpen,
+  Pause,
   Pin,
   PinOff,
   Play,
@@ -43,29 +44,49 @@ import {
   RefreshCw,
   Save,
   Server,
-  PanelBottomClose,
-  Pause,
-  SquareTerminal,
   Square,
+  SquareTerminal,
   Trash2,
   Zap,
 } from "lucide-react";
-import { Folders, Workflow } from "@/components/icons";
+import {
+  ArrowUpDown,
+  CircleDot,
+  FolderOpen,
+  Folders,
+  FolderTree,
+  Layers,
+  Link2Off,
+  Package,
+  Plus,
+  ServerCog,
+  Workflow,
+} from "@/components/icons";
 import { copyableBranchName, isExternalWorktree } from "@/lib/worktreeFilters";
-import { PluginContextMenuSection } from "@/components/Plugin/PluginContextMenuSection";
+import { fileManagerRevealLabel } from "@/lib/platform";
+import { useMenuActionSource, type MenuActionSourceValue } from "@/components/ui/menu-source";
+import { actionService } from "@/services/ActionService";
+import { resourceLifecycleVisibility } from "./utils/resourceLifecycle";
 import type { PluginContextMenuItemEntry } from "@/hooks/usePluginContextMenuItems";
 
 type MenuComponent = React.ElementType;
 type LaunchAgentIcon = React.ComponentType<{ className?: string }>;
 
+const ICON = "w-3.5 h-3.5 mr-2";
+
 export interface WorktreeMenuComponents {
   Item: MenuComponent;
   Label: MenuComponent;
   Separator: MenuComponent;
+  /** Real keybinding hints only. Counts and reasons belong in `Meta`. */
   Shortcut: MenuComponent;
+  /** Trailing muted slot for counts, state and disabled reasons. */
+  Meta: MenuComponent;
   Sub: MenuComponent;
   SubTrigger: MenuComponent;
   SubContent: MenuComponent;
+  RadioGroup: MenuComponent;
+  RadioItem: MenuComponent;
 }
 
 export const CONTEXT_COMPONENTS: WorktreeMenuComponents = {
@@ -73,9 +94,12 @@ export const CONTEXT_COMPONENTS: WorktreeMenuComponents = {
   Label: ContextMenuLabel,
   Separator: ContextMenuSeparator,
   Shortcut: ContextMenuShortcut,
+  Meta: ContextMenuMeta,
   Sub: ContextMenuSub,
   SubTrigger: ContextMenuSubTrigger,
   SubContent: ContextMenuSubContent,
+  RadioGroup: ContextMenuRadioGroup,
+  RadioItem: ContextMenuRadioItem,
 };
 
 export interface WorktreeLaunchAgentItem {
@@ -84,6 +108,16 @@ export interface WorktreeLaunchAgentItem {
   isEnabled: boolean;
   icon?: LaunchAgentIcon;
 }
+
+/**
+ * What Daintree can truthfully offer for this worktree's dev server.
+ *
+ * `restorable` is the state the old menu lied about: a session record exists
+ * but nothing is running, so "Restart" was really a start and "Stop" was a
+ * no-op row. The distinction is the whole reason this is three states rather
+ * than a boolean.
+ */
+export type WorktreeDevServerMenuState = "running" | "restorable" | "none";
 
 export interface WorktreeMenuItemsProps {
   worktree: WorktreeState;
@@ -95,6 +129,7 @@ export interface WorktreeMenuItemsProps {
   counts: {
     grid: number;
     dock: number;
+    /** Live PTY-bearing panels for this worktree. */
     active: number;
     completed: number;
     all: number;
@@ -115,6 +150,7 @@ export interface WorktreeMenuItemsProps {
   onOpenIssueExternal?: () => void;
   onOpenPRExternal?: () => void;
   onAttachIssue?: () => void;
+  onUnlinkIssue?: () => void;
   onViewPlan?: () => void;
   /** Omitted when the worktree has no changes, so the item is absent then. */
   onOpenChanges?: () => void;
@@ -135,7 +171,12 @@ export interface WorktreeMenuItemsProps {
   onCloseAll: () => void;
   onTerminateAll: () => void;
   onClearHistory: () => void;
-  onOpenPanelPalette?: () => void;
+  /**
+   * Receives the resolved surface source. The callback lives in the card body,
+   * outside any menu Root, so it can't resolve `menu` vs `context-menu` itself
+   * (#8322) — this component is inside the Root and passes it down.
+   */
+  onOpenPanelPalette?: (source: MenuActionSourceValue) => void;
   onDeleteWorktree?: () => void;
   hasResourceConfig?: boolean;
   worktreeMode?: string;
@@ -148,6 +189,8 @@ export interface WorktreeMenuItemsProps {
   onResourceConnect?: () => void;
   onResourceStatus?: () => void;
   onResourceTeardown?: () => void;
+  devServerState?: WorktreeDevServerMenuState;
+  onStartDevServer?: (worktreeId: string) => void;
   onStopDevServer?: (worktreeId: string) => void;
   onRestartDevServer?: (worktreeId: string) => void;
   pluginItems?: PluginContextMenuItemEntry[];
@@ -162,6 +205,27 @@ export type WorktreeMenuActions = Omit<
   WorktreeMenuItemsProps,
   "components" | "worktree" | "isPinned"
 >;
+
+/** Drops the `false`/`undefined` slots a conditional row leaves behind. */
+function compact(...nodes: Array<React.ReactNode | false | undefined>): React.ReactNode[] {
+  return nodes.filter((node): node is React.ReactNode => Boolean(node));
+}
+
+/**
+ * Joins the non-empty root groups with exactly one separator between them.
+ *
+ * The old menu scattered `{cond && <Separator/>}` through the JSX and relied on
+ * each optional group owning the rule after it — which still let a menu whose
+ * last group was absent end on an orphan rule. Deciding emptiness first and
+ * interleaving afterwards makes a leading, trailing or doubled separator
+ * unrepresentable rather than merely untested.
+ */
+function joinGroups(groups: React.ReactNode[][], Separator: MenuComponent): React.ReactNode[] {
+  const populated = groups.filter((group) => group.length > 0);
+  return populated.flatMap((group, index) =>
+    index === 0 ? group : [<Separator key={`sep-${index}`} />, ...group]
+  );
+}
 
 export function WorktreeMenuItems({
   worktree,
@@ -185,6 +249,7 @@ export function WorktreeMenuItems({
   onOpenIssueExternal,
   onOpenPRExternal,
   onAttachIssue,
+  onUnlinkIssue,
   onViewPlan,
   onOpenChanges,
   onOpenReviewHub,
@@ -210,429 +275,624 @@ export function WorktreeMenuItems({
   worktreeMode,
   resourceEnvironmentKeys,
   onSwitchEnvironment,
+  resourceStatus,
   onResourceProvision,
   onResourceResume,
   onResourcePause,
   onResourceConnect,
   onResourceStatus,
   onResourceTeardown,
+  devServerState = "none",
+  onStartDevServer,
   onStopDevServer,
   onRestartDevServer,
   pluginItems,
 }: WorktreeMenuItemsProps) {
-  const hasIssueItem = Boolean(worktree.issueNumber && onOpenIssueExternal);
-  const canCopyBranchName = copyableBranchName(worktree) !== null;
-  const hasPRItem = Boolean(worktree.linked?.pr && onOpenPRExternal);
-  const hasIssueOrPrSection = hasIssueItem || hasPRItem;
-  const hasRecipes = recipes.length > 0;
-  const hasRecipeSection = hasRecipes || (onSaveLayout && counts.active > 0);
-  const hasMoveSection = Boolean(onMoveUp || onMoveDown);
+  const source = useMenuActionSource();
 
-  return (
-    <>
-      {hasMoveSection && (
-        <>
-          <C.Item onSelect={onMoveUp} disabled={!onMoveUp || !canMoveUp}>
-            <ArrowUp className="w-3.5 h-3.5 mr-2" />
-            Move Up
-          </C.Item>
-          <C.Item onSelect={onMoveDown} disabled={!onMoveDown || !canMoveDown}>
-            <ArrowDown className="w-3.5 h-3.5 mr-2" />
-            Move Down
-          </C.Item>
-          <C.Separator />
-        </>
-      )}
+  /** A count is part of what the row does, so it belongs in the accessible
+   *  name too — the muted trailing slot is `aria-hidden` decoration. */
+  const counted = (label: string, count: number) => ({
+    "aria-label": `${label}, ${count}`,
+  });
 
-      {/* Launch submenu */}
-      <C.Sub>
-        <C.SubTrigger>
-          <SquareTerminal className="w-3.5 h-3.5 mr-2" />
-          Launch
-        </C.SubTrigger>
-        <C.SubContent>
-          {launchAgents.map((agent) => {
-            const Icon = agent.icon;
-            return (
-              <C.Item
-                key={agent.id}
-                onSelect={() => onLaunchAgent?.(agent.id)}
-                disabled={!onLaunchAgent || !agent.isEnabled}
-              >
-                {Icon ? (
-                  <Icon className="w-3.5 h-3.5 mr-2" />
-                ) : (
-                  <SquareTerminal className="w-3.5 h-3.5 mr-2" />
-                )}
-                {agent.name}
-              </C.Item>
-            );
-          })}
-          {launchAgents.length > 0 && <C.Separator />}
-          <C.Item onSelect={() => onLaunchAgent?.("terminal")} disabled={!onLaunchAgent}>
-            <SquareTerminal className="w-3.5 h-3.5 mr-2" />
-            Open Terminal
-          </C.Item>
-          <C.Item onSelect={() => onLaunchAgent?.("browser")} disabled={!onLaunchAgent}>
-            <Globe className="w-3.5 h-3.5 mr-2" />
-            Open Browser
-          </C.Item>
-          <C.Item onSelect={() => onLaunchAgent?.("dev-preview")} disabled={!onLaunchAgent}>
-            <MonitorPlay className="w-3.5 h-3.5 mr-2" />
-            Open Dev Preview
-          </C.Item>
-        </C.SubContent>
-      </C.Sub>
-
-      {/* Open Panel Palette (flat item) */}
-      {onOpenPanelPalette && (
-        <C.Item onSelect={onOpenPanelPalette}>
-          <LayoutGrid className="w-3.5 h-3.5 mr-2" />
-          Open Panel Palette
+  // ---------------------------------------------------------------- Launch
+  const hasAgentRows = launchAgents.length > 0;
+  const launchSub = (
+    <C.Sub key="launch">
+      <C.SubTrigger>
+        <SquareTerminal className={ICON} />
+        Launch
+      </C.SubTrigger>
+      <C.SubContent>
+        {hasAgentRows && <C.Label>Agents</C.Label>}
+        {launchAgents.map((agent) => {
+          const Icon = agent.icon ?? SquareTerminal;
+          // Never silently degrade to a plain terminal: an agent that isn't
+          // installed says so on the row rather than disappearing or launching
+          // something else, and the full launcher below carries the setup route.
+          return (
+            <C.Item
+              key={agent.id}
+              onSelect={() => onLaunchAgent?.(agent.id)}
+              disabled={!onLaunchAgent || !agent.isEnabled}
+              aria-label={agent.isEnabled ? agent.name : `${agent.name}, not installed`}
+            >
+              <Icon className={ICON} />
+              {agent.name}
+              {!agent.isEnabled && <C.Meta>Not installed</C.Meta>}
+            </C.Item>
+          );
+        })}
+        {hasAgentRows && <C.Separator />}
+        <C.Item onSelect={() => onLaunchAgent?.("terminal")} disabled={!onLaunchAgent}>
+          <SquareTerminal className={ICON} />
+          Terminal
         </C.Item>
-      )}
-
-      {/* Sessions submenu */}
-      <C.Sub>
-        <C.SubTrigger>
-          <Layers className="w-3.5 h-3.5 mr-2" />
-          Sessions
-        </C.SubTrigger>
-        <C.SubContent>
-          <C.Item onSelect={onDockAll} disabled={counts.grid === 0}>
-            <PanelBottomClose className="w-3.5 h-3.5 mr-2" />
-            Dock All
-            <C.Shortcut>({counts.grid})</C.Shortcut>
-          </C.Item>
-          <C.Item onSelect={onMaximizeAll} disabled={counts.dock === 0}>
-            <Maximize2 className="w-3.5 h-3.5 mr-2" />
-            Maximize All
-            <C.Shortcut>({counts.dock})</C.Shortcut>
-          </C.Item>
-          <C.Item onSelect={onCloseAll} disabled={counts.active === 0}>
-            <Trash2 className="w-3.5 h-3.5 mr-2" />
-            Close All
-            <C.Shortcut>({counts.active})</C.Shortcut>
-          </C.Item>
-          <C.Item onSelect={onTerminateAll} disabled={counts.active === 0}>
-            <OctagonX className="w-3.5 h-3.5 mr-2" />
-            Terminate All
-            <C.Shortcut>({counts.active})</C.Shortcut>
-          </C.Item>
-          <C.Item onSelect={onResetRenderers} disabled={counts.active === 0}>
-            <RefreshCw className="w-3.5 h-3.5 mr-2" />
-            Reset All Renderers
-            <C.Shortcut>({counts.active})</C.Shortcut>
-          </C.Item>
-
-          <C.Separator />
-
-          <C.Item onSelect={onClearHistory}>
-            <History className="w-3.5 h-3.5 mr-2" />
-            Clear Session History
-          </C.Item>
-
-          <C.Separator />
-
-          <C.Item onSelect={onSelectAllAgents} disabled={counts.all === 0}>
-            <CheckSquare className="w-3.5 h-3.5 mr-2" />
-            Select All Terminals
-            <C.Shortcut>({counts.all})</C.Shortcut>
-          </C.Item>
-          <C.Item onSelect={onSelectWaitingAgents} disabled={counts.waiting === 0}>
-            <Clock className="w-3.5 h-3.5 mr-2" />
-            Select Waiting Agents
-            <C.Shortcut>({counts.waiting})</C.Shortcut>
-          </C.Item>
-          <C.Item onSelect={onSelectWorkingAgents} disabled={counts.working === 0}>
-            <Zap className="w-3.5 h-3.5 mr-2" />
-            Select Working Agents
-            <C.Shortcut>({counts.working})</C.Shortcut>
-          </C.Item>
-        </C.SubContent>
-      </C.Sub>
-
-      <C.Separator />
-
-      {/* File access */}
-      {onOpenFileBrowser && (
-        <C.Item onSelect={onOpenFileBrowser}>
-          <FolderTree className="w-3.5 h-3.5 mr-2" />
-          Browse Files
+        <C.Item onSelect={() => onLaunchAgent?.("browser")} disabled={!onLaunchAgent}>
+          <Globe className={ICON} />
+          Browser
         </C.Item>
-      )}
-      <C.Item onSelect={onOpenEditor}>
-        <Code className="w-3.5 h-3.5 mr-2" />
-        Open in Editor
+        <C.Item onSelect={() => onLaunchAgent?.("dev-preview")} disabled={!onLaunchAgent}>
+          <MonitorPlay className={ICON} />
+          Dev preview
+        </C.Item>
+        {onOpenPanelPalette && (
+          <>
+            <C.Separator />
+            <C.Item onSelect={() => onOpenPanelPalette(source)}>
+              <Plus className={ICON} />
+              More agents and panels…
+            </C.Item>
+          </>
+        )}
+      </C.SubContent>
+    </C.Sub>
+  );
+
+  // ------------------------------------------------------------------ Open
+  const openSub = (
+    <C.Sub key="open">
+      <C.SubTrigger>
+        <FolderOpen className={ICON} />
+        Open
+      </C.SubTrigger>
+      <C.SubContent>
+        {onOpenFileBrowser && (
+          <C.Item onSelect={onOpenFileBrowser}>
+            <FolderTree className={ICON} />
+            Browse files
+          </C.Item>
+        )}
+        <C.Item onSelect={onOpenEditor}>
+          <Code className={ICON} />
+          Open in editor
+        </C.Item>
+        <C.Item onSelect={onRevealInFinder}>
+          <FolderOpen className={ICON} />
+          {fileManagerRevealLabel()}
+        </C.Item>
+      </C.SubContent>
+    </C.Sub>
+  );
+
+  // ---------------------------------------------------------------- Review
+  const changedFileCount = worktree.worktreeChanges?.changes.length ?? 0;
+  const reviewRows = [
+    onOpenReviewHub && (
+      <C.Item key="review-hub" onSelect={onOpenReviewHub}>
+        <GitCommitHorizontal className={ICON} />
+        Review worktree
       </C.Item>
+    ),
+    onOpenChanges && (
+      <C.Item
+        key="open-changes"
+        onSelect={onOpenChanges}
+        {...counted("View uncommitted changes", changedFileCount)}
+      >
+        <FileDiff className={ICON} />
+        View uncommitted changes
+        <C.Meta>{changedFileCount}</C.Meta>
+      </C.Item>
+    ),
+    onCompareDiff && (
+      <C.Item key="compare" onSelect={onCompareDiff}>
+        <GitCompare className={ICON} />
+        Compare with another worktree…
+      </C.Item>
+    ),
+  ].filter(Boolean);
 
-      <C.Separator />
+  const reviewSub = reviewRows.length > 0 && (
+    <C.Sub key="review">
+      <C.SubTrigger>
+        <GitCommitHorizontal className={ICON} />
+        Review
+      </C.SubTrigger>
+      <C.SubContent>{reviewRows}</C.SubContent>
+    </C.Sub>
+  );
 
-      {(onStopDevServer || onRestartDevServer) && (
-        <>
-          {onStopDevServer && (
-            <C.Item onSelect={() => onStopDevServer(worktree.id)}>
-              <Square className="w-3.5 h-3.5 mr-2" />
-              Stop Dev Server
+  // -------------------------------------------------------------- Sessions
+  const hasLivePanels = counts.active > 0;
+  const hasFleetTargets = counts.all > 0;
+  const sessionsSub = (
+    <C.Sub key="sessions">
+      <C.SubTrigger>
+        <Layers className={ICON} />
+        Sessions
+      </C.SubTrigger>
+      <C.SubContent>
+        {hasLivePanels && (
+          <>
+            <C.Label>Layout</C.Label>
+            <C.Item
+              onSelect={onDockAll}
+              disabled={counts.grid === 0}
+              {...counted("Dock all panels", counts.grid)}
+            >
+              <PanelBottomClose className={ICON} />
+              Dock all panels
+              <C.Meta>{counts.grid}</C.Meta>
             </C.Item>
-          )}
-          {onRestartDevServer && (
-            <C.Item onSelect={() => onRestartDevServer(worktree.id)}>
-              <RefreshCw className="w-3.5 h-3.5 mr-2" />
-              Restart Dev Server
+            <C.Item
+              onSelect={onMaximizeAll}
+              disabled={counts.dock === 0}
+              {...counted("Move all to grid", counts.dock)}
+            >
+              <LayoutGrid className={ICON} />
+              Move all to grid
+              <C.Meta>{counts.dock}</C.Meta>
             </C.Item>
-          )}
-          <C.Separator />
-        </>
-      )}
+          </>
+        )}
 
-      {/* Resource */}
-      {hasResourceConfig && (
-        <C.Sub>
-          <C.SubTrigger>
-            <Server className="w-3.5 h-3.5 mr-2" />
-            Resource
-          </C.SubTrigger>
-          <C.SubContent>
-            {resourceEnvironmentKeys && resourceEnvironmentKeys.length > 0 && (
+        {hasFleetTargets && (
+          <>
+            <C.Label>Fleet selection</C.Label>
+            <C.Item onSelect={onSelectAllAgents} {...counted("Select all terminals", counts.all)}>
+              <CheckSquare className={ICON} />
+              Select all terminals
+              <C.Meta>{counts.all}</C.Meta>
+            </C.Item>
+            <C.Item
+              onSelect={onSelectWaitingAgents}
+              disabled={counts.waiting === 0}
+              {...counted("Select waiting agents", counts.waiting)}
+            >
+              <Clock className={ICON} />
+              Select waiting agents
+              <C.Meta>{counts.waiting}</C.Meta>
+            </C.Item>
+            <C.Item
+              onSelect={onSelectWorkingAgents}
+              disabled={counts.working === 0}
+              {...counted("Select working agents", counts.working)}
+            >
+              <Zap className={ICON} />
+              Select working agents
+              <C.Meta>{counts.working}</C.Meta>
+            </C.Item>
+          </>
+        )}
+
+        {hasLivePanels && (
+          <>
+            <C.Label>Maintenance</C.Label>
+            <C.Item onSelect={onResetRenderers} {...counted("Redraw all terminals", counts.active)}>
+              <RefreshCw className={ICON} />
+              Redraw all terminals
+              <C.Meta>{counts.active}</C.Meta>
+            </C.Item>
+          </>
+        )}
+
+        {(hasLivePanels || hasFleetTargets) && <C.Separator />}
+
+        {/* Deletion, not repair: clearing history destroys journal records
+            permanently, so it sits with the destructive pair rather than beside
+            renderer maintenance. No count — availability isn't cached, and
+            opening a menu must not go and read the journal to find out. */}
+        <C.Item onSelect={onClearHistory}>
+          <History className={ICON} />
+          Clear session history…
+        </C.Item>
+        <C.Item
+          onSelect={onCloseAll}
+          disabled={counts.active === 0}
+          {...counted("Trash all sessions", counts.active)}
+        >
+          <Trash2 className={ICON} />
+          Trash all sessions…
+          <C.Meta>{counts.active}</C.Meta>
+        </C.Item>
+        <C.Item
+          onSelect={onTerminateAll}
+          disabled={counts.active === 0}
+          {...counted("Terminate all sessions", counts.active)}
+        >
+          <OctagonX className={ICON} />
+          Terminate all sessions…
+          <C.Meta>{counts.active}</C.Meta>
+        </C.Item>
+      </C.SubContent>
+    </C.Sub>
+  );
+
+  // --------------------------------------------------------------- Recipes
+  const hasRecipes = recipes.length > 0;
+  const canSaveLayout = Boolean(onSaveLayout) && counts.active > 0;
+  const recipesSub = (hasRecipes || canSaveLayout) && (
+    <C.Sub key="recipes">
+      <C.SubTrigger>
+        <Workflow className={ICON} />
+        Recipes
+      </C.SubTrigger>
+      <C.SubContent>
+        {hasRecipes && <C.Label>Run</C.Label>}
+        {recipes.map((recipe) => (
+          <C.Item
+            key={recipe.id}
+            onSelect={() => onRunRecipe(recipe.id)}
+            disabled={runningRecipeId !== null}
+            aria-label={
+              runningRecipeId !== null ? `${recipe.name}, a recipe is running` : recipe.name
+            }
+          >
+            {recipe.name}
+            {runningRecipeId !== null && <C.Meta>Recipe running</C.Meta>}
+          </C.Item>
+        ))}
+        {hasRecipes && canSaveLayout && <C.Separator />}
+        {canSaveLayout && (
+          <C.Item onSelect={onSaveLayout}>
+            <Save className={ICON} />
+            Save current layout as recipe…
+          </C.Item>
+        )}
+      </C.SubContent>
+    </C.Sub>
+  );
+
+  // --------------------------------------------------------------- Runtime
+  const hasEnvironments = Boolean(hasResourceConfig) && (resourceEnvironmentKeys?.length ?? 0) > 0;
+  const isLocalEnvironment = !worktreeMode || worktreeMode === "local";
+  const lifecycle = resourceLifecycleVisibility(resourceStatus);
+
+  const devServerRows = [
+    devServerState === "restorable" && onStartDevServer && (
+      <C.Item key="start" onSelect={() => onStartDevServer(worktree.id)}>
+        <Play className={ICON} />
+        Start dev server
+      </C.Item>
+    ),
+    devServerState === "running" && onRestartDevServer && (
+      <C.Item key="restart" onSelect={() => onRestartDevServer(worktree.id)}>
+        <RefreshCw className={ICON} />
+        Restart dev server
+      </C.Item>
+    ),
+    devServerState === "running" && onStopDevServer && (
+      <C.Item key="stop" onSelect={() => onStopDevServer(worktree.id)}>
+        <Square className={ICON} />
+        Stop dev server
+      </C.Item>
+    ),
+  ].filter(Boolean);
+
+  // Resource status is free-form text from the project's own status command, so
+  // it can narrow the pair of mutually-exclusive lifecycle rows but must never
+  // be the reason a configured command becomes unreachable: an unrecognized
+  // status shows both. `Check status`, `Connect` and `Provision` are never
+  // status-gated here — a configured command is always offered.
+  const showResume = lifecycle.isRecognized ? lifecycle.showResume : true;
+  const showPause = lifecycle.isRecognized ? lifecycle.showPause : true;
+
+  // In local mode the six remote commands are not "temporarily unavailable",
+  // they don't apply — so the section is just the switcher rather than a wall
+  // of disabled rows the user can't act on.
+  const environmentRows = hasResourceConfig
+    ? [
+        hasEnvironments && (
+          <C.Sub key="switch-env">
+            <C.SubTrigger>
+              <Server className={ICON} />
+              Switch environment
+            </C.SubTrigger>
+            <C.SubContent>
+              <C.RadioGroup
+                value={isLocalEnvironment ? "local" : worktreeMode}
+                onValueChange={(value: string) => onSwitchEnvironment?.(value)}
+              >
+                <C.RadioItem value="local" disabled={!onSwitchEnvironment}>
+                  Local
+                </C.RadioItem>
+                {/* Settings only rejects blank and duplicate environment names,
+                    so a key literally called "local" is representable — and it
+                    would render a second radio carrying the fixed row's value,
+                    leaving two items marked checked. The fixed row already
+                    selects it. */}
+                {resourceEnvironmentKeys
+                  ?.filter((key) => key !== "local")
+                  .map((key) => (
+                    <C.RadioItem key={key} value={key} disabled={!onSwitchEnvironment}>
+                      {key}
+                    </C.RadioItem>
+                  ))}
+              </C.RadioGroup>
+            </C.SubContent>
+          </C.Sub>
+        ),
+        !isLocalEnvironment && onResourceStatus && (
+          <C.Item key="status" onSelect={onResourceStatus}>
+            <Activity className={ICON} />
+            Check status
+          </C.Item>
+        ),
+        !isLocalEnvironment && onResourceConnect && (
+          <C.Item key="connect" onSelect={onResourceConnect}>
+            <Plug className={`${ICON} text-status-info`} />
+            Connect
+          </C.Item>
+        ),
+        !isLocalEnvironment && onResourceProvision && (
+          <C.Item key="provision" onSelect={onResourceProvision}>
+            <Play className={ICON} />
+            Provision
+          </C.Item>
+        ),
+        !isLocalEnvironment && onResourceResume && showResume && (
+          <C.Item key="resume" onSelect={onResourceResume}>
+            <Play className={`${ICON} text-status-success`} />
+            Resume
+          </C.Item>
+        ),
+        !isLocalEnvironment && onResourcePause && showPause && (
+          <C.Item key="pause" onSelect={onResourcePause}>
+            <Pause className={ICON} />
+            Pause
+          </C.Item>
+        ),
+      ].filter(Boolean)
+    : [];
+
+  const teardownRow = !isLocalEnvironment && onResourceTeardown && (
+    <C.Item key="teardown" onSelect={onResourceTeardown} destructive>
+      <Trash2 className={ICON} />
+      Tear down environment…
+    </C.Item>
+  );
+
+  const hasEnvironmentSection = environmentRows.length > 0 || Boolean(teardownRow);
+  const runtimeSub = (devServerRows.length > 0 || hasEnvironmentSection) && (
+    <C.Sub key="runtime">
+      <C.SubTrigger>
+        <ServerCog className={ICON} />
+        Runtime
+      </C.SubTrigger>
+      <C.SubContent>
+        {devServerRows.length > 0 && (
+          <>
+            <C.Label>Dev server</C.Label>
+            {devServerRows}
+          </>
+        )}
+        {hasEnvironmentSection && (
+          <>
+            <C.Label>Environment</C.Label>
+            {environmentRows}
+            {teardownRow && environmentRows.length > 0 && <C.Separator />}
+            {teardownRow}
+          </>
+        )}
+      </C.SubContent>
+    </C.Sub>
+  );
+
+  // ----------------------------------------------------------- Linked work
+  const hasIssue = Boolean(worktree.issueNumber);
+  const hasIssueItem = hasIssue && Boolean(onOpenIssueExternal);
+  const hasPRItem = Boolean(worktree.linked?.pr && onOpenPRExternal);
+  const linkedOpenRows = [
+    onViewPlan && (
+      <C.Item key="plan" onSelect={onViewPlan}>
+        <FileText className={ICON} />
+        View plan
+      </C.Item>
+    ),
+    hasIssueItem && (
+      <C.Item key="issue" onSelect={onOpenIssueExternal}>
+        <CircleDot className={ICON} />
+        Open issue #{worktree.issueNumber}
+      </C.Item>
+    ),
+    hasPRItem && (
+      <C.Item key="pr" onSelect={onOpenPRExternal}>
+        <GitPullRequest className={ICON} />
+        Open PR #{worktree.linked?.pr?.ref.number}
+      </C.Item>
+    ),
+  ].filter(Boolean);
+
+  const linkedAssociationRows = [
+    onAttachIssue && (
+      <C.Item key="attach" onSelect={onAttachIssue}>
+        <Link className={ICON} />
+        {hasIssue ? "Change linked issue…" : "Attach issue…"}
+      </C.Item>
+    ),
+    hasIssue && onUnlinkIssue && (
+      <C.Item key="unlink" onSelect={onUnlinkIssue}>
+        <Link2Off className={ICON} />
+        Unlink issue #{worktree.issueNumber}
+      </C.Item>
+    ),
+  ].filter(Boolean);
+
+  const linkedWorkSub = (linkedOpenRows.length > 0 || linkedAssociationRows.length > 0) && (
+    <C.Sub key="linked-work">
+      <C.SubTrigger>
+        <Link className={ICON} />
+        Linked work
+      </C.SubTrigger>
+      <C.SubContent>
+        {linkedOpenRows}
+        {linkedOpenRows.length > 0 && linkedAssociationRows.length > 0 && <C.Separator />}
+        {linkedAssociationRows}
+      </C.SubContent>
+    </C.Sub>
+  );
+
+  // ------------------------------------------------------------------ Copy
+  const canCopyBranchName = copyableBranchName(worktree) !== null;
+  const copySub = (
+    <C.Sub key="copy">
+      <C.SubTrigger>
+        <Copy className={ICON} />
+        Copy
+      </C.SubTrigger>
+      <C.SubContent>
+        <C.Item onSelect={onCopyContextFull}>
+          <Folders className={ICON} />
+          Full context
+        </C.Item>
+        <C.Item onSelect={onCopyContextModified}>
+          <FileDiff className={ICON} />
+          Modified files only
+        </C.Item>
+        <C.Separator />
+        <C.Item onSelect={onCopyPath}>
+          <Copy className={ICON} />
+          Path
+        </C.Item>
+        {canCopyBranchName && (
+          <C.Item onSelect={onCopyBranchName}>
+            <GitBranch className={ICON} />
+            Branch name
+          </C.Item>
+        )}
+      </C.SubContent>
+    </C.Sub>
+  );
+
+  // -------------------------------------------------------------- Organize
+  const canPin = Boolean(onTogglePin) && !worktree.isMainWorktree && !isExternalWorktree(worktree);
+  const hasMoveRows = Boolean(onMoveUp || onMoveDown);
+  const organizeSub = (canPin || onToggleCollapse || hasMoveRows) && (
+    <C.Sub key="organize">
+      <C.SubTrigger>
+        <ArrowUpDown className={ICON} />
+        Organize
+      </C.SubTrigger>
+      <C.SubContent>
+        {canPin && (
+          <C.Item onSelect={onTogglePin}>
+            {isPinned ? (
               <>
-                <C.Sub>
-                  <C.SubTrigger>
-                    <Server className="w-3.5 h-3.5 mr-2" />
-                    Environment
-                  </C.SubTrigger>
-                  <C.SubContent>
-                    {(() => {
-                      const isLocalSelected = !worktreeMode || worktreeMode === "local";
-                      return (
-                        <C.Item
-                          onSelect={() => onSwitchEnvironment?.("local")}
-                          disabled={!onSwitchEnvironment}
-                        >
-                          <CircleDot
-                            className={`w-3.5 h-3.5 mr-2 ${isLocalSelected ? "text-text-primary" : "opacity-0"}`}
-                          />
-                          Local
-                        </C.Item>
-                      );
-                    })()}
-                    {resourceEnvironmentKeys.map((key) => (
-                      <C.Item
-                        key={key}
-                        onSelect={() => onSwitchEnvironment?.(key)}
-                        disabled={!onSwitchEnvironment}
-                      >
-                        <CircleDot
-                          className={`w-3.5 h-3.5 mr-2 ${worktreeMode === key ? "text-text-primary" : "opacity-0"}`}
-                        />
-                        {key}
-                      </C.Item>
-                    ))}
-                  </C.SubContent>
-                </C.Sub>
-                <C.Separator />
+                <PinOff className={ICON} />
+                Unpin
+              </>
+            ) : (
+              <>
+                <Pin className={ICON} />
+                Pin to top
               </>
             )}
-            {(() => {
-              const isLocal = !worktreeMode || worktreeMode === "local";
-              return (
-                <>
-                  <C.Item onSelect={onResourceProvision} disabled={isLocal || !onResourceProvision}>
-                    <Play className="w-3.5 h-3.5 mr-2" />
-                    Provision
-                  </C.Item>
-                  <C.Item
-                    onSelect={onResourceTeardown}
-                    destructive
-                    disabled={isLocal || !onResourceTeardown}
-                  >
-                    <Trash2 className="w-3.5 h-3.5 mr-2" />
-                    Teardown
-                  </C.Item>
-                  <C.Separator />
-                  <C.Item onSelect={onResourceResume} disabled={isLocal || !onResourceResume}>
-                    <Play className="w-3.5 h-3.5 mr-2 text-status-success" />
-                    Resume
-                  </C.Item>
-                  <C.Item onSelect={onResourcePause} disabled={isLocal || !onResourcePause}>
-                    <Pause className="w-3.5 h-3.5 mr-2" />
-                    Pause
-                  </C.Item>
-                  <C.Separator />
-                  <C.Item onSelect={onResourceConnect} disabled={isLocal || !onResourceConnect}>
-                    <Plug className="w-3.5 h-3.5 mr-2 text-status-info" />
-                    Connect
-                  </C.Item>
-                  <C.Item onSelect={onResourceStatus} disabled={isLocal || !onResourceStatus}>
-                    <Activity className="w-3.5 h-3.5 mr-2" />
-                    Check Status
-                  </C.Item>
-                </>
-              );
-            })()}
-          </C.SubContent>
-        </C.Sub>
-      )}
+          </C.Item>
+        )}
+        {onToggleCollapse && (
+          <C.Item onSelect={onToggleCollapse}>
+            {isCollapsed ? (
+              <>
+                <PanelTopOpen className={ICON} />
+                Expand card
+              </>
+            ) : (
+              <>
+                <PanelTopClose className={ICON} />
+                Collapse card
+              </>
+            )}
+          </C.Item>
+        )}
+        {hasMoveRows && (canPin || onToggleCollapse) && <C.Separator />}
+        {hasMoveRows && (
+          <>
+            <C.Item onSelect={onMoveUp} disabled={!onMoveUp || !canMoveUp}>
+              <ArrowUp className={ICON} />
+              Move up
+            </C.Item>
+            <C.Item onSelect={onMoveDown} disabled={!onMoveDown || !canMoveDown}>
+              <ArrowDown className={ICON} />
+              Move down
+            </C.Item>
+          </>
+        )}
+      </C.SubContent>
+    </C.Sub>
+  );
 
-      {/* Each optional group above closes with its own separator, so a card
-          without resource config doesn't stack two rules on top of each other. */}
-      {hasResourceConfig && <C.Separator />}
-
-      {/* Worktree actions (flat) */}
-      {onAttachIssue && (
-        <C.Item onSelect={onAttachIssue}>
-          <Link className="w-3.5 h-3.5 mr-2" />
-          {worktree.issueNumber ? "Change Issue..." : "Attach to Issue..."}
-        </C.Item>
-      )}
-
-      {onViewPlan && (
-        <C.Item onSelect={onViewPlan}>
-          <FileText className="w-3.5 h-3.5 mr-2" />
-          View Plan
-        </C.Item>
-      )}
-
-      {onOpenChanges && (
-        <C.Item onSelect={onOpenChanges}>
-          <FileDiff className="w-3.5 h-3.5 mr-2" />
-          Open changes
-        </C.Item>
-      )}
-
-      {onOpenReviewHub && (
-        <C.Item onSelect={onOpenReviewHub}>
-          <GitCommitHorizontal className="w-3.5 h-3.5 mr-2" />
-          Review & Commit
-        </C.Item>
-      )}
-
-      {onCompareDiff && (
-        <C.Item onSelect={onCompareDiff}>
-          <GitCompare className="w-3.5 h-3.5 mr-2" />
-          Compare Worktrees…
-        </C.Item>
-      )}
-
-      {/* Copy Context submenu */}
-      <C.Sub>
-        <C.SubTrigger>
-          <Folders className="w-3.5 h-3.5 mr-2" />
-          Copy Context
-        </C.SubTrigger>
-        <C.SubContent>
-          <C.Item onSelect={onCopyContextFull}>Full Context</C.Item>
-          <C.Item onSelect={onCopyContextModified}>Modified Files Only</C.Item>
-        </C.SubContent>
-      </C.Sub>
-
-      <C.Item onSelect={onRevealInFinder}>
-        <Folder className="w-3.5 h-3.5 mr-2" />
-        Reveal in Finder
-      </C.Item>
-      <C.Item onSelect={onCopyPath}>
-        <Copy className="w-3.5 h-3.5 mr-2" />
-        Copy Path
-      </C.Item>
-      {canCopyBranchName && (
-        <C.Item onSelect={onCopyBranchName}>
-          <GitBranch className="w-3.5 h-3.5 mr-2" />
-          Copy branch name
-        </C.Item>
-      )}
-
-      {onTogglePin && !worktree.isMainWorktree && !isExternalWorktree(worktree) && (
-        <C.Item onSelect={onTogglePin}>
-          {isPinned ? (
-            <>
-              <PinOff className="w-3.5 h-3.5 mr-2" />
-              Unpin
-            </>
-          ) : (
-            <>
-              <Pin className="w-3.5 h-3.5 mr-2" />
-              Pin to Top
-            </>
-          )}
-        </C.Item>
-      )}
-
-      {onToggleCollapse && (
-        <C.Item onSelect={onToggleCollapse}>
-          {isCollapsed ? (
-            <>
-              <PanelTopOpen className="w-3.5 h-3.5 mr-2" />
-              Expand Card
-            </>
-          ) : (
-            <>
-              <PanelTopClose className="w-3.5 h-3.5 mr-2" />
-              Collapse Card
-            </>
-          )}
-        </C.Item>
-      )}
-
-      {/* Issue / PR items */}
-      {hasIssueOrPrSection && <C.Separator />}
-      {hasIssueItem && (
-        <C.Item onSelect={onOpenIssueExternal}>
-          <CircleDot className="w-3.5 h-3.5 mr-2" />
-          Open Issue #{worktree.issueNumber}
-        </C.Item>
-      )}
-      {hasPRItem && (
-        <C.Item onSelect={onOpenPRExternal}>
-          <GitPullRequest className="w-3.5 h-3.5 mr-2" />
-          Open PR #{worktree.linked?.pr?.ref.number}
-        </C.Item>
-      )}
-
-      {/* Recipes */}
-      {hasRecipeSection && <C.Separator />}
-      {hasRecipes && (
-        <C.Sub>
-          <C.SubTrigger>
-            <Workflow className="w-3.5 h-3.5 mr-2" />
-            Run Recipe
-          </C.SubTrigger>
-          <C.SubContent>
-            {recipes.map((recipe) => (
+  // ------------------------------------------------------------ Extensions
+  // Plugin contributions used to trail the root menu AFTER `Delete worktree…`,
+  // which broke the one structural promise a menu makes: destruction ends it.
+  // Nesting them keeps the root stable however many plugins are installed, and
+  // makes it impossible for a third party to render past deletion.
+  const pluginsById = new Map<string, PluginContextMenuItemEntry[]>();
+  for (const entry of pluginItems ?? []) {
+    const bucket = pluginsById.get(entry.pluginId);
+    if (bucket) bucket.push(entry);
+    else pluginsById.set(entry.pluginId, [entry]);
+  }
+  const pluginGroups = [...pluginsById.entries()];
+  const extensionsSub = pluginGroups.length > 0 && (
+    <C.Sub key="extensions">
+      <C.SubTrigger>
+        <Package className={ICON} />
+        Extensions
+      </C.SubTrigger>
+      <C.SubContent>
+        {pluginGroups.map(([pluginId, entries], groupIndex) => (
+          <Fragment key={pluginId}>
+            {pluginGroups.length > 1 && groupIndex > 0 && <C.Separator />}
+            {pluginGroups.length > 1 && <C.Label>{pluginId}</C.Label>}
+            {entries.map((entry) => (
               <C.Item
-                key={recipe.id}
-                onSelect={() => onRunRecipe(recipe.id)}
-                disabled={runningRecipeId !== null}
+                key={`${entry.pluginId}:${entry.item.actionId}`}
+                onSelect={() =>
+                  void actionService.dispatch(entry.item.actionId, undefined, { source })
+                }
               >
-                {recipe.name}
+                <span className="truncate">{entry.item.label}</span>
               </C.Item>
             ))}
-          </C.SubContent>
-        </C.Sub>
-      )}
-      {onSaveLayout && counts.active > 0 && (
-        <C.Item onSelect={onSaveLayout}>
-          <Save className="w-3.5 h-3.5 mr-2" />
-          Save Layout as Recipe
-        </C.Item>
-      )}
-
-      {/* Delete */}
-      {onDeleteWorktree && (
-        <>
-          <C.Separator />
-          <C.Item onSelect={onDeleteWorktree} destructive>
-            <Trash2 className="w-3.5 h-3.5 mr-2" />
-            Delete Worktree...
-          </C.Item>
-        </>
-      )}
-
-      {pluginItems && (
-        <PluginContextMenuSection
-          items={pluginItems}
-          components={{ Item: C.Item, Separator: C.Separator }}
-        />
-      )}
-    </>
+          </Fragment>
+        ))}
+      </C.SubContent>
+    </C.Sub>
   );
+
+  // ---------------------------------------------------------------- Delete
+  // The main worktree cannot be deleted, and the card already withholds the
+  // callback for it. Restating the rule here is deliberate: pinning is gated
+  // the same way, and a shared menu that renders a destructive row purely on
+  // callback presence puts the whole safeguard in one caller's hands.
+  const deleteItem = onDeleteWorktree && !worktree.isMainWorktree && (
+    <C.Item key="delete" onSelect={onDeleteWorktree} destructive>
+      <Trash2 className={ICON} />
+      Delete worktree…
+    </C.Item>
+  );
+
+  const rows = joinGroups(
+    [
+      compact(launchSub, openSub, reviewSub),
+      compact(sessionsSub, recipesSub, runtimeSub),
+      compact(linkedWorkSub, copySub, organizeSub, extensionsSub),
+      compact(deleteItem),
+    ],
+    C.Separator
+  );
+
+  return <>{rows}</>;
 }

--- a/src/components/Worktree/__tests__/WorktreeMenuItems.copyBranchName.test.tsx
+++ b/src/components/Worktree/__tests__/WorktreeMenuItems.copyBranchName.test.tsx
@@ -2,108 +2,63 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, vi, afterEach } from "vitest";
-import type * as React from "react";
-import { render, screen, cleanup, fireEvent } from "@testing-library/react";
-import type { WorktreeState } from "../../../types";
-import { WorktreeMenuItems, type WorktreeMenuComponents } from "../WorktreeMenuItems";
-
-vi.mock("@/components/Plugin/PluginContextMenuSection", () => ({
-  PluginContextMenuSection: () => null,
-}));
+import { screen, cleanup, fireEvent } from "@testing-library/react";
+import { makeWorktree, renderWorktreeMenu } from "./worktreeMenuHarness";
 
 afterEach(cleanup);
 
-const components: WorktreeMenuComponents = {
-  Item: ({ children, onSelect }: { children?: React.ReactNode; onSelect?: () => void }) => (
-    <button type="button" onClick={onSelect}>
-      {children}
-    </button>
-  ),
-  Label: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
-  Separator: () => <hr />,
-  Shortcut: ({ children }: { children?: React.ReactNode }) => <span>{children}</span>,
-  Sub: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
-  SubTrigger: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
-  SubContent: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
-};
+const onBranch = () => makeWorktree({ branch: "feature/copy-branch-name" });
 
-function makeWorktree(overrides: Partial<WorktreeState> = {}): WorktreeState {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- WorktreeState has ~60 fields and this render layer reads four of them; the sibling WorktreeMenuItems tests build their fixtures the same way.
-  return {
-    id: "wt-1",
-    name: "feature",
-    path: "/repo/wt-1",
-    branch: "feature/copy-branch-name",
-    ...overrides,
-  } as WorktreeState;
-}
-
-function renderMenu(worktree: WorktreeState, onCopyBranchName: () => void = vi.fn()) {
-  return render(
-    <WorktreeMenuItems
-      worktree={worktree}
-      components={components}
-      launchAgents={[]}
-      recipes={[]}
-      runningRecipeId={null}
-      counts={{ grid: 0, dock: 0, active: 0, completed: 0, all: 0, waiting: 0, working: 0 }}
-      onCopyContextFull={vi.fn()}
-      onCopyContextModified={vi.fn()}
-      onCopyPath={vi.fn()}
-      onCopyBranchName={onCopyBranchName}
-      onOpenEditor={vi.fn()}
-      onRevealInFinder={vi.fn()}
-      onRunRecipe={vi.fn()}
-      onDockAll={vi.fn()}
-      onMaximizeAll={vi.fn()}
-      onResetRenderers={vi.fn()}
-      onSelectAllAgents={vi.fn()}
-      onSelectWaitingAgents={vi.fn()}
-      onSelectWorkingAgents={vi.fn()}
-      onCloseAll={vi.fn()}
-      onTerminateAll={vi.fn()}
-      onClearHistory={vi.fn()}
-    />
-  );
-}
-
-describe("WorktreeMenuItems — Copy branch name (#11930)", () => {
+describe("WorktreeMenuItems — Copy → Branch name (#11930)", () => {
   it("offers the item for a worktree checked out on a branch", () => {
-    renderMenu(makeWorktree());
+    renderWorktreeMenu({ worktree: onBranch() });
 
-    expect(screen.queryByText("Copy branch name")).not.toBeNull();
+    expect(screen.queryByText("Branch name")).not.toBeNull();
   });
 
   it("withholds the item when the worktree reports no branch", () => {
-    renderMenu(makeWorktree({ branch: undefined }));
+    renderWorktreeMenu({ worktree: makeWorktree({ branch: undefined }) });
 
-    expect(screen.queryByText("Copy branch name")).toBeNull();
+    expect(screen.queryByText("Branch name")).toBeNull();
   });
 
   it("withholds the item on a detached HEAD still carrying its pre-detach branch", () => {
-    renderMenu(makeWorktree({ isDetached: true }));
+    renderWorktreeMenu({ worktree: makeWorktree({ isDetached: true }) });
 
-    expect(screen.queryByText("Copy branch name")).toBeNull();
+    expect(screen.queryByText("Branch name")).toBeNull();
   });
 
   it("invokes the supplied callback when the item is chosen", () => {
     const onCopyBranchName = vi.fn();
-    renderMenu(makeWorktree(), onCopyBranchName);
+    renderWorktreeMenu({ worktree: onBranch(), onCopyBranchName });
 
-    fireEvent.click(screen.getByText("Copy branch name"));
+    fireEvent.click(screen.getByText("Branch name"));
 
     expect(onCopyBranchName).toHaveBeenCalledTimes(1);
   });
 
-  it("places the item directly under Copy Path, so the two copy targets read together", () => {
-    renderMenu(makeWorktree());
+  it("places the item directly under Path, so the two copy targets read together", () => {
+    renderWorktreeMenu({ worktree: onBranch() });
 
     // Sibling order, not button indices: an index comparison stays green if a
     // separator or label gets inserted between the two, since neither renders
     // as a button.
-    const copyPath = screen.getByText("Copy Path");
-    const copyBranch = screen.getByText("Copy branch name");
+    const path = screen.getByText("Path");
+    const branch = screen.getByText("Branch name");
 
-    expect(copyPath.nextElementSibling).toBe(copyBranch);
+    expect(path.nextElementSibling).toBe(branch);
+  });
+
+  it("gathers every clipboard route under one Copy submenu", () => {
+    const { container } = renderWorktreeMenu({ worktree: onBranch() });
+
+    const copySub = Array.from(container.querySelectorAll("[data-menu-sub]")).find(
+      (sub) => sub.firstElementChild?.textContent?.trim() === "Copy"
+    );
+    const labels = Array.from(copySub?.querySelectorAll("[data-menu-item]") ?? []).map(
+      (el) => el.textContent
+    );
+
+    expect(labels).toEqual(["Full context", "Modified files only", "Path", "Branch name"]);
   });
 });

--- a/src/components/Worktree/__tests__/WorktreeMenuItems.hierarchy.test.tsx
+++ b/src/components/Worktree/__tests__/WorktreeMenuItems.hierarchy.test.tsx
@@ -1,0 +1,653 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The menu's information architecture, tested as structure rather than as a
+ * snapshot: which root rows exist, in what order, and where the separators
+ * fall. These are the invariants the redesign exists to establish — a flat
+ * root of a dozen unrelated commands is what it replaced — so they are worth
+ * pinning independently of any one row's behaviour.
+ */
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { screen, cleanup, fireEvent } from "@testing-library/react";
+import type { WorktreeState } from "../../../types";
+import { fileManagerRevealLabel } from "@/lib/platform";
+import {
+  makeWorktree,
+  renderWorktreeMenu,
+  rootRowLabels,
+  rootSeparatorCount,
+  zeroCounts,
+} from "./worktreeMenuHarness";
+
+const dispatch = vi.hoisted(() => vi.fn());
+vi.mock("@/services/ActionService", () => ({ actionService: { dispatch } }));
+
+afterEach(() => {
+  cleanup();
+  dispatch.mockClear();
+});
+
+/** Every optional group present: the widest root the menu can produce. */
+function fullyPopulated(): Parameters<typeof renderWorktreeMenu>[0] {
+  return {
+    worktree: makeWorktree({
+      issueNumber: 42,
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- only the PR ref is read.
+      linked: {
+        pr: { ref: { number: 7 }, url: "https://example.test/pr/7" },
+      } as WorktreeState["linked"],
+      worktreeMode: "local",
+    }),
+    counts: { grid: 2, dock: 1, active: 3, completed: 0, all: 3, waiting: 1, working: 2 },
+    recipes: [{ id: "r1", name: "Two agents" }],
+    onSaveLayout: vi.fn(),
+    onOpenReviewHub: vi.fn(),
+    onOpenChanges: vi.fn(),
+    onCompareDiff: vi.fn(),
+    onOpenFileBrowser: vi.fn(),
+    onOpenPanelPalette: vi.fn(),
+    onAttachIssue: vi.fn(),
+    onUnlinkIssue: vi.fn(),
+    onOpenIssueExternal: vi.fn(),
+    onOpenPRExternal: vi.fn(),
+    onViewPlan: vi.fn(),
+    onTogglePin: vi.fn(),
+    onToggleCollapse: vi.fn(),
+    onMoveUp: vi.fn(),
+    onMoveDown: vi.fn(),
+    canMoveUp: true,
+    canMoveDown: true,
+    hasResourceConfig: true,
+    resourceEnvironmentKeys: ["staging"],
+    onSwitchEnvironment: vi.fn(),
+    onDeleteWorktree: vi.fn(),
+    pluginItems: [
+      {
+        pluginId: "acme",
+        item: { location: "worktree", label: "Acme thing", actionId: "acme.go" },
+      },
+    ],
+  };
+}
+
+describe("WorktreeMenuItems — root hierarchy", () => {
+  it("renders the eleven intent groups in the specified order", () => {
+    const { container } = renderWorktreeMenu(fullyPopulated());
+
+    expect(rootRowLabels(container)).toEqual([
+      "Launch",
+      "Open",
+      "Review",
+      "Sessions",
+      "Recipes",
+      "Runtime",
+      "Linked work",
+      "Copy",
+      "Organize",
+      "Extensions",
+      "Delete worktree…",
+    ]);
+  });
+
+  it("separates the four bands with exactly three root separators", () => {
+    const { container } = renderWorktreeMenu(fullyPopulated());
+
+    expect(rootSeparatorCount(container)).toBe(3);
+  });
+
+  it("ends on the destructive row, never on a plugin contribution", () => {
+    const { container } = renderWorktreeMenu(fullyPopulated());
+    const rows = rootRowLabels(container);
+
+    expect(rows.at(-1)).toBe("Delete worktree…");
+    expect(rows.indexOf("Extensions")).toBeLessThan(rows.indexOf("Delete worktree…"));
+  });
+
+  it("drops every conditional group on a fresh worktree without ending on a separator", () => {
+    const { container } = renderWorktreeMenu({
+      onOpenReviewHub: vi.fn(),
+      onDeleteWorktree: vi.fn(),
+      onTogglePin: vi.fn(),
+    });
+
+    expect(rootRowLabels(container)).toEqual([
+      "Launch",
+      "Open",
+      "Review",
+      "Sessions",
+      "Copy",
+      "Organize",
+      "Delete worktree…",
+    ]);
+    expect(container.lastElementChild?.matches("[data-menu-separator]")).toBe(false);
+    expect(container.firstElementChild?.matches("[data-menu-separator]")).toBe(false);
+  });
+
+  it("never renders two separators in a row", () => {
+    const { container } = renderWorktreeMenu({ onDeleteWorktree: vi.fn() });
+
+    const kinds = Array.from(container.children).map((n) =>
+      n.matches("[data-menu-separator]") ? "sep" : "row"
+    );
+    expect(kinds.some((kind, i) => kind === "sep" && kinds[i + 1] === "sep")).toBe(false);
+  });
+
+  it("withholds deletion for the main worktree even when a callback is supplied", () => {
+    // The card already withholds the callback, but the shared menu must not put
+    // the whole safeguard in one caller's hands — pinning is gated here too.
+    const { container } = renderWorktreeMenu({
+      worktree: makeWorktree({ isMainWorktree: true }),
+      onDeleteWorktree: vi.fn(),
+      onToggleCollapse: vi.fn(),
+    });
+
+    const rows = rootRowLabels(container);
+    expect(rows).not.toContain("Delete worktree…");
+    expect(container.lastElementChild?.matches("[data-menu-separator]")).toBe(false);
+  });
+
+  it("still offers deletion for a non-main worktree", () => {
+    // Guards the assertion above against passing for the wrong reason.
+    const { container } = renderWorktreeMenu({ onDeleteWorktree: vi.fn() });
+
+    expect(rootRowLabels(container)).toContain("Delete worktree…");
+  });
+});
+
+describe("WorktreeMenuItems — Launch", () => {
+  it("lists pinned agents in the order given, above the fixed panel rows", () => {
+    const { container } = renderWorktreeMenu({
+      launchAgents: [
+        { id: "claude", name: "Claude", isEnabled: true },
+        { id: "codex", name: "Codex", isEnabled: true },
+      ],
+      onLaunchAgent: vi.fn(),
+    });
+
+    const launchSub = Array.from(container.querySelectorAll("[data-menu-sub]")).find(
+      (sub) => sub.firstElementChild?.textContent?.trim() === "Launch"
+    );
+    const labels = Array.from(launchSub?.querySelectorAll("[data-menu-item]") ?? []).map(
+      (el) => el.textContent
+    );
+
+    expect(labels.slice(0, 2)).toEqual(["Claude", "Codex"]);
+    expect(labels.slice(2)).toEqual(["Terminal", "Browser", "Dev preview"]);
+  });
+
+  it("explains an unavailable agent instead of leaving a bare disabled row", () => {
+    renderWorktreeMenu({
+      launchAgents: [{ id: "codex", name: "Codex", isEnabled: false }],
+      onLaunchAgent: vi.fn(),
+    });
+
+    const row = screen.getByLabelText("Codex, not installed");
+    expect(row).toHaveProperty("disabled", true);
+    expect(row.textContent).toContain("Not installed");
+  });
+
+  it("routes the full launcher through the resolved surface source", () => {
+    const onOpenPanelPalette = vi.fn();
+    renderWorktreeMenu({ onOpenPanelPalette }, "context-menu");
+
+    fireEvent.click(screen.getByText("More agents and panels…"));
+
+    expect(onOpenPanelPalette).toHaveBeenCalledWith("context-menu");
+  });
+
+  it("dispatches as `menu` from the dropdown surface", () => {
+    const onOpenPanelPalette = vi.fn();
+    renderWorktreeMenu({ onOpenPanelPalette }, "menu");
+
+    fireEvent.click(screen.getByText("More agents and panels…"));
+
+    expect(onOpenPanelPalette).toHaveBeenCalledWith("menu");
+  });
+});
+
+describe("WorktreeMenuItems — Sessions", () => {
+  const busy = {
+    counts: { grid: 2, dock: 1, active: 3, completed: 0, all: 3, waiting: 1, working: 2 },
+  };
+
+  it("orders the sections layout → fleet → maintenance → destructive", () => {
+    const { container } = renderWorktreeMenu(busy);
+
+    const sessions = Array.from(container.querySelectorAll("[data-menu-sub]")).find(
+      (sub) => sub.firstElementChild?.textContent?.trim() === "Sessions"
+    );
+    const labels = Array.from(sessions?.querySelectorAll("[data-menu-item]") ?? []).map(
+      (el) => el.textContent?.replace(/\d+$/, "") ?? ""
+    );
+
+    expect(labels).toEqual([
+      "Dock all panels",
+      "Move all to grid",
+      "Select all terminals",
+      "Select waiting agents",
+      "Select working agents",
+      "Redraw all terminals",
+      "Clear session history…",
+      "Trash all sessions…",
+      "Terminate all sessions…",
+    ]);
+  });
+
+  it("names the counts each bulk row acts on in its accessible label", () => {
+    renderWorktreeMenu(busy);
+
+    expect(screen.queryByLabelText("Dock all panels, 2")).not.toBeNull();
+    expect(screen.queryByLabelText("Move all to grid, 1")).not.toBeNull();
+    expect(screen.queryByLabelText("Redraw all terminals, 3")).not.toBeNull();
+    expect(screen.queryByLabelText("Select waiting agents, 1")).not.toBeNull();
+  });
+
+  it("hides the layout, fleet and maintenance sections when nothing is running", () => {
+    renderWorktreeMenu();
+
+    expect(screen.queryByText("Dock all panels")).toBeNull();
+    expect(screen.queryByText("Select all terminals")).toBeNull();
+    expect(screen.queryByText("Redraw all terminals")).toBeNull();
+  });
+
+  it("keeps the clear-history route reachable when no session is live", () => {
+    // Journal availability isn't cached, and opening a menu must not go and
+    // read it — so an unknown count keeps the row rather than guessing zero.
+    renderWorktreeMenu();
+
+    expect(screen.queryByText("Clear session history…")).not.toBeNull();
+  });
+});
+
+describe("WorktreeMenuItems — Runtime", () => {
+  it("stays absent when there is neither a dev server nor an environment", () => {
+    const { container } = renderWorktreeMenu();
+
+    expect(rootRowLabels(container)).not.toContain("Runtime");
+  });
+
+  it("offers a truthful start for a stopped-but-restorable server", () => {
+    renderWorktreeMenu({
+      devServerState: "restorable",
+      onStartDevServer: vi.fn(),
+      onStopDevServer: vi.fn(),
+      onRestartDevServer: vi.fn(),
+    });
+
+    expect(screen.queryByText("Start dev server")).not.toBeNull();
+    expect(screen.queryByText("Restart dev server")).toBeNull();
+    expect(screen.queryByText("Stop dev server")).toBeNull();
+  });
+
+  it("offers restart and stop only while the server is live", () => {
+    renderWorktreeMenu({
+      devServerState: "running",
+      onStartDevServer: vi.fn(),
+      onStopDevServer: vi.fn(),
+      onRestartDevServer: vi.fn(),
+    });
+
+    expect(screen.queryByText("Start dev server")).toBeNull();
+    expect(screen.queryByText("Restart dev server")).not.toBeNull();
+    expect(screen.queryByText("Stop dev server")).not.toBeNull();
+  });
+
+  it("shows only the switcher in local mode, not a wall of dead remote commands", () => {
+    renderWorktreeMenu({
+      hasResourceConfig: true,
+      worktreeMode: "local",
+      resourceEnvironmentKeys: ["staging"],
+      onSwitchEnvironment: vi.fn(),
+      onResourceProvision: vi.fn(),
+      onResourceResume: vi.fn(),
+      onResourcePause: vi.fn(),
+      onResourceConnect: vi.fn(),
+      onResourceStatus: vi.fn(),
+      onResourceTeardown: vi.fn(),
+    });
+
+    expect(screen.queryByText("Switch environment")).not.toBeNull();
+    for (const label of [
+      "Check status",
+      "Connect",
+      "Provision",
+      "Resume",
+      "Pause",
+      "Tear down environment…",
+    ]) {
+      expect(screen.queryByText(label)).toBeNull();
+    }
+  });
+
+  it("uses real radio semantics for the environment choice", () => {
+    renderWorktreeMenu({
+      hasResourceConfig: true,
+      worktreeMode: "staging",
+      resourceEnvironmentKeys: ["staging", "prod"],
+      onSwitchEnvironment: vi.fn(),
+    });
+
+    const radios = screen.getAllByRole("menuitemradio");
+    expect(radios.map((r) => r.textContent?.trim())).toEqual(["Local", "staging", "prod"]);
+    expect(radios[1]?.getAttribute("aria-checked")).toBe("true");
+    expect(radios[0]?.getAttribute("aria-checked")).toBe("false");
+  });
+
+  it("switches environment through the group's value change", () => {
+    const onSwitchEnvironment = vi.fn();
+    renderWorktreeMenu({
+      hasResourceConfig: true,
+      worktreeMode: "staging",
+      resourceEnvironmentKeys: ["staging"],
+      onSwitchEnvironment,
+    });
+
+    fireEvent.click(screen.getByRole("menuitemradio", { name: /Local/ }));
+
+    expect(onSwitchEnvironment).toHaveBeenCalledWith("local");
+  });
+
+  it("keeps every configured command reachable when the status is unrecognized", () => {
+    // `lastStatus` is free-form output from the project's own status command, so
+    // a project that prints "healthy" must not lose Resume, Pause and Connect
+    // to a token list that never claimed to be exhaustive.
+    renderWorktreeMenu({
+      hasResourceConfig: true,
+      worktreeMode: "staging",
+      resourceStatus: "healthy",
+      resourceEnvironmentKeys: ["staging"],
+      onSwitchEnvironment: vi.fn(),
+      onResourceResume: vi.fn(),
+      onResourcePause: vi.fn(),
+      onResourceConnect: vi.fn(),
+      onResourceStatus: vi.fn(),
+    });
+
+    for (const label of ["Resume", "Pause", "Connect", "Check status"]) {
+      expect(screen.queryByText(label)).not.toBeNull();
+    }
+  });
+
+  it("offers Connect on a configured command whatever the status says", () => {
+    renderWorktreeMenu({
+      hasResourceConfig: true,
+      worktreeMode: "staging",
+      resourceStatus: "paused",
+      resourceEnvironmentKeys: ["staging"],
+      onSwitchEnvironment: vi.fn(),
+      onResourceConnect: vi.fn(),
+    });
+
+    expect(screen.queryByText("Connect")).not.toBeNull();
+  });
+
+  it("renders one radio per environment when a key is literally named local", () => {
+    // Settings rejects only blank and duplicate names, so "local" is a
+    // representable key — and two items sharing the fixed row's value would
+    // both come back checked.
+    renderWorktreeMenu({
+      hasResourceConfig: true,
+      worktreeMode: "local",
+      resourceEnvironmentKeys: ["local", "staging"],
+      onSwitchEnvironment: vi.fn(),
+    });
+
+    const radios = screen.getAllByRole("menuitemradio");
+    expect(radios.map((r) => r.textContent?.trim())).toEqual(["Local", "staging"]);
+    expect(radios.filter((r) => r.getAttribute("aria-checked") === "true")).toHaveLength(1);
+  });
+
+  it("prefers Pause over Resume while the environment reports running", () => {
+    renderWorktreeMenu({
+      hasResourceConfig: true,
+      worktreeMode: "staging",
+      resourceStatus: "running",
+      resourceEnvironmentKeys: ["staging"],
+      onSwitchEnvironment: vi.fn(),
+      onResourceResume: vi.fn(),
+      onResourcePause: vi.fn(),
+    });
+
+    expect(screen.queryByText("Pause")).not.toBeNull();
+    expect(screen.queryByText("Resume")).toBeNull();
+  });
+
+  it("renders teardown last within the environment section", () => {
+    const { container } = renderWorktreeMenu({
+      hasResourceConfig: true,
+      worktreeMode: "staging",
+      resourceStatus: "running",
+      resourceEnvironmentKeys: ["staging"],
+      onSwitchEnvironment: vi.fn(),
+      onResourceStatus: vi.fn(),
+      onResourceConnect: vi.fn(),
+      onResourceTeardown: vi.fn(),
+    });
+
+    const runtime = Array.from(container.querySelectorAll("[data-menu-sub]")).find(
+      (sub) => sub.firstElementChild?.textContent?.trim() === "Runtime"
+    );
+    const labels = Array.from(runtime?.querySelectorAll("[data-menu-item]") ?? []).map(
+      (el) => el.textContent
+    );
+
+    expect(labels.at(-1)).toBe("Tear down environment…");
+  });
+});
+
+describe("WorktreeMenuItems — Linked work", () => {
+  it("is absent with no plan, issue, PR or attach capability", () => {
+    const { container } = renderWorktreeMenu();
+
+    expect(rootRowLabels(container)).not.toContain("Linked work");
+  });
+
+  it("says attach when nothing is linked and change when something is", () => {
+    const { unmount } = renderWorktreeMenu({ onAttachIssue: vi.fn() });
+    expect(screen.queryByText("Attach issue…")).not.toBeNull();
+    unmount();
+
+    renderWorktreeMenu({
+      worktree: makeWorktree({ issueNumber: 42 }),
+      onAttachIssue: vi.fn(),
+    });
+    expect(screen.queryByText("Change linked issue…")).not.toBeNull();
+  });
+
+  it("offers a direct unlink naming the linked issue", () => {
+    const onUnlinkIssue = vi.fn();
+    renderWorktreeMenu({
+      worktree: makeWorktree({ issueNumber: 42 }),
+      onAttachIssue: vi.fn(),
+      onUnlinkIssue,
+    });
+
+    fireEvent.click(screen.getByText(/Unlink issue #42/));
+
+    expect(onUnlinkIssue).toHaveBeenCalledTimes(1);
+  });
+
+  it("has no unlink row when no issue is linked", () => {
+    renderWorktreeMenu({ onAttachIssue: vi.fn(), onUnlinkIssue: vi.fn() });
+
+    expect(screen.queryByText(/Unlink issue/)).toBeNull();
+  });
+});
+
+describe("WorktreeMenuItems — Extensions", () => {
+  const item = (pluginId: string, label: string, actionId: string) => ({
+    pluginId,
+    item: { location: "worktree" as const, label, actionId },
+  });
+
+  it("renders no Extensions trigger when no plugin contributes", () => {
+    // `when`-clause filtering happens in `usePluginContextMenuItems`; what the
+    // menu owns is that an empty list produces no trigger at all.
+    const { container } = renderWorktreeMenu({ pluginItems: [] });
+
+    expect(rootRowLabels(container)).not.toContain("Extensions");
+  });
+
+  it("keeps a lone plugin's items nested, so the root stays stable", () => {
+    const { container } = renderWorktreeMenu({
+      pluginItems: [item("acme", "Do the thing", "acme.go")],
+    });
+
+    expect(rootRowLabels(container)).toContain("Extensions");
+    expect(screen.queryByText("Do the thing")).not.toBeNull();
+    // A single contributor gets no group heading — the submenu title is enough.
+    expect(container.querySelector("[data-menu-label]")).toBeNull();
+  });
+
+  it("groups by contributing plugin once more than one contributes", () => {
+    const { container } = renderWorktreeMenu({
+      pluginItems: [item("acme", "Acme thing", "acme.go"), item("zeta", "Zeta thing", "zeta.go")],
+    });
+
+    const labels = Array.from(container.querySelectorAll("[data-menu-label]")).map(
+      (el) => el.textContent
+    );
+    expect(labels).toEqual(["acme", "zeta"]);
+  });
+
+  it("dispatches the plugin's own action id with the surface source", () => {
+    renderWorktreeMenu({ pluginItems: [item("acme", "Do the thing", "acme.go")] }, "context-menu");
+
+    fireEvent.click(screen.getByText("Do the thing"));
+
+    expect(dispatch).toHaveBeenCalledWith("acme.go", undefined, { source: "context-menu" });
+  });
+});
+
+describe("WorktreeMenuItems — Recipes", () => {
+  const recipes = [
+    { id: "r1", name: "Two agents" },
+    { id: "r2", name: "Reviewer" },
+  ];
+
+  it("runs the recipe the row names", () => {
+    const onRunRecipe = vi.fn();
+    renderWorktreeMenu({ recipes, onRunRecipe });
+
+    fireEvent.click(screen.getByText("Reviewer"));
+
+    expect(onRunRecipe).toHaveBeenCalledWith("r2");
+  });
+
+  it("disables the run rows while a recipe is spawning and says why", () => {
+    // `handleRunRecipe` early-returns while one is in flight, so an enabled row
+    // would be a click that silently does nothing.
+    renderWorktreeMenu({ recipes, runningRecipeId: "r1" });
+
+    const row = screen.getByLabelText("Reviewer, a recipe is running");
+    expect(row).toHaveProperty("disabled", true);
+    expect(row.textContent).toContain("Recipe running");
+  });
+
+  it("groups running and saving in one submenu", () => {
+    const { container } = renderWorktreeMenu({
+      recipes,
+      onSaveLayout: vi.fn(),
+      counts: { ...zeroCounts, active: 2 },
+    });
+
+    const sub = Array.from(container.querySelectorAll("[data-menu-sub]")).find(
+      (node) => node.firstElementChild?.textContent?.trim() === "Recipes"
+    );
+    const labels = Array.from(sub?.querySelectorAll("[data-menu-item]") ?? []).map(
+      (el) => el.textContent
+    );
+
+    expect(labels).toEqual(["Two agents", "Reviewer", "Save current layout as recipe…"]);
+  });
+
+  it("withholds save-layout when the worktree has no live session to snapshot", () => {
+    renderWorktreeMenu({ recipes, onSaveLayout: vi.fn() });
+
+    expect(screen.queryByText("Save current layout as recipe…")).toBeNull();
+  });
+
+  it("drops the submenu with neither applicable recipes nor a snapshot to save", () => {
+    const { container } = renderWorktreeMenu({ onSaveLayout: vi.fn() });
+
+    expect(rootRowLabels(container)).not.toContain("Recipes");
+  });
+});
+
+describe("WorktreeMenuItems — Open", () => {
+  it("omits Browse files when no file-browser route is wired", () => {
+    const { container } = renderWorktreeMenu();
+
+    const sub = Array.from(container.querySelectorAll("[data-menu-sub]")).find(
+      (node) => node.firstElementChild?.textContent?.trim() === "Open"
+    );
+    const labels = Array.from(sub?.querySelectorAll("[data-menu-item]") ?? []).map(
+      (el) => el.textContent
+    );
+
+    expect(labels[0]).not.toBe("Browse files");
+    expect(labels).toContain("Open in editor");
+  });
+
+  it("routes each destination to its own callback", () => {
+    const onOpenFileBrowser = vi.fn();
+    const onOpenEditor = vi.fn();
+    const onRevealInFinder = vi.fn();
+    renderWorktreeMenu({ onOpenFileBrowser, onOpenEditor, onRevealInFinder });
+
+    fireEvent.click(screen.getByText("Browse files"));
+    fireEvent.click(screen.getByText("Open in editor"));
+    fireEvent.click(screen.getByText(fileManagerRevealLabel()));
+
+    expect(onOpenFileBrowser).toHaveBeenCalledTimes(1);
+    expect(onOpenEditor).toHaveBeenCalledTimes(1);
+    expect(onRevealInFinder).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("WorktreeMenuItems — Copy", () => {
+  it("routes the two context rows to the full and modified-only callbacks", () => {
+    const onCopyContextFull = vi.fn();
+    const onCopyContextModified = vi.fn();
+    const onCopyPath = vi.fn();
+    renderWorktreeMenu({ onCopyContextFull, onCopyContextModified, onCopyPath });
+
+    fireEvent.click(screen.getByText("Full context"));
+    fireEvent.click(screen.getByText("Modified files only"));
+    fireEvent.click(screen.getByText("Path"));
+
+    expect(onCopyContextFull).toHaveBeenCalledTimes(1);
+    expect(onCopyContextModified).toHaveBeenCalledTimes(1);
+    expect(onCopyPath).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("WorktreeMenuItems — Organize", () => {
+  it("disables the move that would run off the end of the list", () => {
+    const { unmount } = renderWorktreeMenu({
+      onMoveUp: vi.fn(),
+      onMoveDown: vi.fn(),
+      canMoveUp: false,
+      canMoveDown: true,
+    });
+    expect(screen.getByText("Move up").closest("button")).toHaveProperty("disabled", true);
+    expect(screen.getByText("Move down").closest("button")).toHaveProperty("disabled", false);
+    unmount();
+
+    renderWorktreeMenu({
+      onMoveUp: vi.fn(),
+      onMoveDown: vi.fn(),
+      canMoveUp: true,
+      canMoveDown: false,
+    });
+    expect(screen.getByText("Move up").closest("button")).toHaveProperty("disabled", false);
+    expect(screen.getByText("Move down").closest("button")).toHaveProperty("disabled", true);
+  });
+
+  it("omits the move rows for a card variant that cannot be reordered", () => {
+    renderWorktreeMenu({ onToggleCollapse: vi.fn() });
+
+    expect(screen.queryByText("Move up")).toBeNull();
+    expect(screen.queryByText("Move down")).toBeNull();
+  });
+});

--- a/src/components/Worktree/__tests__/WorktreeMenuItems.openChanges.test.tsx
+++ b/src/components/Worktree/__tests__/WorktreeMenuItems.openChanges.test.tsx
@@ -2,106 +2,75 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, vi, afterEach } from "vitest";
-import type * as React from "react";
-import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { screen, cleanup, fireEvent } from "@testing-library/react";
 import type { WorktreeState } from "../../../types";
-import { WorktreeMenuItems, type WorktreeMenuComponents } from "../WorktreeMenuItems";
-
-vi.mock("@/components/Plugin/PluginContextMenuSection", () => ({
-  PluginContextMenuSection: () => null,
-}));
+import { makeWorktree, renderWorktreeMenu } from "./worktreeMenuHarness";
 
 afterEach(cleanup);
 
-/**
- * Plain-DOM stand-ins for the Radix menu primitives. The component is a pure
- * render layer over whatever `components` it is given, so both real surfaces
- * (right-click menu and the ⋯ dropdown) exercise this same tree.
- */
-const components: WorktreeMenuComponents = {
-  Item: ({ children, onSelect }: { children?: React.ReactNode; onSelect?: () => void }) => (
-    <button type="button" onClick={onSelect}>
-      {children}
-    </button>
-  ),
-  Label: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
-  Separator: () => <hr />,
-  Shortcut: ({ children }: { children?: React.ReactNode }) => <span>{children}</span>,
-  Sub: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
-  SubTrigger: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
-  SubContent: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
-};
-
-// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- WorktreeState has ~60 fields and this render layer reads four of them; the repo's other worktree component tests build fixtures the same way.
-const worktree = {
-  id: "wt-1",
-  name: "feature",
-  path: "/repo/wt-1",
-  branch: "feature",
-} as WorktreeState;
-
-function renderMenu(onOpenChanges?: () => void, onOpenReviewHub?: () => void) {
-  return render(
-    <WorktreeMenuItems
-      worktree={worktree}
-      components={components}
-      launchAgents={[]}
-      recipes={[]}
-      runningRecipeId={null}
-      counts={{ grid: 0, dock: 0, active: 0, completed: 0, all: 0, waiting: 0, working: 0 }}
-      onCopyContextFull={vi.fn()}
-      onCopyContextModified={vi.fn()}
-      onCopyPath={vi.fn()}
-      onCopyBranchName={vi.fn()}
-      onOpenEditor={vi.fn()}
-      onRevealInFinder={vi.fn()}
-      onRunRecipe={vi.fn()}
-      onDockAll={vi.fn()}
-      onMaximizeAll={vi.fn()}
-      onResetRenderers={vi.fn()}
-      onSelectAllAgents={vi.fn()}
-      onSelectWaitingAgents={vi.fn()}
-      onSelectWorkingAgents={vi.fn()}
-      onCloseAll={vi.fn()}
-      onTerminateAll={vi.fn()}
-      onClearHistory={vi.fn()}
-      onOpenChanges={onOpenChanges}
-      onOpenReviewHub={onOpenReviewHub}
-    />
-  );
+function withChanges(count: number): Partial<WorktreeState> {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- WorktreeChanges carries per-file git metadata the menu never reads; only the list length reaches the row.
+  const worktreeChanges = {
+    changedFileCount: count,
+    changes: Array.from({ length: count }, (_, i) => ({ path: `file-${i}.ts` })),
+  } as WorktreeState["worktreeChanges"];
+  return { worktreeChanges };
 }
 
-describe("WorktreeMenuItems — Open changes (#11420)", () => {
+describe("WorktreeMenuItems — View uncommitted changes (#11420)", () => {
   it("omits the item when no callback is supplied", () => {
-    renderMenu(undefined);
+    renderWorktreeMenu();
 
-    expect(screen.queryByText("Open changes")).toBeNull();
+    expect(screen.queryByText("View uncommitted changes")).toBeNull();
   });
 
   it("renders the item when a callback is supplied", () => {
-    renderMenu(vi.fn());
+    renderWorktreeMenu({ onOpenChanges: vi.fn() });
 
-    expect(screen.queryByText("Open changes")).not.toBeNull();
+    expect(screen.queryByText("View uncommitted changes")).not.toBeNull();
   });
 
   it("invokes the supplied callback when the item is chosen", () => {
     const onOpenChanges = vi.fn();
-    renderMenu(onOpenChanges);
+    renderWorktreeMenu({ onOpenChanges });
 
-    fireEvent.click(screen.getByText("Open changes"));
+    fireEvent.click(screen.getByText("View uncommitted changes"));
 
     expect(onOpenChanges).toHaveBeenCalledTimes(1);
   });
 
-  it("places the item before Review & Commit, so diffing reads ahead of committing", () => {
-    renderMenu(vi.fn(), vi.fn());
+  it("sits inside Review, after the hub, so the hub reads as the entry point", () => {
+    const { container } = renderWorktreeMenu({
+      onOpenChanges: vi.fn(),
+      onOpenReviewHub: vi.fn(),
+      onCompareDiff: vi.fn(),
+    });
 
-    const labels = screen.getAllByRole("button").map((el) => el.textContent);
-    const openChangesAt = labels.findIndex((t) => t?.includes("Open changes"));
-    const reviewAt = labels.findIndex((t) => t?.includes("Review & Commit"));
+    // Scoped to the Review submenu: a global index comparison would stay green
+    // if the row escaped into a different submenu that happens to render later.
+    const reviewSub = Array.from(container.querySelectorAll("[data-menu-sub]")).find(
+      (node) => node.firstElementChild?.textContent?.trim() === "Review"
+    );
+    const labels = Array.from(reviewSub?.querySelectorAll("[data-menu-item]") ?? []).map((el) =>
+      el.textContent?.replace(/\d+$/, "")
+    );
 
-    expect(openChangesAt).toBeGreaterThanOrEqual(0);
-    expect(reviewAt).toBeGreaterThanOrEqual(0);
-    expect(openChangesAt).toBeLessThan(reviewAt);
+    expect(labels).toEqual([
+      "Review worktree",
+      "View uncommitted changes",
+      "Compare with another worktree…",
+    ]);
+  });
+
+  it("carries the changed-file count into the accessible name, not just the muted slot", () => {
+    renderWorktreeMenu({ onOpenChanges: vi.fn(), worktree: makeWorktree(withChanges(3)) });
+
+    expect(screen.queryByLabelText("View uncommitted changes, 3")).not.toBeNull();
+  });
+
+  it("drops the whole Review submenu when no review route applies", () => {
+    renderWorktreeMenu();
+
+    expect(screen.queryByText("Review")).toBeNull();
   });
 });

--- a/src/components/Worktree/__tests__/WorktreeMenuItems.pin.test.tsx
+++ b/src/components/Worktree/__tests__/WorktreeMenuItems.pin.test.tsx
@@ -2,97 +2,56 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, vi, afterEach } from "vitest";
-import type * as React from "react";
-import { render, screen, cleanup } from "@testing-library/react";
-import type { WorktreeState } from "../../../types";
-import { WorktreeMenuItems, type WorktreeMenuComponents } from "../WorktreeMenuItems";
-
-vi.mock("@/components/Plugin/PluginContextMenuSection", () => ({
-  PluginContextMenuSection: () => null,
-}));
+import { screen, cleanup } from "@testing-library/react";
+import { makeWorktree, renderWorktreeMenu } from "./worktreeMenuHarness";
 
 afterEach(cleanup);
 
-const components: WorktreeMenuComponents = {
-  Item: ({ children, onSelect }: { children?: React.ReactNode; onSelect?: () => void }) => (
-    <button type="button" onClick={onSelect}>
-      {children}
-    </button>
-  ),
-  Label: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
-  Separator: () => <hr />,
-  Shortcut: ({ children }: { children?: React.ReactNode }) => <span>{children}</span>,
-  Sub: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
-  SubTrigger: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
-  SubContent: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
-};
-
-function makeWorktree(overrides: Partial<WorktreeState> = {}): WorktreeState {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- WorktreeState has ~60 fields and this render layer reads four of them; the sibling WorktreeMenuItems test builds its fixture the same way.
-  return {
-    id: "wt-1",
-    name: "feature",
-    path: "/repo/wt-1",
-    branch: "feature",
-    ...overrides,
-  } as WorktreeState;
-}
-
-function renderMenu(worktree: WorktreeState, onTogglePin?: () => void, isPinned = false) {
-  return render(
-    <WorktreeMenuItems
-      worktree={worktree}
-      components={components}
-      launchAgents={[]}
-      recipes={[]}
-      runningRecipeId={null}
-      counts={{ grid: 0, dock: 0, active: 0, completed: 0, all: 0, waiting: 0, working: 0 }}
-      onCopyContextFull={vi.fn()}
-      onCopyContextModified={vi.fn()}
-      onCopyPath={vi.fn()}
-      onCopyBranchName={vi.fn()}
-      onOpenEditor={vi.fn()}
-      onRevealInFinder={vi.fn()}
-      onRunRecipe={vi.fn()}
-      onDockAll={vi.fn()}
-      onMaximizeAll={vi.fn()}
-      onResetRenderers={vi.fn()}
-      onSelectAllAgents={vi.fn()}
-      onSelectWaitingAgents={vi.fn()}
-      onSelectWorkingAgents={vi.fn()}
-      onCloseAll={vi.fn()}
-      onTerminateAll={vi.fn()}
-      onClearHistory={vi.fn()}
-      onTogglePin={onTogglePin}
-      isPinned={isPinned}
-    />
-  );
-}
-
 describe("WorktreeMenuItems — pin suppression for external worktrees (#11434)", () => {
   it("offers the pin action for an internal non-main worktree", () => {
-    renderMenu(makeWorktree(), vi.fn());
+    renderWorktreeMenu({ worktree: makeWorktree(), onTogglePin: vi.fn() });
 
-    expect(screen.queryByText("Pin to Top")).not.toBeNull();
+    expect(screen.queryByText("Pin to top")).not.toBeNull();
   });
 
   it("withholds the pin action for an external worktree even when a callback is supplied", () => {
     // Sorting already sinks external worktrees below the pinned area, so an
     // offered pin command would be a no-op the user can't explain.
-    renderMenu(makeWorktree({ isExternal: true }), vi.fn());
+    renderWorktreeMenu({ worktree: makeWorktree({ isExternal: true }), onTogglePin: vi.fn() });
 
-    expect(screen.queryByText("Pin to Top")).toBeNull();
+    expect(screen.queryByText("Pin to top")).toBeNull();
   });
 
   it("withholds the unpin action for an external worktree carrying a stale pin", () => {
-    renderMenu(makeWorktree({ isExternal: true }), vi.fn(), true);
+    renderWorktreeMenu({
+      worktree: makeWorktree({ isExternal: true }),
+      onTogglePin: vi.fn(),
+      isPinned: true,
+    });
 
     expect(screen.queryByText("Unpin")).toBeNull();
   });
 
   it("keeps offering the pin action when classification is unknown", () => {
-    renderMenu(makeWorktree({ isExternal: undefined }), vi.fn());
+    renderWorktreeMenu({ worktree: makeWorktree({ isExternal: undefined }), onTogglePin: vi.fn() });
 
-    expect(screen.queryByText("Pin to Top")).not.toBeNull();
+    expect(screen.queryByText("Pin to top")).not.toBeNull();
+  });
+
+  it("withholds the pin action for the main worktree", () => {
+    renderWorktreeMenu({
+      worktree: makeWorktree({ isMainWorktree: true }),
+      onTogglePin: vi.fn(),
+    });
+
+    expect(screen.queryByText("Pin to top")).toBeNull();
+  });
+
+  it("drops the whole Organize submenu when nothing about the card can be organized", () => {
+    // External + no collapse + no move rows: an Organize trigger opening onto
+    // nothing is worse than no trigger.
+    renderWorktreeMenu({ worktree: makeWorktree({ isExternal: true }), onTogglePin: vi.fn() });
+
+    expect(screen.queryByText("Organize")).toBeNull();
   });
 });

--- a/src/components/Worktree/__tests__/WorktreeMenuItems.primitives.test.tsx
+++ b/src/components/Worktree/__tests__/WorktreeMenuItems.primitives.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The sibling suites render the menu through plain-DOM stand-ins, which is the
+ * right shape for testing information architecture but supplies some of the
+ * behaviour itself — a fake `RadioItem` that sets its own `aria-checked` cannot
+ * prove the real one does. This file renders through the ACTUAL Radix
+ * primitives, on both surfaces, to pin the two things only real Radix can
+ * answer: that each injected primitive map is complete enough to mount the
+ * whole menu, and that environment selection carries genuine radio semantics.
+ */
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { ContextMenu, ContextMenuContent } from "@/components/ui/context-menu";
+import { DropdownMenu, DropdownMenuContent } from "@/components/ui/dropdown-menu";
+import { primeRadix } from "@/components/ui/radix-loader";
+import { DROPDOWN_COMPONENTS } from "../WorktreeCard/WorktreeActionsToolbar";
+import { CONTEXT_COMPONENTS, WorktreeMenuItems } from "../WorktreeMenuItems";
+import { makeWorktree, zeroCounts } from "./worktreeMenuHarness";
+
+vi.mock("@/services/ActionService", () => ({ actionService: { dispatch: vi.fn() } }));
+
+beforeAll(async () => {
+  await primeRadix();
+});
+
+afterEach(cleanup);
+
+const menuProps = {
+  worktree: makeWorktree({ worktreeMode: "staging" }),
+  launchAgents: [],
+  recipes: [],
+  runningRecipeId: null,
+  counts: zeroCounts,
+  onCopyContextFull: vi.fn(),
+  onCopyContextModified: vi.fn(),
+  onCopyPath: vi.fn(),
+  onCopyBranchName: vi.fn(),
+  onOpenEditor: vi.fn(),
+  onRevealInFinder: vi.fn(),
+  onRunRecipe: vi.fn(),
+  onDockAll: vi.fn(),
+  onMaximizeAll: vi.fn(),
+  onResetRenderers: vi.fn(),
+  onSelectAllAgents: vi.fn(),
+  onSelectWaitingAgents: vi.fn(),
+  onSelectWorkingAgents: vi.fn(),
+  onCloseAll: vi.fn(),
+  onTerminateAll: vi.fn(),
+  onClearHistory: vi.fn(),
+  hasResourceConfig: true,
+  resourceEnvironmentKeys: ["staging", "prod"],
+  onSwitchEnvironment: vi.fn(),
+  onDeleteWorktree: vi.fn(),
+};
+
+const SURFACES = [
+  {
+    name: "context menu",
+    render: () =>
+      render(
+        <ContextMenu open>
+          <ContextMenuContent forceMount>
+            <WorktreeMenuItems {...menuProps} components={CONTEXT_COMPONENTS} />
+          </ContextMenuContent>
+        </ContextMenu>
+      ),
+  },
+  {
+    name: "actions dropdown",
+    render: () =>
+      render(
+        <DropdownMenu open>
+          <DropdownMenuContent forceMount>
+            <WorktreeMenuItems {...menuProps} components={DROPDOWN_COMPONENTS} />
+          </DropdownMenuContent>
+        </DropdownMenu>
+      ),
+  },
+] as const;
+
+describe("WorktreeMenuItems — real Radix primitives", () => {
+  it.each(SURFACES)("$name mounts every root row through its own primitive map", ({ render }) => {
+    render();
+
+    // A map missing an entry throws on render, so reaching these at all is most
+    // of the assertion. The order is the contract the redesign establishes.
+    const rows = screen.getAllByRole("menuitem").map((el) => el.textContent?.trim());
+    expect(rows).toEqual(["Launch", "Open", "Sessions", "Runtime", "Copy", "Delete worktree…"]);
+  });
+
+  it.each(SURFACES)("$name never leads, trails or doubles a root separator", ({ render }) => {
+    const { baseElement } = render();
+
+    // Whichever bands this fixture populates, the rules between them must not
+    // lead, trail or double.
+    const children = Array.from(baseElement.querySelector('[role="menu"]')?.children ?? []).filter(
+      (el) => el.getAttribute("role") !== null
+    );
+    const kinds = children.map((el) => (el.getAttribute("role") === "separator" ? "sep" : "row"));
+
+    expect(kinds[0]).toBe("row");
+    expect(kinds.at(-1)).toBe("row");
+    expect(kinds.some((kind, i) => kind === "sep" && kinds[i + 1] === "sep")).toBe(false);
+  });
+});

--- a/src/components/Worktree/__tests__/devServerMenuState.test.ts
+++ b/src/components/Worktree/__tests__/devServerMenuState.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import type { DevPreviewSessionState, DevPreviewSessionStatus } from "@shared/types/ipc/devPreview";
+import { devServerMenuState } from "../utils/devServerMenuState";
+
+function session(status: DevPreviewSessionStatus): DevPreviewSessionState {
+  return {
+    panelId: "panel-1",
+    projectId: "project-1",
+    worktreeId: "wt-1",
+    status,
+    url: null,
+    predictedUrl: null,
+    error: null,
+    terminalId: null,
+    isRestarting: false,
+    generation: 1,
+    updatedAt: 1,
+  };
+}
+
+describe("devServerMenuState", () => {
+  it("offers nothing when the worktree has never had a dev server", () => {
+    expect(devServerMenuState(undefined, false)).toBe("none");
+  });
+
+  it.each<DevPreviewSessionStatus>(["running", "starting", "installing", "stopping"])(
+    "treats %s as live, so the menu offers restart and stop rather than a start",
+    (status) => {
+      expect(devServerMenuState(session(status), true)).toBe("running");
+    }
+  );
+
+  it("treats an errored server as live, because a readiness timeout leaves the process running", () => {
+    // The old menu's Stop was a no-op row; the new one must not swing the other
+    // way and remove Stop from a process that is still there to be stopped.
+    expect(devServerMenuState(session("error"), true)).toBe("running");
+  });
+
+  it("restores a session that was running when Daintree last closed", () => {
+    // The service keeps a restore manifest for this one, so it revives without
+    // needing the panel to still be around.
+    expect(devServerMenuState(session("restored-stopped"), false)).toBe("restorable");
+  });
+
+  it("offers a start for a server stopped in place, whose panel is still open", () => {
+    expect(devServerMenuState(session("stopped"), true)).toBe("restorable");
+  });
+
+  it("offers no start once the panel is gone, since the session went with it", () => {
+    // Closing the panel broadcasts `stopped` and then deletes the session, but
+    // the renderer keeps the snapshot — restarting it would find nothing to
+    // revive and silently do nothing.
+    expect(devServerMenuState(session("stopped"), false)).toBe("none");
+  });
+});

--- a/src/components/Worktree/__tests__/worktreeMenuHarness.tsx
+++ b/src/components/Worktree/__tests__/worktreeMenuHarness.tsx
@@ -1,0 +1,183 @@
+import { Children, cloneElement, isValidElement } from "react";
+import type * as React from "react";
+import { vi } from "vitest";
+import { render } from "@testing-library/react";
+import type { WorktreeState } from "../../../types";
+import {
+  WorktreeMenuItems,
+  type WorktreeMenuComponents,
+  type WorktreeMenuItemsProps,
+} from "../WorktreeMenuItems";
+import { MenuActionSourceContext, type MenuActionSourceValue } from "@/components/ui/menu-source";
+
+/**
+ * Plain-DOM stand-ins for the Radix menu primitives. `WorktreeMenuItems` is a
+ * pure render layer over whatever `components` it is given, so both real
+ * surfaces (card right-click and the ⋯ dropdown) exercise this same tree.
+ *
+ * Submenu triggers render as buttons too, which is what lets a test assert the
+ * ROOT hierarchy: every root row — trigger or item — is one button, in order.
+ */
+export const menuComponents: WorktreeMenuComponents = {
+  Item: ({
+    children,
+    onSelect,
+    disabled,
+    ...rest
+  }: {
+    children?: React.ReactNode;
+    onSelect?: () => void;
+    disabled?: boolean;
+  }) => (
+    <button type="button" onClick={onSelect} disabled={disabled} data-menu-item {...rest}>
+      {children}
+    </button>
+  ),
+  Label: ({ children }: { children?: React.ReactNode }) => <div data-menu-label>{children}</div>,
+  Separator: () => <hr data-menu-separator />,
+  Shortcut: ({ children }: { children?: React.ReactNode }) => <span>{children}</span>,
+  Meta: ({ children }: { children?: React.ReactNode }) => (
+    <span aria-hidden="true" data-menu-meta>
+      {children}
+    </span>
+  ),
+  Sub: ({ children }: { children?: React.ReactNode }) => <div data-menu-sub>{children}</div>,
+  SubTrigger: ({ children }: { children?: React.ReactNode }) => (
+    <button type="button" data-menu-subtrigger>
+      {children}
+    </button>
+  ),
+  SubContent: ({ children }: { children?: React.ReactNode }) => (
+    <div data-menu-subcontent>{children}</div>
+  ),
+  RadioGroup: ({
+    children,
+    value,
+    onValueChange,
+  }: {
+    children?: React.ReactNode;
+    value?: string;
+    onValueChange?: (value: string) => void;
+  }) => (
+    <div role="group" data-menu-radiogroup data-value={value} data-testid="radio-group">
+      {/* The handler is threaded onto each item below via context-free props;
+          keeping it here mirrors Radix, where the group owns the callback. */}
+      {toRadioChildren(children, value, onValueChange)}
+    </div>
+  ),
+  RadioItem: ({
+    children,
+    onSelect,
+    checked,
+  }: {
+    children?: React.ReactNode;
+    value?: string;
+    onSelect?: () => void;
+    checked?: boolean;
+  }) => (
+    <button type="button" role="menuitemradio" aria-checked={Boolean(checked)} onClick={onSelect}>
+      {children}
+    </button>
+  ),
+};
+
+/** Wires the group's value/onValueChange onto its RadioItem children, as Radix does. */
+function toRadioChildren(
+  children: React.ReactNode,
+  value: string | undefined,
+  onValueChange: ((value: string) => void) | undefined
+): React.ReactNode {
+  return Children.map(children, (child) => {
+    if (!isValidElement(child)) return child;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- every child here is a RadioItem; reading its `value` is the whole point of the stand-in.
+    const childValue = (child.props as { value?: string }).value;
+    return cloneElement(
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- cloneElement needs the prop bag widened to inject `checked`/`onSelect`, exactly as Radix's RadioGroup context does.
+      child as React.ReactElement<Record<string, unknown>>,
+      {
+        checked: childValue !== undefined && childValue === value,
+        onSelect: () => childValue !== undefined && onValueChange?.(childValue),
+      }
+    );
+  });
+}
+
+export function makeWorktree(overrides: Partial<WorktreeState> = {}): WorktreeState {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- WorktreeState has ~60 fields and this render layer reads a handful of them; the repo's other worktree component tests build fixtures the same way.
+  return {
+    id: "wt-1",
+    name: "feature",
+    path: "/repo/wt-1",
+    branch: "feature",
+    ...overrides,
+  } as WorktreeState;
+}
+
+export const zeroCounts = {
+  grid: 0,
+  dock: 0,
+  active: 0,
+  completed: 0,
+  all: 0,
+  waiting: 0,
+  working: 0,
+};
+
+type Overrides = Partial<Omit<WorktreeMenuItemsProps, "components">>;
+
+/**
+ * Renders the menu with every required callback stubbed, under a real menu
+ * source so `useMenuActionSource()` resolves instead of warning.
+ */
+export function renderWorktreeMenu(
+  overrides: Overrides = {},
+  source: MenuActionSourceValue = "menu"
+) {
+  const { worktree, ...rest } = overrides;
+  return render(
+    <MenuActionSourceContext.Provider value={source}>
+      <WorktreeMenuItems
+        worktree={worktree ?? makeWorktree()}
+        components={menuComponents}
+        launchAgents={[]}
+        recipes={[]}
+        runningRecipeId={null}
+        counts={zeroCounts}
+        onCopyContextFull={vi.fn()}
+        onCopyContextModified={vi.fn()}
+        onCopyPath={vi.fn()}
+        onCopyBranchName={vi.fn()}
+        onOpenEditor={vi.fn()}
+        onRevealInFinder={vi.fn()}
+        onRunRecipe={vi.fn()}
+        onDockAll={vi.fn()}
+        onMaximizeAll={vi.fn()}
+        onResetRenderers={vi.fn()}
+        onSelectAllAgents={vi.fn()}
+        onSelectWaitingAgents={vi.fn()}
+        onSelectWorkingAgents={vi.fn()}
+        onCloseAll={vi.fn()}
+        onTerminateAll={vi.fn()}
+        onClearHistory={vi.fn()}
+        {...rest}
+      />
+    </MenuActionSourceContext.Provider>
+  );
+}
+
+/**
+ * The root rows in document order: submenu triggers plus the flat destructive
+ * item, excluding everything nested inside a submenu's content.
+ */
+export function rootRowLabels(container: HTMLElement): string[] {
+  return Array.from(container.children)
+    .flatMap((node) => (node.matches("[data-menu-sub]") ? [node.firstElementChild] : [node]))
+    .filter((node): node is HTMLElement => node instanceof HTMLElement && node.tagName === "BUTTON")
+    .map((node) => node.textContent?.trim() ?? "");
+}
+
+/** Root-level separators only — the ones `joinGroups` inserts. */
+export function rootSeparatorCount(container: HTMLElement): number {
+  return Array.from(container.children).filter((node) => node.matches("[data-menu-separator]"))
+    .length;
+}

--- a/src/components/Worktree/utils/devServerMenuState.ts
+++ b/src/components/Worktree/utils/devServerMenuState.ts
@@ -1,0 +1,34 @@
+import type { DevPreviewSessionState } from "@shared/types/ipc/devPreview";
+import { isLiveDevServerStatus } from "@/lib/worktreeFilters";
+import type { WorktreeDevServerMenuState } from "../WorktreeMenuItems";
+
+/**
+ * What the worktree menu can truthfully offer for a worktree's dev server.
+ *
+ * The subtlety is `stopped`, which is ambiguous. `stopAndRemoveSession`
+ * broadcasts `stopped` and THEN deletes the session (panel closed, project
+ * hibernated, worktree deleted), while the renderer cache deliberately retains
+ * the last snapshot — so a stopped record may describe a session the main
+ * process no longer has. `restartByWorktree` then finds neither a live session
+ * nor a restore manifest and returns an empty placeholder without spawning,
+ * which is exactly the silent no-op row this redesign set out to remove.
+ *
+ * `panelExists` is the discriminator: of the three removal paths, only "panel
+ * closed" leaves the card rendered to be misled by its own stale snapshot.
+ * `restored-stopped` needs no panel — the service keeps a restore manifest for
+ * precisely that case.
+ */
+export function devServerMenuState(
+  session: DevPreviewSessionState | undefined,
+  panelExists: boolean
+): WorktreeDevServerMenuState {
+  if (!session) return "none";
+  // "Live" is the app-wide reading of the term, which counts `error`: a
+  // readiness timeout leaves the process running, so Stop still has something
+  // to stop. `stopping` joins it — a session being torn down is not something
+  // to offer a start for.
+  if (isLiveDevServerStatus(session.status) || session.status === "stopping") return "running";
+  if (session.status === "restored-stopped") return "restorable";
+  if (session.status === "stopped" && panelExists) return "restorable";
+  return "none";
+}

--- a/src/components/Worktree/utils/resourceLifecycle.ts
+++ b/src/components/Worktree/utils/resourceLifecycle.ts
@@ -1,0 +1,41 @@
+/**
+ * How to read a worktree's reported remote-resource status.
+ *
+ * Shared by the card's inline resource controls and the worktree menu's
+ * Runtime → Environment section so the two can't disagree about whether an
+ * environment is resumable or pausable.
+ *
+ * `lastStatus` is free-form text captured from the project's own status
+ * command, so the token set below is a best-effort reading of it, never an
+ * authority. `isRecognized` is what says so: a project whose status command
+ * prints `healthy` or `up` matches nothing here, and a caller that would
+ * otherwise hide a configured command has to fail open on it rather than
+ * leave the user with no way to run something they configured.
+ */
+export interface ResourceLifecycleVisibility {
+  showResume: boolean;
+  showPause: boolean;
+  showConnect: boolean;
+  /** False when the status was absent or matched no known token. */
+  isRecognized: boolean;
+}
+
+const PAUSED_LIKE = new Set(["paused", "stopped", "unknown", "terminated", "down"]);
+const RUNNING_LIKE = new Set(["running", "starting"]);
+
+export function resourceLifecycleVisibility(
+  resourceStatus: string | undefined
+): ResourceLifecycleVisibility {
+  const status = resourceStatus?.toLowerCase();
+  const isPausedLike = status !== undefined && PAUSED_LIKE.has(status);
+  const isRunningLike = status !== undefined && RUNNING_LIKE.has(status);
+  return {
+    // No status yet reads as "not up", which is what the inline controls have
+    // always assumed — the first thing you do to an unprovisioned environment
+    // is resume it.
+    showResume: !status || isPausedLike,
+    showPause: isRunningLike,
+    showConnect: status === "running",
+    isRecognized: isPausedLike || isRunningLike,
+  };
+}

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -11,6 +11,7 @@ export * from "./brands";
 export {
   Activity, // project pulse / live activity heartbeat
   ArrowDownAZ, // alphabetical sort order (A to Z)
+  ArrowUpDown, // card organization — pinning, collapsing and reordering a worktree row
   ArrowLeftRight, // a settings search hit that lives in the other scope — following it switches scope
   AtSign, // @file reference handed to an agent's prompt
   BellDot, // watch alert / notify on completion
@@ -34,6 +35,7 @@ export {
   Globe, // application-wide scope — the setting belongs to Daintree, not one project
   History, // resume closed session / session history
   Layers, // worktree overview (multiple worktrees, stacked)
+  Link2Off, // detach the issue linked to a worktree
   LayoutPanelTop, // workspace plugin category (panels, notes)
   Menu, // the application menu, surfaced in-app where the native menu bar can't render
   Moon, // sleep a project — shut it down the way quitting does, restored on reopen
@@ -41,6 +43,7 @@ export {
   Package, // plugin (a packaged extension) — plugin tray, unresolved plugin glyphs
   Plug, // agent (integration that plugs into the host system)
   Plus, // the toolbar launcher — "make me a new thing" (agent, panel)
+  ServerCog, // a worktree's runtime — dev-server and remote-environment lifecycle
   Sprout, // origin / first step (main worktree, first agent launch)
   TriangleAlert, // a setting failing validation — a shape, not a hue, so it survives forced colors
   Workflow, // terminal recipe / scripted command sequence

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -11,8 +11,8 @@ export * from "./brands";
 export {
   Activity, // project pulse / live activity heartbeat
   ArrowDownAZ, // alphabetical sort order (A to Z)
-  ArrowUpDown, // card organization — pinning, collapsing and reordering a worktree row
   ArrowLeftRight, // a settings search hit that lives in the other scope — following it switches scope
+  ArrowUpDown, // card organization — pinning, collapsing and reordering a worktree row
   AtSign, // @file reference handed to an agent's prompt
   BellDot, // watch alert / notify on completion
   ChartNoAxesColumn, // frecency sort order ("Most used" — decayed access score)
@@ -35,8 +35,8 @@ export {
   Globe, // application-wide scope — the setting belongs to Daintree, not one project
   History, // resume closed session / session history
   Layers, // worktree overview (multiple worktrees, stacked)
-  Link2Off, // detach the issue linked to a worktree
   LayoutPanelTop, // workspace plugin category (panels, notes)
+  Link2Off, // detach the issue linked to a worktree
   Menu, // the application menu, surfaced in-app where the native menu bar can't render
   Moon, // sleep a project — shut it down the way quitting does, restored on reopen
   Network, // Subagent tree — a parent session's spawned child sessions

--- a/src/components/ui/context-menu.tsx
+++ b/src/components/ui/context-menu.tsx
@@ -372,6 +372,22 @@ const ContextMenuShortcut = ({ className, ...props }: React.HTMLAttributes<HTMLS
 };
 ContextMenuShortcut.displayName = "ContextMenuShortcut";
 
+/* Trailing muted slot for item METADATA — a count, a state, a reason an item is
+ * disabled. Deliberately not `ContextMenuShortcut`: a count is not a keybinding,
+ * and rendering it in the shortcut's mono face reads as one. Non-mono, and
+ * `aria-hidden` by default because the number belongs in the item's accessible
+ * name (callers pass one), not as a second stray string after it. */
+const ContextMenuMeta = ({ className, ...props }: React.HTMLAttributes<HTMLSpanElement>) => {
+  return (
+    <span
+      aria-hidden="true"
+      className={cn("ml-auto pl-2 text-2xs text-text-secondary tabular-nums", className)}
+      {...props}
+    />
+  );
+};
+ContextMenuMeta.displayName = "ContextMenuMeta";
+
 type ContextMenuCheckboxItemProps = React.ComponentPropsWithoutRef<
   typeof ContextMenuPrimitiveType.CheckboxItem
 >;
@@ -461,6 +477,7 @@ export {
   ContextMenuSeparator,
   ContextMenuLabel,
   ContextMenuShortcut,
+  ContextMenuMeta,
   ContextMenuGroup,
   ContextMenuPortal,
   ContextMenuSub,

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -441,6 +441,22 @@ const DropdownMenuShortcut = ({ className, ...props }: React.HTMLAttributes<HTML
 };
 DropdownMenuShortcut.displayName = "DropdownMenuShortcut";
 
+/* Trailing muted slot for item METADATA — a count, a state, a reason an item is
+ * disabled. Deliberately not `DropdownMenuShortcut`: a count is not a keybinding,
+ * and rendering it in the shortcut's mono face reads as one. Non-mono, and
+ * `aria-hidden` by default because the number belongs in the item's accessible
+ * name (callers pass one), not as a second stray string after it. */
+const DropdownMenuMeta = ({ className, ...props }: React.HTMLAttributes<HTMLSpanElement>) => {
+  return (
+    <span
+      aria-hidden="true"
+      className={cn("ml-auto pl-2 text-2xs text-text-secondary tabular-nums", className)}
+      {...props}
+    />
+  );
+};
+DropdownMenuMeta.displayName = "DropdownMenuMeta";
+
 type DropdownMenuRadioGroupProps = React.ComponentPropsWithoutRef<
   typeof DropdownMenuPrimitiveType.RadioGroup
 >;
@@ -530,6 +546,7 @@ export {
   DropdownMenuSeparator,
   DropdownMenuLabel,
   DropdownMenuShortcut,
+  DropdownMenuMeta,
   DropdownMenuGroup,
   DropdownMenuPortal,
   DropdownMenuSub,

--- a/src/lib/__tests__/platform.test.ts
+++ b/src/lib/__tests__/platform.test.ts
@@ -88,3 +88,28 @@ describe("isWindows", () => {
     expect(isWindows()).toBe(false);
   });
 });
+
+describe("fileManagerRevealLabel", () => {
+  it("names Finder on macOS", async () => {
+    stubNavigator("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36", "MacIntel");
+    const { fileManagerRevealLabel } = await import("../platform");
+    expect(fileManagerRevealLabel()).toBe("Show in Finder");
+  });
+
+  it("names Explorer on Windows", async () => {
+    stubNavigator("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36", "Win32");
+    const { fileManagerRevealLabel } = await import("../platform");
+    expect(fileManagerRevealLabel()).toBe("Show in Explorer");
+  });
+
+  it("falls back to a generic name on Linux and anything unrecognised", async () => {
+    stubNavigator("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36", "Linux x86_64");
+    const { fileManagerRevealLabel } = await import("../platform");
+    expect(fileManagerRevealLabel()).toBe("Show in file manager");
+
+    stubNavigator("Mozilla/5.0 (Unknown)", "SomethingElse");
+    vi.resetModules();
+    const reloaded = await import("../platform");
+    expect(reloaded.fileManagerRevealLabel()).toBe("Show in file manager");
+  });
+});

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -61,3 +61,14 @@ export function createTooltipWithShortcut(label: string, shortcut: string): stri
   const formatted = formatShortcutForTooltip(shortcut);
   return formatted ? `${label} (${formatted})` : label;
 }
+
+/**
+ * Platform-correct label for the "open this path in the OS file manager"
+ * command. One helper so the dropdown, the right-click menu and their tests
+ * can't drift onto three different names for the same action.
+ */
+export function fileManagerRevealLabel(): string {
+  if (isMac()) return "Show in Finder";
+  if (isWindows()) return "Show in Explorer";
+  return "Show in file manager";
+}

--- a/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
+++ b/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
@@ -6469,7 +6469,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "keywords": undefined,
     "kind": "command",
     "requiresArgs": false,
-    "title": "Maximize All Sessions",
+    "title": "Move All Sessions To Grid",
   },
   {
     "category": "worktree",

--- a/src/services/actions/definitions/worktreeSessionActions.ts
+++ b/src/services/actions/definitions/worktreeSessionActions.ts
@@ -48,7 +48,11 @@ export function registerWorktreeSessionActions(
 
   actions.set("worktree.sessions.maximizeAll", () => ({
     id: "worktree.sessions.maximizeAll",
-    title: "Maximize All Sessions",
+    // "Maximize" described nothing this action does — it moves docked sessions
+    // back into the grid. Renamed everywhere it surfaces so the palette, the
+    // worktree menu and the audit trail name the same operation. The action ID
+    // is load-bearing and stays.
+    title: "Move All Sessions To Grid",
     description: "Move all dock sessions for a worktree into the grid",
     category: "worktree",
     kind: "command",


### PR DESCRIPTION
The worktree card's `⋯` dropdown and its right-click menu were showing around twenty five commands in one flat list, mixing items from ten different areas. Card reordering sat at the top, the three copy actions were scattered across three places, and plugin items rendered *after* `Delete worktree`.

This restructures the root into eleven named groups:

1. **Launch**, **Open**, **Review** (start something, open it, review it)
2. **Sessions**, **Recipes**, **Runtime** (manage what's running)
3. **Linked work**, **Copy**, **Organize**, **Extensions**
4. **Delete worktree…**, always last

Both surfaces still render the same `WorktreeMenuItems` with different injected Radix primitive maps, so they can't drift apart.

## What changed

**Plugin items live in Extensions.** They used to trail the root after the destructive row, which breaks the one structural promise a menu makes. Nesting them also keeps the root stable however many plugins are installed, and stops a third party rendering past deletion.

**Separators are computed, not scattered.** The old menu had `{cond && <Separator/>}` sprinkled through the JSX with each optional group owning the rule after it, which still allowed an orphan trailing rule. `joinGroups()` decides which groups are non-empty first and interleaves afterwards, so a leading, trailing or doubled root separator is unrepresentable rather than just untested.

**Labels say what the thing does.** `Maximize All` never maximized anything (it moves docked panels to the grid), so it's `Move all to grid` in the menu, the palette, the keybinding and the audit trail. `Reset All Renderers` is `Redraw all terminals`. `Close All` and `Terminate All` become `Trash all sessions…` and `Terminate all sessions…` so the reversible one reads as reversible. `Reveal in Finder` is now platform-correct via one shared helper.

## State bugs found on the way

Three rows were lying about what they'd do:

- `Stop Dev Server` and `Restart Dev Server` rendered unconditionally. Stop was a no-op with nothing running and Restart was an undocumented start. Now `devServerMenuState()` distinguishes the three states properly, including the case where a closed panel leaves a stale `stopped` snapshot the main process has already deleted (restart would have silently done nothing there).
- Remote resource commands were gated on `lastStatus` matching a small token set, but that's free-form output from the project's own status command. A project printing `healthy` lost Resume, Pause and Connect entirely. Status now narrows the mutually exclusive Resume/Pause pair only when it's recognised, and never hides a configured command.
- Settings only rejects blank and duplicate environment names, so an environment literally called `local` rendered a second radio carrying the fixed Local row's value, leaving two items marked checked.

Environment selection also moves from a decorative `CircleDot` inside ordinary menu items to real `menuitemradio` semantics, and counts now reach assistive tech through the item's accessible name rather than only a muted trailing slot.

## Not built

`Compare with base branch` from the design doc. The Review Hub has no base-diff mode and the doc explicitly says not to build a second comparison model, so there's nothing to route it to yet.

## Testing

`npm run check` clean. Full suite green at 2386 files / 52471 tests, including a new real-Radix test that mounts the menu through both production primitive maps (the plain-DOM harness can't prove radio semantics or map completeness on its own). E2E specs updated for the new labels, with hover-to-click fallbacks on the new submenu paths since hover gets dropped on Linux CI.
