### PR TITLE
fix(settings): drop the scope line above the section title

### DIFF
--- a/e2e/screenshots/settings-scope-review.spec.ts
+++ b/e2e/screenshots/settings-scope-review.spec.ts
@@ -78,9 +78,9 @@ const navItem = (tab: string) => `[role="tab"][data-tab="${tab}"]`;
 /** The name the fixture project carries for every state but the long-name one. */
 const SHORT_NAME = "Helios Dashboard";
 /**
- * Long enough to actually reach the truncation. The previous value fit inside 43% of
- * the header's width, so the "long name" state proved nothing about what happens when
- * a name genuinely runs out of room.
+ * Long enough to actually reach the truncation, in the Project Name field and the path
+ * row under it. The previous value fit comfortably inside both, so the "long name"
+ * state proved nothing about what happens when a name genuinely runs out of room.
  */
 const LONG_NAME = "acme-platform-infrastructure-monorepo-services-frontend-web-console-workspace";
 
@@ -275,8 +275,9 @@ const STATES: ScopeState[] = [
     },
   },
   {
-    // A long project name. Predictable truncation with a full-value affordance, or a
-    // shell that breaks — the shot decides which.
+    // A long project name. Predictable truncation in the identity row and the sidebar,
+    // or a shell that breaks — the shot decides which. The header no longer names the
+    // project, so this state is about the fields that do.
     slug: "05-project-long-name",
     target: { tab: "project:general" },
     expectSelected: "project:general",

--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -25,7 +25,7 @@ import {
   useSettingsStore,
 } from "@/store";
 import { X, Search, ChevronRight, AlertTriangle } from "lucide-react";
-import { ArrowLeftRight, Folder, Globe, TriangleAlert } from "@/components/icons";
+import { ArrowLeftRight, TriangleAlert } from "@/components/icons";
 import { cn } from "@/lib/utils";
 import { ScrollShadow } from "@/components/ui/ScrollShadow";
 import { SegmentedRadioGroup } from "@/components/ui/SegmentedRadioGroup";
@@ -715,35 +715,26 @@ function SettingsDialogInner({
 
         <div className="settings-shell flex-1 flex flex-col min-w-0">
           <AppDialog.Header plainBody>
-            {/* A title stack, not a bare title: the section name alone is ambiguous —
-                General, Notifications and Code Forge all exist in both scopes — so the
-                line above it names what the change lands on. It rides in the header
-                rather than the scrollport, which is the only part of the pane that
-                survives the user scrolling into a long form. */}
-            <div className="flex flex-col gap-1 min-w-0">
-              <ScopeContext scope={headerScope} projectLabel={hasProject ? projectLabel : null} />
-              <AppDialog.Title
-                as="h3"
-                icon={
-                  isSearching ? (
-                    <Search className="w-5 h-5 text-text-secondary" />
-                  ) : (
-                    tabIcons[activeTab]
-                  )
-                }
-              >
-                {/* The title is what aria-labelledby points at, so the scope has to be
-                    part of it — otherwise opening the modal announces "General, dialog"
-                    and never says whose General. The visible line above is decorative
-                    for the same reason: saying it twice is worse than saying it once. */}
-                <span className="sr-only">
-                  {headerScope === "project" && hasProject
-                    ? `Project settings for ${projectLabel}, `
-                    : "Global settings for Daintree, "}
-                </span>
-                {isSearching ? "Search results" : tabTitles[activeTab]}
-              </AppDialog.Title>
-            </div>
+            <AppDialog.Title
+              as="h3"
+              icon={
+                isSearching ? (
+                  <Search className="w-5 h-5 text-text-secondary" />
+                ) : (
+                  tabIcons[activeTab]
+                )
+              }
+            >
+              {/* The title is what aria-labelledby points at, so the scope has to be part
+                  of it — otherwise opening the modal announces "General, dialog" and never
+                  says whose General. It stays screen-reader-only: a second visible heading
+                  over every section reads as a double title, and the nav the user just
+                  clicked through is the sighted answer to the same question. */}
+              <span className="sr-only">
+                {scopeAnnouncement(headerScope, hasProject ? projectLabel : null)}
+              </span>
+              {isSearching ? "Search results" : tabTitles[activeTab]}
+            </AppDialog.Title>
             <AppDialog.CloseButton aria-label="Close settings" />
           </AppDialog.Header>
 
@@ -1384,46 +1375,23 @@ function MatchBadge({ count }: { count: number }) {
   );
 }
 
-// Global settings belong to the app; the app has a name, and using it keeps the two
-// scopes symmetrical — both name a thing rather than one naming a thing and the other
-// naming an abstraction.
-const GLOBAL_ENTITY_LABEL = "Daintree";
-
 /**
- * The scope line in the content header. Names the entity a change lands on, with the
- * scope carried by the icon so the line stays short enough to sit above the section
- * title at any project-name length.
+ * The clause the dialog's accessible name opens with, so a screen reader hears whose
+ * General it just landed on rather than a bare "General, dialog". Nothing renders it
+ * visibly — the sighted answer is the nav the user clicked through.
+ *
+ * The scope branches before the entity does, and the two are separate questions.
+ * `integrations` is filed under the global nav but every control in it writes against
+ * the current project, so a project-scoped pane is reachable with no project open;
+ * folding that case into the global branch would announce "Global settings for
+ * Daintree" over it outright. With no project there is simply no entity to name, which
+ * is what the shorter project clause says.
+ *
+ * @param project the project's label, or null when no project is open.
  */
-export function ScopeContext({
-  scope,
-  projectLabel,
-}: {
-  scope: SettingsScope;
-  /** null when no project is open, which forces the global reading. */
-  projectLabel: string | null;
-}) {
-  const isProject = scope === "project" && projectLabel !== null;
-  const entity = isProject ? projectLabel : GLOBAL_ENTITY_LABEL;
-  const Icon = isProject ? Folder : Globe;
-  return (
-    <span
-      // gap-2 and a w-5 icon box, matching AppDialog.Title's icon slot exactly, so the
-      // context line's text starts on the same x as the section title's rather than
-      // 8px inside it.
-      className="flex items-center gap-2 min-w-0 text-xs text-text-secondary"
-      data-settings-scope-context={isProject ? "project" : "global"}
-      // Decorative: the same scope and entity are inside the dialog's labelled title,
-      // and a screen reader should hear them once, not on both nodes.
-      aria-hidden="true"
-    >
-      <span className="w-5 flex justify-center shrink-0">
-        <Icon className="w-3.5 h-3.5" />
-      </span>
-      <span className="truncate" title={entity}>
-        {entity}
-      </span>
-    </span>
-  );
+export function scopeAnnouncement(scope: SettingsScope, project: string | null): string {
+  if (scope !== "project") return "Global settings for Daintree, ";
+  return project === null ? "Project settings, " : `Project settings for ${project}, `;
 }
 
 /**

--- a/src/components/Settings/__tests__/SettingsDialogScope.test.tsx
+++ b/src/components/Settings/__tests__/SettingsDialogScope.test.tsx
@@ -2,7 +2,7 @@
 import React from "react";
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
-import { ScopeContext, ScopeChip, NavItem } from "../SettingsDialog";
+import { ScopeChip, NavItem, scopeAnnouncement } from "../SettingsDialog";
 import {
   contentScopeForTab,
   scopeForTab,
@@ -26,57 +26,44 @@ vi.mock("framer-motion", () => ({
  * that "changed" and "broken" never collapse into one another.
  */
 describe("settings scope orientation", () => {
-  describe("ScopeContext", () => {
-    it("renders whatever project it is handed, rather than a fixed word", () => {
-      const { unmount } = render(<ScopeContext scope="project" projectLabel="Helios Dashboard" />);
-      expect(screen.getByText("Helios Dashboard")).toBeTruthy();
-      unmount();
-
-      render(<ScopeContext scope="project" projectLabel="Kestrel API" />);
-      expect(screen.getByText("Kestrel API")).toBeTruthy();
-      expect(screen.queryByText("Helios Dashboard")).toBeNull();
+  describe("scopeAnnouncement", () => {
+    /**
+     * The only place the scope reaches a screen reader. Nothing paints it, so a
+     * refactor can delete or invert it without a single pixel moving — these are what
+     * would notice.
+     */
+    it("names whatever project it is handed, rather than a fixed word", () => {
+      expect(scopeAnnouncement("project", "Helios Dashboard")).toContain("Helios Dashboard");
+      expect(scopeAnnouncement("project", "Kestrel API")).toContain("Kestrel API");
+      expect(scopeAnnouncement("project", "Kestrel API")).not.toContain("Helios Dashboard");
     });
 
-    it("distinguishes the two scopes by more than the entity name", () => {
-      const { container: globalEl, unmount } = render(
-        <ScopeContext scope="global" projectLabel="Helios Dashboard" />
-      );
-      const globalScope = globalEl.querySelector("[data-settings-scope-context]");
-      expect(globalScope?.getAttribute("data-settings-scope-context")).toBe("global");
-      const globalHtml = globalEl.innerHTML;
-      unmount();
-
-      const { container: projectEl } = render(
-        <ScopeContext scope="project" projectLabel="Helios Dashboard" />
-      );
-      expect(
-        projectEl
-          .querySelector("[data-settings-scope-context]")
-          ?.getAttribute("data-settings-scope-context")
-      ).toBe("project");
-      // Same entity string on both, so any difference here is a real scope signal —
-      // the icon and the screen-reader prefix — not just a different name.
-      expect(projectEl.innerHTML).not.toBe(globalHtml);
+    it("never announces a project the user does not have open", () => {
+      // "project" is projectLabel's own fallback string, so a regression that leaked
+      // the label through would still read as a plausible sentence. The entity clause
+      // is what has to be absent, not the word.
+      expect(scopeAnnouncement("project", null)).not.toMatch(/\bfor\b/);
     });
 
-    it("never claims a project when none is open", () => {
-      render(<ScopeContext scope="project" projectLabel={null} />);
-      expect(
-        document
-          .querySelector("[data-settings-scope-context]")
-          ?.getAttribute("data-settings-scope-context")
-      ).toBe("global");
-    });
-
-    it("is decorative — the dialog's own labelled title carries the announced name", () => {
-      // Both the header eyebrow and the dialog title name the scope and the entity.
-      // Only one of them should reach a screen reader, or every open announces it
-      // twice; the title wins, because that is what aria-labelledby points at.
-      const { container } = render(
-        <ScopeContext scope="project" projectLabel="Helios Dashboard" />
+    it("never claims global over a tab whose content is project-scoped", () => {
+      // The failure this exists for: `integrations` is filed under the global nav but
+      // writes per-project, so it is reachable with NO project open. Branching on the
+      // project before the scope announces "Global settings for Daintree" over a pane
+      // where every control saves against a project. Driven off the registry so a tab
+      // added with that same shape later is covered without touching this test.
+      const projectContentTabs = SETTINGS_REGISTRY.map((e) => e.id as SettingsTab).filter(
+        (id) => contentScopeForTab(id) === "project"
       );
-      const line = container.querySelector("[data-settings-scope-context]");
-      expect(line?.getAttribute("aria-hidden")).toBe("true");
+      expect(projectContentTabs.length).toBeGreaterThan(0);
+
+      for (const id of projectContentTabs) {
+        for (const project of ["Helios Dashboard", null]) {
+          expect(
+            scopeAnnouncement(contentScopeForTab(id), project),
+            `${id} announced the global scope`
+          ).not.toBe(scopeAnnouncement("global", project));
+        }
+      }
     });
   });
 

--- a/src/components/Settings/settingsTabRegistry.tsx
+++ b/src/components/Settings/settingsTabRegistry.tsx
@@ -63,7 +63,7 @@ export interface SettingsTabEntry {
   /**
    * What the tab's content actually writes to, when that differs from the nav scope it
    * is filed under. `integrations` lives in the global nav but every control inside it
-   * saves against the current project, so the shell's context line has to name the
+   * saves against the current project, so the dialog's accessible name has to say
    * project or it states the wrong scope outright. Nav placement is unchanged.
    */
   readonly contentScope?: "global" | "project";
@@ -1728,9 +1728,9 @@ export const SETTINGS_REGISTRY = [
 
 /**
  * The scope a tab's content actually writes to — its `contentScope` when it declares
- * one, otherwise the nav scope it is filed under. The shell's context line keys off
+ * one, otherwise the nav scope it is filed under. The dialog's accessible name keys off
  * this rather than `scopeForTab`, so a tab that is filed globally but saves against the
- * current project names the project instead of claiming to be application-wide.
+ * current project announces the project instead of claiming to be application-wide.
  */
 export function contentScopeForTab(tab: SettingsTab): "global" | "project" {
   // Widened to the interface on purpose: SETTINGS_REGISTRY is `as const`, so `find`

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -24,7 +24,6 @@ export {
   CircleSlash, // agent stopped on an error, distinct in shape from a waiting one (Pilot's blocked band)
   Clock, // recency sort order (most recently opened first)
   FileText, // view selected file path in the read-only file viewer
-  Folder, // the project a scoped setting belongs to (settings scope: project)
   FolderGit2, // git worktree (single)
   FolderOpen, // reveal in file manager (Finder / Explorer / file manager)
   FolderOutput, // worktree living outside the project directory (external)
@@ -32,7 +31,6 @@ export {
   Folders, // copy tree / file hierarchy capture (two overlapping folders)
   GitBranchPlus, // per-project worktree setup — creating branches, not browsing them
   GitPullRequest, // forge provider / code-host plugin category
-  Globe, // application-wide scope — the setting belongs to Daintree, not one project
   History, // resume closed session / session history
   Layers, // worktree overview (multiple worktrees, stacked)
   LayoutPanelTop, // workspace plugin category (panels, notes)


### PR DESCRIPTION
## Summary

The settings dialog header carried a small grey line naming the scope, either "Daintree" or the project name, directly above the section title. It doesn't read as context, it reads as two headings stacked over one pane. This removes it and the `ScopeContext` component behind it, so the title is a single line again. The sidebar's Global/Project control is already the sighted answer to which scope a change lands on.

The `sr-only` scope prefix inside `AppDialog.Title` stays. That's what `aria-labelledby` points at, so the modal still announces whose General you just opened rather than a bare "General, dialog".

Removing the visible line put a real bug in that prefix under the light. `integrations` is filed under the global nav but every control in it saves against the current project (`contentScope: "project"`), so it's reachable with no project open. The old condition was `headerScope === "project" && hasProject`, which fell through to announcing "Global settings for Daintree" over a pane where nothing is global. The scope branches before the entity now, and the no-project case says "Project settings" with no entity to name.

## Changes

- Removed `ScopeContext` and its title-stack wrapper from `SettingsDialog.tsx`. `AppDialog.Title` is a direct child of the header again, which is the layout every other `AppDialog` uses.
- Dropped the `Folder` and `Globe` concept aliases from `src/components/icons/index.ts`. `ScopeContext` was their only consumer through the barrel; everything else imports them from `lucide-react` directly.
- Extracted the accessible-name branch as `scopeAnnouncement()` and corrected it, so a project-scoped pane can no longer announce the global scope.
- Added `scopeAnnouncement` tests driven off `SETTINGS_REGISTRY`, so a tab added later with the same global-nav-plus-project-content shape is covered without editing the test.
- Updated comments in `settingsTabRegistry.tsx` and the screenshot harness that still described the deleted line.

This is a partial revert of the visible half of #12040 (#11986). The scope control, the search chips, the project-named error banners and the accessible title all stay.

## Testing

`npm run check` and `npm run typecheck` pass. 989 tests in `src/components/Settings/__tests__/` pass.

The new tests were mutation-checked against the old condition: two of them fail there, and the registry-driven one names `integrations` in its failure message.

Rendered both scopes through `e2e/screenshots/settings-scope-review.spec.ts` and read the shots. Header is a single centred line, close button unmoved, long project names still truncate in the identity row.

Reviewed with Codex before commit. Three findings, all fixed: the announcement bug above, the missing guard on the retained `sr-only` prefix, and the stale comments.
