### PR TITLE
fix(sidebar): remount the worktree list when it shrinks

### DIFF
--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -1366,6 +1366,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
     useSidebarVirtuosoReset({
       itemCount: sidebarItems.length,
       searchQuery: deferredQuery,
+      liveQuery,
       scrollerRef: scrollerElementRef,
     });
 

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -97,6 +97,7 @@ import { WorktreeCardPlaceholder } from "./WorktreeCardPlaceholder";
 import { useWorkspaceRoot } from "@/hooks/useWorkspaceRoot";
 import { useVisibilityAwareInterval } from "@/hooks/useVisibilityAwareInterval";
 import { useScrollIndicator } from "./useScrollIndicator";
+import { useSidebarVirtuosoReset } from "./useSidebarVirtuosoReset";
 import { useRecipeDialogState } from "./useRecipeDialogState";
 import { useWorktreeIds } from "@/hooks/useTerminalSelectors";
 import { logError } from "@/utils/logger";
@@ -1358,6 +1359,16 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
     [scrollIndicatorScrollerRef]
   );
 
+  // Virtuoso's size/offset trees are index-keyed, so a deletion that shrinks the
+  // list leaves them describing the old layout and strands a row that can never
+  // re-measure itself. Remounting is the only way to discard them (#12094).
+  const { resetKey: virtuosoResetKey, initialScrollTop: virtuosoInitialScrollTop } =
+    useSidebarVirtuosoReset({
+      itemCount: sidebarItems.length,
+      liveWorktreeIds: worktreeIdList,
+      scrollerRef: scrollerElementRef,
+    });
+
   // The pinned main row lives OUTSIDE the Virtuoso surface but INSIDE the
   // role="grid" container, so keyboard navigation must visit it before
   // descending into the virtualized list. It carries isPinned so the hook
@@ -1960,6 +1971,8 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
             />
           ) : groupedSections ? (
             <Virtuoso<SidebarFlatItem, SidebarVirtuosoContext>
+              key={virtuosoResetKey}
+              initialScrollTop={virtuosoInitialScrollTop}
               ref={virtuosoRef}
               data={sidebarItems}
               context={virtuosoContext}
@@ -1977,6 +1990,8 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
           ) : (
             <SortableContext items={sortableIds} strategy={verticalListSortingStrategy}>
               <Virtuoso<SidebarFlatItem, SidebarVirtuosoContext>
+                key={virtuosoResetKey}
+                initialScrollTop={virtuosoInitialScrollTop}
                 ref={virtuosoRef}
                 data={sidebarItems}
                 context={virtuosoContext}

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -1359,13 +1359,13 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
     [scrollIndicatorScrollerRef]
   );
 
-  // Virtuoso's size/offset trees are index-keyed, so a deletion that shrinks the
-  // list leaves them describing the old layout and strands a row that can never
-  // re-measure itself. Remounting is the only way to discard them (#12094).
+  // Virtuoso's size/offset trees are index-keyed, so any shrink leaves them
+  // describing the old layout and strands a row that can never re-measure
+  // itself. Remounting is the only way to discard them (#12094).
   const { resetKey: virtuosoResetKey, initialScrollTop: virtuosoInitialScrollTop } =
     useSidebarVirtuosoReset({
       itemCount: sidebarItems.length,
-      liveWorktreeIds: worktreeIdList,
+      searchQuery: deferredQuery,
       scrollerRef: scrollerElementRef,
     });
 

--- a/src/components/Sidebar/__tests__/SidebarContent.virtuosoReset.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.virtuosoReset.test.ts
@@ -59,6 +59,16 @@ describe("SidebarContent Virtuoso reset wiring — issue #12094", () => {
     expect(source).not.toMatch(/searchQuery:\s*liveQuery/);
   });
 
+  it("also hands over the live query so the hook can tell settled from stale", () => {
+    // Without it the hook cannot see the urgent commit that carries a new
+    // character while the filtered list is still the old one, and reads that
+    // commit as the query holding still.
+    const start = source.indexOf("useSidebarVirtuosoReset({");
+    expect(start).toBeGreaterThan(-1);
+    const call = source.slice(start, source.indexOf("});", start));
+    expect(call).toMatch(/\bliveQuery\b/);
+  });
+
   it("measures the shrink against the rendered item array", () => {
     expect(source).toMatch(/itemCount:\s*sidebarItems\.length/);
   });

