### PR TITLE
fix(project): move identity editing off the pill's emoji onto its context menu

### DIFF
--- a/e2e/full/worktree/core-project-lifecycle.spec.ts
+++ b/e2e/full/worktree/core-project-lifecycle.spec.ts
@@ -54,6 +54,40 @@ test.describe.serial("Core: Project Lifecycle", () => {
     await expect(palette).not.toBeVisible({ timeout: T_SHORT });
   });
 
+  test("every part of the pill opens the switcher; identity editing lives on right-click", async () => {
+    const { window } = ctx;
+    const pill = window.locator(SEL.toolbar.projectSwitcherTrigger);
+    const palette = window.locator(SEL.projectSwitcher.palette);
+    const identityEditor = window.getByLabel("Edit project identity");
+
+    // The emoji used to carry an invisible 28px target of its own, so a click
+    // meant for the switcher opened the rename popover instead — and both open
+    // with a text field focused, so the switcher's click-type-Enter habit
+    // renamed the project. Asserted by POSITION because the regression is in
+    // the hit map, not in any handler a unit test can see.
+    const box = await pill.boundingBox();
+    expect(box).not.toBeNull();
+    await pill.click({ position: { x: 14, y: box!.height / 2 } });
+
+    await expect(palette).toBeVisible({ timeout: T_MEDIUM });
+    await expect(identityEditor).not.toBeVisible();
+
+    await window.keyboard.press("Escape");
+    await expect(palette).not.toBeVisible({ timeout: T_SHORT });
+
+    // Right-click anywhere on the pill is the way in now.
+    await pill.click({ button: "right" });
+    const editItem = window.getByRole("menuitem", { name: /Edit name and icon/ });
+    await expect(editItem).toBeVisible({ timeout: T_SHORT });
+    await editItem.click();
+
+    await expect(identityEditor).toBeVisible({ timeout: T_MEDIUM });
+    // Escape cancels the edit rather than committing it, so the suite's later
+    // project-name assertions still hold.
+    await window.keyboard.press("Escape");
+    await expect(identityEditor).not.toBeVisible({ timeout: T_SHORT });
+  });
+
   test("switch between projects with panel isolation", async () => {
     // Switch to Project A and spawn a terminal
     ctx.window = await selectExistingProjectAndRefresh(ctx.app, ctx.window, PROJECT_A);

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -21,6 +21,7 @@ import {
   Ellipsis,
   GitBranch,
   FileText,
+  Pencil,
   Pin,
   PinOff,
   Clipboard,
@@ -1927,6 +1928,61 @@ export function Toolbar({
     void projectSwitcher.togglePinProject(currentProject.id);
   }, [currentProject, projectSwitcher]);
 
+  // Which project's identity editor is open, rather than a bare boolean: a flag
+  // would outlive the project it belongs to and reopen the popover over
+  // whichever project came next.
+  const [identityEditorProjectId, setIdentityEditorProjectId] = useState<string | null>(null);
+  // Dropped rather than merely ignored when the project underneath it goes:
+  // a controlled Radix popover is not told its `open` prop fell to false, so a
+  // stale id would sit here and raise the editor again the next time that
+  // project came back. Adjusted during render for the same reason the editor's
+  // own draft re-seed is — an effect would opt this component out of the
+  // React Compiler.
+  if (identityEditorProjectId !== null && identityEditorProjectId !== currentProject?.id) {
+    setIdentityEditorProjectId(null);
+  }
+  const isIdentityEditorOpen = identityEditorProjectId !== null;
+  // Selecting the item records the intent; the menu's own close hook spends it.
+  // Opening straight from `onSelect` would raise the popover inside the menu's
+  // teardown, where Radix still holds the focus trap and the outside-pointer
+  // lock — so the release that closed the menu can dismiss the popover it just
+  // opened. `onCloseAutoFocus` fires once the menu is actually gone.
+  // Carries WHICH project was right-clicked, not just that something was: the
+  // intent outlives the menu by an exit animation, and the project can change
+  // underneath it in that time.
+  const pendingIdentityEditRef = useRef<string | null>(null);
+  const handleEditProjectIdentity = useCallback(() => {
+    pendingIdentityEditRef.current = currentProject?.id ?? null;
+  }, [currentProject?.id]);
+  // Radix keeps the content mounted through its 120ms exit, so a menu reopened
+  // inside that window never unmounts and never reaches the close hook below.
+  // Dropping the intent on every open means the worst case is one edit request
+  // the user has visibly superseded, rather than a popover that springs open on
+  // some later, unrelated close.
+  const handlePillContextMenuOpenChange = useCallback((open: boolean) => {
+    if (open) pendingIdentityEditRef.current = null;
+  }, []);
+  const handlePillContextMenuCloseAutoFocus = useCallback(
+    (event: Event) => {
+      suppressPillTooltipForFocusRestore();
+      event.preventDefault();
+      const pendingProjectId = pendingIdentityEditRef.current;
+      pendingIdentityEditRef.current = null;
+      // A project swapped in during the exit animation is a different project
+      // than the one the user right-clicked; drop the request rather than
+      // opening the editor over it.
+      if (pendingProjectId === null || pendingProjectId !== currentProject?.id) return;
+      setIdentityEditorProjectId(pendingProjectId);
+    },
+    [currentProject?.id, suppressPillTooltipForFocusRestore]
+  );
+  const handleIdentityEditorOpenChange = useCallback(
+    (next: boolean) => {
+      setIdentityEditorProjectId(next ? (currentProject?.id ?? null) : null);
+    },
+    [currentProject?.id]
+  );
+
   const projectSwitcherTrigger = (
     <ContextMenuTrigger asChild>
       <TooltipTrigger asChild>
@@ -2045,15 +2101,22 @@ export function Toolbar({
             aria-label="Project"
             className="app-no-drag relative flex items-center justify-center min-w-0 max-w-full pointer-events-none justify-self-center"
           >
-            {/* Sibling of the pill, not a child — see ProjectIdentityEditor. */}
-            {currentProject && <ProjectIdentityEditor project={currentProject} />}
+            {/* Anchor-only sibling of the pill — see ProjectIdentityEditor. */}
+            {currentProject && (
+              <ProjectIdentityEditor
+                project={currentProject}
+                open={isIdentityEditorOpen}
+                onOpenChange={handleIdentityEditorOpenChange}
+                onCloseAutoFocus={suppressPillTooltipForFocusRestore}
+              />
+            )}
             <Tooltip
               open={workspaceIdentity.kind !== "none" ? pillTooltipOpen : false}
               onOpenChange={
                 workspaceIdentity.kind !== "none" ? handlePillTooltipOpenChange : undefined
               }
             >
-              <ContextMenu>
+              <ContextMenu onOpenChange={handlePillContextMenuOpenChange}>
                 {shouldMountProjectSwitcherDropdown ? (
                   <Suspense fallback={projectSwitcherTrigger}>
                     <LazyProjectSwitcherPalette
@@ -2130,11 +2193,15 @@ export function Toolbar({
                 {currentProject && (
                   <ContextMenuContent
                     className="max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto"
-                    onCloseAutoFocus={(e) => {
-                      suppressPillTooltipForFocusRestore();
-                      e.preventDefault();
-                    }}
+                    onCloseAutoFocus={handlePillContextMenuCloseAutoFocus}
                   >
+                    {/* The display name and emoji. Distinct from the switcher
+                        row's "Move or rename project…", which relocates the
+                        folder on disk. */}
+                    <ContextMenuItem onSelect={handleEditProjectIdentity}>
+                      <Pencil className="mr-2 h-3.5 w-3.5" />
+                      Edit name and icon…
+                    </ContextMenuItem>
                     <ContextMenuItem onSelect={handlePillTogglePin}>
                       {activeSearchableProject?.isPinned ? (
                         <>

--- a/src/components/Project/ProjectIdentityEditor.tsx
+++ b/src/components/Project/ProjectIdentityEditor.tsx
@@ -50,7 +50,7 @@ function PillRestoreTarget({ open }: { open: boolean }) {
  * put a rare action inside the hit box of a very frequent one with no visible
  * boundary, and the two surfaces were easy to confuse: both open with a text
  * field focused, so the switcher's own click-type-Enter muscle memory landed
- * in the name field and renamed the project (#12093).
+ * in the name field and renamed the project.
  *
  * Anchored rather than triggered: the pill is already wrapped by the switcher
  * popover, the context menu and the tooltip, and it has one job on click. This

--- a/src/components/Project/ProjectIdentityEditor.tsx
+++ b/src/components/Project/ProjectIdentityEditor.tsx
@@ -1,5 +1,6 @@
-import { useCallback, useRef, useState } from "react";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Popover, PopoverAnchor, PopoverContent } from "@/components/ui/popover";
+import { useOverlayFocusRestore } from "@/components/ui/overlay-focus-restore";
 import { EmojiPicker } from "@/components/ui/emoji-picker";
 import { useProjectStore } from "@/store/projectStore";
 import { suggestProjectEmoji, DEFAULT_PROJECT_EMOJI } from "@shared/utils/projectEmoji";
@@ -7,36 +8,72 @@ import type { Project } from "@shared/types";
 
 interface ProjectIdentityEditorProps {
   project: Project;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /**
+   * Fired as the popover hands focus back, so the pill's controlled tooltip
+   * can stay down through the restoration.
+   */
+  onCloseAutoFocus?: () => void;
 }
 
 const PILL_SELECTOR = '[data-testid="project-switcher-trigger"]';
 
+function findPill(): HTMLElement | null {
+  return document.querySelector<HTMLElement>(PILL_SELECTOR);
+}
+
 /**
- * One-click identity editing for the toolbar project pill: the emoji becomes
- * its own target that opens a popover holding the name field and the full
- * picker.
+ * Hands the shared close-time focus policy somewhere to put focus.
  *
- * Rendered as a SIBLING of the pill button, never nested inside it — the pill
- * is already wrapped by the switcher popover, context-menu and tooltip
- * triggers, and nesting a fourth interactive element there produces invalid
- * nested-button markup and fires both handlers on one click (#6928). The
- * transparent overlay sits exactly over the pill's own emoji glyph, so the
- * pill's layout and styling are untouched.
- *
- * Being a sibling means the pill's Radix triggers never see pointer activity
- * over this region, so right-click and hover are replayed onto the pill below
- * (see `replayOnPill`) to keep the project context menu and the identity
- * tooltip alive across the whole pill.
+ * It records the trigger, and an anchored popover has none — so without this
+ * every pointer close falls through to Radix, which focuses a null trigger and
+ * leaves focus on `document.body`. Rendered inside `Popover` because the
+ * context only exists below the root.
  */
-export function ProjectIdentityEditor({ project }: ProjectIdentityEditorProps) {
+function PillRestoreTarget({ open }: { open: boolean }) {
+  const overlay = useOverlayFocusRestore();
+  useEffect(() => {
+    if (!open) return;
+    overlay?.setRestoreTarget(findPill());
+  }, [open, overlay]);
+  return null;
+}
+
+/**
+ * Display-identity editing for the current project — the name and the emoji,
+ * in one popover anchored under the toolbar pill.
+ *
+ * Opened from the pill's context menu, never from a click on the pill itself.
+ * It used to own a transparent 28px overlay sitting on the emoji glyph, so a
+ * left-click there edited the project instead of opening the switcher. That
+ * put a rare action inside the hit box of a very frequent one with no visible
+ * boundary, and the two surfaces were easy to confuse: both open with a text
+ * field focused, so the switcher's own click-type-Enter muscle memory landed
+ * in the name field and renamed the project (#12093).
+ *
+ * Anchored rather than triggered: the pill is already wrapped by the switcher
+ * popover, the context menu and the tooltip, and it has one job on click. This
+ * renders as a sibling of the pill inside the toolbar's project group, but as
+ * a zero-height, pointer-transparent anchor rather than the old overlay — it
+ * borrows the group's position and can never take a click of its own.
+ */
+export function ProjectIdentityEditor({
+  project,
+  open,
+  onOpenChange,
+  onCloseAutoFocus,
+}: ProjectIdentityEditorProps) {
   const updateProject = useProjectStore((state) => state.updateProject);
-  const overlayRef = useRef<HTMLButtonElement>(null);
-  const [isOpen, setIsOpen] = useState(false);
   const [draftName, setDraftName] = useState(project.name);
   // Only a name the user actually typed is worth writing back. Without this,
   // an untouched draft would overwrite a rename that landed from another
   // window while this popover sat open.
   const [isNameDirty, setIsNameDirty] = useState(false);
+  // Whether the last interaction in this opening came from the keyboard. Read
+  // for exactly one decision — see the close handler — and deliberately not a
+  // second copy of the shared policy, which still owns every pointer close.
+  const lastInputWasKeyboardRef = useRef(false);
 
   const resetDraft = useCallback(() => {
     setDraftName(project.name);
@@ -49,7 +86,7 @@ export function ProjectIdentityEditor({ project }: ProjectIdentityEditorProps) {
   // `project.name` would wipe the field mid-edit the moment an optimistic
   // rename lands, and omitting it needs an exhaustive-deps suppression that
   // opts the whole component out of the React Compiler.
-  const seedKey = `${project.id}:${isOpen ? "open" : "closed"}`;
+  const seedKey = `${project.id}:${open ? "open" : "closed"}`;
   const [lastSeedKey, setLastSeedKey] = useState(seedKey);
   if (lastSeedKey !== seedKey) {
     setLastSeedKey(seedKey);
@@ -95,9 +132,9 @@ export function ProjectIdentityEditor({ project }: ProjectIdentityEditorProps) {
   const handleEmojiSelect = useCallback(
     (picked: string) => {
       commitIdentity(picked);
-      setIsOpen(false);
+      onOpenChange(false);
     },
-    [commitIdentity]
+    [commitIdentity, onOpenChange]
   );
 
   // While a project still carries the default tree, offer the name-derived
@@ -110,96 +147,80 @@ export function ProjectIdentityEditor({ project }: ProjectIdentityEditorProps) {
       ? suggestProjectEmoji(draftName.trim() || project.name)
       : null;
 
-  // The pill renders alongside this overlay inside the toolbar's project group.
-  const findPill = useCallback(
-    () => overlayRef.current?.parentElement?.querySelector<HTMLElement>(PILL_SELECTOR) ?? null,
-    []
-  );
-
-  /**
-   * Re-fire a native event on the pill so its Radix triggers react as if the
-   * pointer had reached them. `PointerEvent` is not constructible in every test
-   * environment; `MouseEvent` carries everything these triggers read.
-   */
-  const replayOnPill = useCallback(
-    (type: string, init: MouseEventInit) => {
-      const pill = findPill();
-      if (!pill) return;
-      const Ctor: typeof MouseEvent =
-        typeof PointerEvent === "function" ? PointerEvent : MouseEvent;
-      pill.dispatchEvent(new Ctor(type, { bubbles: true, ...init }));
-    },
-    [findPill]
-  );
-
   return (
     <Popover
-      open={isOpen}
+      open={open}
       onOpenChange={(next) => {
         if (!next) commitIdentity();
-        setIsOpen(next);
+        onOpenChange(next);
       }}
     >
-      <PopoverTrigger asChild>
-        <button
-          ref={overlayRef}
-          type="button"
-          // Joins the toolbar's roving-tabindex domain in DOM order (it renders
-          // just before the pill), so it is one arrow stop rather than a stray
-          // extra Tab stop outside the model.
-          data-toolbar-item=""
-          data-project-identity-trigger=""
-          aria-label={`Edit identity for ${project.name}, currently ${project.emoji}`}
-          // The pill owns the project context menu (pin, copy path, locate,
-          // settings, close); this overlay has none of its own, so hand the
-          // right-click straight down to it.
-          onContextMenu={(event) => {
-            event.preventDefault();
-            replayOnPill("contextmenu", {
-              cancelable: true,
-              clientX: event.clientX,
-              clientY: event.clientY,
-            });
-          }}
-          // Radix's tooltip trigger opens on `pointermove`, so one replayed
-          // move per entry is enough to raise the pill's identity tooltip.
-          onPointerEnter={(event) => {
-            if (event.pointerType === "touch") return;
-            replayOnPill("pointermove", {});
-          }}
-          onPointerLeave={(event) => {
-            const pill = findPill();
-            const next = event.relatedTarget;
-            // Sliding onto the rest of the pill leaves it natively hovered;
-            // closing here would blink the tooltip shut and straight back open.
-            if (!pill || (next instanceof Node && pill.contains(next))) return;
-            // React synthesises `onPointerLeave` from `pointerout`, so a raw
-            // `pointerleave` dispatch would never reach the trigger's handler.
-            // It also reports `window` when the pointer left the React tree
-            // entirely, which is not a valid `relatedTarget` to construct with.
-            replayOnPill("pointerout", { relatedTarget: next instanceof Element ? next : null });
-          }}
-          className="pointer-events-auto absolute left-1.5 top-1/2 z-10 h-7 w-7 -translate-y-1/2 rounded-[var(--radius-md)] bg-transparent transition-colors hover:bg-overlay-subtle focus-visible:outline-2 focus-visible:outline-accent-primary focus-visible:outline-offset-1"
-        />
-      </PopoverTrigger>
+      <PillRestoreTarget open={open} />
+      {/* Spans the group's width along its bottom edge, so the popover centres
+          under the pill. Zero height and no pointer surface: the whole point of
+          this component's rewrite is that nothing here is clickable. */}
+      <PopoverAnchor asChild>
+        <span aria-hidden="true" className="pointer-events-none absolute inset-x-0 bottom-0 h-0" />
+      </PopoverAnchor>
       <PopoverContent
         className="w-auto p-0"
-        align="start"
+        align="center"
         aria-label="Edit project identity"
         // Hand focus to the name field instead of letting Radix park it on the
         // popover container.
         onOpenAutoFocus={(event) => {
           event.preventDefault();
+          lastInputWasKeyboardRef.current = false;
+        }}
+        // Modality, tracked for the close handler below and nothing else. A
+        // keydown supersedes an earlier pointer press for the same reason the
+        // shared policy's own does: a click that did not close the popover —
+        // into the name field, say — must not decide how a later Escape ends.
+        onKeyDown={() => {
+          lastInputWasKeyboardRef.current = true;
+        }}
+        onPointerDown={() => {
+          lastInputWasKeyboardRef.current = false;
+        }}
+        onPointerDownOutside={() => {
+          lastInputWasKeyboardRef.current = false;
         }}
         // Escape means "cancel the edit". Radix's dismissable layer sees the
         // key on a document CAPTURE listener, so its default dismissal would
         // fire `onOpenChange` — and with it the commit — before any handler on
         // the input could revert the draft. Take the close over manually so the
-        // revert lands first and no commit runs at all.
+        // revert lands first and no commit runs at all. The capture listener
+        // also means the content's own `onKeyDown` may never see this key, so
+        // the modality is recorded here too.
         onEscapeKeyDown={(event) => {
           event.preventDefault();
+          lastInputWasKeyboardRef.current = true;
           resetDraft();
-          setIsOpen(false);
+          onOpenChange(false);
+        }}
+        // Pointer closes belong to the shared policy in `overlay-focus-restore`
+        // — it runs straight after this one, and `PillRestoreTarget` has given
+        // it the pill to aim at. Claiming them here instead would steal focus
+        // from whatever the closing click just opened: dismissing this popover
+        // by clicking the pill opens the switcher and focuses its search box,
+        // and a blanket restore would yank focus straight back out of it.
+        //
+        // The keyboard close is the one case the shared policy cannot cover:
+        // it defers to Radix, which restores to a TRIGGER, and an anchored
+        // popover has none — so focus lands on `document.body` and the next Tab
+        // restarts from the top of the document.
+        onCloseAutoFocus={(event) => {
+          onCloseAutoFocus?.();
+          // Cleared before the branch, not inside it: `onOpenAutoFocus` is the
+          // other reset, and Radix skips dispatching it when focus is already
+          // inside the content — which `autoFocus` on the name field arranges
+          // on most openings. So this is the one that always runs.
+          const wasKeyboard = lastInputWasKeyboardRef.current;
+          lastInputWasKeyboardRef.current = false;
+          if (!wasKeyboard) return;
+          event.preventDefault();
+          // Ringed on purpose — a keyboard user has to see where they landed.
+          findPill()?.focus({ preventScroll: true });
         }}
       >
         <div className="flex flex-col">
@@ -226,8 +247,9 @@ export function ProjectIdentityEditor({ project }: ProjectIdentityEditorProps) {
                 // sees it first, on a document capture listener.
                 if (event.key === "Enter") {
                   event.preventDefault();
+                  lastInputWasKeyboardRef.current = true;
                   commitIdentity();
-                  setIsOpen(false);
+                  onOpenChange(false);
                 }
               }}
               className="w-[280px] rounded-[var(--radius-md)] border border-border-default bg-surface-canvas px-3 py-1.5 text-sm text-text-primary placeholder:text-text-placeholder focus:outline-hidden focus:border-daintree-accent/40 focus:ring-1 focus:ring-daintree-accent/30"

--- a/src/components/Project/__tests__/ProjectIdentityEditor.test.tsx
+++ b/src/components/Project/__tests__/ProjectIdentityEditor.test.tsx
@@ -3,7 +3,11 @@
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, act } from "@testing-library/react";
-import type { MouseEventHandler, PointerEventHandler, ReactNode } from "react";
+import type { ReactNode } from "react";
+import {
+  OverlayFocusRestoreContext,
+  type OverlayFocusRestore,
+} from "@/components/ui/overlay-focus-restore";
 import { suggestProjectEmoji, DEFAULT_PROJECT_EMOJI } from "@shared/utils/projectEmoji";
 import type { Project } from "@shared/types";
 
@@ -15,30 +19,77 @@ vi.mock("@/store/projectStore", () => ({
 }));
 
 // Render popover content inline — this test is about the editing contract, not
-// Radix's positioning. `onEscapeKeyDown` is captured rather than swallowed:
-// Radix fires it from a document CAPTURE listener BEFORE the input's own
-// keydown, and the cancel-vs-commit ordering hangs on that. A mock that dropped
-// it would let a broken Escape path pass while production saved the edit.
+// Radix's positioning. Three handlers are captured rather than swallowed
+// because production depends on when each one fires:
+// - `onEscapeKeyDown`: Radix fires it from a document CAPTURE listener BEFORE
+//   the input's own keydown, and the cancel-vs-commit ordering hangs on that.
+//   A mock that dropped it would let a broken Escape path pass while
+//   production saved the edit.
+// - `onCloseAutoFocus`: this popover is anchored rather than triggered, so it
+//   owns the focus return itself.
+// - the root's `onOpenChange`: the dismissal path that commits a pending edit.
 let escapeKeyDownHandler: ((event: { preventDefault: () => void }) => void) | null = null;
+let closeAutoFocusHandler: ((event: { preventDefault: () => void }) => void) | null = null;
+let openChangeHandler: ((open: boolean) => void) | null = null;
+let pointerDownOutsideHandler: (() => void) | null = null;
+
+// Enough of the shared policy for the component to register its restore target
+// against. The real one is exercised by the primitives' own tests.
+const setRestoreTargetMock = vi.fn<(node: HTMLElement | null) => void>();
+const focusRestoreStub = {
+  setRestoreTarget: setRestoreTargetMock,
+  resetForOpen: () => {},
+  deferToRadix: () => {},
+  onContentPointerDown: () => {},
+  onContentPointerDownOutside: () => {},
+  onContentInteractOutside: () => {},
+  onContentKeyDown: () => {},
+  onContentClick: () => {},
+  onContentCloseAutoFocus: () => {},
+} satisfies OverlayFocusRestore;
 
 vi.mock("@/components/ui/popover", () => ({
-  // Radix's Popover root renders no DOM of its own, and neither can this mock:
-  // the trigger locates the toolbar pill through its own parentElement, so an
-  // extra wrapper would hide the pill from it.
-  Popover: ({ children }: { children: ReactNode }) => <>{children}</>,
-  PopoverTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  // Radix's Popover root renders no DOM of its own, and neither can this mock —
+  // but it does provide the shared focus-restore context, which is how the
+  // component hands the policy a restore target.
+  Popover: ({
+    children,
+    onOpenChange,
+  }: {
+    children: ReactNode;
+    onOpenChange?: (o: boolean) => void;
+  }) => {
+    openChangeHandler = onOpenChange ?? null;
+    return (
+      <OverlayFocusRestoreContext.Provider value={focusRestoreStub}>
+        {children}
+      </OverlayFocusRestoreContext.Provider>
+    );
+  },
+  PopoverAnchor: ({ children }: { children: ReactNode }) => <>{children}</>,
   PopoverContent: ({
     children,
     onEscapeKeyDown,
+    onCloseAutoFocus,
+    // Not a DOM prop — kept off the div, and handed to the tests instead.
+    onPointerDownOutside,
     onOpenAutoFocus: _onOpenAutoFocus,
     ...rest
   }: {
     children: ReactNode;
     onEscapeKeyDown?: (event: { preventDefault: () => void }) => void;
+    onCloseAutoFocus?: (event: { preventDefault: () => void }) => void;
+    onPointerDownOutside?: () => void;
     onOpenAutoFocus?: (event: { preventDefault: () => void }) => void;
   }) => {
     escapeKeyDownHandler = onEscapeKeyDown ?? null;
-    return <div {...rest}>{children}</div>;
+    closeAutoFocusHandler = onCloseAutoFocus ?? null;
+    pointerDownOutsideHandler = onPointerDownOutside ?? null;
+    return (
+      <div data-testid="popover-content" {...rest}>
+        {children}
+      </div>
+    );
   },
 }));
 
@@ -49,6 +100,19 @@ function pressEscape(): boolean {
   // makes need an explicit act().
   act(() => {
     escapeKeyDownHandler?.({
+      preventDefault: () => {
+        defaultPrevented = true;
+      },
+    });
+  });
+  return defaultPrevented;
+}
+
+/** Drive the close-time focus return the way Radix does. */
+function closeAutoFocus(): boolean {
+  let defaultPrevented = false;
+  act(() => {
+    closeAutoFocusHandler?.({
       preventDefault: () => {
         defaultPrevented = true;
       },
@@ -82,105 +146,173 @@ function nameField() {
   return screen.getByLabelText<HTMLInputElement>(/project name/i);
 }
 
+/** The component is controlled by the toolbar; every test opens it. */
+function renderEditor(
+  project: Project = makeProject(),
+  props: { onOpenChange?: (open: boolean) => void; onCloseAutoFocus?: () => void } = {}
+) {
+  return render(
+    <ProjectIdentityEditor
+      project={project}
+      open
+      onOpenChange={props.onOpenChange ?? (() => {})}
+      onCloseAutoFocus={props.onCloseAutoFocus}
+    />
+  );
+}
+
+/** Mirrors the toolbar: the pill this popover anchors to and hands focus back to. */
+function renderPill() {
+  const pill = document.createElement("button");
+  pill.type = "button";
+  pill.dataset.testid = "project-switcher-trigger";
+  document.body.appendChild(pill);
+  return pill;
+}
+
 describe("ProjectIdentityEditor", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     updateProjectMock.mockResolvedValue(undefined);
+    escapeKeyDownHandler = null;
+    closeAutoFocusHandler = null;
+    openChangeHandler = null;
+    pointerDownOutsideHandler = null;
+    document.body.innerHTML = "";
   });
 
   describe("markup contract", () => {
-    it("renders the trigger as a standalone button, never nesting one inside another", () => {
-      const { container } = render(<ProjectIdentityEditor project={makeProject()} />);
-      // A nested <button> inside a <button> is invalid HTML and fires both
-      // handlers on one click — the #6928 failure mode.
+    it("offers no clickable surface of its own outside the popover", () => {
+      const { container } = renderEditor();
+      // The whole point of the rewrite: the editor no longer owns a target on
+      // the pill, so nothing it renders into the toolbar can take a click.
+      // Only the popover body's own controls are interactive.
+      const toolbarSide = container.querySelectorAll("[aria-hidden='true']");
+      for (const node of toolbarSide) {
+        expect(node.tagName).not.toBe("BUTTON");
+        expect(node.getAttribute("tabindex")).toBeNull();
+      }
       expect(container.querySelector("button button")).toBeNull();
     });
 
     it("names the popover so it is not announced as a bare dialog", () => {
-      render(<ProjectIdentityEditor project={makeProject()} />);
+      renderEditor();
       expect(screen.getByLabelText("Edit project identity")).not.toBeNull();
     });
   });
 
-  describe("pill event forwarding", () => {
-    /**
-     * Mirrors the toolbar layout: the overlay is painted on top of the pill but
-     * is a DOM sibling, so events landing on it never reach the pill's Radix
-     * context-menu and tooltip triggers unless the overlay replays them.
-     */
-    function renderOverPill() {
-      const pillHandlers = {
-        onContextMenu: vi.fn<MouseEventHandler<HTMLButtonElement>>(),
-        onPointerMove: vi.fn<PointerEventHandler<HTMLButtonElement>>(),
-        onPointerLeave: vi.fn<PointerEventHandler<HTMLButtonElement>>(),
-      };
-      render(
-        <div>
-          <ProjectIdentityEditor project={makeProject()} />
-          <button type="button" data-testid="project-switcher-trigger" {...pillHandlers}>
-            <span data-testid="pill-label">my-api</span>
-          </button>
-        </div>
-      );
-      return {
-        overlay: screen.getByRole("button", { name: /edit identity/i }),
-        pill: screen.getByTestId("project-switcher-trigger"),
-        pillHandlers,
-      };
-    }
+  describe("focus return", () => {
+    it("hands focus back to the pill after a keyboard close, which Radix cannot", () => {
+      const pill = renderPill();
+      renderEditor();
 
-    it("replays right-click onto the pill so the project context menu still opens", () => {
-      const { overlay, pillHandlers } = renderOverPill();
+      pressEscape();
+      // Radix restores to a TRIGGER; an anchored popover has none, so an
+      // unclaimed keyboard close drops focus on document.body and the next Tab
+      // restarts from the top of the document.
+      expect(closeAutoFocus()).toBe(true);
 
-      fireEvent.contextMenu(overlay, { clientX: 42, clientY: 7 });
-
-      expect(pillHandlers.onContextMenu).toHaveBeenCalledTimes(1);
-      // Radix anchors the context menu at the pointer, so the coordinates have
-      // to survive the replay or the menu lands in the corner.
-      const replayed = pillHandlers.onContextMenu.mock.calls[0]![0];
-      expect([replayed.clientX, replayed.clientY]).toEqual([42, 7]);
+      expect(document.activeElement).toBe(pill);
     });
 
-    it("replays hover onto the pill so the identity tooltip still opens", () => {
-      const { overlay, pillHandlers } = renderOverPill();
+    it("asks for the ring on a keyboard close, since Chromium paints one either way", () => {
+      const pill = renderPill();
+      const focusSpy = vi.spyOn(pill, "focus");
+      renderEditor();
 
-      fireEvent.pointerOver(overlay);
+      pressEscape();
+      closeAutoFocus();
 
-      expect(pillHandlers.onPointerMove).toHaveBeenCalledTimes(1);
+      // Anything but an explicit `focusVisible: false` leaves the ring on,
+      // which is what a keyboard user is owed.
+      expect(focusSpy).toHaveBeenCalledTimes(1);
+      expect(focusSpy.mock.calls[0]![0]).not.toMatchObject({ focusVisible: false });
     });
 
-    it("closes the pill's tooltip when the pointer leaves the pill entirely", () => {
-      const { overlay, pillHandlers } = renderOverPill();
-      fireEvent.pointerOver(overlay);
+    it("counts a keyboard emoji pick as a keyboard close", () => {
+      const pill = renderPill();
+      renderEditor();
 
-      fireEvent.pointerOut(overlay, { relatedTarget: document.body });
+      // Tabbing into the picker and pressing Enter reaches the same select
+      // callback a mouse click does, so modality is read off the interaction.
+      fireEvent.keyDown(screen.getByTestId("popover-content"), { key: "Tab" });
+      fireEvent.click(screen.getByText("pick-unicorn"), { detail: 0 });
+      closeAutoFocus();
 
-      expect(pillHandlers.onPointerLeave).toHaveBeenCalledTimes(1);
+      expect(document.activeElement).toBe(pill);
     });
 
-    it("keeps the tooltip up when the pointer slides from the overlay onto the pill", () => {
-      const { overlay, pillHandlers } = renderOverPill();
-      fireEvent.pointerOver(overlay);
+    it("gives the shared policy the pill to aim at, since it has no trigger to record", () => {
+      const pill = renderPill();
 
-      // The pill is natively hovered from here on, so forwarding a leave would
-      // blink the tooltip shut and straight back open.
-      fireEvent.pointerOut(overlay, { relatedTarget: screen.getByTestId("pill-label") });
+      renderEditor();
 
-      expect(pillHandlers.onPointerLeave).not.toHaveBeenCalled();
+      // Without this the shared policy has nowhere to put focus on a pointer
+      // close, and Radix's own restoration targets a null trigger.
+      expect(setRestoreTargetMock).toHaveBeenCalledWith(pill);
+    });
+
+    it("leaves a pointer close alone so it cannot steal focus from the switcher", () => {
+      const pill = renderPill();
+      const focusSpy = vi.spyOn(pill, "focus");
+      renderEditor();
+
+      // Dismissing by clicking the pill opens the switcher and focuses its
+      // search box. Restoring here would yank focus straight back out of it —
+      // the shared policy in overlay-focus-restore owns this case.
+      act(() => pointerDownOutsideHandler?.());
+      expect(closeAutoFocus()).toBe(false);
+
+      expect(focusSpy).not.toHaveBeenCalled();
+    });
+
+    it("does not treat a pointer press that never closed the popover as keyboard", () => {
+      const pill = renderPill();
+      const focusSpy = vi.spyOn(pill, "focus");
+      renderEditor();
+
+      // Click into the name field, type, then click away: the typing must not
+      // reclassify the pointer dismissal that follows it.
+      fireEvent.keyDown(nameField(), { key: "a" });
+      act(() => pointerDownOutsideHandler?.());
+      closeAutoFocus();
+
+      expect(focusSpy).not.toHaveBeenCalled();
+    });
+
+    it("lets the toolbar hold the pill's tooltip down across every close", () => {
+      renderPill();
+      const onCloseAutoFocus = vi.fn();
+      renderEditor(makeProject(), { onCloseAutoFocus });
+
+      // Fires whoever owns the restoration — the tooltip half is never a policy
+      // choice.
+      closeAutoFocus();
+
+      expect(onCloseAutoFocus).toHaveBeenCalledTimes(1);
     });
   });
 
   describe("emoji", () => {
     it("persists an emoji picked from the full picker", () => {
-      render(<ProjectIdentityEditor project={makeProject()} />);
+      renderEditor();
 
       fireEvent.click(screen.getByText("pick-unicorn"));
 
       expect(updateProjectMock).toHaveBeenCalledWith("p1", { emoji: "🦄" });
     });
 
+    it("closes itself once an emoji is picked", () => {
+      const onOpenChange = vi.fn();
+      renderEditor(makeProject(), { onOpenChange });
+
+      fireEvent.click(screen.getByText("pick-unicorn"));
+
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+
     it("offers the name-derived suggestion while the project still shows the tree", () => {
-      render(<ProjectIdentityEditor project={makeProject({ name: "my-api" })} />);
+      renderEditor(makeProject({ name: "my-api" }));
 
       const suggested = screen.getByRole("button", { name: /use suggested/i });
       fireEvent.click(suggested);
@@ -191,13 +323,13 @@ describe("ProjectIdentityEditor", () => {
     });
 
     it("hides the suggestion once the project has a non-default emoji", () => {
-      render(<ProjectIdentityEditor project={makeProject({ emoji: "🚀" })} />);
+      renderEditor(makeProject({ emoji: "🚀" }));
 
       expect(screen.queryByRole("button", { name: /use suggested/i })).toBeNull();
     });
 
     it("does not write when the picked emoji already matches", () => {
-      render(<ProjectIdentityEditor project={makeProject({ emoji: "🦄" })} />);
+      renderEditor(makeProject({ emoji: "🦄" }));
 
       fireEvent.click(screen.getByText("pick-unicorn"));
 
@@ -205,7 +337,7 @@ describe("ProjectIdentityEditor", () => {
     });
 
     it("carries a pending name edit along when an emoji is picked", () => {
-      render(<ProjectIdentityEditor project={makeProject()} />);
+      renderEditor();
 
       fireEvent.change(nameField(), { target: { value: "Renamed" } });
       // Picking closes the popover programmatically, which does NOT fire
@@ -220,7 +352,7 @@ describe("ProjectIdentityEditor", () => {
     });
 
     it("suggests from the edited draft, not the committed name", () => {
-      render(<ProjectIdentityEditor project={makeProject({ name: "plain" })} />);
+      renderEditor(makeProject({ name: "plain" }));
 
       fireEvent.change(nameField(), { target: { value: "docs" } });
       fireEvent.click(screen.getByRole("button", { name: /use suggested/i }));
@@ -234,7 +366,7 @@ describe("ProjectIdentityEditor", () => {
 
   describe("name", () => {
     it("commits a renamed project on Enter", () => {
-      render(<ProjectIdentityEditor project={makeProject()} />);
+      renderEditor();
 
       fireEvent.change(nameField(), { target: { value: "Renamed" } });
       fireEvent.keyDown(nameField(), { key: "Enter" });
@@ -242,8 +374,19 @@ describe("ProjectIdentityEditor", () => {
       expect(updateProjectMock).toHaveBeenCalledWith("p1", { name: "Renamed" });
     });
 
+    it("commits a pending edit when the popover is dismissed", () => {
+      renderEditor();
+
+      fireEvent.change(nameField(), { target: { value: "Renamed" } });
+      // Clicking away closes through the root rather than through either of the
+      // component's own exits.
+      act(() => openChangeHandler?.(false));
+
+      expect(updateProjectMock).toHaveBeenCalledWith("p1", { name: "Renamed" });
+    });
+
     it("trims before committing", () => {
-      render(<ProjectIdentityEditor project={makeProject()} />);
+      renderEditor();
 
       fireEvent.change(nameField(), { target: { value: "   Spaced   " } });
       fireEvent.keyDown(nameField(), { key: "Enter" });
@@ -252,7 +395,7 @@ describe("ProjectIdentityEditor", () => {
     });
 
     it("treats an emptied field as no change rather than erasing the name", () => {
-      render(<ProjectIdentityEditor project={makeProject()} />);
+      renderEditor();
 
       fireEvent.change(nameField(), { target: { value: "   " } });
       fireEvent.keyDown(nameField(), { key: "Enter" });
@@ -262,7 +405,7 @@ describe("ProjectIdentityEditor", () => {
     });
 
     it("does not write when the name is unchanged", () => {
-      render(<ProjectIdentityEditor project={makeProject()} />);
+      renderEditor();
 
       fireEvent.keyDown(nameField(), { key: "Enter" });
 
@@ -270,7 +413,7 @@ describe("ProjectIdentityEditor", () => {
     });
 
     it("reverts the draft on Escape without writing", () => {
-      render(<ProjectIdentityEditor project={makeProject()} />);
+      renderEditor();
 
       fireEvent.change(nameField(), { target: { value: "Abandoned" } });
       // Radix dismisses on Escape by default, which would run the close-commit
@@ -282,20 +425,28 @@ describe("ProjectIdentityEditor", () => {
     });
 
     it("re-seeds the draft when the project changes underneath it", () => {
-      const { rerender } = render(<ProjectIdentityEditor project={makeProject()} />);
+      const { rerender } = renderEditor();
       fireEvent.change(nameField(), { target: { value: "Draft" } });
 
-      rerender(<ProjectIdentityEditor project={makeProject({ id: "p2", name: "other" })} />);
+      rerender(
+        <ProjectIdentityEditor
+          project={makeProject({ id: "p2", name: "other" })}
+          open
+          onOpenChange={() => {}}
+        />
+      );
 
       // A stale draft must never be committable against a different project.
       expect(nameField().value).toBe("other");
     });
 
     it("does not write an untouched draft over a rename from elsewhere", () => {
-      const { rerender } = render(<ProjectIdentityEditor project={makeProject({ name: "A" })} />);
+      const { rerender } = renderEditor(makeProject({ name: "A" }));
       // Same project id, renamed in another window while this sat open and
       // untouched. Closing must not resurrect the old name.
-      rerender(<ProjectIdentityEditor project={makeProject({ name: "B" })} />);
+      rerender(
+        <ProjectIdentityEditor project={makeProject({ name: "B" })} open onOpenChange={() => {}} />
+      );
 
       fireEvent.click(screen.getByText("pick-unicorn"));
 


### PR DESCRIPTION
## The problem

The toolbar project pill had a transparent 28px button sitting on top of its emoji glyph. Clicking there opened the name-and-emoji editor; clicking anywhere else on the pill opened the project switcher. One control, two outcomes, and no visible boundary between them — the sub-target only revealed itself as a faint hover wash, after you'd already committed to the click.

The switcher is a many-times-a-day action. Renaming a project is a once-ever action. The rare one was sitting inside the hit box of the frequent one.

And the mis-click was worse than landing on the wrong surface. Both surfaces open with a text field focused, so the switcher's habitual click-type-Enter sequence typed into the **name field** and committed a rename. Dismissing the popover committed a dirty draft too, so even an abandoned mistype landed.

## The change

The whole pill opens the switcher. Identity editing moves behind **Edit name and icon…** in the pill's existing right-click menu.

The label is deliberately not "Rename project" — the switcher's row menu already has *Move or rename project…*, which is the on-disk relocation dialog. These are different things and shouldn't read alike.

The editor keeps its commit semantics unchanged and becomes a controlled, anchored popover. Everything that existed only to hold the overlay illusion together goes with it: the contextmenu/pointer replay onto the pill, the extra roving-tabindex stop, the sibling `parentElement` lookup, and the five tests that pinned the replay.

## Focus

An anchored popover has no trigger, so Radix restores focus to `null` and it lands on `document.body`. `PillRestoreTarget` hands the shared policy in `overlay-focus-restore.ts` the pill to aim at, which leaves every pointer close where it belongs — dismissing this popover by clicking the pill opens the switcher and focuses its search box, and a blanket restore would yank focus straight back out of it. Only the keyboard close is claimed locally, ringed, because that's the single case the shared policy hands back to Radix.

The menu item records its intent (scoped to the project that was right-clicked) and the menu's own close hook spends it, so the popover is raised after the menu is gone rather than inside its teardown, where the pointer release that closed the menu could dismiss the popover it just opened.

## Why the menu and not Project Settings

Settings → General already has name, emoji, colour and icon, and the pill's menu already links to it — so this is a fast path, not the only path. A two-field edit didn't warrant opening a full settings dialog.

## Notes

- Prior art for the overlay was #6928, which established it must be a sibling rather than a nested button. That constraint disappears along with the overlay.
- The pill ContextMenuContent's `preventDefault()` in `onCloseAutoFocus` is pre-existing and untouched here.

## Testing

- `npm run check` ✅ · `npm run typecheck` ✅
- Full vitest suite: 52,583 passing
- `ProjectIdentityEditor.test.tsx` rewritten around the new contract — 24 tests covering the focus outcome for each close path, the modality split, and the `setRestoreTarget` wiring
- New Playwright test in `e2e/full/worktree/core-project-lifecycle.spec.ts` position-clicks the emoji region and asserts the **switcher** opens, then right-clicks and opens the identity popover. Asserted by position because the regression is in the hit map, not in any handler a unit test can see. That spec (6 tests) passes locally against a real build.