### PR TITLE
fix(pty-host): forward worktreeId on the terminal-info query payload

### DIFF
--- a/electron/ipc/handlers/terminal/__tests__/snapshots.getForProject.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/snapshots.getForProject.test.ts
@@ -217,4 +217,36 @@ describe("terminal:get-for-project handler", () => {
     const unknown = result.find((t) => t.id === "t-unknown");
     expect(unknown?.ptyCols).toBeUndefined();
   });
+
+  it("strips backend worktree attribution, which is renderer-owned (#5176)", async () => {
+    // Hydration's primary path. The pty-host mapper only began reporting
+    // worktreeId in #12078, so this projection had never seen a populated
+    // value — a refactor to a spread would now let the backend win a placement
+    // decision that belongs to the renderer's saved layout state alone.
+    const ptyClient = {
+      getTerminalsForProjectAsync: vi.fn(async () => ["t-worktreed"]),
+      getTerminalAsync: vi.fn(async (id: string) => ({
+        id,
+        kind: "terminal",
+        type: "terminal",
+        cwd: "/repo/.worktrees/backend",
+        spawnedAt: Date.now(),
+        worktreeId: "/repo/.worktrees/backend",
+      })),
+    };
+
+    const deps = { ptyClient } as unknown as HandlerDependencies;
+    registerTerminalSnapshotHandlers(deps);
+
+    const calls = (ipcMain.handle as unknown as { mock: { calls: Array<[string, unknown]> } }).mock
+      .calls;
+    const handler = calls.find(
+      (c) => c[0] === CHANNELS.TERMINAL_GET_FOR_PROJECT
+    )?.[1] as unknown as (event: unknown, projectId: string) => Promise<unknown[]>;
+
+    const result = await handler({ senderFrame: { url: "http://localhost:5173" } }, "project-1");
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).not.toHaveProperty("worktreeId");
+  });
 });

--- a/electron/ipc/handlers/terminal/__tests__/snapshots.reconnectBulk.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/snapshots.reconnectBulk.test.ts
@@ -107,6 +107,12 @@ const TERMINALS = new Map<string, Record<string, unknown>>([
   ["t-scratch", makeTerminal("t-scratch", "scratch-1")],
   // Carries the live PTY grid the pty-host mapper reports (#11718).
   ["t-sized", { ...makeTerminal("t-sized", "project-a"), ptyCols: 203, ptyRows: 51 }],
+  // Carries backend worktree attribution, which the mapper began reporting in
+  // #12078 and this projection must keep stripping (#5176).
+  [
+    "t-worktreed",
+    { ...makeTerminal("t-worktreed", "project-a"), worktreeId: "/repo/.worktrees/backend" },
+  ],
 ]);
 
 /** An invoke event whose URL can be mutated mid-flight, to prove identity is snapshotted. */