--- a/src/components/Sidebar/__tests__/SidebarContent.virtuosoReset.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.virtuosoReset.test.ts
@@ -35,23 +35,28 @@ describe("SidebarContent Virtuoso reset wiring — issue #12094", () => {
   });
 
   it("keys both call sites off the reset generation", () => {
-    for (const site of virtuosoCallSites(source)) {
+    const sites = virtuosoCallSites(source);
+    expect(sites).toHaveLength(2);
+    for (const site of sites) {
       expect(site).toContain("key={virtuosoResetKey}");
     }
   });
 
   it("restores the replaced scroll offset on both call sites", () => {
-    for (const site of virtuosoCallSites(source)) {
+    const sites = virtuosoCallSites(source);
+    expect(sites).toHaveLength(2);
+    for (const site of sites) {
       expect(site).toContain("initialScrollTop={virtuosoInitialScrollTop}");
     }
   });
 
-  it("feeds the hook the unfiltered live worktree ids", () => {
-    // `dragStartOrder` is the filtered order — it would report every search
-    // keystroke as a deletion and remount the list under the user.
+  it("suppresses the remount against the deferred query, not the live one", () => {
+    // `liveQuery` updates on the keystroke, a render before the list narrows —
+    // comparing against it would let every typed character through as an
+    // uncorrelated shrink and remount the list under the user.
     expect(source).toContain("useSidebarVirtuosoReset({");
-    expect(source).toMatch(/liveWorktreeIds:\s*worktreeIdList/);
-    expect(source).not.toMatch(/liveWorktreeIds:\s*dragStartOrder/);
+    expect(source).toMatch(/searchQuery:\s*deferredQuery/);
+    expect(source).not.toMatch(/searchQuery:\s*liveQuery/);
   });
 
   it("measures the shrink against the rendered item array", () => {

--- a/src/components/Sidebar/__tests__/SidebarContent.virtuosoReset.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.virtuosoReset.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import fs from "fs/promises";
+import path from "path";
+
+const SIDEBAR_CONTENT_PATH = path.resolve(__dirname, "../SidebarContent.tsx");
+
+// jsdom gives Virtuoso no real geometry (no layout, no ResizeObserver sizes), so
+// the remount itself can't be driven in a unit test. What can be protected is
+// the wiring: the surface renders from two sibling branches, and the regression
+// returns the moment either one loses the key.
+describe("SidebarContent Virtuoso reset wiring — issue #12094", () => {
+  let source: string;
+
+  beforeEach(async () => {
+    source = await fs.readFile(SIDEBAR_CONTENT_PATH, "utf-8");
+  });
+
+  function virtuosoCallSites(src: string): string[] {
+    const sites: string[] = [];
+    const open = "<Virtuoso<SidebarFlatItem, SidebarVirtuosoContext>";
+    let from = src.indexOf(open);
+    while (from !== -1) {
+      const end = src.indexOf("/>", from);
+      expect(end).toBeGreaterThan(from);
+      sites.push(src.slice(from, end));
+      from = src.indexOf(open, end);
+    }
+    return sites;
+  }
+
+  it("still renders exactly two Virtuoso call sites", () => {
+    // The grouped-sections branch and the SortableContext branch. A third would
+    // need the same wiring, so the count is part of the contract.
+    expect(virtuosoCallSites(source)).toHaveLength(2);
+  });
+
+  it("keys both call sites off the reset generation", () => {
+    for (const site of virtuosoCallSites(source)) {
+      expect(site).toContain("key={virtuosoResetKey}");
+    }
+  });
+
+  it("restores the replaced scroll offset on both call sites", () => {
+    for (const site of virtuosoCallSites(source)) {
+      expect(site).toContain("initialScrollTop={virtuosoInitialScrollTop}");
+    }
+  });
+
+  it("feeds the hook the unfiltered live worktree ids", () => {
+    // `dragStartOrder` is the filtered order — it would report every search
+    // keystroke as a deletion and remount the list under the user.
+    expect(source).toContain("useSidebarVirtuosoReset({");
+    expect(source).toMatch(/liveWorktreeIds:\s*worktreeIdList/);
+    expect(source).not.toMatch(/liveWorktreeIds:\s*dragStartOrder/);
+  });
+
+  it("measures the shrink against the rendered item array", () => {
+    expect(source).toMatch(/itemCount:\s*sidebarItems\.length/);
+  });
+});

--- a/src/components/Sidebar/__tests__/useSidebarVirtuosoReset.test.tsx
+++ b/src/components/Sidebar/__tests__/useSidebarVirtuosoReset.test.tsx
@@ -140,6 +140,28 @@ describe("useSidebarVirtuosoReset — issue #12094", () => {
     expect(result.current.resetKey).toBe(1);
   });
 
+  it("still honours a shrink that landed on the same commit as a keystroke", () => {
+    // A deletion arriving mid-search is structural, and nothing later reports
+    // it again — so the exempted shrink is owed, not forgiven.
+    const { result, rerender } = renderReset({ itemCount: 9, searchQuery: "" });
+    rerender({ itemCount: 4, searchQuery: "feat" });
+    expect(result.current.resetKey).toBe(0);
+    // Query holds still and the list does not shrink again; the owed reset
+    // fires anyway.
+    rerender({ itemCount: 4, searchQuery: "feat" });
+    expect(result.current.resetKey).toBe(1);
+  });
+
+  it("collapses a whole typing burst into one owed reset", () => {
+    const { result, rerender } = renderReset({ itemCount: 9, searchQuery: "" });
+    rerender({ itemCount: 7, searchQuery: "f" });
+    rerender({ itemCount: 5, searchQuery: "fe" });
+    rerender({ itemCount: 3, searchQuery: "fea" });
+    expect(result.current.resetKey).toBe(0);
+    rerender({ itemCount: 3, searchQuery: "fea" });
+    expect(result.current.resetKey).toBe(1);
+  });
+
   it("resets once per shrink, not on every subsequent render", () => {
     const { result, rerender } = renderReset({ itemCount: 5, searchQuery: "" });
     rerender({ itemCount: 2, searchQuery: "" });

--- a/src/components/Sidebar/__tests__/useSidebarVirtuosoReset.test.tsx
+++ b/src/components/Sidebar/__tests__/useSidebarVirtuosoReset.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
-import { renderHook, act } from "@testing-library/react";
+import { renderHook, render, act } from "@testing-library/react";
+import { useDeferredValue, useEffect, useState } from "react";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import type { DndMonitorListener } from "@dnd-kit/core";
 import { useSidebarVirtuosoReset } from "../useSidebarVirtuosoReset";
@@ -45,6 +46,8 @@ function makeScroller(scrollTop: number): HTMLElement {
 interface Props {
   itemCount: number;
   searchQuery: string;
+  /** Defaults to `searchQuery` — the settled state these cases all describe. */
+  liveQuery?: string;
 }
 
 /**
@@ -58,13 +61,72 @@ function renderReset(initialProps: Props, scrollTop: number | null = 400) {
   const seenScrollTops: (number | undefined)[] = [];
   const view = renderHook(
     (props: Props) => {
-      const result = useSidebarVirtuosoReset({ ...props, scrollerRef });
+      const result = useSidebarVirtuosoReset({
+        itemCount: props.itemCount,
+        searchQuery: props.searchQuery,
+        liveQuery: props.liveQuery ?? props.searchQuery,
+        scrollerRef,
+      });
       seenScrollTops.push(result.initialScrollTop);
       return result;
     },
     { initialProps }
   );
   return { ...view, scrollerRef, seenScrollTops };
+}
+
+/** How far the roster narrows as "feat" is typed one character at a time. */
+const COUNT_FOR_QUERY: Record<string, number> = { "": 9, f: 7, fe: 5, fea: 3, feat: 2 };
+
+interface TypingHandle {
+  type: (query: string) => void;
+  /** A background commit that touches neither the count nor the query. */
+  tick: () => void;
+}
+
+/**
+ * Drives the hook behind a *real* `useDeferredValue`, the way SidebarContent
+ * wires it. Hand-driven prop pairs cannot express the shape that matters: each
+ * keystroke commits twice, and the interleaved urgent commit — new input, list
+ * not yet narrowed — is where a naive quiet test fires the previous keystroke's
+ * reset. Every render's key is recorded, since a remount that is undone by the
+ * next commit still tore the list down.
+ */
+function renderTypingHarness() {
+  const scrollerRef: { current: HTMLElement | null } = { current: makeScroller(400) };
+  const resetKeys: number[] = [];
+  // Throwing placeholders, so a harness that never mounted fails loudly instead
+  // of leaving every assertion below reading a key nothing ever drove.
+  const unmounted = () => {
+    throw new Error("typing harness has not mounted");
+  };
+  const handle: TypingHandle = { type: unmounted, tick: unmounted };
+
+  function Harness() {
+    const [liveQuery, setLiveQuery] = useState("");
+    const [tick, setTick] = useState(0);
+    const deferredQuery = useDeferredValue(liveQuery);
+    const { resetKey } = useSidebarVirtuosoReset({
+      itemCount: COUNT_FOR_QUERY[deferredQuery] ?? 0,
+      searchQuery: deferredQuery,
+      liveQuery,
+      scrollerRef,
+    });
+    resetKeys.push(resetKey);
+    useEffect(() => {
+      handle.type = setLiveQuery;
+      handle.tick = () => setTick((n) => n + 1);
+    }, []);
+    return <span data-tick={tick}>{resetKey}</span>;
+  }
+
+  render(<Harness />);
+  return {
+    resetKeys,
+    type: (query: string) => act(() => handle.type(query)),
+    tick: () => act(() => handle.tick()),
+    currentKey: () => resetKeys[resetKeys.length - 1],
+  };
 }
 
 beforeEach(() => {
@@ -160,6 +222,27 @@ describe("useSidebarVirtuosoReset — issue #12094", () => {
     expect(result.current.resetKey).toBe(0);
     rerender({ itemCount: 3, searchQuery: "fea" });
     expect(result.current.resetKey).toBe(1);
+  });
+
+  describe("behind a real useDeferredValue", () => {
+    it("does not remount once per keystroke", () => {
+      const harness = renderTypingHarness();
+      for (const query of ["f", "fe", "fea", "feat"]) harness.type(query);
+      // The regression scored one remount per keystroke, lagged by one: the
+      // urgent commit carrying the next character read as quiet and paid off
+      // the previous character's owed reset.
+      expect(harness.resetKeys.filter((key) => key !== 0)).toEqual([]);
+    });
+
+    it("pays the burst off with a single reset once the query settles", () => {
+      const harness = renderTypingHarness();
+      for (const query of ["f", "fe", "fea", "feat"]) harness.type(query);
+      expect(harness.currentKey()).toBe(0);
+      harness.tick();
+      expect(harness.currentKey()).toBe(1);
+      harness.tick();
+      expect(harness.currentKey()).toBe(1);
+    });
   });
 
   it("resets once per shrink, not on every subsequent render", () => {

--- a/src/components/Sidebar/__tests__/useSidebarVirtuosoReset.test.tsx
+++ b/src/components/Sidebar/__tests__/useSidebarVirtuosoReset.test.tsx
@@ -1,0 +1,265 @@
+// @vitest-environment jsdom
+import { renderHook, act } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import type { DndMonitorListener } from "@dnd-kit/core";
+import { useSidebarVirtuosoReset } from "../useSidebarVirtuosoReset";
+
+// The hook only ever reaches dnd-kit for the drag lifecycle, so a factory
+// exposing just `useDndMonitor` covers its whole import surface.
+let dndListeners: DndMonitorListener | null;
+vi.mock("@dnd-kit/core", () => ({
+  useDndMonitor: (listener: DndMonitorListener) => {
+    dndListeners = listener;
+  },
+}));
+
+// Controllable rAF queue: the post-drag release schedules a nested frame, so
+// draining one level at a time is what proves the reset waits for dnd-kit's
+// focus-restoration frame rather than landing on the first one.
+let rafQueue: Map<number, FrameRequestCallback>;
+let nextRafId: number;
+
+function flushFrames() {
+  const pending = [...rafQueue.values()];
+  rafQueue.clear();
+  act(() => {
+    for (const cb of pending) cb(0);
+  });
+}
+
+function makeScroller(scrollTop: number): HTMLElement {
+  const el = document.createElement("div");
+  Object.defineProperty(el, "scrollTop", { value: scrollTop, configurable: true });
+  return el;
+}
+
+interface Props {
+  itemCount: number;
+  liveWorktreeIds: readonly string[];
+}
+
+/**
+ * Renders the hook and records every `initialScrollTop` it returns. The offset
+ * is transient by design — a passive effect clears it once the keyed mount has
+ * consumed it — so the restored value is only observable across renders, never
+ * in the settled result.
+ */
+function renderReset(initialProps: Props, scrollTop: number | null = 400) {
+  const scrollerRef = { current: scrollTop === null ? null : makeScroller(scrollTop) };
+  const seenScrollTops: (number | undefined)[] = [];
+  const view = renderHook(
+    (props: Props) => {
+      const result = useSidebarVirtuosoReset({ ...props, scrollerRef });
+      seenScrollTops.push(result.initialScrollTop);
+      return result;
+    },
+    { initialProps }
+  );
+  return { ...view, scrollerRef, seenScrollTops };
+}
+
+beforeEach(() => {
+  dndListeners = null;
+  rafQueue = new Map();
+  nextRafId = 0;
+  vi.spyOn(window, "requestAnimationFrame").mockImplementation((cb) => {
+    const id = ++nextRafId;
+    rafQueue.set(id, cb);
+    return id;
+  });
+  vi.spyOn(window, "cancelAnimationFrame").mockImplementation((id) => {
+    rafQueue.delete(id);
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useSidebarVirtuosoReset — issue #12094", () => {
+  it("does not reset on the first commit", () => {
+    const { result } = renderReset({ itemCount: 5, liveWorktreeIds: ["a", "b", "c"] });
+    expect(result.current.resetKey).toBe(0);
+    expect(result.current.initialScrollTop).toBeUndefined();
+  });
+
+  it("resets when a shrink coincides with a removed live worktree", () => {
+    const { result, rerender } = renderReset({
+      itemCount: 5,
+      liveWorktreeIds: ["a", "b", "c"],
+    });
+    // Two worktrees deleted at once: their rows go, and the two tombstones
+    // collapse into a single group item — a net shrink.
+    rerender({ itemCount: 2, liveWorktreeIds: ["a"] });
+    expect(result.current.resetKey).toBe(1);
+  });
+
+  it("ignores a shrink whose live worktrees are all still present", () => {
+    const { result, rerender } = renderReset({
+      itemCount: 5,
+      liveWorktreeIds: ["a", "b", "c"],
+    });
+    // Narrowing a search or a quick-state filter, and a tombstone retiring on
+    // its own, all shrink the surface without deleting a worktree. Remounting
+    // here would reset scroll under a user who did nothing.
+    rerender({ itemCount: 3, liveWorktreeIds: ["a", "b", "c"] });
+    expect(result.current.resetKey).toBe(0);
+  });
+
+  it("ignores a deletion that does not shrink the surface", () => {
+    const { result, rerender } = renderReset({
+      itemCount: 5,
+      liveWorktreeIds: ["a", "b", "c"],
+    });
+    // A lone deletion swaps a row for a tombstone card — same item count, and
+    // the geometry never goes stale. This is why single deletes never repro.
+    rerender({ itemCount: 5, liveWorktreeIds: ["a", "b"] });
+    expect(result.current.resetKey).toBe(0);
+  });
+
+  it("ignores growth and reordering", () => {
+    const { result, rerender } = renderReset({
+      itemCount: 5,
+      liveWorktreeIds: ["a", "b", "c"],
+    });
+    rerender({ itemCount: 7, liveWorktreeIds: ["a", "b", "c", "d"] });
+    rerender({ itemCount: 7, liveWorktreeIds: ["c", "a", "d", "b"] });
+    expect(result.current.resetKey).toBe(0);
+  });
+
+  it("resets when a removal and an addition land together, shrinking the surface", () => {
+    const { result, rerender } = renderReset({
+      itemCount: 6,
+      liveWorktreeIds: ["a", "b", "c"],
+    });
+    // Live count is unchanged, so only membership reveals the removal.
+    rerender({ itemCount: 4, liveWorktreeIds: ["a", "b", "d"] });
+    expect(result.current.resetKey).toBe(1);
+  });
+
+  it("resets once per shrink, not on every subsequent render", () => {
+    const { result, rerender } = renderReset({
+      itemCount: 5,
+      liveWorktreeIds: ["a", "b", "c"],
+    });
+    rerender({ itemCount: 2, liveWorktreeIds: ["a"] });
+    rerender({ itemCount: 2, liveWorktreeIds: ["a"] });
+    rerender({ itemCount: 2, liveWorktreeIds: ["a"] });
+    expect(result.current.resetKey).toBe(1);
+  });
+
+  it("hands the fresh instance the scroll offset it replaced, then drops it", () => {
+    const { result, rerender, seenScrollTops } = renderReset(
+      { itemCount: 5, liveWorktreeIds: ["a", "b", "c"] },
+      400
+    );
+    rerender({ itemCount: 2, liveWorktreeIds: ["a"] });
+    // Observable only mid-flight: the keyed mount reads it, then it is cleared
+    // so a later empty-state remount can't restore a position from a list that
+    // no longer exists.
+    expect(seenScrollTops).toContain(400);
+    expect(result.current.initialScrollTop).toBeUndefined();
+  });
+
+  it("leaves the offset unset when the list was already at the top", () => {
+    const { seenScrollTops, rerender } = renderReset(
+      { itemCount: 5, liveWorktreeIds: ["a", "b", "c"] },
+      0
+    );
+    rerender({ itemCount: 2, liveWorktreeIds: ["a"] });
+    expect(seenScrollTops.every((v) => v === undefined)).toBe(true);
+  });
+
+  it("skips the remount when Virtuoso is already unmounted", () => {
+    // No scroller means the empty-state branch is showing: the geometry died
+    // with the instance, and bumping the key would discard a healthy mount.
+    const { result, rerender } = renderReset(
+      { itemCount: 5, liveWorktreeIds: ["a", "b", "c"] },
+      null
+    );
+    rerender({ itemCount: 2, liveWorktreeIds: ["a"] });
+    expect(result.current.resetKey).toBe(0);
+  });
+
+  describe("drag safety (past lesson #8478)", () => {
+    it("holds the reset while a drag is in flight", () => {
+      const { result, rerender } = renderReset({
+        itemCount: 5,
+        liveWorktreeIds: ["a", "b", "c"],
+      });
+      act(() => dndListeners?.onDragStart?.({} as never));
+      rerender({ itemCount: 2, liveWorktreeIds: ["a"] });
+      expect(result.current.resetKey).toBe(0);
+    });
+
+    it("releases it a frame after dnd-kit restores focus, not before", () => {
+      const { result, rerender } = renderReset({
+        itemCount: 5,
+        liveWorktreeIds: ["a", "b", "c"],
+      });
+      act(() => dndListeners?.onDragStart?.({} as never));
+      rerender({ itemCount: 2, liveWorktreeIds: ["a"] });
+      act(() => dndListeners?.onDragEnd?.({} as never));
+
+      flushFrames();
+      expect(result.current.resetKey).toBe(0);
+      flushFrames();
+      expect(result.current.resetKey).toBe(1);
+    });
+
+    it("releases it on a cancelled drag too", () => {
+      const { result, rerender } = renderReset({
+        itemCount: 5,
+        liveWorktreeIds: ["a", "b", "c"],
+      });
+      act(() => dndListeners?.onDragStart?.({} as never));
+      rerender({ itemCount: 2, liveWorktreeIds: ["a"] });
+      act(() => dndListeners?.onDragCancel?.({} as never));
+
+      flushFrames();
+      flushFrames();
+      expect(result.current.resetKey).toBe(1);
+    });
+
+    it("postpones again when a new drag starts inside the settling window", () => {
+      const { result, rerender } = renderReset({
+        itemCount: 5,
+        liveWorktreeIds: ["a", "b", "c"],
+      });
+      act(() => dndListeners?.onDragStart?.({} as never));
+      rerender({ itemCount: 2, liveWorktreeIds: ["a"] });
+      act(() => dndListeners?.onDragEnd?.({} as never));
+      act(() => dndListeners?.onDragStart?.({} as never));
+
+      flushFrames();
+      flushFrames();
+      expect(result.current.resetKey).toBe(0);
+
+      act(() => dndListeners?.onDragEnd?.({} as never));
+      flushFrames();
+      flushFrames();
+      expect(result.current.resetKey).toBe(1);
+    });
+
+    it("schedules nothing when a drag ends with no reset pending", () => {
+      renderReset({ itemCount: 5, liveWorktreeIds: ["a", "b", "c"] });
+      act(() => dndListeners?.onDragStart?.({} as never));
+      act(() => dndListeners?.onDragEnd?.({} as never));
+      expect(rafQueue.size).toBe(0);
+    });
+
+    it("drops the queued frame on unmount so no state lands after teardown", () => {
+      const { rerender, unmount } = renderReset({
+        itemCount: 5,
+        liveWorktreeIds: ["a", "b", "c"],
+      });
+      act(() => dndListeners?.onDragStart?.({} as never));
+      rerender({ itemCount: 2, liveWorktreeIds: ["a"] });
+      act(() => dndListeners?.onDragEnd?.({} as never));
+      expect(rafQueue.size).toBe(1);
+
+      unmount();
+      expect(rafQueue.size).toBe(0);
+    });
+  });
+});

--- a/src/components/Sidebar/__tests__/useSidebarVirtuosoReset.test.tsx
+++ b/src/components/Sidebar/__tests__/useSidebarVirtuosoReset.test.tsx
@@ -13,6 +13,15 @@ vi.mock("@dnd-kit/core", () => ({
   },
 }));
 
+// Dispatch through a helper that throws rather than optional-chaining: a
+// listener that silently went missing would otherwise leave every drag test
+// asserting nothing and still passing.
+function dispatchDrag(event: "onDragStart" | "onDragEnd" | "onDragCancel") {
+  const listener = dndListeners?.[event];
+  if (!listener) throw new Error(`useDndMonitor received no ${event} listener`);
+  act(() => listener({} as never));
+}
+
 // Controllable rAF queue: the post-drag release schedules a nested frame, so
 // draining one level at a time is what proves the reset waits for dnd-kit's
 // focus-restoration frame rather than landing on the first one.
@@ -35,7 +44,7 @@ function makeScroller(scrollTop: number): HTMLElement {
 
 interface Props {
   itemCount: number;
-  liveWorktreeIds: readonly string[];
+  searchQuery: string;
 }
 
 /**
@@ -78,82 +87,89 @@ afterEach(() => {
 
 describe("useSidebarVirtuosoReset — issue #12094", () => {
   it("does not reset on the first commit", () => {
-    const { result } = renderReset({ itemCount: 5, liveWorktreeIds: ["a", "b", "c"] });
+    const { result } = renderReset({ itemCount: 5, searchQuery: "" });
     expect(result.current.resetKey).toBe(0);
     expect(result.current.initialScrollTop).toBeUndefined();
   });
 
-  it("resets when a shrink coincides with a removed live worktree", () => {
-    const { result, rerender } = renderReset({
-      itemCount: 5,
-      liveWorktreeIds: ["a", "b", "c"],
-    });
+  it("resets when the surface shrinks", () => {
+    const { result, rerender } = renderReset({ itemCount: 5, searchQuery: "" });
     // Two worktrees deleted at once: their rows go, and the two tombstones
     // collapse into a single group item — a net shrink.
-    rerender({ itemCount: 2, liveWorktreeIds: ["a"] });
+    rerender({ itemCount: 4, searchQuery: "" });
     expect(result.current.resetKey).toBe(1);
   });
 
-  it("ignores a shrink whose live worktrees are all still present", () => {
-    const { result, rerender } = renderReset({
-      itemCount: 5,
-      liveWorktreeIds: ["a", "b", "c"],
-    });
-    // Narrowing a search or a quick-state filter, and a tombstone retiring on
-    // its own, all shrink the surface without deleting a worktree. Remounting
-    // here would reset scroll under a user who did nothing.
-    rerender({ itemCount: 3, liveWorktreeIds: ["a", "b", "c"] });
+  it("resets on a shrink no deletion could be correlated with", () => {
+    // A quick-state filter hides a row because its agent stopped, or a tombstone
+    // is pruned when its last terminal leaves. Neither changes the live worktree
+    // roster in the same commit, and both shift every index below them.
+    const { result, rerender } = renderReset({ itemCount: 6, searchQuery: "" });
+    rerender({ itemCount: 5, searchQuery: "" });
+    expect(result.current.resetKey).toBe(1);
+  });
+
+  it("ignores growth", () => {
+    const { result, rerender } = renderReset({ itemCount: 5, searchQuery: "" });
+    rerender({ itemCount: 7, searchQuery: "" });
+    rerender({ itemCount: 9, searchQuery: "" });
     expect(result.current.resetKey).toBe(0);
   });
 
-  it("ignores a deletion that does not shrink the surface", () => {
-    const { result, rerender } = renderReset({
-      itemCount: 5,
-      liveWorktreeIds: ["a", "b", "c"],
-    });
+  it("ignores a same-size update", () => {
     // A lone deletion swaps a row for a tombstone card — same item count, and
     // the geometry never goes stale. This is why single deletes never repro.
-    rerender({ itemCount: 5, liveWorktreeIds: ["a", "b"] });
+    const { result, rerender } = renderReset({ itemCount: 5, searchQuery: "" });
+    rerender({ itemCount: 5, searchQuery: "" });
     expect(result.current.resetKey).toBe(0);
   });
 
-  it("ignores growth and reordering", () => {
-    const { result, rerender } = renderReset({
-      itemCount: 5,
-      liveWorktreeIds: ["a", "b", "c"],
-    });
-    rerender({ itemCount: 7, liveWorktreeIds: ["a", "b", "c", "d"] });
-    rerender({ itemCount: 7, liveWorktreeIds: ["c", "a", "d", "b"] });
+  it("does not remount while the user is typing", () => {
+    const { result, rerender } = renderReset({ itemCount: 9, searchQuery: "" });
+    rerender({ itemCount: 4, searchQuery: "fea" });
+    rerender({ itemCount: 2, searchQuery: "feat" });
     expect(result.current.resetKey).toBe(0);
   });
 
-  it("resets when a removal and an addition land together, shrinking the surface", () => {
-    const { result, rerender } = renderReset({
-      itemCount: 6,
-      liveWorktreeIds: ["a", "b", "c"],
-    });
-    // Live count is unchanged, so only membership reveals the removal.
-    rerender({ itemCount: 4, liveWorktreeIds: ["a", "b", "d"] });
+  it("resumes resetting once the query stops changing", () => {
+    const { result, rerender } = renderReset({ itemCount: 9, searchQuery: "" });
+    rerender({ itemCount: 4, searchQuery: "feat" });
+    expect(result.current.resetKey).toBe(0);
+    // Same query, list shrank anyway — a deletion landed under the filter.
+    rerender({ itemCount: 3, searchQuery: "feat" });
     expect(result.current.resetKey).toBe(1);
   });
 
   it("resets once per shrink, not on every subsequent render", () => {
-    const { result, rerender } = renderReset({
-      itemCount: 5,
-      liveWorktreeIds: ["a", "b", "c"],
-    });
-    rerender({ itemCount: 2, liveWorktreeIds: ["a"] });
-    rerender({ itemCount: 2, liveWorktreeIds: ["a"] });
-    rerender({ itemCount: 2, liveWorktreeIds: ["a"] });
+    const { result, rerender } = renderReset({ itemCount: 5, searchQuery: "" });
+    rerender({ itemCount: 2, searchQuery: "" });
+    rerender({ itemCount: 2, searchQuery: "" });
+    rerender({ itemCount: 2, searchQuery: "" });
+    expect(result.current.resetKey).toBe(1);
+  });
+
+  it("resets again for a second, independent shrink", () => {
+    // A one-shot reset would pass every other test here and still strand a row
+    // on the user's second bulk deletion.
+    const { result, rerender } = renderReset({ itemCount: 5, searchQuery: "" });
+    rerender({ itemCount: 3, searchQuery: "" });
+    expect(result.current.resetKey).toBe(1);
+    rerender({ itemCount: 1, searchQuery: "" });
+    expect(result.current.resetKey).toBe(2);
+  });
+
+  it("resets when the surface empties out", () => {
+    const { result, rerender } = renderReset({ itemCount: 3, searchQuery: "" });
+    rerender({ itemCount: 0, searchQuery: "" });
     expect(result.current.resetKey).toBe(1);
   });
 
   it("hands the fresh instance the scroll offset it replaced, then drops it", () => {
     const { result, rerender, seenScrollTops } = renderReset(
-      { itemCount: 5, liveWorktreeIds: ["a", "b", "c"] },
+      { itemCount: 5, searchQuery: "" },
       400
     );
-    rerender({ itemCount: 2, liveWorktreeIds: ["a"] });
+    rerender({ itemCount: 2, searchQuery: "" });
     // Observable only mid-flight: the keyed mount reads it, then it is cleared
     // so a later empty-state remount can't restore a position from a list that
     // no longer exists.
@@ -162,44 +178,47 @@ describe("useSidebarVirtuosoReset — issue #12094", () => {
   });
 
   it("leaves the offset unset when the list was already at the top", () => {
-    const { seenScrollTops, rerender } = renderReset(
-      { itemCount: 5, liveWorktreeIds: ["a", "b", "c"] },
-      0
-    );
-    rerender({ itemCount: 2, liveWorktreeIds: ["a"] });
+    const { seenScrollTops, rerender } = renderReset({ itemCount: 5, searchQuery: "" }, 0);
+    rerender({ itemCount: 2, searchQuery: "" });
     expect(seenScrollTops.every((v) => v === undefined)).toBe(true);
   });
 
   it("skips the remount when Virtuoso is already unmounted", () => {
     // No scroller means the empty-state branch is showing: the geometry died
     // with the instance, and bumping the key would discard a healthy mount.
-    const { result, rerender } = renderReset(
-      { itemCount: 5, liveWorktreeIds: ["a", "b", "c"] },
-      null
-    );
-    rerender({ itemCount: 2, liveWorktreeIds: ["a"] });
+    const { result, rerender } = renderReset({ itemCount: 5, searchQuery: "" }, null);
+    rerender({ itemCount: 2, searchQuery: "" });
     expect(result.current.resetKey).toBe(0);
   });
 
   describe("drag safety (past lesson #8478)", () => {
     it("holds the reset while a drag is in flight", () => {
-      const { result, rerender } = renderReset({
-        itemCount: 5,
-        liveWorktreeIds: ["a", "b", "c"],
-      });
-      act(() => dndListeners?.onDragStart?.({} as never));
-      rerender({ itemCount: 2, liveWorktreeIds: ["a"] });
+      const { result, rerender } = renderReset({ itemCount: 5, searchQuery: "" });
+      dispatchDrag("onDragStart");
+      rerender({ itemCount: 2, searchQuery: "" });
       expect(result.current.resetKey).toBe(0);
     });
 
     it("releases it a frame after dnd-kit restores focus, not before", () => {
-      const { result, rerender } = renderReset({
-        itemCount: 5,
-        liveWorktreeIds: ["a", "b", "c"],
-      });
-      act(() => dndListeners?.onDragStart?.({} as never));
-      rerender({ itemCount: 2, liveWorktreeIds: ["a"] });
-      act(() => dndListeners?.onDragEnd?.({} as never));
+      const { result, rerender } = renderReset({ itemCount: 5, searchQuery: "" });
+      dispatchDrag("onDragStart");
+      rerender({ itemCount: 2, searchQuery: "" });
+      dispatchDrag("onDragEnd");
+
+      flushFrames();
+      expect(result.current.resetKey).toBe(0);
+      flushFrames();
+      expect(result.current.resetKey).toBe(1);
+    });
+
+    it("holds a shrink that arrives after the drop but before focus is restored", () => {
+      // The drag is already over, so a dragging-only guard would let this
+      // through and destroy the activator dnd-kit is about to focus.
+      const { result, rerender } = renderReset({ itemCount: 5, searchQuery: "" });
+      dispatchDrag("onDragStart");
+      dispatchDrag("onDragEnd");
+      rerender({ itemCount: 2, searchQuery: "" });
+      expect(result.current.resetKey).toBe(0);
 
       flushFrames();
       expect(result.current.resetKey).toBe(0);
@@ -208,13 +227,10 @@ describe("useSidebarVirtuosoReset — issue #12094", () => {
     });
 
     it("releases it on a cancelled drag too", () => {
-      const { result, rerender } = renderReset({
-        itemCount: 5,
-        liveWorktreeIds: ["a", "b", "c"],
-      });
-      act(() => dndListeners?.onDragStart?.({} as never));
-      rerender({ itemCount: 2, liveWorktreeIds: ["a"] });
-      act(() => dndListeners?.onDragCancel?.({} as never));
+      const { result, rerender } = renderReset({ itemCount: 5, searchQuery: "" });
+      dispatchDrag("onDragStart");
+      rerender({ itemCount: 2, searchQuery: "" });
+      dispatchDrag("onDragCancel");
 
       flushFrames();
       flushFrames();
@@ -222,40 +238,39 @@ describe("useSidebarVirtuosoReset — issue #12094", () => {
     });
 
     it("postpones again when a new drag starts inside the settling window", () => {
-      const { result, rerender } = renderReset({
-        itemCount: 5,
-        liveWorktreeIds: ["a", "b", "c"],
-      });
-      act(() => dndListeners?.onDragStart?.({} as never));
-      rerender({ itemCount: 2, liveWorktreeIds: ["a"] });
-      act(() => dndListeners?.onDragEnd?.({} as never));
-      act(() => dndListeners?.onDragStart?.({} as never));
+      const { result, rerender } = renderReset({ itemCount: 5, searchQuery: "" });
+      dispatchDrag("onDragStart");
+      rerender({ itemCount: 2, searchQuery: "" });
+      dispatchDrag("onDragEnd");
+      dispatchDrag("onDragStart");
 
       flushFrames();
       flushFrames();
       expect(result.current.resetKey).toBe(0);
 
-      act(() => dndListeners?.onDragEnd?.({} as never));
+      dispatchDrag("onDragEnd");
       flushFrames();
       flushFrames();
       expect(result.current.resetKey).toBe(1);
     });
 
-    it("schedules nothing when a drag ends with no reset pending", () => {
-      renderReset({ itemCount: 5, liveWorktreeIds: ["a", "b", "c"] });
-      act(() => dndListeners?.onDragStart?.({} as never));
-      act(() => dndListeners?.onDragEnd?.({} as never));
-      expect(rafQueue.size).toBe(0);
+    it("coalesces several shrinks during one drag into a single remount", () => {
+      const { result, rerender } = renderReset({ itemCount: 9, searchQuery: "" });
+      dispatchDrag("onDragStart");
+      rerender({ itemCount: 6, searchQuery: "" });
+      rerender({ itemCount: 3, searchQuery: "" });
+      dispatchDrag("onDragEnd");
+
+      flushFrames();
+      flushFrames();
+      expect(result.current.resetKey).toBe(1);
     });
 
     it("drops the queued frame on unmount so no state lands after teardown", () => {
-      const { rerender, unmount } = renderReset({
-        itemCount: 5,
-        liveWorktreeIds: ["a", "b", "c"],
-      });
-      act(() => dndListeners?.onDragStart?.({} as never));
-      rerender({ itemCount: 2, liveWorktreeIds: ["a"] });
-      act(() => dndListeners?.onDragEnd?.({} as never));
+      const { rerender, unmount } = renderReset({ itemCount: 5, searchQuery: "" });
+      dispatchDrag("onDragStart");
+      rerender({ itemCount: 2, searchQuery: "" });
+      dispatchDrag("onDragEnd");
       expect(rafQueue.size).toBe(1);
 
       unmount();

--- a/src/components/Sidebar/useSidebarVirtuosoReset.ts
+++ b/src/components/Sidebar/useSidebarVirtuosoReset.ts
@@ -53,7 +53,9 @@ const INITIAL_STATE: ResetState = { key: 0, scrollTop: undefined };
  * The single exception is typing. Narrowing a search shrinks the list on most
  * keystrokes, and a full teardown per keystroke would put exactly the work this
  * file defers out of the input path (#10908) back into it — for a list the user
- * is about to change again anyway.
+ * is about to change again anyway. That shrink is deferred, not forgiven: it
+ * stays owed and fires on the first commit the query holds still, so a deletion
+ * that merely coincided with a keystroke still gets its reset.
  */
 function useSidebarVirtuosoReset({
   itemCount,
@@ -95,16 +97,23 @@ function useSidebarVirtuosoReset({
     }));
   }, [scrollerRef]);
 
+  // Deliberately un-gated: an owed reset has to be retried on plain commits
+  // too. Keying this to the inputs would strand a shrink that arrived on the
+  // same commit as the user's last keystroke, because the next commit that
+  // could pay it off often changes neither the count nor the query.
   useLayoutEffect(() => {
     const prevCount = prevItemCountRef.current;
     const prevQuery = prevQueryRef.current;
     prevItemCountRef.current = itemCount;
     prevQueryRef.current = searchQuery;
-    if (prevCount === null || itemCount >= prevCount) return;
+    if (prevCount === null) return;
+    if (itemCount < prevCount) pendingRef.current = true;
+    // Hold while the query is still moving, but keep the shrink owed rather
+    // than dropping it: a deletion that happens to land in the same commit as
+    // a keystroke is structural, and nothing later would report it again.
     if (searchQuery !== prevQuery) return;
-    pendingRef.current = true;
     flush();
-  }, [itemCount, searchQuery, flush]);
+  });
 
   const releaseAfterDrag = useCallback(() => {
     draggingRef.current = false;

--- a/src/components/Sidebar/useSidebarVirtuosoReset.ts
+++ b/src/components/Sidebar/useSidebarVirtuosoReset.ts
@@ -1,0 +1,145 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import type { RefObject } from "react";
+import { useDndMonitor } from "@dnd-kit/core";
+
+interface UseSidebarVirtuosoResetParams {
+  /** Length of the flat item array backing the Virtuoso surface. */
+  itemCount: number;
+  /**
+   * Unfiltered live worktree ids, read from the same deferred timeline as the
+   * items. A filtered order (`dragStartOrder`) would report every search
+   * keystroke as a removal; the raw store list would run ahead of the items and
+   * report removals a render early.
+   */
+  liveWorktreeIds: readonly string[];
+  /** The live scroller element, so the pre-remount offset can be restored. */
+  scrollerRef: RefObject<HTMLElement | null>;
+}
+
+interface UseSidebarVirtuosoResetReturn {
+  /** Feed to Virtuoso's `key`. A change discards the stale geometry trees. */
+  resetKey: number;
+  /** Feed to Virtuoso's `initialScrollTop`. Transient — cleared once consumed. */
+  initialScrollTop: number | undefined;
+}
+
+interface ResetState {
+  key: number;
+  scrollTop: number | undefined;
+}
+
+const INITIAL_STATE: ResetState = { key: 0, scrollTop: undefined };
+
+/**
+ * Replaces the sidebar's Virtuoso instance after a worktree deletion shrinks the
+ * list (#12094).
+ *
+ * react-virtuoso keys its size and offset trees by index, not by
+ * `computeItemKey` — that only steers React reconciliation. `firstItemIndex` is
+ * the sole remap path and exists for prepending, `restoreStateFrom` restores the
+ * measurements rather than clearing them, and `VirtuosoHandle` has no imperative
+ * reset. So when the list shrinks, the trees keep describing the pre-deletion
+ * layout, and the failure is self-sustaining: a row left outside the computed
+ * visible range never mounts, so its ResizeObserver never fires, so its stale
+ * entry is never corrected. Remounting is the only way to discard those trees.
+ *
+ * The trigger is deliberately narrow. A shrink alone is far too broad — search
+ * and filter narrowing shrink the list, and so does `pruneDeletedWorktrees`
+ * retiring a tombstone on its own, which would yank a scrolled user to the top
+ * with no action on their part. Requiring that a live worktree id also
+ * disappeared isolates real deletions: a lone deletion swaps a row for a
+ * tombstone card and doesn't shrink at all, while a batch collapses several
+ * tombstones into one group item and does.
+ */
+function useSidebarVirtuosoReset({
+  itemCount,
+  liveWorktreeIds,
+  scrollerRef,
+}: UseSidebarVirtuosoResetParams): UseSidebarVirtuosoResetReturn {
+  const [reset, setReset] = useState<ResetState>(INITIAL_STATE);
+  // `null` until the first commit — there is no previous layout to have
+  // stranded anything, so the first pass only records a baseline.
+  const prevItemCountRef = useRef<number | null>(null);
+  // Held by reference, not copied: `liveWorktreeIds` arrives from a useMemo and
+  // is never mutated in place.
+  const prevIdsRef = useRef<readonly string[]>([]);
+  const pendingRef = useRef(false);
+  const draggingRef = useRef(false);
+  const rafRef = useRef<number | null>(null);
+
+  const cancelScheduled = useCallback(() => {
+    if (rafRef.current !== null) {
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
+    }
+  }, []);
+
+  const flush = useCallback(() => {
+    if (!pendingRef.current || draggingRef.current) return;
+    pendingRef.current = false;
+    const scroller = scrollerRef.current;
+    // No scroller means Virtuoso is already unmounted — the empty-state branch
+    // is showing, its geometry died with it, and the next mount is fresh.
+    // Bumping the key here would only discard that healthy instance.
+    if (!scroller) return;
+    const { scrollTop } = scroller;
+    setReset((prev) => ({
+      key: prev.key + 1,
+      scrollTop: scrollTop > 0 ? scrollTop : undefined,
+    }));
+  }, [scrollerRef]);
+
+  useLayoutEffect(() => {
+    const prevCount = prevItemCountRef.current;
+    const prevIds = prevIdsRef.current;
+    prevItemCountRef.current = itemCount;
+    prevIdsRef.current = liveWorktreeIds;
+    if (prevCount === null || itemCount >= prevCount) return;
+    const live = new Set(liveWorktreeIds);
+    // Membership, not counts: a removal landing alongside an addition in the
+    // same update leaves the live id count unchanged while still deleting a
+    // worktree, and the shrunk surface strands geometry all the same.
+    if (!prevIds.some((id) => !live.has(id))) return;
+    pendingRef.current = true;
+    flush();
+  }, [itemCount, liveWorktreeIds, flush]);
+
+  const releaseAfterDrag = useCallback(() => {
+    draggingRef.current = false;
+    if (!pendingRef.current) return;
+    cancelScheduled();
+    // dnd-kit restores focus to the drag activator a frame after the drop
+    // settles; remounting first would destroy the node it is about to focus
+    // (past lesson #8478). Clear that frame before swapping the list out.
+    rafRef.current = requestAnimationFrame(() => {
+      rafRef.current = requestAnimationFrame(() => {
+        rafRef.current = null;
+        flush();
+      });
+    });
+  }, [cancelScheduled, flush]);
+
+  useDndMonitor({
+    onDragStart() {
+      draggingRef.current = true;
+      cancelScheduled();
+    },
+    onDragEnd: releaseAfterDrag,
+    onDragCancel: releaseAfterDrag,
+  });
+
+  // The keyed mount has consumed the offset. Drop it so a later natural remount
+  // — the filter empty-state branch swapping back in — doesn't restore a
+  // position from a list that no longer exists.
+  useEffect(() => {
+    if (reset.scrollTop === undefined) return;
+    setReset((prev) => (prev.key === reset.key ? { ...prev, scrollTop: undefined } : prev));
+  }, [reset]);
+
+  useEffect(() => cancelScheduled, [cancelScheduled]);
+
+  return { resetKey: reset.key, initialScrollTop: reset.scrollTop };
+}
+
+export { useSidebarVirtuosoReset };
+export type { UseSidebarVirtuosoResetParams, UseSidebarVirtuosoResetReturn };

--- a/src/components/Sidebar/useSidebarVirtuosoReset.ts
+++ b/src/components/Sidebar/useSidebarVirtuosoReset.ts
@@ -10,6 +10,12 @@ interface UseSidebarVirtuosoResetParams {
    * input value, so it moves in the same commit the list narrows.
    */
   searchQuery: string;
+  /**
+   * The uncommitted input value. Only ever compared against `searchQuery`: while
+   * the two disagree a deferred render is still owed, so the query is in motion
+   * even on a commit that changed neither the count nor the filter.
+   */
+  liveQuery: string;
   /** The live scroller element, so the pre-remount offset can be restored. */
   scrollerRef: RefObject<HTMLElement | null>;
 }
@@ -56,10 +62,20 @@ const INITIAL_STATE: ResetState = { key: 0, scrollTop: undefined };
  * is about to change again anyway. That shrink is deferred, not forgiven: it
  * stays owed and fires on the first commit the query holds still, so a deletion
  * that merely coincided with a keystroke still gets its reset.
+ *
+ * "Holds still" has to mean *settled*, not merely unchanged since the last
+ * commit. Each keystroke lands as two commits: an urgent one carrying the new
+ * input with the filtered list still stale, then the deferred one that actually
+ * narrows it. On that urgent commit the deferred query has not moved, so an
+ * unchanged-since-last-commit test reads it as quiet and pays off the previous
+ * keystroke's owed reset — one remount per keystroke, lagged by one, which is
+ * the very teardown this exemption exists to prevent. Comparing the live query
+ * against the deferred one is what identifies those commits.
  */
 function useSidebarVirtuosoReset({
   itemCount,
   searchQuery,
+  liveQuery,
   scrollerRef,
 }: UseSidebarVirtuosoResetParams): UseSidebarVirtuosoResetReturn {
   const [reset, setReset] = useState<ResetState>(INITIAL_STATE);
@@ -108,10 +124,12 @@ function useSidebarVirtuosoReset({
     prevQueryRef.current = searchQuery;
     if (prevCount === null) return;
     if (itemCount < prevCount) pendingRef.current = true;
-    // Hold while the query is still moving, but keep the shrink owed rather
-    // than dropping it: a deletion that happens to land in the same commit as
-    // a keystroke is structural, and nothing later would report it again.
-    if (searchQuery !== prevQuery) return;
+    // Hold while the query is still moving — either it moved on this commit, or
+    // a deferred render is still owed and it is about to. Keep the shrink owed
+    // rather than dropping it: a deletion that happens to land in the same
+    // commit as a keystroke is structural, and nothing later would report it
+    // again.
+    if (searchQuery !== prevQuery || liveQuery !== searchQuery) return;
     flush();
   });
 

--- a/src/components/Sidebar/useSidebarVirtuosoReset.ts
+++ b/src/components/Sidebar/useSidebarVirtuosoReset.ts
@@ -6,12 +6,10 @@ interface UseSidebarVirtuosoResetParams {
   /** Length of the flat item array backing the Virtuoso surface. */
   itemCount: number;
   /**
-   * Unfiltered live worktree ids, read from the same deferred timeline as the
-   * items. A filtered order (`dragStartOrder`) would report every search
-   * keystroke as a removal; the raw store list would run ahead of the items and
-   * report removals a render early.
+   * The query the list is actually filtered by — the deferred one, not the live
+   * input value, so it moves in the same commit the list narrows.
    */
-  liveWorktreeIds: readonly string[];
+  searchQuery: string;
   /** The live scroller element, so the pre-remount offset can be restored. */
   scrollerRef: RefObject<HTMLElement | null>;
 }
@@ -31,40 +29,48 @@ interface ResetState {
 const INITIAL_STATE: ResetState = { key: 0, scrollTop: undefined };
 
 /**
- * Replaces the sidebar's Virtuoso instance after a worktree deletion shrinks the
- * list (#12094).
+ * Replaces the sidebar's Virtuoso instance whenever the list shrinks (#12094).
  *
  * react-virtuoso keys its size and offset trees by index, not by
  * `computeItemKey` — that only steers React reconciliation. `firstItemIndex` is
  * the sole remap path and exists for prepending, `restoreStateFrom` restores the
  * measurements rather than clearing them, and `VirtuosoHandle` has no imperative
- * reset. So when the list shrinks, the trees keep describing the pre-deletion
- * layout, and the failure is self-sustaining: a row left outside the computed
- * visible range never mounts, so its ResizeObserver never fires, so its stale
- * entry is never corrected. Remounting is the only way to discard those trees.
+ * reset. So a shrink leaves the trees describing the old layout, and the failure
+ * is self-sustaining: a row left outside the computed visible range never
+ * mounts, so its ResizeObserver never fires, so its stale entry is never
+ * corrected. Remounting is the only way to discard those trees.
  *
- * The trigger is deliberately narrow. A shrink alone is far too broad — search
- * and filter narrowing shrink the list, and so does `pruneDeletedWorktrees`
- * retiring a tombstone on its own, which would yank a scrolled user to the top
- * with no action on their part. Requiring that a live worktree id also
- * disappeared isolates real deletions: a lone deletion swaps a row for a
- * tombstone card and doesn't shrink at all, while a batch collapses several
- * tombstones into one group item and does.
+ * Growth is safe — appended entries extend an already-valid prefix-sum tree —
+ * so only shrinks are worth reacting to. Correlating a shrink with the deletion
+ * that caused it was tried and abandoned: with a quick-state filter active, a
+ * deleted worktree stops matching the filter in the urgent commit (its terminals
+ * leave `useWorktreeIds` immediately) while `deferredWorktrees` still lists it,
+ * so the shrink and the id removal land in *different* commits and no
+ * single-commit correlation holds. Treating every shrink as suspect fails open
+ * instead: a needless remount costs one frame and restores its own scroll
+ * offset, where a missed one leaves the row stranded for good.
+ *
+ * The single exception is typing. Narrowing a search shrinks the list on most
+ * keystrokes, and a full teardown per keystroke would put exactly the work this
+ * file defers out of the input path (#10908) back into it — for a list the user
+ * is about to change again anyway.
  */
 function useSidebarVirtuosoReset({
   itemCount,
-  liveWorktreeIds,
+  searchQuery,
   scrollerRef,
 }: UseSidebarVirtuosoResetParams): UseSidebarVirtuosoResetReturn {
   const [reset, setReset] = useState<ResetState>(INITIAL_STATE);
   // `null` until the first commit — there is no previous layout to have
   // stranded anything, so the first pass only records a baseline.
   const prevItemCountRef = useRef<number | null>(null);
-  // Held by reference, not copied: `liveWorktreeIds` arrives from a useMemo and
-  // is never mutated in place.
-  const prevIdsRef = useRef<readonly string[]>([]);
+  const prevQueryRef = useRef(searchQuery);
   const pendingRef = useRef(false);
   const draggingRef = useRef(false);
+  // Stays set from the drop until dnd-kit has finished restoring focus. Without
+  // it a shrink landing inside that window would flush straight through, since
+  // the drag itself is already over.
+  const settlingRef = useRef(false);
   const rafRef = useRef<number | null>(null);
 
   const cancelScheduled = useCallback(() => {
@@ -75,7 +81,7 @@ function useSidebarVirtuosoReset({
   }, []);
 
   const flush = useCallback(() => {
-    if (!pendingRef.current || draggingRef.current) return;
+    if (!pendingRef.current || draggingRef.current || settlingRef.current) return;
     pendingRef.current = false;
     const scroller = scrollerRef.current;
     // No scroller means Virtuoso is already unmounted — the empty-state branch
@@ -91,29 +97,27 @@ function useSidebarVirtuosoReset({
 
   useLayoutEffect(() => {
     const prevCount = prevItemCountRef.current;
-    const prevIds = prevIdsRef.current;
+    const prevQuery = prevQueryRef.current;
     prevItemCountRef.current = itemCount;
-    prevIdsRef.current = liveWorktreeIds;
+    prevQueryRef.current = searchQuery;
     if (prevCount === null || itemCount >= prevCount) return;
-    const live = new Set(liveWorktreeIds);
-    // Membership, not counts: a removal landing alongside an addition in the
-    // same update leaves the live id count unchanged while still deleting a
-    // worktree, and the shrunk surface strands geometry all the same.
-    if (!prevIds.some((id) => !live.has(id))) return;
+    if (searchQuery !== prevQuery) return;
     pendingRef.current = true;
     flush();
-  }, [itemCount, liveWorktreeIds, flush]);
+  }, [itemCount, searchQuery, flush]);
 
   const releaseAfterDrag = useCallback(() => {
     draggingRef.current = false;
-    if (!pendingRef.current) return;
+    settlingRef.current = true;
     cancelScheduled();
     // dnd-kit restores focus to the drag activator a frame after the drop
     // settles; remounting first would destroy the node it is about to focus
-    // (past lesson #8478). Clear that frame before swapping the list out.
+    // (past lesson #8478). Hold the swap — including one that arrives inside
+    // this window — until that frame has passed.
     rafRef.current = requestAnimationFrame(() => {
       rafRef.current = requestAnimationFrame(() => {
         rafRef.current = null;
+        settlingRef.current = false;
         flush();
       });
     });
@@ -122,6 +126,7 @@ function useSidebarVirtuosoReset({
   useDndMonitor({
     onDragStart() {
       draggingRef.current = true;
+      settlingRef.current = false;
       cancelScheduled();
     },
     onDragEnd: releaseAfterDrag,


### PR DESCRIPTION
## Summary

- Deleting several worktrees at once left the sidebar rendering one fewer card than its header counted. The stranded row couldn't be scrolled to, and only a quick-state filter round trip brought it back.
- `react-virtuoso` keys its size and offset trees by index, not by `computeItemKey`, so a shrink leaves those trees describing the old layout and the failure sustains itself.
- Fixed with a new `useSidebarVirtuosoReset` hook that remounts Virtuoso on any list shrink and hands the fresh instance the scroll offset it replaced.

Resolves #12094

## Root cause

`react-virtuoso` keys its size and offset trees by index, not by `computeItemKey`. That prop only steers React's own reconciliation. `firstItemIndex` is the sole remap path Virtuoso exposes, and it exists for prepending. `restoreStateFrom` restores measurements rather than clearing them, and `VirtuosoHandle` has no imperative reset at all.

So when the list shrinks, the trees still describe the pre-deletion layout, and the failure is self-sustaining: a row that lands outside the (stale) computed visible range never mounts, so its `ResizeObserver` never fires, so its stale entry is never corrected. The quick-state filter round trip only ever worked by accident: an empty result takes a different JSX branch and unmounts Virtuoso outright, which is the one thing that actually clears the trees.

## Why only bulk deletions trigger it

A single deletion swaps a row for a tombstone card, so the item count never changes. Two or more collapse into one `deletedWorktreeGroup` (`DELETED_WORKTREE_GROUP_THRESHOLD = 2`), which is a real one-tick shrink in the list.

## The fix

`useSidebarVirtuosoReset` bumps a generation key that both `<Virtuoso>` call sites mount against, which discards the stale trees, and passes the fresh instance the scroll offset the old one had via a transient `initialScrollTop`.

The trigger is any shrink, not one correlated with a deletion specifically. Correlating the two was tried and abandoned: with a quick-state filter active, a deleted worktree stops matching the filter in the urgent commit (its terminals leave `useWorktreeIds` immediately), while `deferredWorktrees` still lists it. The shrink and the id removal land in different commits, so no single-commit correlation holds. Treating every shrink as suspect fails open instead: a needless remount costs a frame and restores its own scroll offset, where a missed one strands the row for good.

Typing is the one exemption. Narrowing a search shrinks the list on most keystrokes, and a teardown per keystroke would put the work #10908 deliberately deferred out of the input path back into it. That shrink is deferred rather than forgiven: it stays owed and fires on the first commit the query holds still, so a deletion that merely coincided with a keystroke still gets its reset.

A reset that lands during a drag, or after the drop but before dnd-kit restores focus to the activator, is held until that frame has passed (past lesson: #8478).

## Changes

- `src/components/Sidebar/useSidebarVirtuosoReset.ts`: new hook, generation key + transient scroll offset.
- `src/components/Sidebar/SidebarContent.tsx`: wire the hook into both `<Virtuoso>` call sites.
- `src/components/Sidebar/__tests__/useSidebarVirtuosoReset.test.tsx`: unit tests for the hook's transitions.
- `src/components/Sidebar/__tests__/SidebarContent.virtuosoReset.test.ts`: source-contract suite pinning both call sites' wiring.

## Testing

240 tests across 10 sidebar suites pass. eslint and prettier are clean on the changed files. jsdom can't drive Virtuoso's real geometry, so the hook's transitions are unit-tested directly, and the source-contract suite pins both call sites' wiring rather than relying on a DOM assertion that jsdom can't back up.

## Known limitation

A background agent-state transition while a quick-state or facet filter is active now remounts the list, which drops focus if it was parked on a control inside a row. Keyboard navigation is unaffected: the `aria-activedescendant` tab stop lives on the `role="grid"` container, outside Virtuoso. Guarding the reset on focus was considered and rejected, since it would defer the actual fix whenever the user's focus happens to be in the sidebar.
