### PR TITLE
fix(dialog): put the header, body and footer on one column

### DIFF
--- a/src/components/HelpPanel/FigureLightbox.tsx
+++ b/src/components/HelpPanel/FigureLightbox.tsx
@@ -71,7 +71,7 @@ export function FigureLightbox({
       maxHeight="max-h-[90vh]"
       data-testid="figure-lightbox"
     >
-      <AppDialog.Header plainBody>
+      <AppDialog.Header>
         <AppDialog.Title>Figure {figure.figureNumber}</AppDialog.Title>
         <AppDialog.CloseButton />
       </AppDialog.Header>

--- a/src/components/Panel/PanelDialogHost.tsx
+++ b/src/components/Panel/PanelDialogHost.tsx
@@ -115,7 +115,7 @@ function PanelDialogFrame({
       zIndex={isNested ? "nested" : "modal"}
       data-testid="panel-dialog"
     >
-      <AppDialog.Header plainBody>
+      <AppDialog.Header>
         <AppDialog.Title>{panel.title}</AppDialog.Title>
         <div className="flex items-center gap-1">
           {/* Promotion always targets the topmost dialog, so it is only offered
@@ -134,10 +134,13 @@ function PanelDialogFrame({
           <AppDialog.CloseButton />
         </div>
       </AppDialog.Header>
-      {/* BodyScroll, not Body: Body puts its padding on an inner scroll
-          element (scrollClassName="p-6"), so a p-0 on the outer wrapper would
-          not reach it and the panel would sit inside a 24px inset. */}
-      <AppDialog.BodyScroll className="flex min-h-0 flex-1 flex-col overflow-hidden p-0">
+      {/* A plain element, not `AppDialog.Body`/`BodyScroll`: a hosted panel
+          fills the dialog edge to edge and wants none of the dialog column.
+          Both body variants reserve a scrollbar gutter, and `scrollbar-gutter`
+          reserves its space on an `overflow: hidden` box too — so cancelling
+          their padding would still leave the reservation behind as dead inset
+          down both sides of the panel. */}
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
         <ErrorBoundary
           variant="component"
           componentName={`PanelDialog:${panel.kind ?? "terminal"}`}
@@ -153,7 +156,7 @@ function PanelDialogFrame({
             onClose={handleClose}
           />
         </ErrorBoundary>
-      </AppDialog.BodyScroll>
+      </div>
     </AppDialog>
   );
 }

--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -714,7 +714,7 @@ function SettingsDialogInner({
         </div>
 
         <div className="settings-shell flex-1 flex flex-col min-w-0">
-          <AppDialog.Header plainBody>
+          <AppDialog.Header>
             <AppDialog.Title
               as="h3"
               icon={
@@ -767,7 +767,7 @@ function SettingsDialogInner({
             </div>
           )}
 
-          <ScrollShadow className="flex-1" scrollClassName="p-6">
+          <ScrollShadow className="flex-1" scrollClassName="py-6 dialog-body-inset">
             {isSearching && (
               <div role="region" aria-label="Search results">
                 <SearchResults

--- a/src/components/Terminal/HybridInputBar.tsx
+++ b/src/components/Terminal/HybridInputBar.tsx
@@ -1104,7 +1104,7 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
           maxHeight="max-h-[70vh]"
           dismissible
         >
-          <AppDialog.Header plainBody>
+          <AppDialog.Header>
             <AppDialog.Title>Expanded Editor</AppDialog.Title>
             <AppDialog.CloseButton />
           </AppDialog.Header>

--- a/src/components/Worktree/IssuePickerDialog.tsx
+++ b/src/components/Worktree/IssuePickerDialog.tsx
@@ -194,7 +194,7 @@ export function IssuePickerDialog({
 
   return (
     <AppDialog isOpen={isOpen} onClose={onClose} size="md" maxHeight="max-h-[70vh]">
-      <AppDialog.Header plainBody>
+      <AppDialog.Header>
         <AppDialog.Title icon={<Link className="w-5 h-5 text-pr-open" />}>
           Attach Issue
         </AppDialog.Title>
@@ -233,7 +233,7 @@ export function IssuePickerDialog({
         </div>
       </div>
 
-      <div className="flex-1 overflow-y-auto min-h-0 px-6 pb-4">
+      <div className="flex-1 overflow-y-auto min-h-0 dialog-body-inset pb-4">
         {isPending && issues.length === 0 ? (
           <Skeleton label="Loading issues" className="space-y-1">
             {Array.from({ length: 6 }).map((_, i) => (
@@ -292,7 +292,7 @@ export function IssuePickerDialog({
       </div>
 
       {currentIssueNumber && (
-        <AppDialog.Footer plainBody>
+        <AppDialog.Footer>
           <Button variant="ghost" onClick={handleDetach} className="text-text-secondary mr-auto">
             <Unlink className="w-4 h-4 mr-2" />
             Detach Issue

--- a/src/components/Worktree/WorktreeOverviewModal.tsx
+++ b/src/components/Worktree/WorktreeOverviewModal.tsx
@@ -1057,7 +1057,7 @@ export function WorktreeOverviewModal({
             is what keeps the title and the `N of M` count on screen while a
             destructive bulk action is one click away. */}
         {hasSelection ? (
-          <div className="flex items-center justify-between gap-3 px-[calc(1.5rem+11px)] py-2 border-b border-divider shrink-0">
+          <div className="flex items-center justify-between gap-3 px-6 py-2 border-b border-divider shrink-0">
             <div className="flex items-center gap-3 min-w-0">
               {/* Visual only — the announcement is owned by the status region
                   above, so this must not be a second live region. */}
@@ -1108,7 +1108,7 @@ export function WorktreeOverviewModal({
           // would make filtering permanently unreachable — no filter could be
           // set, so `hasActiveFilters()` could never become true.
           (hasActivitySummary || hasActiveFilters() || !hasNonMainWorktrees) && (
-            <div className="flex items-center gap-2 px-[calc(1.5rem+11px)] py-2 border-b border-divider shrink-0 flex-wrap">
+            <div className="flex items-center gap-2 px-6 py-2 border-b border-divider shrink-0 flex-wrap">
               {/* Aggregate activity statistics — clickable chips that set quickStateFilter.
                   Ordered waiting → working → finished: "something is asking me
                   for input" is the highest-value signal on this surface, so it
@@ -1237,9 +1237,10 @@ export function WorktreeOverviewModal({
 
         {/* Content. `AppDialog.Body` brings the shared scroll box: a
             ScrollShadow at both edges, so content no longer just stops
-            mid-glyph against the footer, and a reserved scrollbar gutter so
-            the grid does not shift by 11px the moment it starts to overflow. */}
-        <AppDialog.Body className="p-6">
+            mid-glyph against the footer, a reserved scrollbar gutter so the
+            grid does not shift the moment it starts to overflow, and the
+            dialog column the two bars above are aligned to. */}
+        <AppDialog.Body>
           {isLoading && worktrees.length === 0 ? (
             <Skeleton label="Loading worktrees">
               <div

--- a/src/components/Worktree/WorktreeSidebarSearchBar.tsx
+++ b/src/components/Worktree/WorktreeSidebarSearchBar.tsx
@@ -218,9 +218,10 @@ export function WorktreeSidebarSearchBar({
         // the rule above it.
         "px-3 pb-3 border-b border-divider shrink-0",
         // In the dialog the horizontal neighbours are different too: the header,
-        // the footer and the rows below all sit on AppDialog's chrome inset
-        // (24px plus the 11px scrollbar gutter `AppDialog.Body` reserves), so
-        // the bar carries that one instead of the rail's 12px.
+        // the footer and the rows below all sit on AppDialog's 24px column, so
+        // the bar carries that one instead of the rail's 12px. Plain `px-6`:
+        // the body absorbs whatever the platform reserves for a scrollbar out
+        // of its own padding, so nothing out here compensates for it (#12101).
         variant === "modal" && "pt-3 px-6",
         variant === "sidebar" && "worktree-filter-bar"
       )}

--- a/src/components/Worktree/WorktreeSidebarSearchBar.tsx
+++ b/src/components/Worktree/WorktreeSidebarSearchBar.tsx
@@ -221,7 +221,7 @@ export function WorktreeSidebarSearchBar({
         // the footer and the rows below all sit on AppDialog's chrome inset
         // (24px plus the 11px scrollbar gutter `AppDialog.Body` reserves), so
         // the bar carries that one instead of the rail's 12px.
-        variant === "modal" && "pt-3 px-[calc(1.5rem+11px)]",
+        variant === "modal" && "pt-3 px-6",
         variant === "sidebar" && "worktree-filter-bar"
       )}
     >

--- a/src/components/ui/AppDialog.tsx
+++ b/src/components/ui/AppDialog.tsx
@@ -25,6 +25,7 @@ import {
   ESCAPE_BACKSTOP_DIALOG_ATTR,
 } from "@/lib/dialogEscapeBackstop";
 import { APP_DIALOG_SURFACE_ATTR } from "@/lib/appDialogSurface";
+import { publishScrollbarGutter } from "@/lib/scrollbarGutter";
 import { useDockPopoverOpen } from "@/lib/dockPopoverLayer";
 import { usePortalStore } from "@/store";
 import { clearDialogOverlays } from "@/lib/dialogOverlayDismissal";
@@ -204,6 +205,19 @@ export function AppDialog({
   });
 
   useOverlayState(isOpen || shouldRender);
+
+  // Re-measure the platform's reserved scrollbar gutter as the dialog opens.
+  // It is a UA/OS property, not a stylesheet value — and one the user can
+  // change under a running app (macOS System Settings › Appearance › Show
+  // scroll bars), which would otherwise leave the body's column and the
+  // chrome's disagreeing until the next restart. Layout effect, not passive:
+  // the figure has to be published before this dialog's first paint or the
+  // column visibly settles. Cheap to repeat — one off-screen probe, and the
+  // custom property is only written when the number actually moved.
+  useLayoutEffect(() => {
+    if (!isOpen) return;
+    publishScrollbarGutter();
+  }, [isOpen]);
 
   // Clear stranded tooltips and shortcut hints on every open and close
   // transition (issue #11030): on open before the RAF-deferred autofocus
@@ -475,27 +489,22 @@ export function AppDialog({
 interface AppDialogHeaderProps {
   children: React.ReactNode;
   className?: string;
-  /** This dialog pads its own body rather than using `AppDialog.Body` — see {@link CHROME_INSET}. */
-  plainBody?: boolean;
 }
 
 /**
- * Header and footer sit outside the body's scroll box, so a bare `px-6` leaves
- * them 11px short of it: `AppDialog.Body` reserves a scrollbar gutter on both
- * edges, which pushes every field in the form that much further in. Padding the
- * chrome by the same gutter puts the title, the fields and the buttons on one
- * column instead of three that nearly agree.
+ * One column for the whole dialog: title, fields and buttons all sit 1.5rem
+ * from the card's inner edge.
  *
- * The 11px is the same figure `AppDialog.Body` reserves — `scrollbar-width:
- * thin` in `index.css`. It has to be a literal: Tailwind only sees class names
- * it can find in the source, so this cannot be built from a shared constant.
- *
- * Dialogs that pad their own body instead (`AppDialog.BodyScroll`, a custom
- * scroller) have no gutter to line up with and pass `plainBody` — for them this
- * inset would be the misalignment rather than the fix.
+ * The chrome used to add the body's reserved scrollbar gutter back on
+ * (`calc(1.5rem + 11px)`) so the two would meet. That figure was a guess at a
+ * platform property — macOS reserves nothing for an overlay scrollbar — so the
+ * compensation landed on top of a gutter that wasn't there and pushed the
+ * header and footer 11px inside the form (#12101). The body now absorbs
+ * whatever the platform actually reserves out of its own padding
+ * (`.dialog-body-inset` in `index.css`), which leaves the chrome with nothing
+ * to compensate for and no reason to know what a scrollbar costs.
  */
-const CHROME_INSET = "px-[calc(1.5rem+11px)]";
-const PLAIN_INSET = "px-6";
+const DIALOG_INSET = "px-6";
 
 // Footer actions announce unavailability with `aria-disabled`, never the native
 // attribute — a natively-disabled button leaves the tab order and refuses focus,
@@ -509,18 +518,10 @@ const PLAIN_INSET = "px-6";
 // suppress hover and put the control back out of reach.
 const DISABLED_ACTION_CLASSES = "aria-disabled:opacity-50 aria-disabled:cursor-not-allowed";
 
-AppDialog.Header = function AppDialogHeader({
-  children,
-  className,
-  plainBody,
-}: AppDialogHeaderProps) {
+AppDialog.Header = function AppDialogHeader({ children, className }: AppDialogHeaderProps) {
   // `density` is deliberately not forwarded: every dialog header is comfortable,
   // and exposing it would widen AppDialog's public surface for no caller.
-  return (
-    <SurfaceHeader className={cn(plainBody ? PLAIN_INSET : CHROME_INSET, className)}>
-      {children}
-    </SurfaceHeader>
-  );
+  return <SurfaceHeader className={cn(DIALOG_INSET, className)}>{children}</SurfaceHeader>;
 };
 
 interface AppDialogTitleProps {
@@ -597,17 +598,16 @@ AppDialog.Body = function AppDialogBody({
     // hung a stray margin off the scroll box while the actual fields got no
     // spacing at all. Matches where `BodyScroll` puts it.
     //
-    // The gutter is reserved, and on both edges. The app's scrollbar is 11px of
-    // real layout (`scrollbar-width: thin` in `index.css`, which outranks the
-    // 6px `::-webkit-scrollbar` rule), so without this every control in a
-    // dialog resizes by 11px the moment its body crosses the overflow
-    // threshold — a hint row appearing, a validation banner clearing, a form
-    // swapping sections. `both-edges` keeps the padding symmetric; reserving
-    // one side only trades a jump for a permanent lopsided inset.
+    // `dialog-body-inset` reserves the gutter on both edges and takes it back
+    // out of the horizontal padding, so the fields land on the chrome's column
+    // whatever the platform charges for a scrollbar. Reserving it at all is
+    // what stops every control resizing the moment the body crosses the
+    // overflow threshold — a hint row appearing, a validation banner clearing,
+    // a form swapping sections; `both-edges` is what keeps that symmetric.
     <ScrollShadow
       ref={scrollRef}
       className="flex-1 min-h-0"
-      scrollClassName={cn("p-6 [scrollbar-gutter:stable_both-edges]", className)}
+      scrollClassName={cn("py-6 dialog-body-inset", className)}
     >
       {children}
     </ScrollShadow>
@@ -623,12 +623,16 @@ AppDialog.BodyScroll = function AppDialogBodyScroll({
   children,
   className,
 }: AppDialogBodyScrollProps) {
-  // Deliberately NOT carrying `Body`'s reserved gutter. This variant is the
-  // escape hatch for callers that own their own scrolling and padding, and
-  // `scrollbar-gutter` reserves its space on an `overflow: hidden` box too — so
-  // it would put 22px of dead inset inside `PanelDialogHost`'s edge-to-edge
-  // panel host, which sets `overflow-hidden p-0` precisely to fill the dialog.
-  return <div className={cn("flex-1 overflow-auto min-h-0 p-6", className)}>{children}</div>;
+  // Same column as `Body`, without the scroll shadows — that is the whole
+  // difference between the two. A surface that wants no column at all wants a
+  // plain element, not this: `scrollbar-gutter` reserves its space on an
+  // `overflow: hidden` box too, so a `p-0` here would cancel the padding and
+  // leave the reservation behind as dead inset.
+  return (
+    <div className={cn("flex-1 overflow-auto min-h-0 py-6 dialog-body-inset", className)}>
+      {children}
+    </div>
+  );
 };
 
 export interface DialogAction {
@@ -650,8 +654,6 @@ interface AppDialogFooterProps {
   primaryAction?: DialogAction;
   secondaryAction?: DialogAction;
   hint?: React.ReactNode;
-  /** This dialog pads its own body rather than using `AppDialog.Body` — see {@link CHROME_INSET}. */
-  plainBody?: boolean;
 }
 
 AppDialog.Footer = function AppDialogFooter({
@@ -660,7 +662,6 @@ AppDialog.Footer = function AppDialogFooter({
   primaryAction,
   secondaryAction,
   hint,
-  plainBody,
 }: AppDialogFooterProps) {
   const context = useContext(AppDialogContext);
   const dialogVariant = context?.variant ?? "default";
@@ -680,7 +681,7 @@ AppDialog.Footer = function AppDialogFooter({
   return (
     <div
       className={cn(
-        plainBody ? PLAIN_INSET : CHROME_INSET,
+        DIALOG_INSET,
         "py-4 border-t border-border-strong bg-surface-panel flex items-center gap-3 shrink-0",
         hint ? "justify-between" : "justify-end",
         className

--- a/src/components/ui/__tests__/AppDialog.test.tsx
+++ b/src/components/ui/__tests__/AppDialog.test.tsx
@@ -12,6 +12,7 @@ import {
   _resetForTests as _resetDockPopoverForTests,
 } from "@/lib/dockPopoverLayer";
 import { useGlobalEscapeDispatcher } from "@/hooks/useGlobalEscapeDispatcher";
+import { publishScrollbarGutter } from "@/lib/scrollbarGutter";
 
 vi.mock("zustand/react/shallow", () => ({
   useShallow: (fn: unknown) => fn,
@@ -43,6 +44,12 @@ vi.mock("@/hooks/useAnimatedPresence", () => ({
     mockPrevOpen = isOpen;
     return { isVisible: isOpen, shouldRender: isOpen };
   },
+}));
+
+vi.mock("@/lib/scrollbarGutter", () => ({
+  SCROLLBAR_GUTTER_VAR: "--app-scrollbar-gutter",
+  measureScrollbarGutter: vi.fn(() => 0),
+  publishScrollbarGutter: vi.fn(() => 0),
 }));
 
 vi.stubGlobal(
@@ -1561,5 +1568,75 @@ describe("AppDialog.Footer primary variant resolution", () => {
 
   it("resolves destructive from dialog context when the action states no intent", () => {
     expectVariant(renderFooter({ dialogVariant: "destructive" }), "destructive");
+  });
+});
+
+describe("AppDialog scrollbar gutter", () => {
+  // What a dialog's body subtracts from its padding is whatever the platform
+  // actually reserves for a scrollbar, published as a custom property. The
+  // bootstrap seed alone would look fine in every test and still go stale the
+  // moment a user flips macOS "Show scroll bars: Always" under a running app,
+  // so the re-measure on open is the part worth pinning (#12101).
+  function renderGated(isOpen: boolean) {
+    return render(
+      <AppDialog isOpen={isOpen} onClose={vi.fn()}>
+        <AppDialog.Body>body</AppDialog.Body>
+      </AppDialog>
+    );
+  }
+
+  beforeEach(() => {
+    vi.mocked(publishScrollbarGutter).mockClear();
+  });
+
+  it("does not measure while the dialog is closed", () => {
+    renderGated(false);
+
+    expect(publishScrollbarGutter).not.toHaveBeenCalled();
+  });
+
+  it("measures as the dialog opens", () => {
+    const { rerender } = renderGated(false);
+    expect(publishScrollbarGutter).not.toHaveBeenCalled();
+
+    rerender(
+      <AppDialog isOpen onClose={vi.fn()}>
+        <AppDialog.Body>body</AppDialog.Body>
+      </AppDialog>
+    );
+
+    expect(publishScrollbarGutter).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not re-measure on a render while it stays open", () => {
+    const { rerender } = renderGated(true);
+    expect(publishScrollbarGutter).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <AppDialog isOpen onClose={vi.fn()}>
+        <AppDialog.Body>changed</AppDialog.Body>
+      </AppDialog>
+    );
+
+    expect(publishScrollbarGutter).toHaveBeenCalledTimes(1);
+  });
+
+  it("measures again on reopen, so a mid-session change is picked up", () => {
+    const { rerender } = renderGated(true);
+    expect(publishScrollbarGutter).toHaveBeenCalledTimes(1);
+
+    const closed = (
+      <AppDialog isOpen={false} onClose={vi.fn()}>
+        <AppDialog.Body>body</AppDialog.Body>
+      </AppDialog>
+    );
+    rerender(closed);
+    rerender(
+      <AppDialog isOpen onClose={vi.fn()}>
+        <AppDialog.Body>body</AppDialog.Body>
+      </AppDialog>
+    );
+
+    expect(publishScrollbarGutter).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/config/__tests__/dialogInset.contract.test.ts
+++ b/src/config/__tests__/dialogInset.contract.test.ts
@@ -27,9 +27,11 @@ import { SCROLLBAR_GUTTER_VAR } from "@/lib/scrollbarGutter";
 //     is outside this file's view.
 //   - Only the specific `calc(<column> + <literal>)` shape is rejected. A fresh
 //     magic number spelled some other way (`px-[35px]`) would pass.
-//   - Custom scrollports that are not `AppDialog.Body`/`BodyScroll` are not
-//     inspected. `HybridInputBar`'s expanded editor deliberately sits on a
-//     tighter column than the dialog's, and is not a defect.
+//   - Custom scrollports are inspected only if listed in `CUSTOM_SCROLLPORTS`.
+//     `HybridInputBar`'s expanded editor deliberately sits on a tighter column
+//     than the dialog's, and is not a defect, so it is not listed.
+//   - Only the class expression carrying the inset is scanned, so a nested
+//     child inside the header or footer may pad itself freely.
 
 const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(TEST_DIR, "../../..");
@@ -123,6 +125,11 @@ function stringLiteralsIn(node: ts.Node): string[] {
   walk(node, (child) => {
     if (ts.isStringLiteral(child) || ts.isNoSubstitutionTemplateLiteral(child)) {
       found.push(child.text);
+    } else if (ts.isTemplateHead(child) || ts.isTemplateMiddle(child) || ts.isTemplateTail(child)) {
+      // `className={`p-0 ${extra}`}` is a TemplateExpression, whose literal
+      // halves are these — not a NoSubstitutionTemplateLiteral. Missing them
+      // would let an interpolated class string past the scan entirely.
+      found.push(child.text);
     }
   });
   return found;
@@ -155,10 +162,50 @@ function attribute(el: ts.JsxOpeningLikeElement, name: string): ts.JsxAttribute 
 /** A horizontal-padding utility, in any of Tailwind's spellings for one. */
 const HORIZONTAL_PADDING = /(?:^|\s|:)!?(?:p|px|ps|pe|pl|pr)-\S+/;
 
-/** The shape the old chrome compensation took: the column plus a literal. */
-const COMPENSATED_INSET = /calc\(\s*1\.5rem\s*\+/;
+/**
+ * The shape the old chrome compensation took: the column plus a literal.
+ * `[\s_]` because Tailwind spells a space in an arbitrary value as an
+ * underscore, so `calc(1.5rem_+_11px)` is the same class as `calc(1.5rem + 11px)`.
+ */
+const COMPENSATED_INSET = /calc\([\s_]*1\.5rem[\s_]*\+/;
+
+/**
+ * Scrollports that are not `AppDialog.Body`/`BodyScroll` but are still the
+ * dialog's form body, and so still have to sit on the dialog column. Without
+ * this list, dropping the class from one of them would fail nothing: they are
+ * ordinary elements, invisible to the `AppDialog.*` scan below.
+ */
+const CUSTOM_SCROLLPORTS = [
+  { file: "src/components/Settings/SettingsDialog.tsx", what: "the right pane's form scrollport" },
+  { file: "src/components/Worktree/IssuePickerDialog.tsx", what: "the issue list scrollport" },
+];
 
 const ALL_FILES = SCAN_ROOTS.flatMap((root) => tsxFiles(root));
+
+/** Does any class string in this node name the class? */
+function carriesClass(node: ts.Node, className: string): boolean {
+  return stringLiteralsIn(node).some((literal) => literal.split(/\s+/).includes(className));
+}
+
+/**
+ * The class expression that carries `token` — the `cn(...)` call the inset is
+ * passed to. Narrowing to it keeps the padding scan off nested children, whose
+ * own padding cannot move the outer box.
+ */
+function insetExpression(member: ts.Node, token: string, isIdentifier: boolean): ts.Node | null {
+  let found: ts.Node | null = null;
+  walk(member, (node) => {
+    if (found || !ts.isCallExpression(node)) return;
+    const names = node.arguments.some((arg) =>
+      isIdentifier
+        ? ts.isIdentifier(arg) && arg.text === token
+        : (ts.isStringLiteral(arg) || ts.isNoSubstitutionTemplateLiteral(arg)) &&
+          arg.text.split(/\s+/).includes(token)
+    );
+    if (names) found = node;
+  });
+  return found;
+}
 
 describe("dialog inset contract — one column for header, body and footer", () => {
   const appDialog = parse(APP_DIALOG_PATH);
@@ -192,17 +239,12 @@ describe("dialog inset contract — one column for header, body and footer", () 
   });
 
   it.each(["Header", "Footer"])(
-    "%s takes its inset from the shared constant and adds no padding of its own",
+    "%s takes its inset from the shared constant and adds no padding beside it",
     (name) => {
-      const member = chromeMember(name);
+      const expression = insetExpression(chromeMember(name), INSET_CONST, true);
+      expect(expression, `AppDialog.${name} must inset via ${INSET_CONST}`).not.toBeNull();
 
-      let usesConstant = false;
-      walk(member, (node) => {
-        if (ts.isIdentifier(node) && node.text === INSET_CONST) usesConstant = true;
-      });
-      expect(usesConstant, `AppDialog.${name} must inset via ${INSET_CONST}`).toBe(true);
-
-      for (const literal of stringLiteralsIn(member)) {
+      for (const literal of stringLiteralsIn(expression as ts.Node)) {
         expect(
           HORIZONTAL_PADDING.test(literal),
           `AppDialog.${name} hard-codes horizontal padding in ${JSON.stringify(literal)}, ` +
@@ -213,14 +255,10 @@ describe("dialog inset contract — one column for header, body and footer", () 
   );
 
   it.each(["Body", "BodyScroll"])("%s absorbs the reserved gutter into its padding", (name) => {
-    const literals = stringLiteralsIn(chromeMember(name));
+    const expression = insetExpression(chromeMember(name), BODY_INSET_CLASS, false);
+    expect(expression, `AppDialog.${name} must carry \`${BODY_INSET_CLASS}\``).not.toBeNull();
 
-    expect(
-      literals.some((literal) => literal.split(/\s+/).includes(BODY_INSET_CLASS)),
-      `AppDialog.${name} must carry \`${BODY_INSET_CLASS}\``
-    ).toBe(true);
-
-    for (const literal of literals) {
+    for (const literal of stringLiteralsIn(expression as ts.Node)) {
       expect(
         HORIZONTAL_PADDING.test(literal),
         `AppDialog.${name} hard-codes horizontal padding in ${JSON.stringify(literal)}, ` +
@@ -229,24 +267,41 @@ describe("dialog inset contract — one column for header, body and footer", () 
     }
   });
 
-  it("keeps the measured-gutter plumbing joined up from module to stylesheet", () => {
-    const css = fs.readFileSync(INDEX_CSS_PATH, "utf8");
+  it.each(CUSTOM_SCROLLPORTS)("$what stays on the dialog column", ({ file }) => {
+    const source = parse(path.join(REPO_ROOT, file));
 
-    // Take the rule body first. The comment above the selector quotes the very
-    // figures asserted below, so a scan of the whole file would pass on prose.
-    const rule = new RegExp(`\\.${BODY_INSET_CLASS}\\s*\\{([^}]*)\\}`).exec(css);
-    const body = rule?.[1];
-    if (body === undefined) {
-      throw new Error(`\`.${BODY_INSET_CLASS}\` must be declared in index.css`);
-    }
-
-    expect(body, "the padding must subtract the measured gutter from the column").toMatch(
-      new RegExp(`padding-inline:\\s*max\\(\\s*0px\\s*,\\s*calc\\(\\s*${COLUMN_REM}\\s*-`)
-    );
     expect(
-      body.includes(`var(${SCROLLBAR_GUTTER_VAR}`),
-      `the padding must read ${SCROLLBAR_GUTTER_VAR}, the property the probe publishes`
+      carriesClass(source, BODY_INSET_CLASS),
+      `${file} is a dialog form body, so it must carry \`${BODY_INSET_CLASS}\` — ` +
+        "without it the fields drift off the chrome's column wherever the platform " +
+        "reserves a scrollbar gutter"
     ).toBe(true);
+  });
+
+  it("keeps the measured-gutter plumbing joined up from module to stylesheet", () => {
+    // Comments go first: the block above the selector quotes the very figures
+    // asserted below, and a commented-out rule must not satisfy the contract.
+    const css = fs.readFileSync(INDEX_CSS_PATH, "utf8").replace(/\/\*[\s\S]*?\*\//g, "");
+
+    // Exactly one — a second rule for the same selector would silently win.
+    const declarations = css.match(new RegExp(`\\.${BODY_INSET_CLASS}\\s*\\{`, "g")) ?? [];
+    expect(
+      declarations.length,
+      `\`.${BODY_INSET_CLASS}\` must be declared exactly once in index.css`
+    ).toBe(1);
+
+    const rule = new RegExp(`\\.${BODY_INSET_CLASS}\\s*\\{([^}]*)\\}`).exec(css);
+    const body = rule?.[1] ?? "";
+
+    // One assertion, not two: the column, the subtraction and the property the
+    // probe publishes have to appear in that order in the same declaration.
+    // Checked separately, `var(--app-scrollbar-gutter-v2)` would satisfy both.
+    expect(body, "the padding must subtract the measured gutter from the column").toMatch(
+      new RegExp(
+        `padding-inline:\\s*max\\(\\s*0px\\s*,\\s*calc\\(\\s*${COLUMN_REM}\\s*-\\s*` +
+          `var\\(\\s*${SCROLLBAR_GUTTER_VAR}\\s*[,)]`
+      )
+    );
     // Reserving the gutter is what stops the body shifting sideways the moment
     // it starts to overflow; `both-edges` is what keeps that symmetric.
     expect(body).toMatch(/scrollbar-gutter:\s*stable\s+both-edges/);
@@ -272,8 +327,11 @@ describe("dialog inset contract — one column for header, body and footer", () 
     const offenders: string[] = [];
     for (const file of ALL_FILES) {
       const source = parse(file);
+      const binding = dialogBinding(source);
       for (const el of openingElements(source)) {
-        if (attribute(el, "plainBody")) {
+        // Scoped to `AppDialog.*`: an unrelated component is free to have a
+        // prop of the same name.
+        if (memberName(el.tagName, binding) && attribute(el, "plainBody")) {
           offenders.push(path.relative(REPO_ROOT, file));
         }
       }

--- a/src/config/__tests__/dialogInset.contract.test.ts
+++ b/src/config/__tests__/dialogInset.contract.test.ts
@@ -1,0 +1,342 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+import { SCROLLBAR_GUTTER_VAR } from "@/lib/scrollbarGutter";
+
+// A dialog's header, body and footer sit in three different boxes and are
+// supposed to land on one column. Nothing renders wrong when they drift — the
+// title is simply a few pixels off the field below it, which survives review
+// indefinitely because it is invisible without a ruler. #12101 shipped that way
+// for months: the chrome compensated for a scrollbar gutter with a hardcoded
+// 11px, macOS reserved 0, and the header and footer sat 11px inside the form.
+//
+// The fix removed the figure rather than correcting it — the body absorbs
+// whatever the platform actually reserves, and the chrome is a plain `px-6`. So
+// what this guards is the shape of that arrangement:
+//   - header and footer take their inset from one constant, not two literals;
+//   - both body variants carry the class that does the absorbing;
+//   - nobody overrides that class's padding from a call site;
+//   - the measured-gutter plumbing (module → custom property → CSS) stays
+//     joined up end to end;
+//   - `plainBody`, the opt-in that split dialogs across two columns, stays gone.
+//
+// KNOWN LIMITS (deliberate — a regression guard, not a sound checker):
+//   - A class string built at runtime, or reached through a wrapper component,
+//     is outside this file's view.
+//   - Only the specific `calc(<column> + <literal>)` shape is rejected. A fresh
+//     magic number spelled some other way (`px-[35px]`) would pass.
+//   - Custom scrollports that are not `AppDialog.Body`/`BodyScroll` are not
+//     inspected. `HybridInputBar`'s expanded editor deliberately sits on a
+//     tighter column than the dialog's, and is not a defect.
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(TEST_DIR, "../../..");
+const SCAN_ROOTS = [
+  path.join(REPO_ROOT, "src"),
+  path.join(REPO_ROOT, "plugins/builtin/github/renderer"),
+];
+
+const APP_DIALOG_PATH = path.join(REPO_ROOT, "src/components/ui/AppDialog.tsx");
+const INDEX_CSS_PATH = path.join(REPO_ROOT, "src/index.css");
+
+const APP_DIALOG_MODULE = "/AppDialog";
+const DEFAULT_DIALOG_BINDING = "AppDialog";
+
+/** The constant both chrome members must resolve their inset through. */
+const INSET_CONST = "DIALOG_INSET";
+/** The class that reserves the gutter and takes it back out of the padding. */
+const BODY_INSET_CLASS = "dialog-body-inset";
+/**
+ * Tailwind's `px-6` is 1.5rem, which is the figure `.dialog-body-inset`
+ * subtracts the gutter from. The two spellings are the coupling this file
+ * exists to hold: change one and the chrome and the body stop agreeing.
+ */
+const CHROME_INSET_CLASS = "px-6";
+const COLUMN_REM = "1.5rem";
+
+// Coverage ratchets, set to the current actuals. This is a static scan, so the
+// numbers only move when someone adds or removes a dialog. Growth passes; a
+// DROP fails, which is the point — it means a rename stopped matching and the
+// contract went blind.
+const MIN_HEADERS_INSPECTED = 33;
+const MIN_FOOTERS_INSPECTED = 25;
+const MIN_BODIES_INSPECTED = 28;
+
+function tsxFiles(dir: string, found: string[] = []): string[] {
+  if (!fs.existsSync(dir)) return found;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "node_modules" || entry.name === "__tests__") continue;
+      tsxFiles(full, found);
+    } else if (entry.name.endsWith(".tsx")) {
+      found.push(full);
+    }
+  }
+  return found;
+}
+
+function parse(file: string): ts.SourceFile {
+  return ts.createSourceFile(
+    file,
+    fs.readFileSync(file, "utf8"),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX
+  );
+}
+
+/**
+ * The local name `AppDialog` is bound to in this file. Almost always
+ * "AppDialog", but an alias would otherwise slip every dialog in the file past
+ * the tag-name match.
+ */
+function dialogBinding(source: ts.SourceFile): string {
+  for (const statement of source.statements) {
+    if (!ts.isImportDeclaration(statement)) continue;
+    const specifier = statement.moduleSpecifier;
+    if (!ts.isStringLiteral(specifier) || !specifier.text.endsWith(APP_DIALOG_MODULE)) continue;
+    const bindings = statement.importClause?.namedBindings;
+    if (!bindings || !ts.isNamedImports(bindings)) continue;
+    for (const element of bindings.elements) {
+      const imported = element.propertyName?.text ?? element.name.text;
+      if (imported === DEFAULT_DIALOG_BINDING) return element.name.text;
+    }
+  }
+  return DEFAULT_DIALOG_BINDING;
+}
+
+function walk(node: ts.Node, visit: (node: ts.Node) => void): void {
+  visit(node);
+  node.forEachChild((child) => walk(child, visit));
+}
+
+/**
+ * Every string literal reachable inside a node. AST, not text: `AppDialog.tsx`
+ * quotes `px-6` and the old `11px` in its own prose, and a scan of the file's
+ * characters cannot tell a class name from a comment about one.
+ */
+function stringLiteralsIn(node: ts.Node): string[] {
+  const found: string[] = [];
+  walk(node, (child) => {
+    if (ts.isStringLiteral(child) || ts.isNoSubstitutionTemplateLiteral(child)) {
+      found.push(child.text);
+    }
+  });
+  return found;
+}
+
+/** `AppDialog.Header` → "Header", for a JSX tag written as a property access. */
+function memberName(tag: ts.JsxTagNameExpression, binding: string): string | null {
+  if (!ts.isPropertyAccessExpression(tag)) return null;
+  if (!ts.isIdentifier(tag.expression) || tag.expression.text !== binding) return null;
+  return tag.name.text;
+}
+
+function openingElements(source: ts.SourceFile): ts.JsxOpeningLikeElement[] {
+  const found: ts.JsxOpeningLikeElement[] = [];
+  walk(source, (node) => {
+    if (ts.isJsxOpeningElement(node) || ts.isJsxSelfClosingElement(node)) found.push(node);
+  });
+  return found;
+}
+
+function attribute(el: ts.JsxOpeningLikeElement, name: string): ts.JsxAttribute | null {
+  for (const prop of el.attributes.properties) {
+    if (ts.isJsxAttribute(prop) && ts.isIdentifier(prop.name) && prop.name.text === name) {
+      return prop;
+    }
+  }
+  return null;
+}
+
+/** A horizontal-padding utility, in any of Tailwind's spellings for one. */
+const HORIZONTAL_PADDING = /(?:^|\s|:)!?(?:p|px|ps|pe|pl|pr)-\S+/;
+
+/** The shape the old chrome compensation took: the column plus a literal. */
+const COMPENSATED_INSET = /calc\(\s*1\.5rem\s*\+/;
+
+const ALL_FILES = SCAN_ROOTS.flatMap((root) => tsxFiles(root));
+
+describe("dialog inset contract — one column for header, body and footer", () => {
+  const appDialog = parse(APP_DIALOG_PATH);
+
+  function chromeMember(name: string): ts.Node {
+    let found: ts.Node | null = null;
+    walk(appDialog, (node) => {
+      if (!ts.isBinaryExpression(node)) return;
+      const { left, operatorToken, right } = node;
+      if (operatorToken.kind !== ts.SyntaxKind.EqualsToken) return;
+      if (!ts.isPropertyAccessExpression(left) || left.name.text !== name) return;
+      found = right;
+    });
+    if (!found) throw new Error(`AppDialog.${name} assignment not found`);
+    return found;
+  }
+
+  it("declares the chrome inset once, as the dialog column", () => {
+    let literal: string | null = null;
+    walk(appDialog, (node) => {
+      if (!ts.isVariableDeclaration(node)) return;
+      if (!ts.isIdentifier(node.name) || node.name.text !== INSET_CONST) return;
+      if (node.initializer && ts.isStringLiteral(node.initializer)) {
+        literal = node.initializer.text;
+      }
+    });
+
+    expect(literal, `${INSET_CONST} must be a string literal Tailwind can see`).toBe(
+      CHROME_INSET_CLASS
+    );
+  });
+
+  it.each(["Header", "Footer"])(
+    "%s takes its inset from the shared constant and adds no padding of its own",
+    (name) => {
+      const member = chromeMember(name);
+
+      let usesConstant = false;
+      walk(member, (node) => {
+        if (ts.isIdentifier(node) && node.text === INSET_CONST) usesConstant = true;
+      });
+      expect(usesConstant, `AppDialog.${name} must inset via ${INSET_CONST}`).toBe(true);
+
+      for (const literal of stringLiteralsIn(member)) {
+        expect(
+          HORIZONTAL_PADDING.test(literal),
+          `AppDialog.${name} hard-codes horizontal padding in ${JSON.stringify(literal)}, ` +
+            `which would override ${INSET_CONST}`
+        ).toBe(false);
+      }
+    }
+  );
+
+  it.each(["Body", "BodyScroll"])("%s absorbs the reserved gutter into its padding", (name) => {
+    const literals = stringLiteralsIn(chromeMember(name));
+
+    expect(
+      literals.some((literal) => literal.split(/\s+/).includes(BODY_INSET_CLASS)),
+      `AppDialog.${name} must carry \`${BODY_INSET_CLASS}\``
+    ).toBe(true);
+
+    for (const literal of literals) {
+      expect(
+        HORIZONTAL_PADDING.test(literal),
+        `AppDialog.${name} hard-codes horizontal padding in ${JSON.stringify(literal)}, ` +
+          `which would fight \`${BODY_INSET_CLASS}\``
+      ).toBe(false);
+    }
+  });
+
+  it("keeps the measured-gutter plumbing joined up from module to stylesheet", () => {
+    const css = fs.readFileSync(INDEX_CSS_PATH, "utf8");
+
+    // Take the rule body first. The comment above the selector quotes the very
+    // figures asserted below, so a scan of the whole file would pass on prose.
+    const rule = new RegExp(`\\.${BODY_INSET_CLASS}\\s*\\{([^}]*)\\}`).exec(css);
+    const body = rule?.[1];
+    if (body === undefined) {
+      throw new Error(`\`.${BODY_INSET_CLASS}\` must be declared in index.css`);
+    }
+
+    expect(body, "the padding must subtract the measured gutter from the column").toMatch(
+      new RegExp(`padding-inline:\\s*max\\(\\s*0px\\s*,\\s*calc\\(\\s*${COLUMN_REM}\\s*-`)
+    );
+    expect(
+      body.includes(`var(${SCROLLBAR_GUTTER_VAR}`),
+      `the padding must read ${SCROLLBAR_GUTTER_VAR}, the property the probe publishes`
+    ).toBe(true);
+    // Reserving the gutter is what stops the body shifting sideways the moment
+    // it starts to overflow; `both-edges` is what keeps that symmetric.
+    expect(body).toMatch(/scrollbar-gutter:\s*stable\s+both-edges/);
+  });
+
+  it("has no dialog anywhere still compensating for a guessed gutter", () => {
+    const offenders: string[] = [];
+    for (const file of ALL_FILES) {
+      for (const literal of stringLiteralsIn(parse(file))) {
+        if (COMPENSATED_INSET.test(literal)) {
+          offenders.push(`${path.relative(REPO_ROOT, file)}: ${JSON.stringify(literal)}`);
+        }
+      }
+    }
+
+    expect(
+      offenders,
+      "the reserved gutter is a platform property — measure it, do not add a literal back"
+    ).toEqual([]);
+  });
+
+  it("has no call site opting out of the shared column", () => {
+    const offenders: string[] = [];
+    for (const file of ALL_FILES) {
+      const source = parse(file);
+      for (const el of openingElements(source)) {
+        if (attribute(el, "plainBody")) {
+          offenders.push(path.relative(REPO_ROOT, file));
+        }
+      }
+    }
+
+    expect(
+      offenders,
+      "`plainBody` split dialogs across two columns and was removed with #12101"
+    ).toEqual([]);
+  });
+
+  it("has no call site overriding the body's horizontal padding", () => {
+    const offenders: string[] = [];
+    let bodies = 0;
+
+    for (const file of ALL_FILES) {
+      const source = parse(file);
+      if (path.resolve(file) === APP_DIALOG_PATH) continue;
+      const binding = dialogBinding(source);
+
+      for (const el of openingElements(source)) {
+        const member = memberName(el.tagName, binding);
+        if (member !== "Body" && member !== "BodyScroll") continue;
+        bodies += 1;
+
+        const className = attribute(el, "className");
+        if (!className?.initializer) continue;
+        for (const literal of stringLiteralsIn(className.initializer)) {
+          if (HORIZONTAL_PADDING.test(literal)) {
+            offenders.push(
+              `${path.relative(REPO_ROOT, file)}: ${JSON.stringify(literal)} on ${binding}.${member}`
+            );
+          }
+        }
+      }
+    }
+
+    expect(
+      offenders,
+      `a padding utility on the body outranks \`.${BODY_INSET_CLASS}\` and puts the fields ` +
+        "back off the chrome's column"
+    ).toEqual([]);
+    expect(bodies, "body scan went blind — did a rename stop matching?").toBeGreaterThanOrEqual(
+      MIN_BODIES_INSPECTED
+    );
+  });
+
+  it("still sees every dialog's chrome", () => {
+    let headers = 0;
+    let footers = 0;
+
+    for (const file of ALL_FILES) {
+      const source = parse(file);
+      if (path.resolve(file) === APP_DIALOG_PATH) continue;
+      const binding = dialogBinding(source);
+      for (const el of openingElements(source)) {
+        const member = memberName(el.tagName, binding);
+        if (member === "Header") headers += 1;
+        if (member === "Footer") footers += 1;
+      }
+    }
+
+    expect(headers).toBeGreaterThanOrEqual(MIN_HEADERS_INSPECTED);
+    expect(footers).toBeGreaterThanOrEqual(MIN_FOOTERS_INSPECTED);
+  });
+});

--- a/src/index.css
+++ b/src/index.css
@@ -918,6 +918,26 @@ code.hljs {
     background: var(--scrollbar-track);
   }
 
+  /* The dialog column. Header, body and footer all land 1.5rem from the card's
+     inner edge — on every platform, whether or not the body is scrolling.
+
+     The body reserves a scrollbar gutter so its content does not jump sideways
+     the moment it crosses the overflow threshold. What that gutter costs is not
+     a constant: macOS overlay scrollbars reserve nothing, classic scrollbars
+     reserve their full width, and no CSS primitive reports which happened. So
+     `publishScrollbarGutter()` measures it, and the padding here absorbs it
+     instead of asking the header and footer to add it back — a compensating
+     literal in the chrome was right on exactly one platform and wrong on the
+     rest (#12101).
+
+     `max()` floors the padding at zero if a platform ever reserves more than
+     the column itself; negative padding cannot claw space back from a native
+     scrollbar, so widening the column is the only safe overflow. */
+  .dialog-body-inset {
+    padding-inline: max(0px, calc(1.5rem - var(--app-scrollbar-gutter, 0px)));
+    scrollbar-gutter: stable both-edges;
+  }
+
   /* The agent grid draws its own scrollbar — the GridScrollbar component, a
      chunky physical handle modelled on xterm's (VS Code's) slider, sitting in
      a real reserved gutter. The native scrollbar is hidden entirely: the grid

--- a/src/lib/__tests__/scrollbarGutter.test.ts
+++ b/src/lib/__tests__/scrollbarGutter.test.ts
@@ -1,0 +1,148 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  SCROLLBAR_GUTTER_VAR,
+  measureScrollbarGutter,
+  publishScrollbarGutter,
+} from "../scrollbarGutter";
+
+/**
+ * jsdom has no layout, so the probe's box metrics are stubbed. That is the
+ * whole point of these tests: the arithmetic and the DOM bookkeeping around the
+ * measurement are what can regress, and both are testable without a real
+ * engine. The pixel figure itself is a platform property — no unit test can
+ * assert it, and one that hardcoded 11px would be re-asserting the bug #12101
+ * was filed for.
+ */
+
+const restore: (() => void)[] = [];
+
+function stubProbeBox(read: (probe: HTMLElement) => { offsetWidth: number; clientWidth: number }) {
+  const offset = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "offsetWidth");
+  const client = Object.getOwnPropertyDescriptor(Element.prototype, "clientWidth");
+
+  Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
+    configurable: true,
+    get(this: HTMLElement) {
+      return read(this).offsetWidth;
+    },
+  });
+  Object.defineProperty(Element.prototype, "clientWidth", {
+    configurable: true,
+    get(this: HTMLElement) {
+      return read(this).clientWidth;
+    },
+  });
+
+  restore.push(() => {
+    if (offset) Object.defineProperty(HTMLElement.prototype, "offsetWidth", offset);
+    if (client) Object.defineProperty(Element.prototype, "clientWidth", client);
+  });
+}
+
+/** A fixed gutter of `gutter` px, whatever the probe looks like. */
+function stubGutter(gutter: number) {
+  stubProbeBox(() => ({ offsetWidth: 100, clientWidth: 100 - gutter }));
+}
+
+afterEach(() => {
+  for (const undo of restore.splice(0)) undo();
+  document.documentElement.style.removeProperty(SCROLLBAR_GUTTER_VAR);
+  vi.restoreAllMocks();
+});
+
+describe("measureScrollbarGutter", () => {
+  it("reports the difference between the probe's border box and its content box", () => {
+    stubGutter(11);
+    expect(measureScrollbarGutter()).toBe(11);
+  });
+
+  it("reports 0 under overlay scrollbars, which reserve nothing", () => {
+    stubGutter(0);
+    expect(measureScrollbarGutter()).toBe(0);
+  });
+
+  it("clamps a negative difference to 0", () => {
+    stubProbeBox(() => ({ offsetWidth: 100, clientWidth: 120 }));
+    expect(measureScrollbarGutter()).toBe(0);
+  });
+
+  it("measures the probe while it is in the document — a detached box has no layout", () => {
+    let connectedWhenMeasured: boolean | null = null;
+    stubProbeBox((probe) => {
+      connectedWhenMeasured = probe.isConnected;
+      return { offsetWidth: 100, clientWidth: 89 };
+    });
+
+    measureScrollbarGutter();
+
+    expect(connectedWhenMeasured).toBe(true);
+  });
+
+  it("leaves no probe behind", () => {
+    stubGutter(11);
+    const before = document.body.childElementCount;
+
+    measureScrollbarGutter();
+
+    expect(document.body.childElementCount).toBe(before);
+  });
+
+  it("leaves no probe behind when the measurement throws", () => {
+    stubProbeBox(() => {
+      throw new Error("layout exploded");
+    });
+    const before = document.body.childElementCount;
+
+    expect(() => measureScrollbarGutter()).toThrow("layout exploded");
+    expect(document.body.childElementCount).toBe(before);
+  });
+});
+
+describe("publishScrollbarGutter", () => {
+  it("writes the measured gutter to the document root as px", () => {
+    stubGutter(11);
+
+    expect(publishScrollbarGutter()).toBe(11);
+    expect(document.documentElement.style.getPropertyValue(SCROLLBAR_GUTTER_VAR)).toBe("11px");
+  });
+
+  it("publishes 0px rather than leaving the property unset", () => {
+    stubGutter(0);
+
+    publishScrollbarGutter();
+
+    expect(document.documentElement.style.getPropertyValue(SCROLLBAR_GUTTER_VAR)).toBe("0px");
+  });
+
+  it("publishes a gutter wider than the dialog column unchanged — CSS owns the clamp", () => {
+    stubGutter(30);
+
+    publishScrollbarGutter();
+
+    expect(document.documentElement.style.getPropertyValue(SCROLLBAR_GUTTER_VAR)).toBe("30px");
+  });
+
+  it("does not rewrite the property when the figure has not moved", () => {
+    stubGutter(11);
+    publishScrollbarGutter();
+
+    const setProperty = vi.spyOn(document.documentElement.style, "setProperty");
+    publishScrollbarGutter();
+    publishScrollbarGutter();
+
+    expect(setProperty).not.toHaveBeenCalled();
+  });
+
+  it("rewrites the property when the platform's gutter changes under it", () => {
+    stubGutter(0);
+    publishScrollbarGutter();
+    expect(document.documentElement.style.getPropertyValue(SCROLLBAR_GUTTER_VAR)).toBe("0px");
+
+    for (const undo of restore.splice(0)) undo();
+    stubGutter(11);
+
+    expect(publishScrollbarGutter()).toBe(11);
+    expect(document.documentElement.style.getPropertyValue(SCROLLBAR_GUTTER_VAR)).toBe("11px");
+  });
+});

--- a/src/lib/__tests__/scrollbarGutter.test.ts
+++ b/src/lib/__tests__/scrollbarGutter.test.ts
@@ -4,6 +4,7 @@ import {
   SCROLLBAR_GUTTER_VAR,
   measureScrollbarGutter,
   publishScrollbarGutter,
+  watchScrollbarGutter,
 } from "../scrollbarGutter";
 
 /**
@@ -67,16 +68,44 @@ describe("measureScrollbarGutter", () => {
     expect(measureScrollbarGutter()).toBe(0);
   });
 
-  it("measures the probe while it is in the document — a detached box has no layout", () => {
-    let connectedWhenMeasured: boolean | null = null;
+  it("measures a dedicated probe, in the document and configured to reserve a gutter", () => {
+    // The stub answers for ANY element, so without pinning down *which* element
+    // was read, an implementation that measured `document.body` — or a probe
+    // missing `overflow: scroll` and thus reserving nothing — would pass every
+    // other test here and still report 0 on Windows.
+    const reads: { el: Element; connected: boolean; style: string | null }[] = [];
     stubProbeBox((probe) => {
-      connectedWhenMeasured = probe.isConnected;
+      reads.push({ el: probe, connected: probe.isConnected, style: probe.getAttribute("style") });
       return { offsetWidth: 100, clientWidth: 89 };
     });
 
-    measureScrollbarGutter();
+    expect(measureScrollbarGutter()).toBe(11);
 
-    expect(connectedWhenMeasured).toBe(true);
+    expect(reads.length, "both box metrics must be read").toBeGreaterThanOrEqual(2);
+    const probe = reads[0]!.el;
+    expect(
+      reads.every((read) => read.el === probe),
+      "both metrics must come off the same element"
+    ).toBe(true);
+    expect(probe).not.toBe(document.body);
+    expect(probe).not.toBe(document.documentElement);
+    expect(probe.tagName).toBe("DIV");
+
+    expect(
+      reads.every((read) => read.connected),
+      "a detached element has no layout, so the gutter would read as 0 everywhere"
+    ).toBe(true);
+
+    const style = reads[0]!.style ?? "";
+    // Each of these is load-bearing: drop one and the probe measures nothing.
+    expect(style, "must force a scrollbar to be reserved").toMatch(/overflow:\s*scroll/);
+    expect(style, "one gutter, not two").toMatch(/scrollbar-gutter:\s*stable(?!\s+both-edges)/);
+    expect(style, "must match what dialog bodies inherit").toMatch(/scrollbar-width:\s*thin/);
+    expect(style, "needs a real box to put a scrollbar in").toMatch(/width:\s*100px/);
+    expect(style, "border and padding would be counted as gutter").toMatch(/border:\s*0/);
+    expect(style).toMatch(/padding:\s*0/);
+
+    expect(probe.isConnected, "the probe must not outlive the measurement").toBe(false);
   });
 
   it("leaves no probe behind", () => {
@@ -89,12 +118,20 @@ describe("measureScrollbarGutter", () => {
   });
 
   it("leaves no probe behind when the measurement throws", () => {
-    stubProbeBox(() => {
+    let probe: Element | null = null;
+    stubProbeBox((el) => {
+      probe = el;
       throw new Error("layout exploded");
     });
     const before = document.body.childElementCount;
 
     expect(() => measureScrollbarGutter()).toThrow("layout exploded");
+
+    // Not just a body-count check: that would pass if the probe were never
+    // appended at all. The element that threw must have been attached, and
+    // must have been taken back out by the `finally`.
+    expect(probe, "the probe must have been measured").not.toBeNull();
+    expect((probe as unknown as Element).isConnected).toBe(false);
     expect(document.body.childElementCount).toBe(before);
   });
 });
@@ -144,5 +181,34 @@ describe("publishScrollbarGutter", () => {
 
     expect(publishScrollbarGutter()).toBe(11);
     expect(document.documentElement.style.getPropertyValue(SCROLLBAR_GUTTER_VAR)).toBe("11px");
+  });
+});
+
+describe("watchScrollbarGutter", () => {
+  it("re-publishes on focus, so a dialog that is already open does not stay stale", () => {
+    stubGutter(0);
+    const stop = watchScrollbarGutter();
+    publishScrollbarGutter();
+    expect(document.documentElement.style.getPropertyValue(SCROLLBAR_GUTTER_VAR)).toBe("0px");
+
+    for (const undo of restore.splice(0)) undo();
+    stubGutter(11);
+    window.dispatchEvent(new Event("focus"));
+
+    expect(document.documentElement.style.getPropertyValue(SCROLLBAR_GUTTER_VAR)).toBe("11px");
+    stop();
+  });
+
+  it("stops measuring once disposed", () => {
+    stubGutter(0);
+    const stop = watchScrollbarGutter();
+    publishScrollbarGutter();
+    stop();
+
+    for (const undo of restore.splice(0)) undo();
+    stubGutter(11);
+    window.dispatchEvent(new Event("focus"));
+
+    expect(document.documentElement.style.getPropertyValue(SCROLLBAR_GUTTER_VAR)).toBe("0px");
   });
 });

--- a/src/lib/scrollbarGutter.ts
+++ b/src/lib/scrollbarGutter.ts
@@ -1,0 +1,81 @@
+/**
+ * How much room the platform's scrollbar actually takes, measured rather than
+ * assumed.
+ *
+ * `scrollbar-gutter: stable` reserves a scrollbar-width of layout — but only
+ * where the scrollbar is a classic, space-taking one. macOS draws overlay
+ * scrollbars, which sit on top of the content and reserve nothing, so the same
+ * declaration reserves 0 there and the full bar width on Windows and Linux.
+ * Nothing in CSS exposes which of those happened, and the user can switch
+ * between them mid-session (System Settings › Appearance › Show scroll bars).
+ *
+ * So a stylesheet that has to line up with a reserved gutter cannot name a
+ * number: #12101 shipped `calc(1.5rem + 11px)` against a gutter that turned out
+ * to be 0px on macOS, which put every dialog's header and footer 11px inside
+ * its own form. This module measures the real figure and publishes it, and
+ * `.dialog-body-inset` in `index.css` subtracts it back out of the body's
+ * padding so the column lands on 24px either way.
+ */
+
+/** The custom property `.dialog-body-inset` reads. */
+export const SCROLLBAR_GUTTER_VAR = "--app-scrollbar-gutter";
+
+/**
+ * The width of one reserved gutter, in CSS px. 0 under overlay scrollbars.
+ *
+ * The probe has to be in the document to have layout at all — a detached
+ * element reports 0 for every box metric, which would read as "overlay
+ * scrollbars" on every platform. It is parked off-screen and hidden rather
+ * than sized to nothing: `overflow: scroll` on a zero-sized box has no room to
+ * put a scrollbar in.
+ *
+ * `stable` (not `both-edges`) so the result is one gutter, which is what the
+ * padding subtracts per side.
+ */
+export function measureScrollbarGutter(): number {
+  const probe = document.createElement("div");
+  probe.setAttribute("aria-hidden", "true");
+  probe.style.cssText = [
+    "position:absolute",
+    "top:-9999px",
+    "left:-9999px",
+    "width:100px",
+    "height:100px",
+    "padding:0",
+    "border:0",
+    "overflow:scroll",
+    "scrollbar-gutter:stable",
+    // Matches what dialog bodies inherit from `* { scrollbar-width: thin }`.
+    // A probe left on `auto` would measure the wider bar and over-subtract.
+    "scrollbar-width:thin",
+    "visibility:hidden",
+    "pointer-events:none",
+  ].join(";");
+
+  document.body.appendChild(probe);
+  try {
+    return Math.max(0, probe.offsetWidth - probe.clientWidth);
+  } finally {
+    probe.remove();
+  }
+}
+
+/**
+ * Measure and publish onto the document root, returning the figure (or `null`
+ * if there is no document to measure in yet).
+ *
+ * The write is skipped when the value has not moved. It normally never moves,
+ * and every dialog opening calls this — an unconditional `setProperty` on
+ * `documentElement` would invalidate style for the whole tree each time.
+ */
+export function publishScrollbarGutter(): number | null {
+  if (typeof document === "undefined" || !document.body) return null;
+
+  const gutter = measureScrollbarGutter();
+  const next = `${gutter}px`;
+  const root = document.documentElement;
+  if (root.style.getPropertyValue(SCROLLBAR_GUTTER_VAR) !== next) {
+    root.style.setProperty(SCROLLBAR_GUTTER_VAR, next);
+  }
+  return gutter;
+}

--- a/src/lib/scrollbarGutter.ts
+++ b/src/lib/scrollbarGutter.ts
@@ -21,6 +21,29 @@
 export const SCROLLBAR_GUTTER_VAR = "--app-scrollbar-gutter";
 
 /**
+ * The probe's configuration, which is the whole measurement: `overflow: scroll`
+ * and `scrollbar-gutter: stable` force exactly one gutter to be reserved, and
+ * `scrollbar-width: thin` matches what a dialog body inherits from
+ * `* { scrollbar-width: thin }` in `index.css` — a probe left on `auto` would
+ * measure the wider bar and over-subtract. It needs a real size and no border
+ * or padding of its own for `offsetWidth - clientWidth` to be the gutter alone.
+ */
+const PROBE_STYLE = [
+  "position:absolute",
+  "top:-9999px",
+  "left:-9999px",
+  "width:100px",
+  "height:100px",
+  "padding:0",
+  "border:0",
+  "overflow:scroll",
+  "scrollbar-gutter:stable",
+  "scrollbar-width:thin",
+  "visibility:hidden",
+  "pointer-events:none",
+].join(";");
+
+/**
  * The width of one reserved gutter, in CSS px. 0 under overlay scrollbars.
  *
  * The probe has to be in the document to have layout at all — a detached
@@ -35,22 +58,12 @@ export const SCROLLBAR_GUTTER_VAR = "--app-scrollbar-gutter";
 export function measureScrollbarGutter(): number {
   const probe = document.createElement("div");
   probe.setAttribute("aria-hidden", "true");
-  probe.style.cssText = [
-    "position:absolute",
-    "top:-9999px",
-    "left:-9999px",
-    "width:100px",
-    "height:100px",
-    "padding:0",
-    "border:0",
-    "overflow:scroll",
-    "scrollbar-gutter:stable",
-    // Matches what dialog bodies inherit from `* { scrollbar-width: thin }`.
-    // A probe left on `auto` would measure the wider bar and over-subtract.
-    "scrollbar-width:thin",
-    "visibility:hidden",
-    "pointer-events:none",
-  ].join(";");
+  // `setAttribute` rather than `style.cssText` so the declaration survives
+  // verbatim on the attribute: a CSSOM that does not implement
+  // `scrollbar-gutter` drops it when re-serialising `cssText`, and the probe's
+  // configuration would then be unassertable in a test. It changes nothing in
+  // an engine that supports the property.
+  probe.setAttribute("style", PROBE_STYLE);
 
   document.body.appendChild(probe);
   try {
@@ -78,4 +91,29 @@ export function publishScrollbarGutter(): number | null {
     root.style.setProperty(SCROLLBAR_GUTTER_VAR, next);
   }
   return gutter;
+}
+
+/**
+ * Keep the published figure current for the lifetime of the renderer, and
+ * return a disposer.
+ *
+ * `AppDialog` re-measures as it opens, which covers the usual path — change the
+ * setting, then open a dialog. It does not cover a dialog that is *already*
+ * open: Chromium re-lays out its scrollport straight away, and the published
+ * figure would stay stale until that dialog was reopened, leaving its content
+ * a gutter's width off the chrome's column in the meantime.
+ *
+ * Focus is the event that catches it, because changing the setting means going
+ * to System Settings and coming back. The measurement is one off-screen probe
+ * and the write is skipped unless the figure actually moved, so an ordinary
+ * alt-tab costs a layout read and nothing else.
+ */
+export function watchScrollbarGutter(): () => void {
+  if (typeof window === "undefined") return () => {};
+
+  const onFocus = () => {
+    publishScrollbarGutter();
+  };
+  window.addEventListener("focus", onFocus);
+  return () => window.removeEventListener("focus", onFocus);
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -18,7 +18,7 @@ import latin400Woff2Url from "@fontsource/jetbrains-mono/files/jetbrains-mono-la
 import "@fontsource/jetbrains-mono/latin-700.css";
 import "./index.css";
 import { applyDefaultAppTheme } from "./theme/applyAppTheme";
-import { publishScrollbarGutter } from "./lib/scrollbarGutter";
+import { publishScrollbarGutter, watchScrollbarGutter } from "./lib/scrollbarGutter";
 import { ensureLatin400Preload } from "./lib/fontPreload";
 // Importing this module has the side effect of starting the font load (via
 // the eagerly-initialised `terminalFontReady` singleton). Terminals open
@@ -39,6 +39,7 @@ import {
 import { WorktreeStoreProvider } from "./contexts/WorktreeStoreContext";
 
 let cleanupGlobalErrorHandlers: (() => void) | undefined;
+let cleanupScrollbarGutterWatch: (() => void) | undefined;
 let cleanupOrchestrator: (() => void) | undefined;
 
 ensureLatin400Preload(latin400Woff2Url);
@@ -58,9 +59,10 @@ async function bootstrap() {
 
   // Publish the platform's reserved scrollbar gutter before the first render,
   // so dialogs paint on the right column from their first frame rather than
-  // settling onto it. AppDialog re-measures on each open to track a mid-session
-  // change; this is only the seed.
+  // settling onto it. AppDialog re-measures as it opens and the watcher below
+  // catches a change made while a dialog is already open.
   publishScrollbarGutter();
+  cleanupScrollbarGutterWatch = watchScrollbarGutter();
 
   // Paint-fabric surface view (Phase 1V): the preload seeds the surface-host
   // role from additionalArguments. A surface view hosts terminals only —
@@ -149,6 +151,7 @@ bootstrap().catch((error: unknown) => {
 if (import.meta.hot) {
   import.meta.hot.dispose(() => {
     cleanupGlobalErrorHandlers?.();
+    cleanupScrollbarGutterWatch?.();
     cleanupOrchestrator?.();
   });
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -18,6 +18,7 @@ import latin400Woff2Url from "@fontsource/jetbrains-mono/files/jetbrains-mono-la
 import "@fontsource/jetbrains-mono/latin-700.css";
 import "./index.css";
 import { applyDefaultAppTheme } from "./theme/applyAppTheme";
+import { publishScrollbarGutter } from "./lib/scrollbarGutter";
 import { ensureLatin400Preload } from "./lib/fontPreload";
 // Importing this module has the side effect of starting the font load (via
 // the eagerly-initialised `terminalFontReady` singleton). Terminals open
@@ -54,6 +55,12 @@ async function bootstrap() {
   cleanupGlobalErrorHandlers = registerRendererGlobalErrorHandlers();
 
   applyDefaultAppTheme(document.documentElement);
+
+  // Publish the platform's reserved scrollbar gutter before the first render,
+  // so dialogs paint on the right column from their first frame rather than
+  // settling onto it. AppDialog re-measures on each open to track a mid-session
+  // change; this is only the seed.
+  publishScrollbarGutter();
 
   // Paint-fabric surface view (Phase 1V): the preload seeds the surface-host
   // role from additionalArguments. A surface view hosts terminals only —


### PR DESCRIPTION
## Summary
- A dialog's header and footer sat about 11px inside its own form body. `AppDialog` reserved a scrollbar gutter on the body with `scrollbar-gutter: stable both-edges`, then the chrome added the same 11px back with a hardcoded `CHROME_INSET`.
- Measured instead of guessed: in a real Electron 42 / Chromium 148.0.7778.280 window on macOS, `scrollbar-gutter: stable both-edges` reserves 0px. `offsetWidth - clientWidth` came back 0 across all nine permutations tested (overflowing or not, `stable` vs `both-edges`, with `scrollbar-width: thin` plus `scrollbar-color`, with `scrollbar-width: thin` alone, with neither). macOS draws overlay scrollbars, and the spec only reserves a gutter for classic, space-taking ones, so the chrome was compensating for a gutter that was never there.
- Deleting the compensation outright would have been the wrong fix: Windows and Linux draw classic scrollbars and the gutter genuinely reserves about 10 to 11px per edge there, so a flat `px-6` everywhere would have fixed macOS and inverted the bug on the other two platforms.

Resolves #12101

## Changes
- Added `src/lib/scrollbarGutter.ts`: an off-screen probe that measures what the current platform actually reserves and publishes it as `--app-scrollbar-gutter`.
- `AppDialog.Body` now absorbs that value out of its own padding via a `dialog-body-inset` class: `padding-inline: max(0px, calc(1.5rem - var(--app-scrollbar-gutter, 0px)))`. The column lands at 24px everywhere (24 + 0 on macOS, 14 + 10 on Windows), so the chrome is now a plain `px-6` with nothing left to compensate for.
- Deleted `plainBody`, an opt-in prop that split dialogs across two padding conventions, along with its 6 call sites. `BodyScroll` gets the same padding column. `PanelDialogHost` moves onto a plain element, since a reserved gutter applies even to an `overflow: hidden` box, so its old `p-0` was never actually cancelling anything, which is what an edge-to-edge panel host wants anyway.
- Folded three hand-copied `calc(1.5rem+11px)` insets back to plain `px-6` (`WorktreeOverviewModal` x2, `WorktreeSidebarSearchBar`), and dropped a `className="p-6"` override on `WorktreeOverviewModal`'s `Body`.

## Testing
- Re-measured in a real Electron window after the change: header, body content and footer all land at `left: 24px`, both while the body is scrolling and while it isn't.
- Added an AST source contract at `src/config/__tests__/dialogInset.contract.test.ts` plus unit tests for the probe, and proved both non-vacuous by reintroducing 8 separate defects one at a time (chrome compensation returning, the body losing `dialog-body-inset`, a caller padding override returning, `plainBody` returning, the layout effect deleted, the probe losing `overflow: scroll`, a custom scrollport dropped, the CSS rule commented out) and confirming each turns the tests red.
- Full local suite: 5,267 tests passing across config, lib, ui, Panel, Worktree, Settings, HelpPanel and Terminal. eslint, typecheck and prettier all clean on the 14 changed files.
- No screenshots. Verification was headless.