### PR TITLE
fix(diff): keep the unified diff's horizontal scrollbar reachable mid-file

### DIFF
--- a/src/components/Worktree/DiffViewer.css
+++ b/src/components/Worktree/DiffViewer.css
@@ -552,10 +552,28 @@
   border-spacing: 0;
 }
 
+/* Non-scrolling per-file shell whose only job is to be the sticky proxy
+   strip's containing block. The strip cannot live inside .diff-file-scroll:
+   `overflow-x: auto` with overflow-y at its initial `visible` computes to
+   `auto` (CSS Overflow 3 §3.3), making that div a scroll container on both
+   axes, so a sticky child would resolve against a scrollport the full height
+   of the file and pin exactly where the native bar already sits. From out here
+   the strip resolves against .diff-scroll-root instead, while still clamping
+   to this shell's box — which is also why two stacked files can never pin
+   their strips to the same viewport row. Must never gain overflow, contain,
+   transform, filter or perspective; any of those would become the sticky
+   containing block and silently re-pin the strip to the bottom of the file. */
+.diff-viewer .diff-file-shell {
+  position: relative;
+}
+
 /* Per-file horizontal scroll wrapper — gives each file its own scrollbar
    so all rows scroll together instead of each <td> scrolling independently.
    Used by unified view and single-side (add/delete) split tables; two-column
-   split tables use the centered-split system below instead. */
+   split tables use the centered-split system below instead. Stays a real
+   native scroller so find-in-page reveal, scrollIntoView, drag-select
+   autoscroll and native panning keep working — the sticky strip above is a
+   second control for the same offset, not a replacement. */
 .diff-viewer .diff-file-scroll {
   overflow-x: auto;
   /* Re-enable the ::-webkit-scrollbar styling below for a classic always-visible
@@ -636,6 +654,14 @@
   );
 }
 
+/* The native path's strip stands in for a real scroller, so its spacer takes
+   that scroller's measured scrollWidth instead of the centered path's
+   longest-line estimate — the two ranges then match exactly, which is what
+   keeps the two-way scrollLeft mirroring from fighting over a clamp. */
+.diff-viewer .diff-hscrollbar[data-scroll-mode="native"] .diff-hscroll-spacer {
+  width: var(--diff-native-scroll-width, 100%);
+}
+
 .diff-viewer .diff-hscrollbar::-webkit-scrollbar {
   height: 12px;
 }
@@ -670,6 +696,19 @@
 .diff-viewer .diff-file-scroll::-webkit-scrollbar {
   width: 8px;
   height: 8px;
+}
+
+/* Exactly one horizontal control per file: once the proxy strip has measured
+   real overflow and taken height, the scroller's own bar goes away. Both
+   attributes are written from the same `hasHOverflow` in one render, so the
+   handoff is atomic — and before the first measurement the strip is 0px tall
+   and this rule is off, so there is never a moment with no bar at all. */
+.diff-viewer .diff-file-scroll[data-proxy-active] {
+  scrollbar-width: none;
+}
+
+.diff-viewer .diff-file-scroll[data-proxy-active]::-webkit-scrollbar {
+  height: 0;
 }
 
 .diff-viewer .diff-file-scroll::-webkit-scrollbar-track {

--- a/src/components/Worktree/DiffViewer.css
+++ b/src/components/Worktree/DiffViewer.css
@@ -626,6 +626,13 @@
   bottom: 0;
   z-index: 3;
   overflow-x: auto;
+  /* Explicit, not incidental: left at its initial `visible` this would compute
+     to `auto` (CSS Overflow 3 §3.3) and the 1px spacer would overflow the
+     strip's 12px box — which the 12px horizontal bar already fills — reserving
+     width for a vertical scrollbar. That shrinks the strip's clientWidth below
+     the scroller's, so the proxy's scroll range runs past the content's and its
+     last few pixels of travel would have nothing to scroll to. */
+  overflow-y: hidden;
   height: 0;
   background: var(--color-surface-canvas);
   /* The global `* { scrollbar-width: thin; scrollbar-color: … }` opts every

--- a/src/components/Worktree/DiffViewer.tsx
+++ b/src/components/Worktree/DiffViewer.tsx
@@ -919,8 +919,10 @@ function FileDiff({
   // and fires no scroll event at all, because from its point of view nothing
   // moved. Waiting for an echo would leave the pair permanently out of step, so
   // the landed value is pushed back to the source instead. That second write
-  // can never clamp in turn (it is <= the value the source already held), which
-  // is what makes this settle within the one call.
+  // can never clamp in turn — a clamp only ever moves a value *closer* to the
+  // shared zero endpoint (RTL runs [-max, 0], so its clamped offsets are
+  // numerically greater), which always lands inside the source's own range.
+  // That is what makes this settle within the one call.
   const syncNativeHScroll = useCallback((source: "content" | "proxy") => {
     const content = nativeScrollerRef.current;
     const proxy = hScrollbarRef.current;
@@ -971,7 +973,13 @@ function FileDiff({
   // hunk reveal) — the strip may clamp scrollLeft without firing a scroll
   // event. The native path re-syncs inside its measurement effect instead,
   // because its proxy range depends on a spacer width published there.
-  useEffect(() => {
+  //
+  // Layout, not passive, for the same reason as the measurement below: React
+  // reuses this div and the strip node across the centered/native branches, so
+  // the strip can arrive here still holding the native path's offset while the
+  // reused div still holds the old --diff-hscroll. Reconciling that passively
+  // paints one frame of code at the wrong indent.
+  useLayoutEffect(() => {
     const region = regionRef.current;
     if (!region) return;
     region.style.setProperty("--diff-hscroll", `${hScrollbarRef.current?.scrollLeft ?? 0}px`);

--- a/src/components/Worktree/DiffViewer.tsx
+++ b/src/components/Worktree/DiffViewer.tsx
@@ -5,6 +5,7 @@ import {
   useDeferredValue,
   useEffect,
   useId,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -909,19 +910,27 @@ function FileDiff({
 
   // Two-way scrollLeft mirroring between the real scroller and its proxy strip.
   // Deliberately no re-entrancy flag: a synchronously cleared flag can't guard
-  // a scroll event that arrives asynchronously anyway. Instead each direction
-  // writes only when the two are a whole pixel or more apart, so the echo event
-  // the write triggers finds them equal and stops. If one end clamps (its range
-  // is momentarily the shorter of the two) the pair settles on the clamped
-  // value one tick later instead of oscillating.
+  // a scroll event that arrives asynchronously anyway. Instead the write is
+  // skipped once the two already agree, so the echo event each write triggers
+  // finds them equal and stops there.
+  //
+  // The read-back is not belt-and-braces. If the target clamps the write — its
+  // scroll range is the shorter of the two — it lands on a *different* value
+  // and fires no scroll event at all, because from its point of view nothing
+  // moved. Waiting for an echo would leave the pair permanently out of step, so
+  // the landed value is pushed back to the source instead. That second write
+  // can never clamp in turn (it is <= the value the source already held), which
+  // is what makes this settle within the one call.
   const syncNativeHScroll = useCallback((source: "content" | "proxy") => {
     const content = nativeScrollerRef.current;
     const proxy = hScrollbarRef.current;
     if (!content || !proxy) return;
     const from = source === "content" ? content : proxy;
     const to = source === "content" ? proxy : content;
-    if (Math.abs(to.scrollLeft - from.scrollLeft) < 1) return;
-    to.scrollLeft = from.scrollLeft;
+    const target = from.scrollLeft;
+    if (to.scrollLeft === target) return;
+    to.scrollLeft = target;
+    if (to.scrollLeft !== target && from.scrollLeft === target) from.scrollLeft = to.scrollLeft;
   }, []);
 
   const handleNativeHScroll = useCallback(() => {
@@ -978,7 +987,12 @@ function FileDiff({
   // re-expanding a file remounts both elements, and `usesNativeHScrollProxy`
   // because a unified wrap toggle never changes `isCenteredSplit`.
   const [hasHOverflow, setHasHOverflow] = useState(false);
-  useEffect(() => {
+  // Layout, not passive: `hasHOverflow` carries across a mode switch, so a
+  // centered split that overflowed would render the native branch with its bar
+  // already hidden while the freshly mounted strip still has no measured width
+  // — one painted frame of a dead proxy and no scrollbar at all. Measuring
+  // before paint retires that frame.
+  useLayoutEffect(() => {
     const proxy = hScrollbarRef.current;
     const native = usesNativeHScrollProxy ? nativeScrollerRef.current : null;
     if (!proxy || (usesNativeHScrollProxy && !native)) {

--- a/src/components/Worktree/DiffViewer.tsx
+++ b/src/components/Worktree/DiffViewer.tsx
@@ -882,8 +882,18 @@ function FileDiff({
     return max;
   }, [visibleHunks, isCenteredSplit]);
 
+  // Unified and single-side (add/delete) tables keep a real native
+  // overflow-x scroller and get the sticky strip as a *sibling* proxy that
+  // mirrors its offset, rather than replacing it the way centered split does.
+  // Keeping the native scroller preserves everything the browser gives for
+  // free — find-in-page reveal, scrollIntoView, drag-select autoscroll,
+  // shift+wheel and trackpad panning, arrow keys. Wrap mode has no horizontal
+  // overflow at all, so it gets no strip.
+  const usesNativeHScrollProxy = !isCenteredSplit && !wrapLines;
+
   const regionRef = useRef<HTMLDivElement | null>(null);
   const hScrollbarRef = useRef<HTMLDivElement | null>(null);
+  const nativeScrollerRef = useRef<HTMLDivElement | null>(null);
 
   // The scrollbar strip is the single scroll surface for both panes: its
   // scrollLeft becomes --diff-hscroll, which shifts every code cell's content
@@ -896,6 +906,31 @@ function FileDiff({
     if (!region || !bar) return;
     region.style.setProperty("--diff-hscroll", `${bar.scrollLeft}px`);
   }, []);
+
+  // Two-way scrollLeft mirroring between the real scroller and its proxy strip.
+  // Deliberately no re-entrancy flag: a synchronously cleared flag can't guard
+  // a scroll event that arrives asynchronously anyway. Instead each direction
+  // writes only when the two are a whole pixel or more apart, so the echo event
+  // the write triggers finds them equal and stops. If one end clamps (its range
+  // is momentarily the shorter of the two) the pair settles on the clamped
+  // value one tick later instead of oscillating.
+  const syncNativeHScroll = useCallback((source: "content" | "proxy") => {
+    const content = nativeScrollerRef.current;
+    const proxy = hScrollbarRef.current;
+    if (!content || !proxy) return;
+    const from = source === "content" ? content : proxy;
+    const to = source === "content" ? proxy : content;
+    if (Math.abs(to.scrollLeft - from.scrollLeft) < 1) return;
+    to.scrollLeft = from.scrollLeft;
+  }, []);
+
+  const handleNativeHScroll = useCallback(() => {
+    syncNativeHScroll("content");
+  }, [syncNativeHScroll]);
+
+  const handleNativeProxyScroll = useCallback(() => {
+    syncNativeHScroll("proxy");
+  }, [syncNativeHScroll]);
 
   // Trackpad/wheel gestures over the diff forward their horizontal component
   // to the scrollbar strip. Native listener because React delegates wheel as
@@ -922,40 +957,60 @@ function FileDiff({
     };
   }, [isCenteredSplit]);
 
-  // Keep the indent in sync when the scroll system mounts/unmounts or content
-  // changes under a non-zero offset (wrap toggle round-trip, collapse, hunk
-  // reveal) — the strip may clamp scrollLeft without firing a scroll event.
+  // Keep the centered indent in sync when the scroll system mounts/unmounts or
+  // content changes under a non-zero offset (wrap toggle round-trip, collapse,
+  // hunk reveal) — the strip may clamp scrollLeft without firing a scroll
+  // event. The native path re-syncs inside its measurement effect instead,
+  // because its proxy range depends on a spacer width published there.
   useEffect(() => {
     const region = regionRef.current;
     if (!region) return;
     region.style.setProperty("--diff-hscroll", `${hScrollbarRef.current?.scrollLeft ?? 0}px`);
-  }, [isCenteredSplit, visibleHunks]);
+  }, [isCenteredSplit, isCollapsed, visibleHunks]);
 
   // The strip only takes up vertical space when there is real overflow to
-  // scroll, measured from the spacer (estimated longest line) against the
-  // strip's own width. ResizeObserver re-measures on dialog resizes and
-  // spacer-width changes; it is absent under jsdom, where the initial
-  // measurement (always 0 > 0 → false) is all we need.
+  // scroll. Centered split measures its own spacer (an estimate of the longest
+  // line) against the strip's width; the native path measures the real
+  // scroller and publishes that scrollWidth so the proxy's range matches the
+  // content exactly instead of estimating it. Both observe a second element —
+  // the content box, not just the container — because ResizeObserver never
+  // fires for a scrollWidth-only change. `isCollapsed` is a dependency because
+  // re-expanding a file remounts both elements, and `usesNativeHScrollProxy`
+  // because a unified wrap toggle never changes `isCenteredSplit`.
   const [hasHOverflow, setHasHOverflow] = useState(false);
   useEffect(() => {
-    if (!isCenteredSplit) {
+    const proxy = hScrollbarRef.current;
+    const native = usesNativeHScrollProxy ? nativeScrollerRef.current : null;
+    if (!proxy || (usesNativeHScrollProxy && !native)) {
       setHasHOverflow(false);
       return;
     }
-    const bar = hScrollbarRef.current;
-    if (!bar) return;
+    const source = native ?? proxy;
     const measure = () => {
-      setHasHOverflow(bar.scrollWidth > bar.clientWidth + 1);
+      // Ordered: the proxy's scroll range has to match the content before the
+      // offset is mirrored into it, or the write clamps against a stale width.
+      if (native) {
+        proxy.style.setProperty("--diff-native-scroll-width", `${native.scrollWidth}px`);
+      }
+      setHasHOverflow(source.scrollWidth > source.clientWidth + 1);
+      if (native) syncNativeHScroll("content");
     };
     measure();
     if (typeof ResizeObserver === "undefined") return;
     const observer = new ResizeObserver(measure);
-    observer.observe(bar);
-    if (bar.firstElementChild) observer.observe(bar.firstElementChild);
+    observer.observe(source);
+    if (source.firstElementChild) observer.observe(source.firstElementChild);
     return () => {
       observer.disconnect();
     };
-  }, [isCenteredSplit, visibleHunks, maxLineCols]);
+  }, [
+    isCenteredSplit,
+    usesNativeHScrollProxy,
+    isCollapsed,
+    visibleHunks,
+    maxLineCols,
+    syncNativeHScroll,
+  ]);
 
   // Arrow-key horizontal scrolling parity with the focusable native scroller
   // used by the other view modes.
@@ -1130,6 +1185,52 @@ function FileDiff({
     return rows;
   };
 
+  const diffBody = (
+    <>
+      <Diff
+        viewType={viewType}
+        diffType={diffType}
+        hunks={visibleHunks}
+        tokens={tokens ?? undefined}
+        renderGutter={renderGutter}
+        renderToken={renderTokenWithInvisibles}
+        generateLineClassName={generateLineClassName}
+        optimizeSelection
+      >
+        {renderHunkRows}
+      </Diff>
+      {hiddenHunkCount > 0 && (
+        <button
+          type="button"
+          onClick={handleShowMoreHunks}
+          className="flex w-full items-center justify-center gap-2 px-3 py-2 text-xs text-text-muted hover:bg-tint/5 transition-colors"
+        >
+          <UnfoldVertical className="w-3 h-3" />
+          Show {Math.min(hiddenHunkCount, SHOW_MORE_HUNKS_STEP)} more{" "}
+          {hiddenHunkCount === 1 ? "hunk" : "hunks"} ({hiddenHunkCount} remaining)
+        </button>
+      )}
+    </>
+  );
+
+  // One strip serves both scroll systems: centered split drives every code
+  // cell's text-indent through --diff-hscroll, the native path mirrors a real
+  // scroller's scrollLeft. Wrap mode has no horizontal overflow, so no strip.
+  const hScrollbar = wrapLines ? null : (
+    <div
+      ref={hScrollbarRef}
+      className="diff-hscrollbar"
+      data-testid="diff-hscrollbar"
+      data-scroll-mode={isCenteredSplit ? "centered" : "native"}
+      data-active={hasHOverflow || undefined}
+      onScroll={isCenteredSplit ? handleHScroll : handleNativeProxyScroll}
+      aria-hidden="true"
+      tabIndex={-1}
+    >
+      <div className="diff-hscroll-spacer" />
+    </div>
+  );
+
   return (
     <div className="mb-2" style={fileStyle}>
       {relPath && (
@@ -1214,54 +1315,43 @@ function FileDiff({
           </span>
         </button>
       )}
-      {!isCollapsed && (
-        <div
-          id={diffRegionId}
-          ref={regionRef}
-          className={isCenteredSplit ? "diff-file-centered" : "diff-file-scroll"}
-          tabIndex={0}
-          role="region"
-          aria-label={relPath || "Diff"}
-          onKeyDown={isCenteredSplit ? handleRegionKeyDown : undefined}
-        >
-          <Diff
-            viewType={viewType}
-            diffType={diffType}
-            hunks={visibleHunks}
-            tokens={tokens ?? undefined}
-            renderGutter={renderGutter}
-            renderToken={renderTokenWithInvisibles}
-            generateLineClassName={generateLineClassName}
-            optimizeSelection
+      {!isCollapsed &&
+        (isCenteredSplit ? (
+          <div
+            id={diffRegionId}
+            ref={regionRef}
+            className="diff-file-centered"
+            tabIndex={0}
+            role="region"
+            aria-label={relPath || "Diff"}
+            onKeyDown={handleRegionKeyDown}
           >
-            {renderHunkRows}
-          </Diff>
-          {hiddenHunkCount > 0 && (
-            <button
-              type="button"
-              onClick={handleShowMoreHunks}
-              className="flex w-full items-center justify-center gap-2 px-3 py-2 text-xs text-text-muted hover:bg-tint/5 transition-colors"
-            >
-              <UnfoldVertical className="w-3 h-3" />
-              Show {Math.min(hiddenHunkCount, SHOW_MORE_HUNKS_STEP)} more{" "}
-              {hiddenHunkCount === 1 ? "hunk" : "hunks"} ({hiddenHunkCount} remaining)
-            </button>
-          )}
-          {isCenteredSplit && (
+            {diffBody}
+            {hScrollbar}
+          </div>
+        ) : (
+          // The shell exists only so the strip can be a sibling of the real
+          // scroller: `overflow-x: auto` with overflow-y at its initial
+          // `visible` computes to `auto` (CSS Overflow 3 §3.3), so
+          // .diff-file-scroll is a scroll container on both axes and a sticky
+          // strip inside it would resolve against a scrollport the full height
+          // of the file — pinning exactly where the native bar already is.
+          <div className="diff-file-shell">
             <div
-              ref={hScrollbarRef}
-              className="diff-hscrollbar"
-              data-testid="diff-hscrollbar"
-              data-active={hasHOverflow || undefined}
-              onScroll={handleHScroll}
-              aria-hidden="true"
-              tabIndex={-1}
+              id={diffRegionId}
+              ref={nativeScrollerRef}
+              className="diff-file-scroll"
+              data-proxy-active={(usesNativeHScrollProxy && hasHOverflow) || undefined}
+              tabIndex={0}
+              role="region"
+              aria-label={relPath || "Diff"}
+              onScroll={usesNativeHScrollProxy ? handleNativeHScroll : undefined}
             >
-              <div className="diff-hscroll-spacer" />
+              {diffBody}
             </div>
-          )}
-        </div>
-      )}
+            {hScrollbar}
+          </div>
+        ))}
     </div>
   );
 }

--- a/src/components/Worktree/__tests__/DiffViewer.test.tsx
+++ b/src/components/Worktree/__tests__/DiffViewer.test.tsx
@@ -842,6 +842,29 @@ describe("DiffViewer native scroll proxy", () => {
     return state;
   }
 
+  /**
+   * Chromium clamps a write past the end and fires NO scroll event for it —
+   * from that element's point of view nothing moved. jsdom does neither, so
+   * model both to exercise the clamp reconciliation.
+   */
+  function stubScrollLeft(element: HTMLElement, max: number) {
+    let current = 0;
+    const writes: number[] = [];
+    Object.defineProperty(element, "scrollLeft", {
+      get: () => current,
+      set: (next: number) => {
+        writes.push(next);
+        if (writes.length > 20) throw new Error("scrollLeft mirroring never settled");
+        const clamped = Math.min(max, Math.max(0, next));
+        if (clamped === current) return;
+        current = clamped;
+        element.dispatchEvent(new Event("scroll"));
+      },
+      configurable: true,
+    });
+    return { writes, value: () => current };
+  }
+
   function parts(container: HTMLElement) {
     const shell = container.querySelector<HTMLElement>(".diff-file-shell");
     const scroller = container.querySelector<HTMLElement>(".diff-file-scroll");
@@ -988,5 +1011,164 @@ describe("DiffViewer native scroll proxy", () => {
     expect(firstProxy!.scrollLeft).toBe(70);
     expect(secondProxy!.scrollLeft).toBe(0);
     expect(secondScroller!.scrollLeft).toBe(0);
+  });
+
+  it("activates only the stacked file that actually overflows", () => {
+    const { container } = render(
+      wrap(<DiffViewer diff={`${ADDED_FILE_DIFF}\n${DELETED_FILE_DIFF}`} viewType="unified" />)
+    );
+    const [first, second] = Array.from(
+      container.querySelectorAll<HTMLElement>(".diff-file-scroll")
+    );
+    stubLayout(first!, 200, 500);
+    stubLayout(second!, 200, 200);
+
+    resize(first!);
+    resize(second!);
+
+    const [firstProxy, secondProxy] = screen.getAllByTestId("diff-hscrollbar");
+    expect(firstProxy!.getAttribute("data-active")).toBe("true");
+    expect(first!.getAttribute("data-proxy-active")).toBe("true");
+    expect(secondProxy!.hasAttribute("data-active")).toBe(false);
+    expect(second!.hasAttribute("data-proxy-active")).toBe(false);
+  });
+
+  it("settles on the clamped offset when the two scroll ranges disagree", () => {
+    const { container } = render(wrap(<DiffViewer diff={SMALL_DIFF} viewType="unified" />));
+    const { scroller, proxy } = parts(container);
+    // The strip's range outruns the content's — exactly the state the sticky
+    // strip's own scrollbar reservation used to produce.
+    const content = stubScrollLeft(scroller!, 90);
+    const strip = stubScrollLeft(proxy, 100);
+
+    act(() => {
+      proxy.scrollLeft = 100;
+    });
+
+    // The content clamps to 90 and stays silent; without the read-back the
+    // strip would sit at 100 forever, its thumb past the end of the content.
+    expect(content.value()).toBe(90);
+    expect(strip.value()).toBe(90);
+    expect(strip.writes.length + content.writes.length).toBeLessThan(8);
+  });
+
+  it("re-attaches to the elements a collapse round-trip remounts", () => {
+    // isCollapsed is in the measurement effect's deps for exactly this: the
+    // effect first runs while both refs are null, and nothing else changes when
+    // the user expands.
+    const { container } = render(wrap(<DiffViewer diff={LOCKFILE_DIFF} viewType="unified" />));
+    expect(container.querySelector(".diff-file-scroll")).toBeNull();
+
+    fireEvent.click(screen.getByText("Show diff"));
+    const scroller = container.querySelector<HTMLElement>(".diff-file-scroll");
+    stubLayout(scroller!, 200, 500);
+    resize(scroller!);
+    expect(scroller?.getAttribute("data-proxy-active")).toBe("true");
+
+    fireEvent.click(screen.getByText("Hide diff"));
+    expect(screen.queryByTestId("diff-hscrollbar")).toBeNull();
+
+    fireEvent.click(screen.getByText("Show diff"));
+    const reopened = container.querySelector<HTMLElement>(".diff-file-scroll");
+    stubLayout(reopened!, 200, 500);
+    resize(reopened!);
+    expect(screen.getByTestId("diff-hscrollbar").getAttribute("data-active")).toBe("true");
+  });
+
+  it("leaves both surfaces agreeing across a view-type round-trip", () => {
+    const { container, rerender } = render(
+      wrap(<DiffViewer diff={SMALL_DIFF} viewType="unified" />)
+    );
+    const scroller = container.querySelector<HTMLElement>(".diff-file-scroll");
+    stubLayout(scroller!, 200, 500);
+    resize(scroller!);
+    scroller!.scrollLeft = 60;
+    fireEvent.scroll(scroller!);
+    expect(screen.getByTestId("diff-hscrollbar").scrollLeft).toBe(60);
+
+    rerender(wrap(<DiffViewer diff={SMALL_DIFF} viewType="split" />));
+    expect(container.querySelector(".diff-file-centered")).not.toBeNull();
+    expect(screen.getByTestId("diff-hscrollbar").getAttribute("data-scroll-mode")).toBe("centered");
+
+    rerender(wrap(<DiffViewer diff={SMALL_DIFF} viewType="unified" />));
+    // The offset does not survive a view-type change — both surfaces remount at
+    // 0. What must never happen is one of them keeping a stale offset.
+    const back = container.querySelector<HTMLElement>(".diff-file-scroll");
+    expect(back!.scrollLeft).toBe(screen.getByTestId("diff-hscrollbar").scrollLeft);
+  });
+
+  it("still measures the centered-split strip through the shared effect", () => {
+    render(wrap(<DiffViewer diff={SMALL_DIFF} viewType="split" />));
+    const proxy = screen.getByTestId("diff-hscrollbar");
+    expect(proxy.getAttribute("data-scroll-mode")).toBe("centered");
+    const layout = stubLayout(proxy, 200, 500);
+
+    resize(proxy);
+
+    expect(proxy.getAttribute("data-active")).toBe("true");
+    // Centered split sizes its spacer from the estimated longest line, so the
+    // native measurement must not leak into it.
+    expect(proxy.style.getPropertyValue("--diff-native-scroll-width")).toBe("");
+
+    layout.scrollWidth = 200;
+    resize(proxy.firstElementChild!);
+    expect(proxy.hasAttribute("data-active")).toBe(false);
+  });
+
+  it("disconnects its observer when the diff unmounts", () => {
+    const { container, unmount } = render(
+      wrap(<DiffViewer diff={SMALL_DIFF} viewType="unified" />)
+    );
+    const scroller = container.querySelector<HTMLElement>(".diff-file-scroll");
+    expect(observers.some((observer) => observer.targets.has(scroller!))).toBe(true);
+
+    unmount();
+
+    expect(observers.some((observer) => observer.targets.size > 0)).toBe(false);
+  });
+});
+
+// The behavioural tests above can only see attributes and inline custom
+// properties. Everything that turns those into a usable scrollbar lives in the
+// stylesheet, and deleting any of it would leave them all green.
+describe("DiffViewer native scroll proxy CSS contract (#12103)", () => {
+  const declarations = () =>
+    readFileSync(join(__dirname, "..", "DiffViewer.css"), "utf8").replace(/\/\*[\s\S]*?\*\//g, "");
+
+  it("sizes the native strip's spacer from the measured content width", () => {
+    expect(declarations()).toMatch(
+      /\.diff-hscrollbar\[data-scroll-mode="native"\]\s+\.diff-hscroll-spacer\s*\{[^}]*width:\s*var\(--diff-native-scroll-width/
+    );
+  });
+
+  it("hands the bar over rather than showing two or none", () => {
+    const css = declarations();
+    // Height only when active — otherwise the strip would reserve space under
+    // every file whether or not it can scroll.
+    expect(css).toMatch(/\.diff-hscrollbar\s*\{[^}]*height:\s*0/);
+    expect(css).toMatch(/\.diff-hscrollbar\[data-active\]\s*\{[^}]*height:\s*12px/);
+    // ...and the scroller's own bar goes away only once the strip has taken over.
+    expect(css).toMatch(/\.diff-file-scroll\[data-proxy-active\]\s*\{[^}]*scrollbar-width:\s*none/);
+    expect(css).toMatch(
+      /\.diff-file-scroll\[data-proxy-active\]::-webkit-scrollbar\s*\{[^}]*height:\s*0/
+    );
+  });
+
+  it("pins the strip's vertical overflow so its range can match the scroller's", () => {
+    // Left at its initial `visible` this computes to `auto`, the 1px spacer
+    // overflows the strip's 12px box, and the vertical scrollbar it reserves
+    // shrinks the strip's clientWidth below the scroller's — giving the proxy
+    // travel the content cannot follow.
+    expect(declarations()).toMatch(/\.diff-hscrollbar\s*\{[^}]*overflow-y:\s*hidden/);
+  });
+
+  it("never lets the shell become the sticky containing block", () => {
+    // position: sticky resolves against the nearest scroll container. overflow,
+    // contain, transform, filter or perspective on the shell would make it one
+    // and silently re-pin the strip to the bottom of the file — the exact bug
+    // #12103 is about.
+    const shell = declarations().match(/\.diff-viewer\s+\.diff-file-shell\s*\{[^}]*\}/)?.[0];
+    expect(shell).toBeTruthy();
+    expect(shell).not.toMatch(/overflow|contain|transform|filter|perspective/);
   });
 });

--- a/src/components/Worktree/__tests__/DiffViewer.test.tsx
+++ b/src/components/Worktree/__tests__/DiffViewer.test.tsx
@@ -847,8 +847,8 @@ describe("DiffViewer native scroll proxy", () => {
    * from that element's point of view nothing moved. jsdom does neither, so
    * model both to exercise the clamp reconciliation.
    */
-  function stubScrollLeft(element: HTMLElement, max: number) {
-    let current = 0;
+  function stubScrollLeft(element: HTMLElement, max: number, initial = 0) {
+    let current = initial;
     const writes: number[] = [];
     Object.defineProperty(element, "scrollLeft", {
       get: () => current,
@@ -1033,23 +1033,51 @@ describe("DiffViewer native scroll proxy", () => {
     expect(second!.hasAttribute("data-proxy-active")).toBe(false);
   });
 
-  it("settles on the clamped offset when the two scroll ranges disagree", () => {
+  it("settles when the shorter side is already at its end and stays silent", () => {
     const { container } = render(wrap(<DiffViewer diff={SMALL_DIFF} viewType="unified" />));
     const { scroller, proxy } = parts(container);
-    // The strip's range outruns the content's — exactly the state the sticky
-    // strip's own scrollbar reservation used to produce.
-    const content = stubScrollLeft(scroller!, 90);
-    const strip = stubScrollLeft(proxy, 100);
+    // Both parked at their own maximum, the strip's range outrunning the
+    // content's. This is the case an echo can never fix: writing 100 to the
+    // content clamps to the 90 it already holds, so it does not move and fires
+    // no scroll event at all. Only reading the landed value back settles it.
+    const content = stubScrollLeft(scroller!, 90, 90);
+    const strip = stubScrollLeft(proxy, 100, 100);
 
-    act(() => {
-      proxy.scrollLeft = 100;
-    });
+    fireEvent.scroll(proxy);
 
-    // The content clamps to 90 and stays silent; without the read-back the
-    // strip would sit at 100 forever, its thumb past the end of the content.
     expect(content.value()).toBe(90);
     expect(strip.value()).toBe(90);
     expect(strip.writes.length + content.writes.length).toBeLessThan(8);
+  });
+
+  it("settles the same way when the content is the longer of the two", () => {
+    const { container } = render(wrap(<DiffViewer diff={SMALL_DIFF} viewType="unified" />));
+    const { scroller, proxy } = parts(container);
+    const content = stubScrollLeft(scroller!, 100, 100);
+    const strip = stubScrollLeft(proxy, 90, 90);
+
+    fireEvent.scroll(scroller!);
+
+    expect(content.value()).toBe(90);
+    expect(strip.value()).toBe(90);
+    expect(strip.writes.length + content.writes.length).toBeLessThan(8);
+  });
+
+  it("holds a one-pixel overflow below the activation threshold", () => {
+    // scrollWidth/clientWidth are rounded integers, so a sub-pixel layout
+    // difference can surface as a 1px delta. Popping a 12px strip for that is
+    // disproportionate, and the scroller keeps its own bar either way — the
+    // same tolerance centered split has always used.
+    const { container } = render(wrap(<DiffViewer diff={SMALL_DIFF} viewType="unified" />));
+    const { scroller, proxy } = parts(container);
+    const layout = stubLayout(scroller!, 200, 201);
+
+    resize(scroller!);
+    expect(proxy.hasAttribute("data-active")).toBe(false);
+
+    layout.scrollWidth = 202;
+    resize(scroller!);
+    expect(proxy.getAttribute("data-active")).toBe("true");
   });
 
   it("re-attaches to the elements a collapse round-trip remounts", () => {
@@ -1091,8 +1119,10 @@ describe("DiffViewer native scroll proxy", () => {
     expect(screen.getByTestId("diff-hscrollbar").getAttribute("data-scroll-mode")).toBe("centered");
 
     rerender(wrap(<DiffViewer diff={SMALL_DIFF} viewType="unified" />));
-    // The offset does not survive a view-type change — both surfaces remount at
-    // 0. What must never happen is one of them keeping a stale offset.
+    // React reuses the strip node across the two branches, so it arrives here
+    // still holding the old offset while the inner scroller is freshly mounted
+    // at 0. The reconciliation has to pull the reused strip back to the
+    // scroller; what must never happen is the two disagreeing.
     const back = container.querySelector<HTMLElement>(".diff-file-scroll");
     expect(back!.scrollLeft).toBe(screen.getByTestId("diff-hscrollbar").scrollLeft);
   });

--- a/src/components/Worktree/__tests__/DiffViewer.test.tsx
+++ b/src/components/Worktree/__tests__/DiffViewer.test.tsx
@@ -299,15 +299,15 @@ describe("DiffViewer centered split", () => {
 
     expect(container.querySelector(".diff-file-centered")).not.toBeNull();
     expect(container.querySelector(".diff-file-scroll")).toBeNull();
-    expect(screen.getByTestId("diff-hscrollbar")).toBeTruthy();
+    expect(screen.getByTestId("diff-hscrollbar").getAttribute("data-scroll-mode")).toBe("centered");
   });
 
-  it("keeps the native scroller in unified view", () => {
+  it("keeps the native scroller in unified view, with a proxy strip beside it", () => {
     const { container } = render(wrap(<DiffViewer diff={SMALL_DIFF} viewType="unified" />));
 
     expect(container.querySelector(".diff-file-centered")).toBeNull();
     expect(container.querySelector(".diff-file-scroll")).not.toBeNull();
-    expect(screen.queryByTestId("diff-hscrollbar")).toBeNull();
+    expect(screen.getByTestId("diff-hscrollbar").getAttribute("data-scroll-mode")).toBe("native");
   });
 
   it("keeps the native scroller when wrapping lines", () => {
@@ -324,7 +324,7 @@ describe("DiffViewer centered split", () => {
     // the horizontal-scroll fallback path rather than the two-column centered split.
     expect(container.querySelector(".diff-file-centered")).toBeNull();
     expect(container.querySelector(".diff-file-scroll")).not.toBeNull();
-    expect(screen.queryByTestId("diff-hscrollbar")).toBeNull();
+    expect(screen.getByTestId("diff-hscrollbar").getAttribute("data-scroll-mode")).toBe("native");
   });
 
   it("keeps the native scroller for single-side deleted-file diffs", () => {
@@ -332,7 +332,7 @@ describe("DiffViewer centered split", () => {
 
     expect(container.querySelector(".diff-file-centered")).toBeNull();
     expect(container.querySelector(".diff-file-scroll")).not.toBeNull();
-    expect(screen.queryByTestId("diff-hscrollbar")).toBeNull();
+    expect(screen.getByTestId("diff-hscrollbar").getAttribute("data-scroll-mode")).toBe("native");
   });
 
   it("mirrors the scrollbar strip's scrollLeft into --diff-hscroll", () => {
@@ -778,5 +778,215 @@ describe("DiffViewer token CSS contract (Tailwind display-utility collision)", (
     // With the real stylesheet the reset pins the token back to inline.
     const css = readFileSync(join(__dirname, "..", "DiffViewer.css"), "utf8");
     expect(computeTokenDisplay(css)).toBe("inline");
+  });
+});
+
+// The unified / single-side path keeps a REAL native scroller and adds the
+// sticky strip as its sibling, so the strip resolves against .diff-scroll-root
+// and stays reachable mid-file. jsdom has no layout, so these tests stub the
+// widths the measurement reads and drive ResizeObserver by hand — the global
+// stub installed in vitest.setup.ts is a no-op and would never call back.
+type FakeObserver = { callback: () => void; targets: Set<Element> };
+
+describe("DiffViewer native scroll proxy", () => {
+  const observers: FakeObserver[] = [];
+  let originalResizeObserver: typeof ResizeObserver;
+
+  class FakeResizeObserver {
+    private readonly entry: FakeObserver;
+    constructor(callback: () => void) {
+      this.entry = { callback, targets: new Set() };
+      observers.push(this.entry);
+    }
+    observe(target: Element) {
+      this.entry.targets.add(target);
+    }
+    unobserve(target: Element) {
+      this.entry.targets.delete(target);
+    }
+    disconnect() {
+      this.entry.targets.clear();
+    }
+  }
+
+  beforeEach(() => {
+    observers.length = 0;
+    originalResizeObserver = globalThis.ResizeObserver;
+    globalThis.ResizeObserver = FakeResizeObserver as unknown as typeof ResizeObserver;
+  });
+
+  afterEach(() => {
+    globalThis.ResizeObserver = originalResizeObserver;
+  });
+
+  /** Fire every observer currently watching `target`; the callback sets state. */
+  function resize(target: Element) {
+    act(() => {
+      for (const observer of observers) {
+        if (observer.targets.has(target)) observer.callback();
+      }
+    });
+  }
+
+  /** jsdom reports 0 for every layout box; hand the element real numbers. */
+  function stubLayout(element: Element, clientWidth: number, scrollWidth: number) {
+    const state = { scrollWidth };
+    Object.defineProperty(element, "scrollWidth", {
+      get: () => state.scrollWidth,
+      configurable: true,
+    });
+    Object.defineProperty(element, "clientWidth", {
+      get: () => clientWidth,
+      configurable: true,
+    });
+    return state;
+  }
+
+  function parts(container: HTMLElement) {
+    const shell = container.querySelector<HTMLElement>(".diff-file-shell");
+    const scroller = container.querySelector<HTMLElement>(".diff-file-scroll");
+    const proxy = screen.getByTestId("diff-hscrollbar");
+    return { shell, scroller, proxy };
+  }
+
+  it("makes the strip a sibling of the scroller, never a descendant of it", () => {
+    const { container } = render(wrap(<DiffViewer diff={SMALL_DIFF} viewType="unified" />));
+    const { shell, scroller, proxy } = parts(container);
+
+    expect(shell).not.toBeNull();
+    expect(scroller?.parentElement).toBe(shell);
+    expect(proxy.parentElement).toBe(shell);
+    // The whole point: a sticky strip inside the horizontally scrolling box
+    // would slide sideways with the user's own scroll.
+    expect(scroller?.contains(proxy)).toBe(false);
+    expect(scroller?.contains(screen.getByTestId("diff-element"))).toBe(true);
+  });
+
+  it("leaves the region semantics on the element that actually scrolls", () => {
+    const { container } = render(wrap(<DiffViewer diff={SMALL_DIFF} viewType="unified" />));
+    const { shell, scroller } = parts(container);
+
+    expect(scroller?.getAttribute("role")).toBe("region");
+    expect(scroller?.getAttribute("tabindex")).toBe("0");
+    expect(scroller?.id.startsWith("diff-region-")).toBe(true);
+    expect(shell?.hasAttribute("id")).toBe(false);
+  });
+
+  it("keeps the native bar and an inert strip until overflow is measured", () => {
+    const { container } = render(wrap(<DiffViewer diff={SMALL_DIFF} viewType="unified" />));
+    const { scroller, proxy } = parts(container);
+
+    expect(proxy.hasAttribute("data-active")).toBe(false);
+    expect(scroller?.hasAttribute("data-proxy-active")).toBe(false);
+  });
+
+  it("activates both halves of the handoff and sizes the strip to the content", () => {
+    const { container } = render(wrap(<DiffViewer diff={SMALL_DIFF} viewType="unified" />));
+    const { scroller, proxy } = parts(container);
+    stubLayout(scroller!, 200, 500);
+
+    resize(scroller!);
+
+    expect(proxy.getAttribute("data-active")).toBe("true");
+    expect(scroller?.getAttribute("data-proxy-active")).toBe("true");
+    expect(proxy.style.getPropertyValue("--diff-native-scroll-width")).toBe("500px");
+  });
+
+  it("re-measures from the content box, which is where a scrollWidth-only change shows up", () => {
+    const { container } = render(wrap(<DiffViewer diff={SMALL_DIFF} viewType="unified" />));
+    const { scroller, proxy } = parts(container);
+    const layout = stubLayout(scroller!, 200, 500);
+    resize(scroller!);
+    expect(proxy.getAttribute("data-active")).toBe("true");
+
+    // The scroller's own border box never changes here — only its content
+    // narrows, so ResizeObserver fires for the table, not the container.
+    layout.scrollWidth = 200;
+    resize(scroller!.firstElementChild!);
+
+    expect(proxy.hasAttribute("data-active")).toBe(false);
+    expect(scroller?.hasAttribute("data-proxy-active")).toBe(false);
+  });
+
+  it("mirrors scrollLeft both ways and settles instead of ping-ponging", () => {
+    const { container } = render(wrap(<DiffViewer diff={SMALL_DIFF} viewType="unified" />));
+    const { scroller, proxy } = parts(container);
+
+    scroller!.scrollLeft = 80;
+    fireEvent.scroll(scroller!);
+    expect(proxy.scrollLeft).toBe(80);
+
+    proxy.scrollLeft = 30;
+    fireEvent.scroll(proxy);
+    expect(scroller!.scrollLeft).toBe(30);
+
+    // The echo event each write triggers finds the pair equal and stops.
+    fireEvent.scroll(scroller!);
+    fireEvent.scroll(proxy);
+    expect(scroller!.scrollLeft).toBe(30);
+    expect(proxy.scrollLeft).toBe(30);
+  });
+
+  it("drops the strip while wrapping and restores it on the way back", () => {
+    const { container, rerender } = render(
+      wrap(<DiffViewer diff={SMALL_DIFF} viewType="unified" />)
+    );
+    const scroller = container.querySelector<HTMLElement>(".diff-file-scroll");
+    const layout = stubLayout(scroller!, 200, 500);
+    resize(scroller!);
+    expect(scroller?.getAttribute("data-proxy-active")).toBe("true");
+
+    rerender(wrap(<DiffViewer diff={SMALL_DIFF} viewType="unified" wrapLines />));
+    expect(screen.queryByTestId("diff-hscrollbar")).toBeNull();
+    expect(container.querySelector(".diff-file-scroll")?.hasAttribute("data-proxy-active")).toBe(
+      false
+    );
+
+    rerender(wrap(<DiffViewer diff={SMALL_DIFF} viewType="unified" />));
+    const restored = container.querySelector<HTMLElement>(".diff-file-scroll");
+    layout.scrollWidth = 500;
+    resize(restored!);
+    expect(screen.getByTestId("diff-hscrollbar").getAttribute("data-active")).toBe("true");
+  });
+
+  it("re-syncs the strip after hunk expansion changes the content width", () => {
+    const { container } = render(
+      wrap(<DiffViewer diff={FAR_HUNKS_DIFF} source={FAR_HUNKS_SOURCE} viewType="unified" />)
+    );
+    const { scroller, proxy } = parts(container);
+    stubLayout(scroller!, 200, 500);
+
+    // A scroll the strip never saw: the browser can move the real scroller
+    // through find-in-page, scrollIntoView or drag-select without one either.
+    scroller!.scrollLeft = 90;
+    expect(proxy.scrollLeft).toBe(0);
+
+    fireEvent.click(screen.getByRole("button", { name: /Expand down/ }));
+
+    expect(screen.getByTestId("diff-hscrollbar").scrollLeft).toBe(90);
+  });
+
+  it("gives each stacked file its own strip and its own offset", () => {
+    const { container } = render(
+      wrap(<DiffViewer diff={`${ADDED_FILE_DIFF}\n${DELETED_FILE_DIFF}`} viewType="unified" />)
+    );
+
+    const shells = container.querySelectorAll(".diff-file-shell");
+    const scrollers = container.querySelectorAll<HTMLElement>(".diff-file-scroll");
+    const proxies = screen.getAllByTestId("diff-hscrollbar");
+    expect(shells.length).toBe(2);
+    expect(proxies.length).toBe(2);
+    for (const shell of shells) {
+      expect(shell.querySelectorAll('[data-testid="diff-hscrollbar"]').length).toBe(1);
+    }
+
+    const [firstScroller, secondScroller] = Array.from(scrollers);
+    const [firstProxy, secondProxy] = proxies;
+    firstScroller!.scrollLeft = 70;
+    fireEvent.scroll(firstScroller!);
+
+    expect(firstProxy!.scrollLeft).toBe(70);
+    expect(secondProxy!.scrollLeft).toBe(0);
+    expect(secondScroller!.scrollLeft).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

In unified view, and in the single-side add/delete split views, each file's horizontal scrollbar was a native scrollbar on `.diff-file-scroll`, a content-height `overflow-x: auto` div. The outer `.diff-scroll-root` owns vertical scroll, so that bar rendered at the bottom of an 8000px box that only ever shows about 700px: unreachable at the exact moment you need it, when a line runs off the right edge mid-file. Two-pane centered split already had a sticky proxy strip for this; unified never got one.

Resolves #12103

It wasn't a one-line fix. You can't just drop a sticky strip inside `.diff-file-scroll`: `overflow-x: auto` with `overflow-y` at its initial `visible` computes overflow-y to `auto` too (CSS Overflow 3 §3.3), so the div is a scroll container on both axes. A sticky child resolves against a scrollport the full height of the file and pins exactly where the native bar already sits, and stickifying only `bottom` means it slides sideways with the user's own horizontal scroll. Silently wrong, no error.

## Changes

- Added a new non-scrolling `.diff-file-shell` wrapping the unified/single-side path, so the sticky `.diff-hscrollbar` strip is a sibling of the real scroller, not its child. It sticks against `.diff-scroll-root` while clamping to its own file's box, which is also why two stacked files never pin their strips to the same viewport row, with no `IntersectionObserver` bookkeeping needed.
- `.diff-file-scroll` stays a real native scroller, so find-in-page reveal, `scrollIntoView`, drag-select autoscroll, shift+wheel/trackpad panning, and arrow keys all keep working. The strip is a second control for the same offset, not a replacement. (Centered split, which trades all of that away to lock two panes together, is untouched.)
- The two mirror `scrollLeft` both ways. The write reads the landed value back rather than waiting for an echo: when the target clamps a write it fires no scroll event at all, so an echo-based sync would leave the pair permanently out of step.
- Generalized the overflow measurement to publish the scroller's real `scrollWidth` as `--diff-native-scroll-width`, sizing the strip's spacer exactly instead of estimating it. It runs in a layout effect so a mode switch never paints a stale handoff.
- `data-active` on the strip and `data-proxy-active` on the scroller come from the same value in one render, so there's exactly one horizontal bar at any moment, never two, never none.
- `overflow-y: hidden` on the strip: left implicit it computed to `auto`, and the 1px spacer overflowing the 12px box reserved a vertical scrollbar that shrank the strip's range past the content's.
- Wrap mode renders no strip, since there's no horizontal overflow to scroll.

## Testing

68 tests in `DiffViewer.test.tsx` (15 new behavioral, 4 new CSS-contract), covering the sibling-not-descendant invariant, the two-way mirror and its clamp reconciliation in both directions, per-file activation across stacked files, collapse and view-type round-trips, observer teardown, and the overflow threshold. 2765 tests pass across the 119 files covering the diff/file panels and the Worktree components. Typecheck is clean; own files are lint- and format-clean.

**Out of scope:** `CrossWorktreeDiff` never passes `wrapLines` to `DiffViewer`, noted in the issue as a separate follow-up.

**Note:** `npm run compiler-budget:check` reports a bailout regression in `plugins/builtin/github/renderer/components/GitHubResourceList.tsx`, a file this branch doesn't touch. It's pre-existing on `develop`, and that script is deliberately out of CI pre-1.0.
