### PR TITLE
Shrink the alarm pill and status tick on collapsed rows

### DIFF
--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -970,12 +970,21 @@ export function WorktreeCard({
               edge and the mark is now ON that edge, so anything that painted
               over it would bridge its segment gaps rather than just tint it.
 
+              A collapsed row gets the same mark as a 6x6 square rather than a
+              16px bar: one line has no corner for a bar that tall to sit on,
+              only an edge to run down. The count survives the shrink, because
+              it is the only thing that separates two of these states.
+
               The geometry, and the reason every number in it is what it is,
               lives in `WorktreeStatusTick`. */}
           {chipState !== null && (
             <Tooltip>
               <TooltipTrigger asChild>
-                <WorktreeStatusTick state={chipState} variant={variant} />
+                <WorktreeStatusTick
+                  state={chipState}
+                  variant={variant}
+                  collapsed={effectiveIsCollapsed}
+                />
               </TooltipTrigger>
               <TooltipContent side="right" align="start" className="text-xs">
                 {CHIP_LABELS[chipState]}

--- a/src/components/Worktree/WorktreeCard/CollapsedAlarmPill.tsx
+++ b/src/components/Worktree/WorktreeCard/CollapsedAlarmPill.tsx
@@ -1,24 +1,81 @@
-import { CircleAlert } from "lucide-react";
+import { ArrowDown, CircleX, KeyRound } from "@/components/icons";
 import { Badge } from "@/components/ui/badge";
-import type { AlarmDescriptor } from "@/lib/worktreeAlarmTier";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import type { AlarmDescriptor, AlarmKind } from "@/lib/worktreeAlarmTier";
+
+/**
+ * One silhouette per alarm kind.
+ *
+ * All three kinds used to be a single `CircleAlert` separated by the badge's
+ * warning/error wash, which put the whole distinction on hue — and under
+ * `forced-colors`, where the wash is gone and the glyph is one system colour,
+ * on nothing at all. Arrow, key and circled cross are three shapes, so they
+ * still separate once the colour has been taken away.
+ */
+const ALARM_ICONS: Record<Exclude<AlarmKind, "none">, typeof ArrowDown> = {
+  behind: ArrowDown,
+  "auth-failed": KeyRound,
+  "ci-failed": CircleX,
+};
 
 interface CollapsedAlarmPillProps {
   alarm: AlarmDescriptor;
+  /** The line under the label in the tooltip — the counts, or what to do about it. */
+  detail?: string;
 }
 
-export function CollapsedAlarmPill({ alarm }: CollapsedAlarmPillProps) {
-  if (alarm.tier === 0) return null;
+/**
+ * The alarm mark on a collapsed row: a glyph in a toned chip, with the words in
+ * a tooltip.
+ *
+ * It carried its label inline — `Behind`, `CI failed`, `Auth failed` — and on a
+ * one-line row that made the alarm the loudest thing in it, ahead of the branch
+ * name the row exists to show. The glyph in its wash is flag enough; what the
+ * flag means is a hover away.
+ *
+ * Deliberately NOT `pointer-events-none`, which is what it used to be: Radix
+ * opens a tooltip from pointer events on the trigger, so blocking them blocks
+ * the hover this depends on. Losing the class costs nothing on the row, because
+ * this stays a `<span>` with no `tabIndex`, no click handler and no button
+ * role — a click lands on it and bubbles straight to the card, exactly as it
+ * did through the pass-through. Same shape as `CollapsedSessionIndicators`
+ * beside it, and as the status tick on the card's corner.
+ *
+ * The accessible name carries the detail as well as the label, and that is a
+ * requirement rather than a nicety: a non-focusable trigger cannot be reached
+ * by keyboard, so the tooltip is a pointer-only surface and the name is the
+ * only place the rest of it is spoken.
+ */
+export function CollapsedAlarmPill({ alarm, detail }: CollapsedAlarmPillProps) {
+  // Tier 0 is the no-alarm case; `kind` is tested alongside it so the icon
+  // lookup below is total rather than needing a glyph for "none".
+  if (alarm.tier === 0 || alarm.kind === "none") return null;
+
+  const Icon = ALARM_ICONS[alarm.kind];
+  const accessibleName = detail ? `${alarm.label} — ${detail}` : alarm.label;
 
   return (
-    <Badge
-      tone={alarm.tone === "error" ? "error" : "warning"}
-      data-testid="collapsed-alarm-pill"
-      data-alarm-kind={alarm.kind}
-      aria-label={alarm.label}
-      className="pointer-events-none"
-    >
-      <CircleAlert aria-hidden="true" />
-      <span>{alarm.label}</span>
-    </Badge>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Badge
+          size="xs"
+          tone={alarm.tone === "error" ? "error" : "warning"}
+          data-testid="collapsed-alarm-pill"
+          data-alarm-kind={alarm.kind}
+          role="img"
+          aria-label={accessibleName}
+          // Even padding, against the variant's `px-1.5`: with the label gone
+          // the chip is one glyph, and a chip wider than it is tall reads as a
+          // word that failed to render rather than as a mark.
+          className="px-1"
+        >
+          <Icon aria-hidden="true" />
+        </Badge>
+      </TooltipTrigger>
+      <TooltipContent side="top" className="text-xs">
+        <span className="block">{alarm.label}</span>
+        {detail !== undefined && <span className="mt-0.5 block text-text-secondary">{detail}</span>}
+      </TooltipContent>
+    </Tooltip>
   );
 }

--- a/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
@@ -22,7 +22,7 @@ import { MainWorktreeSecondaryRow } from "./MainWorktreeSecondaryRow";
 import { NonMainSecondaryRow } from "./NonMainSecondaryRow";
 import { scheduleFlip } from "@/utils/flipScheduler";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { computeAlarmTier } from "@/lib/worktreeAlarmTier";
+import { computeAlarmTier, formatAlarmDetail } from "@/lib/worktreeAlarmTier";
 
 export interface WorktreeHeaderProps {
   worktree: WorktreeState;
@@ -241,17 +241,45 @@ export function WorktreeHeader({
 
   const prState = worktree.linked?.pr?.state;
   const isPrLive = prState !== undefined && prState !== "closed" && prState !== "declined";
-  const ciState = isPrLive ? worktree.linked?.pr?.ciStatus?.state : undefined;
-  const collapsedAlarm = useMemo(
-    () =>
-      computeAlarmTier({
-        ciState,
-        authFailed: hasAuthFailedSignIn,
+  const ciStatus = isPrLive ? worktree.linked?.pr?.ciStatus : undefined;
+  const ciState = ciStatus?.state;
+  // Tier and detail in one memo: they describe the same alarm, so deriving
+  // them from two different snapshots of the counts would let the pill say
+  // "Behind" over a line that names no drift.
+  const { collapsedAlarm, collapsedAlarmDetail } = useMemo(() => {
+    const alarm = computeAlarmTier({
+      ciState,
+      authFailed: hasAuthFailedSignIn,
+      behindCount: worktree.behindCount,
+      baseBehindCount: worktree.baseBehindCount,
+    });
+    return {
+      collapsedAlarm: alarm,
+      collapsedAlarmDetail: formatAlarmDetail(alarm.kind, {
+        aheadCount: worktree.aheadCount,
         behindCount: worktree.behindCount,
+        baseAheadCount: worktree.baseAheadCount,
         baseBehindCount: worktree.baseBehindCount,
+        baseBranchName: worktree.baseBranchName,
+        baseCompareRef: worktree.baseCompareRef,
+        baseMatchesUpstream: worktree.baseMatchesUpstream,
+        ciFailed: ciStatus?.failed,
+        ciTotal: ciStatus?.total,
       }),
-    [ciState, hasAuthFailedSignIn, worktree.behindCount, worktree.baseBehindCount]
-  );
+    };
+  }, [
+    ciState,
+    ciStatus?.failed,
+    ciStatus?.total,
+    hasAuthFailedSignIn,
+    worktree.aheadCount,
+    worktree.behindCount,
+    worktree.baseAheadCount,
+    worktree.baseBehindCount,
+    worktree.baseBranchName,
+    worktree.baseCompareRef,
+    worktree.baseMatchesUpstream,
+  ]);
 
   const { visibleStates, sessionAriaLabel } = useMemo(() => {
     if (!sessionStates || !sessionTotal || sessionTotal === 0) {
@@ -341,7 +369,9 @@ export function WorktreeHeader({
               {gitStateIndicator.label}
             </span>
           )}
-          {isCollapsed && <CollapsedAlarmPill alarm={collapsedAlarm} />}
+          {isCollapsed && (
+            <CollapsedAlarmPill alarm={collapsedAlarm} detail={collapsedAlarmDetail} />
+          )}
         </div>
 
         {((isPinned && !isMainWorktree) ||

--- a/src/components/Worktree/WorktreeCard/WorktreeStatusTick.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeStatusTick.tsx
@@ -60,6 +60,31 @@ const CHIP_FILLS: Record<WorktreeStatusTickState, string> = {
 };
 
 /**
+ * How each state's pieces are laid into the collapsed square's 2x2 grid.
+ *
+ * The slot is 6px with a 2px gap, so both tracks are 2px and every piece lands
+ * on whole pixels. The counts are the SAME 1/2/3 as the bar — the channel does
+ * not change on a collapsed row, only the footprint it is drawn in — and the
+ * ink still falls as urgency does, harder here than the bar managed:
+ *
+ *   waiting  — one piece across both tracks. A solid 6x6, 36 square pixels.
+ *   cleanup  — two full-width pieces, one per row. Two 6x2 stripes, 24.
+ *   complete — three ordinary cells, placed in reading order, so the empty
+ *              fourth corner is what makes three read as three. 12.
+ *
+ * A stacked bar cut down to a square was the obvious move and the wrong one:
+ * the only square where three stacked segments still divide into whole pixels
+ * at 2px or more is 10x10, and that is 100 square pixels for `waiting` against
+ * the 16x4 bar's 64. The mark this issue exists to quieten would have got
+ * louder. Two dimensions, not one, is what buys a smaller square.
+ */
+const COLLAPSED_SEGMENT_SPANS: Record<WorktreeStatusTickState, string> = {
+  waiting: "col-span-2 row-span-2",
+  cleanup: "col-span-2",
+  complete: "",
+};
+
+/**
  * The card's status mark: a segmented vertical tick in the card's top-left
  * corner.
  *
@@ -99,6 +124,18 @@ const CHIP_FILLS: Record<WorktreeStatusTickState, string> = {
  * Equal on both axes wherever it is inset, so the mark sits on the corner's
  * diagonal rather than hanging off one edge of it.
  *
+ * `collapsed` shrinks the whole thing to a 6x6 square. A collapsed row is one
+ * line, and a 16px bar down the side of a single line reads as a rail the row
+ * hangs off rather than as a mark on a card — the corner is the statement, and
+ * at that height there is no corner left, just an edge. The square keeps the
+ * segment count (see `COLLAPSED_SEGMENT_SPANS`), which is not optional: it is
+ * the only thing separating `cleanup` from `complete` anywhere on the card, and
+ * under `forced-colors` the only thing separating any of the three.
+ *
+ * A separate flag rather than a third `variant`: `variant` is which card the
+ * mark sits on, and the two are near-exclusive anyway — `canCollapse` is
+ * `variant !== "grid"`, so the grid cell never collapses.
+ *
  * Logical `start-*`, not `left-*`: the overview grid's membership rail is
  * itself logical, so a physical inset would put the two on the same side again
  * under RTL.
@@ -121,11 +158,14 @@ const CHIP_FILLS: Record<WorktreeStatusTickState, string> = {
 export function WorktreeStatusTick({
   state,
   variant = "sidebar",
+  collapsed = false,
   ...rest
 }: {
   state: WorktreeStatusTickState;
   /** Which card the mark is sitting on — the corner it gets is a property of that card's radius, not of the mark. */
   variant?: "sidebar" | "grid";
+  /** True on a collapsed row, where the bar shrinks to a square in the same corner. */
+  collapsed?: boolean;
 } & React.ComponentProps<"div">) {
   return (
     <div
@@ -134,7 +174,8 @@ export function WorktreeStatusTick({
       // line is the component's own and must win over what Radix passes.
       {...rest}
       className={cn(
-        "absolute z-30 flex h-4 w-1 cursor-default flex-col gap-0.5",
+        "absolute z-30 cursor-default gap-0.5",
+        collapsed ? "grid h-1.5 w-1.5 grid-cols-2 grid-rows-2" : "flex h-4 w-1 flex-col",
         variant === "grid" ? "top-1 start-1" : "top-0 start-0"
       )}
       data-testid="worktree-status-tick"
@@ -152,7 +193,8 @@ export function WorktreeStatusTick({
             // each SEGMENT, never the container — the gaps are real absences
             // between elements, and that is what keeps the three states apart
             // once the repaint has taken the hue away.
-            "status-mark flex-1",
+            "status-mark",
+            collapsed ? COLLAPSED_SEGMENT_SPANS[state] : "flex-1",
             CHIP_FILLS[state]
           )}
         />

--- a/src/components/Worktree/WorktreeCard/__tests__/CollapsedAlarmPill.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/CollapsedAlarmPill.test.tsx
@@ -1,53 +1,21 @@
 /**
  * @vitest-environment jsdom
  */
-import * as React from "react";
-import { describe, it, expect, vi, afterEach } from "vitest";
-import { render, cleanup } from "@testing-library/react";
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
 import { CollapsedAlarmPill } from "../CollapsedAlarmPill";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import type { AlarmDescriptor } from "@/lib/worktreeAlarmTier";
 
 /**
- * The overlay primitives load from a deferred chunk, so an unmocked render
- * settles asynchronously and the tooltip's content is portalled behind an open
- * state no assertion here cares about. This stub is the shape the real Radix
- * trigger has — `asChild` composes onto the child through `Slot`, exactly as
- * `Primitive.button` does — with the Portal and Content rendered inline so the
- * tooltip's copy is readable without driving a hover.
+ * Rendered against the REAL overlay primitives — `vitest.setup.ts` primes the
+ * deferred chunk before any suite runs, so there is nothing to stub. That
+ * matters more than the convenience: a fake trigger renders whatever it is
+ * told to, and the two things most worth proving here are that the badge stays
+ * the whole trigger under `asChild` (no button wrapped around it to steal the
+ * row's click) and that hover still opens the tooltip now the label lives
+ * behind one.
  */
-vi.mock("@/components/ui/radix-loader", async () => {
-  const { Slot } = await import("@radix-ui/react-slot");
-  return {
-    primeRadix: vi.fn().mockResolvedValue({}),
-    getRadixPrimitives: () => null,
-    primeOnEvent: vi.fn(),
-    composeHandlers: (a: unknown, b: unknown) => a ?? b,
-    useRadixPrimitives: () => ({
-      TooltipPrimitive: {
-        Provider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-        Root: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-        // Always the Slot half: the pill only ever uses `asChild`, and that is
-        // the branch whose prop and ref merging this suite depends on.
-        Trigger: ({
-          asChild: _asChild,
-          children,
-          ref,
-          ...rest
-        }: React.HTMLAttributes<HTMLElement> & {
-          asChild?: boolean;
-          children: React.ReactNode;
-          ref?: React.Ref<HTMLElement>;
-        }) => (
-          <Slot ref={ref} {...rest}>
-            {children}
-          </Slot>
-        ),
-        Portal: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-        Content: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-      },
-    }),
-  };
-});
 
 afterEach(cleanup);
 
@@ -69,15 +37,21 @@ const ciFailed: AlarmDescriptor = {
 const KINDS = [behind, authFailed, ciFailed];
 
 function renderPill(alarm: AlarmDescriptor, detail?: string) {
-  const { getByTestId, queryByText, container } = render(
-    <CollapsedAlarmPill alarm={alarm} detail={detail} />
+  const { container } = render(
+    <TooltipProvider delayDuration={0}>
+      <CollapsedAlarmPill alarm={alarm} detail={detail} />
+    </TooltipProvider>
   );
-  return { pill: getByTestId("collapsed-alarm-pill"), queryByText, container };
+  return { pill: screen.getByTestId("collapsed-alarm-pill"), container };
 }
 
 describe("CollapsedAlarmPill", () => {
   it("renders nothing for tier 0", () => {
-    const { container } = render(<CollapsedAlarmPill alarm={none} />);
+    const { container } = render(
+      <TooltipProvider delayDuration={0}>
+        <CollapsedAlarmPill alarm={none} />
+      </TooltipProvider>
+    );
     expect(container.firstChild).toBeNull();
   });
 
@@ -137,10 +111,19 @@ describe("CollapsedAlarmPill", () => {
     expect(pill.getAttribute("aria-label")).toBe("Behind");
   });
 
-  it("puts the label and the detail in the tooltip", () => {
-    const { queryByText } = renderPill(ciFailed, "2 of 7 checks failing");
-    expect(queryByText("CI failed")).not.toBeNull();
-    expect(queryByText("2 of 7 checks failing")).not.toBeNull();
+  it("opens on hover and puts the label and the detail in the tooltip", async () => {
+    // The regression this guards is the one the issue names: the pill was
+    // `pointer-events-none`, and Radix opens from pointer events on the
+    // trigger, so the words it now hides behind a hover would be unreachable.
+    const { pill } = renderPill(ciFailed, "2 of 7 checks failing");
+    expect(screen.queryByRole("tooltip"), "the tooltip is open before any hover").toBeNull();
+
+    fireEvent.pointerEnter(pill, { pointerType: "mouse" });
+    fireEvent.pointerMove(pill, { pointerType: "mouse" });
+
+    const tip = await screen.findByRole("tooltip");
+    expect(tip.textContent).toContain("CI failed");
+    expect(tip.textContent).toContain("2 of 7 checks failing");
   });
 
   it("does not use accent classes", () => {
@@ -154,6 +137,18 @@ describe("CollapsedAlarmPill", () => {
     expect(pill.hasAttribute("tabindex")).toBe(false);
     expect(pill.getAttribute("role")).not.toBe("button");
     expect(pill.hasAttribute("type")).toBe(false);
+  });
+
+  it("puts no interactive element around itself either", () => {
+    // `asChild` is what keeps the badge as the whole trigger. Drop it and
+    // Radix renders its own <button> around this span — a control inside a row
+    // that is already the click target, swallowing the click that should
+    // select the worktree. An assertion on the badge alone would not see it.
+    const { pill } = renderPill(ciFailed, "2 of 7 checks failing");
+    expect(
+      pill.closest("button, a, [role='button'], [tabindex]"),
+      "something interactive wraps the alarm mark"
+    ).toBeNull();
   });
 
   it("takes pointer events, which is what the tooltip runs on", () => {

--- a/src/components/Worktree/WorktreeCard/__tests__/CollapsedAlarmPill.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/CollapsedAlarmPill.test.tsx
@@ -1,10 +1,55 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, it, expect } from "vitest";
-import { render } from "@testing-library/react";
+import * as React from "react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, cleanup } from "@testing-library/react";
 import { CollapsedAlarmPill } from "../CollapsedAlarmPill";
 import type { AlarmDescriptor } from "@/lib/worktreeAlarmTier";
+
+/**
+ * The overlay primitives load from a deferred chunk, so an unmocked render
+ * settles asynchronously and the tooltip's content is portalled behind an open
+ * state no assertion here cares about. This stub is the shape the real Radix
+ * trigger has — `asChild` composes onto the child through `Slot`, exactly as
+ * `Primitive.button` does — with the Portal and Content rendered inline so the
+ * tooltip's copy is readable without driving a hover.
+ */
+vi.mock("@/components/ui/radix-loader", async () => {
+  const { Slot } = await import("@radix-ui/react-slot");
+  return {
+    primeRadix: vi.fn().mockResolvedValue({}),
+    getRadixPrimitives: () => null,
+    primeOnEvent: vi.fn(),
+    composeHandlers: (a: unknown, b: unknown) => a ?? b,
+    useRadixPrimitives: () => ({
+      TooltipPrimitive: {
+        Provider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+        Root: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+        // Always the Slot half: the pill only ever uses `asChild`, and that is
+        // the branch whose prop and ref merging this suite depends on.
+        Trigger: ({
+          asChild: _asChild,
+          children,
+          ref,
+          ...rest
+        }: React.HTMLAttributes<HTMLElement> & {
+          asChild?: boolean;
+          children: React.ReactNode;
+          ref?: React.Ref<HTMLElement>;
+        }) => (
+          <Slot ref={ref} {...rest}>
+            {children}
+          </Slot>
+        ),
+        Portal: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+        Content: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+      },
+    }),
+  };
+});
+
+afterEach(cleanup);
 
 const none: AlarmDescriptor = { tier: 0, kind: "none", label: "", tone: "none" };
 const behind: AlarmDescriptor = { tier: 1, kind: "behind", label: "Behind", tone: "warning" };
@@ -21,6 +66,15 @@ const ciFailed: AlarmDescriptor = {
   tone: "error",
 };
 
+const KINDS = [behind, authFailed, ciFailed];
+
+function renderPill(alarm: AlarmDescriptor, detail?: string) {
+  const { getByTestId, queryByText, container } = render(
+    <CollapsedAlarmPill alarm={alarm} detail={detail} />
+  );
+  return { pill: getByTestId("collapsed-alarm-pill"), queryByText, container };
+}
+
 describe("CollapsedAlarmPill", () => {
   it("renders nothing for tier 0", () => {
     const { container } = render(<CollapsedAlarmPill alarm={none} />);
@@ -28,46 +82,91 @@ describe("CollapsedAlarmPill", () => {
   });
 
   it("renders CI failed chip with error tone", () => {
-    const { getByTestId } = render(<CollapsedAlarmPill alarm={ciFailed} />);
-    const pill = getByTestId("collapsed-alarm-pill");
+    const { pill } = renderPill(ciFailed);
     expect(pill.getAttribute("data-tone")).toBe("error");
-    expect(pill.textContent).toBe("CI failed");
     expect(pill.getAttribute("data-alarm-kind")).toBe("ci-failed");
   });
 
   it("renders auth-failed chip with warning tone", () => {
-    const { getByTestId } = render(<CollapsedAlarmPill alarm={authFailed} />);
-    const pill = getByTestId("collapsed-alarm-pill");
+    const { pill } = renderPill(authFailed);
     expect(pill.getAttribute("data-tone")).toBe("warning");
-    expect(pill.textContent).toBe("Auth failed");
     expect(pill.getAttribute("data-alarm-kind")).toBe("auth-failed");
   });
 
   it("renders behind chip with warning tone", () => {
-    const { getByTestId } = render(<CollapsedAlarmPill alarm={behind} />);
-    const pill = getByTestId("collapsed-alarm-pill");
+    const { pill } = renderPill(behind);
     expect(pill.getAttribute("data-tone")).toBe("warning");
-    expect(pill.textContent).toBe("Behind");
     expect(pill.getAttribute("data-alarm-kind")).toBe("behind");
   });
 
+  it("carries no words of its own — that is the whole point of the change", () => {
+    // The label used to sit inline and out-shout the branch name beside it.
+    for (const alarm of KINDS) {
+      const { pill } = renderPill(alarm);
+      expect(pill.textContent, `${alarm.kind} still renders text`).toBe("");
+      expect(pill.querySelectorAll("svg").length, `${alarm.kind} glyph count`).toBe(1);
+      cleanup();
+    }
+  });
+
+  it("gives every kind its own glyph, so forced colors has a shape to tell them apart", () => {
+    // With the label gone, tone is the only other channel — and forced colors
+    // repaints all three the same. If these silhouettes collapsed into one, a
+    // high-contrast reader could not tell a stale branch from a broken build.
+    const glyphs = KINDS.map((alarm) => {
+      const { pill } = renderPill(alarm);
+      const svg = pill.querySelector("svg")?.innerHTML;
+      cleanup();
+      return svg;
+    });
+    expect(glyphs.every(Boolean), "a kind renders no glyph at all").toBe(true);
+    expect(new Set(glyphs).size, "two alarm kinds share a glyph").toBe(glyphs.length);
+  });
+
+  it("speaks the label and the detail through its accessible name", () => {
+    // The trigger is deliberately not focusable, so the tooltip is a
+    // pointer-only surface and the name is the only place a screen-reader
+    // user hears the rest of it.
+    const { pill } = renderPill(behind, "Upstream: 3 commits behind");
+    expect(pill.getAttribute("role")).toBe("img");
+    expect(pill.getAttribute("aria-label")).toBe("Behind — Upstream: 3 commits behind");
+  });
+
+  it("names the alarm without a detail line when there is nothing to add", () => {
+    const { pill } = renderPill(behind);
+    expect(pill.getAttribute("aria-label")).toBe("Behind");
+  });
+
+  it("puts the label and the detail in the tooltip", () => {
+    const { queryByText } = renderPill(ciFailed, "2 of 7 checks failing");
+    expect(queryByText("CI failed")).not.toBeNull();
+    expect(queryByText("2 of 7 checks failing")).not.toBeNull();
+  });
+
   it("does not use accent classes", () => {
-    const { getByTestId } = render(<CollapsedAlarmPill alarm={ciFailed} />);
-    const pill = getByTestId("collapsed-alarm-pill");
+    const { pill } = renderPill(ciFailed);
     expect(pill.className).not.toContain("accent");
   });
 
   it("stays a non-interactive marker", () => {
-    const { getByTestId } = render(<CollapsedAlarmPill alarm={ciFailed} />);
-    const pill = getByTestId("collapsed-alarm-pill");
+    const { pill } = renderPill(ciFailed);
     expect(pill.tagName).toBe("SPAN");
-    expect(pill.className).toContain("pointer-events-none");
     expect(pill.hasAttribute("tabindex")).toBe(false);
+    expect(pill.getAttribute("role")).not.toBe("button");
+    expect(pill.hasAttribute("type")).toBe(false);
+  });
+
+  it("takes pointer events, which is what the tooltip runs on", () => {
+    // It was `pointer-events-none`, and Radix opens a tooltip from pointer
+    // events on the trigger — so putting that class back silently removes the
+    // hover the label now lives behind. jsdom does not honour the CSS, so this
+    // is the assertion that catches it.
+    const { pill } = renderPill(ciFailed);
+    expect(pill.className).not.toContain("pointer-events-none");
   });
 
   it("does not use transition-all", () => {
-    const { getByTestId } = render(<CollapsedAlarmPill alarm={ciFailed} />);
-    const pill = getByTestId("collapsed-alarm-pill");
+    const { pill } = renderPill(ciFailed);
     expect(pill.className).not.toContain("transition-all");
   });
 });

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
@@ -1049,7 +1049,10 @@ describe("WorktreeHeader collapsed alarm pill", () => {
     const pill = screen.getByTestId("collapsed-alarm-pill");
     expect(pill.getAttribute("data-alarm-kind")).toBe("ci-failed");
     expect(pill.className).toContain("text-status-error");
-    expect(pill.textContent).toBe("CI failed");
+    // The label moved into the tooltip and the accessible name; the mark on the
+    // row is a glyph, so it carries no text of its own.
+    expect(pill.textContent).toBe("");
+    expect(pill.getAttribute("aria-label")).toContain("CI failed");
   });
 
   it("renders the pill with warning treatment for GitHub auth-failed remote", () => {
@@ -1086,6 +1089,26 @@ describe("WorktreeHeader collapsed alarm pill", () => {
     const pill = screen.getByTestId("collapsed-alarm-pill");
     expect(pill.getAttribute("data-alarm-kind")).toBe("behind");
     expect(pill.className).toContain("text-status-warning");
+    expect(pill.getAttribute("aria-label")).toBe("Behind — Upstream: 3 commits behind");
+  });
+
+  it("threads the base compare ref into the detail for base-only drift", () => {
+    // The counts only reach the tooltip if every field is actually passed
+    // through — a formatter that works in isolation over a header that hands
+    // it half the worktree is the failure this catches.
+    renderHeader({
+      isCollapsed: true,
+      worktree: {
+        ...baseWorktree,
+        behindCount: 0,
+        baseBehindCount: 4,
+        baseBranchName: "develop",
+        baseCompareRef: "upstream/develop",
+      },
+    });
+    expect(screen.getByTestId("collapsed-alarm-pill").getAttribute("aria-label")).toBe(
+      "Behind — Base (upstream/develop): 4 commits behind"
+    );
   });
 
   it("does not duplicate gitStateIndicator for detached HEAD", () => {

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
@@ -1052,7 +1052,10 @@ describe("WorktreeHeader collapsed alarm pill", () => {
     // The label moved into the tooltip and the accessible name; the mark on the
     // row is a glyph, so it carries no text of its own.
     expect(pill.textContent).toBe("");
-    expect(pill.getAttribute("aria-label")).toContain("CI failed");
+    // The whole name, not a substring: the fixture reports 1 of 1 check
+    // failing, so a `contains` would still pass if the counts stopped being
+    // forwarded and the detail fell back to its countless wording.
+    expect(pill.getAttribute("aria-label")).toBe("CI failed — 1 of 1 check failing");
   });
 
   it("renders the pill with warning treatment for GitHub auth-failed remote", () => {

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeStatusTick.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeStatusTick.test.tsx
@@ -3,6 +3,8 @@
  */
 import { describe, it, expect, afterEach } from "vitest";
 import { render, screen, cleanup } from "@testing-library/react";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import {
   CHIP_LABELS,
   CHIP_SEGMENTS,
@@ -79,6 +81,18 @@ function expectWholePixelPieces(tick: HTMLElement, divisor: (count: number) => n
     ).toBe(true);
     expect(piece, `${state}: pieces too thin to read`).toBeGreaterThanOrEqual(2);
   }
+}
+
+/**
+ * The gap in px on whichever axis is asked for. `gap-*` sets both, so the
+ * collapsed grid's rows and columns are the same number — but reading them
+ * separately is what makes an axis-scoped `gap-x-*`/`gap-y-*` show up as the
+ * closed encoding it would be rather than passing on the other axis's value.
+ */
+function readGap(tick: HTMLElement, axis: "x" | "y"): number {
+  const gap = [...tick.classList].find((c) => new RegExp(`^gap-(${axis}-)?\\d`).test(c));
+  expect(gap, `no ${axis} gap on the tick: ${tick.className}`).toBeDefined();
+  return readScalePx(gap!);
 }
 
 /** The tick's corner inset in px, read off whichever axis is asked for. */
@@ -304,17 +318,60 @@ describe("WorktreeStatusTick — collapsed", () => {
   });
 
   it("cuts its square into whole pixels on both axes", () => {
-    // Two tracks each way whatever the count, because the states differ by how
+    // Two tracks each way whatever the state, because the states differ by how
     // many cells they fill rather than by how finely the slot is divided —
     // which is what lets the square be 6px instead of the 10px three stacked
-    // segments would have needed.
+    // segments would have needed. Asserted once per axis rather than once per
+    // state: the tracks do not vary with the state, and a loop over states
+    // here would repeat one sum three times under three different labels.
     const { tick } = renderTick("waiting", "sidebar", true);
     expect(tick.classList.contains("grid"), `not a grid: ${tick.className}`).toBe(true);
-    expectWholePixelPieces(tick, () => 2);
-    expect(
-      readVerticalGap(tick),
-      "the gap is too small to survive antialiasing"
-    ).toBeGreaterThanOrEqual(2);
+    for (const [axis, size] of [
+      ["y", readAxis(tick, "h")],
+      ["x", readAxis(tick, "w")],
+    ] as const) {
+      const gap = readGap(tick, axis);
+      const track = (size - gap) / 2;
+      expect(
+        Number.isInteger(track),
+        `${axis}: two tracks of a ${size}px slot are ${track}px`
+      ).toBe(true);
+      expect(track, `${axis}: tracks too thin to read`).toBeGreaterThanOrEqual(2);
+      expect(gap, `${axis}: the gap is too small to survive antialiasing`).toBeGreaterThanOrEqual(
+        2
+      );
+    }
+  });
+
+  it("lays the pieces out without letting any two of them share a cell", () => {
+    // The count only reads as a count while the pieces occupy DIFFERENT cells.
+    // Pinning them with explicit `col-start-*`/`row-start-*` would stack three
+    // spans on one corner: the sibling-element and segment-count assertions
+    // above would all still pass, and forced colors would render one square
+    // where it should render three. Auto-placement in reading order is what
+    // keeps them apart, so nothing may override it.
+    const cells = 4;
+    for (const state of STATES) {
+      const { segments } = renderTick(state, "sidebar", true);
+      const covered = segments.reduce((total, segment) => {
+        const cols = segment.classList.contains("col-span-2") ? 2 : 1;
+        const rows = segment.classList.contains("row-span-2") ? 2 : 1;
+        for (const placement of segment.classList) {
+          expect(
+            /^(col|row)-start-/.test(placement),
+            `${state}: ${placement} pins a piece instead of letting it flow`
+          ).toBe(false);
+        }
+        return total + cols * rows;
+      }, 0);
+      expect(covered, `${state}: its pieces cover ${covered} of ${cells} cells`).toBe(
+        state === "complete" ? CHIP_SEGMENTS[state] : cells
+      );
+      expect(covered, `${state}: its pieces need more cells than the grid has`).toBeLessThanOrEqual(
+        cells
+      );
+      cleanup();
+    }
   });
 
   it("spends less ink the less the state wants, and less than the bar at every state", () => {
@@ -366,6 +423,23 @@ describe("WorktreeStatusTick — collapsed", () => {
       Number(layer!.slice(2)),
       `${layer} lets the z-20 card overlays paint across the mark`
     ).toBeGreaterThan(20);
+  });
+});
+
+/**
+ * The square only reaches a collapsed row if the card asks for it, and nothing
+ * that renders the tick directly can see that it stopped. Dropping the prop at
+ * the call site would leave every test above green while the shipped rows kept
+ * the bar — so the hand-off is asserted where it is made.
+ */
+describe("WorktreeStatusTick — the card's call site", () => {
+  it("hands the row's collapsed state to the mark", () => {
+    const source = readFileSync(resolve(__dirname, "../../WorktreeCard.tsx"), "utf-8");
+    const call = source.match(/<WorktreeStatusTick[\s\S]*?\/>/);
+    expect(call?.[0], "WorktreeCard no longer renders the status tick").toBeDefined();
+    expect(call![0], `the tick is rendered without the row's collapsed state: ${call![0]}`).toMatch(
+      /collapsed=\{effectiveIsCollapsed\}/
+    );
   });
 });
 

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeStatusTick.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeStatusTick.test.tsx
@@ -43,11 +43,42 @@ function readVerticalGap(tick: HTMLElement): number {
   return readScalePx(gap!);
 }
 
-function renderTick(state: WorktreeStatusTickState, variant?: "sidebar" | "grid") {
-  render(<WorktreeStatusTick state={state} variant={variant} />);
+function renderTick(
+  state: WorktreeStatusTickState,
+  variant?: "sidebar" | "grid",
+  collapsed?: boolean
+) {
+  render(<WorktreeStatusTick state={state} variant={variant} collapsed={collapsed} />);
   const tick = screen.getByTestId("worktree-status-tick");
   const segments = screen.getAllByTestId("worktree-status-tick-segment");
   return { tick, segments };
+}
+
+/** A Tailwind size utility's value in px, read off whichever axis is asked for. */
+function readAxis(tick: HTMLElement, axis: "h" | "w"): number {
+  const size = [...tick.classList].find((c) => new RegExp(`^${axis}-\\d`).test(c));
+  expect(size, `the tick declares no ${axis}: ${tick.className}`).toBeDefined();
+  return readScalePx(size!);
+}
+
+/**
+ * Every piece lands on a whole pixel at every count. A piece on a half pixel
+ * blurs at 1x, and the blur closes the gaps — which are the entire encoding.
+ * Read off what actually rendered, so retuning a slot or a gap has to keep the
+ * arithmetic working rather than silently softening the mark.
+ */
+function expectWholePixelPieces(tick: HTMLElement, divisor: (count: number) => number) {
+  const slot = readAxis(tick, "h");
+  const gap = readVerticalGap(tick);
+  for (const state of STATES) {
+    const tracks = divisor(CHIP_SEGMENTS[state]);
+    const piece = (slot - gap * (tracks - 1)) / tracks;
+    expect(
+      Number.isInteger(piece),
+      `${state}: ${tracks} tracks of a ${slot}px slot are ${piece}px`
+    ).toBe(true);
+    expect(piece, `${state}: pieces too thin to read`).toBeGreaterThanOrEqual(2);
+  }
 }
 
 /** The tick's corner inset in px, read off whichever axis is asked for. */
@@ -139,17 +170,7 @@ describe("WorktreeStatusTick", () => {
     // rendered, so retuning the height or the gap has to keep the arithmetic
     // working rather than silently softening the mark.
     const { tick } = renderTick("waiting");
-    const slot = readScalePx([...tick.classList].find((c) => /^h-\d/.test(c))!);
-    const gap = readVerticalGap(tick);
-    for (const state of STATES) {
-      const count = CHIP_SEGMENTS[state];
-      const segment = (slot - gap * (count - 1)) / count;
-      expect(
-        Number.isInteger(segment),
-        `${state}: ${count} segments of a ${slot}px slot are ${segment}px`
-      ).toBe(true);
-      expect(segment, `${state}: segments too thin to read`).toBeGreaterThanOrEqual(2);
-    }
+    expectWholePixelPieces(tick, (count) => count);
   });
 
   it("stacks the segments along the slot with a gap wide enough to survive antialiasing", () => {
@@ -220,6 +241,125 @@ describe("WorktreeStatusTick", () => {
     // segmented one bridges the gaps rather than tinting them, flattening
     // every state to a single bar.
     const { tick } = renderTick("complete", "sidebar");
+    const layer = [...tick.classList].find((c) => /^z-\d+$/.test(c));
+    expect(layer, `the tick declares no stacking layer: ${tick.className}`).toBeDefined();
+    expect(
+      Number(layer!.slice(2)),
+      `${layer} lets the z-20 card overlays paint across the mark`
+    ).toBeGreaterThan(20);
+  });
+});
+
+/**
+ * The collapsed row is a single line, and a 16px bar down the side of it reads
+ * as a rail the row hangs off rather than as a mark on a card. The square is
+ * the answer, and the thing it must not quietly cost is the segment count —
+ * the only channel that separates `cleanup` from `complete` anywhere, and the
+ * only channel of any kind once forced colors has taken the hue.
+ */
+describe("WorktreeStatusTick — collapsed", () => {
+  it("is square, and smaller than the bar it replaces", () => {
+    const { tick } = renderTick("complete", "sidebar", true);
+    const height = readAxis(tick, "h");
+    const width = readAxis(tick, "w");
+    expect(height, `not square: ${height}px tall, ${width}px wide`).toBe(width);
+    cleanup();
+    const bar = readAxis(renderTick("complete", "sidebar").tick, "h");
+    expect(height, "the collapsed mark is no shorter than the bar").toBeLessThan(bar);
+  });
+
+  it("still gives every state a different number of segments", () => {
+    const counts = STATES.map((state) => {
+      const { segments } = renderTick(state, "sidebar", true);
+      cleanup();
+      return segments.length;
+    });
+    expect(new Set(counts).size, `states share a segment count: ${counts.join(" | ")}`).toBe(
+      counts.length
+    );
+  });
+
+  it("keeps the forced-colors hook on every segment and never on the container", () => {
+    for (const state of STATES) {
+      const { tick, segments } = renderTick(state, "sidebar", true);
+      expect(tick.classList.contains("status-mark"), `${state}: hook is on the container`).toBe(
+        false
+      );
+      for (const segment of segments) {
+        expect(segment.classList.contains("status-mark"), `${state}: segment missing hook`).toBe(
+          true
+        );
+      }
+      cleanup();
+    }
+  });
+
+  it("keeps the pieces as real sibling elements, which is what forced colors leaves alone", () => {
+    const { segments } = renderTick("complete", "sidebar", true);
+    expect(segments.length).toBeGreaterThan(1);
+    for (const segment of segments) {
+      expect(segment.tagName).toBe("SPAN");
+      expect(segment.parentElement?.getAttribute("data-testid")).toBe("worktree-status-tick");
+    }
+  });
+
+  it("cuts its square into whole pixels on both axes", () => {
+    // Two tracks each way whatever the count, because the states differ by how
+    // many cells they fill rather than by how finely the slot is divided —
+    // which is what lets the square be 6px instead of the 10px three stacked
+    // segments would have needed.
+    const { tick } = renderTick("waiting", "sidebar", true);
+    expect(tick.classList.contains("grid"), `not a grid: ${tick.className}`).toBe(true);
+    expectWholePixelPieces(tick, () => 2);
+    expect(
+      readVerticalGap(tick),
+      "the gap is too small to survive antialiasing"
+    ).toBeGreaterThanOrEqual(2);
+  });
+
+  it("spends less ink the less the state wants, and less than the bar at every state", () => {
+    // The point of the issue: the mark got quieter. Measured off the rendered
+    // spans, so a span class going missing shows up as ink that stopped
+    // descending rather than as nothing at all.
+    const inkOf = (state: WorktreeStatusTickState, collapsed: boolean) => {
+      const { tick, segments } = renderTick(state, "sidebar", collapsed);
+      const slot = readAxis(tick, "h");
+      const across = readAxis(tick, "w");
+      const gap = readVerticalGap(tick);
+      const area = segments.reduce((total, segment) => {
+        const cols = segment.classList.contains("col-span-2") || !collapsed ? across : 2;
+        const rows = segment.classList.contains("row-span-2")
+          ? slot
+          : collapsed
+            ? 2
+            : (slot - gap * (segments.length - 1)) / segments.length;
+        return total + cols * rows;
+      }, 0);
+      cleanup();
+      return area;
+    };
+
+    const collapsedInk = STATES.map((state) => inkOf(state, true));
+    expect(collapsedInk, `collapsed ink does not descend: ${collapsedInk.join(" | ")}`).toEqual(
+      [...collapsedInk].sort((a, b) => b - a)
+    );
+    for (const [index, state] of STATES.entries()) {
+      expect(
+        collapsedInk[index]!,
+        `${state}: the collapsed mark is not quieter than the bar`
+      ).toBeLessThan(inkOf(state, false));
+    }
+  });
+
+  it("stays flush in the sidebar corner", () => {
+    const { tick } = renderTick("complete", "sidebar", true);
+    for (const axis of ["top-", "start-"] as const) {
+      expect(readInset(tick, axis), `${axis} is holding the mark off a square corner`).toBe(0);
+    }
+  });
+
+  it("still outranks the full-card overlays it shares an edge with", () => {
+    const { tick } = renderTick("complete", "sidebar", true);
     const layer = [...tick.classList].find((c) => /^z-\d+$/.test(c));
     expect(layer, `the tick declares no stacking layer: ${tick.className}`).toBeDefined();
     expect(

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -10,6 +10,7 @@ export * from "./brands";
 // Each was chosen to fit the metaphor.
 export {
   Activity, // project pulse / live activity heartbeat
+  ArrowDown, // a branch behind what it tracks — the same ↓ the upstream badge writes beside the count, so the collapsed alarm and the expanded one name the drift alike
   ArrowDownAZ, // alphabetical sort order (A to Z)
   ArrowLeftRight, // a settings search hit that lives in the other scope — following it switches scope
   ArrowUpDown, // card organization — pinning, collapsing and reordering a worktree row
@@ -22,6 +23,7 @@ export {
   CircleHelp, // workspace whose metadata is missing (removed while its agents ran)
   CirclePause, // run the user parked — shelved on purpose (Pilot's parked band)
   CircleSlash, // agent stopped on an error, distinct in shape from a waiting one (Pilot's blocked band)
+  CircleX, // CI that failed — the cross the PR badge already uses, enclosed so a glyph standing alone reads as a verdict rather than a dismiss control
   Clock, // recency sort order (most recently opened first)
   FileText, // view selected file path in the read-only file viewer
   FolderGit2, // git worktree (single)
@@ -32,6 +34,7 @@ export {
   GitBranchPlus, // per-project worktree setup — creating branches, not browsing them
   GitPullRequest, // forge provider / code-host plugin category
   History, // resume closed session / session history
+  KeyRound, // forge credentials that stopped working — a key names what has to be fixed, and it shares a silhouette with nothing else here, so it survives forced colors
   Layers, // worktree overview (multiple worktrees, stacked)
   LayoutPanelTop, // workspace plugin category (panels, notes)
   Link2Off, // detach the issue linked to a worktree

--- a/src/lib/__tests__/worktreeAlarmTier.test.ts
+++ b/src/lib/__tests__/worktreeAlarmTier.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { computeAlarmTier } from "../worktreeAlarmTier";
+import { computeAlarmTier, formatAlarmDetail } from "../worktreeAlarmTier";
 
 describe("computeAlarmTier", () => {
   describe("tier 0 (none)", () => {
@@ -119,5 +119,122 @@ describe("computeAlarmTier — base-branch drift", () => {
 
   it("keeps an auth failure above base drift", () => {
     expect(computeAlarmTier({ authFailed: true, baseBehindCount: 9 }).kind).toBe("auth-failed");
+  });
+});
+
+/**
+ * The collapsed pill dropped its label, and on a collapsed row nothing else
+ * states the drift — the upstream badge only renders expanded. So this string
+ * is the only place the counts appear, and the thing it must never do is
+ * invent one: an absent count is "not measured", not zero.
+ */
+describe("formatAlarmDetail", () => {
+  it("says nothing for the no-alarm kind", () => {
+    expect(formatAlarmDetail("none", { behindCount: 3 })).toBeUndefined();
+  });
+
+  describe("behind", () => {
+    it("names the upstream distance, pluralised", () => {
+      expect(formatAlarmDetail("behind", { behindCount: 3 })).toBe("Upstream: 3 commits behind");
+      expect(formatAlarmDetail("behind", { behindCount: 1 })).toBe("Upstream: 1 commit behind");
+    });
+
+    it("adds the ahead count behind the behind one, which is what raised the alarm", () => {
+      expect(formatAlarmDetail("behind", { behindCount: 3, aheadCount: 2 })).toBe(
+        "Upstream: 3 commits behind, 2 ahead"
+      );
+    });
+
+    it("falls back to the base when the branch has no upstream count at all", () => {
+      // A worktree branch created without tracking never reports an upstream
+      // distance; its drift from the base is the only "behind" it will have.
+      expect(
+        formatAlarmDetail("behind", { baseBehindCount: 4, baseCompareRef: "upstream/develop" })
+      ).toBe("Base (upstream/develop): 4 commits behind");
+    });
+
+    it("prefers the compare ref over the bare branch name — that is what was measured", () => {
+      expect(
+        formatAlarmDetail("behind", {
+          baseBehindCount: 4,
+          baseBranchName: "develop",
+          baseCompareRef: "upstream/develop",
+        })
+      ).toBe("Base (upstream/develop): 4 commits behind");
+    });
+
+    it("falls back to the branch name, then to no name at all", () => {
+      expect(formatAlarmDetail("behind", { baseBehindCount: 4, baseBranchName: "develop" })).toBe(
+        "Base (develop): 4 commits behind"
+      );
+      expect(formatAlarmDetail("behind", { baseBehindCount: 4 })).toBe("Base: 4 commits behind");
+    });
+
+    it("names both distances when they are genuinely different measurements", () => {
+      expect(
+        formatAlarmDetail("behind", {
+          behindCount: 1,
+          baseBehindCount: 4,
+          baseCompareRef: "upstream/develop",
+        })
+      ).toBe("Upstream: 1 commit behind · Base (upstream/develop): 4 commits behind");
+    });
+
+    it("drops the unlabelled pair when the two refs are the same commit", () => {
+      // The dedupe `UpstreamSyncBadge` already does: one measurement written
+      // twice, and only the labelled half says what it was counted against.
+      expect(
+        formatAlarmDetail("behind", {
+          behindCount: 4,
+          baseBehindCount: 4,
+          baseCompareRef: "upstream/develop",
+          baseMatchesUpstream: true,
+        })
+      ).toBe("Base (upstream/develop): 4 commits behind");
+    });
+
+    it("keeps the upstream pair when the base counts raced to zero", () => {
+      // `baseMatchesUpstream` with nothing to dedupe onto must not render
+      // nothing — the upstream pair is the fresher of the two.
+      expect(
+        formatAlarmDetail("behind", {
+          behindCount: 4,
+          baseBehindCount: 0,
+          baseMatchesUpstream: true,
+        })
+      ).toBe("Upstream: 4 commits behind");
+    });
+
+    it("claims no distance it was not given", () => {
+      expect(formatAlarmDetail("behind", {})).toBeUndefined();
+      expect(formatAlarmDetail("behind", { behindCount: 0, baseBehindCount: 0 })).toBeUndefined();
+      expect(formatAlarmDetail("behind", { behindCount: undefined })).toBeUndefined();
+    });
+  });
+
+  describe("ci-failed", () => {
+    it("counts the failing checks when the forge reported them", () => {
+      expect(formatAlarmDetail("ci-failed", { ciFailed: 2, ciTotal: 7 })).toBe(
+        "2 of 7 checks failing"
+      );
+      expect(formatAlarmDetail("ci-failed", { ciFailed: 1, ciTotal: 1 })).toBe(
+        "1 of 1 check failing"
+      );
+    });
+
+    it("still says what happened when it has no counts to give", () => {
+      expect(formatAlarmDetail("ci-failed", {})).toBe("Checks failed on the linked pull request");
+      expect(formatAlarmDetail("ci-failed", { ciFailed: 0, ciTotal: 0 })).toBe(
+        "Checks failed on the linked pull request"
+      );
+    });
+  });
+
+  describe("auth-failed", () => {
+    it("points at the affordance rather than implying the mark is one", () => {
+      expect(formatAlarmDetail("auth-failed", {})).toBe(
+        "Expand the card to reconnect your code forge"
+      );
+    });
   });
 });

--- a/src/lib/__tests__/worktreeAlarmTier.test.ts
+++ b/src/lib/__tests__/worktreeAlarmTier.test.ts
@@ -193,6 +193,39 @@ describe("formatAlarmDetail", () => {
       ).toBe("Base (upstream/develop): 4 commits behind");
     });
 
+    it("keeps the upstream pair when the two refs match but the base has no name", () => {
+      // `UpstreamSyncBadge` gates its own dedupe on the base name. An
+      // unlabelled `Base:` is not the labelled half, so deduping onto it would
+      // trade the clearer line for a vaguer one.
+      expect(
+        formatAlarmDetail("behind", {
+          behindCount: 4,
+          baseBehindCount: 4,
+          baseMatchesUpstream: true,
+        })
+      ).toBe("Upstream: 4 commits behind");
+    });
+
+    it("names an unnamed base count rather than leaving the alarm unexplained", () => {
+      // Wider than the expanded badge, deliberately: this tooltip is the only
+      // place a collapsed row says anything about the drift.
+      expect(formatAlarmDetail("behind", { baseBehindCount: 4 })).toBe("Base: 4 commits behind");
+    });
+
+    it("carries a base-ahead count alongside an upstream-behind one", () => {
+      expect(
+        formatAlarmDetail("behind", {
+          behindCount: 2,
+          baseAheadCount: 5,
+          baseBranchName: "develop",
+        })
+      ).toBe("Upstream: 2 commits behind · Base (develop): 5 ahead");
+    });
+
+    it("ignores counts below zero rather than rendering them", () => {
+      expect(formatAlarmDetail("behind", { behindCount: -1, aheadCount: -2 })).toBeUndefined();
+    });
+
     it("keeps the upstream pair when the base counts raced to zero", () => {
       // `baseMatchesUpstream` with nothing to dedupe onto must not render
       // nothing — the upstream pair is the fresher of the two.
@@ -225,6 +258,20 @@ describe("formatAlarmDetail", () => {
     it("still says what happened when it has no counts to give", () => {
       expect(formatAlarmDetail("ci-failed", {})).toBe("Checks failed on the linked pull request");
       expect(formatAlarmDetail("ci-failed", { ciFailed: 0, ciTotal: 0 })).toBe(
+        "Checks failed on the linked pull request"
+      );
+    });
+
+    it("needs BOTH counts before it states a ratio", () => {
+      // Half a pair is not a ratio. Either half missing has to fall back, or
+      // the tooltip invents a number the forge never reported.
+      expect(formatAlarmDetail("ci-failed", { ciTotal: 7 })).toBe(
+        "Checks failed on the linked pull request"
+      );
+      expect(formatAlarmDetail("ci-failed", { ciFailed: 2 })).toBe(
+        "Checks failed on the linked pull request"
+      );
+      expect(formatAlarmDetail("ci-failed", { ciFailed: -1, ciTotal: 7 })).toBe(
         "Checks failed on the linked pull request"
       );
     });

--- a/src/lib/__tests__/worktreeAlarmTier.test.ts
+++ b/src/lib/__tests__/worktreeAlarmTier.test.ts
@@ -187,6 +187,10 @@ describe("formatAlarmDetail", () => {
         formatAlarmDetail("behind", {
           behindCount: 4,
           baseBehindCount: 4,
+          // Both names, as the producer emits them — the expanded badge gates
+          // its own dedupe on `baseBranchName`, so a fixture carrying only the
+          // compare ref would not be testing the same state it sees.
+          baseBranchName: "develop",
           baseCompareRef: "upstream/develop",
           baseMatchesUpstream: true,
         })

--- a/src/lib/worktreeAlarmTier.ts
+++ b/src/lib/worktreeAlarmTier.ts
@@ -72,8 +72,14 @@ export interface AlarmDetailInput {
   behindCount?: number;
   baseAheadCount?: number | null;
   baseBehindCount?: number | null;
+  /**
+   * The base branch's name and the ref its counts were measured against. The
+   * producer emits the pair together (`BaseDivergence` never resolves one
+   * without the other), which is what keeps this tooltip and the expanded
+   * `UpstreamSyncBadge` — whose own base gate reads `baseBranchName` — from
+   * disagreeing about the same measurement.
+   */
   baseBranchName?: string | null;
-  /** The ref the base counts were measured against — named in full here. */
   baseCompareRef?: string | null;
   /** True when `@{u}` and the base compare ref are the same commit. */
   baseMatchesUpstream?: boolean;

--- a/src/lib/worktreeAlarmTier.ts
+++ b/src/lib/worktreeAlarmTier.ts
@@ -59,3 +59,79 @@ export function computeAlarmTier(input: AlarmTierInput): AlarmDescriptor {
   }
   return NONE;
 }
+
+/**
+ * The counts and identity the collapsed pill's tooltip needs to say what the
+ * alarm is actually about. Separate from {@link AlarmTierInput} on purpose:
+ * that one decides which alarm outranks which and is read by the expanded
+ * row's badge ordering too, this one is copy for a single tooltip.
+ */
+export interface AlarmDetailInput {
+  /** Commits ahead of the branch's own upstream, when it has one. */
+  aheadCount?: number;
+  behindCount?: number;
+  baseAheadCount?: number | null;
+  baseBehindCount?: number | null;
+  baseBranchName?: string | null;
+  /** The ref the base counts were measured against — named in full here. */
+  baseCompareRef?: string | null;
+  /** True when `@{u}` and the base compare ref are the same commit. */
+  baseMatchesUpstream?: boolean;
+  /** Failing and total check counts on the linked PR, when the forge reports them. */
+  ciFailed?: number;
+  ciTotal?: number;
+}
+
+/** `3 commits behind, 2 ahead` — behind first, because behind is what raised the alarm. */
+function describeDrift(behind: number, ahead: number): string | undefined {
+  const parts: string[] = [];
+  if (behind > 0) parts.push(`${behind} commit${behind === 1 ? "" : "s"} behind`);
+  if (ahead > 0) parts.push(`${ahead} ahead`);
+  return parts.length > 0 ? parts.join(", ") : undefined;
+}
+
+/**
+ * The second line of the collapsed pill's tooltip, or `undefined` when there is
+ * nothing true to add.
+ *
+ * The pill lost its text so it would stop out-shouting the branch name, and on
+ * a collapsed row nothing else states the drift — `NonMainSecondaryRow` and its
+ * upstream badge only render expanded. So the counts have to be somewhere, and
+ * this is where they went.
+ *
+ * Only positive counts are named. An absent count is "we have not measured
+ * that", never zero, and a tooltip that turns the difference into `0 commits
+ * behind` makes a claim the fetch never made.
+ */
+export function formatAlarmDetail(kind: AlarmKind, input: AlarmDetailInput): string | undefined {
+  switch (kind) {
+    case "ci-failed": {
+      const failed = input.ciFailed ?? 0;
+      const total = input.ciTotal ?? 0;
+      if (failed <= 0 || total <= 0) return "Checks failed on the linked pull request";
+      return `${failed} of ${total} check${total === 1 ? "" : "s"} failing`;
+    }
+    case "auth-failed":
+      // Names where the affordance is rather than implying this mark is it:
+      // the pill takes hover for the tooltip and nothing else, and the button
+      // that actually reconnects lives on the expanded card.
+      return "Expand the card to reconnect your code forge";
+    case "behind": {
+      const upstream = describeDrift(input.behindCount ?? 0, input.aheadCount ?? 0);
+      const base = describeDrift(input.baseBehindCount ?? 0, input.baseAheadCount ?? 0);
+      const ref = input.baseCompareRef || input.baseBranchName;
+      const baseLine = base === undefined ? undefined : `Base${ref ? ` (${ref})` : ""}: ${base}`;
+      // The same dedupe the expanded badge does: when `@{u}` and the base
+      // compare ref are the same commit the two pairs are one measurement, and
+      // the labelled half is the only one that says what it was counted
+      // against. Drop the unlabelled pair, never the label.
+      if (input.baseMatchesUpstream === true && baseLine !== undefined) return baseLine;
+      const lines = [upstream === undefined ? undefined : `Upstream: ${upstream}`, baseLine].filter(
+        (line): line is string => line !== undefined
+      );
+      return lines.length > 0 ? lines.join(" · ") : undefined;
+    }
+    case "none":
+      return undefined;
+  }
+}

--- a/src/lib/worktreeAlarmTier.ts
+++ b/src/lib/worktreeAlarmTier.ts
@@ -121,14 +121,26 @@ export function formatAlarmDetail(kind: AlarmKind, input: AlarmDetailInput): str
       const base = describeDrift(input.baseBehindCount ?? 0, input.baseAheadCount ?? 0);
       const ref = input.baseCompareRef || input.baseBranchName;
       const baseLine = base === undefined ? undefined : `Base${ref ? ` (${ref})` : ""}: ${base}`;
+      const upstreamLine = upstream === undefined ? undefined : `Upstream: ${upstream}`;
       // The same dedupe the expanded badge does: when `@{u}` and the base
       // compare ref are the same commit the two pairs are one measurement, and
-      // the labelled half is the only one that says what it was counted
-      // against. Drop the unlabelled pair, never the label.
-      if (input.baseMatchesUpstream === true && baseLine !== undefined) return baseLine;
-      const lines = [upstream === undefined ? undefined : `Upstream: ${upstream}`, baseLine].filter(
-        (line): line is string => line !== undefined
-      );
+      // only one of them should be stated. Keep the half that says what it was
+      // counted against — which is the base line ONLY while it has a ref to
+      // name. `UpstreamSyncBadge` gates its own `dedupeToBase` on the base
+      // name for the same reason: an unlabelled `Base:` is not the labelled
+      // half, and deduping onto it would drop the clearer line for a vaguer
+      // one. Where neither is named the upstream pair keeps the line, as it
+      // does there.
+      if (input.baseMatchesUpstream === true) {
+        if (ref && baseLine !== undefined) return baseLine;
+        return upstreamLine ?? baseLine;
+      }
+      // Outside the dedupe an unnamed base count still gets stated, which is
+      // wider than the expanded badge goes — it drops a base relationship it
+      // cannot name because the row around it has other lines to fall back on.
+      // This tooltip is the only place a collapsed row says anything about the
+      // drift, so a nameless count beats leaving the alarm unexplained.
+      const lines = [upstreamLine, baseLine].filter((line): line is string => line !== undefined);
       return lines.length > 0 ? lines.join(" · ") : undefined;
     }
     case "none":


### PR DESCRIPTION
## Summary

Two marks on the collapsed sidebar row were carrying more visual weight than the state deserved: the alarm pill and the status tick. Both get scaled back without losing the signal they carry.

### Alarm pill

The text label is gone; the icon stays. Instead of one `CircleAlert` icon shared across all three alarm kinds and distinguished only by tone, each kind now gets its own Lucide icon:

- Behind: `ArrowDown`, matching the same down arrow the upstream badge already writes next to its count.
- Auth failed: `KeyRound`.
- CI failed: `CircleX`, the same X the PR badge already uses, drawn inside a circle so a lone X doesn't read as a dismiss control.

That's not just decoration. Under `forced-colors` accessibility mode the tone wash disappears and all three icons repaint to a single system color, so shape is the only channel left to tell the three alarm kinds apart.

The pill's `pointer-events-none` had to go. Radix's tooltip opens off pointer events on the trigger, and `pointer-events-none` was blocking the hover the label now lives behind. The pill stays a non-focusable `span` with no `tabIndex` and no click handler, so the row keeps its own click behavior. Because a non-focusable trigger means the tooltip only opens on hover and never on keyboard focus, the label and detail text are also carried in the element's accessible name.

### Detail line

A new `formatAlarmDetail`, alongside the existing `computeAlarmTier`, supplies the tooltip's count text: `Upstream: 3 commits behind, 2 ahead`, `Base (upstream/develop): 4 commits behind`, `2 of 7 checks failing`. `AlarmDescriptor` is untouched, since it also drives badge ordering on the expanded row, and this string is just copy for one tooltip.

It reuses the same upstream-versus-base dedupe rule `UpstreamSyncBadge` already applies, including the gate that requires the base to actually have a ref name before it counts as the labeled half of the dedupe: an unlabeled `Base:` isn't something you can dedupe against. It never fabricates a count from a value that isn't there.

### Status tick

The tick was a 16px tall, 4px wide bar down the side of a single collapsed row, and it read like a rail the row was hanging off rather than a small status mark. The collapsed form is now a 6x6 grid, arranged two by two: one solid square for waiting, two 6x2 stripes for cleanup, three 2x2 cells for complete.

The one/two/three segment count survives intact. It's the only thing distinguishing cleanup from complete anywhere on the card, and the only channel of any kind under `forced-colors`. Total ink drops from 64/56/48 square pixels to 36/24/12 for the three states.

Worth noting the road not taken: shrinking the existing stacked bar into a square instead would need a 10x10 grid for three segments to divide evenly into whole pixels at 2px or more, which makes the waiting state a 100 square pixel block, louder than the bar it was replacing. Using two dimensions instead of one is specifically what buys the smaller square.

`collapsed` is a separate boolean prop rather than a third `variant` value, since `variant` is a surface axis (card vs. grid) and the existing `canCollapse = variant !== "grid"` already makes `variant` and `collapsed` mutually exclusive.

Resolves #12093

## Changes

- `src/components/Worktree/WorktreeCard/CollapsedAlarmPill.tsx`: per-kind icons, tooltip wiring, accessible name.
- `src/components/Worktree/WorktreeCard/WorktreeStatusTick.tsx`: collapsed 6x6 grid geometry.
- `src/components/Worktree/WorktreeCard/WorktreeHeader.tsx`, `src/components/Worktree/WorktreeCard.tsx`: wire the `collapsed` prop through.
- `src/lib/worktreeAlarmTier.ts`: `formatAlarmDetail`.
- `src/components/icons/index.ts`: new icon exports.
- Test coverage across all of the above, plus a source contract on the `WorktreeCard` call site.

## Testing

435 tests pass across this branch's suites and the contract suites around them. `npm run typecheck` exits `0`. Prettier and eslint are clean on the changed files.

The alarm pill suite renders against the real Radix primitives instead of a stub, which catches `asChild` going missing (that would wrap the mark in a button and steal the row's click) and proves hover actually opens the tooltip. The status tick's collapsed geometry is asserted on both axes, its pieces are checked to never share a grid cell, and the source contract on the `WorktreeCard` call site keeps `collapsed=` from being dropped silently.
