### PR TITLE
fix(worktree-card): make Retry and Dismiss reachable on the error banners

### DIFF
--- a/src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx
@@ -625,12 +625,33 @@ export function WorktreeDeleteErrorBanner({
   onRetry,
   onDismiss,
 }: WorktreeDeleteErrorBannerProps) {
+  // The card root selects the worktree on any click that reaches it, and
+  // `handleCardClick` has no interactive-target guard — the card's convention
+  // (documented on its `handleDoubleClick`, #10319) is that interactive
+  // children stop click propagation themselves, as `handleRetrySetup` above
+  // does. Without this, dismissing an error on a background card would also
+  // switch the active worktree (#12087).
+  const handleRetryClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onRetry?.();
+  };
+  const handleDismissClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onDismiss?.();
+  };
   return (
     <div
       role="alert"
       aria-live="assertive"
       data-testid="worktree-delete-error-banner"
-      className="mt-2 flex items-start gap-2 rounded-[var(--radius-lg)] border border-status-error/20 bg-status-error/10 p-3 text-xs"
+      // `relative z-10` is load-bearing, not decoration. Both banners mount as
+      // bare siblings of the card's `relative z-10` content column, inside a
+      // `relative isolate` root that also carries the sidebar's full-card select
+      // overlay at `absolute inset-0 z-0`. A static block paints in an earlier
+      // step than a positioned `z-0` sibling regardless of DOM order, so without
+      // this the overlay covered the banner and swallowed every click on Retry
+      // and Dismiss (#12087). Joins the tier the content column already uses.
+      className="relative z-10 mt-2 flex items-start gap-2 rounded-[var(--radius-lg)] border border-status-error/20 bg-status-error/10 p-3 text-xs"
     >
       <AlertTriangle className="w-4 h-4 shrink-0 text-status-error" aria-hidden="true" />
       <div className="flex min-w-0 flex-1 flex-col gap-2">
@@ -642,7 +663,7 @@ export function WorktreeDeleteErrorBanner({
           {onRetry && (
             <button
               type="button"
-              onClick={onRetry}
+              onClick={handleRetryClick}
               data-testid="worktree-delete-retry"
               className="rounded-[var(--radius-md)] border border-status-error/30 px-2 py-1 text-status-error transition-colors hover:bg-status-error/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent-primary focus-visible:outline-offset-2"
             >
@@ -652,7 +673,7 @@ export function WorktreeDeleteErrorBanner({
           {onDismiss && (
             <button
               type="button"
-              onClick={onDismiss}
+              onClick={handleDismissClick}
               data-testid="worktree-delete-dismiss"
               className="rounded-[var(--radius-md)] px-2 py-1 text-text-secondary transition-colors hover:bg-overlay-soft focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent-primary focus-visible:outline-offset-2"
             >
@@ -685,12 +706,33 @@ export function WorktreeIssueErrorBanner({
   onDismiss,
 }: WorktreeIssueErrorBannerProps) {
   const title = mutationType === "attach-issue" ? "Couldn't attach issue" : "Couldn't detach issue";
+  // The card root selects the worktree on any click that reaches it, and
+  // `handleCardClick` has no interactive-target guard — the card's convention
+  // (documented on its `handleDoubleClick`, #10319) is that interactive
+  // children stop click propagation themselves, as `handleRetrySetup` above
+  // does. Without this, dismissing an error on a background card would also
+  // switch the active worktree (#12087).
+  const handleRetryClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onRetry?.();
+  };
+  const handleDismissClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onDismiss?.();
+  };
   return (
     <div
       role="alert"
       aria-live="assertive"
       data-testid="worktree-issue-error-banner"
-      className="mt-2 flex items-start gap-2 rounded-[var(--radius-lg)] border border-status-error/20 bg-status-error/10 p-3 text-xs"
+      // `relative z-10` is load-bearing, not decoration. Both banners mount as
+      // bare siblings of the card's `relative z-10` content column, inside a
+      // `relative isolate` root that also carries the sidebar's full-card select
+      // overlay at `absolute inset-0 z-0`. A static block paints in an earlier
+      // step than a positioned `z-0` sibling regardless of DOM order, so without
+      // this the overlay covered the banner and swallowed every click on Retry
+      // and Dismiss (#12087). Joins the tier the content column already uses.
+      className="relative z-10 mt-2 flex items-start gap-2 rounded-[var(--radius-lg)] border border-status-error/20 bg-status-error/10 p-3 text-xs"
     >
       <AlertTriangle className="w-4 h-4 shrink-0 text-status-error" aria-hidden="true" />
       <div className="flex min-w-0 flex-1 flex-col gap-2">
@@ -702,7 +744,7 @@ export function WorktreeIssueErrorBanner({
           {onRetry && (
             <button
               type="button"
-              onClick={onRetry}
+              onClick={handleRetryClick}
               data-testid="worktree-issue-retry"
               className="rounded-[var(--radius-md)] border border-status-error/30 px-2 py-1 text-status-error transition-colors hover:bg-status-error/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent-primary focus-visible:outline-offset-2"
             >
@@ -712,7 +754,7 @@ export function WorktreeIssueErrorBanner({
           {onDismiss && (
             <button
               type="button"
-              onClick={onDismiss}
+              onClick={handleDismissClick}
               data-testid="worktree-issue-dismiss"
               className="rounded-[var(--radius-md)] px-2 py-1 text-text-secondary transition-colors hover:bg-overlay-soft focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent-primary focus-visible:outline-offset-2"
             >

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeCardInteraction.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeCardInteraction.test.tsx
@@ -272,3 +272,84 @@ describe("WorktreeCard disabled drag handle (issue #8395)", () => {
     expect(cardSource).toMatch(/\{hasRowDragHandle &&/);
   });
 });
+
+// Issue #12087 — Retry/Dismiss on the delete and issue error banners were dead
+// on sidebar cards. Both banners mount as bare siblings of the card's content
+// column inside a `relative isolate` root that also carries the sidebar's
+// full-card select overlay at `absolute inset-0 z-0`. A static in-flow block
+// paints in an earlier step than a positioned `z-0` sibling no matter the DOM
+// order (CSS 2.1 Appendix E), so the overlay covered the banners and, since
+// hit-testing follows paint order, swallowed every click.
+//
+// jsdom has no layout engine and loads no CSS, so the real coordinate check is
+// impossible here — this asserts the ORDERING that makes it true. Renumbering
+// either tier keeps the test green; breaking the relationship fails it.
+
+/** Positioning/stacking tokens carried by one element's Tailwind class list. */
+function stackingTokens(classList: string): { positioned: boolean; z: number | null } {
+  const tokens = classList.split(/\s+/).filter(Boolean);
+  const positioned = tokens.some((t) => ["relative", "absolute", "fixed", "sticky"].includes(t));
+  const zToken = tokens.filter((t) => /^z-\d+$/.test(t)).pop();
+  return { positioned, z: zToken ? Number(zToken.slice(2)) : null };
+}
+
+/** A z-tier that must exist — fails with the element's name rather than
+ *  comparing against null (or asserting the type away). */
+function requireZ(label: string, tokens: { z: number | null }): number {
+  if (tokens.z === null) throw new Error(`${label} carries no z-* utility`);
+  return tokens.z;
+}
+
+/** The sidebar select overlay's class string, anchored on its unique attribute. */
+function selectOverlayClasses(): string {
+  const classes = cardSource.match(
+    /data-card-select-overlay=""\s*\n\s*className=\{cn\(\s*\n\s*"([^"]+)"/
+  )?.[1];
+  if (classes === undefined) {
+    throw new Error("no [data-card-select-overlay] className in WorktreeCard.tsx");
+  }
+  return classes;
+}
+
+/** A banner root's class string, anchored on its unique test id. The bounded
+ *  lazy span tolerates the comment block between the attribute and className
+ *  without letting the match run on into an unrelated element. */
+function bannerRootClasses(testId: string): string {
+  const classes = detailsSource.match(
+    new RegExp(`data-testid="${testId}"[\\s\\S]{0,900}?className="([^"]+)"`)
+  )?.[1];
+  if (classes === undefined) {
+    throw new Error(`no root className for [data-testid="${testId}"]`);
+  }
+  return classes;
+}
+
+describe("worktree error banner stacking (issue #12087)", () => {
+  it("mounts both banners outside the card's z-10 content column", () => {
+    // The premise the ordering assertion below exists to defend. If a later
+    // refactor moves the banners inside the column they inherit its tier and
+    // this suite should be revisited rather than left asserting a dead rule.
+    expect(cardSource).toMatch(/\{deleteError && \(\s*<WorktreeDeleteErrorBanner/);
+    expect(cardSource).toMatch(/\{issueError && \(\s*<WorktreeIssueErrorBanner/);
+  });
+
+  it("gives the select overlay a positioned, z-indexed full-card layer", () => {
+    // Guards the ordering assertions from passing vacuously if the overlay's
+    // class string ever stops being extractable.
+    const overlay = stackingTokens(selectOverlayClasses());
+    expect(overlay.positioned).toBe(true);
+    expect(overlay.z).not.toBeNull();
+  });
+
+  it.each([["worktree-delete-error-banner"], ["worktree-issue-error-banner"]])(
+    "%s is positioned above the select overlay so its buttons take the click",
+    (testId) => {
+      const overlayZ = requireZ("the select overlay", stackingTokens(selectOverlayClasses()));
+      const banner = stackingTokens(bannerRootClasses(testId));
+
+      // A z-index on a static element is inert — both halves are required.
+      expect(banner.positioned).toBe(true);
+      expect(requireZ(testId, banner)).toBeGreaterThan(overlayZ);
+    }
+  );
+});

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeCardInteraction.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeCardInteraction.test.tsx
@@ -300,39 +300,34 @@ function requireZ(label: string, tokens: { z: number | null }): number {
   return tokens.z;
 }
 
+/** The single opening tag carrying `attribute`, and nothing past its `>`. The
+ *  `[^>]*` fences keep the match inside one element, so a className lifted out
+ *  of it can never belong to a descendant however the attributes are ordered. */
+function openingTagWith(source: string, tag: string, attribute: string): string {
+  const found = source.match(new RegExp(`<${tag}\\b[^>]*\\b${attribute}[^>]*>`))?.[0];
+  if (found === undefined) throw new Error(`no <${tag}> carrying ${attribute}`);
+  return found;
+}
+
 /** The sidebar select overlay's class string, anchored on its unique attribute. */
 function selectOverlayClasses(): string {
-  const classes = cardSource.match(
-    /data-card-select-overlay=""\s*\n\s*className=\{cn\(\s*\n\s*"([^"]+)"/
-  )?.[1];
+  const tag = openingTagWith(cardSource, "button", 'data-card-select-overlay=""');
+  const classes = tag.match(/className=\{cn\(\s*"([^"]+)"/)?.[1];
   if (classes === undefined) {
-    throw new Error("no [data-card-select-overlay] className in WorktreeCard.tsx");
+    throw new Error("no className={cn(...)} on the [data-card-select-overlay] button");
   }
   return classes;
 }
 
-/** A banner root's class string, anchored on its unique test id. The bounded
- *  lazy span tolerates the comment block between the attribute and className
- *  without letting the match run on into an unrelated element. */
+/** A banner root's class string, anchored on its unique test id. */
 function bannerRootClasses(testId: string): string {
-  const classes = detailsSource.match(
-    new RegExp(`data-testid="${testId}"[\\s\\S]{0,900}?className="([^"]+)"`)
-  )?.[1];
-  if (classes === undefined) {
-    throw new Error(`no root className for [data-testid="${testId}"]`);
-  }
+  const tag = openingTagWith(detailsSource, "div", `data-testid="${testId}"`);
+  const classes = tag.match(/className="([^"]+)"/)?.[1];
+  if (classes === undefined) throw new Error(`no root className for [data-testid="${testId}"]`);
   return classes;
 }
 
 describe("worktree error banner stacking (issue #12087)", () => {
-  it("mounts both banners outside the card's z-10 content column", () => {
-    // The premise the ordering assertion below exists to defend. If a later
-    // refactor moves the banners inside the column they inherit its tier and
-    // this suite should be revisited rather than left asserting a dead rule.
-    expect(cardSource).toMatch(/\{deleteError && \(\s*<WorktreeDeleteErrorBanner/);
-    expect(cardSource).toMatch(/\{issueError && \(\s*<WorktreeIssueErrorBanner/);
-  });
-
   it("gives the select overlay a positioned, z-indexed full-card layer", () => {
     // Guards the ordering assertions from passing vacuously if the overlay's
     // class string ever stops being extractable.

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeCardInteraction.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeCardInteraction.test.tsx
@@ -328,6 +328,15 @@ function bannerRootClasses(testId: string): string {
 }
 
 describe("worktree error banner stacking (issue #12087)", () => {
+  it("renders both banners from the card", () => {
+    // Named for what it actually proves: the card still mounts them. Every
+    // other test here reads the banner definitions or renders the exports
+    // directly, so deleting these two blocks from WorktreeCard would otherwise
+    // leave the whole suite green. It says nothing about WHERE they sit.
+    expect(cardSource).toMatch(/\{deleteError && \(\s*<WorktreeDeleteErrorBanner/);
+    expect(cardSource).toMatch(/\{issueError && \(\s*<WorktreeIssueErrorBanner/);
+  });
+
   it("gives the select overlay a positioned, z-indexed full-card layer", () => {
     // Guards the ordering assertions from passing vacuously if the overlay's
     // class string ever stops being extractable.

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeDetailsSection.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeDetailsSection.test.tsx
@@ -506,9 +506,13 @@ describe("worktree error banners (issue #12087)", () => {
 
   it("renders no action buttons when neither handler is supplied", () => {
     const { rerender } = render(<WorktreeDeleteErrorBanner message="boom" />);
+    // Assert the banner is actually on screen first, so "no buttons" can't pass
+    // by way of nothing having rendered at all.
+    expect(screen.getByRole("alert").textContent).toContain("Couldn't delete worktree");
     expect(screen.queryByRole("button")).toBeNull();
 
     rerender(<WorktreeIssueErrorBanner message="boom" mutationType="detach-issue" />);
+    expect(screen.getByRole("alert").textContent).toContain("Couldn't detach issue");
     expect(screen.queryByRole("button")).toBeNull();
   });
 });

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeDetailsSection.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeDetailsSection.test.tsx
@@ -505,14 +505,16 @@ describe("worktree error banners (issue #12087)", () => {
   });
 
   it("renders no action buttons when neither handler is supplied", () => {
-    const { rerender } = render(<WorktreeDeleteErrorBanner message="boom" />);
+    const { rerender } = render(<WorktreeDeleteErrorBanner message="disk on fire" />);
     // Assert the banner is actually on screen first, so "no buttons" can't pass
-    // by way of nothing having rendered at all.
-    expect(screen.getByRole("alert").textContent).toContain("Couldn't delete worktree");
+    // by way of nothing having rendered. Checked via the message passed in — an
+    // input/output contract — rather than the title, which is microcopy the
+    // implementation owns.
+    expect(screen.getByRole("alert").textContent).toContain("disk on fire");
     expect(screen.queryByRole("button")).toBeNull();
 
-    rerender(<WorktreeIssueErrorBanner message="boom" mutationType="detach-issue" />);
-    expect(screen.getByRole("alert").textContent).toContain("Couldn't detach issue");
+    rerender(<WorktreeIssueErrorBanner message="disk on fire" mutationType="detach-issue" />);
+    expect(screen.getByRole("alert").textContent).toContain("disk on fire");
     expect(screen.queryByRole("button")).toBeNull();
   });
 });

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeDetailsSection.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeDetailsSection.test.tsx
@@ -11,6 +11,8 @@ import type { ComputedSubtitle } from "../hooks/useWorktreeStatus";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import {
   WorktreeDetailsSection,
+  WorktreeDeleteErrorBanner,
+  WorktreeIssueErrorBanner,
   type WorktreeDetailsSectionProps,
 } from "../WorktreeDetailsSection";
 
@@ -452,5 +454,61 @@ describe("WorktreeDetailsSection activity chip (collapsed row)", () => {
   it("removes the standalone 'No activity' placeholder", () => {
     renderSection({ worktree: withCommit({}), hasChanges: false });
     expect(screen.queryByText("No activity")).toBeNull();
+  });
+});
+
+// Issue #12087 — the banners mount as bare siblings of the card's `relative
+// z-10` content column, under a full-card select overlay whose click handler
+// selects the worktree. Their buttons have to reach the user AND stop the click
+// there; jsdom can't test the stacking half (no layout engine, no CSS), so the
+// paint-order invariant is asserted as a source contract in
+// WorktreeCardInteraction.test.tsx and the propagation half is asserted here.
+describe("worktree error banners (issue #12087)", () => {
+  const banners = [
+    {
+      name: "delete",
+      renderBanner: (props: { onRetry: () => void; onDismiss: () => void }) => (
+        <WorktreeDeleteErrorBanner message="cannot remove a locked working tree" {...props} />
+      ),
+    },
+    {
+      name: "issue",
+      renderBanner: (props: { onRetry: () => void; onDismiss: () => void }) => (
+        <WorktreeIssueErrorBanner
+          message="network unreachable"
+          mutationType="attach-issue"
+          {...props}
+        />
+      ),
+    },
+  ];
+
+  describe.each(banners)("$name banner", ({ renderBanner }) => {
+    it.each([["Retry"], ["Dismiss"]])(
+      "%s fires its own handler without bubbling to the card's click handler",
+      (label) => {
+        const onRetry = vi.fn();
+        const onDismiss = vi.fn();
+        const onCardClick = vi.fn();
+        render(<div onClick={onCardClick}>{renderBanner({ onRetry, onDismiss })}</div>);
+
+        fireEvent.click(screen.getByRole("button", { name: label }));
+
+        const [fired, quiet] = label === "Retry" ? [onRetry, onDismiss] : [onDismiss, onRetry];
+        expect(fired).toHaveBeenCalledTimes(1);
+        expect(quiet).not.toHaveBeenCalled();
+        // The card root selects the worktree on any click that reaches it, so a
+        // bubbled Dismiss would switch worktrees as a side effect.
+        expect(onCardClick).not.toHaveBeenCalled();
+      }
+    );
+  });
+
+  it("renders no action buttons when neither handler is supplied", () => {
+    const { rerender } = render(<WorktreeDeleteErrorBanner message="boom" />);
+    expect(screen.queryByRole("button")).toBeNull();
+
+    rerender(<WorktreeIssueErrorBanner message="boom" mutationType="detach-issue" />);
+    expect(screen.queryByRole("button")).toBeNull();
   });
 });

--- a/src/store/__tests__/createWorktreeStore.delete.test.ts
+++ b/src/store/__tests__/createWorktreeStore.delete.test.ts
@@ -340,6 +340,39 @@ describe("createWorktreeStore — delete in-flight state (#8417)", () => {
     expect(store.getState().deleteErrorArgs.has("wt-1")).toBe(false);
   });
 
+  // #12087 — Dismiss has to abandon the delete, not just hide its banner. A
+  // non-permanent failure parks the outbox entry at `pending`, and the reconnect
+  // sweep replays anything that isn't `failed`/`in-flight`, so clearing only the
+  // presentation state left a dismissed delete queued to re-fire.
+  it("clearDeleteError drops the outbox entry so a dismissed delete cannot replay", async () => {
+    worktreeClientDeleteMock.mockRejectedValueOnce(
+      new Error("fatal: cannot remove a locked working tree")
+    );
+
+    const store = createWorktreeStore();
+    store.getState().applySnapshot([makeSnapshot("wt-1")], nextV());
+
+    store.getState().startDelete("wt-1", { force: false });
+    await flushPromises();
+    await flushPromises();
+
+    // Precondition: a retryable failure leaves a live entry behind the banner.
+    expect(store.getState().deleteErrors.has("wt-1")).toBe(true);
+    expect(store.getState().mutationOutbox.size).toBe(1);
+    expect(worktreeClientDeleteMock).toHaveBeenCalledTimes(1);
+
+    store.getState().clearDeleteError("wt-1");
+    expect(store.getState().mutationOutbox.size).toBe(0);
+
+    // The worktree is still in the snapshot, so a surviving entry would be a
+    // replay candidate rather than being pruned as already-gone.
+    store.getState().replayOutboxAfterReconnect();
+    await flushPromises();
+    await flushPromises();
+
+    expect(worktreeClientDeleteMock).toHaveBeenCalledTimes(1);
+  });
+
   it("partial-success path: when worktree-removed arrives first, failure routes to notify() so it is not swallowed", async () => {
     // The backend emits `worktree-removed` BEFORE `git branch -d`. A branch
     // deletion failure thus arrives after `applyRemove` has cleared the card.

--- a/src/store/__tests__/createWorktreeStore.delete.test.ts
+++ b/src/store/__tests__/createWorktreeStore.delete.test.ts
@@ -373,6 +373,77 @@ describe("createWorktreeStore — delete in-flight state (#8417)", () => {
     expect(worktreeClientDeleteMock).toHaveBeenCalledTimes(1);
   });
 
+  it("clearDeleteError relaunches the terminals the failed delete closed", async () => {
+    captureWorktreeTerminalSnapshotMock.mockReturnValueOnce([{ id: "term-1" }]);
+    worktreeClientDeleteMock.mockRejectedValueOnce(
+      new Error("fatal: cannot remove a locked working tree")
+    );
+
+    const store = createWorktreeStore();
+    store.getState().applySnapshot([makeSnapshot("wt-1")], nextV());
+
+    store.getState().startDelete("wt-1", { force: false, closeTerminals: true });
+    await flushPromises();
+    await flushPromises();
+
+    // A retryable failure deliberately holds the snapshot back — the retry that
+    // may still come would only close the terminals again.
+    expect(store.getState().deleteErrors.has("wt-1")).toBe(true);
+    expect(restoreClosedTerminalsMock).not.toHaveBeenCalled();
+
+    store.getState().clearDeleteError("wt-1");
+    await flushPromises();
+
+    expect(restoreClosedTerminalsMock).toHaveBeenCalledTimes(1);
+    expect(restoreClosedTerminalsMock).toHaveBeenCalledWith([{ id: "term-1" }]);
+
+    // Snapshot consumed: dismissing again must not relaunch them a second time.
+    store.getState().clearDeleteError("wt-1");
+    await flushPromises();
+    expect(restoreClosedTerminalsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("clearDeleteError leaves an in-flight replay alone rather than orphaning it", async () => {
+    captureWorktreeTerminalSnapshotMock.mockReturnValueOnce([{ id: "term-1" }]);
+    worktreeClientDeleteMock.mockRejectedValueOnce(new Error("boom"));
+
+    const store = createWorktreeStore();
+    store.getState().applySnapshot([makeSnapshot("wt-1")], nextV());
+
+    store.getState().startDelete("wt-1", { force: false, closeTerminals: true });
+    await flushPromises();
+    await flushPromises();
+    expect(store.getState().deleteErrors.has("wt-1")).toBe(true);
+
+    // The reconnect sweep replays the pending entry and flips it to `in-flight`
+    // WITHOUT clearing the banner, so Dismiss can land on a live delete.
+    let settleDelete: () => void = () => {};
+    worktreeClientDeleteMock.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          settleDelete = resolve;
+        })
+    );
+    store.getState().replayOutboxAfterReconnect();
+    await flushPromises();
+
+    const entryId = Array.from(store.getState().mutationOutbox.keys())[0];
+    if (entryId === undefined) throw new Error("expected a delete outbox entry");
+    expect(store.getState().mutationOutbox.get(entryId)?.status).toBe("in-flight");
+
+    store.getState().clearDeleteError("wt-1");
+
+    // The banner goes, but the running removal keeps its entry and its
+    // terminals stay closed — relaunching them would race a delete that is
+    // still on its way to succeeding.
+    expect(store.getState().deleteErrors.has("wt-1")).toBe(false);
+    expect(store.getState().mutationOutbox.has(entryId)).toBe(true);
+    expect(restoreClosedTerminalsMock).not.toHaveBeenCalled();
+
+    settleDelete();
+    await flushPromises();
+  });
+
   it("partial-success path: when worktree-removed arrives first, failure routes to notify() so it is not swallowed", async () => {
     // The backend emits `worktree-removed` BEFORE `git branch -d`. A branch
     // deletion failure thus arrives after `applyRemove` has cleared the card.

--- a/src/store/__tests__/createWorktreeStore.outbox.test.ts
+++ b/src/store/__tests__/createWorktreeStore.outbox.test.ts
@@ -645,6 +645,53 @@ describe("createWorktreeStore — mutation outbox (#8405)", () => {
       expect(store.getState().deleteErrors.has("wt-1")).toBe(false);
       expect(store.getState().deleteErrorArgs.has("wt-1")).toBe(false);
     });
+
+    // #12087 — the banner carrying this Dismiss only became clickable on
+    // sidebar cards with that fix, which makes the stale-click window real: a
+    // reconnect replay flips an entry to `in-flight` without clearing the
+    // banner, so Dismiss can land on a mutation that is still running. Pruning
+    // it there would make the success handler discard a write the host had
+    // already committed.
+    it("dismissOutboxEntry keeps an in-flight issue entry so its result still applies", async () => {
+      worktreeClientAttachIssueMock.mockRejectedValueOnce(new Error("network blip"));
+
+      const store = createWorktreeStore();
+      store.getState().applySnapshot([makeSnapshot("wt-1")], nextV());
+
+      store.getState().startAttachIssue({
+        worktreeId: "wt-1",
+        issueNumber: 42,
+        issueTitle: "Issue 42",
+      });
+      await flushPromises();
+      await flushPromises();
+      expect(store.getState().issueErrors.has("wt-1")).toBe(true);
+
+      let settleAttach: () => void = () => {};
+      worktreeClientAttachIssueMock.mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            settleAttach = resolve;
+          })
+      );
+      store.getState().replayOutboxAfterReconnect();
+      await flushPromises();
+
+      const entry = [...store.getState().mutationOutbox.values()][0]!;
+      expect(entry.status).toBe("in-flight");
+
+      store.getState().dismissOutboxEntry(entry.mutationId);
+
+      // Banner goes; the live mutation and its in-flight guard do not.
+      expect(store.getState().issueErrors.has("wt-1")).toBe(false);
+      expect(store.getState().mutationOutbox.has(entry.mutationId)).toBe(true);
+
+      // The host commits the write, so the renderer must still record it.
+      settleAttach();
+      await flushPromises();
+      await flushPromises();
+      expect(store.getState().manualAssociations.get("wt-1")?.issueNumber).toBe(42);
+    });
   });
 
   describe("issue-association mutations (#9163)", () => {

--- a/src/store/createWorktreeStore.ts
+++ b/src/store/createWorktreeStore.ts
@@ -1094,6 +1094,18 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
           ? new Map(prev.issueErrors)
           : prev.issueErrors;
         if (prev.issueErrors.has(entry.worktreeId)) nextIssueErrors.delete(entry.worktreeId);
+
+        // ...unless the mutation is still running. `replayOutboxAfterReconnect`
+        // flips entries to `in-flight` without clearing `issueErrors`, so a
+        // Dismiss can land on a live attach/detach. Pruning it would make
+        // `applyIssueMutationSuccess` discard a write the host had already
+        // committed, leaving the renderer's association permanently stale.
+        // Hide the banner; leave the entry and its guard to settle (#12087).
+        if (entry.status === "in-flight") {
+          set({ issueErrors: nextIssueErrors });
+          return;
+        }
+
         const nextIssueMutatingIds = prev.issueMutatingIds.has(entry.worktreeId)
           ? new Set(prev.issueMutatingIds)
           : prev.issueMutatingIds;

--- a/src/store/createWorktreeStore.ts
+++ b/src/store/createWorktreeStore.ts
@@ -1370,17 +1370,26 @@ function abandonDelete(
 ): void {
   const prev = get();
   const mutationId = knownMutationId ?? findDeleteMutationId(prev.mutationOutbox, worktreeId);
+  const entry = mutationId === undefined ? undefined : prev.mutationOutbox.get(mutationId);
   const hadError = prev.deleteErrors.has(worktreeId);
   const hadArgs = prev.deleteErrorArgs.has(worktreeId);
-  const hadEntry = mutationId !== undefined && prev.mutationOutbox.has(mutationId);
-  if (!hadError && !hadArgs && !hadEntry) return;
+
+  // An `in-flight` entry still has a live `runDeleteAsync` behind it, and the
+  // banner can be showing over one: `replayOutboxAfterReconnect` flips entries
+  // to `in-flight` without clearing `deleteErrors`, so a Dismiss can land on a
+  // delete that is actively running. Pruning that entry would orphan a removal
+  // still on its way to the host, and relaunching its terminals would race the
+  // removal that is about to succeed. Drop the banner, leave the mutation to
+  // settle on its own — `handleDeleteFailure` re-surfaces it if it fails again.
+  const prunable = entry !== undefined && entry.status !== "in-flight";
+  if (!hadError && !hadArgs && !prunable) return;
 
   const nextDeleteErrors = hadError ? new Map(prev.deleteErrors) : prev.deleteErrors;
   if (hadError) nextDeleteErrors.delete(worktreeId);
   const nextDeleteErrorArgs = hadArgs ? new Map(prev.deleteErrorArgs) : prev.deleteErrorArgs;
   if (hadArgs) nextDeleteErrorArgs.delete(worktreeId);
-  const nextOutbox = hadEntry ? new Map(prev.mutationOutbox) : prev.mutationOutbox;
-  if (hadEntry && mutationId !== undefined) nextOutbox.delete(mutationId);
+  const nextOutbox = prunable ? new Map(prev.mutationOutbox) : prev.mutationOutbox;
+  if (prunable && mutationId !== undefined) nextOutbox.delete(mutationId);
 
   set({
     deleteErrors: nextDeleteErrors,
@@ -1388,7 +1397,7 @@ function abandonDelete(
     mutationOutbox: nextOutbox,
   });
 
-  if (mutationId !== undefined) consumeTerminalRestore(worktreeId, mutationId);
+  if (prunable && mutationId !== undefined) consumeTerminalRestore(worktreeId, mutationId);
 }
 
 /** Drop any pending/in-flight restore bookkeeping for a worktree. Called when

--- a/src/store/createWorktreeStore.ts
+++ b/src/store/createWorktreeStore.ts
@@ -879,18 +879,10 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
     },
 
     clearDeleteError(worktreeId: string) {
-      const prev = get();
-      const hadError = prev.deleteErrors.has(worktreeId);
-      const hadArgs = prev.deleteErrorArgs.has(worktreeId);
-      if (!hadError && !hadArgs) return;
-      const nextDeleteErrors = hadError ? new Map(prev.deleteErrors) : prev.deleteErrors;
-      if (hadError) nextDeleteErrors.delete(worktreeId);
-      const nextDeleteErrorArgs = hadArgs ? new Map(prev.deleteErrorArgs) : prev.deleteErrorArgs;
-      if (hadArgs) nextDeleteErrorArgs.delete(worktreeId);
-      set({
-        deleteErrors: nextDeleteErrors,
-        deleteErrorArgs: nextDeleteErrorArgs,
-      });
+      // Dismiss on the delete banner. Abandons the whole delete, not just its
+      // presentation — see `abandonDelete` for why the outbox entry and the
+      // closed terminals have to go with the banner (#12087).
+      abandonDelete(get, set, worktreeId);
     },
 
     startAttachIssue(payload: AttachIssuePayload) {
@@ -1115,19 +1107,9 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
         return;
       }
 
-      const nextDeleteErrors = prev.deleteErrors.has(entry.worktreeId)
-        ? new Map(prev.deleteErrors)
-        : prev.deleteErrors;
-      if (prev.deleteErrors.has(entry.worktreeId)) nextDeleteErrors.delete(entry.worktreeId);
-      const nextDeleteErrorArgs = prev.deleteErrorArgs.has(entry.worktreeId)
-        ? new Map(prev.deleteErrorArgs)
-        : prev.deleteErrorArgs;
-      if (prev.deleteErrorArgs.has(entry.worktreeId)) nextDeleteErrorArgs.delete(entry.worktreeId);
-      set({
-        mutationOutbox: next,
-        deleteErrors: nextDeleteErrors,
-        deleteErrorArgs: nextDeleteErrorArgs,
-      });
+      // Same abandon as the banner's Dismiss — routed through one helper so the
+      // two paths can't drift apart (#12087).
+      abandonDelete(get, set, entry.worktreeId, mutationId);
     },
 
     replayOutboxAfterReconnect() {
@@ -1347,6 +1329,66 @@ function consumeTerminalRestore(worktreeId: string, mutationId: string): void {
     if (restoreInFlight.get(worktreeId) === done) restoreInFlight.delete(worktreeId);
   });
   restoreInFlight.set(worktreeId, done);
+}
+
+/** The delete entry parked in the outbox for a worktree, if any. A worktree has
+ *  at most one in flight — `startDelete` reuses the existing `mutationId`. */
+function findDeleteMutationId(
+  outbox: ReadonlyMap<string, MutationOutboxEntry>,
+  worktreeId: string
+): string | undefined {
+  for (const entry of outbox.values()) {
+    if (entry.type === "delete-worktree" && entry.worktreeId === worktreeId) {
+      return entry.mutationId;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Abandon a failed delete: the banner, the stored retry args and the outbox
+ * entry all go together.
+ *
+ * Clearing only the presentation state was a silent replay hazard (#12087). A
+ * failure that isn't permanent and hasn't hit the retry cap — "cannot remove a
+ * locked working tree", say — parks its entry at `pending`, and
+ * `replayOutboxAfterReconnect` skips only `failed`/`in-flight`. So a dismissed
+ * delete stayed queued and re-fired on the next reconnect.
+ *
+ * The terminals the delete closed are relaunched here for the same reason
+ * `handleDeleteFailure` relaunches them once an entry goes `failed`: the
+ * snapshot is held only while an automatic retry could still use it, and a
+ * dismissed delete is definitively abandoned.
+ */
+function abandonDelete(
+  get: () => WorktreeViewStore,
+  set: (
+    partial: Partial<WorktreeViewStore> | ((state: WorktreeViewStore) => Partial<WorktreeViewStore>)
+  ) => void,
+  worktreeId: string,
+  knownMutationId?: string
+): void {
+  const prev = get();
+  const mutationId = knownMutationId ?? findDeleteMutationId(prev.mutationOutbox, worktreeId);
+  const hadError = prev.deleteErrors.has(worktreeId);
+  const hadArgs = prev.deleteErrorArgs.has(worktreeId);
+  const hadEntry = mutationId !== undefined && prev.mutationOutbox.has(mutationId);
+  if (!hadError && !hadArgs && !hadEntry) return;
+
+  const nextDeleteErrors = hadError ? new Map(prev.deleteErrors) : prev.deleteErrors;
+  if (hadError) nextDeleteErrors.delete(worktreeId);
+  const nextDeleteErrorArgs = hadArgs ? new Map(prev.deleteErrorArgs) : prev.deleteErrorArgs;
+  if (hadArgs) nextDeleteErrorArgs.delete(worktreeId);
+  const nextOutbox = hadEntry ? new Map(prev.mutationOutbox) : prev.mutationOutbox;
+  if (hadEntry && mutationId !== undefined) nextOutbox.delete(mutationId);
+
+  set({
+    deleteErrors: nextDeleteErrors,
+    deleteErrorArgs: nextDeleteErrorArgs,
+    mutationOutbox: nextOutbox,
+  });
+
+  if (mutationId !== undefined) consumeTerminalRestore(worktreeId, mutationId);
 }
 
 /** Drop any pending/in-flight restore bookkeeping for a worktree. Called when


### PR DESCRIPTION
## The bug

On sidebar worktree cards, Retry and Dismiss on the delete- and issue-error banners did nothing. The error stuck to the card for the rest of the session.

The card root is `relative isolate`. Its sidebar-only select overlay is an `absolute inset-0 z-0` button, and everything normally interactive lives in a `relative z-10` content column — which is why the header, session list and row toolbar stay clickable over it. The two error banners mount as bare siblings of that column, with no `position` and no `z-index`. Per CSS 2.1 Appendix E, in-flow non-positioned blocks paint in step (3) and positioned `z-index: 0` descendants in step (6), so the overlay painted over the banners regardless of DOM order — and hit-testing follows paint order. Sidebar-only, because the overlay is gated on `variant === "sidebar"`; both buttons dead rather than one, because the whole banner was covered.

## The fix

- **Raise both banner roots to `relative z-10`**, joining the tier the content column already uses. Fixed at the component rather than the mount site, so the banners are correct wherever they are mounted.
- **Stop click propagation from Retry/Dismiss.** The card root's `handleCardClick` calls `onSelect()` on any bubbled click with no interactive-target guard; the card's convention (documented on its own `handleDoubleClick`, and followed by `handleRetrySetup` in the same file) is that interactive children stop propagation themselves. Without this, a newly clickable Dismiss would also switch the active worktree.
- **Make Dismiss abandon the delete, not just its banner.** `clearDeleteError` cleared only presentation state. A non-permanent failure — "cannot remove a locked working tree" is not in `PERMANENT_ERROR_PATTERNS` — parks its outbox entry at `pending`, and `replayOutboxAfterReconnect` replays anything that is not `failed`/`in-flight`. So a dismissed delete stayed queued and re-fired on the next reconnect, and the terminals it had closed were never relaunched (that only happens when an entry goes `failed`). Both paths now route through one `abandonDelete` helper shared with `dismissOutboxEntry` so they cannot drift.
- **Never abandon a mutation that is still running.** `replayOutboxAfterReconnect` flips entries to `in-flight` without clearing the banner, so a Dismiss can land on a live mutation. Pruning there would orphan a removal already on its way to the host, and for issue mutations would make `applyIssueMutationSuccess` discard a write the host had already committed. Dismiss now hides the banner and leaves an `in-flight` entry, its guard and its terminal snapshot alone.

## Tests

Every new test was verified to fail against the pre-fix code before being kept.

- **Propagation** (`WorktreeDetailsSection.test.tsx`) — both banners x both buttons: the handler fires exactly once and a parent click handler does not.
- **Stacking** (`WorktreeCardInteraction.test.tsx`) — jsdom has no layout engine and loads no CSS, so a literal coordinate click is impossible there. Instead this parses both tiers out of the source and asserts the *ordering* (banner is positioned AND its z-tier is strictly above the overlay's), so renumbering either tier keeps it green while breaking the relationship fails it. The extractors are bounded to each element's own opening tag, so they cannot capture a descendant's className.
- **Store** (`createWorktreeStore.delete.test.ts`, `createWorktreeStore.outbox.test.ts`) — a dismissed delete leaves nothing for the reconnect sweep to replay; it relaunches the closed terminals exactly once and not twice; and an in-flight delete or issue mutation survives Dismiss with its result still applied.

## Verification

Full `npm test` (52,597 tests / 2,394 files) and `npm run check` both pass, exit 0.

## Note on coverage

The issue asks for a test that clicks at the banner's coordinates. That needs a real layout engine, so Playwright is the only tier that could do it — but PR CI runs no E2E while the `full-*` buckets gate every release, so a flaky `git worktree lock` fixture would block publishes, and this repo's guidance is not to add or run E2E unprompted. The stacking-order invariant above is the substitute; a real hit-test remains the one gap.

Two related pre-existing issues were found and deliberately left alone as outside this fix: `replayOutboxAfterReconnect` does not clear `deleteErrors`/`issueErrors` when it re-fires (so a stale banner can show over a live replay — now harmless, but still cosmetically wrong), and `runDeleteAsync` has no per-worktree mutation-identity staleness check after its awaits.

Resolves #12087