### PR TITLE
fix(panels): land duplicated panel next to its source

### DIFF
--- a/shared/types/addPanelOptions.ts
+++ b/shared/types/addPanelOptions.ts
@@ -35,6 +35,26 @@ export interface AddPanelOptionsBase {
   worktreeIdSource?: "explicit" | "inferred";
   cwd?: string;
   location?: PanelLocation;
+  /**
+   * Opt-in placement hint: land the new panel immediately after this one
+   * instead of at the end. Resolved against live store state at commit time,
+   * never precomputed as a numeric index — `addPanel` has async gaps (agent
+   * settings IPC, project-store resolution) during which the source can be
+   * reordered, re-homed, or trashed.
+   *
+   * Honored only when the source shares the new panel's rendered scope
+   * (`panelMatchesWorktreeScope` at the resolved grid/dock location). A source
+   * in an explicit tab group anchors to that group's rendered slot — its
+   * earliest member — because both grid and dock emit a group at that position;
+   * anchoring to a later member would drop the copy past the panels rendered in
+   * between. The copy stays ungrouped either way: joining the source's group is
+   * `addTabForPanel`'s job, not this hint's.
+   *
+   * Falls back to the ordinary append whenever the hint can't be honored
+   * (absent, out of scope, source gone) and is ignored inside hydration/spawn
+   * batches, whose `panelIds` append is deferred to flush.
+   */
+  insertAfterId?: string;
   /** If provided, request a stable ID when spawning a new backend process */
   requestedId?: string;
   /** If provided, reconnect to existing backend process instead of spawning */

--- a/src/services/actions/definitions/__tests__/terminalSpawnActions.test.ts
+++ b/src/services/actions/definitions/__tests__/terminalSpawnActions.test.ts
@@ -213,6 +213,21 @@ describe("terminal.duplicate (copy) suffix", () => {
     expect(addPanel.mock.calls[0]![0]).not.toHaveProperty("insertAfterId");
   });
 
+  it("terminal.duplicate does not anchor the last-closed reopen fallback", async () => {
+    const addPanel = vi.fn().mockResolvedValue("p-new");
+    setPanelState({
+      panels: [],
+      lastClosedConfig: { kind: "terminal", command: "bash", cwd: "/repo" },
+      addPanel,
+    });
+    const run = setupActions();
+
+    await run("terminal.duplicate");
+
+    expect(addPanel).toHaveBeenCalledTimes(1);
+    expect(addPanel.mock.calls[0]![0]).not.toHaveProperty("insertAfterId");
+  });
+
   it("terminal.duplicate preserves spawnedBy for MCP-origin duplicated agent panels", async () => {
     const addPanel = vi.fn().mockResolvedValue(undefined);
     setPanelState({

--- a/src/services/actions/definitions/__tests__/terminalSpawnActions.test.ts
+++ b/src/services/actions/definitions/__tests__/terminalSpawnActions.test.ts
@@ -167,6 +167,52 @@ describe("terminal.duplicate (copy) suffix", () => {
     );
   });
 
+  it("terminal.duplicate asks the store to land the copy after its source (#12095)", async () => {
+    const addPanel = vi.fn().mockResolvedValue(undefined);
+    setPanelState({
+      focusedId: "p2",
+      panels: [
+        { id: "p1", location: "grid", kind: "terminal", title: "One" },
+        { id: "p2", location: "grid", kind: "terminal", title: "Two" },
+        { id: "p3", location: "grid", kind: "terminal", title: "Three" },
+      ],
+      addPanel,
+    });
+    const run = setupActions();
+
+    await run("terminal.duplicate");
+
+    expect(addPanel).toHaveBeenCalledWith(expect.objectContaining({ insertAfterId: "p2" }));
+  });
+
+  it("terminal.duplicate anchors on an explicitly targeted panel, not the focused one", async () => {
+    const addPanel = vi.fn().mockResolvedValue(undefined);
+    setPanelState({
+      focusedId: "p1",
+      panels: [
+        { id: "p1", location: "grid", kind: "terminal", title: "One" },
+        { id: "p2", location: "grid", kind: "terminal", title: "Two" },
+      ],
+      addPanel,
+    });
+    const run = setupActions();
+
+    await run("terminal.duplicate", { terminalId: "p2" });
+
+    expect(addPanel).toHaveBeenCalledWith(expect.objectContaining({ insertAfterId: "p2" }));
+  });
+
+  it("terminal.duplicate does not anchor the empty-state fallback terminal", async () => {
+    const addPanel = vi.fn().mockResolvedValue("p-new");
+    setPanelState({ panels: [], addPanel });
+    const run = setupActions();
+
+    await run("terminal.duplicate");
+
+    expect(addPanel).toHaveBeenCalledTimes(1);
+    expect(addPanel.mock.calls[0]![0]).not.toHaveProperty("insertAfterId");
+  });
+
   it("terminal.duplicate preserves spawnedBy for MCP-origin duplicated agent panels", async () => {
     const addPanel = vi.fn().mockResolvedValue(undefined);
     setPanelState({

--- a/src/services/actions/definitions/terminalSpawnActions.ts
+++ b/src/services/actions/definitions/terminalSpawnActions.ts
@@ -142,6 +142,11 @@ export function registerTerminalSpawnActions(
         if (focusPolicy) {
           options.focusPolicy = focusPolicy;
         }
+        // Land the copy directly after the panel it was copied from instead of
+        // at the end of the list (#12095). Passed as an id, not a position:
+        // `buildPanelDuplicateOptions` above can await agent-settings IPC, so
+        // any index computed here would be stale by the time the store commits.
+        options.insertAfterId = targetId;
         await state.addPanel(options);
       } else if (nonTrashed.length === 0) {
         const lastClosed = state.lastClosedConfig;

--- a/src/store/slices/panelRegistry/__tests__/addPanelInsertAfter.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/addPanelInsertAfter.test.ts
@@ -317,18 +317,25 @@ describe("addPanel insertAfterId (#12095)", () => {
       expect(dockRenderOrder("wt-A")).toEqual([["bp"], ["outsider"], ["src"], ["copy"]]);
     });
 
-    it("skips a group member that is no longer in scope when picking the anchor", async () => {
-      seed("stale", "wt-A", "trash");
+    it("skips a group member that is only optimistically closed", async () => {
+      // `closing` still reads as a live grid panel — only `trashedTerminals`
+      // knows it is on its way out, which is the set both renderers filter on.
+      seed("closing", "wt-A");
       seed("g1", "wt-A");
       seed("outsider", "wt-A");
       seed("g2", "wt-A");
-      usePanelStore.getState().createTabGroup("grid", "wt-A", ["stale", "g1", "g2"]);
+      usePanelStore.getState().createTabGroup("grid", "wt-A", ["closing", "g1", "g2"]);
+      usePanelStore.setState({
+        trashedTerminals: new Map([
+          ["closing", { id: "closing", expiresAt: Date.now() + 60_000, originalLocation: "grid" }],
+        ]),
+      });
 
       await addBrowser("copy", { worktreeId: "wt-A", insertAfterId: "g2" });
 
-      // `stale` is trashed, so the group renders at `g1` and the copy follows it.
-      expect(panelIds()).toEqual(["stale", "g1", "copy", "outsider", "g2"]);
-      expect(bucket("wt-A")).toEqual(["stale", "g1", "copy", "outsider", "g2"]);
+      // The group renders at `g1`, so the copy follows it — not `closing`.
+      expect(panelIds()).toEqual(["closing", "g1", "copy", "outsider", "g2"]);
+      expect(bucket("wt-A")).toEqual(["closing", "g1", "copy", "outsider", "g2"]);
     });
 
     it("ignores a group pinned to another worktree and anchors on the source", async () => {
@@ -349,16 +356,21 @@ describe("addPanel insertAfterId (#12095)", () => {
     it("resolves the anchor in each structure independently", async () => {
       // A cross-worktree transfer appends to the destination bucket without
       // moving the flat id, so bucket order is not flat order projected by
-      // worktree. Each structure must anchor on what it sees.
-      seed("t1", "wt-A");
-      seed("t2", "wt-A");
-      seed("t3", "wt-A");
-      usePanelStore.setState({ panelIdsByWorktreeId: { "wt-A": ["t2", "t3", "t1"] } });
+      // worktree. With a two-member group the structures pick DIFFERENT
+      // members as the group's slot, which is the whole point of resolving an
+      // anchor set rather than sharing one id.
+      seed("g1", "wt-A");
+      seed("outsider", "wt-A");
+      seed("g2", "wt-A");
+      usePanelStore.setState({ panelIdsByWorktreeId: { "wt-A": ["g2", "outsider", "g1"] } });
+      usePanelStore.getState().createTabGroup("grid", "wt-A", ["g1", "g2"]);
 
-      await addBrowser("copy", { worktreeId: "wt-A", insertAfterId: "t1" });
+      await addBrowser("copy", { worktreeId: "wt-A", insertAfterId: "g2" });
 
-      expect(panelIds()).toEqual(["t1", "copy", "t2", "t3"]);
-      expect(bucket("wt-A")).toEqual(["t2", "t3", "t1", "copy"]);
+      // Flat order renders the group at `g1`; the bucket's own order puts `g2`
+      // first. Sharing one anchor would land the copy at the bucket's tail.
+      expect(panelIds()).toEqual(["g1", "copy", "outsider", "g2"]);
+      expect(bucket("wt-A")).toEqual(["g2", "copy", "outsider", "g1"]);
     });
 
     it("keeps a worktree-less dock source adjacent in the __none__ bucket", async () => {

--- a/src/store/slices/panelRegistry/__tests__/addPanelInsertAfter.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/addPanelInsertAfter.test.ts
@@ -72,7 +72,10 @@ beforeEach(() => {
 });
 
 const { usePanelStore } = await import("../../../panelStore");
-const { addToWorktreeIndex } = await import("../worktreeIndex");
+const { addToWorktreeIndex, collectUngroupedCandidateIds, NO_WORKTREE } =
+  await import("../worktreeIndex");
+const { buildDockRenderItems } = await import("@/components/Layout/dockRenderItems");
+const { saveNormalized } = await import("../persistence");
 
 /**
  * Seed a committed panel without going through `addPanel`, so a test's
@@ -106,15 +109,14 @@ function bucket(worktreeId: string): string[] {
   return usePanelStore.getState().panelIdsByWorktreeId[worktreeId] ?? [];
 }
 
+interface AddOpts {
+  worktreeId?: string;
+  location?: "grid" | "dock";
+  insertAfterId?: string;
+}
+
 /** Add a non-PTY panel through the real live commit branch. */
-async function addBrowser(
-  id: string,
-  opts: {
-    worktreeId?: string;
-    location?: "grid" | "dock";
-    insertAfterId?: string;
-  }
-): Promise<void> {
+async function addBrowser(id: string, opts: AddOpts): Promise<void> {
   await usePanelStore.getState().addPanel({
     kind: "browser",
     requestedId: id,
@@ -124,6 +126,39 @@ async function addBrowser(
     focusPolicy: "preserve",
     insertAfterId: opts.insertAfterId,
   });
+}
+
+/** Add a PTY panel through the real live commit branch. */
+async function addTerminal(id: string, opts: AddOpts): Promise<void> {
+  await usePanelStore.getState().addPanel({
+    kind: "terminal",
+    requestedId: id,
+    cwd: "/tmp",
+    location: opts.location ?? "grid",
+    worktreeId: opts.worktreeId,
+    focusPolicy: "preserve",
+    insertAfterId: opts.insertAfterId,
+  });
+}
+
+/**
+ * Ordered dock panels the way `ContentDock` derives them, so a placement can be
+ * checked against what the rail actually renders rather than only the store.
+ */
+function dockRenderOrder(worktreeId: string | undefined): string[][] {
+  const state = usePanelStore.getState();
+  const ordered = [];
+  for (const id of collectUngroupedCandidateIds(
+    state.panelIds,
+    state.panelIdsByWorktreeId,
+    worktreeId
+  )) {
+    const panel = state.panelsById[id];
+    if (panel && panel.location === "dock" && !state.trashedTerminals.has(id)) ordered.push(panel);
+  }
+  return buildDockRenderItems(ordered, state.tabGroups, worktreeId ?? null).map(
+    (item) => item.group.panelIds
+  );
 }
 
 describe("addPanel insertAfterId (#12095)", () => {
@@ -261,6 +296,116 @@ describe("addPanel insertAfterId (#12095)", () => {
 
       expect(panelIds()).toEqual(["t1", "copy"]);
       expect(bucket("wt-A")).toEqual(["t1", "copy"]);
+    });
+  });
+
+  describe("tab-group anchoring the renderers actually use", () => {
+    it("anchors on the group's earliest PTY member in the dock, not a non-PTY one", async () => {
+      // The dock resolves explicit groups PTY-only and chips every non-PTY
+      // member standalone in place (#11332), so a browser member is not the
+      // group's rendered slot even when it comes first.
+      await addBrowser("bp", { worktreeId: "wt-A", location: "dock" });
+      await addTerminal("outsider", { worktreeId: "wt-A", location: "dock" });
+      await addTerminal("src", { worktreeId: "wt-A", location: "dock" });
+      usePanelStore.getState().createTabGroup("dock", "wt-A", ["bp", "src"]);
+
+      expect(dockRenderOrder("wt-A")).toEqual([["bp"], ["outsider"], ["src"]]);
+
+      await addTerminal("copy", { worktreeId: "wt-A", location: "dock", insertAfterId: "src" });
+
+      expect(panelIds()).toEqual(["bp", "outsider", "src", "copy"]);
+      expect(dockRenderOrder("wt-A")).toEqual([["bp"], ["outsider"], ["src"], ["copy"]]);
+    });
+
+    it("skips a group member that is no longer in scope when picking the anchor", async () => {
+      seed("stale", "wt-A", "trash");
+      seed("g1", "wt-A");
+      seed("outsider", "wt-A");
+      seed("g2", "wt-A");
+      usePanelStore.getState().createTabGroup("grid", "wt-A", ["stale", "g1", "g2"]);
+
+      await addBrowser("copy", { worktreeId: "wt-A", insertAfterId: "g2" });
+
+      // `stale` is trashed, so the group renders at `g1` and the copy follows it.
+      expect(panelIds()).toEqual(["stale", "g1", "copy", "outsider", "g2"]);
+      expect(bucket("wt-A")).toEqual(["stale", "g1", "copy", "outsider", "g2"]);
+    });
+
+    it("ignores a group pinned to another worktree and anchors on the source", async () => {
+      seed("other", "wt-A");
+      seed("outsider", "wt-A");
+      seed("src", "wt-A");
+      // A repaired/corrupt group scoped to wt-B is not rendered in wt-A at all,
+      // so it must not move the copy either.
+      usePanelStore.getState().createTabGroup("grid", "wt-B", ["other", "src"]);
+
+      await addBrowser("copy", { worktreeId: "wt-A", insertAfterId: "src" });
+
+      expect(panelIds()).toEqual(["other", "outsider", "src", "copy"]);
+    });
+  });
+
+  describe("structures that disagree on order", () => {
+    it("resolves the anchor in each structure independently", async () => {
+      // A cross-worktree transfer appends to the destination bucket without
+      // moving the flat id, so bucket order is not flat order projected by
+      // worktree. Each structure must anchor on what it sees.
+      seed("t1", "wt-A");
+      seed("t2", "wt-A");
+      seed("t3", "wt-A");
+      usePanelStore.setState({ panelIdsByWorktreeId: { "wt-A": ["t2", "t3", "t1"] } });
+
+      await addBrowser("copy", { worktreeId: "wt-A", insertAfterId: "t1" });
+
+      expect(panelIds()).toEqual(["t1", "copy", "t2", "t3"]);
+      expect(bucket("wt-A")).toEqual(["t2", "t3", "t1", "copy"]);
+    });
+
+    it("keeps a worktree-less dock source adjacent in the __none__ bucket", async () => {
+      seed("global1", undefined, "dock");
+      seed("global2", undefined, "dock");
+
+      await addBrowser("copy", { location: "dock", insertAfterId: "global1" });
+
+      expect(panelIds()).toEqual(["global1", "copy", "global2"]);
+      expect(usePanelStore.getState().panelIdsByWorktreeId[NO_WORKTREE]).toEqual([
+        "global1",
+        "copy",
+        "global2",
+      ]);
+    });
+  });
+
+  describe("hydration batches", () => {
+    it("ignores the hint while a batch defers the panelIds append", async () => {
+      seed("t1", "wt-A");
+      seed("t2", "wt-A");
+
+      const { beginHydrationBatch, flushHydrationBatch } = usePanelStore.getState();
+      const token = beginHydrationBatch();
+      await addBrowser("copy", { worktreeId: "wt-A", insertAfterId: "t1" });
+
+      // The bucket commits eagerly during a batch; it must not honor the hint,
+      // or it would disagree with the plain append the flush performs.
+      expect(bucket("wt-A")).toEqual(["t1", "t2", "copy"]);
+
+      flushHydrationBatch(token);
+
+      expect(panelIds()).toEqual(["t1", "t2", "copy"]);
+      expect(bucket("wt-A")).toEqual(["t1", "t2", "copy"]);
+    });
+  });
+
+  describe("persistence", () => {
+    it("persists the anchored order, not the append order", async () => {
+      seed("t1", "wt-A");
+      seed("t2", "wt-A");
+      vi.mocked(saveNormalized).mockClear();
+
+      await addBrowser("copy", { worktreeId: "wt-A", insertAfterId: "t1" });
+
+      const lastCall = vi.mocked(saveNormalized).mock.calls.at(-1);
+      expect(lastCall?.[1]).toEqual(["t1", "copy", "t2"]);
     });
   });
 

--- a/src/store/slices/panelRegistry/__tests__/addPanelInsertAfter.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/addPanelInsertAfter.test.ts
@@ -1,0 +1,302 @@
+/**
+ * Tests for `AddPanelOptions.insertAfterId` (#12095).
+ *
+ * A duplicated panel must land directly after the panel it was copied from
+ * rather than at the end of the list. The hint is resolved inside the commit
+ * `set()`, so these tests assert both ordered structures — the flat `panelIds`
+ * (which `getTabGroups` and the dock read) and the per-worktree bucket (which
+ * `gridTerminals` iterates) — since an append in either one puts the copy in a
+ * different place than the other.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { BrowserPanelData } from "@shared/types/panel";
+
+vi.mock("@/clients", () => ({
+  terminalClient: {
+    spawn: vi.fn(),
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn().mockResolvedValue(undefined),
+    trash: vi.fn().mockResolvedValue(undefined),
+    restore: vi.fn().mockResolvedValue(undefined),
+    onData: vi.fn(),
+    onExit: vi.fn(),
+    onAgentStateChanged: vi.fn(),
+  },
+  appClient: {
+    setState: vi.fn().mockResolvedValue(undefined),
+  },
+  projectClient: {
+    getTerminals: vi.fn().mockResolvedValue([]),
+    setTerminals: vi.fn().mockResolvedValue(undefined),
+    setTabGroups: vi.fn().mockResolvedValue(undefined),
+    getSettings: vi.fn().mockResolvedValue({}),
+  },
+  globalEnvClient: {
+    get: vi.fn().mockResolvedValue({}),
+    set: vi.fn().mockResolvedValue(undefined),
+    invalidate: vi.fn(),
+  },
+  agentSettingsClient: {
+    get: vi.fn().mockResolvedValue({}),
+  },
+  systemClient: {
+    getAppMetrics: vi.fn().mockResolvedValue({ totalMemoryMB: 512 }),
+  },
+}));
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: {
+    cleanup: vi.fn(),
+    applyRendererPolicy: vi.fn(),
+    onPanelBackgrounded: vi.fn(),
+    destroy: vi.fn(),
+    prewarmTerminal: vi.fn(),
+    setInputLocked: vi.fn(),
+    sendPtyResize: vi.fn(),
+    waitForAttachSettled: vi.fn().mockResolvedValue(undefined),
+    get: vi.fn(() => null),
+  },
+}));
+
+vi.mock("../persistence", async () => {
+  const actual = await vi.importActual<typeof import("../persistence")>("../persistence");
+  return { ...actual, saveNormalized: vi.fn() };
+});
+
+beforeEach(() => {
+  (globalThis as { window?: unknown }).window = {
+    electron: { globalEnv: { get: vi.fn().mockResolvedValue({}) } },
+  };
+});
+
+const { usePanelStore } = await import("../../../panelStore");
+const { addToWorktreeIndex } = await import("../worktreeIndex");
+
+/**
+ * Seed a committed panel without going through `addPanel`, so a test's
+ * starting order is exact. Mirrors the live commit: flat array plus bucket.
+ */
+function seed(
+  id: string,
+  worktreeId: string | undefined,
+  location: "grid" | "dock" | "trash" = "grid"
+): void {
+  const panel: BrowserPanelData = {
+    id,
+    title: id,
+    kind: "browser",
+    location,
+    worktreeId,
+    isVisible: location === "grid",
+  };
+  usePanelStore.setState((state) => ({
+    panelsById: { ...state.panelsById, [id]: panel },
+    panelIds: [...state.panelIds, id],
+    panelIdsByWorktreeId: addToWorktreeIndex(state.panelIdsByWorktreeId, worktreeId, id),
+  }));
+}
+
+function panelIds(): string[] {
+  return usePanelStore.getState().panelIds;
+}
+
+function bucket(worktreeId: string): string[] {
+  return usePanelStore.getState().panelIdsByWorktreeId[worktreeId] ?? [];
+}
+
+/** Add a non-PTY panel through the real live commit branch. */
+async function addBrowser(
+  id: string,
+  opts: {
+    worktreeId?: string;
+    location?: "grid" | "dock";
+    insertAfterId?: string;
+  }
+): Promise<void> {
+  await usePanelStore.getState().addPanel({
+    kind: "browser",
+    requestedId: id,
+    cwd: "",
+    location: opts.location ?? "grid",
+    worktreeId: opts.worktreeId,
+    focusPolicy: "preserve",
+    insertAfterId: opts.insertAfterId,
+  });
+}
+
+describe("addPanel insertAfterId (#12095)", () => {
+  beforeEach(async () => {
+    const { reset } = usePanelStore.getState();
+    await reset();
+  });
+
+  describe("non-PTY live commit", () => {
+    it("lands the copy directly after its source in both ordered structures", async () => {
+      seed("t1", "wt-A");
+      seed("t2", "wt-A");
+      seed("t3", "wt-A");
+
+      await addBrowser("copy", { worktreeId: "wt-A", insertAfterId: "t1" });
+
+      expect(panelIds()).toEqual(["t1", "copy", "t2", "t3"]);
+      expect(bucket("wt-A")).toEqual(["t1", "copy", "t2", "t3"]);
+    });
+
+    it("appends when the hint is omitted", async () => {
+      seed("t1", "wt-A");
+      seed("t2", "wt-A");
+
+      await addBrowser("copy", { worktreeId: "wt-A" });
+
+      expect(panelIds()).toEqual(["t1", "t2", "copy"]);
+      expect(bucket("wt-A")).toEqual(["t1", "t2", "copy"]);
+    });
+
+    it("keeps the copy adjacent in the dock, skipping interleaved grid panels", async () => {
+      seed("d1", "wt-A", "dock");
+      seed("g1", "wt-A", "grid");
+      seed("d2", "wt-A", "dock");
+
+      await addBrowser("copy", { worktreeId: "wt-A", location: "dock", insertAfterId: "d1" });
+
+      expect(panelIds()).toEqual(["d1", "copy", "g1", "d2"]);
+      expect(bucket("wt-A")).toEqual(["d1", "copy", "g1", "d2"]);
+    });
+
+    it("ignores panels from another worktree when placing the copy", async () => {
+      seed("a1", "wt-A");
+      seed("b1", "wt-B");
+      seed("a2", "wt-A");
+
+      await addBrowser("copy", { worktreeId: "wt-A", insertAfterId: "a1" });
+
+      expect(panelIds()).toEqual(["a1", "copy", "b1", "a2"]);
+      expect(bucket("wt-A")).toEqual(["a1", "copy", "a2"]);
+      expect(bucket("wt-B")).toEqual(["b1"]);
+    });
+  });
+
+  describe("tab-group anchoring", () => {
+    it("anchors to the group's rendered slot when the source is a later member", async () => {
+      // A grid group renders at its EARLIEST member's position, so inserting
+      // after the active (later) member would drop the copy past `outsider`.
+      seed("g1", "wt-A");
+      seed("outsider", "wt-A");
+      seed("g2", "wt-A");
+      usePanelStore.getState().createTabGroup("grid", "wt-A", ["g1", "g2"]);
+
+      await addBrowser("copy", { worktreeId: "wt-A", insertAfterId: "g2" });
+
+      expect(panelIds()).toEqual(["g1", "copy", "outsider", "g2"]);
+      expect(bucket("wt-A")).toEqual(["g1", "copy", "outsider", "g2"]);
+      expect(
+        usePanelStore
+          .getState()
+          .getTabGroups("grid", "wt-A")
+          .map((g) => g.panelIds)
+      ).toEqual([["g1", "g2"], ["copy"], ["outsider"]]);
+    });
+
+    it("leaves the copy ungrouped rather than folding it into the source's group", async () => {
+      seed("g1", "wt-A");
+      seed("g2", "wt-A");
+      usePanelStore.getState().createTabGroup("grid", "wt-A", ["g1", "g2"]);
+
+      await addBrowser("copy", { worktreeId: "wt-A", insertAfterId: "g1" });
+
+      const groups = usePanelStore.getState().getTabGroups("grid", "wt-A");
+      const explicit = groups.find((g) => g.panelIds.length > 1);
+      expect(explicit?.panelIds).toEqual(["g1", "g2"]);
+      expect(groups.map((g) => g.panelIds)).toEqual([["g1", "g2"], ["copy"]]);
+    });
+  });
+
+  describe("fallbacks to append", () => {
+    it("appends when the source sits on the other surface", async () => {
+      seed("d1", "wt-A", "dock");
+      seed("g1", "wt-A", "grid");
+
+      await addBrowser("copy", { worktreeId: "wt-A", location: "grid", insertAfterId: "d1" });
+
+      expect(panelIds()).toEqual(["d1", "g1", "copy"]);
+      expect(bucket("wt-A")).toEqual(["d1", "g1", "copy"]);
+    });
+
+    it("appends when the source belongs to another worktree", async () => {
+      seed("a1", "wt-A");
+      seed("b1", "wt-B");
+
+      await addBrowser("copy", { worktreeId: "wt-B", insertAfterId: "a1" });
+
+      expect(panelIds()).toEqual(["a1", "b1", "copy"]);
+      expect(bucket("wt-B")).toEqual(["b1", "copy"]);
+      expect(bucket("wt-A")).toEqual(["a1"]);
+    });
+
+    it("appends when the source was trashed before the commit", async () => {
+      seed("t1", "wt-A", "trash");
+      seed("t2", "wt-A");
+
+      await addBrowser("copy", { worktreeId: "wt-A", insertAfterId: "t1" });
+
+      expect(panelIds()).toEqual(["t1", "t2", "copy"]);
+      expect(bucket("wt-A")).toEqual(["t1", "t2", "copy"]);
+    });
+
+    it("appends when the source id no longer resolves", async () => {
+      seed("t1", "wt-A");
+
+      await addBrowser("copy", { worktreeId: "wt-A", insertAfterId: "gone" });
+
+      expect(panelIds()).toEqual(["t1", "copy"]);
+      expect(bucket("wt-A")).toEqual(["t1", "copy"]);
+    });
+
+    it("appends when the hint points at the panel being created", async () => {
+      seed("t1", "wt-A");
+
+      await addBrowser("copy", { worktreeId: "wt-A", insertAfterId: "copy" });
+
+      expect(panelIds()).toEqual(["t1", "copy"]);
+      expect(bucket("wt-A")).toEqual(["t1", "copy"]);
+    });
+  });
+
+  describe("PTY live commit", () => {
+    it("lands a duplicated terminal directly after its source", async () => {
+      seed("t1", "wt-A");
+      seed("t2", "wt-A");
+
+      await usePanelStore.getState().addPanel({
+        kind: "terminal",
+        requestedId: "copy",
+        cwd: "/tmp",
+        location: "grid",
+        worktreeId: "wt-A",
+        focusPolicy: "preserve",
+        insertAfterId: "t1",
+      });
+
+      expect(panelIds()).toEqual(["t1", "copy", "t2"]);
+      expect(bucket("wt-A")).toEqual(["t1", "copy", "t2"]);
+    });
+
+    it("appends a terminal when no hint is given", async () => {
+      seed("t1", "wt-A");
+
+      await usePanelStore.getState().addPanel({
+        kind: "terminal",
+        requestedId: "fresh",
+        cwd: "/tmp",
+        location: "grid",
+        worktreeId: "wt-A",
+        focusPolicy: "preserve",
+      });
+
+      expect(panelIds()).toEqual(["t1", "fresh"]);
+      expect(bucket("wt-A")).toEqual(["t1", "fresh"]);
+    });
+  });
+});

--- a/src/store/slices/panelRegistry/__tests__/worktreeIndex.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/worktreeIndex.test.ts
@@ -45,6 +45,38 @@ describe("worktreeIndex", () => {
       expect(after["wt-B"]).toBe(wtBBucket);
       expect(after["wt-A"]).not.toBe(before["wt-A"]);
     });
+
+    it("splices directly after the anchor when one is given (#12095)", () => {
+      const next = addToWorktreeIndex(
+        { "wt-A": ["panel-1", "panel-2", "panel-3"] },
+        "wt-A",
+        "copy",
+        "panel-1"
+      );
+      expect(next).toEqual({ "wt-A": ["panel-1", "copy", "panel-2", "panel-3"] });
+    });
+
+    it("appends when the anchor is the last entry", () => {
+      const next = addToWorktreeIndex({ "wt-A": ["panel-1"] }, "wt-A", "copy", "panel-1");
+      expect(next).toEqual({ "wt-A": ["panel-1", "copy"] });
+    });
+
+    it("falls back to appending when the anchor is not in the bucket", () => {
+      const next = addToWorktreeIndex({ "wt-A": ["panel-1"] }, "wt-A", "copy", "elsewhere");
+      expect(next).toEqual({ "wt-A": ["panel-1", "copy"] });
+    });
+
+    it("keeps other buckets reference-stable across an anchored insert", () => {
+      const wtBBucket = ["panel-2"];
+      const before: PanelIdsByWorktreeId = { "wt-A": ["panel-1"], "wt-B": wtBBucket };
+      const after = addToWorktreeIndex(before, "wt-A", "copy", "panel-1");
+      expect(after["wt-B"]).toBe(wtBBucket);
+    });
+
+    it("creates the bucket when anchored into an empty index", () => {
+      const next = addToWorktreeIndex({}, "wt-A", "copy", "panel-1");
+      expect(next).toEqual({ "wt-A": ["copy"] });
+    });
   });
 
   describe("removeFromWorktreeIndex", () => {

--- a/src/store/slices/panelRegistry/__tests__/worktreeIndex.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/worktreeIndex.test.ts
@@ -51,30 +51,70 @@ describe("worktreeIndex", () => {
         { "wt-A": ["panel-1", "panel-2", "panel-3"] },
         "wt-A",
         "copy",
-        "panel-1"
+        ["panel-1"]
       );
       expect(next).toEqual({ "wt-A": ["panel-1", "copy", "panel-2", "panel-3"] });
     });
 
     it("appends when the anchor is the last entry", () => {
-      const next = addToWorktreeIndex({ "wt-A": ["panel-1"] }, "wt-A", "copy", "panel-1");
+      const next = addToWorktreeIndex({ "wt-A": ["panel-1"] }, "wt-A", "copy", ["panel-1"]);
       expect(next).toEqual({ "wt-A": ["panel-1", "copy"] });
     });
 
-    it("falls back to appending when the anchor is not in the bucket", () => {
-      const next = addToWorktreeIndex({ "wt-A": ["panel-1"] }, "wt-A", "copy", "elsewhere");
+    it("falls back to appending when no anchor is in the bucket", () => {
+      const next = addToWorktreeIndex({ "wt-A": ["panel-1"] }, "wt-A", "copy", ["elsewhere"]);
       expect(next).toEqual({ "wt-A": ["panel-1", "copy"] });
     });
 
-    it("keeps other buckets reference-stable across an anchored insert", () => {
+    it("anchors on whichever candidate comes first in THIS bucket", () => {
+      // The bucket order deliberately differs from the order the ids are
+      // passed in: a cross-worktree transfer appends to the destination bucket
+      // without moving the flat id, so the anchor must be resolved here.
+      const next = addToWorktreeIndex(
+        { "wt-A": ["panel-3", "panel-1", "panel-2"] },
+        "wt-A",
+        "copy",
+        ["panel-1", "panel-3"]
+      );
+      expect(next).toEqual({ "wt-A": ["panel-3", "copy", "panel-1", "panel-2"] });
+    });
+
+    it("skips candidates missing from the bucket", () => {
+      const next = addToWorktreeIndex({ "wt-A": ["panel-1", "panel-2"] }, "wt-A", "copy", [
+        "gone",
+        "panel-1",
+      ]);
+      expect(next).toEqual({ "wt-A": ["panel-1", "copy", "panel-2"] });
+    });
+
+    it("anchors into the __none__ bucket for worktree-less panels", () => {
+      const next = addToWorktreeIndex(
+        { [NO_WORKTREE]: ["global-1", "global-2"] },
+        undefined,
+        "copy",
+        ["global-1"]
+      );
+      expect(next).toEqual({ [NO_WORKTREE]: ["global-1", "copy", "global-2"] });
+    });
+
+    it("still no-ops when the panel is already present, anchor or not", () => {
+      const before: PanelIdsByWorktreeId = { "wt-A": ["panel-1", "copy"] };
+      expect(addToWorktreeIndex(before, "wt-A", "copy", ["panel-1"])).toBe(before);
+    });
+
+    it("keeps other buckets reference-stable and leaves the source bucket untouched", () => {
       const wtBBucket = ["panel-2"];
-      const before: PanelIdsByWorktreeId = { "wt-A": ["panel-1"], "wt-B": wtBBucket };
-      const after = addToWorktreeIndex(before, "wt-A", "copy", "panel-1");
+      const wtABucket = ["panel-1", "panel-3"];
+      const before: PanelIdsByWorktreeId = { "wt-A": wtABucket, "wt-B": wtBBucket };
+      const after = addToWorktreeIndex(before, "wt-A", "copy", ["panel-1"]);
       expect(after["wt-B"]).toBe(wtBBucket);
+      expect(after["wt-A"]).not.toBe(wtABucket);
+      expect(wtABucket).toEqual(["panel-1", "panel-3"]);
+      expect(after["wt-A"]).toEqual(["panel-1", "copy", "panel-3"]);
     });
 
     it("creates the bucket when anchored into an empty index", () => {
-      const next = addToWorktreeIndex({}, "wt-A", "copy", "panel-1");
+      const next = addToWorktreeIndex({}, "wt-A", "copy", ["panel-1"]);
       expect(next).toEqual({ "wt-A": ["copy"] });
     });
   });

--- a/src/store/slices/panelRegistry/addPanel.ts
+++ b/src/store/slices/panelRegistry/addPanel.ts
@@ -1,6 +1,14 @@
 import type { TerminalRuntimeStatus } from "@/types";
 import type { PanelRegistryStoreApi, PanelRegistrySlice } from "./types";
-import { isPtyPanel, type PanelInstance, type PtyPanelData } from "@shared/types/panel";
+import {
+  isGridPanelLocation,
+  isPtyPanel,
+  type PanelInstance,
+  type PanelLocation,
+  type PtyPanelData,
+  type TabGroup,
+  type TabGroupLocation,
+} from "@shared/types/panel";
 import { getNarrowPanel } from "./selectors";
 
 type CarrierPanel = Parameters<typeof getNarrowPanel>[0][string];
@@ -35,7 +43,11 @@ import { logDebug, logWarn, logError } from "@/utils/logger";
 import { markRendererPerformance } from "@/utils/performance";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { collectPanelIdForBatch, isHydrationBatchActive } from "./hydrationBatch";
-import { addToWorktreeIndex, transferBetweenWorktreeIndex } from "./worktreeIndex";
+import {
+  addToWorktreeIndex,
+  panelMatchesWorktreeScope,
+  transferBetweenWorktreeIndex,
+} from "./worktreeIndex";
 import { agentLifecycleLedger } from "@/services/terminal/lifecycleLedger";
 import { computeEnvProvenance } from "@shared/utils/agentLifecycleLedger";
 import { getViewWorkspaceId } from "@/store/viewWorkspaceId";
@@ -51,6 +63,69 @@ async function resolveProjectStore() {
     _cachedProjectStore = mod.useProjectStore;
   }
   return _cachedProjectStore;
+}
+
+/**
+ * Resolve `AddPanelOptions.insertAfterId` to a flat `panelIds` index for a live
+ * add, or `null` to fall back to the ordinary append.
+ *
+ * Runs inside the commit `set()` on purpose. `addPanel` has async gaps before
+ * it lands (agent-settings IPC while the duplicate recipe is built, then
+ * `resolveProjectStore()` on the PTY path), so a numeric index computed at
+ * dispatch would be stale by the time it is used. Only the id is durable
+ * intent; the position is whatever that id means at commit.
+ */
+function resolveInsertAfterAnchor(
+  state: {
+    panelIds: string[];
+    panelsById: Record<string, CarrierPanel>;
+    tabGroups: Map<string, TabGroup>;
+  },
+  panel: { id: string; location?: PanelLocation; worktreeId?: string | null },
+  insertAfterId: string | undefined
+): { index: number; anchorId: string } | null {
+  if (!insertAfterId || insertAfterId === panel.id) return null;
+
+  // Grid and dock are the only surfaces with a user-visible order to be
+  // adjacent within — an overlay/dialog/trash landing has no slot to take.
+  const location: TabGroupLocation | null = isGridPanelLocation(panel.location)
+    ? "grid"
+    : panel.location === "dock"
+      ? "dock"
+      : null;
+  if (location === null) return null;
+
+  const inScope = (candidate: CarrierPanel | undefined): boolean => {
+    if (!candidate) return false;
+    const onSurface =
+      location === "grid" ? isGridPanelLocation(candidate.location) : candidate.location === "dock";
+    return onSurface && panelMatchesWorktreeScope(candidate.worktreeId, panel.worktreeId, location);
+  };
+
+  // A source that has been trashed, moved to the other surface, or re-homed to
+  // another worktree since dispatch no longer has a slot the copy can sit next
+  // to; the same goes for one that never made it into `panelIds`.
+  if (!inScope(state.panelsById[insertAfterId])) return null;
+  const sourceIndex = state.panelIds.indexOf(insertAfterId);
+  if (sourceIndex === -1) return null;
+
+  // Both `getTabGroups` and the dock's render items emit an explicit group at
+  // its EARLIEST member's position, so a copy spliced after a later member
+  // would land past every panel rendered between the two. Anchor to the slot
+  // the user actually sees. The copy itself stays ungrouped — folding it into
+  // the source's group is `addTabForPanel`'s job.
+  let anchorIndex = sourceIndex;
+  for (const group of state.tabGroups.values()) {
+    if (group.location !== location || !group.panelIds.includes(insertAfterId)) continue;
+    for (const memberId of group.panelIds) {
+      if (!inScope(state.panelsById[memberId])) continue;
+      const memberIndex = state.panelIds.indexOf(memberId);
+      if (memberIndex !== -1 && memberIndex < anchorIndex) anchorIndex = memberIndex;
+    }
+    break;
+  }
+
+  return { index: anchorIndex + 1, anchorId: state.panelIds[anchorIndex]! };
 }
 
 type Set = PanelRegistryStoreApi["setState"];
@@ -323,8 +398,15 @@ export const createAddPanelActions = (
             return { panelsById: newById, panelIdsByWorktreeId: newIndex };
           }
           const newById = { ...state.panelsById, [id]: terminal };
-          const newIds = [...state.panelIds, id];
-          const newIndex = addToWorktreeIndex(state.panelIdsByWorktreeId, terminal.worktreeId, id);
+          const anchor = resolveInsertAfterAnchor(state, terminal, options.insertAfterId);
+          const newIds = [...state.panelIds];
+          newIds.splice(anchor ? anchor.index : newIds.length, 0, id);
+          const newIndex = addToWorktreeIndex(
+            state.panelIdsByWorktreeId,
+            terminal.worktreeId,
+            id,
+            anchor?.anchorId
+          );
           saveNormalized(newById, newIds);
           // Fold dock activation into this commit so the watchdog effect in
           // `DockPanelOffscreenContainer` cannot observe `activeDockTerminalId`
@@ -672,8 +754,15 @@ export const createAddPanelActions = (
           return { panelsById: newById, panelIdsByWorktreeId: newIndex };
         }
         const newById = { ...state.panelsById, [id]: terminal };
-        const newIds = [...state.panelIds, id];
-        const newIndex = addToWorktreeIndex(state.panelIdsByWorktreeId, terminal.worktreeId, id);
+        const anchor = resolveInsertAfterAnchor(state, terminal, options.insertAfterId);
+        const newIds = [...state.panelIds];
+        newIds.splice(anchor ? anchor.index : newIds.length, 0, id);
+        const newIndex = addToWorktreeIndex(
+          state.panelIdsByWorktreeId,
+          terminal.worktreeId,
+          id,
+          anchor?.anchorId
+        );
         saveNormalized(newById, newIds);
         // Fold dock activation into this commit so the watchdog effect in
         // `DockPanelOffscreenContainer` cannot observe `activeDockTerminalId`

--- a/src/store/slices/panelRegistry/addPanel.ts
+++ b/src/store/slices/panelRegistry/addPanel.ts
@@ -66,8 +66,25 @@ async function resolveProjectStore() {
 }
 
 /**
+ * Earliest position any of `ids` holds in `order`, or `-1` when none appear.
+ * Each ordered structure resolves the anchor against itself: a cross-worktree
+ * transfer appends to the destination bucket without moving the flat id, so
+ * bucket order is not guaranteed to be flat order projected by worktree, and
+ * reusing one structure's answer in the other would misplace the copy.
+ */
+function earliestIndexOf(order: readonly string[], ids: readonly string[]): number {
+  let earliest = -1;
+  for (const id of ids) {
+    const at = order.indexOf(id);
+    if (at !== -1 && (earliest === -1 || at < earliest)) earliest = at;
+  }
+  return earliest;
+}
+
+/**
  * Resolve `AddPanelOptions.insertAfterId` to a flat `panelIds` index for a live
- * add, or `null` to fall back to the ordinary append.
+ * add, plus the anchor ids each ordered structure should place the new panel
+ * after. `null` falls back to the ordinary append.
  *
  * Runs inside the commit `set()` on purpose. `addPanel` has async gaps before
  * it lands (agent-settings IPC while the duplicate recipe is built, then
@@ -80,10 +97,11 @@ function resolveInsertAfterAnchor(
     panelIds: string[];
     panelsById: Record<string, CarrierPanel>;
     tabGroups: Map<string, TabGroup>;
+    trashedTerminals: Map<string, unknown>;
   },
   panel: { id: string; location?: PanelLocation; worktreeId?: string | null },
   insertAfterId: string | undefined
-): { index: number; anchorId: string } | null {
+): { index: number; anchorIds: string[] } | null {
   if (!insertAfterId || insertAfterId === panel.id) return null;
 
   // Grid and dock are the only surfaces with a user-visible order to be
@@ -95,8 +113,10 @@ function resolveInsertAfterAnchor(
       : null;
   if (location === null) return null;
 
-  const inScope = (candidate: CarrierPanel | undefined): boolean => {
-    if (!candidate) return false;
+  // Mirrors the per-member filter both renderers apply, `trashedTerminals`
+  // (optimistic close) included, so the anchor is a slot the user can see.
+  const inScope = (candidate: CarrierPanel): boolean => {
+    if (state.trashedTerminals.has(candidate.id)) return false;
     const onSurface =
       location === "grid" ? isGridPanelLocation(candidate.location) : candidate.location === "dock";
     return onSurface && panelMatchesWorktreeScope(candidate.worktreeId, panel.worktreeId, location);
@@ -105,27 +125,41 @@ function resolveInsertAfterAnchor(
   // A source that has been trashed, moved to the other surface, or re-homed to
   // another worktree since dispatch no longer has a slot the copy can sit next
   // to; the same goes for one that never made it into `panelIds`.
-  if (!inScope(state.panelsById[insertAfterId])) return null;
-  const sourceIndex = state.panelIds.indexOf(insertAfterId);
-  if (sourceIndex === -1) return null;
+  const source = state.panelsById[insertAfterId];
+  if (!source || !inScope(source) || state.panelIds.indexOf(insertAfterId) === -1) return null;
 
-  // Both `getTabGroups` and the dock's render items emit an explicit group at
-  // its EARLIEST member's position, so a copy spliced after a later member
-  // would land past every panel rendered between the two. Anchor to the slot
-  // the user actually sees. The copy itself stays ungrouped — folding it into
-  // the source's group is `addTabForPanel`'s job.
-  let anchorIndex = sourceIndex;
-  for (const group of state.tabGroups.values()) {
-    if (group.location !== location || !group.panelIds.includes(insertAfterId)) continue;
-    for (const memberId of group.panelIds) {
-      if (!inScope(state.panelsById[memberId])) continue;
-      const memberIndex = state.panelIds.indexOf(memberId);
-      if (memberIndex !== -1 && memberIndex < anchorIndex) anchorIndex = memberIndex;
+  // Both renderers emit an explicit group once, at its earliest surviving
+  // member — so a copy anchored on a later member would land past every panel
+  // rendered in between. Anchor on the whole group instead and let each
+  // structure pick its own earliest. The copy itself stays ungrouped: folding
+  // it into the source's group is `addTabForPanel`'s job.
+  //
+  // The dock resolves groups PTY-only, chipping every non-PTY member standalone
+  // in place (#11332), so there a non-PTY source is its own anchor and non-PTY
+  // siblings are not candidates.
+  let anchorIds = [insertAfterId];
+  const groupsThisSource = location === "grid" || isPtyPanel(source);
+  if (groupsThisSource) {
+    for (const group of state.tabGroups.values()) {
+      if (group.location !== location) continue;
+      // Group-level scope, matching `getTabGroups`/`buildDockRenderItems`: a
+      // group pinned to another worktree is not rendered here at all.
+      if (!panelMatchesWorktreeScope(group.worktreeId, panel.worktreeId, location)) continue;
+      if (!group.panelIds.includes(insertAfterId)) continue;
+      const members = group.panelIds.filter((memberId) => {
+        const member = state.panelsById[memberId];
+        if (!member || !inScope(member)) return false;
+        return location === "grid" || isPtyPanel(member);
+      });
+      // The store enforces single-group membership, so the first match is the
+      // source's group; stop either way rather than blending two groups.
+      if (members.includes(insertAfterId)) anchorIds = members;
+      break;
     }
-    break;
   }
 
-  return { index: anchorIndex + 1, anchorId: state.panelIds[anchorIndex]! };
+  const index = earliestIndexOf(state.panelIds, anchorIds);
+  return index === -1 ? null : { index: index + 1, anchorIds };
 }
 
 type Set = PanelRegistryStoreApi["setState"];
@@ -405,7 +439,7 @@ export const createAddPanelActions = (
             state.panelIdsByWorktreeId,
             terminal.worktreeId,
             id,
-            anchor?.anchorId
+            anchor?.anchorIds
           );
           saveNormalized(newById, newIds);
           // Fold dock activation into this commit so the watchdog effect in
@@ -761,7 +795,7 @@ export const createAddPanelActions = (
           state.panelIdsByWorktreeId,
           terminal.worktreeId,
           id,
-          anchor?.anchorId
+          anchor?.anchorIds
         );
         saveNormalized(newById, newIds);
         // Fold dock activation into this commit so the watchdog effect in

--- a/src/store/slices/panelRegistry/worktreeIndex.ts
+++ b/src/store/slices/panelRegistry/worktreeIndex.ts
@@ -92,15 +92,32 @@ function bucketKey(worktreeId: string | undefined | null): string {
   return worktreeId ?? NO_WORKTREE;
 }
 
+/**
+ * Add a panel to its worktree bucket. Appends by default; with `afterPanelId`
+ * it splices directly after that anchor so a positional add (`insertAfterId`
+ * in `AddPanelOptions`) leaves the bucket in the same relative order as the
+ * flat `panelIds` splice it accompanies — `gridTerminals` iterates the bucket,
+ * so an append here would order the grid differently from the dock.
+ *
+ * Positional adds stay in this targeted helper rather than going through
+ * `buildWorktreeIndex`: a full rebuild replaces every worktree's bucket array,
+ * breaking the reference-stability invariant above for worktrees that never
+ * changed. An anchor missing from the bucket falls back to appending, which is
+ * the same fallback the flat-array side takes.
+ */
 export function addToWorktreeIndex(
   index: PanelIdsByWorktreeId,
   worktreeId: string | undefined | null,
-  panelId: string
+  panelId: string,
+  afterPanelId?: string
 ): PanelIdsByWorktreeId {
   const key = bucketKey(worktreeId);
   const existing = index[key];
   if (existing && existing.includes(panelId)) return index;
-  const next = existing ? [...existing, panelId] : [panelId];
+  if (!existing) return { ...index, [key]: [panelId] };
+  const anchor = afterPanelId === undefined ? -1 : existing.indexOf(afterPanelId);
+  const next = [...existing];
+  next.splice(anchor === -1 ? next.length : anchor + 1, 0, panelId);
   return { ...index, [key]: next };
 }
 

--- a/src/store/slices/panelRegistry/worktreeIndex.ts
+++ b/src/store/slices/panelRegistry/worktreeIndex.ts
@@ -93,29 +93,41 @@ function bucketKey(worktreeId: string | undefined | null): string {
 }
 
 /**
- * Add a panel to its worktree bucket. Appends by default; with `afterPanelId`
- * it splices directly after that anchor so a positional add (`insertAfterId`
- * in `AddPanelOptions`) leaves the bucket in the same relative order as the
- * flat `panelIds` splice it accompanies — `gridTerminals` iterates the bucket,
- * so an append here would order the grid differently from the dock.
+ * Add a panel to its worktree bucket. Appends by default; with `afterPanelIds`
+ * it splices directly after whichever of those anchors comes first in THIS
+ * bucket, so a positional add (`insertAfterId` in `AddPanelOptions`) leaves the
+ * bucket adjacent the same way the accompanying flat `panelIds` splice does.
+ * `gridTerminals` iterates the bucket while the dock reads `panelIds`, so an
+ * append here would order the two surfaces differently.
+ *
+ * The anchor set is resolved per structure rather than shared: bucket order is
+ * not guaranteed to be flat order projected by worktree, because
+ * `transferBetweenWorktreeIndex` appends to the destination bucket without
+ * moving the flat id. Passing several ids (an explicit tab group's members)
+ * lets each structure anchor on the member it renders the group at.
  *
  * Positional adds stay in this targeted helper rather than going through
  * `buildWorktreeIndex`: a full rebuild replaces every worktree's bucket array,
  * breaking the reference-stability invariant above for worktrees that never
- * changed. An anchor missing from the bucket falls back to appending, which is
- * the same fallback the flat-array side takes.
+ * changed. When no anchor is in this bucket — a dock-global source is visible
+ * in a concrete worktree's dock but lives in the `__none__` bucket — the panel
+ * appends, which is the only adjacency this bucket can express.
  */
 export function addToWorktreeIndex(
   index: PanelIdsByWorktreeId,
   worktreeId: string | undefined | null,
   panelId: string,
-  afterPanelId?: string
+  afterPanelIds?: readonly string[]
 ): PanelIdsByWorktreeId {
   const key = bucketKey(worktreeId);
   const existing = index[key];
   if (existing && existing.includes(panelId)) return index;
   if (!existing) return { ...index, [key]: [panelId] };
-  const anchor = afterPanelId === undefined ? -1 : existing.indexOf(afterPanelId);
+  let anchor = -1;
+  for (const candidate of afterPanelIds ?? []) {
+    const at = existing.indexOf(candidate);
+    if (at !== -1 && (anchor === -1 || at < anchor)) anchor = at;
+  }
   const next = [...existing];
   next.splice(anchor === -1 ? next.length : anchor + 1, 0, panelId);
   return { ...index, [key]: next };


### PR DESCRIPTION
## Summary

- `terminal.duplicate` (`Cmd+T`) always appended the copy to the end of the panel list. Duplicate the panel at position 0 of three and the copy showed up at position 3 instead of position 1.
- `addPanel` only ever did `[...state.panelIds, id]`, and `AddPanelOptions` had no way to express a position, so this needed a new placement capability, not a one-line fix.
- Adds an opt-in `insertAfterId` on `AddPanelOptions`, resolved inside `addPanel`'s commit `set()` call and honored only on the two live (non-batched) commit branches.

Resolves #12095

## Approach

Resolution happens at commit time on purpose. `addPanel` has async gaps before it lands (an agent-settings IPC call while the duplicate recipe is built, then `resolveProjectStore()` on the PTY path), so a numeric index computed at dispatch would be stale by the time it's used. Only the id is durable intent.

Three things made this more than a simple splice:

1. **Two ordered structures, not one.** The dock and `getTabGroups` read the flat `panelIds`; `gridTerminals` iterates the derived per-worktree `panelIdsByWorktreeId` bucket. Both have to move, or the two surfaces order the copy differently. The bucket insert stays in the existing `addToWorktreeIndex` helper rather than going through a full `buildWorktreeIndex` rebuild, since a rebuild replaces every worktree's bucket array and breaks the reference-stability invariant that per-row selectors depend on (#7451).
2. **The two structures can legitimately disagree on order.** `transferBetweenWorktreeIndex` appends to the destination bucket without moving the flat id, so the bucket isn't guaranteed to be flat order projected onto a worktree. So the resolver returns a set of candidate anchor ids, and each structure picks whichever comes first within itself.
3. **Tab groups render at their earliest member.** Both `getTabGroups` and `buildDockRenderItems` emit a group once, at its earliest surviving member, so a copy anchored on a later member would land past everything rendered in between. The resolver anchors on the group instead. The dock additionally resolves groups PTY-only, chipping non-PTY members off as standalone in place (#11332), so a browser member isn't the group's slot there and a non-PTY source anchors on itself.

The copy stays ungrouped. Folding it into the source's tab group is what the panel header's "Duplicate panel as new tab" button (`addTabForPanel`) already does, and that path was already correct and untouched.

## Changes

- `shared/types/addPanelOptions.ts`: new optional `insertAfterId` on `AddPanelOptionsBase`.
- `src/store/slices/panelRegistry/addPanel.ts`: new `resolveInsertAfterAnchor` and `earliestIndexOf` helpers, wired into the two live commit branches.
- `src/store/slices/panelRegistry/worktreeIndex.ts`: `addToWorktreeIndex` gained an optional `afterPanelIds` anchor set.
- `src/services/actions/definitions/terminalSpawnActions.ts`: `terminal.duplicate` passes `insertAfterId`.

Falls back to a plain append whenever the hint can't be honored: absent, source on the other surface, source in another worktree scope, source trashed or optimistically closing, or source gone entirely. It's ignored inside hydration and spawn batches, whose `panelIds` append is deferred to flush. Strictly opt-in: the other ~30 `addPanel` call sites pass nothing and are unaffected.

Scope is the kinds `terminal.duplicate` can actually copy: `terminal`, `browser`, `dev-preview`, `review`. File panels have no duplicate recipe and stay a no-op.

## Testing

20 new store tests covering the grid, the dock (asserted through `buildDockRenderItems`, not just store state), mixed PTY/non-PTY dock groups, group members outside scope, structures that disagree on order, the `__none__` global bucket, batch pass-through, persisted order, and every fallback path. 9 new `addToWorktreeIndex` unit tests. 4 new action tests.

Locally: 3,699 tests green across the panel registry, actions, terminal, and layout/Terminal component suites. `npm run typecheck` clean. Own files clean on eslint (0 errors, no new warnings) and prettier.

## Known limitation

The resolver doesn't model `buildDockRenderItems`' greedy cross-group claiming, so a panel belonging to two overlapping tab groups could anchor differently than the dock actually renders it. That's corrupt-only state: the store enforces single group membership and hydration repairs it, and the grid (last-writer-wins) and the dock (first-wins) already disagree with each other there.
