### PR TITLE
fix(worktree): let the base branch name yield before the counts

### DIFF
--- a/src/components/Worktree/WorktreeCard/UpstreamSyncBadge.tsx
+++ b/src/components/Worktree/WorktreeCard/UpstreamSyncBadge.tsx
@@ -180,7 +180,10 @@ export function UpstreamSyncBadge({
 
   if (fetchAuthFailed && hasAuthFailedSignIn) {
     return (
-      <Tooltip>
+      // autoDismiss={false}: the pill can ellipsize the base name now, so this
+      // tooltip is the only place to read it in full — a full-text reveal, which
+      // `tooltip.tsx` exempts from the 2.5s deadline meant for transient hints.
+      <Tooltip autoDismiss={false}>
         <TooltipTrigger asChild>
           <button
             type="button"
@@ -222,7 +225,7 @@ export function UpstreamSyncBadge({
                   )}
                 </>
               )}
-              {!showUpstreamDelta && !showBaseSegment && <span className="shrink-0">—</span>}
+              {!showUpstreamDelta && !showBaseSegment && <span>—</span>}
             </span>
           </button>
         </TooltipTrigger>
@@ -233,7 +236,9 @@ export function UpstreamSyncBadge({
               never said what it was. Without this line the auth state is the
               one place a truncated name has nowhere to be read in full. */}
           {showBaseSegment && baseBranchName && (
-            <div className="text-text-muted">Compared with {baseCompareRef || baseBranchName}</div>
+            <div className="text-text-muted break-words">
+              Compared with {baseCompareRef || baseBranchName}
+            </div>
           )}
           {lastFetchedAt != null && (
             <div className="text-text-muted">Last fetched {formatRelativeTime(lastFetchedAt)}</div>
@@ -246,7 +251,8 @@ export function UpstreamSyncBadge({
   if (!showUpstreamDelta && !showBaseSegment) return null;
 
   return (
-    <Tooltip>
+    // Same full-text reveal as the auth-failed variant above.
+    <Tooltip autoDismiss={false}>
       <TooltipTrigger asChild>
         <span
           className={cn(
@@ -332,7 +338,7 @@ export function UpstreamSyncBadge({
           </div>
         )}
         {showBaseDivergence && baseBranchName && (
-          <div className="text-text-muted/70">
+          <div className="text-text-muted/70 break-words">
             {baseAheadCount != null && baseAheadCount > 0 && (
               <span>
                 {baseAheadCount} ahead of {baseCompareRef || baseBranchName}
@@ -346,7 +352,9 @@ export function UpstreamSyncBadge({
           </div>
         )}
         {showBaseResting && baseBranchName && (
-          <div className="text-text-muted">In sync with {baseCompareRef || baseBranchName}</div>
+          <div className="text-text-muted break-words">
+            In sync with {baseCompareRef || baseBranchName}
+          </div>
         )}
         {hasNoUpstream && showBaseSegment && (
           <div className="text-text-muted">No upstream branch configured</div>

--- a/src/components/Worktree/WorktreeCard/UpstreamSyncBadge.tsx
+++ b/src/components/Worktree/WorktreeCard/UpstreamSyncBadge.tsx
@@ -194,26 +194,47 @@ export function UpstreamSyncBadge({
             data-fetch-auth-failed="true"
             aria-label="Forge authentication failed — click to reconnect"
           >
-            <span className="flex items-center gap-1.5 text-text-muted">
-              {showUpstreamDelta && hasAhead && <span>↑{aheadCount}</span>}
-              {showUpstreamDelta && hasBehind && <span>↓{behindCount}</span>}
+            {/* min-w-0: this row is a flex *item* of the button above it, so
+                its own automatic minimum size is its min-content width — the
+                whole unbroken branch name, since the label below sets
+                white-space: nowrap. Without this the row refuses to shrink and
+                the label never gets narrow enough to ellipsize. The normal
+                variant has no equivalent level: its row is a cross-axis child
+                of the card's column, where min-width: auto resolves to 0. */}
+            <span className="flex items-center gap-1.5 text-text-muted min-w-0">
+              {showUpstreamDelta && hasAhead && <span className="shrink-0">↑{aheadCount}</span>}
+              {showUpstreamDelta && hasBehind && <span className="shrink-0">↓{behindCount}</span>}
               {showBaseSegment && (
                 <>
-                  <span data-testid="upstream-sync-base">
+                  <span className="min-w-0 truncate" data-testid="upstream-sync-base">
                     {showBaseDivergence ? "Δ" : "≡"} {baseBranchName}
                   </span>
-                  {displayedBaseAhead != null && <span>↑{displayedBaseAhead}</span>}
-                  {displayedBaseBehind != null && <span>↓{displayedBaseBehind}</span>}
-                  {hasNoUpstream && <span data-testid="upstream-sync-unpushed">· local</span>}
+                  {displayedBaseAhead != null && (
+                    <span className="shrink-0">↑{displayedBaseAhead}</span>
+                  )}
+                  {displayedBaseBehind != null && (
+                    <span className="shrink-0">↓{displayedBaseBehind}</span>
+                  )}
+                  {hasNoUpstream && (
+                    <span className="shrink-0" data-testid="upstream-sync-unpushed">
+                      · local
+                    </span>
+                  )}
                 </>
               )}
-              {!showUpstreamDelta && !showBaseSegment && <span>—</span>}
+              {!showUpstreamDelta && !showBaseSegment && <span className="shrink-0">—</span>}
             </span>
           </button>
         </TooltipTrigger>
         <TooltipContent side="right" className="text-xs">
           <div>Forge authentication failed</div>
           <div className="text-text-secondary mt-0.5">Click to reconnect your code forge</div>
+          {/* The pill can now ellipsize the base name, and this variant's copy
+              never said what it was. Without this line the auth state is the
+              one place a truncated name has nowhere to be read in full. */}
+          {showBaseSegment && baseBranchName && (
+            <div className="text-text-muted">Compared with {baseCompareRef || baseBranchName}</div>
+          )}
           {lastFetchedAt != null && (
             <div className="text-text-muted">Last fetched {formatRelativeTime(lastFetchedAt)}</div>
           )}
@@ -242,10 +263,10 @@ export function UpstreamSyncBadge({
           onAnimationEnd={() => setIsFlashing(false)}
         >
           {showUpstreamDelta && hasAhead && (
-            <span className="text-status-success">↑{aheadCount}</span>
+            <span className="text-status-success shrink-0">↑{aheadCount}</span>
           )}
           {showUpstreamDelta && hasBehind && (
-            <span className="text-status-warning">↓{behindCount}</span>
+            <span className="text-status-warning shrink-0">↓{behindCount}</span>
           )}
           {showBaseSegment && (
             <>
@@ -263,19 +284,29 @@ export function UpstreamSyncBadge({
                   `Δ develop` beside a `Δ develop ↑3` would claim a divergence
                   it does not have. ≡ says the two are the same commit, which
                   is the whole content of the resting line. */}
-              <span className="text-text-secondary" data-testid="upstream-sync-base">
+              {/* The only thing on this line allowed to shrink. Everything
+                  beside it is shrink-0, so a base branch long enough to
+                  outgrow the card ellipsizes here instead of pushing the
+                  counts and the · local marker off the right edge — they are
+                  the state the line exists to carry, and the tooltip below
+                  still names the branch in full. Glyph and name stay one text
+                  run so the ellipsis eats the name from the right. */}
+              <span
+                className="text-text-secondary min-w-0 truncate"
+                data-testid="upstream-sync-base"
+              >
                 {showBaseDivergence ? "Δ" : "≡"} {baseBranchName}
               </span>
               {baseAheadCount != null && baseAheadCount > 0 && (
-                <span className="text-status-success">↑{baseAheadCount}</span>
+                <span className="text-status-success shrink-0">↑{baseAheadCount}</span>
               )}
               {baseBehindCount != null && baseBehindCount > 0 && (
-                <span className="text-status-warning">↓{baseBehindCount}</span>
+                <span className="text-status-warning shrink-0">↓{baseBehindCount}</span>
               )}
               {/* Same tier as the branch name it qualifies, so it inherits the
                   same contrast reasoning — never text-muted. */}
               {hasNoUpstream && (
-                <span className="text-text-secondary" data-testid="upstream-sync-unpushed">
+                <span className="text-text-secondary shrink-0" data-testid="upstream-sync-unpushed">
                   · local
                 </span>
               )}

--- a/src/components/Worktree/WorktreeCard/__tests__/UpstreamSyncBadge.compareRef.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/UpstreamSyncBadge.compareRef.test.tsx
@@ -197,3 +197,38 @@ describe("UpstreamSyncBadge — a branch tracking its own base", () => {
     expect(pill.textContent?.match(/↓4/g)).toHaveLength(1);
   });
 });
+
+describe("UpstreamSyncBadge — the auth-failed tooltip (#12074)", () => {
+  it("names the compare ref, so a base name the pill had to ellipsize is still readable", () => {
+    // The normal tooltip has always named the ref; the auth-failed one carried
+    // only recovery copy. Once the pill can truncate the name, that is the one
+    // state with nowhere left to read it in full.
+    renderBadge({
+      baseBranchName: "release/2026-08-long-lived-integration-branch",
+      baseCompareRef: "upstream/release/2026-08-long-lived-integration-branch",
+      fetchAuthFailed: true,
+      hasAuthFailedSignIn: true,
+    });
+
+    expect(document.body.textContent).toContain(
+      "Compared with upstream/release/2026-08-long-lived-integration-branch"
+    );
+
+    // Still bare in the dense row itself, same as the normal variant.
+    const pill = screen.getByTestId("upstream-sync-indicator");
+    expect(pill.textContent).not.toContain("upstream/");
+  });
+
+  it("says nothing about a base it has no name for", () => {
+    renderBadge({
+      baseBranchName: null,
+      baseAheadCount: null,
+      baseBehindCount: null,
+      baseCompareRef: null,
+      fetchAuthFailed: true,
+      hasAuthFailedSignIn: true,
+    });
+
+    expect(document.body.textContent).not.toContain("Compared with");
+  });
+});

--- a/src/components/Worktree/WorktreeCard/__tests__/UpstreamSyncBadge.compareRef.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/UpstreamSyncBadge.compareRef.test.tsx
@@ -199,36 +199,42 @@ describe("UpstreamSyncBadge — a branch tracking its own base", () => {
 });
 
 describe("UpstreamSyncBadge — the auth-failed tooltip (#12074)", () => {
-  it("names the compare ref, so a base name the pill had to ellipsize is still readable", () => {
-    // The normal tooltip has always named the ref; the auth-failed one carried
-    // only recovery copy. Once the pill can truncate the name, that is the one
-    // state with nowhere left to read it in full.
-    renderBadge({
-      baseBranchName: "release/2026-08-long-lived-integration-branch",
-      baseCompareRef: "upstream/release/2026-08-long-lived-integration-branch",
-      fetchAuthFailed: true,
-      hasAuthFailedSignIn: true,
+  const longBase = "release/2026-08-long-lived-integration-branch";
+  const authed: Partial<Props> = { fetchAuthFailed: true, hasAuthFailedSignIn: true };
+
+  it("names the ref it compared against, so a name the pill had to ellipsize is still readable", () => {
+    // The normal tooltip has always named the ref; this variant carried only
+    // recovery copy. Once the pill can truncate the name, this is the one state
+    // with nowhere left to read it in full.
+    const { rerender } = renderBadge({
+      ...authed,
+      baseBranchName: longBase,
+      baseCompareRef: `upstream/${longBase}`,
     });
-
-    expect(document.body.textContent).toContain(
-      "Compared with upstream/release/2026-08-long-lived-integration-branch"
-    );
-
+    expect(document.body.textContent).toContain(`Compared with upstream/${longBase}`);
     // Still bare in the dense row itself, same as the normal variant.
-    const pill = screen.getByTestId("upstream-sync-indicator");
-    expect(pill.textContent).not.toContain("upstream/");
-  });
+    expect(screen.getByTestId("upstream-sync-indicator").textContent).not.toContain("upstream/");
 
-  it("says nothing about a base it has no name for", () => {
-    renderBadge({
-      baseBranchName: null,
-      baseAheadCount: null,
-      baseBehindCount: null,
-      baseCompareRef: null,
-      fetchAuthFailed: true,
-      hasAuthFailedSignIn: true,
-    });
+    rerender(
+      <UpstreamSyncBadge
+        {...baseProps}
+        {...authed}
+        baseBranchName={longBase}
+        baseCompareRef={null}
+      />
+    );
+    expect(document.body.textContent).toContain(`Compared with ${longBase}`);
 
+    rerender(
+      <UpstreamSyncBadge
+        {...baseProps}
+        {...authed}
+        baseBranchName={null}
+        baseAheadCount={null}
+        baseBehindCount={null}
+        baseCompareRef={null}
+      />
+    );
     expect(document.body.textContent).not.toContain("Compared with");
   });
 });

--- a/src/components/Worktree/WorktreeCard/__tests__/UpstreamSyncBadge.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/UpstreamSyncBadge.test.tsx
@@ -395,3 +395,82 @@ describe("UpstreamSyncBadge — resting base relationship", () => {
     expect(screen.queryByTestId("upstream-sync-unpushed")).not.toBeNull();
   });
 });
+
+describe("UpstreamSyncBadge — a base branch longer than the card (#12074)", () => {
+  const longBase = "feature/stacked-worktree-base-branch-name-that-keeps-going";
+
+  // Every token the line can hold at once: upstream pair, base pair, marker.
+  // This is the crowded case, where something has to give.
+  const crowded: Partial<Props> = {
+    aheadCount: 12,
+    behindCount: 3,
+    baseBranchName: longBase,
+    baseAheadCount: 12,
+    baseBehindCount: 3,
+    baseMatchesUpstream: false,
+    hasNoUpstream: true,
+  };
+
+  /**
+   * jsdom computes no widths, so the ellipsis itself is not observable. What
+   * is observable — and is the actual invariant — is the layout priority:
+   * whichever tokens the row happens to hold, exactly one of them may give up
+   * width, and it has to be the same one that clips its overflow. Asserted as
+   * a relationship over the rendered row rather than a list of class literals,
+   * so it survives a restyle and still catches a token added without
+   * shrink protection.
+   */
+  function assertOnlyTheNameYields() {
+    const label = screen.getByTestId("upstream-sync-base");
+    const children = Array.from(label.parentElement!.children);
+    expect(children.length).toBeGreaterThan(1);
+
+    const shrinkable = children.filter((el) => !el.classList.contains("shrink-0"));
+    expect(shrinkable).toHaveLength(1);
+    expect(shrinkable[0]).toBe(label);
+
+    const clipping = children.filter((el) => el.classList.contains("truncate"));
+    expect(clipping).toHaveLength(1);
+    expect(clipping[0]).toBe(label);
+
+    // The counts and the marker are the state the line exists to carry, so
+    // they are what has to survive beside the name that yielded.
+    const line = children.map((el) => el.textContent).join(" ");
+    expect(line).toContain("↑12");
+    expect(line).toContain("↓3");
+    expect(line).toContain("· local");
+
+    // Nothing caps the name on the way in — the fix is presentation-only, so
+    // the full ref stays in the DOM for the tooltip and for assistive tech.
+    expect(label.textContent).toBe(`Δ ${longBase}`);
+  }
+
+  it("yields the name and keeps the counts on the normal badge", () => {
+    renderBadge(crowded);
+    assertOnlyTheNameYields();
+  });
+
+  it("yields the name and keeps the counts on the auth-failed badge too", () => {
+    vi.stubGlobal("electron", { worktree: { retryAuthFetch: mockRetryAuthFetch } });
+    renderBadge({ ...crowded, fetchAuthFailed: true, hasAuthFailedSignIn: true });
+    assertOnlyTheNameYields();
+  });
+
+  it("protects the em-dash the auth badge falls back to when there is nothing to report", () => {
+    vi.stubGlobal("electron", { worktree: { retryAuthFetch: mockRetryAuthFetch } });
+    renderBadge({
+      aheadCount: 0,
+      behindCount: 0,
+      baseBranchName: null,
+      baseAheadCount: null,
+      baseBehindCount: null,
+      fetchAuthFailed: true,
+      hasAuthFailedSignIn: true,
+    });
+
+    const dash = screen
+      .getAllByText("—")
+      .find((el) => el.tagName === "SPAN" && el.textContent === "—");
+    expect(dash?.classList.contains("shrink-0")).toBe(true);
+  });
+});

--- a/src/components/Worktree/WorktreeCard/__tests__/UpstreamSyncBadge.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/UpstreamSyncBadge.test.tsx
@@ -51,6 +51,7 @@ function renderBadge(extra: Partial<Props> = {}) {
 
 afterEach(() => {
   cleanup();
+  vi.unstubAllGlobals();
 });
 
 describe("UpstreamSyncBadge — auth-failed sign-in branch (issue #9982)", () => {
@@ -399,31 +400,32 @@ describe("UpstreamSyncBadge — resting base relationship", () => {
 describe("UpstreamSyncBadge — a base branch longer than the card (#12074)", () => {
   const longBase = "feature/stacked-worktree-base-branch-name-that-keeps-going";
 
-  // Every token the line can hold at once: upstream pair, base pair, marker.
-  // This is the crowded case, where something has to give.
+  // Distinct numbers per pair: identical ones would let a whole pair go
+  // missing without any assertion noticing.
   const crowded: Partial<Props> = {
     aheadCount: 12,
     behindCount: 3,
     baseBranchName: longBase,
-    baseAheadCount: 12,
-    baseBehindCount: 3,
     baseMatchesUpstream: false,
     hasNoUpstream: true,
   };
 
   /**
-   * jsdom computes no widths, so the ellipsis itself is not observable. What
-   * is observable — and is the actual invariant — is the layout priority:
-   * whichever tokens the row happens to hold, exactly one of them may give up
-   * width, and it has to be the same one that clips its overflow. Asserted as
-   * a relationship over the rendered row rather than a list of class literals,
-   * so it survives a restyle and still catches a token added without
-   * shrink protection.
+   * jsdom computes no widths, so the ellipsis itself is not observable. What is
+   * observable is the layout priority the fix installs: of the tokens the row
+   * happens to hold, exactly one may give up width, it is the base label, and
+   * it is the same element that clips. Read off the rendered row rather than
+   * hardcoded per variant, so it holds for both and for tokens added later.
+   *
+   * It is still spelled in Tailwind's utilities, so an equivalent restyle would
+   * have to update it — the trade for having any coverage at all here, since
+   * mocking layout would only test the mock.
    */
-  function assertOnlyTheNameYields() {
+  function assertOnlyTheNameYields(glyph: string, tokens: string[]) {
     const label = screen.getByTestId("upstream-sync-base");
-    const children = Array.from(label.parentElement!.children);
-    expect(children.length).toBeGreaterThan(1);
+    const row = label.parentElement!;
+    const children = Array.from(row.children);
+    expect(children.length).toBe(tokens.length + 1);
 
     const shrinkable = children.filter((el) => !el.classList.contains("shrink-0"));
     expect(shrinkable).toHaveLength(1);
@@ -433,44 +435,44 @@ describe("UpstreamSyncBadge — a base branch longer than the card (#12074)", ()
     expect(clipping).toHaveLength(1);
     expect(clipping[0]).toBe(label);
 
+    // The row itself has to be able to give up width, or the label inside it
+    // never gets narrow enough to yield. In the auth-failed variant the row is
+    // a flex item of the button above it and needs its own floor removed; in
+    // the normal variant the row is the badge root, stretched across the card,
+    // and there is nothing in between.
+    const root = screen.getByTestId("upstream-sync-indicator");
+    for (let el = row; el !== root; el = el.parentElement!) {
+      expect(el.classList.contains("min-w-0")).toBe(true);
+    }
+
     // The counts and the marker are the state the line exists to carry, so
     // they are what has to survive beside the name that yielded.
-    const line = children.map((el) => el.textContent).join(" ");
-    expect(line).toContain("↑12");
-    expect(line).toContain("↓3");
-    expect(line).toContain("· local");
+    const rendered = children.filter((el) => el !== label).map((el) => el.textContent);
+    expect(rendered).toEqual(tokens);
 
-    // Nothing caps the name on the way in — the fix is presentation-only, so
-    // the full ref stays in the DOM for the tooltip and for assistive tech.
-    expect(label.textContent).toBe(`Δ ${longBase}`);
+    // Nothing caps the name on the way in — this is presentation-only, so the
+    // full ref stays in the DOM for the tooltip to reveal.
+    expect(label.textContent).toBe(`${glyph} ${longBase}`);
   }
 
-  it("yields the name and keeps the counts on the normal badge", () => {
-    renderBadge(crowded);
-    assertOnlyTheNameYields();
+  it("yields the name and keeps every count on the normal badge", () => {
+    renderBadge({ ...crowded, baseAheadCount: 7, baseBehindCount: 5 });
+    assertOnlyTheNameYields("Δ", ["↑12", "↓3", "↑7", "↓5", "· local"]);
   });
 
-  it("yields the name and keeps the counts on the auth-failed badge too", () => {
-    vi.stubGlobal("electron", { worktree: { retryAuthFetch: mockRetryAuthFetch } });
-    renderBadge({ ...crowded, fetchAuthFailed: true, hasAuthFailedSignIn: true });
-    assertOnlyTheNameYields();
-  });
-
-  it("protects the em-dash the auth badge falls back to when there is nothing to report", () => {
-    vi.stubGlobal("electron", { worktree: { retryAuthFetch: mockRetryAuthFetch } });
+  it("yields the name and keeps every count on the auth-failed badge too", () => {
     renderBadge({
-      aheadCount: 0,
-      behindCount: 0,
-      baseBranchName: null,
-      baseAheadCount: null,
-      baseBehindCount: null,
+      ...crowded,
+      baseAheadCount: 7,
+      baseBehindCount: 5,
       fetchAuthFailed: true,
       hasAuthFailedSignIn: true,
     });
+    assertOnlyTheNameYields("Δ", ["↑12", "↓3", "↑7", "↓5", "· local"]);
+  });
 
-    const dash = screen
-      .getAllByText("—")
-      .find((el) => el.tagName === "SPAN" && el.textContent === "—");
-    expect(dash?.classList.contains("shrink-0")).toBe(true);
+  it("yields a long name on the resting line too, where there are no base counts", () => {
+    renderBadge({ ...crowded, baseAheadCount: 0, baseBehindCount: 0 });
+    assertOnlyTheNameYields("≡", ["↑12", "↓3", "· local"]);
   });
 });

--- a/src/components/Worktree/WorktreeCard/__tests__/UpstreamSyncBadge.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/UpstreamSyncBadge.test.tsx
@@ -51,7 +51,6 @@ function renderBadge(extra: Partial<Props> = {}) {
 
 afterEach(() => {
   cleanup();
-  vi.unstubAllGlobals();
 });
 
 describe("UpstreamSyncBadge — auth-failed sign-in branch (issue #9982)", () => {


### PR DESCRIPTION
## Summary

- The worktree sidebar card's base branch line rendered the base branch name raw in `UpstreamSyncBadge.tsx`. Flex children default to `min-width: auto`, so the name refused to shrink, pushed the row past the card, and the sidebar's clipping scroller silently ate the trailing content, the ahead/behind counts and the `· local` marker, instead of the name.
- Most base branches are `main` or `develop`, so this rarely bit. Stacked worktrees, where the base is another feature branch, are where it did.
- Fix makes the base branch name the only thing on that line allowed to give up width, and gives the tooltip the job of showing the full name on hover.

Resolves #12074

## Changes

- `min-w-0` and `truncate` on the base label in both render paths (the normal badge and the auth-failed variant), with the glyph and name kept as one text run so `Δ develop` still reads as one string.
- `shrink-0` on every fixed token beside it: upstream ↑/↓, base ↑/↓, and the `· local` marker.
- `min-w-0` on the auth-failed variant's inner row too. That row is a flex item of the button above it, so its own automatic minimum size is its min-content width, and `truncate`'s `white-space: nowrap` makes that the entire unbroken branch name. Without it, that variant holds the row open and the label never ellipsizes (Flexbox spec §9.9, CSS Sizing spec §5.2: `overflow: hidden` zeroes an item's own automatic minimum size but not its min-content contribution to its parent's intrinsic width). The normal variant deliberately doesn't get this: its row is a cross-axis child of the card's column, where `min-width: auto` resolves to 0 and stretch already supplies a finite width.
- Both tooltips now opt out of the 2.5s auto-dismiss that `tooltip.tsx` reserves for tooltips whose body *is* the content, rich hover cards, full-text reveals.
- The auth-failed tooltip never named the base branch at all. It now shows `Compared with {baseCompareRef || baseBranchName}`.
- Long refs wrap inside the tooltip's `max-w-xs overflow-hidden` container instead of being clipped there too.
- Nothing caps the name upstream. `BaseDivergence`, `GitStatusPass`, and `SnapshotBuilder` stay lossless, the full ref is still in the DOM, and this is presentation-only.

## Testing

New regression tests assert the layout priority relationally instead of mirroring class literals: of the tokens the row holds, exactly one may give up width, it's the base label, it's the same element that clips, and every element between it and the badge root can shrink too. Verified by mutation, deleting the auth row's `min-w-0` fails exactly the auth test. Covers both variants plus the resting `≡` line, and pins the exact token multiset with distinct per-pair counts.

Local: 162 tests across the four WorktreeCard suites, 926 across `src/components/ui/__tests__` (tooltip contract and radix source-contract suites), 492 across `src/config/__tests__`. eslint and prettier clean on the changed files.

**Known limitation:** if the fixed tokens alone exceed the row (`↑999 ↓999 ↑999 ↓999 · local` at the 200px minimum sidebar width), nothing can shrink and the row overflows again, with the label reaching zero width first. Fixing that needs a real degradation policy (wrapping, or compacting a token group into the tooltip), which is a product decision beyond this bug. The issue sets the priority as counts and `· local` staying visible.