@@ -199,6 +205,18 @@ describe("terminal:reconnect — workspace ownership", () => {
     };
     expect(result.ptyCols).toBe(203);
     expect(result.ptyRows).toBe(51);
+  });
+
+  it("strips backend worktree attribution, which is renderer-owned (#5176)", async () => {
+    // The pty-host mapper only began reporting worktreeId in #12078, so this
+    // projection had never actually seen a populated value — a refactor to a
+    // spread would now hand restore a placement authority that must stay the
+    // renderer's saved state alone.
+    register();
+
+    const result = await reconnect(senderEvent(SENDER_A), "t-worktreed");
+
+    expect(result).not.toHaveProperty("worktreeId");
   });
 
   it("serves each project its own terminal in the same session", async () => {

--- a/electron/pty-host/handlers/__tests__/terminalInfo.test.ts
+++ b/electron/pty-host/handlers/__tests__/terminalInfo.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, expectTypeOf, vi } from "vitest";
 import { mapTerminalInfo, narrowDetectedAgentId } from "../terminalInfo.js";
 import type { HostContext } from "../types.js";
+import type { PtyHostTerminalInfo } from "../../../../shared/types/pty-host.js";
 
 function createCtx(overrides: Partial<HostContext> = {}): HostContext {
   const ptyManager = {
@@ -68,6 +69,7 @@ function makeTerminal(overrides: Record<string, unknown> = {}) {
     agentSessionId: undefined,
     agentLaunchFlags: undefined,
     agentModelId: undefined,
+    worktreeId: undefined,
     agentPresetId: undefined,
     agentPresetColor: undefined,
     originalAgentPresetId: undefined,
@@ -152,6 +154,37 @@ describe("mapTerminalInfo", () => {
     const result = mapTerminalInfo(makeTerminal({ lastInputTime: 111, lastOutputTime: 222 }), ctx);
     expect(result.lastInputTime).toBe(111);
     expect(result.lastOutputTime).toBe(222);
+  });
+
+  it("forwards worktreeId so fleet rows keep their worktree attribution (#12078)", () => {
+    // FleetSnapshotService copies worktreeId onto every FleetRunRow and the
+    // palette groups on it; a dropped field files every agent under the single
+    // "No worktree" heading no matter which worktree it actually runs in.
+    const ctx = createCtx();
+    const t = makeTerminal({ worktreeId: "/repo/.worktrees/feature" });
+
+    expect(mapTerminalInfo(t, ctx).worktreeId).toBe(t.worktreeId);
+  });
+
+  it("leaves a worktree-less terminal unattributed rather than guessing from cwd", () => {
+    // The grouping key must stay absent for a terminal that genuinely has no
+    // worktree — inferring one from `cwd` here would file project-root shells
+    // under the repo's own worktree.
+    const ctx = createCtx();
+    const result = mapTerminalInfo(makeTerminal({ cwd: "/repo" }), ctx);
+
+    expect(result.worktreeId).toBeUndefined();
+  });
+
+  it("emits every field the host response type declares", () => {
+    // Compile-time only: `PtyHostTerminalInfo`'s fields are optional, so a
+    // mapper that silently stops emitting one still type-checks at every call
+    // site — which is how #12078 shipped. Mapper-only extras stay legal.
+    type UnmappedField = Exclude<
+      keyof PtyHostTerminalInfo,
+      keyof ReturnType<typeof mapTerminalInfo>
+    >;
+    expectTypeOf<UnmappedField>().toBeNever();
   });
 
   it("reports the pty handle's live grid so restore can rebuild on it (#11718)", () => {

--- a/electron/pty-host/handlers/__tests__/terminalInfo.test.ts
+++ b/electron/pty-host/handlers/__tests__/terminalInfo.test.ts
@@ -167,24 +167,22 @@ describe("mapTerminalInfo", () => {
   });
 
   it("leaves a worktree-less terminal unattributed rather than guessing from cwd", () => {
-    // The grouping key must stay absent for a terminal that genuinely has no
-    // worktree — inferring one from `cwd` here would file project-root shells
-    // under the repo's own worktree.
     const ctx = createCtx();
     const result = mapTerminalInfo(makeTerminal({ cwd: "/repo" }), ctx);
 
     expect(result.worktreeId).toBeUndefined();
   });
 
-  it("emits every field the host response type declares", () => {
-    // Compile-time only: `PtyHostTerminalInfo`'s fields are optional, so a
-    // mapper that silently stops emitting one still type-checks at every call
-    // site — which is how #12078 shipped. Mapper-only extras stay legal.
-    type UnmappedField = Exclude<
-      keyof PtyHostTerminalInfo,
-      keyof ReturnType<typeof mapTerminalInfo>
-    >;
-    expectTypeOf<UnmappedField>().toBeNever();
+  it("emits exactly the field set the host response type declares", () => {
+    // Compile-time only. Nearly every field on PtyHostTerminalInfo is optional,
+    // so dropping one from the mapper still type-checks at all four call sites
+    // — which is how #12078 shipped. Equality (not a subset check) is the point:
+    // it also catches the mapper growing a field the wire type never declared,
+    // which is how `lastObservedTitle` rode across undeclared for as long as it
+    // did.
+    expectTypeOf<keyof ReturnType<typeof mapTerminalInfo>>().toEqualTypeOf<
+      keyof PtyHostTerminalInfo
+    >();
   });
 
   it("reports the pty handle's live grid so restore can rebuild on it (#11718)", () => {

--- a/electron/pty-host/handlers/terminalInfo.ts
+++ b/electron/pty-host/handlers/terminalInfo.ts
@@ -65,6 +65,7 @@ export function mapTerminalInfo(t: NonNullable<TerminalInfoLike>, ctx: HostConte
     agentSessionId: t.agentSessionId,
     agentLaunchFlags: t.agentLaunchFlags,
     agentModelId: t.agentModelId,
+    worktreeId: t.worktreeId,
     agentPresetId: t.agentPresetId,
     agentPresetColor: t.agentPresetColor,
     originalAgentPresetId: t.originalAgentPresetId,

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -833,10 +833,15 @@ export interface PtyHostTerminalInfo {
   launchAgentId?: AgentId;
   title?: string;
   titleMode?: PanelTitleMode;
+  /** Last non-useless OSC title observed from the agent — preferred over `title` for resume-record labels. */
+  lastObservedTitle?: string;
   cwd: string;
   agentState?: AgentState;
   waitingReason?: WaitingReason;
   lastStateChange?: number;
+  /** Activity timestamps idle detection runs on; absent means "unknown activity", not "idle". */
+  lastInputTime?: number;
+  lastOutputTime?: number;
   spawnedAt: number;
   isTrashed?: boolean;
   trashExpiresAt?: number;


### PR DESCRIPTION
## Summary

- The fleet palette (`Cmd+Option+I`, drilled into a project) filed every agent terminal under a single `No worktree` heading instead of grouping them per worktree the way the worktree sidebar does.
- Root cause: `mapTerminalInfo()` in `electron/pty-host/handlers/terminalInfo.ts` is the single producer of the IPC terminal-info payload for all four query families (`get-terminal`, `get-available-terminals`, `get-terminals-by-state`, `get-all-terminals`), and its return object never copied `worktreeId`, even though the live `TerminalProcess` record carries it correctly.
- Fix is one missing field copy in the mapper, backed by a bidirectional compile-time guard so it can't silently regress again.

Resolves #12078

## The bug

`PtyHostTerminalInfo` declares `worktreeId` as optional, so nothing type-checked the omission. Downstream, `FleetSnapshotService` only spreads `worktreeId` onto its row when it's `!== undefined`, which was never true, so `FleetRunRow.worktreeId` was always absent and `worktreeKey()` in `pilotRows.ts` bucketed every run into `wt:none`.

## Knock-on, fixed for free

`persistCloseRecord` (`electron/ipc/handlers/terminal/lifecycle.ts`) and `electron/lifecycle/shutdown.ts` both journal `info.worktreeId ?? null` into `agent-session-history.json`, so every close record was recording a null worktree. They're pure pass-throughs of the same payload and get repaired by the mapper fix with no change of their own. Same for `electron/services/pty/projectSessionJournal.ts`. Session-history retention is capped per worktree and supports worktree filtering, both of which previously fell into the global bucket.

## Worth flagging for reviewers

Shutdown and project-teardown now resolve branches for the worktrees they discover, which never happened before since the worktree list was always empty. Each lookup is time-boxed at 200ms and they run in parallel over unique worktree ids, so worst-case added wall-clock is about 200ms total, not per terminal. Well inside the 10s cleanup budget.

## Why it wasn't caught

The existing `FleetSnapshotService` test hand-supplies `worktreeId` on its fake `PtyClient` fixtures, so it stayed green while production was broken underneath it. Left that test alone: the fixture correctly models `PtyClient` output, and routing it through the host mapper would couple two unit-test boundaries that should stay separate.

## The guard

Rather than just a regression test, the mapper's field coverage is now compile-checked: `expectTypeOf<keyof ReturnType<typeof mapTerminalInfo>>().toEqualTypeOf<keyof PtyHostTerminalInfo>()`. Making that equality hold required declaring three fields the mapper already emitted and main already consumed but the wire type never declared (`lastObservedTitle`, `lastInputTime`, `lastOutputTime`). The check is bidirectional on purpose, catching both a dropped field and one riding across undeclared. Verified load-bearing empirically: pull the one-line fix and both the runtime test and the electron typecheck fail.

## The #5176 boundary

Panel `worktreeId` is renderer-owned layout state, and the backend must never win a placement decision. Traced end to end: the restore projections in `snapshots.ts` (`getForProject` and the reconnect probe) both omit the field, `BackendTerminalInfo` doesn't declare it, and `statePatcher` assigns only `saved.worktreeId` with no `saved ?? backend` merge. Since those projections had never actually seen a populated `worktreeId` before this change, both now carry an explicit regression test asserting they keep stripping it.

## Testing

- 359 test files / 9680 tests pass
- Root typecheck and the electron project typecheck both clean
- eslint and prettier clean on all changed files
