### PR TITLE
feat(assistant): run multiple concurrent Assistant sessions per project

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -564,6 +564,7 @@ export const CHANNELS = {
   HELP_PEEK_PENDING_HIBERNATION: "help:peek-pending-hibernation",
   HELP_TAKE_PENDING_HIBERNATION: "help:take-pending-hibernation",
   HELP_RESTORE_PENDING_HIBERNATION: "help:restore-pending-hibernation",
+  HELP_LIST_PENDING_HIBERNATION_SLOTS: "help:list-pending-hibernation-slots",
   HELP_REPORT_PANEL_OPEN: "help:report-panel-open",
   HELP_GET_PINNED_ACTION_CONTEXT: "help:get-pinned-action-context",
 

--- a/electron/ipc/handlers/__tests__/project.bulkStats.test.ts
+++ b/electron/ipc/handlers/__tests__/project.bulkStats.test.ts
@@ -134,6 +134,10 @@ vi.mock("../../../window/portDistribution.js", () => ({
 // Same default as the push-path suite: on screen unless a test hides it.
 const helpSessionMock = vi.hoisted(() => ({
   isPanelVisible: vi.fn<(id: string) => boolean>(() => true),
+  // #12108: the counts path resolves each help terminal's lane so concurrent
+  // assistants can be ranked by who needs the user. These fixtures run one
+  // assistant, which is lane 0.
+  getSlotForTerminal: vi.fn<(terminalId: string) => number | null>(() => 0),
 }));
 vi.mock("../../../services/HelpSessionService.js", () => ({
   helpSessionService: helpSessionMock,

--- a/electron/ipc/handlers/help.preload.ts
+++ b/electron/ipc/handlers/help.preload.ts
@@ -10,6 +10,7 @@ export const HELP_METHOD_CHANNELS = {
   peekPendingHibernation: "help:peek-pending-hibernation",
   takePendingHibernation: "help:take-pending-hibernation",
   restorePendingHibernation: "help:restore-pending-hibernation",
+  listPendingHibernationSlots: "help:list-pending-hibernation-slots",
   reportPanelOpen: "help:report-panel-open",
   getPinnedActionContext: "help:get-pinned-action-context",
 } as const satisfies Record<string, keyof IpcInvokeMap>;

--- a/electron/ipc/handlers/help.ts
+++ b/electron/ipc/handlers/help.ts
@@ -7,6 +7,22 @@ import { getAgentAvailabilityStore } from "../../services/AgentAvailabilityStore
 import type { HelpAssistantTier } from "../../../shared/types/ipc/maps.js";
 import type { ActionContext } from "../../../shared/types/actions.js";
 import type { PinnedActionContextSnapshot } from "../../../shared/types/ipc/help.js";
+import {
+  DEFAULT_ASSISTANT_SLOT,
+  isValidAssistantSlot,
+} from "../../../shared/config/assistantSlots.js";
+
+/**
+ * Resolve a renderer-supplied slot (#12108). Absent means slot 0 — an older
+ * renderer, or a caller that only ever had the one lane. Present but invalid
+ * returns null so the handler refuses: clamping would silently act on a lane
+ * the caller never named, and every one of these ops either displaces a
+ * backend or consumes a resume token.
+ */
+function resolveSlot(value: unknown): number | null {
+  if (value === undefined || value === null) return DEFAULT_ASSISTANT_SLOT;
+  return isValidAssistantSlot(value) ? value : null;
+}
 
 let cachedHelpService: typeof HelpServiceModule | null = null;
 async function getHelpService(): Promise<typeof HelpServiceModule> {
@@ -76,6 +92,8 @@ async function handleProvisionSession(
      * dispatch targets the worktree/terminal focused at launch (#8317).
      */
     context?: ActionContext;
+    /** Assistant lane to provision into (#12108). Absent means slot 0. */
+    slot?: number;
   }
 ): Promise<{
   sessionId: string;
@@ -89,6 +107,11 @@ async function handleProvisionSession(
     console.warn("[help] provisionSession invoked without a senderWindow — skipping");
     return null;
   }
+  const slot = resolveSlot(input.slot);
+  if (slot === null) {
+    console.warn("[help] provisionSession: slot out of range — refusing", { slot: input.slot });
+    return null;
+  }
   const { helpSessionService } = await getHelpSessionService();
   return helpSessionService.provisionSession({
     projectId: input.projectId,
@@ -97,6 +120,7 @@ async function handleProvisionSession(
     windowId: ctx.senderWindow.id,
     projectViewWebContentsId: ctx.webContentsId,
     actionContext: input.context,
+    slot,
   });
 }
 
@@ -149,7 +173,8 @@ async function handleRevokeSession(sessionId: string): Promise<void> {
 
 async function handlePeekPendingHibernation(
   ctx: import("../types.js").IpcContext,
-  projectId: string
+  projectId: string,
+  rawSlot?: number
 ): Promise<{
   agentId: string;
   agentSessionId: string;
@@ -170,13 +195,40 @@ async function handlePeekPendingHibernation(
     );
     return null;
   }
+  const slot = resolveSlot(rawSlot);
+  if (slot === null) return null;
   const { helpSessionService } = await getHelpSessionService();
-  return helpSessionService.peekPendingHibernation(projectId);
+  return helpSessionService.peekPendingHibernation(projectId, slot);
+}
+
+/**
+ * Which lanes of this project hold an eviction-captured resume entry (#12108).
+ *
+ * A cold renderer has no memory of lanes 1+, so without this their captured
+ * conversations would be stranded on disk with no tab to reach them from.
+ * Same cross-project guard as the rest of the hibernation namespace; the reply
+ * carries only slot numbers, never entry data.
+ */
+async function handleListPendingHibernationSlots(
+  ctx: import("../types.js").IpcContext,
+  projectId: string
+): Promise<number[]> {
+  if (typeof projectId !== "string" || !projectId) return [];
+  if (!ctx.projectId || ctx.projectId !== projectId) {
+    console.warn(
+      "[help] listPendingHibernationSlots: projectId mismatch — refusing cross-project read",
+      { requested: projectId, fromView: ctx.projectId, webContentsId: ctx.webContentsId }
+    );
+    return [];
+  }
+  const { helpSessionService } = await getHelpSessionService();
+  return helpSessionService.listPendingHibernationSlots(projectId);
 }
 
 async function handleTakePendingHibernation(
   ctx: import("../types.js").IpcContext,
-  projectId: string
+  projectId: string,
+  rawSlot?: number
 ): Promise<{
   agentId: string;
   agentSessionId: string;
@@ -198,16 +250,21 @@ async function handleTakePendingHibernation(
     );
     return null;
   }
+  const slot = resolveSlot(rawSlot);
+  if (slot === null) return null;
   const { helpSessionService } = await getHelpSessionService();
   // The owner is the view's own id from context, never renderer-supplied — it
   // binds the resulting claim to this view so no other can release it (#11477).
-  return helpSessionService.takePendingHibernation(projectId, ctx.webContentsId);
+  // With lanes the claim is keyed by (slot, claimId, owner), so one view
+  // holding claims on several lanes keeps them independent.
+  return helpSessionService.takePendingHibernation(projectId, slot, ctx.webContentsId);
 }
 
 async function handleRestorePendingHibernation(
   ctx: import("../types.js").IpcContext,
   projectId: string,
-  claimId: string
+  claimId: string,
+  rawSlot?: number
 ): Promise<boolean> {
   if (typeof projectId !== "string" || !projectId) return false;
   if (typeof claimId !== "string" || !claimId) return false;
@@ -221,8 +278,10 @@ async function handleRestorePendingHibernation(
     );
     return false;
   }
+  const slot = resolveSlot(rawSlot);
+  if (slot === null) return false;
   const { helpSessionService } = await getHelpSessionService();
-  return helpSessionService.restorePendingHibernation(projectId, claimId, ctx.webContentsId);
+  return helpSessionService.restorePendingHibernation(projectId, slot, claimId, ctx.webContentsId);
 }
 
 async function handleReportPanelOpen(
@@ -291,6 +350,11 @@ export const helpNamespace = defineIpcNamespace({
     takePendingHibernation: op(
       HELP_METHOD_CHANNELS.takePendingHibernation,
       handleTakePendingHibernation,
+      { withContext: true }
+    ),
+    listPendingHibernationSlots: op(
+      HELP_METHOD_CHANNELS.listPendingHibernationSlots,
+      handleListPendingHibernationSlots,
       { withContext: true }
     ),
     restorePendingHibernation: op(

--- a/electron/ipc/handlers/help.ts
+++ b/electron/ipc/handlers/help.ts
@@ -20,7 +20,10 @@ import {
  * backend or consumes a resume token.
  */
 function resolveSlot(value: unknown): number | null {
-  if (value === undefined || value === null) return DEFAULT_ASSISTANT_SLOT;
+  // Only ABSENT means slot 0. An explicit `null` from an untyped renderer is a
+  // supplied-but-invalid lane, and treating it as 0 would displace lane 0's
+  // backend or consume its resume token on a caller that never named a lane.
+  if (value === undefined) return DEFAULT_ASSISTANT_SLOT;
   return isValidAssistantSlot(value) ? value : null;
 }
 

--- a/electron/ipc/handlers/projectCrud/stats.ts
+++ b/electron/ipc/handlers/projectCrud/stats.ts
@@ -223,7 +223,10 @@ export function registerProjectStatsHandlers(deps: HandlerDependencies): () => v
       runAttentionServiceInstance?.getActiveSnoozes(),
       // A hidden assistant reports nothing, exactly as the pushed status map
       // has it — the two paths answering differently is what #10989 was.
-      (id) => helpSessionService.isPanelVisible(id)
+      (id) => helpSessionService.isPanelVisible(id),
+      // Lets concurrent assistants be ranked by who needs the user,
+      // rather than by whichever started last (#12108).
+      (terminalId) => helpSessionService.getSlotForTerminal(terminalId)
     );
 
     const result: BulkProjectStats = {};

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -378,7 +378,8 @@ if (!gotTheLock) {
       // electron/window/ so the eviction controller stays free of both services.
       // The static import is free: PtyClient already value-imports
       // HelpSessionService, so it is in the eager graph either way.
-      assistantBackendForProject: (projectId) => helpSessionService.getAssistantBackend(projectId),
+      assistantBackendsForProject: (projectId) =>
+        helpSessionService.getAssistantBackends(projectId),
       // The liveness half. PtyClient's spawn registry is main-local and
       // synchronous — written by spawn() before the host round-trip, dropped on
       // exit and on kill — so it is authoritative from the assistant's first

--- a/electron/services/HelpSessionService.ts
+++ b/electron/services/HelpSessionService.ts
@@ -19,6 +19,13 @@ import type {
   PendingHelpHibernation,
   PendingHelpHibernationStore,
 } from "./PendingHelpHibernationStore.js";
+import {
+  ASSISTANT_SLOTS,
+  assistantSlotDirName,
+  assistantSlotKey,
+  isValidAssistantSlot,
+  parseAssistantSlotDirName,
+} from "../../shared/config/assistantSlots.js";
 
 // Narrow type so the test suite (and any future caller) can satisfy this
 // dependency without instantiating a full PtyClient. `kill` is the original
@@ -82,6 +89,14 @@ interface ProvisionInput {
   windowId: number;
   projectViewWebContentsId: number;
   /**
+   * Which assistant lane this session occupies (#12108). Optional on the way
+   * in so pre-slot callers and fixtures still mean slot 0, but an explicitly
+   * supplied out-of-range slot is rejected by `validateProvisionInput` rather
+   * than clamped — silently landing in a neighbouring lane would displace a
+   * session the caller never named.
+   */
+  slot?: number;
+  /**
    * Snapshot of the renderer's `ActionContext` captured synchronously when
    * the user launched the assistant, before any `await`. Bound to the MCP
    * session at handshake and replayed as `contextOverride` on every tool
@@ -107,6 +122,14 @@ interface HelpSessionRecord {
   windowId: number;
   projectViewWebContentsId: number;
   projectId: string;
+  /**
+   * The assistant lane this record owns (#12108). Required — every internal
+   * lookup that used to key on `projectId` alone now keys on
+   * `assistantSlotKey(projectId, slot)`, and a record whose lane were unknown
+   * could neither be displaced by its successor nor protected from its
+   * siblings.
+   */
+  slot: number;
   projectPath: string;
   sessionPath: string;
   agentId: string;
@@ -268,25 +291,33 @@ export class HelpSessionService {
   // otherwise race the .mcp.json overwrite, producing a Claude instance
   // authenticating with the wrong session record.
   private readonly provisionLocks = new Map<string, Promise<void>>();
-  // Single-backend invariant (#7509): at most one assistant PTY per project
-  // at any given time. The renderer's cooperative cleanup paths (removePanel,
-  // gracefulKill on hibernate, visibilitychange tearDown) are fire-and-forget
-  // and can drop the kill IPC, leaving an orphan PTY that keeps dispatching
-  // MCP tool calls under a still-valid bearer. These maps let the main process
-  // displace prior backends regardless of what the renderer did.
-  private readonly activeHelpTerminalByProjectId = new Map<string, string>();
+  // Single-backend invariant (#7509), scoped to a lane since #12108: at most
+  // one assistant PTY per (project, slot) at any given time. The renderer's
+  // cooperative cleanup paths (removePanel, gracefulKill on hibernate,
+  // visibilitychange tearDown) are fire-and-forget and can drop the kill IPC,
+  // leaving an orphan PTY that keeps dispatching MCP tool calls under a
+  // still-valid bearer. These maps let the main process displace prior
+  // backends regardless of what the renderer did.
+  //
+  // Narrowing the key from project to lane does not weaken the property: the
+  // decisive step is removing the record from `sessionsByToken` BEFORE the
+  // fire-and-forget kill, so a lost kill IPC still leaves an orphan whose
+  // bearer no longer validates. What changes is only which sessions count as
+  // priors — a sibling in another lane is a live session the user asked for,
+  // not an orphan.
+  private readonly activeHelpTerminalBySlotKey = new Map<string, string>();
   private readonly terminalBySessionId = new Map<string, string>();
   private mcpRegistry: WindowRegistry | null = null;
   private ptyClient: PtyKillClient | null = null;
   private pendingHibernationStore: PendingHelpHibernationStore | null = null;
-  // #9639: tracks the in-flight capture owner per project (projectId →
+  // #9639: tracks the in-flight capture owner per lane (slot key →
   // sessionId) while `gracefulKill` is outstanding. A placeholder
   // pending-hibernation entry is written synchronously before the kill so a
   // racing project switch-back resumes instead of fresh-launching; this map
   // decides who is allowed to overwrite/clear that placeholder afterwards so a
   // mid-kill displacement can't let a stale resume ID shadow the new session.
   // In-memory only — no in-flight capture is meaningful across an app restart.
-  private readonly pendingCapturesByProject = new Map<string, string>();
+  private readonly pendingCapturesBySlotKey = new Map<string, string>();
   // #11477: the entry most recently handed out by `takePendingHibernation`, per
   // project, so a taker whose launch aborts can put it back verbatim via
   // `restorePendingHibernation` — original `capturedAt` intact, `panelWasOpen`
@@ -303,7 +334,7 @@ export class HelpSessionService {
   //
   // In-memory only, one deep per project: a take that is never answered is
   // dropped, and a later take supersedes the stash outright.
-  private readonly lastTakenByProject = new Map<
+  private readonly lastTakenBySlotKey = new Map<
     string,
     { entry: PendingHelpHibernation; claimId: string; ownerWebContentsId: number | null }
   >();
@@ -438,13 +469,17 @@ export class HelpSessionService {
     const record = this.sessionsByToken.get(token);
     if (!record || record.revoked) return false;
 
-    const existingTerminal = this.activeHelpTerminalByProjectId.get(record.projectId);
+    // The lane comes from the authenticated record, never from the caller — a
+    // renderer-supplied slot here could evict a sibling lane's PTY using a
+    // bearer that was only ever issued for its own.
+    const slotKey = assistantSlotKey(record.projectId, record.slot);
+    const existingTerminal = this.activeHelpTerminalBySlotKey.get(slotKey);
     if (existingTerminal && existingTerminal !== terminalId) {
       this.killTerminal(existingTerminal, "help-session-displaced");
       this.removeTerminalFromMaps(existingTerminal);
     }
 
-    this.activeHelpTerminalByProjectId.set(record.projectId, terminalId);
+    this.activeHelpTerminalBySlotKey.set(slotKey, terminalId);
     this.terminalBySessionId.set(record.sessionId, terminalId);
     return true;
   }
@@ -461,8 +496,27 @@ export class HelpSessionService {
   }
 
   /**
+   * The lane `terminalId` currently serves, or null when it serves none.
+   *
+   * Null is the meaningful answer for a displaced backend whose kill has not
+   * landed yet: `displacePriorSessions` drops the record synchronously, so a
+   * corpse resolves to no lane while its live successor resolves to one. That
+   * is what lets project status rank concurrent assistants by attention
+   * without a mid-kill corpse outranking them (see `projectAgentCounts`).
+   */
+  getSlotForTerminal(terminalId: string): number | null {
+    if (!terminalId) return null;
+    for (const [sessionId, boundId] of this.terminalBySessionId.entries()) {
+      if (boundId !== terminalId) continue;
+      const record = this.sessionsById.get(sessionId);
+      if (record && !record.revoked) return record.slot;
+    }
+    return null;
+  }
+
+  /**
    * Reports whether `terminalId` is currently the active help-session PTY
-   * for any project. The PtyEventRouter's `terminal-pid` callback uses this
+   * for any lane. The PtyEventRouter's `terminal-pid` callback uses this
    * to filter help-session terminals into the Windows Job Object so the OS
    * reaps the agent tree on a hard Daintree crash (#7526). Returns false
    * once the binding is dropped (revoke / displace / unbind) — a late PID
@@ -470,16 +524,22 @@ export class HelpSessionService {
    */
   isHelpTerminal(terminalId: string): boolean {
     if (!terminalId) return false;
-    for (const boundId of this.activeHelpTerminalByProjectId.values()) {
+    for (const boundId of this.activeHelpTerminalBySlotKey.values()) {
       if (boundId === terminalId) return true;
     }
     return false;
   }
 
   /**
-   * The assistant backend bound to `projectId` — its PTY and the WebContents
-   * the session pinned at provision time — or null when the project has no
-   * unrevoked help session with a spawned terminal.
+   * Every assistant backend bound to `projectId` — each one's PTY, the
+   * WebContents the session pinned at provision time, and its lane — in slot
+   * order. Empty when the project has no unrevoked help session with a spawned
+   * terminal.
+   *
+   * Returns all lanes rather than a single winner (#12108) because callers use
+   * this as a floor: with concurrent sessions a lane whose PTY has exited must
+   * not mask a live sibling, or reclaiming the project would kill the sibling
+   * — the #11807 regression in a new shape.
    *
    * ProjectViewManager's eviction policy reads this synchronously to keep the
    * view hosting a running assistant out of the routine LRU candidate pool
@@ -501,21 +561,28 @@ export class HelpSessionService {
    * must cross-check `terminalId` against a registry that tracks PTY exits, or
    * an assistant the user quit would pin its view forever.
    */
-  getAssistantBackend(projectId: string): { terminalId: string; webContentsId: number } | null {
-    if (!projectId) return null;
-    const terminalId = this.activeHelpTerminalByProjectId.get(projectId);
-    if (!terminalId) return null;
-    for (const record of this.sessionsById.values()) {
-      if (record.revoked) continue;
-      // Match on the project too, not just the terminal id: nothing enforces
-      // terminal-id uniqueness across projects, and picking up another
-      // project's record would return the wrong pin — which reads as "this view
-      // isn't the pinned one" and hands the running assistant back to the LRU.
-      if (record.projectId !== projectId) continue;
-      if (this.terminalBySessionId.get(record.sessionId) !== terminalId) continue;
-      return { terminalId, webContentsId: record.projectViewWebContentsId };
+  getAssistantBackends(
+    projectId: string
+  ): Array<{ terminalId: string; webContentsId: number; slot: number }> {
+    if (!projectId) return [];
+    const backends: Array<{ terminalId: string; webContentsId: number; slot: number }> = [];
+    for (const slot of ASSISTANT_SLOTS) {
+      const terminalId = this.activeHelpTerminalBySlotKey.get(assistantSlotKey(projectId, slot));
+      if (!terminalId) continue;
+      for (const record of this.sessionsById.values()) {
+        if (record.revoked) continue;
+        // Match on the project and lane too, not just the terminal id: nothing
+        // enforces terminal-id uniqueness across projects, and picking up
+        // another project's record would return the wrong pin — which reads as
+        // "this view isn't the pinned one" and hands the running assistant
+        // back to the LRU.
+        if (record.projectId !== projectId || record.slot !== slot) continue;
+        if (this.terminalBySessionId.get(record.sessionId) !== terminalId) continue;
+        backends.push({ terminalId, webContentsId: record.projectViewWebContentsId, slot });
+        break;
+      }
     }
-    return null;
+    return backends;
   }
 
   /**
@@ -629,14 +696,20 @@ export class HelpSessionService {
       return null;
     }
 
+    // Lock on the LANE's directory, not the project's: the race the lock
+    // exists for is the `.mcp.json` overwrite, and each lane writes its own
+    // file. Two lanes of one project therefore provision in parallel, while a
+    // same-lane re-provision still serializes — which is what makes
+    // `displacePriorSessions` below an atomic step.
     const pathHash = projectPathHash(input.projectPath);
-    const previous = this.provisionLocks.get(pathHash);
+    const lockKey = assistantSlotDirName(pathHash, input.slot ?? 0);
+    const previous = this.provisionLocks.get(lockKey);
     let resolveLock!: () => void;
     const next = new Promise<void>((resolve) => {
       resolveLock = resolve;
     });
     this.provisionLocks.set(
-      pathHash,
+      lockKey,
       (previous ?? Promise.resolve()).then(() => next)
     );
     if (previous) await previous;
@@ -647,8 +720,8 @@ export class HelpSessionService {
       resolveLock();
       // Drop the lock entry once it resolves so the map doesn't grow without
       // bound. Anyone awaiting `previous` already has the resolved promise.
-      if (this.provisionLocks.get(pathHash) === next) {
-        this.provisionLocks.delete(pathHash);
+      if (this.provisionLocks.get(lockKey) === next) {
+        this.provisionLocks.delete(lockKey);
       }
     }
   }
@@ -668,10 +741,11 @@ export class HelpSessionService {
     // the Settings tier selector lie about the surface it hands out (#11907).
     // What each tier permits is locked in `mcp-server/__tests__/tierAuth.test.ts`.
     const tier: HelpAssistantTier = settings.tier;
+    const slot = input.slot ?? 0;
     const sessionId = randomUUID();
     const token = randomBytes(SESSION_TOKEN_BYTES).toString("hex");
     const sessionsRoot = this.getSessionsRoot();
-    const sessionPath = path.join(sessionsRoot, pathHash);
+    const sessionPath = path.join(sessionsRoot, assistantSlotDirName(pathHash, slot));
 
     if (settings.daintreeControl) {
       try {
@@ -691,15 +765,15 @@ export class HelpSessionService {
     }
 
     // Single-backend invariant (#7509): displace any prior unrevoked record
-    // for this project BEFORE writing a fresh `.mcp.json`. The bearer is
+    // for this LANE BEFORE writing a fresh `.mcp.json`. The bearer is
     // marked revoked first so any in-flight MCP call from the orphan 401s
     // before the kill IPC reaches the PTY host. Runs inside `provisionLocks`
-    // (per pathHash), so concurrent provisions for the same project see this
-    // as an atomic step. The renderer still calls `revokeHelpSession` from
-    // its cooperative cleanup paths — this enforcement is defense-in-depth
+    // (per lane directory), so concurrent provisions for the same lane see
+    // this as an atomic step. The renderer still calls `revokeHelpSession`
+    // from its cooperative cleanup paths — this enforcement is defense-in-depth
     // for when those paths drop the kill or never fire (crash, project
     // switch, hibernate race).
-    this.displacePriorSessions(input.projectId);
+    this.displacePriorSessions(input.projectId, slot);
 
     await fs.mkdir(sessionsRoot, { recursive: true, mode: 0o700 });
     await fs.chmod(sessionsRoot, 0o700).catch(() => {});
@@ -843,6 +917,7 @@ export class HelpSessionService {
       windowId: input.windowId,
       projectViewWebContentsId: input.projectViewWebContentsId,
       projectId: input.projectId,
+      slot,
       projectPath: input.projectPath,
       sessionPath,
       agentId: input.agentId,
@@ -1011,6 +1086,7 @@ export class HelpSessionService {
     if (!record || record.revoked) return;
 
     const terminalId = this.terminalBySessionId.get(sessionId);
+    const slotKey = assistantSlotKey(record.projectId, record.slot);
 
     // Capture FIRST (while the session record is still valid for token
     // lookups by the agent process). gracefulKill resolves with the agent's
@@ -1032,10 +1108,10 @@ export class HelpSessionService {
       // resume-latest path instead; once gracefulKill returns we overwrite the
       // placeholder with the agent's real resume ID (below).
       if (this.pendingHibernationStore) {
-        this.pendingCapturesByProject.set(record.projectId, sessionId);
+        this.pendingCapturesBySlotKey.set(slotKey, sessionId);
         const panelWasOpen = this.panelOpenByProjectId.get(record.projectId) === true;
         void this.pendingHibernationStore
-          .set(record.projectId, {
+          .set(slotKey, {
             agentId: record.agentId,
             agentSessionId: "",
             cwd: record.sessionPath,
@@ -1084,11 +1160,8 @@ export class HelpSessionService {
       this.terminalBySessionId.delete(sessionId);
       // If displaced, the new provision already cleared the active slot (and
       // may have set it to a new terminal id) — never touch it here.
-      if (
-        !displacedDuringCapture &&
-        this.activeHelpTerminalByProjectId.get(record.projectId) === terminalId
-      ) {
-        this.activeHelpTerminalByProjectId.delete(record.projectId);
+      if (!displacedDuringCapture && this.activeHelpTerminalBySlotKey.get(slotKey) === terminalId) {
+        this.activeHelpTerminalBySlotKey.delete(slotKey);
       }
       if (!capturedAgentSessionId) {
         this.killTerminal(terminalId, "help-session-revoked");
@@ -1113,20 +1186,17 @@ export class HelpSessionService {
     }
 
     // #9639: finalize the placeholder written before gracefulKill. Only act if
-    // we still own the capture — a same-project re-provision that ran
+    // we still own the capture — a same-lane re-provision that ran
     // `displacePriorSessions` during the await clears our ownership and the
     // placeholder, so the old resume ID can't shadow the fresh session that
-    // took the slot. When we still own it: overwrite with the real resume ID
+    // took the lane. When we still own it: overwrite with the real resume ID
     // if gracefulKill yielded one, otherwise leave the empty-sentinel in place
     // (resume-latest beats a fresh launch). Then release ownership.
-    if (
-      this.pendingHibernationStore &&
-      this.pendingCapturesByProject.get(record.projectId) === sessionId
-    ) {
+    if (this.pendingHibernationStore && this.pendingCapturesBySlotKey.get(slotKey) === sessionId) {
       if (capturedAgentSessionId) {
         const panelWasOpen = this.panelOpenByProjectId.get(record.projectId) === true;
         void this.pendingHibernationStore
-          .set(record.projectId, {
+          .set(slotKey, {
             agentId: record.agentId,
             agentSessionId: capturedAgentSessionId,
             cwd: record.sessionPath,
@@ -1141,7 +1211,7 @@ export class HelpSessionService {
             );
           });
       }
-      this.pendingCapturesByProject.delete(record.projectId);
+      this.pendingCapturesBySlotKey.delete(slotKey);
     }
 
     // Claude bakes a literal session bearer into `.mcp.json`; Copilot
@@ -1163,14 +1233,17 @@ export class HelpSessionService {
    * before the user commits to a launch. The actual resume still goes through
    * `takePendingHibernation` (atomic take) inside the launch flow.
    */
-  peekPendingHibernation(projectId: string): {
+  peekPendingHibernation(
+    projectId: string,
+    slot: number
+  ): {
     agentId: string;
     agentSessionId: string;
     cwd: string;
     panelWasOpen: boolean;
   } | null {
     if (!this.pendingHibernationStore) return null;
-    const entry = this.pendingHibernationStore.get(projectId);
+    const entry = this.pendingHibernationStore.get(assistantSlotKey(projectId, slot));
     if (!entry) return null;
     return {
       agentId: entry.agentId,
@@ -1197,6 +1270,7 @@ export class HelpSessionService {
    */
   async takePendingHibernation(
     projectId: string,
+    slot: number,
     ownerWebContentsId?: number
   ): Promise<{
     agentId: string;
@@ -1205,25 +1279,30 @@ export class HelpSessionService {
     claimId: string;
   } | null> {
     if (!this.pendingHibernationStore) return null;
-    const entry = this.pendingHibernationStore.get(projectId);
+    const slotKey = assistantSlotKey(projectId, slot);
+    const entry = this.pendingHibernationStore.get(slotKey);
     if (!entry) return null;
     // #10048: invalidate the in-flight capture owner before the await so the
     // post-gracefulKill finalize block's ownership guard fails and the
     // already-killed agent's (now-stale) resume ID cannot overwrite the
     // placeholder the renderer just claimed. Mirrors displacePriorSessions.
-    this.pendingCapturesByProject.delete(projectId);
+    this.pendingCapturesBySlotKey.delete(slotKey);
     // Stash the exact entry (original `capturedAt` and all) so a taker that
     // aborts can hand it back via `restorePendingHibernation` (#11477).
-    // Overwrites any prior stash: only the most recent take is restorable, and
-    // an earlier taker's put-back must not resurrect a superseded entry.
+    // Overwrites any prior stash for this lane: only the most recent take is
+    // restorable, and an earlier taker's put-back must not resurrect a
+    // superseded entry. Stashes are per lane, so one view holding claims on
+    // several lanes keeps them independent — the CAS identity is
+    // (slotKey, claimId, ownerWebContentsId), and the same owner appearing in
+    // more than one bucket is expected rather than ambiguous.
     const { panelWasOpen: _panelWasOpen, ...restorable } = entry;
     const claimId = randomUUID();
-    this.lastTakenByProject.set(projectId, {
+    this.lastTakenBySlotKey.set(slotKey, {
       entry: restorable,
       claimId,
       ownerWebContentsId: ownerWebContentsId ?? null,
     });
-    await this.pendingHibernationStore.clear(projectId);
+    await this.pendingHibernationStore.clear(slotKey);
     return {
       agentId: entry.agentId,
       agentSessionId: entry.agentSessionId,
@@ -1268,11 +1347,13 @@ export class HelpSessionService {
    */
   async restorePendingHibernation(
     projectId: string,
+    slot: number,
     claimId: string,
     ownerWebContentsId?: number
   ): Promise<boolean> {
     if (!this.pendingHibernationStore) return false;
-    const stashed = this.lastTakenByProject.get(projectId);
+    const slotKey = assistantSlotKey(projectId, slot);
+    const stashed = this.lastTakenBySlotKey.get(slotKey);
     if (!stashed) return false;
     // Compare-and-swap on the specific take. A release quoting a superseded
     // claim (a later take replaced the stash) or arriving from a view other
@@ -1288,16 +1369,46 @@ export class HelpSessionService {
     }
     // One-shot from here: the claim is now spent either way, so a duplicate
     // release can't re-resurrect an entry a subsequent take consumed.
-    this.lastTakenByProject.delete(projectId);
-    if (this.pendingHibernationStore.get(projectId)) return false;
-    if (this.pendingCapturesByProject.has(projectId)) return false;
-    await this.pendingHibernationStore.set(projectId, stashed.entry);
+    this.lastTakenBySlotKey.delete(slotKey);
+    if (this.pendingHibernationStore.get(slotKey)) return false;
+    if (this.pendingCapturesBySlotKey.has(slotKey)) return false;
+    await this.pendingHibernationStore.set(slotKey, stashed.entry);
     return true;
   }
 
-  private displacePriorSessions(projectId: string): void {
+  /**
+   * Which lanes of `projectId` hold an eviction-captured resume entry.
+   *
+   * A cold renderer knows nothing about lanes 1+ — the ephemeral per-slot
+   * state is gone and only the persisted entries survive — so without this the
+   * tabs for those lanes would never be recreated and their captured
+   * conversations would be unreachable despite still being on disk. Returns
+   * lanes in slot order.
+   */
+  listPendingHibernationSlots(projectId: string): number[] {
+    if (!this.pendingHibernationStore || !projectId) return [];
+    return ASSISTANT_SLOTS.filter((slot) =>
+      Boolean(this.pendingHibernationStore?.get(assistantSlotKey(projectId, slot)))
+    );
+  }
+
+  /**
+   * Revoke every prior session occupying `(projectId, slot)`.
+   *
+   * Scoped to the lane since #12108. The #7509 property is unchanged and lives
+   * in the ORDER below, not in the breadth of the filter: the record leaves
+   * `sessionsByToken` before the fire-and-forget PTY kill, so even a dropped
+   * kill IPC leaves an orphan whose bearer no longer validates. Narrowing the
+   * filter only stops us killing sessions in other lanes, which are live
+   * sessions the user asked for rather than orphans.
+   *
+   * This is why `record.slot` is required rather than optional: a record whose
+   * lane were unknown would be displaced by nobody and would protect nobody.
+   */
+  private displacePriorSessions(projectId: string, slot: number): void {
+    const slotKey = assistantSlotKey(projectId, slot);
     const priors = [...this.sessionsById.values()].filter(
-      (record) => record.projectId === projectId && !record.revoked
+      (record) => record.projectId === projectId && record.slot === slot && !record.revoked
     );
     for (const prior of priors) {
       prior.revoked = true;
@@ -1305,10 +1416,10 @@ export class HelpSessionService {
       this.sessionsById.delete(prior.sessionId);
       // #9639: if this displaced session owns an in-flight capture placeholder,
       // drop it (and release ownership) so the old, soon-to-be-stale resume ID
-      // can't shadow the fresh session now taking the project's slot.
-      if (this.pendingCapturesByProject.get(projectId) === prior.sessionId) {
-        this.pendingCapturesByProject.delete(projectId);
-        void this.pendingHibernationStore?.clear(projectId).catch((err) => {
+      // can't shadow the fresh session now taking this lane.
+      if (this.pendingCapturesBySlotKey.get(slotKey) === prior.sessionId) {
+        this.pendingCapturesBySlotKey.delete(slotKey);
+        void this.pendingHibernationStore?.clear(slotKey).catch((err) => {
           console.warn(
             "[HelpSessionService] Failed to clear displaced pending hibernation:",
             projectId,
@@ -1322,7 +1433,7 @@ export class HelpSessionService {
         this.killTerminal(terminalId, "help-session-displaced");
       }
       // Tear down the displaced session's live MCP transport too (#9151).
-      // Displacement is just a same-project re-provision flavour of revoke —
+      // Displacement is just a same-lane re-provision flavour of revoke —
       // without this the old bearer keeps its tier/grants/pin until the
       // 30-minute idle reaper, exactly the stale state this issue closes on
       // the `revokeSession` path.
@@ -1337,10 +1448,10 @@ export class HelpSessionService {
       }
     }
     // Also clear any stale active-terminal binding the renderer never
-    // confirmed via `markTerminalForToken` — leaving it would leak the
-    // project's slot and cause the next `markTerminalForToken` to kill
+    // confirmed via `markTerminalForToken` — leaving it would leak this
+    // lane's binding and cause the next `markTerminalForToken` to kill
     // the wrong PTY.
-    this.activeHelpTerminalByProjectId.delete(projectId);
+    this.activeHelpTerminalBySlotKey.delete(slotKey);
   }
 
   private killTerminal(terminalId: string, reason: string): void {
@@ -1358,8 +1469,8 @@ export class HelpSessionService {
   }
 
   private removeTerminalFromMaps(terminalId: string): void {
-    for (const [pid, tid] of this.activeHelpTerminalByProjectId.entries()) {
-      if (tid === terminalId) this.activeHelpTerminalByProjectId.delete(pid);
+    for (const [pid, tid] of this.activeHelpTerminalBySlotKey.entries()) {
+      if (tid === terminalId) this.activeHelpTerminalBySlotKey.delete(pid);
     }
     for (const [sid, tid] of this.terminalBySessionId.entries()) {
       if (tid === terminalId) this.terminalBySessionId.delete(sid);
@@ -1423,7 +1534,7 @@ export class HelpSessionService {
     // Take-side stashes are launch-scoped and hold a resume id; nothing can
     // release one across a restart, so drop them rather than carry them to
     // shutdown. The persisted entries themselves are untouched (#11477).
-    this.lastTakenByProject.clear();
+    this.lastTakenBySlotKey.clear();
   }
 
   /**
@@ -1508,8 +1619,18 @@ export class HelpSessionService {
     void this.revokeAll();
   }
 
+  /**
+   * Whether `name` is a session directory we own and must keep.
+   *
+   * Load-bearing: `gcStaleSessions` recursively DELETES every directory this
+   * rejects, so a lane directory that failed to parse here would have its
+   * workspace trust and its transcripts collected out from under a live
+   * session. `parseAssistantSlotDirName` accepts the bare hash (slot 0) and
+   * exactly the in-range `-s<n>` suffixes, so legacy per-launch UUID dirs are
+   * still collected while lanes 1+ survive.
+   */
   private isProjectHashDirName(name: string): boolean {
-    return name.length === PROJECT_HASH_LEN && /^[0-9a-f]+$/.test(name);
+    return parseAssistantSlotDirName(name, PROJECT_HASH_LEN) !== null;
   }
 
   private validateProvisionInput(input: ProvisionInput): void {
@@ -1521,6 +1642,13 @@ export class HelpSessionService {
     }
     if (typeof input.projectPath !== "string" || !input.projectPath.trim()) {
       throw new Error("projectPath is required");
+    }
+    // Absent means slot 0 (pre-slot callers and fixtures). Present but invalid
+    // is a caller bug: clamping it would silently displace whichever lane the
+    // clamp landed on, which is exactly the cross-lane kill the slot key
+    // exists to prevent.
+    if (input.slot !== undefined && !isValidAssistantSlot(input.slot)) {
+      throw new Error(`slot must be an integer in [0, ${ASSISTANT_SLOTS.length}) — got ${String(input.slot)}`);
     }
     if (!path.isAbsolute(input.projectPath)) {
       throw new Error("projectPath must be absolute");
@@ -2024,7 +2152,13 @@ export class HelpSessionService {
     const auth = entry.headers?.Authorization ?? "";
     const match = /^Bearer\s+(.+)$/.exec(auth);
     const token = match?.[1]?.trim();
-    if (token && this.sessionsByToken.has(token)) return;
+    // A token is only live FOR THIS DIRECTORY. Once lanes each own a session
+    // dir (#12108), a bearer that is valid for another lane sitting in this
+    // one is misplaced, not live — keeping it would leave a working credential
+    // in a directory its session never owned, which is the stray-`claude`-in-
+    // cwd hole this strip exists to close.
+    const live = token ? this.sessionsByToken.get(token) : undefined;
+    if (live && live.sessionPath === sessionPath) return;
 
     delete servers["daintree"];
     try {

--- a/electron/services/HelpSessionService.ts
+++ b/electron/services/HelpSessionService.ts
@@ -714,10 +714,12 @@ export class HelpSessionService {
     const next = new Promise<void>((resolve) => {
       resolveLock = resolve;
     });
-    this.provisionLocks.set(
-      lockKey,
-      (previous ?? Promise.resolve()).then(() => next)
-    );
+    // Keep the CHAINED promise, which is what actually lands in the map — the
+    // cleanup below compares against it to decide whether this call is still
+    // the tail of the queue. Comparing against `next` never matched, so the
+    // entry was never dropped and the map grew for the life of the process.
+    const tail = (previous ?? Promise.resolve()).then(() => next);
+    this.provisionLocks.set(lockKey, tail);
     if (previous) await previous;
 
     try {
@@ -726,7 +728,7 @@ export class HelpSessionService {
       resolveLock();
       // Drop the lock entry once it resolves so the map doesn't grow without
       // bound. Anyone awaiting `previous` already has the resolved promise.
-      if (this.provisionLocks.get(lockKey) === next) {
+      if (this.provisionLocks.get(lockKey) === tail) {
         this.provisionLocks.delete(lockKey);
       }
     }
@@ -2163,10 +2165,13 @@ export class HelpSessionService {
     // spawn. Matching it against the token map always misses, so an unrevoked
     // Copilot session owning this exact directory would have its own live
     // config stripped out from under it.
-    const ownedByLiveSession = [...this.sessionsByToken.values()].some(
-      (record) => !record.revoked && record.sessionPath === sessionPath
+    // Narrowed to Copilot: a Claude session owning the directory does not make
+    // a leftover Copilot entry legitimate, and keeping one would leave Claude
+    // with a stale server it cannot authenticate against.
+    const ownedByLiveCopilot = [...this.sessionsByToken.values()].some(
+      (record) => !record.revoked && record.agentId === "copilot" && record.sessionPath === sessionPath
     );
-    if (token === COPILOT_BEARER_PLACEHOLDER && ownedByLiveSession) return;
+    if (token === COPILOT_BEARER_PLACEHOLDER && ownedByLiveCopilot) return;
 
     // Otherwise a token is only live FOR THIS DIRECTORY. Once lanes each own a
     // session dir (#12108), a bearer that is valid for another lane sitting in

--- a/electron/services/HelpSessionService.ts
+++ b/electron/services/HelpSessionService.ts
@@ -42,6 +42,9 @@ const SESSION_TOKEN_BYTES = 32;
 // in 64 bits of project-path-derived entropy are not a real concern for a
 // machine-local set of projects.
 const PROJECT_HASH_LEN = 16;
+// Copilot substitutes this from PTY env at spawn rather than baking a literal
+// bearer into `.mcp.json`, so the stale-entry sweep has to recognize it.
+const COPILOT_BEARER_PLACEHOLDER = "$DAINTREE_MCP_TOKEN";
 // Stamp file written into the per-project session dir after a successful
 // `fs.cp` of the bundled help template. Lives inside the session dir (not
 // inside `helpFolder`), so it's never part of the source being hashed and
@@ -696,13 +699,16 @@ export class HelpSessionService {
       return null;
     }
 
-    // Lock on the LANE's directory, not the project's: the race the lock
-    // exists for is the `.mcp.json` overwrite, and each lane writes its own
-    // file. Two lanes of one project therefore provision in parallel, while a
-    // same-lane re-provision still serializes — which is what makes
-    // `displacePriorSessions` below an atomic step.
+    // Lock on the LANE ITSELF — `(projectId, slot)` — because that is the
+    // identity the single-backend invariant is stated in. A path-derived key
+    // would not serialize two callers that spell the same project differently
+    // (`/work/p` vs `/work/p/`): they would hash apart, both run
+    // `displacePriorSessions` before either registered its record, and both
+    // end up live in one lane. Different lanes and different projects still
+    // provision in parallel, which is all the parallelism this needs — each
+    // lane writes its own `.mcp.json` in its own directory.
     const pathHash = projectPathHash(input.projectPath);
-    const lockKey = assistantSlotDirName(pathHash, input.slot ?? 0);
+    const lockKey = assistantSlotKey(input.projectId, input.slot ?? 0);
     const previous = this.provisionLocks.get(lockKey);
     let resolveLock!: () => void;
     const next = new Promise<void>((resolve) => {
@@ -1922,7 +1928,7 @@ export class HelpSessionService {
       mcpServers["daintree"] = {
         type: "http",
         url: `http://127.0.0.1:${port}/mcp`,
-        headers: { Authorization: "Bearer $DAINTREE_MCP_TOKEN" },
+        headers: { Authorization: `Bearer ${COPILOT_BEARER_PLACEHOLDER}` },
       };
     }
     const target = path.join(sessionPath, ".mcp.json");
@@ -2152,11 +2158,21 @@ export class HelpSessionService {
     const auth = entry.headers?.Authorization ?? "";
     const match = /^Bearer\s+(.+)$/.exec(auth);
     const token = match?.[1]?.trim();
-    // A token is only live FOR THIS DIRECTORY. Once lanes each own a session
-    // dir (#12108), a bearer that is valid for another lane sitting in this
-    // one is misplaced, not live — keeping it would leave a working credential
-    // in a directory its session never owned, which is the stray-`claude`-in-
-    // cwd hole this strip exists to close.
+    // Copilot never writes a literal bearer — `writeCopilotMcpConfig` emits the
+    // `$DAINTREE_MCP_TOKEN` placeholder, which is substituted from PTY env at
+    // spawn. Matching it against the token map always misses, so an unrevoked
+    // Copilot session owning this exact directory would have its own live
+    // config stripped out from under it.
+    const ownedByLiveSession = [...this.sessionsByToken.values()].some(
+      (record) => !record.revoked && record.sessionPath === sessionPath
+    );
+    if (token === COPILOT_BEARER_PLACEHOLDER && ownedByLiveSession) return;
+
+    // Otherwise a token is only live FOR THIS DIRECTORY. Once lanes each own a
+    // session dir (#12108), a bearer that is valid for another lane sitting in
+    // this one is misplaced, not live — keeping it would leave a working
+    // credential in a directory its session never owned, which is the
+    // stray-`claude`-in-cwd hole this strip exists to close.
     const live = token ? this.sessionsByToken.get(token) : undefined;
     if (live && live.sessionPath === sessionPath) return;
 

--- a/electron/services/HelpSessionService.ts
+++ b/electron/services/HelpSessionService.ts
@@ -1656,7 +1656,9 @@ export class HelpSessionService {
     // clamp landed on, which is exactly the cross-lane kill the slot key
     // exists to prevent.
     if (input.slot !== undefined && !isValidAssistantSlot(input.slot)) {
-      throw new Error(`slot must be an integer in [0, ${ASSISTANT_SLOTS.length}) — got ${String(input.slot)}`);
+      throw new Error(
+        `slot must be an integer in [0, ${ASSISTANT_SLOTS.length}) — got ${String(input.slot)}`
+      );
     }
     if (!path.isAbsolute(input.projectPath)) {
       throw new Error("projectPath must be absolute");
@@ -2169,7 +2171,8 @@ export class HelpSessionService {
     // a leftover Copilot entry legitimate, and keeping one would leave Claude
     // with a stale server it cannot authenticate against.
     const ownedByLiveCopilot = [...this.sessionsByToken.values()].some(
-      (record) => !record.revoked && record.agentId === "copilot" && record.sessionPath === sessionPath
+      (record) =>
+        !record.revoked && record.agentId === "copilot" && record.sessionPath === sessionPath
     );
     if (token === COPILOT_BEARER_PLACEHOLDER && ownedByLiveCopilot) return;
 

--- a/electron/services/IdleBackgroundAutoCloseService.ts
+++ b/electron/services/IdleBackgroundAutoCloseService.ts
@@ -116,9 +116,12 @@ export class IdleBackgroundAutoCloseService {
    * be unconditional; it lifts as soon as the PTY exits.
    */
   private hasLiveAssistantBackend(projectId: string): boolean {
-    const backend = helpSessionService.getAssistantBackend(projectId);
-    if (!backend) return false;
-    return this.ptyClient?.hasTerminal(backend.terminalId) === true;
+    // ANY live lane floors the whole project (#12108). Reclaim closes the
+    // project, not one lane, and it finishes by revoking every session the
+    // project owns — so a lane whose PTY has exited must never be read as
+    // "clear" while a sibling is still running.
+    const backends = helpSessionService.getAssistantBackends(projectId);
+    return backends.some((backend) => this.ptyClient?.hasTerminal(backend.terminalId) === true);
   }
 
   /**

--- a/electron/services/PendingHelpHibernationStore.ts
+++ b/electron/services/PendingHelpHibernationStore.ts
@@ -3,9 +3,19 @@ import path from "node:path";
 import { app } from "electron";
 import { resilientAtomicWriteFile } from "../utils/fs.js";
 import { rebaseAbsolutePath } from "../../shared/utils/projectPathRelocation.js";
+import {
+  DEFAULT_ASSISTANT_SLOT,
+  assistantSlotKey,
+  projectIdFromSlotKey,
+} from "../../shared/config/assistantSlots.js";
 
 const FILE_NAME = "help-pending-hibernation.json";
-const FILE_VERSION = 1;
+// v2 keys entries by `assistantSlotKey(projectId, slot)` instead of bare
+// projectId (#12108). v1 files are migrated on read rather than dropped —
+// `load()` discards anything whose version it doesn't recognize, so skipping
+// the migration would silently destroy every existing user's resume tokens.
+const FILE_VERSION = 2;
+const LEGACY_UNSLOTTED_FILE_VERSION = 1;
 // Anything older than this on read is treated as stale and dropped. The
 // hibernation token is the agent's resume ID; stale tokens point at a
 // transcript file the agent may have rotated or pruned, so resume would
@@ -62,12 +72,16 @@ export class PendingHelpHibernationStore {
       const raw = await fs.readFile(this.filePath, "utf-8");
       const parsed = JSON.parse(raw) as Partial<FileShape>;
       if (!parsed || typeof parsed !== "object") return;
-      if (parsed.version !== FILE_VERSION) return;
+      const legacyUnslotted = parsed.version === LEGACY_UNSLOTTED_FILE_VERSION;
+      if (parsed.version !== FILE_VERSION && !legacyUnslotted) return;
       const entries = parsed.entries;
       if (!entries || typeof entries !== "object") return;
       const cutoff = Date.now() - STALE_AFTER_MS;
-      for (const [projectId, entry] of Object.entries(entries)) {
-        if (!projectId) continue;
+      for (const [rawKey, entry] of Object.entries(entries)) {
+        if (!rawKey) continue;
+        // A v1 key is a bare project id, which by definition described the one
+        // lane that existed then — slot 0.
+        const key = legacyUnslotted ? assistantSlotKey(rawKey, DEFAULT_ASSISTANT_SLOT) : rawKey;
         if (!this.isValid(entry)) continue;
         if (entry.capturedAt < cutoff) continue;
         // Defensively strip any `panelWasOpen` that reached disk (manual edit,
@@ -75,7 +89,7 @@ export class PendingHelpHibernationStore {
         // only and a disk-loaded `true` would auto-resume a prior-session token
         // on app restart — the exact invariant this feature must never break.
         const { panelWasOpen: _panelWasOpen, ...safeEntry } = entry as PendingHelpHibernation;
-        this.entries.set(projectId, safeEntry);
+        this.entries.set(key, safeEntry);
       }
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code === "ENOENT") return;
@@ -83,18 +97,19 @@ export class PendingHelpHibernationStore {
     }
   }
 
-  get(projectId: string): PendingHelpHibernation | null {
-    return this.entries.get(projectId) ?? null;
+  /** `slotKey` is `assistantSlotKey(projectId, slot)` — see #12108. */
+  get(slotKey: string): PendingHelpHibernation | null {
+    return this.entries.get(slotKey) ?? null;
   }
 
-  set(projectId: string, entry: PendingHelpHibernation): Promise<void> {
-    this.entries.set(projectId, entry);
+  set(slotKey: string, entry: PendingHelpHibernation): Promise<void> {
+    this.entries.set(slotKey, entry);
     return this.persist();
   }
 
-  clear(projectId: string): Promise<void> {
-    if (!this.entries.has(projectId)) return Promise.resolve();
-    this.entries.delete(projectId);
+  clear(slotKey: string): Promise<void> {
+    if (!this.entries.has(slotKey)) return Promise.resolve();
+    this.entries.delete(slotKey);
     return this.persist();
   }
 
@@ -106,12 +121,18 @@ export class PendingHelpHibernationStore {
    */
   async rewriteProjectPath(projectId: string, oldRoot: string, newRoot: string): Promise<void> {
     await this.load();
-    const entry = this.entries.get(projectId);
-    if (!entry) return;
-    const nextCwd = rebaseAbsolutePath(entry.cwd, oldRoot, newRoot);
-    if (nextCwd === entry.cwd) return;
-    this.entries.set(projectId, { ...entry, cwd: nextCwd });
-    await this.persist();
+    // Every lane of the project, not one key (#12108): each lane captured its
+    // own cwd under the old root, and leaving a sibling behind would resume it
+    // in a folder that no longer exists.
+    let changed = false;
+    for (const [slotKey, entry] of this.entries) {
+      if (projectIdFromSlotKey(slotKey) !== projectId) continue;
+      const nextCwd = rebaseAbsolutePath(entry.cwd, oldRoot, newRoot);
+      if (nextCwd === entry.cwd) continue;
+      this.entries.set(slotKey, { ...entry, cwd: nextCwd });
+      changed = true;
+    }
+    if (changed) await this.persist();
   }
 
   private isValid(value: unknown): value is PendingHelpHibernation {
@@ -139,9 +160,9 @@ export class PendingHelpHibernationStore {
     // Strip `panelWasOpen` (in-memory only) so reloaded entries on app restart
     // are treated as prior-session tokens that never auto-resume.
     const persistedEntries: Record<string, PersistedHelpHibernation> = {};
-    for (const [projectId, entry] of this.entries.entries()) {
+    for (const [slotKey, entry] of this.entries.entries()) {
       const { panelWasOpen: _panelWasOpen, ...persisted } = entry;
-      persistedEntries[projectId] = persisted;
+      persistedEntries[slotKey] = persisted;
     }
     const snapshot: FileShape = {
       version: FILE_VERSION,

--- a/electron/services/ProjectRelocationCoordinator.ts
+++ b/electron/services/ProjectRelocationCoordinator.ts
@@ -237,8 +237,8 @@ export class ProjectRelocationCoordinator {
     // never stops the Assistant, so blocking on it there would be a phantom.
     if (usesPipeline) {
       try {
-        const assistant = await getAssistantBackend(projectId);
-        if (assistant) {
+        const assistantActive = await hasAssistantBackend(projectId);
+        if (assistantActive) {
           blockers.push({
             reason: "assistant-active",
             message: "Stop the Daintree Assistant for this project before moving it.",
@@ -371,9 +371,9 @@ export class ProjectRelocationCoordinator {
     // rather than silently destroying in-flight agent work. A failed check is
     // treated as "may be active" — never as "clear". Phase 4/5 own hibernate.
     if (disposition === "refuse") {
-      let assistant: { terminalId: string; webContentsId: number } | null;
+      let assistantActive: boolean;
       try {
-        assistant = await getAssistantBackend(projectId);
+        assistantActive = await hasAssistantBackend(projectId);
       } catch (error) {
         logError("relocate-assistant-check-failed", error, { projectId });
         throw new ProjectRelocationError(
@@ -381,7 +381,7 @@ export class ProjectRelocationCoordinator {
           "Couldn't check the Daintree Assistant for this project — stop it and try again."
         );
       }
-      if (assistant) {
+      if (assistantActive) {
         throw new ProjectRelocationError(
           "assistant-active",
           "Stop the Daintree Assistant for this project before moving it."
@@ -711,17 +711,18 @@ export class ProjectRelocationCoordinator {
 }
 
 /**
- * Read the Assistant backend for a project, if one is live. Dynamically imported
- * to avoid pulling the heavy HelpSessionService into this module's eval graph
+ * Whether the project has any live Assistant backend. Dynamically imported to
+ * avoid pulling the heavy HelpSessionService into this module's eval graph
  * (the IPC layer loads it lazily too). THROWS on failure — the caller fails
  * closed (treats an unverifiable Assistant as possibly-active) rather than
  * risking a silent sub-agent-tree kill.
+ *
+ * Any lane counts (#12108): relocation quiesces the whole project, so one
+ * running lane is enough to refuse.
  */
-async function getAssistantBackend(
-  projectId: string
-): Promise<{ terminalId: string; webContentsId: number } | null> {
+async function hasAssistantBackend(projectId: string): Promise<boolean> {
   const { helpSessionService } = await import("./HelpSessionService.js");
-  return helpSessionService.getAssistantBackend(projectId);
+  return helpSessionService.getAssistantBackends(projectId).length > 0;
 }
 
 export const projectRelocationCoordinator = new ProjectRelocationCoordinator();

--- a/electron/services/ProjectStatsService.ts
+++ b/electron/services/ProjectStatsService.ts
@@ -244,7 +244,10 @@ export class ProjectStatsService {
         // side is the drift the shared helper exists to prevent: the push
         // suppresses unchanged payloads, so a row hydrated with a hidden
         // assistant would keep reporting it until agent state next moved.
-        (id) => helpSessionService.isPanelVisible(id)
+        (id) => helpSessionService.isPanelVisible(id),
+        // Lets concurrent assistants be ranked by who needs the user,
+        // rather than by whichever started last (#12108).
+        (terminalId) => helpSessionService.getSlotForTerminal(terminalId)
       );
 
       const statusMap: ProjectStatusMap = {};

--- a/electron/services/__tests__/HelpSessionService.test.ts
+++ b/electron/services/__tests__/HelpSessionService.test.ts
@@ -1343,20 +1343,18 @@ describe("HelpSessionService", () => {
       // Lane 0 keeps the historical bare-hash directory, so an existing
       // install's Claude workspace-trust acceptance survives this change.
       expect(path.basename(laneZero.sessionPath)).toMatch(/^[0-9a-f]{16}$/);
-      expect(path.basename(laneOne.sessionPath)).toBe(
-        `${path.basename(laneZero.sessionPath)}-s1`
-      );
+      expect(path.basename(laneOne.sessionPath)).toBe(`${path.basename(laneZero.sessionPath)}-s1`);
     });
 
     it("rejects an out-of-range lane instead of clamping it onto a neighbour", async () => {
       // Clamping would displace whichever lane the clamp landed on — a session
       // the caller never named.
-      await expect(
-        service.provisionSession({ ...provisionInput(), slot: 99 })
-      ).rejects.toThrow(/slot/);
-      await expect(
-        service.provisionSession({ ...provisionInput(), slot: -1 })
-      ).rejects.toThrow(/slot/);
+      await expect(service.provisionSession({ ...provisionInput(), slot: 99 })).rejects.toThrow(
+        /slot/
+      );
+      await expect(service.provisionSession({ ...provisionInput(), slot: -1 })).rejects.toThrow(
+        /slot/
+      );
     });
 
     it("reports every live lane so a dead one can't mask a live sibling", async () => {
@@ -1527,7 +1525,9 @@ describe("HelpSessionService", () => {
       // #9639: an empty-sentinel placeholder is written SYNCHRONOUSLY before
       // gracefulKill so a racing switch-back resumes rather than fresh-launches;
       // the real resume ID overwrites it once gracefulKill resolves.
-      const setCalls = hibernationStore.set.mock.calls.filter((c) => c[0] === slotKey("proj-evicted", 0));
+      const setCalls = hibernationStore.set.mock.calls.filter(
+        (c) => c[0] === slotKey("proj-evicted", 0)
+      );
       expect(setCalls[0][1].agentSessionId).toBe("");
       expect(setCalls[setCalls.length - 1][1]).toEqual(
         expect.objectContaining({
@@ -1557,7 +1557,9 @@ describe("HelpSessionService", () => {
       // #9639: with no real resume ID, the empty-sentinel placeholder stays —
       // resume-latest on next open beats a fresh launch. Exactly one write
       // (the placeholder), never overwritten.
-      const setCalls = hibernationStore.set.mock.calls.filter((c) => c[0] === slotKey("proj-no-resume", 0));
+      const setCalls = hibernationStore.set.mock.calls.filter(
+        (c) => c[0] === slotKey("proj-no-resume", 0)
+      );
       expect(setCalls).toHaveLength(1);
       expect(setCalls[0][1].agentSessionId).toBe("");
     });
@@ -1812,15 +1814,15 @@ describe("HelpSessionService", () => {
         hibernationStore.get.mockReturnValue(null);
         hibernationStore.set.mockClear();
 
-        await expect(service.restorePendingHibernation("proj-A", 0, taken!.claimId, 22)).resolves.toBe(
-          false
-        );
+        await expect(
+          service.restorePendingHibernation("proj-A", 0, taken!.claimId, 22)
+        ).resolves.toBe(false);
         expect(hibernationStore.set).not.toHaveBeenCalled();
 
         // The rightful owner can still put it back.
-        await expect(service.restorePendingHibernation("proj-A", 0, taken!.claimId, 11)).resolves.toBe(
-          true
-        );
+        await expect(
+          service.restorePendingHibernation("proj-A", 0, taken!.claimId, 11)
+        ).resolves.toBe(true);
       });
 
       it("restores the empty-string resume-latest sentinel unchanged (#9639)", async () => {
@@ -1912,7 +1914,9 @@ describe("HelpSessionService", () => {
       await service.revokeByWebContentsId(99);
       await Promise.resolve();
 
-      const setCalls = hibernationStore.set.mock.calls.filter((c) => c[0] === slotKey("proj-open", 0));
+      const setCalls = hibernationStore.set.mock.calls.filter(
+        (c) => c[0] === slotKey("proj-open", 0)
+      );
       // Both the synchronous placeholder and the real-resume-id overwrite carry
       // the open flag so a switch-back at any point auto-resumes.
       expect(setCalls[0][1].panelWasOpen).toBe(true);
@@ -1939,7 +1943,9 @@ describe("HelpSessionService", () => {
       await service.revokeByWebContentsId(98);
       await Promise.resolve();
 
-      const setCalls = hibernationStore.set.mock.calls.filter((c) => c[0] === slotKey("proj-closed", 0));
+      const setCalls = hibernationStore.set.mock.calls.filter(
+        (c) => c[0] === slotKey("proj-closed", 0)
+      );
       expect(setCalls[setCalls.length - 1][1].panelWasOpen).toBe(false);
     });
 
@@ -1961,7 +1967,9 @@ describe("HelpSessionService", () => {
       await service.revokeByWebContentsId(97);
       await Promise.resolve();
 
-      const setCalls = hibernationStore.set.mock.calls.filter((c) => c[0] === slotKey("proj-toggle", 0));
+      const setCalls = hibernationStore.set.mock.calls.filter(
+        (c) => c[0] === slotKey("proj-toggle", 0)
+      );
       expect(setCalls[setCalls.length - 1][1].panelWasOpen).toBe(false);
     });
 

--- a/electron/services/__tests__/HelpSessionService.test.ts
+++ b/electron/services/__tests__/HelpSessionService.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import fs from "node:fs/promises";
 import type { McpRuntimeSnapshot } from "../../../shared/types/ipc/mcpServer.js";
+import { assistantSlotKey as slotKey } from "../../../shared/config/assistantSlots.js";
 
 const {
   mockUserDataDir,
@@ -892,6 +893,32 @@ describe("HelpSessionService", () => {
     await fs.access(fresh.sessionPath);
   });
 
+  it("gcStaleSessions preserves lane directories while still sweeping look-alikes (#12108)", async () => {
+    // The predicate GC uses to decide what to keep is the ONLY thing standing
+    // between a live lane and recursive deletion of its transcripts and its
+    // workspace-trust acceptance. A bare 16-hex check would delete `-s1`.
+    const laneZero = await service.provisionSession({ ...provisionInput(), slot: 0 });
+    const laneOne = await service.provisionSession({ ...provisionInput(), slot: 1 });
+    if (!laneZero || !laneOne) throw new Error("expected both provisions");
+
+    const hash = path.basename(laneZero.sessionPath);
+    const sessionsRoot = path.join(userData, "help-sessions");
+    // Not lanes: `-s0` is slot 0's second spelling, and `-s99` is out of range.
+    // Keeping either alive would strand a directory nothing collects.
+    const bogusZeroSuffix = path.join(sessionsRoot, `${hash}-s0`);
+    const outOfRange = path.join(sessionsRoot, `${hash}-s99`);
+    await fs.mkdir(bogusZeroSuffix, { recursive: true });
+    await fs.mkdir(outOfRange, { recursive: true });
+
+    await service.gcStaleSessions();
+
+    await fs.access(laneZero.sessionPath);
+    await fs.access(laneOne.sessionPath);
+    for (const dir of [bogusZeroSuffix, outOfRange]) {
+      await expect(fs.access(dir)).rejects.toThrow();
+    }
+  });
+
   it("returns null when the bundled help folder is unavailable", async () => {
     mockHelpFolderPath.mockReturnValue(null);
     const result = await service.provisionSession(provisionInput());
@@ -1185,22 +1212,28 @@ describe("HelpSessionService", () => {
   // the pinned WebContents so only the view that would do the killing is
   // protected.
   describe("getAssistantBackend (#11157)", () => {
+    // These cases predate lanes (#12108) and all describe a project running a
+    // single assistant, so they read the first (only) backend. The multi-lane
+    // behaviour has its own describe block below.
+    const firstBackend = (projectId: string) => service.getAssistantBackends(projectId)[0] ?? null;
+
     it("resolves only once a terminal is bound, and only for the owning project", async () => {
       const result = await service.provisionSession(provisionInput());
       if (!result) throw new Error("expected result");
 
       // Provisioned but not spawned: the bearer exists, the backend does not.
-      expect(service.getAssistantBackend("proj-1")).toBeNull();
+      expect(firstBackend("proj-1")).toBeNull();
 
       expect(service.markTerminalForToken(result.token, "term-1")).toBe(true);
 
       // provisionInput() pins the session to WebContents 42.
-      expect(service.getAssistantBackend("proj-1")).toEqual({
+      expect(firstBackend("proj-1")).toEqual({
         terminalId: "term-1",
         webContentsId: 42,
+        slot: 0,
       });
-      expect(service.getAssistantBackend("proj-2")).toBeNull();
-      expect(service.getAssistantBackend("")).toBeNull();
+      expect(firstBackend("proj-2")).toBeNull();
+      expect(firstBackend("")).toBeNull();
     });
 
     it("follows the binding through displacement", async () => {
@@ -1211,7 +1244,7 @@ describe("HelpSessionService", () => {
 
       // The displaced PTY is dead; protecting the view on its behalf would pin
       // a project whose assistant is gone.
-      expect(service.getAssistantBackend("proj-1")?.terminalId).toBe("term-new");
+      expect(firstBackend("proj-1")?.terminalId).toBe("term-new");
     });
 
     it("clears on unbind", async () => {
@@ -1221,7 +1254,7 @@ describe("HelpSessionService", () => {
 
       service.unbindTerminal("term-1");
 
-      expect(service.getAssistantBackend("proj-1")).toBeNull();
+      expect(firstBackend("proj-1")).toBeNull();
     });
 
     it("clears on revoke", async () => {
@@ -1231,7 +1264,7 @@ describe("HelpSessionService", () => {
 
       await service.revokeSession(result.sessionId);
 
-      expect(service.getAssistantBackend("proj-1")).toBeNull();
+      expect(firstBackend("proj-1")).toBeNull();
     });
 
     it("returns the owning project's pin when two projects share a terminal id", async () => {
@@ -1254,8 +1287,122 @@ describe("HelpSessionService", () => {
       expect(service.markTerminalForToken(one.token, "shared-term")).toBe(true);
       expect(service.markTerminalForToken(two.token, "shared-term")).toBe(true);
 
-      expect(service.getAssistantBackend("proj-1")?.webContentsId).toBe(42);
-      expect(service.getAssistantBackend("proj-2")?.webContentsId).toBe(77);
+      expect(firstBackend("proj-1")?.webContentsId).toBe(42);
+      expect(firstBackend("proj-2")?.webContentsId).toBe(77);
+    });
+  });
+
+  // #12108. The #7509 single-backend invariant above is NOT relaxed here — it
+  // is re-scoped. Every case in that describe block runs at the default lane
+  // and still passes unchanged; these add the orthogonal axis it never covered,
+  // namely that two DIFFERENT lanes of one project are independent.
+  describe("concurrent assistant lanes (#12108)", () => {
+    it("keeps both bearers valid and kills neither PTY across two lanes of one project", async () => {
+      const first = await service.provisionSession({ ...provisionInput(), slot: 0 });
+      if (!first) throw new Error("expected first provision");
+      expect(service.markTerminalForToken(first.token, "term-slot-0")).toBe(true);
+
+      const second = await service.provisionSession({ ...provisionInput(), slot: 1 });
+      if (!second) throw new Error("expected second provision");
+      expect(service.markTerminalForToken(second.token, "term-slot-1")).toBe(true);
+
+      // The whole point of the feature: neither session displaced the other.
+      expect(service.validateToken(first.token)).toBe("action");
+      expect(service.validateToken(second.token)).toBe("action");
+      expect(mockPtyKill).not.toHaveBeenCalled();
+    });
+
+    it("still displaces within a lane while leaving the sibling lane untouched", async () => {
+      const laneZero = await service.provisionSession({ ...provisionInput(), slot: 0 });
+      const laneOne = await service.provisionSession({ ...provisionInput(), slot: 1 });
+      if (!laneZero || !laneOne) throw new Error("expected both provisions");
+      expect(service.markTerminalForToken(laneZero.token, "term-slot-0")).toBe(true);
+      expect(service.markTerminalForToken(laneOne.token, "term-slot-1")).toBe(true);
+
+      // Re-provisioning lane 0 must behave exactly as the pre-lane invariant
+      // did — revoke the old bearer, kill its PTY — and touch nothing else.
+      const replacement = await service.provisionSession({ ...provisionInput(), slot: 0 });
+      if (!replacement) throw new Error("expected replacement provision");
+
+      expect(service.validateToken(laneZero.token)).toBe(false);
+      expect(service.validateToken(replacement.token)).toBe("action");
+      expect(mockPtyKill).toHaveBeenCalledWith("term-slot-0", "help-session-displaced");
+      expect(mockPtyKill).not.toHaveBeenCalledWith("term-slot-1", "help-session-displaced");
+      // The sibling is still fully live.
+      expect(service.validateToken(laneOne.token)).toBe("action");
+    });
+
+    it("gives each lane its own session directory so one bearer can't overwrite another", async () => {
+      const laneZero = await service.provisionSession({ ...provisionInput(), slot: 0 });
+      const laneOne = await service.provisionSession({ ...provisionInput(), slot: 1 });
+      if (!laneZero || !laneOne) throw new Error("expected both provisions");
+
+      // Same cwd would mean one `.mcp.json`, and the second provision would
+      // silently overwrite the first session's literal bearer.
+      expect(laneOne.sessionPath).not.toBe(laneZero.sessionPath);
+      // Lane 0 keeps the historical bare-hash directory, so an existing
+      // install's Claude workspace-trust acceptance survives this change.
+      expect(path.basename(laneZero.sessionPath)).toMatch(/^[0-9a-f]{16}$/);
+      expect(path.basename(laneOne.sessionPath)).toBe(
+        `${path.basename(laneZero.sessionPath)}-s1`
+      );
+    });
+
+    it("rejects an out-of-range lane instead of clamping it onto a neighbour", async () => {
+      // Clamping would displace whichever lane the clamp landed on — a session
+      // the caller never named.
+      await expect(
+        service.provisionSession({ ...provisionInput(), slot: 99 })
+      ).rejects.toThrow(/slot/);
+      await expect(
+        service.provisionSession({ ...provisionInput(), slot: -1 })
+      ).rejects.toThrow(/slot/);
+    });
+
+    it("reports every live lane so a dead one can't mask a live sibling", async () => {
+      const laneZero = await service.provisionSession({ ...provisionInput(), slot: 0 });
+      const laneOne = await service.provisionSession({ ...provisionInput(), slot: 1 });
+      if (!laneZero || !laneOne) throw new Error("expected both provisions");
+      service.markTerminalForToken(laneZero.token, "term-slot-0");
+      service.markTerminalForToken(laneOne.token, "term-slot-1");
+
+      expect(service.getAssistantBackends("proj-1")).toEqual([
+        { terminalId: "term-slot-0", webContentsId: 42, slot: 0 },
+        { terminalId: "term-slot-1", webContentsId: 42, slot: 1 },
+      ]);
+
+      // Lane 0 exits under its own steam. Reclaiming the project on the
+      // strength of that alone would kill lane 1 — the #11807 regression.
+      service.unbindTerminal("term-slot-0");
+      expect(service.getAssistantBackends("proj-1")).toEqual([
+        { terminalId: "term-slot-1", webContentsId: 42, slot: 1 },
+      ]);
+    });
+
+    it("resolves a terminal to its lane, and a displaced backend to none", async () => {
+      const laneOne = await service.provisionSession({ ...provisionInput(), slot: 1 });
+      if (!laneOne) throw new Error("expected provision");
+      service.markTerminalForToken(laneOne.token, "term-slot-1");
+
+      expect(service.getSlotForTerminal("term-slot-1")).toBe(1);
+      expect(service.getSlotForTerminal("not-a-terminal")).toBeNull();
+
+      // After displacement the record is gone synchronously, so the corpse
+      // reports no lane — which is what stops it outranking a live sibling in
+      // the project-status ranking.
+      await service.provisionSession({ ...provisionInput(), slot: 1 });
+      expect(service.getSlotForTerminal("term-slot-1")).toBeNull();
+    });
+
+    it("revokeByProjectId still tears down every lane", async () => {
+      const laneZero = await service.provisionSession({ ...provisionInput(), slot: 0 });
+      const laneOne = await service.provisionSession({ ...provisionInput(), slot: 1 });
+      if (!laneZero || !laneOne) throw new Error("expected both provisions");
+
+      await service.revokeByProjectId("proj-1");
+
+      expect(service.validateToken(laneZero.token)).toBe(false);
+      expect(service.validateToken(laneOne.token)).toBe(false);
     });
   });
 
@@ -1380,7 +1527,7 @@ describe("HelpSessionService", () => {
       // #9639: an empty-sentinel placeholder is written SYNCHRONOUSLY before
       // gracefulKill so a racing switch-back resumes rather than fresh-launches;
       // the real resume ID overwrites it once gracefulKill resolves.
-      const setCalls = hibernationStore.set.mock.calls.filter((c) => c[0] === "proj-evicted");
+      const setCalls = hibernationStore.set.mock.calls.filter((c) => c[0] === slotKey("proj-evicted", 0));
       expect(setCalls[0][1].agentSessionId).toBe("");
       expect(setCalls[setCalls.length - 1][1]).toEqual(
         expect.objectContaining({
@@ -1410,7 +1557,7 @@ describe("HelpSessionService", () => {
       // #9639: with no real resume ID, the empty-sentinel placeholder stays —
       // resume-latest on next open beats a fresh launch. Exactly one write
       // (the placeholder), never overwritten.
-      const setCalls = hibernationStore.set.mock.calls.filter((c) => c[0] === "proj-no-resume");
+      const setCalls = hibernationStore.set.mock.calls.filter((c) => c[0] === slotKey("proj-no-resume", 0));
       expect(setCalls).toHaveLength(1);
       expect(setCalls[0][1].agentSessionId).toBe("");
     });
@@ -1443,7 +1590,7 @@ describe("HelpSessionService", () => {
 
       expect(mockPtyGracefulKill).toHaveBeenCalledWith("term-win");
       expect(hibernationStore.set).toHaveBeenCalledWith(
-        "proj-1",
+        slotKey("proj-1", 0),
         expect.objectContaining({ agentSessionId: "win-close-resume-id" })
       );
     });
@@ -1472,7 +1619,7 @@ describe("HelpSessionService", () => {
       expect(mockPtyGracefulKill).toHaveBeenCalledWith("term-reclaimed");
       expect(mockPtyGracefulKill).not.toHaveBeenCalledWith("term-untouched");
       expect(hibernationStore.set).toHaveBeenCalledWith(
-        "proj-reclaimed",
+        slotKey("proj-reclaimed", 0),
         expect.objectContaining({ agentSessionId: "auto-close-resume-id" })
       );
       // …and the other project's session survives with a live bearer
@@ -1503,7 +1650,7 @@ describe("HelpSessionService", () => {
         capturedAt: Date.now(),
       });
 
-      const taken = await service.takePendingHibernation("proj-A");
+      const taken = await service.takePendingHibernation("proj-A", 0, 0);
 
       expect(taken).toEqual({
         agentId: "claude",
@@ -1514,7 +1661,7 @@ describe("HelpSessionService", () => {
         claimId: expect.any(String),
       });
       expect(taken!.claimId).not.toBe("");
-      expect(hibernationStore.clear).toHaveBeenCalledWith("proj-A");
+      expect(hibernationStore.clear).toHaveBeenCalledWith(slotKey("proj-A", 0));
     });
 
     it("issues a distinct claim per take, so a stale release can be told apart", async () => {
@@ -1525,8 +1672,8 @@ describe("HelpSessionService", () => {
         capturedAt: Date.now(),
       });
 
-      const first = await service.takePendingHibernation("proj-A");
-      const second = await service.takePendingHibernation("proj-A");
+      const first = await service.takePendingHibernation("proj-A", 0, 0);
+      const second = await service.takePendingHibernation("proj-A", 0, 0);
 
       expect(first!.claimId).not.toBe(second!.claimId);
     });
@@ -1534,7 +1681,7 @@ describe("HelpSessionService", () => {
     it("takePendingHibernation returns null and does not clear when no entry exists", async () => {
       hibernationStore.get.mockReturnValueOnce(null);
 
-      const taken = await service.takePendingHibernation("proj-empty");
+      const taken = await service.takePendingHibernation("proj-empty", 0, 0);
 
       expect(taken).toBeNull();
       expect(hibernationStore.clear).not.toHaveBeenCalled();
@@ -1551,11 +1698,11 @@ describe("HelpSessionService", () => {
 
       it("puts back exactly what was taken, minus panelWasOpen", async () => {
         hibernationStore.get.mockReturnValueOnce(captured);
-        const taken = await service.takePendingHibernation("proj-A");
+        const taken = await service.takePendingHibernation("proj-A", 0, 0);
         // The slot is empty again after the take — nothing newer has landed.
         hibernationStore.get.mockReturnValue(null);
 
-        await expect(service.restorePendingHibernation("proj-A", taken!.claimId)).resolves.toBe(
+        await expect(service.restorePendingHibernation("proj-A", 0, taken!.claimId)).resolves.toBe(
           true
         );
 
@@ -1563,7 +1710,7 @@ describe("HelpSessionService", () => {
         // refresh an entry past the store's 14-day staleness cutoff. And
         // panelWasOpen is dropped, so a put-back entry is offered for an
         // explicit resume but never auto-resumes on cold switch-back (#10815).
-        expect(hibernationStore.set).toHaveBeenCalledWith("proj-A", {
+        expect(hibernationStore.set).toHaveBeenCalledWith(slotKey("proj-A", 0), {
           agentId: "claude",
           agentSessionId: "pulled-id",
           cwd: "/help/dir",
@@ -1573,7 +1720,7 @@ describe("HelpSessionService", () => {
 
       it("refuses when a newer capture already occupies the slot", async () => {
         hibernationStore.get.mockReturnValueOnce(captured);
-        const taken = await service.takePendingHibernation("proj-A");
+        const taken = await service.takePendingHibernation("proj-A", 0, 0);
         hibernationStore.set.mockClear();
         // A fresh eviction captured a later conversation while we were aborting.
         hibernationStore.get.mockReturnValue({
@@ -1583,7 +1730,7 @@ describe("HelpSessionService", () => {
           capturedAt: Date.now(),
         });
 
-        await expect(service.restorePendingHibernation("proj-A", taken!.claimId)).resolves.toBe(
+        await expect(service.restorePendingHibernation("proj-A", 0, taken!.claimId)).resolves.toBe(
           false
         );
         expect(hibernationStore.set).not.toHaveBeenCalled();
@@ -1597,7 +1744,7 @@ describe("HelpSessionService", () => {
 
         // A prior taker is holding a stashed entry...
         hibernationStore.get.mockReturnValueOnce(captured);
-        const taken = await service.takePendingHibernation("proj-1");
+        const taken = await service.takePendingHibernation("proj-1", 0, 0);
 
         // ...and a capture-revoke starts and parks on gracefulKill, claiming
         // ownership of the slot via its synchronous placeholder write (#9646).
@@ -1606,7 +1753,7 @@ describe("HelpSessionService", () => {
         hibernationStore.set.mockClear();
         hibernationStore.get.mockReturnValue(null);
 
-        await expect(service.restorePendingHibernation("proj-1", taken!.claimId)).resolves.toBe(
+        await expect(service.restorePendingHibernation("proj-1", 0, taken!.claimId)).resolves.toBe(
           false
         );
         expect(hibernationStore.set).not.toHaveBeenCalled();
@@ -1614,15 +1761,15 @@ describe("HelpSessionService", () => {
 
       it("answers a take at most once, so a duplicate release cannot resurrect a consumed entry", async () => {
         hibernationStore.get.mockReturnValueOnce(captured);
-        const taken = await service.takePendingHibernation("proj-A");
+        const taken = await service.takePendingHibernation("proj-A", 0, 0);
         hibernationStore.get.mockReturnValue(null);
 
-        await expect(service.restorePendingHibernation("proj-A", taken!.claimId)).resolves.toBe(
+        await expect(service.restorePendingHibernation("proj-A", 0, taken!.claimId)).resolves.toBe(
           true
         );
         hibernationStore.set.mockClear();
 
-        await expect(service.restorePendingHibernation("proj-A", taken!.claimId)).resolves.toBe(
+        await expect(service.restorePendingHibernation("proj-A", 0, taken!.claimId)).resolves.toBe(
           false
         );
         expect(hibernationStore.set).not.toHaveBeenCalled();
@@ -1634,26 +1781,26 @@ describe("HelpSessionService", () => {
         // from A arrives. Without a per-take claim that second release restores
         // B's stash out from under B.
         hibernationStore.get.mockReturnValueOnce(captured);
-        const takenByA = await service.takePendingHibernation("proj-A", 11);
+        const takenByA = await service.takePendingHibernation("proj-A", 0, 11);
         hibernationStore.get.mockReturnValue(null);
         await expect(
-          service.restorePendingHibernation("proj-A", takenByA!.claimId, 11)
+          service.restorePendingHibernation("proj-A", 0, takenByA!.claimId, 11)
         ).resolves.toBe(true);
 
         hibernationStore.get.mockReturnValueOnce(captured);
-        const takenByB = await service.takePendingHibernation("proj-A", 22);
+        const takenByB = await service.takePendingHibernation("proj-A", 0, 22);
         expect(takenByB!.claimId).not.toBe(takenByA!.claimId);
         hibernationStore.get.mockReturnValue(null);
         hibernationStore.set.mockClear();
 
         // A's stale release is refused...
         await expect(
-          service.restorePendingHibernation("proj-A", takenByA!.claimId, 11)
+          service.restorePendingHibernation("proj-A", 0, takenByA!.claimId, 11)
         ).resolves.toBe(false);
         expect(hibernationStore.set).not.toHaveBeenCalled();
         // ...and, crucially, did not consume B's claim.
         await expect(
-          service.restorePendingHibernation("proj-A", takenByB!.claimId, 22)
+          service.restorePendingHibernation("proj-A", 0, takenByB!.claimId, 22)
         ).resolves.toBe(true);
       });
 
@@ -1661,17 +1808,17 @@ describe("HelpSessionService", () => {
         // The owner comes from the IPC context, not the renderer, so a second
         // window cannot release a claim it does not hold even by guessing.
         hibernationStore.get.mockReturnValueOnce(captured);
-        const taken = await service.takePendingHibernation("proj-A", 11);
+        const taken = await service.takePendingHibernation("proj-A", 0, 11);
         hibernationStore.get.mockReturnValue(null);
         hibernationStore.set.mockClear();
 
-        await expect(service.restorePendingHibernation("proj-A", taken!.claimId, 22)).resolves.toBe(
+        await expect(service.restorePendingHibernation("proj-A", 0, taken!.claimId, 22)).resolves.toBe(
           false
         );
         expect(hibernationStore.set).not.toHaveBeenCalled();
 
         // The rightful owner can still put it back.
-        await expect(service.restorePendingHibernation("proj-A", taken!.claimId, 11)).resolves.toBe(
+        await expect(service.restorePendingHibernation("proj-A", 0, taken!.claimId, 11)).resolves.toBe(
           true
         );
       });
@@ -1681,21 +1828,21 @@ describe("HelpSessionService", () => {
         // put-back that normalized or dropped it would silently downgrade an
         // in-flight capture's placeholder into "no resume available".
         hibernationStore.get.mockReturnValueOnce({ ...captured, agentSessionId: "" });
-        const taken = await service.takePendingHibernation("proj-A");
+        const taken = await service.takePendingHibernation("proj-A", 0, 0);
         expect(taken!.agentSessionId).toBe("");
         hibernationStore.get.mockReturnValue(null);
 
-        await expect(service.restorePendingHibernation("proj-A", taken!.claimId)).resolves.toBe(
+        await expect(service.restorePendingHibernation("proj-A", 0, taken!.claimId)).resolves.toBe(
           true
         );
         expect(hibernationStore.set).toHaveBeenCalledWith(
-          "proj-A",
+          slotKey("proj-A", 0),
           expect.objectContaining({ agentSessionId: "" })
         );
       });
 
       it("is a no-op for a project that never took anything", async () => {
-        await expect(service.restorePendingHibernation("proj-untouched", "any")).resolves.toBe(
+        await expect(service.restorePendingHibernation("proj-untouched", 0, "any")).resolves.toBe(
           false
         );
         expect(hibernationStore.set).not.toHaveBeenCalled();
@@ -1710,7 +1857,7 @@ describe("HelpSessionService", () => {
         capturedAt: Date.now(),
       });
 
-      const peeked = service.peekPendingHibernation("proj-A");
+      const peeked = service.peekPendingHibernation("proj-A", 0);
 
       expect(peeked).toEqual({
         agentId: "claude",
@@ -1728,7 +1875,7 @@ describe("HelpSessionService", () => {
     it("peekPendingHibernation returns null when no entry exists", () => {
       hibernationStore.get.mockReturnValueOnce(null);
 
-      expect(service.peekPendingHibernation("proj-empty")).toBeNull();
+      expect(service.peekPendingHibernation("proj-empty", 0)).toBeNull();
       expect(hibernationStore.clear).not.toHaveBeenCalled();
     });
 
@@ -1744,7 +1891,7 @@ describe("HelpSessionService", () => {
         panelWasOpen: true,
       });
 
-      expect(service.peekPendingHibernation("proj-A")?.panelWasOpen).toBe(true);
+      expect(service.peekPendingHibernation("proj-A", 0)?.panelWasOpen).toBe(true);
     });
 
     it("stamps panelWasOpen:true on the captured entry when the panel was reported open (#10815)", async () => {
@@ -1765,7 +1912,7 @@ describe("HelpSessionService", () => {
       await service.revokeByWebContentsId(99);
       await Promise.resolve();
 
-      const setCalls = hibernationStore.set.mock.calls.filter((c) => c[0] === "proj-open");
+      const setCalls = hibernationStore.set.mock.calls.filter((c) => c[0] === slotKey("proj-open", 0));
       // Both the synchronous placeholder and the real-resume-id overwrite carry
       // the open flag so a switch-back at any point auto-resumes.
       expect(setCalls[0][1].panelWasOpen).toBe(true);
@@ -1792,7 +1939,7 @@ describe("HelpSessionService", () => {
       await service.revokeByWebContentsId(98);
       await Promise.resolve();
 
-      const setCalls = hibernationStore.set.mock.calls.filter((c) => c[0] === "proj-closed");
+      const setCalls = hibernationStore.set.mock.calls.filter((c) => c[0] === slotKey("proj-closed", 0));
       expect(setCalls[setCalls.length - 1][1].panelWasOpen).toBe(false);
     });
 
@@ -1814,7 +1961,7 @@ describe("HelpSessionService", () => {
       await service.revokeByWebContentsId(97);
       await Promise.resolve();
 
-      const setCalls = hibernationStore.set.mock.calls.filter((c) => c[0] === "proj-toggle");
+      const setCalls = hibernationStore.set.mock.calls.filter((c) => c[0] === slotKey("proj-toggle", 0));
       expect(setCalls[setCalls.length - 1][1].panelWasOpen).toBe(false);
     });
 
@@ -1875,14 +2022,14 @@ describe("HelpSessionService", () => {
       const revokePromise = service.revokeByWebContentsId(60);
 
       // Renderer peeks mid-flight — pure read, no consumption.
-      const peeked = service.peekPendingHibernation("proj-peek-race");
+      const peeked = service.peekPendingHibernation("proj-peek-race", 0);
       expect(peeked).toEqual({
         agentId: "claude",
         agentSessionId: "",
         cwd: "/help/peek-race",
         panelWasOpen: false,
       });
-      expect(hibernationStore.clear).not.toHaveBeenCalledWith("proj-peek-race");
+      expect(hibernationStore.clear).not.toHaveBeenCalledWith(slotKey("proj-peek-race", 0));
 
       // gracefulKill resolves with the real resume id; because peek left the
       // capture owner intact, finalize still overwrites the placeholder.
@@ -1891,7 +2038,7 @@ describe("HelpSessionService", () => {
       await Promise.resolve();
 
       expect(hibernationStore.set).toHaveBeenCalledWith(
-        "proj-peek-race",
+        slotKey("proj-peek-race", 0),
         expect.objectContaining({ agentSessionId: "real-resume-id" })
       );
     });
@@ -1946,10 +2093,10 @@ describe("HelpSessionService", () => {
       // #9639 placeholder was written synchronously, but displacement clears it
       // and releases ownership so the post-gracefulKill overwrite is skipped.
       expect(hibernationStore.set).not.toHaveBeenCalledWith(
-        "proj-race",
+        slotKey("proj-race", 0),
         expect.objectContaining({ agentSessionId: "stale-resume-id-from-displaced-session" })
       );
-      expect(hibernationStore.clear).toHaveBeenCalledWith("proj-race");
+      expect(hibernationStore.clear).toHaveBeenCalledWith(slotKey("proj-race", 0));
     });
 
     it("a gracefulKill rejection does not abort the eviction revoke — bearer still invalidated", async () => {
@@ -2024,7 +2171,7 @@ describe("HelpSessionService", () => {
       // Before gracefulKill resolves, the renderer's takePendingHibernation
       // sees the empty-sentinel placeholder — so it resumes instead of starting
       // a fresh session (the visible "restart" #9639 fixes).
-      const early = await service.takePendingHibernation("proj-visible");
+      const early = await service.takePendingHibernation("proj-visible", 0, 0);
       expect(early).toEqual(
         expect.objectContaining({ agentId: "claude", agentSessionId: "", cwd: result.sessionPath })
       );

--- a/electron/services/__tests__/HelpSessionService.test.ts
+++ b/electron/services/__tests__/HelpSessionService.test.ts
@@ -2184,7 +2184,7 @@ describe("HelpSessionService", () => {
       await revokePromise;
       await Promise.resolve();
 
-      expect(backing.get("proj-visible")).toBeUndefined();
+      expect(backing.get(slotKey("proj-visible", 0))).toBeUndefined();
     });
 
     it("placeholder gets overwritten with the real id when no take happens (#9639 baseline — finalize-block still updates an untouched capture)", async () => {
@@ -2232,7 +2232,7 @@ describe("HelpSessionService", () => {
 
       // Sanity: the empty-sentinel placeholder is observable during the kill
       // window, exactly as #9639 promises.
-      expect(backing.get("proj-no-take")?.agentSessionId).toBe("");
+      expect(backing.get(slotKey("proj-no-take", 0))?.agentSessionId).toBe("");
 
       // No take happens; gracefulKill yields the real resume id and the
       // finalize block is still the legitimate writer.
@@ -2240,7 +2240,7 @@ describe("HelpSessionService", () => {
       await revokePromise;
       await Promise.resolve();
 
-      expect(backing.get("proj-no-take")?.agentSessionId).toBe("real-resume-id-abc");
+      expect(backing.get(slotKey("proj-no-take", 0))?.agentSessionId).toBe("real-resume-id-abc");
     });
   });
 

--- a/electron/services/__tests__/IdleBackgroundAutoCloseService.test.ts
+++ b/electron/services/__tests__/IdleBackgroundAutoCloseService.test.ts
@@ -103,9 +103,9 @@ const liveTerminalIds = vi.hoisted(() => new Set<string>());
 
 const helpSessionServiceMock = vi.hoisted(() => ({
   revokeByProjectId: vi.fn(async (_projectId: string) => {}),
-  getAssistantBackend: vi.fn((projectId: string) => {
+  getAssistantBackends: vi.fn((projectId: string) => {
     const terminalId = assistantBackends.get(projectId);
-    return terminalId ? { terminalId, webContentsId: 42 } : null;
+    return terminalId ? [{ terminalId, webContentsId: 42, slot: 0 }] : [];
   }),
 }));
 
@@ -430,9 +430,9 @@ describe("IdleBackgroundAutoCloseService", () => {
       // re-check ran, so the second look finds one. Queued per-call rather than
       // via a persistent mockImplementation, which `clearAllMocks` would not
       // undo and would poison later tests.
-      helpSessionServiceMock.getAssistantBackend
-        .mockReturnValueOnce(null)
-        .mockReturnValueOnce({ terminalId: "t-help-late", webContentsId: 42 });
+      helpSessionServiceMock.getAssistantBackends
+        .mockReturnValueOnce([])
+        .mockReturnValueOnce([{ terminalId: "t-help-late", webContentsId: 42, slot: 0 }]);
       const service = makeService();
       await runCheck(service);
 

--- a/electron/services/__tests__/PendingHelpHibernationStore.test.ts
+++ b/electron/services/__tests__/PendingHelpHibernationStore.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { PendingHelpHibernationStore } from "../PendingHelpHibernationStore.js";
+import { assistantSlotKey as slotKey } from "../../../shared/config/assistantSlots.js";
 
 describe("PendingHelpHibernationStore", () => {
   let tmpDir: string;
@@ -86,6 +87,59 @@ describe("PendingHelpHibernationStore", () => {
     expect(store.get("proj-B")).not.toBeNull();
   });
 
+  // #12108
+  it("migrates v1 bare-projectId keys onto slot 0 rather than dropping the file", async () => {
+    // `load()` returns early on an unrecognized version, so without the
+    // migration a version bump would silently destroy every existing user's
+    // captured resume tokens.
+    await fs.writeFile(
+      filePath,
+      JSON.stringify({
+        version: 1,
+        entries: {
+          "proj-legacy": {
+            agentId: "claude",
+            agentSessionId: "legacy-id",
+            cwd: "/legacy",
+            capturedAt: Date.now(),
+          },
+        },
+      }),
+      "utf-8"
+    );
+
+    const store = new PendingHelpHibernationStore(filePath);
+    await store.load();
+
+    expect(store.get(slotKey("proj-legacy", 0))?.agentSessionId).toBe("legacy-id");
+    // The bare key is gone — nothing looks it up any more.
+    expect(store.get("proj-legacy")).toBeNull();
+  });
+
+  it("rewrites every lane's cwd when a project folder moves", async () => {
+    const store = new PendingHelpHibernationStore(filePath);
+    await store.load();
+    await store.set(slotKey("proj-multi", 0), {
+      agentId: "claude",
+      agentSessionId: "s0",
+      cwd: "/old/root/sessions/a",
+      capturedAt: Date.now(),
+    });
+    await store.set(slotKey("proj-multi", 1), {
+      agentId: "claude",
+      agentSessionId: "s1",
+      cwd: "/old/root/sessions/b",
+      capturedAt: Date.now(),
+    });
+
+    await store.rewriteProjectPath("proj-multi", "/old/root", "/new/root");
+
+    // Leaving a sibling behind would resume it in a folder that no longer
+    // exists — the failure the rebase exists to prevent, once per lane.
+    expect(store.get(slotKey("proj-multi", 0))?.cwd).toBe("/new/root/sessions/a");
+    expect(store.get(slotKey("proj-multi", 1))?.cwd).toBe("/new/root/sessions/b");
+  });
+
   it("drops entries older than the staleness cutoff on load", async () => {
     // Stale = older than 14 days. Write a file directly with one stale and
     // one fresh entry, then load and verify only the fresh one survives.
@@ -114,8 +168,8 @@ describe("PendingHelpHibernationStore", () => {
 
     const store = new PendingHelpHibernationStore(filePath);
     await store.load();
-    expect(store.get("proj-stale")).toBeNull();
-    expect(store.get("proj-fresh")).not.toBeNull();
+    expect(store.get(slotKey("proj-stale", 0))).toBeNull();
+    expect(store.get(slotKey("proj-fresh", 0))).not.toBeNull();
   });
 
   it("accepts an empty agentSessionId as the resume-latest sentinel (#9639)", async () => {
@@ -162,7 +216,7 @@ describe("PendingHelpHibernationStore", () => {
 
     const store = new PendingHelpHibernationStore(filePath);
     await store.load();
-    expect(store.get("proj-stale-sentinel")).toBeNull();
+    expect(store.get(slotKey("proj-stale-sentinel", 0))).toBeNull();
   });
 
   it("rejects entries with a far-future capturedAt (corruption / clock skew)", async () => {
@@ -186,7 +240,7 @@ describe("PendingHelpHibernationStore", () => {
 
     const store = new PendingHelpHibernationStore(filePath);
     await store.load();
-    expect(store.get("proj-future-stamp")).toBeNull();
+    expect(store.get(slotKey("proj-future-stamp", 0))).toBeNull();
   });
 
   it("ignores entries with the wrong shape", async () => {
@@ -209,8 +263,8 @@ describe("PendingHelpHibernationStore", () => {
 
     const store = new PendingHelpHibernationStore(filePath);
     await store.load();
-    expect(store.get("proj-malformed")).toBeNull();
-    expect(store.get("proj-ok")).not.toBeNull();
+    expect(store.get(slotKey("proj-malformed", 0))).toBeNull();
+    expect(store.get(slotKey("proj-ok", 0))).not.toBeNull();
   });
 
   it("ignores files written with a future version (forward incompatibility)", async () => {
@@ -298,7 +352,7 @@ describe("PendingHelpHibernationStore", () => {
 
     const store = new PendingHelpHibernationStore(filePath);
     await store.load();
-    const entry = store.get("proj-tainted");
+    const entry = store.get(slotKey("proj-tainted", 0));
     expect(entry).not.toBeNull();
     expect(entry?.panelWasOpen).toBeUndefined();
   });

--- a/electron/services/__tests__/ProjectRelocationCoordinator.test.ts
+++ b/electron/services/__tests__/ProjectRelocationCoordinator.test.ts
@@ -71,7 +71,7 @@ const mockBroadcast = vi.hoisted(() => vi.fn());
 vi.mock("../../ipc/utils.js", () => ({ broadcastToRenderer: mockBroadcast }));
 
 const mockAssistant = vi.hoisted(() => ({
-  getAssistantBackend: vi.fn(() => null as { terminalId: string; webContentsId: number } | null),
+  getAssistantBackends: vi.fn(() => [] as Array<{ terminalId: string; webContentsId: number; slot: number }>),
 }));
 vi.mock("../HelpSessionService.js", () => ({ helpSessionService: mockAssistant }));
 
@@ -165,7 +165,7 @@ beforeEach(() => {
   mockProjectStore.relocateProject.mockResolvedValue(makeProject({ path: NEW_ROOT }));
   mockProjectStore.countRebasedPanels.mockResolvedValue(0);
   mockListWorktrees.mockResolvedValue([]);
-  mockAssistant.getAssistantBackend.mockReturnValue(null);
+  mockAssistant.getAssistantBackends.mockReturnValue([]);
 });
 
 describe("ProjectRelocationCoordinator — managed move of an open project", () => {
@@ -337,7 +337,9 @@ describe("ProjectRelocationCoordinator — rollback vs forward-fail boundary", (
 
 describe("ProjectRelocationCoordinator — guards", () => {
   it("refuses to relocate while the Daintree Assistant is active", async () => {
-    mockAssistant.getAssistantBackend.mockReturnValue({ terminalId: "help-1", webContentsId: 5 });
+    mockAssistant.getAssistantBackends.mockReturnValue([
+      { terminalId: "help-1", webContentsId: 5, slot: 0 },
+    ]);
     const pvm = makePvm(PROJECT_ID);
     const deps = makeDeps(pvm);
     const coordinator = new ProjectRelocationCoordinator();
@@ -352,7 +354,7 @@ describe("ProjectRelocationCoordinator — guards", () => {
   });
 
   it("fails CLOSED when the Assistant check itself throws", async () => {
-    mockAssistant.getAssistantBackend.mockImplementation(() => {
+    mockAssistant.getAssistantBackends.mockImplementation(() => {
       throw new Error("help service unavailable");
     });
     const pvm = makePvm(PROJECT_ID);
@@ -607,7 +609,9 @@ describe("ProjectRelocationCoordinator — previewRelocate", () => {
   });
 
   it("surfaces an active Assistant as a blocker", async () => {
-    mockAssistant.getAssistantBackend.mockReturnValue({ terminalId: "t9", webContentsId: 2 });
+    mockAssistant.getAssistantBackends.mockReturnValue([
+      { terminalId: "t9", webContentsId: 2, slot: 0 },
+    ]);
     const coordinator = new ProjectRelocationCoordinator();
     configure(coordinator, makeDeps(makePvm(PROJECT_ID)));
 
@@ -645,7 +649,9 @@ describe("ProjectRelocationCoordinator — previewRelocate", () => {
     fsState.existing.add(NEW_ROOT);
     // A stale Assistant record survives a natural PTY exit; a closed reattach's
     // apply path never checks it, so the preview must not block on it (fix B).
-    mockAssistant.getAssistantBackend.mockReturnValue({ terminalId: "t9", webContentsId: 2 });
+    mockAssistant.getAssistantBackends.mockReturnValue([
+      { terminalId: "t9", webContentsId: 2, slot: 0 },
+    ]);
     const deps = makeDeps(makePvm(null)); // project not open anywhere
     deps.ptyClient.getProjectStats.mockResolvedValue({ terminalCount: 5 });
     const coordinator = new ProjectRelocationCoordinator();

--- a/electron/services/__tests__/ProjectRelocationCoordinator.test.ts
+++ b/electron/services/__tests__/ProjectRelocationCoordinator.test.ts
@@ -71,7 +71,9 @@ const mockBroadcast = vi.hoisted(() => vi.fn());
 vi.mock("../../ipc/utils.js", () => ({ broadcastToRenderer: mockBroadcast }));
 
 const mockAssistant = vi.hoisted(() => ({
-  getAssistantBackends: vi.fn(() => [] as Array<{ terminalId: string; webContentsId: number; slot: number }>),
+  getAssistantBackends: vi.fn(
+    () => [] as Array<{ terminalId: string; webContentsId: number; slot: number }>
+  ),
 }));
 vi.mock("../HelpSessionService.js", () => ({ helpSessionService: mockAssistant }));
 

--- a/electron/services/__tests__/ProjectStatsService.adversarial.test.ts
+++ b/electron/services/__tests__/ProjectStatsService.adversarial.test.ts
@@ -31,6 +31,9 @@ const availabilityMock = vi.hoisted(() => ({
 // what a live assistant reports, not about where it is rendered.
 const helpSessionMock = vi.hoisted(() => ({
   isPanelVisible: vi.fn<(id: string) => boolean>(() => true),
+  // #12108: the counts path resolves each help terminal's lane so concurrent
+  // assistants rank by who needs the user. These fixtures run one, at lane 0.
+  getSlotForTerminal: vi.fn<(terminalId: string) => number | null>(() => 0),
 }));
 
 vi.mock("../../ipc/utils.js", () => ({

--- a/electron/services/__tests__/projectAgentCounts.test.ts
+++ b/electron/services/__tests__/projectAgentCounts.test.ts
@@ -155,6 +155,107 @@ describe("computeProjectAgentCounts", () => {
     expect(p1.assistantState).toBe("waiting");
   });
 
+  // #12108
+  describe("choosing which assistant speaks for a project across lanes", () => {
+    const laneOf = (map: Record<string, number>) => (id: string) => map[id] ?? null;
+
+    it("lets a lane that needs the user outrank a busy sibling", () => {
+      availabilityMock.isHelpTerminal.mockImplementation((id) => id.startsWith("help"));
+
+      const counts = computeProjectAgentCounts(
+        ["p1"],
+        [
+          agent({ id: "help-a", agentState: "working", spawnedAt: 100 }),
+          agent({ id: "help-b", agentState: "waiting", spawnedAt: 200 }),
+        ],
+        undefined,
+        undefined,
+        undefined,
+        laneOf({ "help-a": 0, "help-b": 1 })
+      );
+
+      // The row exists to surface attention: a lane blocked on the user must
+      // not be silenced by a sibling that is merely busy.
+      expect(counts.get("p1")!.assistantState).toBe("waiting");
+      expect(counts.get("p1")!.helpTerminals).toBe(2);
+    });
+
+    it("still lets the newest record win a displacement inside one lane", () => {
+      availabilityMock.isHelpTerminal.mockImplementation((id) => id.startsWith("help"));
+
+      const counts = computeProjectAgentCounts(
+        ["p1"],
+        [
+          // The corpse: kill not landed, so it still reads "working".
+          agent({ id: "help-old", agentState: "working", spawnedAt: 100 }),
+          agent({ id: "help-new", agentState: "waiting", spawnedAt: 300 }),
+        ],
+        undefined,
+        undefined,
+        undefined,
+        laneOf({ "help-old": 0, "help-new": 0 })
+      );
+
+      // Within a lane spawn time leads, so the corpse cannot keep reporting
+      // over the session that replaced it.
+      expect(counts.get("p1")!.assistantState).toBe("waiting");
+    });
+
+    it("gives the same answer whichever order the host lists the terminals in", () => {
+      // The cycle a single mixed comparator produces: A beats B on same-lane
+      // spawn time, B beats C on cross-lane liveness, C beats A on cross-lane
+      // liveness. Reducing per lane first and only then across lanes removes it.
+      availabilityMock.isHelpTerminal.mockImplementation((id) => id.startsWith("help"));
+      const lanes = laneOf({ "help-a": 0, "help-b": 0, "help-c": 1 });
+      const terminals = [
+        agent({ id: "help-a", agentState: "idle", spawnedAt: 300 }),
+        agent({ id: "help-b", agentState: "working", spawnedAt: 100 }),
+        agent({ id: "help-c", agentState: "waiting", spawnedAt: 200 }),
+      ];
+
+      const forward = computeProjectAgentCounts(
+        ["p1"],
+        terminals,
+        undefined,
+        undefined,
+        undefined,
+        lanes
+      );
+      const reversed = computeProjectAgentCounts(
+        ["p1"],
+        [...terminals].reverse(),
+        undefined,
+        undefined,
+        undefined,
+        lanes
+      );
+
+      expect(forward.get("p1")!.assistantState).toBe(reversed.get("p1")!.assistantState);
+      // Lane 0 reduces to help-a (newest), then lane 1's waiting help-c wins on
+      // attention.
+      expect(forward.get("p1")!.assistantState).toBe("waiting");
+    });
+
+    it("never lets a displaced corpse outrank a lane that still has a record", () => {
+      availabilityMock.isHelpTerminal.mockImplementation((id) => id.startsWith("help"));
+
+      const counts = computeProjectAgentCounts(
+        ["p1"],
+        [
+          // Unslotted: displacePriorSessions already dropped its record.
+          agent({ id: "help-corpse", agentState: "working", spawnedAt: 900 }),
+          agent({ id: "help-live", agentState: "idle", spawnedAt: 100 }),
+        ],
+        undefined,
+        undefined,
+        undefined,
+        laneOf({ "help-live": 0 })
+      );
+
+      expect(counts.get("p1")!.assistantState).toBe("idle");
+    });
+  });
+
   it("excludes trashed, dev-preview, PTY-less, and non-agent terminals", () => {
     const counts = computeProjectAgentCounts(
       ["p1"],

--- a/electron/services/projectAgentCounts.ts
+++ b/electron/services/projectAgentCounts.ts
@@ -105,6 +105,13 @@ export interface CountableTerminal {
    * overlapping records is the current one.
    */
   spawnedAt?: number;
+  /**
+   * Which assistant lane this help terminal serves (#12108), or undefined when
+   * it serves none — an ordinary terminal, or a displaced assistant backend
+   * whose record has already been dropped. Resolved from `HelpSessionService`
+   * rather than stored on the panel, so it tracks displacement synchronously.
+   */
+  assistantSlot?: number;
 }
 
 /**
@@ -200,21 +207,27 @@ function assistantLiveness(state: AgentState | undefined): number {
  * Whether `candidate` should replace `incumbent` as the project's reported
  * assistant.
  *
- * `HelpSessionService` enforces at most one assistant PTY per project, so in
- * steady state there is nothing to choose between. The window this exists for
- * is displacement: a new backend is provisioned while the old one is still
- * being killed, and for those moments two terminals answer to the same
- * project.
+ * Two terminals answer to one project for two very different reasons, and the
+ * lane (`assistantSlot`) is what tells them apart (#12108):
  *
- * Spawn time decides it, because that is the fact that actually identifies the
- * session — `AgentStateService` uses the same stamp to reject state updates
- * from a superseded run. Liveness cannot lead here: a displaced PTY whose kill
- * has not landed yet still reads `working`, so ranking activity first would let
- * the corpse keep reporting over a new session that is genuinely blocked.
+ * - DIFFERENT lanes are concurrent sessions the user deliberately started.
+ *   Whichever one needs the user leads, because the project row exists to
+ *   surface attention — a freshly spawned idle lane must not silence a sibling
+ *   that is blocked on a question.
+ * - The SAME lane (or no lane at all) is displacement: a new backend is
+ *   provisioned while the old one is still being killed. There, spawn time has
+ *   to lead, exactly as it did before lanes existed — a displaced PTY whose
+ *   kill has not landed still reads `working`, so ranking activity first would
+ *   let the corpse keep reporting over a genuinely blocked new session.
  *
- * The remaining tie-breaks only matter when spawn times are missing or equal,
- * and terminal id closes the last gap, so the answer never depends on listing
- * order.
+ * A displaced record resolves to `assistantSlot: undefined`, because
+ * `displacePriorSessions` drops it from the session map synchronously. That is
+ * what keeps a mid-kill corpse from outranking a live lane: an unslotted
+ * candidate never beats a slotted incumbent.
+ *
+ * The remaining tie-breaks only matter when the leading facts are missing or
+ * equal, and terminal id closes the last gap, so the answer never depends on
+ * listing order.
  */
 function beatsIncumbent(
   candidate: CountableTerminal,
@@ -222,13 +235,27 @@ function beatsIncumbent(
 ): boolean {
   if (incumbent === null) return true;
 
-  const candidateSpawn = usableTimestamp(candidate.spawnedAt);
-  const incumbentSpawn = usableTimestamp(incumbent.spawnedAt);
-  if (candidateSpawn !== incumbentSpawn) return candidateSpawn > incumbentSpawn;
+  // A backend still bound to a lane always outranks one that is not — the
+  // unslotted side is a corpse mid-teardown, not a session.
+  const candidateSlotted = candidate.assistantSlot !== undefined;
+  const incumbentSlotted = incumbent.assistantSlot !== undefined;
+  if (candidateSlotted !== incumbentSlotted) return candidateSlotted;
+
+  const concurrentLanes =
+    candidateSlotted && incumbentSlotted && candidate.assistantSlot !== incumbent.assistantSlot;
 
   const candidateRank = assistantLiveness(candidate.agentState);
   const incumbentRank = assistantLiveness(incumbent.agentState);
-  if (candidateRank !== incumbentRank) return candidateRank < incumbentRank;
+  const candidateSpawn = usableTimestamp(candidate.spawnedAt);
+  const incumbentSpawn = usableTimestamp(incumbent.spawnedAt);
+
+  if (concurrentLanes) {
+    if (candidateRank !== incumbentRank) return candidateRank < incumbentRank;
+    if (candidateSpawn !== incumbentSpawn) return candidateSpawn > incumbentSpawn;
+  } else {
+    if (candidateSpawn !== incumbentSpawn) return candidateSpawn > incumbentSpawn;
+    if (candidateRank !== incumbentRank) return candidateRank < incumbentRank;
+  }
 
   const candidateSince = usableTimestamp(candidate.lastStateChange);
   const incumbentSince = usableTimestamp(incumbent.lastStateChange);
@@ -285,7 +312,22 @@ export function computeProjectAgentCounts(
    * every live assistant reports, which is what a harness computing raw tallies
    * wants.
    */
-  isAssistantVisible?: (workspaceId: string) => boolean
+  isAssistantVisible?: (workspaceId: string) => boolean,
+  /**
+   * Which assistant lane a help terminal serves, or null when it serves none
+   * (#12108). `HelpSessionService.getSlotForTerminal` is the intended source.
+   *
+   * Needed once a project can run concurrent assistants, because "two
+   * terminals answer to this project" stops meaning "one is a corpse". See
+   * {@link beatsIncumbent}: without a lane, concurrent sessions are ranked by
+   * spawn time and a freshly started one silences a sibling that is blocked on
+   * the user.
+   *
+   * Omitting the resolver leaves every candidate unslotted, which is exactly
+   * the pre-lane spawn-time ordering — the right answer for a harness
+   * computing raw tallies, and for any caller that has no session service.
+   */
+  assistantSlotForTerminal?: (terminalId: string) => number | null
 ): Map<string, ProjectAgentCounts> {
   const counts = new Map<string, ProjectAgentCounts>();
   for (const id of projectIds) counts.set(id, empty());
@@ -307,8 +349,12 @@ export function computeProjectAgentCounts(
       // subtracted from the host's count nor speak for the project.
       if (terminal.hasPty !== false) {
         entry.helpTerminals += 1;
-        if (beatsIncumbent(terminal, assistantByProject.get(terminal.projectId) ?? null)) {
-          assistantByProject.set(terminal.projectId, terminal);
+        const slot =
+          terminal.id !== undefined ? (assistantSlotForTerminal?.(terminal.id) ?? null) : null;
+        const candidate: CountableTerminal =
+          slot === null ? terminal : { ...terminal, assistantSlot: slot };
+        if (beatsIncumbent(candidate, assistantByProject.get(terminal.projectId) ?? null)) {
+          assistantByProject.set(terminal.projectId, candidate);
         }
       }
       continue;

--- a/electron/services/projectAgentCounts.ts
+++ b/electron/services/projectAgentCounts.ts
@@ -204,64 +204,116 @@ function assistantLiveness(state: AgentState | undefined): number {
 }
 
 /**
- * Whether `candidate` should replace `incumbent` as the project's reported
- * assistant.
+ * Whether `candidate` should replace `incumbent` WITHIN one lane.
  *
- * Two terminals answer to one project for two very different reasons, and the
- * lane (`assistantSlot`) is what tells them apart (#12108):
+ * Two records answer for the same lane only during displacement: a new backend
+ * is provisioned while the old one is still being killed. Spawn time decides
+ * it, because that is the fact that actually identifies the session —
+ * `AgentStateService` uses the same stamp to reject state updates from a
+ * superseded run. Liveness cannot lead here: a displaced PTY whose kill has not
+ * landed yet still reads `working`, so ranking activity first would let the
+ * corpse keep reporting over a new session that is genuinely blocked.
  *
- * - DIFFERENT lanes are concurrent sessions the user deliberately started.
- *   Whichever one needs the user leads, because the project row exists to
- *   surface attention — a freshly spawned idle lane must not silence a sibling
- *   that is blocked on a question.
- * - The SAME lane (or no lane at all) is displacement: a new backend is
- *   provisioned while the old one is still being killed. There, spawn time has
- *   to lead, exactly as it did before lanes existed — a displaced PTY whose
- *   kill has not landed still reads `working`, so ranking activity first would
- *   let the corpse keep reporting over a genuinely blocked new session.
- *
- * A displaced record resolves to `assistantSlot: undefined`, because
- * `displacePriorSessions` drops it from the session map synchronously. That is
- * what keeps a mid-kill corpse from outranking a live lane: an unslotted
- * candidate never beats a slotted incumbent.
- *
- * The remaining tie-breaks only matter when the leading facts are missing or
- * equal, and terminal id closes the last gap, so the answer never depends on
- * listing order.
+ * The remaining tie-breaks only matter when spawn times are missing or equal,
+ * and terminal id closes the last gap, so the answer never depends on listing
+ * order.
  */
-function beatsIncumbent(
-  candidate: CountableTerminal,
-  incumbent: CountableTerminal | null
-): boolean {
-  if (incumbent === null) return true;
-
-  // A backend still bound to a lane always outranks one that is not — the
-  // unslotted side is a corpse mid-teardown, not a session.
-  const candidateSlotted = candidate.assistantSlot !== undefined;
-  const incumbentSlotted = incumbent.assistantSlot !== undefined;
-  if (candidateSlotted !== incumbentSlotted) return candidateSlotted;
-
-  const concurrentLanes =
-    candidateSlotted && incumbentSlotted && candidate.assistantSlot !== incumbent.assistantSlot;
+function beatsWithinLane(candidate: CountableTerminal, incumbent: CountableTerminal): boolean {
+  const candidateSpawn = usableTimestamp(candidate.spawnedAt);
+  const incumbentSpawn = usableTimestamp(incumbent.spawnedAt);
+  if (candidateSpawn !== incumbentSpawn) return candidateSpawn > incumbentSpawn;
 
   const candidateRank = assistantLiveness(candidate.agentState);
   const incumbentRank = assistantLiveness(incumbent.agentState);
+  if (candidateRank !== incumbentRank) return candidateRank < incumbentRank;
+
+  return finalTieBreak(candidate, incumbent);
+}
+
+/**
+ * Attention rank for picking BETWEEN lanes. Lower wins: blocked on the user,
+ * then busy, then settled.
+ *
+ * Deliberately not {@link assistantLiveness}, which ranks `working` above
+ * `waiting` — the right order inside a lane, where the question is "which of
+ * these two records is the live session", but the wrong one across lanes,
+ * where the question is "which of these sessions needs the user". A busy lane
+ * must not silence a sibling that is waiting on an answer.
+ */
+function assistantAttention(state: AgentState | undefined): number {
+  if (state === "waiting") return 0;
+  if (state === "working" || state === "directing") return 1;
+  return 2;
+}
+
+/**
+ * Whether `candidate` should replace `incumbent` ACROSS lanes.
+ *
+ * Different lanes are concurrent sessions the user deliberately started, so
+ * whichever one needs the user leads: the project row exists to surface
+ * attention, and a busy lane must not silence a sibling that is blocked on a
+ * question.
+ */
+function beatsAcrossLanes(candidate: CountableTerminal, incumbent: CountableTerminal): boolean {
+  const candidateRank = assistantAttention(candidate.agentState);
+  const incumbentRank = assistantAttention(incumbent.agentState);
+  if (candidateRank !== incumbentRank) return candidateRank < incumbentRank;
+
   const candidateSpawn = usableTimestamp(candidate.spawnedAt);
   const incumbentSpawn = usableTimestamp(incumbent.spawnedAt);
+  if (candidateSpawn !== incumbentSpawn) return candidateSpawn > incumbentSpawn;
 
-  if (concurrentLanes) {
-    if (candidateRank !== incumbentRank) return candidateRank < incumbentRank;
-    if (candidateSpawn !== incumbentSpawn) return candidateSpawn > incumbentSpawn;
-  } else {
-    if (candidateSpawn !== incumbentSpawn) return candidateSpawn > incumbentSpawn;
-    if (candidateRank !== incumbentRank) return candidateRank < incumbentRank;
-  }
+  return finalTieBreak(candidate, incumbent);
+}
 
+function finalTieBreak(candidate: CountableTerminal, incumbent: CountableTerminal): boolean {
   const candidateSince = usableTimestamp(candidate.lastStateChange);
   const incumbentSince = usableTimestamp(incumbent.lastStateChange);
   if (candidateSince !== incumbentSince) return candidateSince > incumbentSince;
 
   return (candidate.id ?? "") < (incumbent.id ?? "");
+}
+
+/**
+ * The one assistant that speaks for a project, chosen from every live help
+ * terminal it owns (#12108).
+ *
+ * Reduced in two stages rather than by one pairwise comparator, because the
+ * two rules genuinely disagree: within a lane spawn time must lead (a mid-kill
+ * corpse still reads `working`), across lanes liveness must lead (attention is
+ * the whole point of the row). A single comparator mixing them is CYCLIC — with
+ * A(lane 0, idle, t=300), B(lane 0, working, t=100) and C(lane 1, waiting,
+ * t=200), A beats B, B beats C and C beats A — so the winner would depend on
+ * the order the host happened to list terminals in.
+ *
+ * Unslotted records are displacement corpses whose session record has already
+ * been dropped; they are reduced among themselves and only ever win when no
+ * lane has a live representative at all.
+ */
+function pickProjectAssistant(candidates: CountableTerminal[]): CountableTerminal | null {
+  const byLane = new Map<number, CountableTerminal>();
+  let unslotted: CountableTerminal | null = null;
+
+  for (const candidate of candidates) {
+    if (candidate.assistantSlot === undefined) {
+      if (unslotted === null || beatsWithinLane(candidate, unslotted)) unslotted = candidate;
+      continue;
+    }
+    const incumbent = byLane.get(candidate.assistantSlot);
+    if (incumbent === undefined || beatsWithinLane(candidate, incumbent)) {
+      byLane.set(candidate.assistantSlot, candidate);
+    }
+  }
+
+  let winner: CountableTerminal | null = null;
+  // Ascending lane order so the reduction itself cannot depend on Map insertion
+  // order, only on the comparator.
+  for (const slot of [...byLane.keys()].sort((a, b) => a - b)) {
+    const laneWinner = byLane.get(slot)!;
+    if (winner === null || beatsAcrossLanes(laneWinner, winner)) winner = laneWinner;
+  }
+
+  return winner ?? unslotted;
 }
 
 /**
@@ -319,9 +371,9 @@ export function computeProjectAgentCounts(
    *
    * Needed once a project can run concurrent assistants, because "two
    * terminals answer to this project" stops meaning "one is a corpse". See
-   * {@link beatsIncumbent}: without a lane, concurrent sessions are ranked by
-   * spawn time and a freshly started one silences a sibling that is blocked on
-   * the user.
+   * {@link pickProjectAssistant}: without a lane, concurrent sessions are
+   * ranked by spawn time and a freshly started one silences a sibling that is
+   * blocked on the user.
    *
    * Omitting the resolver leaves every candidate unslotted, which is exactly
    * the pre-lane spawn-time ordering — the right answer for a harness
@@ -333,10 +385,11 @@ export function computeProjectAgentCounts(
   for (const id of projectIds) counts.set(id, empty());
 
   const availability = getAgentAvailabilityStore();
-  // Which assistant terminal currently speaks for each project. Held aside
-  // rather than written straight into `counts` so the winner is decided by
-  // `beatsIncumbent` alone and never by which terminal happened to come first.
-  const assistantByProject = new Map<string, CountableTerminal>();
+  // Every live assistant terminal per project. Collected rather than reduced
+  // inline so the winner is decided by `pickProjectAssistant` over the whole
+  // set — the two ranking rules (within a lane, across lanes) cannot be
+  // expressed as one pairwise comparator without introducing a cycle.
+  const assistantsByProject = new Map<string, CountableTerminal[]>();
 
   for (const terminal of terminals) {
     if (!terminal.projectId) continue;
@@ -353,9 +406,9 @@ export function computeProjectAgentCounts(
           terminal.id !== undefined ? (assistantSlotForTerminal?.(terminal.id) ?? null) : null;
         const candidate: CountableTerminal =
           slot === null ? terminal : { ...terminal, assistantSlot: slot };
-        if (beatsIncumbent(candidate, assistantByProject.get(terminal.projectId) ?? null)) {
-          assistantByProject.set(terminal.projectId, candidate);
-        }
+        const bucket = assistantsByProject.get(terminal.projectId);
+        if (bucket) bucket.push(candidate);
+        else assistantsByProject.set(terminal.projectId, [candidate]);
       }
       continue;
     }
@@ -435,9 +488,11 @@ export function computeProjectAgentCounts(
 
   // Assistant presence, written last so it can never be mistaken for a tally
   // that accumulated alongside the worker states above.
-  for (const [projectId, assistant] of assistantByProject) {
+  for (const [projectId, laneCandidates] of assistantsByProject) {
     const entry = counts.get(projectId);
     if (!entry) continue;
+    const assistant = pickProjectAssistant(laneCandidates);
+    if (!assistant) continue;
     // Out of sight, out of the tallies. Left as the `null` every state field
     // starts at, so a hidden assistant is indistinguishable from no assistant
     // — which is the point: every surface reading these fields asks the same

--- a/electron/window/ProjectViewEvictionController.ts
+++ b/electron/window/ProjectViewEvictionController.ts
@@ -62,11 +62,18 @@ function hasLiveAssistantBackend(
   projectId: string,
   entry: ViewEntry
 ): boolean {
-  const backend = host.assistantBackendForProject?.(projectId);
-  if (!backend) return false;
-  if (host.isTerminalLive?.(backend.terminalId) !== true) return false;
+  const backends = host.assistantBackendsForProject?.(projectId) ?? [];
+  if (backends.length === 0) return false;
   const wc = entry.view.webContents;
-  return !wc.isDestroyed() && wc.id === backend.webContentsId;
+  if (wc.isDestroyed()) return false;
+  // All three conditions must hold for the SAME lane (#12108): a dead lane
+  // must not borrow a live sibling's liveness, and a lane pinned to another
+  // window must not protect this view. Checking them per backend rather than
+  // across the set is what keeps both from happening.
+  return backends.some(
+    (backend) =>
+      host.isTerminalLive?.(backend.terminalId) === true && wc.id === backend.webContentsId
+  );
 }
 
 /**

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -186,12 +186,12 @@ export interface ProjectViewManagerOptions {
    * Absent — as in tests that don't exercise the assistant — every project reads
    * as having no backend, which is the pre-#11157 behavior.
    */
-  assistantBackendForProject?: (projectId: string) => {
+  assistantBackendsForProject?: (projectId: string) => Array<{
     terminalId: string;
     webContentsId: number;
-  } | null;
+  }>;
   /**
-   * Whether a PTY is still running. Paired with `assistantBackendForProject`:
+   * Whether a PTY is still running. Paired with `assistantBackendsForProject`:
    * the help-session binding outlives an assistant that exits on its own, so
    * eviction protection needs a liveness source that tracks exits.
    */
@@ -199,7 +199,7 @@ export interface ProjectViewManagerOptions {
   /**
    * Why MCP needs this view kept running right now (#11790) — a live session
    * binding, an in-flight dispatch, or neither. Injected from the composition
-   * root for the same reason as `assistantBackendForProject`: electron/window/
+   * root for the same reason as `assistantBackendsForProject`: electron/window/
    * stays free of the service, and here it also keeps the MCP module graph off
    * eager boot, since it is deliberately behind a dynamic import.
    *
@@ -274,10 +274,10 @@ export class ProjectViewManager {
   onViewCached?: (webContentsId: number) => void;
   onViewReady?: (webContents: Electron.WebContents) => void;
   onViewCrashed?: (webContents: Electron.WebContents) => void;
-  assistantBackendForProject?: (projectId: string) => {
+  assistantBackendsForProject?: (projectId: string) => Array<{
     terminalId: string;
     webContentsId: number;
-  } | null;
+  }>;
   isTerminalLive?: (terminalId: string) => boolean;
   mcpViewActivity?: (workspaceId: string, webContentsId: number) => McpViewActivity | null;
   windowRegistry?: import("./WindowRegistry.js").WindowRegistry;
@@ -345,7 +345,7 @@ export class ProjectViewManager {
     this.onViewCached = opts.onViewCached;
     this.onViewReady = opts.onViewReady;
     this.onViewCrashed = opts.onViewCrashed;
-    this.assistantBackendForProject = opts.assistantBackendForProject;
+    this.assistantBackendsForProject = opts.assistantBackendsForProject;
     this.isTerminalLive = opts.isTerminalLive;
     this.mcpViewActivity = opts.mcpViewActivity;
     this.windowRegistry = opts.windowRegistry;

--- a/electron/window/__tests__/ProjectViewManager.eviction.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.eviction.test.ts
@@ -200,7 +200,12 @@ const mockPtyClient = {
 // project reads as assistant-free.
 const assistantBackends = new Map<string, { terminalId: string; webContentsId: number }>();
 const liveTerminals = new Set<string>();
-const assistantBackendForProject = (projectId: string) => assistantBackends.get(projectId) ?? null;
+// Plural since #12108: the manager asks for every lane so a dead one can't
+// mask a live sibling. These cases seed at most one, which is the old shape.
+const assistantBackendsForProject = (projectId: string) => {
+  const backend = assistantBackends.get(projectId);
+  return backend ? [backend] : [];
+};
 const isTerminalLive = (terminalId: string): boolean => liveTerminals.has(terminalId);
 
 import { ProjectViewManager } from "../ProjectViewManager.js";
@@ -266,7 +271,7 @@ describe("ProjectViewManager — eviction safety", () => {
       warmPaintGateTimeoutMs: 0,
       warmPaintGateHardTimeoutMs: 0,
       cachedProjectViews: 3,
-      assistantBackendForProject,
+      assistantBackendsForProject,
       isTerminalLive,
     });
   });
@@ -692,7 +697,7 @@ describe("ProjectViewManager — eviction safety", () => {
         warmPaintGateTimeoutMs: 0,
         warmPaintGateHardTimeoutMs: 0,
         cachedProjectViews,
-        assistantBackendForProject,
+        assistantBackendsForProject,
         isTerminalLive,
       });
     }
@@ -811,7 +816,7 @@ describe("ProjectViewManager — eviction safety", () => {
       // The assistant's PTY exits: PtyClient drops it from the spawn registry,
       // while HelpSessionService's binding survives.
       liveTerminals.delete("t-help-a");
-      expect(assistantBackendForProject("proj-a")).not.toBeNull();
+      expect(assistantBackendsForProject("proj-a")).not.toHaveLength(0);
 
       await managerWithLimit.switchTo("proj-c", "/path/c");
       await flushImmediates();
@@ -2469,7 +2474,7 @@ describe("ProjectViewManager — low-memory eviction", () => {
       warmPaintGateTimeoutMs: 0,
       warmPaintGateHardTimeoutMs: 0,
       cachedProjectViews: 3,
-      assistantBackendForProject,
+      assistantBackendsForProject,
       isTerminalLive,
     });
   });
@@ -2958,7 +2963,7 @@ describe("ProjectViewManager — graduated memory reclaim (#11469)", () => {
       warmPaintGateTimeoutMs: 0,
       warmPaintGateHardTimeoutMs: 0,
       cachedProjectViews,
-      assistantBackendForProject,
+      assistantBackendsForProject,
       isTerminalLive,
     });
   }
@@ -3371,7 +3376,7 @@ describe("ProjectViewManager — MCP bound sessions and dispatch leases (#11790)
       warmPaintGateTimeoutMs: 0,
       warmPaintGateHardTimeoutMs: 0,
       cachedProjectViews,
-      assistantBackendForProject,
+      assistantBackendsForProject,
       isTerminalLive,
       mcpViewActivity: (workspaceId: string, webContentsId: number) => {
         if (activityThrowsFor.has(workspaceId)) throw new Error("MCP service mid-teardown");
@@ -3686,7 +3691,7 @@ describe("ProjectViewManager — MCP bound sessions and dispatch leases (#11790)
       warmPaintGateTimeoutMs: 0,
       warmPaintGateHardTimeoutMs: 0,
       cachedProjectViews: 3,
-      assistantBackendForProject,
+      assistantBackendsForProject,
       isTerminalLive,
     });
     // Built directly rather than via makeManager (the point is the missing

--- a/electron/window/__tests__/globalServicesInit.order.test.ts
+++ b/electron/window/__tests__/globalServicesInit.order.test.ts
@@ -300,7 +300,7 @@ vi.mock("../../services/HelpSessionService.js", () => ({
     startOrphanSweep: vi.fn(),
     validateToken: vi.fn(),
     gcStaleSessions: vi.fn(async () => {}),
-    getAssistantBackend: vi.fn(() => null),
+    getAssistantBackends: vi.fn(() => []),
   },
 }));
 
@@ -871,18 +871,18 @@ describe("initGlobalServices task ordering", () => {
     ) => boolean;
     expect(typeof predicate).toBe("function");
 
-    const getAssistantBackend = helpSessionService.getAssistantBackend as unknown as Mock;
+    const getAssistantBackends = helpSessionService.getAssistantBackends as unknown as Mock;
     const hasTerminal = vi.fn<(terminalId: string) => boolean>(() => true);
 
     // No backend bound: nothing to protect, and resolving it must not throw
     // before the PtyClient exists (the predicate is wired lazily).
-    getAssistantBackend.mockReturnValue(null);
+    getAssistantBackends.mockReturnValue([]);
     expect(predicate("proj-1")).toBe(false);
 
     // Bound but the PtyClient isn't up yet — still false. Binding alone is NOT
     // liveness: it outlives an assistant that exited under its own steam
     // (#11162), so a stale binding must not pin the project forever.
-    getAssistantBackend.mockReturnValue({ terminalId: "t-help", webContentsId: 5 });
+    getAssistantBackends.mockReturnValue([{ terminalId: "t-help", webContentsId: 5, slot: 0 }]);
     expect(predicate("proj-1")).toBe(false);
 
     // Both halves satisfied.
@@ -897,7 +897,7 @@ describe("initGlobalServices task ordering", () => {
       expect(predicate("proj-1")).toBe(false);
     } finally {
       setPtyClientRef(null);
-      getAssistantBackend.mockReturnValue(null);
+      getAssistantBackends.mockReturnValue([]);
     }
   });
 

--- a/electron/window/globalServicesInit.ts
+++ b/electron/window/globalServicesInit.ts
@@ -449,9 +449,12 @@ export async function initGlobalServices(
       // instant. Lazy, like the provider above — the PtyClient is not resolved
       // yet at wiring time.
       svc.setHasLiveAssistantBackend((projectId) => {
-        const backend = helpSessionService.getAssistantBackend(projectId);
-        if (!backend) return false;
-        return getPtyClient()?.hasTerminal(backend.terminalId) === true;
+        // Any live lane floors the project (#12108) — hibernating it would
+        // revoke every lane, taking running siblings with it.
+        const backends = helpSessionService.getAssistantBackends(projectId);
+        return backends.some(
+          (backend) => getPtyClient()?.hasTerminal(backend.terminalId) === true
+        );
       });
     },
   });

--- a/electron/window/globalServicesInit.ts
+++ b/electron/window/globalServicesInit.ts
@@ -452,9 +452,7 @@ export async function initGlobalServices(
         // Any live lane floors the project (#12108) — hibernating it would
         // revoke every lane, taking running siblings with it.
         const backends = helpSessionService.getAssistantBackends(projectId);
-        return backends.some(
-          (backend) => getPtyClient()?.hasTerminal(backend.terminalId) === true
-        );
+        return backends.some((backend) => getPtyClient()?.hasTerminal(backend.terminalId) === true);
       });
     },
   });

--- a/scripts/perf/lib/ipcFixture.ts
+++ b/scripts/perf/lib/ipcFixture.ts
@@ -456,6 +456,9 @@ export const PTY_LINE_MARKER = "PERFLINE";
 
 let payloadScriptPath: string | null = null;
 
+/** How long the payload waits for its release byte before exiting anyway. */
+export const PTY_PAYLOAD_HOLD_TIMEOUT_MS = 10_000;
+
 /**
  * A generator for a known, countable terminal payload.
  *
@@ -463,6 +466,21 @@ let payloadScriptPath: string | null = null;
  * crosses a PTY spawn, and Windows argv quoting through ConPTY is not a thing
  * to make a measurement depend on. Each line carries its own index, so the
  * receiver can prove which lines arrived rather than only how many bytes did.
+ *
+ * IT DOES NOT EXIT ON ITS OWN, and that is load-bearing. node-pty gives the pty
+ * socket `DESTROY_SOCKET_TIMEOUT_MS` (200ms) after the child dies to close by
+ * itself and then calls `destroy()` on it — which throws away whatever the read
+ * side has not taken yet. Both the timer and the socket reads live on the
+ * host's event loop, so a stall longer than 200ms fires the expired timer
+ * first, and the last kernel buffer of output is gone. That is a truncation
+ * this fixture cannot distinguish from a dropped chunk, and it read as
+ * `lineMisses` on a loaded CI box. So the child stays alive until the reader
+ * says it has everything (any byte on stdin) and only then exits 0.
+ *
+ * Raw mode before the wait: canonical echo would put the release byte back on
+ * the master, and `payloadBytes` would stop reproducing to the byte. The
+ * timeout is a wedge guard — a handshake that never arrives must not leave a
+ * live PTY behind the scenario's own timeout.
  */
 export function ptyPayloadScript(): string {
   if (!payloadScriptPath) {
@@ -477,6 +495,9 @@ export function ptyPayloadScript(): string {
         "for (let i = 1; i <= total; i += 1) {",
         `  process.stdout.write(\`${PTY_LINE_MARKER}-\${i}-\${pad}\\n\`);`,
         "}",
+        "try { process.stdin.setRawMode(true); } catch {}",
+        "process.stdin.once('data', () => process.exit(0));",
+        `setTimeout(() => process.exit(0), ${PTY_PAYLOAD_HOLD_TIMEOUT_MS});`,
         "",
       ].join("\n"),
       "utf8"

--- a/scripts/perf/lib/projectViewFixture.ts
+++ b/scripts/perf/lib/projectViewFixture.ts
@@ -667,10 +667,13 @@ export class ProjectViewHarness {
       warmPaintGateHardTimeoutMs: 600,
       viewLoadTimeoutMs: 500,
       viewLoadHardTimeoutMs: 2_000,
-      assistantBackendForProject: (projectId) =>
+      // Plural since #12108: a project can run concurrent assistant lanes, and
+      // the eviction floor reads every one so a dead lane can't mask a live
+      // sibling. This fixture models a single lane.
+      assistantBackendsForProject: (projectId: string) =>
         projectId === assistantProject
-          ? { terminalId: ASSISTANT_TERMINAL_ID, webContentsId: assistantPin.webContentsId }
-          : null,
+          ? [{ terminalId: ASSISTANT_TERMINAL_ID, webContentsId: assistantPin.webContentsId }]
+          : [],
       isTerminalLive: (terminalId) => terminalId === ASSISTANT_TERMINAL_ID,
     });
 

--- a/scripts/perf/lib/projectViewFixture.ts
+++ b/scripts/perf/lib/projectViewFixture.ts
@@ -702,7 +702,7 @@ export class ProjectViewHarness {
 
   /**
    * Re-point the assistant floor at the assistant project's CURRENT view. The
-   * product re-reads `assistantBackendForProject` on every eviction pass, and
+   * product re-reads `assistantBackendsForProject` on every eviction pass, and
    * a stale WebContents id would silently stop protecting anything.
    */
   syncAssistantPin(): void {

--- a/scripts/perf/scenarios/ipc.ts
+++ b/scripts/perf/scenarios/ipc.ts
@@ -55,8 +55,23 @@ const PTY_RUN_TIMEOUT_MS = 60_000;
  * Chunks can still be in flight when `exit` lands — the PTY's read side and the
  * process's exit are different events. Draining before reading the counters
  * keeps a trailing chunk from being reported as a dropped line.
+ *
+ * It is NOT what makes the line count complete: the payload does not exit until
+ * the reader has released it (see `ptyPayloadScript`), because no drain on this
+ * side can recover output node-pty destroyed with the socket.
  */
 const PTY_DRAIN_MS = 400;
+
+/**
+ * How long PERF-045 waits for all 2000 lines before releasing the payload
+ * anyway. Reaching it means output really is missing, which is what
+ * `lineMisses` then reports — the wait is bounded so a genuine loss stays a
+ * measurement rather than becoming a hang.
+ */
+const PTY_STREAM_TIMEOUT_MS = 8_000;
+
+/** Poll interval for that wait. Short enough not to pad the reading. */
+const PTY_STREAM_POLL_MS = 20;
 
 /** Batches of the five-request cycle below. 20 x 5 = 100 round trips. */
 const ROUND_TRIP_BATCHES = 20;
@@ -352,7 +367,7 @@ export const ipcScenarios: PerfScenario[] = [
     id: "PERF-045",
     name: "PTY Host Output Volume (messages and bytes per terminal)",
     description:
-      "One real PTY in the real pty-host, emitting 2000 indexed lines. Reports how many messages and structured-clone bytes that output costs on the main<->pty-host channel, and proves every line arrived. This is the parent-IPC fallback path: with no renderer MessagePort transferred, the host has nowhere else to send a chunk. Production's visual path is the direct renderer port, which a forked child's channel cannot carry.",
+      "One real PTY in the real pty-host, emitting 2000 indexed lines, then holding the terminal open until the reader has them all. Reports how many messages and structured-clone bytes that output costs on the main<->pty-host channel, and proves every line arrived. This is the parent-IPC fallback path: with no renderer MessagePort transferred, the host has nowhere else to send a chunk. Production's visual path is the direct renderer port, which a forked child's channel cannot carry.",
     tier: "heavy",
     modes: ["smoke", "ci", "nightly"],
     iterations: { smoke: 3, ci: 5, nightly: 8 },
@@ -396,6 +411,7 @@ export const ipcScenarios: PerfScenario[] = [
         let ptyMirrorMessages = 0;
         let ptyDataBytes = 0;
         let spawnSucceeded = false;
+        let spawnAnswered = false;
         const chunks: string[] = [];
 
         const stop = host.onMessage((message) => {
@@ -414,6 +430,7 @@ export const ipcScenarios: PerfScenario[] = [
           } else if (message.type === "spawn-result") {
             const result = message.result as { success?: boolean } | undefined;
             spawnSucceeded = result?.success === true;
+            spawnAnswered = true;
           }
         });
 
@@ -432,6 +449,21 @@ export const ipcScenarios: PerfScenario[] = [
             isEphemeral: true,
           },
         });
+
+        // The payload holds the PTY open until it is released, so the host
+        // reads at its own pace and node-pty never destroys a socket with
+        // unread bytes behind it. Wait for the output, THEN let it exit.
+        const streamDeadline = performance.now() + PTY_STREAM_TIMEOUT_MS;
+        while (
+          countDeliveredLines(chunks.join(""), PTY_LINES) < PTY_LINES &&
+          performance.now() < streamDeadline
+        ) {
+          // A spawn that failed will never produce a line; waiting out the
+          // whole window for it only delays the miss counts that say so.
+          if (spawnAnswered && !spawnSucceeded) break;
+          await sleep(PTY_STREAM_POLL_MS);
+        }
+        host.send({ type: "write", id: terminalId, data: "\n" });
 
         const exit = await host.waitFor(
           (message) => message.type === "exit" && message.id === terminalId,

--- a/shared/config/assistantSlots.ts
+++ b/shared/config/assistantSlots.ts
@@ -1,0 +1,98 @@
+/**
+ * Assistant session slots (#12108).
+ *
+ * A project runs up to {@link MAX_ASSISTANT_SLOTS} concurrent Daintree
+ * Assistant sessions. A *slot* is the durable lane identity: stable across
+ * launches, unlike the per-provision `sessionId`. Two things force that
+ * stability — Claude Code's per-folder workspace-trust acceptance is keyed by
+ * the session directory, and an agent's resume token is keyed by the cwd it
+ * was captured from. A directory named after the ephemeral session id would
+ * re-prompt for trust and strand the resume token on every launch, which is
+ * why `HelpSessionService` moved off per-launch UUID dirs in the first place.
+ *
+ * Slot 0 is the historical single session: same directory, same persisted
+ * keys after migration, so an existing install keeps its trust acceptance and
+ * its resume token.
+ *
+ * The single-backend invariant (#7509) is scoped to the slot rather than
+ * dropped: at most one assistant PTY per (project, slot). A same-slot
+ * re-provision still revokes the prior bearer before killing its PTY; only
+ * genuinely different lanes coexist.
+ */
+
+/**
+ * Concurrent assistant sessions allowed per project. Each costs a billed CLI
+ * process, a PTY, an xterm instance, a live MCP transport and a session
+ * directory, so the ceiling is deliberate rather than configurable.
+ */
+export const MAX_ASSISTANT_SLOTS = 3;
+
+/** The lane an install had before slots existed. Never re-numbered. */
+export const DEFAULT_ASSISTANT_SLOT = 0;
+
+/** Every slot, ascending — the canonical order tabs and sweeps iterate in. */
+export const ASSISTANT_SLOTS: readonly number[] = Array.from(
+  { length: MAX_ASSISTANT_SLOTS },
+  (_, i) => i
+);
+
+export function isValidAssistantSlot(value: unknown): value is number {
+  return (
+    typeof value === "number" &&
+    Number.isInteger(value) &&
+    value >= 0 &&
+    value < MAX_ASSISTANT_SLOTS
+  );
+}
+
+/**
+ * Composite key for the per-(project, slot) bookkeeping that used to be keyed
+ * by project alone. Uses a NUL delimiter because a project id can be a
+ * filesystem path and every printable separator is a legal path character —
+ * the same reasoning behind `WorkspaceService`'s control-char delimiters.
+ */
+export function assistantSlotKey(projectId: string, slot: number): string {
+  return `${projectId}\u0000${slot}`;
+}
+
+/**
+ * Recover the project id from a slot key. Splits on the last delimiter so a
+ * project id that itself contains a NUL round-trips.
+ */
+export function projectIdFromSlotKey(slotKey: string): string {
+  const at = slotKey.lastIndexOf("\u0000");
+  return at === -1 ? slotKey : slotKey.slice(0, at);
+}
+
+/**
+ * Session directory name for a slot. Slot 0 keeps the bare project hash so an
+ * existing install's directory — and the workspace trust granted to it — is
+ * untouched by this change.
+ */
+export function assistantSlotDirName(projectPathHash: string, slot: number): string {
+  return slot === DEFAULT_ASSISTANT_SLOT ? projectPathHash : `${projectPathHash}-s${slot}`;
+}
+
+/**
+ * Parse a session-directory name back to its slot, or null when the name is
+ * not a recognized slot directory.
+ *
+ * Load-bearing for GC: `gcStaleSessions` recursively deletes every directory
+ * it does not recognize, so a name that fails to parse here is a *deleted*
+ * session directory, not merely an unclassified one. Rejecting `-s0` (slot 0
+ * has no suffix) and out-of-range suffixes keeps exactly one spelling per
+ * slot, so a directory orphaned by a lowered ceiling is still collected
+ * instead of being kept alive by a permissive pattern.
+ */
+export function parseAssistantSlotDirName(
+  name: string,
+  projectHashLength: number
+): { projectPathHash: string; slot: number } | null {
+  const match = new RegExp(`^([0-9a-f]{${projectHashLength}})(?:-s([1-9][0-9]*))?$`).exec(name);
+  if (!match) return null;
+  const projectPathHash = match[1]!;
+  const rawSlot = match[2];
+  if (rawSlot === undefined) return { projectPathHash, slot: DEFAULT_ASSISTANT_SLOT };
+  const slot = Number(rawSlot);
+  return isValidAssistantSlot(slot) ? { projectPathHash, slot } : null;
+}

--- a/shared/types/ipc/generated-api.ts
+++ b/shared/types/ipc/generated-api.ts
@@ -262,6 +262,9 @@ export interface GeneratedElectronAPI {
     getPinnedActionContext(
       ...args: IpcInvokeMap["help:get-pinned-action-context"]["args"]
     ): Promise<IpcInvokeMap["help:get-pinned-action-context"]["result"]>;
+    listPendingHibernationSlots(
+      ...args: IpcInvokeMap["help:list-pending-hibernation-slots"]["args"]
+    ): Promise<IpcInvokeMap["help:list-pending-hibernation-slots"]["result"]>;
     markTerminal(
       ...args: IpcInvokeMap["help:mark-terminal"]["args"]
     ): Promise<IpcInvokeMap["help:mark-terminal"]["result"]>;

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -749,6 +749,10 @@ export interface GeneratedIpcInvokeMap {
     args: [sessionId: string];
     result: import("./help.js").PinnedActionContextSnapshot | null;
   };
+  "help:list-pending-hibernation-slots": {
+    args: [projectId: string];
+    result: number[];
+  };
   "help:mark-terminal": {
     args: [terminalId: string];
     result: void;
@@ -758,7 +762,7 @@ export interface GeneratedIpcInvokeMap {
     result: { path: string; opened: boolean } | null;
   };
   "help:peek-pending-hibernation": {
-    args: [projectId: string];
+    args: [projectId: string, rawSlot?: number | undefined];
     result: { agentId: string; agentSessionId: string; cwd: string; panelWasOpen: boolean } | null;
   };
   "help:provision-session": {
@@ -768,6 +772,7 @@ export interface GeneratedIpcInvokeMap {
         projectPath: string;
         agentId: string;
         context?: import("../actions.js").ActionContext | undefined;
+        slot?: number | undefined;
       },
     ];
     result: {
@@ -784,7 +789,7 @@ export interface GeneratedIpcInvokeMap {
     result: void;
   };
   "help:restore-pending-hibernation": {
-    args: [projectId: string, claimId: string];
+    args: [projectId: string, claimId: string, rawSlot?: number | undefined];
     result: boolean;
   };
   "help:revoke-session": {
@@ -792,7 +797,7 @@ export interface GeneratedIpcInvokeMap {
     result: void;
   };
   "help:take-pending-hibernation": {
-    args: [projectId: string];
+    args: [projectId: string, rawSlot?: number | undefined];
     result: { agentId: string; agentSessionId: string; cwd: string; claimId: string } | null;
   };
   "help:unmark-terminal": {

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -537,42 +537,13 @@ export function HelpPanel({
     setAutoResumeAgentId(null);
   }, [autoResumeAgentId, isOpen, terminalId, controller]);
 
-  // Lifecycle — arms IPC subscriptions on mount, clears all timers on
-  // unmount. `start()` is idempotent across StrictMode's double-mount.
-  useEffect(() => {
-    controller.start();
-    return () => controller.stop();
-  }, [controller]);
-
-  // Sync the controller's inputs whenever the upstream state changes. The
-  // controller decides what to do (clear version block, arm hibernate,
-  // attempt auto-launch). Centralizing the inputs means the controller can
-  // reason about transitions (e.g. preferredAgentId changing mid-launch)
-  // without scattering effects across the component.
-  useEffect(() => {
-    controller.syncInputs({
-      isOpen,
-      isReadyToLaunch,
-      // Legacy field name — carries the active workspace, project or scratch.
-      currentProject: activeWorkspace,
-      terminalId,
-      preferredAgentId,
-      supportedInstalledAgentIds,
-      autoLaunchEnabled,
-      visibilityEpoch,
-    });
-  }, [
-    controller,
-    isOpen,
-    isReadyToLaunch,
-    activeWorkspace,
-    terminalId,
-    preferredAgentId,
-    supportedInstalledAgentIdsKey,
-    supportedInstalledAgentIds,
-    autoLaunchEnabled,
-    visibilityEpoch,
-  ]);
+  // Lifecycle is NOT driven from here (#12108). Every open lane — the active
+  // one included — is armed by its own `HelpSessionLaneRuntime` below.
+  //
+  // Keying an arm/disarm effect on `controller` would tear the OUTGOING lane
+  // down on every tab switch, and `stop()` is not a neutral pause: it bumps
+  // `_launchGen`, which makes an in-flight launch bail at its next checkpoint.
+  // Switching tabs mid-launch would silently abandon that launch.
 
   // The renderer being hidden is NOT a teardown signal. A hidden renderer
   // means one of: project-switch cached, project-switch about-to-be-evicted,
@@ -1382,16 +1353,15 @@ export function HelpPanel({
         onClose={handleCloseSlot}
       />
 
-      {/* Background lanes: no body, but their controllers must keep running so
-          a session the user has tabbed away from still surfaces approvals and
-          still hibernates when idle. */}
-      {openSlots
-        .filter((slot) => slot !== activeSlot)
-        .map((slot) => (
+      {/* One runtime per open lane. Background lanes need theirs so a session
+          the user has tabbed away from still surfaces approvals and still
+          hibernates when idle; the ACTIVE lane needs one too, so that switching
+          tabs never disarms a live lane (see the lifecycle note above). */}
+      {openSlots.map((slot) => (
           <HelpSessionLaneRuntime
             key={slot}
             slot={slot}
-            isActive={false}
+            isActive={slot === activeSlot}
             isOpen={isOpen}
             isReadyToLaunch={isReadyToLaunch}
             currentProject={activeWorkspace}
@@ -1400,7 +1370,7 @@ export function HelpPanel({
             autoLaunchEnabled={autoLaunchEnabled}
             visibilityEpoch={visibilityEpoch}
           />
-        ))}
+      ))}
 
       {/* Content */}
       <div className="flex-1 flex flex-col min-h-0 relative">

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -26,6 +26,12 @@ import { safeFireAndForget } from "@/utils/safeFireAndForget";
 import { isBuiltInAgentId } from "@shared/config/agentIds";
 import { HelpIntroBanner } from "./HelpIntroBanner";
 import { HelpPanelHeader } from "./HelpPanelHeader";
+import { HelpSessionTabs, type HelpSessionTab } from "./HelpSessionTabs";
+import { HelpSessionLaneRuntime } from "./HelpSessionLaneRuntime";
+import {
+  acquireHelpSessionController,
+  releaseHelpSessionController,
+} from "@/controllers/helpSessionControllerRegistry";
 import { HelpPanelBanners } from "./HelpPanelBanners";
 import { HelpPanelVersionGate } from "./HelpPanelVersionGate";
 import { HelpLaunchingState } from "./HelpLaunchingState";
@@ -35,9 +41,12 @@ import { TurnOutcomePip } from "./TurnOutcomePip";
 import { FigureRail } from "./FigureRail";
 import {
   useHelpPanelStore,
+  selectSlot,
+  selectOpenSlots,
   HELP_PANEL_MIN_WIDTH,
   HELP_PANEL_MAX_WIDTH,
 } from "@/store/helpPanelStore";
+import { MAX_ASSISTANT_SLOTS } from "@shared/config/assistantSlots";
 import {
   usePanelStore,
   getTerminalRefreshTier,
@@ -65,7 +74,6 @@ import { isPtyPanel } from "@shared/types/panel";
 import type { PinnedActionContextSnapshot } from "@shared/types/ipc/help";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { TABBABLE_SELECTOR } from "@/lib/accessibility";
-import { HelpSessionController } from "@/controllers/HelpSessionController";
 
 const LazyHybridInputBar = lazy(() =>
   import("@/components/Terminal/HybridInputBar").then((m) => ({ default: m.HybridInputBar }))
@@ -183,12 +191,15 @@ export function HelpPanel({
   const prevPreferredAgentIdRef = useRef<string | null>(null);
   const [visibilityEpoch, setVisibilityEpoch] = useState(0);
 
-  // useState lazy initializer guarantees a single instantiation across
-  // renders and StrictMode double-mount, and unlike a ref it doesn't trip
-  // React Compiler's "no ref access during render" rule. The constructor is
-  // pure; side effects live in `start()` which fires from the lifecycle
-  // effect below.
-  const [controller] = useState(() => new HelpSessionController());
+  // The lane this panel body is showing, and its controller (#12108).
+  //
+  // The controller comes from the per-view registry rather than `useState`:
+  // switching tabs must hand this component a DIFFERENT controller while
+  // leaving the previous lane's instance running, and a lane that scrolls off
+  // screen keeps its launch phase, banners and IPC subscriptions intact. A
+  // `useState` instance would be per-component and would die on tab switch.
+  const activeSlot = useHelpPanelStore((s) => s.activeSlot);
+  const controller = acquireHelpSessionController(activeSlot);
 
   const session = useSyncExternalStore(controller.subscribe, controller.getSnapshot);
 
@@ -215,16 +226,16 @@ export function HelpPanel({
     useShallow((s) => ({
       isOpen: s.isOpen,
       width: s.width,
-      terminalId: s.terminalId,
-      sessionId: s.sessionId,
-      agentId: s.agentId,
+      terminalId: selectSlot(s, s.activeSlot).terminalId,
+      sessionId: selectSlot(s, s.activeSlot).sessionId,
+      agentId: selectSlot(s, s.activeSlot).agentId,
       preferredAgentId: s.preferredAgentId,
       autoLaunchEnabled: s.autoLaunchEnabled,
       droppedPreferredAgentId: s.droppedPreferredAgentId,
       introDismissed: s.introDismissed,
-      conversationTouched: s.conversationTouched,
+      conversationTouched: selectSlot(s, s.activeSlot).conversationTouched,
       focusRequest: s.focusRequest,
-      figures: s.figures,
+      figures: selectSlot(s, s.activeSlot).figures,
       markConversationStarted: s.markConversationStarted,
       setWidth: s.setWidth,
       setOpen: s.setOpen,
@@ -617,8 +628,8 @@ export function HelpPanel({
   useEffect(() => {
     if (terminalId && terminalPty?.agentState !== undefined && terminalPty.agentState !== "idle") {
       const store = useHelpPanelStore.getState();
-      if (store.terminalId === terminalId) {
-        markConversationStarted();
+      if (selectSlot(store, store.activeSlot).terminalId === terminalId) {
+        markConversationStarted(store.activeSlot);
       }
     }
   }, [terminalId, terminalPty?.agentState, markConversationStarted]);
@@ -736,7 +747,7 @@ export function HelpPanel({
         // The panel can close, or rebind to a different session, between this
         // effect and the frame that runs it. A frame already dequeued when
         // cleanup ran can't be cancelled, so re-read both.
-        if (!state.isOpen || state.terminalId !== terminalId) return;
+        if (!state.isOpen || selectSlot(state, state.activeSlot).terminalId !== terminalId) return;
 
         // Ownership is re-checked here, on the final deferred frame, rather
         // than in the effect body — focus can move during the frame boundary,
@@ -1035,6 +1046,62 @@ export function HelpPanel({
       CLOSE_CONFIRM_AGENT_STATES.has(terminalPty.agentState)) ||
     conversationTouched;
 
+  // --- Parallel lanes (#12108) -------------------------------------------
+  const openSlots = useHelpPanelStore(useShallow(selectOpenSlots));
+  const canOpenParallelSession = openSlots.length < MAX_ASSISTANT_SLOTS;
+
+  const laneAgentStates = usePanelStore(
+    useShallow((s: ReturnType<typeof usePanelStore.getState>) =>
+      openSlots.map((slot) => {
+        const laneTerminalId = useHelpPanelStore.getState().sessions[slot]?.terminalId;
+        if (!laneTerminalId) return undefined;
+        const panel = s.panelsById[laneTerminalId];
+        return panel && isPtyPanel(panel) ? panel.agentState : undefined;
+      })
+    )
+  );
+
+  const sessionTabs = useMemo<HelpSessionTab[]>(
+    () =>
+      openSlots.map((slot, index) => ({
+        slot,
+        // Numbered by position rather than by slot, so closing lane 1 of three
+        // leaves "Session 1 / Session 2" rather than a gap at 2.
+        label: `Session ${index + 1}`,
+        agentState: laneAgentStates[index],
+      })),
+    [openSlots, laneAgentStates]
+  );
+
+  const handleOpenParallelSession = useCallback(() => {
+    const slot = useHelpPanelStore.getState().openSlot();
+    if (slot === null) return;
+    useHelpPanelStore.getState().setOpen(true);
+    useHelpPanelStore.getState().requestFocus();
+  }, []);
+
+  const handleSelectSlot = useCallback((slot: number) => {
+    useHelpPanelStore.getState().setActiveSlot(slot);
+    // A lane's xterm was hidden while it was in the background, so it has no
+    // trustworthy geometry until it is measured on screen. `requestFocus`
+    // drives HelpPanel's existing reveal path, which fits and repaints before
+    // handing it the caret — the same treatment a panel reveal gets.
+    useHelpPanelStore.getState().requestFocus();
+  }, []);
+
+  const handleCloseSlot = useCallback((slot: number) => {
+    const state = useHelpPanelStore.getState();
+    const lane = state.sessions[slot];
+    // Revoke and kill BEFORE dropping the lane. `stop()` only disarms
+    // listeners — it deliberately does not end the session — so releasing the
+    // controller first would strand a live agent with nothing to shut it down.
+    if (lane?.terminalId || lane?.sessionId) {
+      acquireHelpSessionController(slot).endSession();
+    }
+    releaseHelpSessionController(slot);
+    state.closeSlot(slot);
+  }, []);
+
   const handleNewSession = useCallback(() => {
     if (!terminalId || !agentId) return;
     if (shouldConfirmNewSession) {
@@ -1299,12 +1366,41 @@ export function HelpPanel({
         agentState={terminalPty?.agentState}
         canStartNewSession={Boolean(terminalId && agentId)}
         canEndSession={Boolean(terminalId && agentId)}
+        canOpenParallelSession={canOpenParallelSession}
         onNewSession={handleNewSession}
+        onOpenParallelSession={handleOpenParallelSession}
         onEndSession={handleEndSession}
         onOpenDocs={handleOpenAssistantDocs}
         onClose={handleClose}
         isFocused={isHighlighted}
       />
+
+      <HelpSessionTabs
+        tabs={sessionTabs}
+        activeSlot={activeSlot}
+        onSelect={handleSelectSlot}
+        onClose={handleCloseSlot}
+      />
+
+      {/* Background lanes: no body, but their controllers must keep running so
+          a session the user has tabbed away from still surfaces approvals and
+          still hibernates when idle. */}
+      {openSlots
+        .filter((slot) => slot !== activeSlot)
+        .map((slot) => (
+          <HelpSessionLaneRuntime
+            key={slot}
+            slot={slot}
+            isActive={false}
+            isOpen={isOpen}
+            isReadyToLaunch={isReadyToLaunch}
+            currentProject={activeWorkspace}
+            preferredAgentId={preferredAgentId}
+            supportedInstalledAgentIds={supportedInstalledAgentIds}
+            autoLaunchEnabled={autoLaunchEnabled}
+            visibilityEpoch={visibilityEpoch}
+          />
+        ))}
 
       {/* Content */}
       <div className="flex-1 flex flex-col min-h-0 relative">

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -399,7 +399,7 @@ export function HelpPanel({
     }
     // Optional-chained like the `onViewRevealed` subscription below: a missing
     // binding degrades to the normal "Start assistant" CTA rather than throwing.
-    const peek = window.electron.help.peekPendingHibernation?.(activeWorkspaceId);
+    const peek = window.electron.help.peekPendingHibernation?.(activeWorkspaceId, activeSlot);
     if (!peek) {
       setResumablePending(null);
       return;
@@ -497,7 +497,7 @@ export function HelpPanel({
   useEffect(() => {
     if (!activeWorkspaceId || terminalId || !isReadyToLaunch) return;
     if (coldResumeArmedRef.current === activeWorkspaceId) return;
-    const peek = window.electron.help.peekPendingHibernation?.(activeWorkspaceId);
+    const peek = window.electron.help.peekPendingHibernation?.(activeWorkspaceId, activeSlot);
     if (!peek) return;
     let cancelled = false;
     void peek

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -185,6 +185,10 @@ export function HelpPanel({
   const [showNewSessionConfirm, setShowNewSessionConfirm] = useState(false);
   const [showEndSessionConfirm, setShowEndSessionConfirm] = useState(false);
   const [showAgentSwitchConfirm, setShowAgentSwitchConfirm] = useState(false);
+  // The lane a tab's close button is waiting on confirmation for (#12108).
+  // Null means no close is pending — closing is destructive (the conversation
+  // is discarded, not paused), so it takes the same gate the Stop control uses.
+  const [pendingCloseSlot, setPendingCloseSlot] = useState<number | null>(null);
   // Tracks the last preferredAgentId the switch effect acted on so a single
   // preference change drives at most one switch attempt (the effect re-runs
   // on unrelated dep changes while the async launch settles).
@@ -1045,6 +1049,41 @@ export function HelpPanel({
     [openSlots, laneAgentStates]
   );
 
+  // Bring back the tabs for lanes whose conversations an eviction or crash
+  // captured (#12108). A cold view starts at slot 0 alone, so lanes 1+ — whose
+  // resume entries survived on disk — would have no tab to reach them from and
+  // their conversations would be stranded despite still being there. The
+  // listing is non-consuming, like the peeks: a recreated lane simply lands on
+  // its own "Resume assistant" empty state, and nothing launches (or bills)
+  // until the user asks. Background lanes report `isOpen: false` to their
+  // controller, so auto-launch can't fire behind the tab strip either.
+  //
+  // One-shot per workspace, and only while the view is genuinely cold — a
+  // single, unbound lane — so it can never fight the user's own tab edits.
+  const restoredLaneWorkspaceRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!activeWorkspaceId || restoredLaneWorkspaceRef.current === activeWorkspaceId) return;
+    if (openSlots.length > 1 || terminalId) return;
+    // Optional-chained like the hibernation peeks: a missing binding degrades
+    // to the pre-lane behaviour rather than throwing.
+    const listing = window.electron.help.listPendingHibernationSlots?.(activeWorkspaceId);
+    if (!listing) return;
+    let cancelled = false;
+    void listing
+      .then((slots) => {
+        if (cancelled || restoredLaneWorkspaceRef.current === activeWorkspaceId) return;
+        restoredLaneWorkspaceRef.current = activeWorkspaceId;
+        const store = useHelpPanelStore.getState();
+        for (const slot of slots) store.ensureSlot(slot);
+      })
+      .catch((err) => {
+        logWarn("HelpPanel: failed to list pending hibernation lanes", err);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [activeWorkspaceId, openSlots.length, terminalId]);
+
   const handleOpenParallelSession = useCallback(() => {
     const slot = useHelpPanelStore.getState().openSlot();
     if (slot === null) return;
@@ -1061,18 +1100,64 @@ export function HelpPanel({
     useHelpPanelStore.getState().requestFocus();
   }, []);
 
-  const handleCloseSlot = useCallback((slot: number) => {
+  const closeSlotNow = useCallback((slot: number) => {
     const state = useHelpPanelStore.getState();
     const lane = state.sessions[slot];
     // Revoke and kill BEFORE dropping the lane. `stop()` only disarms
     // listeners — it deliberately does not end the session — so releasing the
     // controller first would strand a live agent with nothing to shut it down.
     if (lane?.terminalId || lane?.sessionId) {
-      acquireHelpSessionController(slot).endSession();
+      // Keep the panel on screen while a sibling lane is still live: the tab
+      // strip only exists at two lanes or more, so an unconditional close would
+      // slide a running Session 1 out because Session 2 was dismissed. Closing
+      // the LAST lane still closes — `closeSlot` recreates an empty slot 0
+      // whose fresh controller would auto-launch straight back into a session
+      // the user just ended if the panel stayed open.
+      const isLastLane = selectOpenSlots(state).length <= 1;
+      acquireHelpSessionController(slot).endSession({ closePanel: isLastLane });
     }
     releaseHelpSessionController(slot);
     state.closeSlot(slot);
   }, []);
+
+  // Same "something to lose" gate the Stop control uses, but evaluated against
+  // the lane BEING CLOSED rather than the one on screen — a background lane is
+  // exactly where a working agent goes unnoticed.
+  const laneNeedsCloseConfirm = useCallback((slot: number) => {
+    const lane = useHelpPanelStore.getState().sessions[slot];
+    if (!lane) return false;
+    if (lane.conversationTouched) return true;
+    if (!lane.terminalId) return false;
+    const panel = usePanelStore.getState().panelsById[lane.terminalId];
+    const agentState = panel && isPtyPanel(panel) ? panel.agentState : undefined;
+    return agentState !== undefined && CLOSE_CONFIRM_AGENT_STATES.has(agentState);
+  }, []);
+
+  const handleCloseSlot = useCallback(
+    (slot: number) => {
+      if (laneNeedsCloseConfirm(slot)) {
+        setPendingCloseSlot(slot);
+        return;
+      }
+      closeSlotNow(slot);
+    },
+    [laneNeedsCloseConfirm, closeSlotNow]
+  );
+
+  const handleConfirmCloseSlot = useCallback(() => {
+    const slot = pendingCloseSlot;
+    setPendingCloseSlot(null);
+    if (slot !== null) closeSlotNow(slot);
+  }, [pendingCloseSlot, closeSlotNow]);
+
+  const handleCancelCloseSlot = useCallback(() => {
+    setPendingCloseSlot(null);
+  }, []);
+
+  const pendingCloseLabel =
+    pendingCloseSlot === null
+      ? null
+      : (sessionTabs.find((tab) => tab.slot === pendingCloseSlot)?.label ?? "this session");
 
   const handleNewSession = useCallback(() => {
     if (!terminalId || !agentId) return;
@@ -1712,6 +1797,15 @@ export function HelpPanel({
         confirmLabel="Stop assistant"
         onConfirm={handleConfirmEndSession}
         onClose={handleCancelEndSession}
+        variant="destructive"
+      />
+      <ConfirmDialog
+        isOpen={pendingCloseSlot !== null}
+        title={`Close ${pendingCloseLabel ?? "this session"}?`}
+        description="The assistant will stop and the conversation will be discarded"
+        confirmLabel="Close session"
+        onConfirm={handleConfirmCloseSlot}
+        onClose={handleCancelCloseSlot}
         variant="destructive"
       />
       <ConfirmDialog

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -434,6 +434,7 @@ export function HelpPanel({
     isOpen,
     terminalId,
     activeWorkspaceId,
+    activeSlot,
     supportedInstalledAgentIdsKey,
     supportedInstalledAgentIds,
   ]);
@@ -514,7 +515,7 @@ export function HelpPanel({
     return () => {
       cancelled = true;
     };
-  }, [activeWorkspaceId, terminalId, isReadyToLaunch, setOpen]);
+  }, [activeWorkspaceId, activeSlot, terminalId, isReadyToLaunch, setOpen]);
 
   // Fire the captured resume once the panel has opened. The `!terminalId` guard
   // covers two cases: a DevTools reload that still holds a live session, and the
@@ -1358,18 +1359,18 @@ export function HelpPanel({
           hibernates when idle; the ACTIVE lane needs one too, so that switching
           tabs never disarms a live lane (see the lifecycle note above). */}
       {openSlots.map((slot) => (
-          <HelpSessionLaneRuntime
-            key={slot}
-            slot={slot}
-            isActive={slot === activeSlot}
-            isOpen={isOpen}
-            isReadyToLaunch={isReadyToLaunch}
-            currentProject={activeWorkspace}
-            preferredAgentId={preferredAgentId}
-            supportedInstalledAgentIds={supportedInstalledAgentIds}
-            autoLaunchEnabled={autoLaunchEnabled}
-            visibilityEpoch={visibilityEpoch}
-          />
+        <HelpSessionLaneRuntime
+          key={slot}
+          slot={slot}
+          isActive={slot === activeSlot}
+          isOpen={isOpen}
+          isReadyToLaunch={isReadyToLaunch}
+          currentProject={activeWorkspace}
+          preferredAgentId={preferredAgentId}
+          supportedInstalledAgentIds={supportedInstalledAgentIds}
+          autoLaunchEnabled={autoLaunchEnabled}
+          visibilityEpoch={visibilityEpoch}
+        />
       ))}
 
       {/* Content */}

--- a/src/components/HelpPanel/HelpPanelHeader.tsx
+++ b/src/components/HelpPanel/HelpPanelHeader.tsx
@@ -1,4 +1,4 @@
-import { ChevronRight, CircleHelp, CircleStop, Ellipsis, Plus } from "lucide-react";
+import { ChevronRight, CircleHelp, CircleStop, Columns2, Ellipsis, Plus } from "lucide-react";
 import { SpinnerCircle, HollowCircle, InteractingCircle } from "@/components/icons";
 import { DaintreeIcon } from "@/components/icons/DaintreeIcon";
 import {
@@ -66,7 +66,10 @@ interface HelpPanelHeaderProps {
   agentState: AgentState | null | undefined;
   canStartNewSession: boolean;
   canEndSession: boolean;
+  /** False once every assistant lane is occupied (#12108). */
+  canOpenParallelSession: boolean;
   onNewSession: () => void;
+  onOpenParallelSession: () => void;
   onEndSession: () => void;
   onOpenDocs: () => void;
   onClose: () => void;
@@ -77,7 +80,9 @@ export function HelpPanelHeader({
   agentState,
   canStartNewSession,
   canEndSession,
+  canOpenParallelSession,
   onNewSession,
+  onOpenParallelSession,
   onEndSession,
   onOpenDocs,
   onClose,
@@ -112,6 +117,7 @@ export function HelpPanelHeader({
           onClick={onNewSession}
           className="p-1 rounded-[var(--radius-sm)] text-daintree-text/50 hover:text-text-primary hover:bg-tint/8 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent-primary focus-visible:outline-offset-2"
           aria-label="Start new session"
+          title="Start a new conversation in this session"
         >
           <Plus className="w-3.5 h-3.5" />
         </button>
@@ -132,6 +138,14 @@ export function HelpPanelHeader({
           </button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="min-w-[160px]">
+          {/* Distinct from the header's "+" — that restarts THIS conversation,
+              this one opens a second conversation beside it. Lives in the
+              overflow to keep the header at its 3-icon budget. */}
+          <DropdownMenuItem onSelect={onOpenParallelSession} disabled={!canOpenParallelSession}>
+            <Columns2 className="w-3.5 h-3.5 mr-2" aria-hidden="true" />
+            Open parallel session
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
           <DropdownMenuItem onSelect={onOpenDocs}>
             <CircleHelp className="w-3.5 h-3.5 mr-2" aria-hidden="true" />
             Open docs

--- a/src/components/HelpPanel/HelpSessionLaneRuntime.tsx
+++ b/src/components/HelpPanel/HelpSessionLaneRuntime.tsx
@@ -1,0 +1,84 @@
+import { useEffect } from "react";
+import { useHelpPanelStore, selectSlot } from "@/store/helpPanelStore";
+import { acquireHelpSessionController } from "@/controllers/helpSessionControllerRegistry";
+import type { HelpProjectRef } from "@/controllers/HelpSessionController";
+
+interface HelpSessionLaneRuntimeProps {
+  slot: number;
+  isReadyToLaunch: boolean;
+  currentProject: HelpProjectRef | null;
+  preferredAgentId: string | null;
+  supportedInstalledAgentIds: readonly string[];
+  autoLaunchEnabled: boolean;
+  visibilityEpoch: number;
+  /** Panel-level open state — shared by every lane, since one panel hosts them all. */
+  isOpen: boolean;
+  /** Whether this lane is the one currently on screen. */
+  isActive: boolean;
+}
+
+/**
+ * Keeps one background assistant lane running (#12108). Renders nothing.
+ *
+ * The visible lane's controller is driven by `HelpPanel` itself; this covers
+ * every other open lane, whose controller must stay armed even though its body
+ * is not mounted. Without it a background session would silently stop
+ * surfacing tool-call activity and approval prompts — and a tier-mismatch
+ * prompt that nobody answers stalls that session outright — while its idle
+ * hibernate timer would never fire.
+ *
+ * `isOpen` is deliberately reported as false for a lane that is not on screen.
+ * The controller treats "open" as "the user is looking at this conversation",
+ * and it gates auto-launch and the idle-hibernate arm on it: a background lane
+ * must not auto-launch (that would bill a session the user never asked for)
+ * and SHOULD be allowed to hibernate once idle.
+ */
+export function HelpSessionLaneRuntime({
+  slot,
+  isReadyToLaunch,
+  currentProject,
+  preferredAgentId,
+  supportedInstalledAgentIds,
+  autoLaunchEnabled,
+  visibilityEpoch,
+  isOpen,
+  isActive,
+}: HelpSessionLaneRuntimeProps) {
+  const controller = acquireHelpSessionController(slot);
+  const terminalId = useHelpPanelStore((s) => selectSlot(s, slot).terminalId);
+
+  useEffect(() => {
+    controller.start();
+    // Deliberately NOT stopped on unmount. This component unmounts when its
+    // lane becomes the active one (HelpPanel takes over driving the same
+    // controller instance), and stopping there would disarm the listeners of a
+    // live session. A lane that is genuinely closed is released explicitly via
+    // `releaseHelpSessionController`.
+  }, [controller]);
+
+  useEffect(() => {
+    controller.syncInputs({
+      isOpen: isOpen && isActive,
+      isReadyToLaunch,
+      currentProject,
+      terminalId,
+      preferredAgentId,
+      supportedInstalledAgentIds,
+      autoLaunchEnabled,
+      visibilityEpoch,
+    });
+  }, [
+    controller,
+    isOpen,
+    isActive,
+    isReadyToLaunch,
+    currentProject,
+    terminalId,
+    preferredAgentId,
+    supportedInstalledAgentIds,
+    autoLaunchEnabled,
+    visibilityEpoch,
+  ]);
+
+  return null;
+}

--- a/src/components/HelpPanel/HelpSessionTabs.tsx
+++ b/src/components/HelpPanel/HelpSessionTabs.tsx
@@ -55,13 +55,20 @@ interface HelpSessionTabsProps {
  * No accent anywhere: the strip sits inside the assistant focus region, whose
  * one load-bearing accent is already spent on the focus ring. The active tab
  * is distinguished by surface and text hierarchy instead.
+ *
+ * Deliberately a toggle-button group rather than the ARIA tabs pattern. Tabs
+ * promise a roving tabindex with arrow-key navigation and one `tabpanel` per
+ * tab; this strip drives a single shared body and keeps each lane's close
+ * button in the tab order on purpose, so claiming `role="tab"` would announce
+ * keyboard behaviour that isn't there. `aria-pressed` says exactly what is
+ * true: one of these selectors is currently on.
  */
 export function HelpSessionTabs({ tabs, activeSlot, onSelect, onClose }: HelpSessionTabsProps) {
   if (tabs.length < 2) return null;
 
   return (
     <div
-      role="tablist"
+      role="group"
       aria-label="Assistant sessions"
       className="flex items-stretch gap-1 px-2 py-1 border-b border-border-default shrink-0 overflow-x-auto"
     >
@@ -78,8 +85,7 @@ export function HelpSessionTabs({ tabs, activeSlot, onSelect, onClose }: HelpSes
           >
             <button
               type="button"
-              role="tab"
-              aria-selected={isActive}
+              aria-pressed={isActive}
               onClick={() => onSelect(tab.slot)}
               className={cn(
                 "flex items-center gap-1.5 min-w-0 text-xs transition-colors duration-150 ease-out",

--- a/src/components/HelpPanel/HelpSessionTabs.tsx
+++ b/src/components/HelpPanel/HelpSessionTabs.tsx
@@ -1,0 +1,112 @@
+import { X } from "lucide-react";
+import { SpinnerCircle, HollowCircle, InteractingCircle } from "@/components/icons";
+import { cn } from "@/lib/utils";
+import type { AgentState } from "@/types";
+
+/**
+ * Per-lane state marker (#12108).
+ *
+ * Same triad and tokens as the header's indicator — only working, directing
+ * and waiting earn a marker; idle and exited stay quiet. This is the whole
+ * reason the strip carries state at all: the header can only speak for the
+ * lane on screen, so a background session that has gone to `waiting` is
+ * otherwise invisible until the user happens to switch to it.
+ */
+function TabStateIndicator({ agentState }: { agentState: AgentState | null | undefined }) {
+  if (agentState === "working") {
+    return (
+      <SpinnerCircle
+        className="w-3 h-3 shrink-0 text-state-working animate-spin-slow motion-reduce:animate-none"
+        aria-label="working"
+      />
+    );
+  }
+  if (agentState === "directing") {
+    return <InteractingCircle className="w-3 h-3 shrink-0 text-category-blue" aria-label="directing" />;
+  }
+  if (agentState === "waiting") {
+    return <HollowCircle className="w-3 h-3 shrink-0 text-state-waiting" aria-label="waiting" />;
+  }
+  return null;
+}
+
+export interface HelpSessionTab {
+  slot: number;
+  label: string;
+  agentState: AgentState | null | undefined;
+}
+
+interface HelpSessionTabsProps {
+  tabs: HelpSessionTab[];
+  activeSlot: number;
+  onSelect: (slot: number) => void;
+  onClose: (slot: number) => void;
+}
+
+/**
+ * The parallel-session strip.
+ *
+ * Rendered only when a project has more than one assistant lane open, so a
+ * single-session panel looks exactly as it did before lanes existed — the
+ * common case pays nothing for the capability.
+ *
+ * No accent anywhere: the strip sits inside the assistant focus region, whose
+ * one load-bearing accent is already spent on the focus ring. The active tab
+ * is distinguished by surface and text hierarchy instead.
+ */
+export function HelpSessionTabs({ tabs, activeSlot, onSelect, onClose }: HelpSessionTabsProps) {
+  if (tabs.length < 2) return null;
+
+  return (
+    <div
+      role="tablist"
+      aria-label="Assistant sessions"
+      className="flex items-stretch gap-1 px-2 py-1 border-b border-border-default shrink-0 overflow-x-auto"
+    >
+      {tabs.map((tab) => {
+        const isActive = tab.slot === activeSlot;
+        return (
+          <div
+            key={tab.slot}
+            className={cn(
+              "group flex items-center gap-1.5 pl-2 pr-1 py-1 rounded-[var(--radius-sm)] shrink-0",
+              "transition-colors duration-150 ease-out",
+              isActive ? "bg-overlay-subtle" : "hover:bg-tint/8"
+            )}
+          >
+            <button
+              type="button"
+              role="tab"
+              aria-selected={isActive}
+              onClick={() => onSelect(tab.slot)}
+              className={cn(
+                "flex items-center gap-1.5 min-w-0 text-xs transition-colors duration-150 ease-out",
+                "focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent-primary focus-visible:outline-offset-2",
+                isActive ? "text-text-primary font-medium" : "text-text-secondary"
+              )}
+            >
+              <TabStateIndicator agentState={tab.agentState} />
+              <span className="truncate max-w-[10rem]">{tab.label}</span>
+            </button>
+            <button
+              type="button"
+              onClick={() => onClose(tab.slot)}
+              // Always in the DOM so the control is reachable by keyboard and
+              // by assistive tech; only its paint is hover/focus-gated, which
+              // keeps the strip quiet without hiding the affordance.
+              className={cn(
+                "p-0.5 rounded-[var(--radius-sm)] shrink-0 text-text-secondary",
+                "opacity-0 group-hover:opacity-100 focus-visible:opacity-100",
+                "hover:text-text-primary hover:bg-tint/8 transition-[opacity,color,background-color] duration-150 ease-out",
+                "focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent-primary focus-visible:outline-offset-2"
+              )}
+              aria-label={`Close ${tab.label}`}
+            >
+              <X className="w-3 h-3" aria-hidden="true" />
+            </button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/HelpPanel/HelpSessionTabs.tsx
+++ b/src/components/HelpPanel/HelpSessionTabs.tsx
@@ -22,7 +22,9 @@ function TabStateIndicator({ agentState }: { agentState: AgentState | null | und
     );
   }
   if (agentState === "directing") {
-    return <InteractingCircle className="w-3 h-3 shrink-0 text-category-blue" aria-label="directing" />;
+    return (
+      <InteractingCircle className="w-3 h-3 shrink-0 text-category-blue" aria-label="directing" />
+    );
   }
   if (agentState === "waiting") {
     return <HollowCircle className="w-3 h-3 shrink-0 text-state-waiting" aria-label="waiting" />;

--- a/src/components/HelpPanel/__tests__/HelpLaunchingState.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpLaunchingState.test.tsx
@@ -3,9 +3,13 @@ import { act, render } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { HelpLaunchingState } from "../HelpLaunchingState";
+import { __resetHelpSessionControllersForTests } from "@/controllers/helpSessionControllerRegistry";
 
 describe("HelpLaunchingState", () => {
   beforeEach(() => {
+  // #12108: controllers live in a per-view registry, not component
+  // state, so they outlive a render and must be reset between tests.
+  __resetHelpSessionControllersForTests();
     vi.useFakeTimers();
   });
 

--- a/src/components/HelpPanel/__tests__/HelpLaunchingState.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpLaunchingState.test.tsx
@@ -7,9 +7,9 @@ import { __resetHelpSessionControllersForTests } from "@/controllers/helpSession
 
 describe("HelpLaunchingState", () => {
   beforeEach(() => {
-  // #12108: controllers live in a per-view registry, not component
-  // state, so they outlive a render and must be reset between tests.
-  __resetHelpSessionControllersForTests();
+    // #12108: controllers live in a per-view registry, not component
+    // state, so they outlive a render and must be reset between tests.
+    __resetHelpSessionControllersForTests();
     vi.useFakeTimers();
   });
 

--- a/src/components/HelpPanel/__tests__/HelpPanel.agentExit.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.agentExit.test.tsx
@@ -12,6 +12,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const { handleAgentExitedMock, helpPanelState, panelStoreState } = vi.hoisted(() => ({
   handleAgentExitedMock: vi.fn(),
   helpPanelState: {
+    clearDroppedPreferredAgent: vi.fn(),
+    setAutoLaunchEnabled: vi.fn(),
+    requestFocus: vi.fn(),
+    setActiveFigureNumber: vi.fn(),
+    addFigure: vi.fn(),
+    setActiveSlot: vi.fn(),
+    closeSlot: vi.fn(),
+    openSlot: vi.fn(),
+    // #12108: the panel reads its lane pointer; the mocked selectors
+    // above project this same flat object as that lane.
+    activeSlot: 0,
+    sessions: {} as Record<number, unknown>,
     isOpen: true,
     width: 380,
     terminalId: "t-1" as string | null,
@@ -149,7 +161,18 @@ vi.mock("@/store/helpPanelStore", () => {
   const store = (selector?: (s: typeof helpPanelState) => unknown) =>
     selector ? selector(helpPanelState) : helpPanelState;
   store.getState = () => helpPanelState;
-  return { useHelpPanelStore: store, HELP_PANEL_MIN_WIDTH: 320, HELP_PANEL_MAX_WIDTH: 800 };
+  return {
+    useHelpPanelStore: store,
+    HELP_PANEL_MIN_WIDTH: 320,
+    HELP_PANEL_MAX_WIDTH: 800,
+    // #12108 selectors. Fixtures stay flat, so these project the same object
+    // as the lane and every existing assertion keeps working.
+    selectSlot: (s) => s,
+    selectActiveSlot: (s) => s,
+    selectOpenSlots: () => [0],
+    selectSlotTerminalIds: (s) => (s.terminalId ? [s.terminalId] : []),
+    selectSlotForTerminal: (s, id) => (s.terminalId === id && id ? 0 : null),
+  };
 });
 
 vi.mock("@/store", () => {

--- a/src/components/HelpPanel/__tests__/HelpPanel.agentExit.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.agentExit.test.tsx
@@ -167,11 +167,12 @@ vi.mock("@/store/helpPanelStore", () => {
     HELP_PANEL_MAX_WIDTH: 800,
     // #12108 selectors. Fixtures stay flat, so these project the same object
     // as the lane and every existing assertion keeps working.
-    selectSlot: (s) => s,
-    selectActiveSlot: (s) => s,
+    selectSlot: (s: typeof helpPanelState) => s,
+    selectActiveSlot: (s: typeof helpPanelState) => s,
     selectOpenSlots: () => [0],
-    selectSlotTerminalIds: (s) => (s.terminalId ? [s.terminalId] : []),
-    selectSlotForTerminal: (s, id) => (s.terminalId === id && id ? 0 : null),
+    selectSlotTerminalIds: (s: typeof helpPanelState) => (s.terminalId ? [s.terminalId] : []),
+    selectSlotForTerminal: (s: typeof helpPanelState, id: string) =>
+      s.terminalId === id && id ? 0 : null,
   };
 });
 
@@ -240,6 +241,7 @@ vi.mock("@/components/ui/ConfirmDialog", () => ({ ConfirmDialog: () => null }));
 vi.mock("../FigureRail", () => ({ FigureRail: () => null }));
 
 import { HelpPanel } from "../HelpPanel";
+import { __resetHelpSessionControllersForTests } from "@/controllers/helpSessionControllerRegistry";
 
 function setAgentState(state: string): void {
   panelStoreState.panelsById = {
@@ -248,6 +250,9 @@ function setAgentState(state: string): void {
 }
 
 beforeEach(() => {
+  // #12108: controllers live in a per-view registry, not component
+  // state, so they outlive a render and must be reset between tests.
+  __resetHelpSessionControllersForTests();
   vi.useFakeTimers();
   handleAgentExitedMock.mockClear();
 

--- a/src/components/HelpPanel/__tests__/HelpPanel.agentSwitch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.agentSwitch.test.tsx
@@ -159,11 +159,12 @@ vi.mock("@/store/helpPanelStore", () => {
     HELP_PANEL_MAX_WIDTH: 800,
     // #12108 selectors. Fixtures stay flat, so these project the same object
     // as the lane and every existing assertion keeps working.
-    selectSlot: (s) => s,
-    selectActiveSlot: (s) => s,
+    selectSlot: (s: typeof helpPanelState) => s,
+    selectActiveSlot: (s: typeof helpPanelState) => s,
     selectOpenSlots: () => [0],
-    selectSlotTerminalIds: (s) => (s.terminalId ? [s.terminalId] : []),
-    selectSlotForTerminal: (s, id) => (s.terminalId === id && id ? 0 : null),
+    selectSlotTerminalIds: (s: typeof helpPanelState) => (s.terminalId ? [s.terminalId] : []),
+    selectSlotForTerminal: (s: typeof helpPanelState, id: string) =>
+      s.terminalId === id && id ? 0 : null,
   };
 });
 
@@ -264,6 +265,7 @@ vi.mock("@/components/ui/ConfirmDialog", () => ({
 vi.mock("../FigureRail", () => ({ FigureRail: () => null }));
 
 import { HelpPanel } from "../HelpPanel";
+import { __resetHelpSessionControllersForTests } from "@/controllers/helpSessionControllerRegistry";
 
 function resetState() {
   helpPanelState.isOpen = true;
@@ -278,6 +280,9 @@ function resetState() {
 }
 
 beforeEach(() => {
+  // #12108: controllers live in a per-view registry, not component
+  // state, so they outlive a render and must be reset between tests.
+  __resetHelpSessionControllersForTests();
   vi.clearAllMocks();
   resetState();
 

--- a/src/components/HelpPanel/__tests__/HelpPanel.agentSwitch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.agentSwitch.test.tsx
@@ -10,6 +10,18 @@ const { controllerSpies, helpPanelState, panelStoreState } = vi.hoisted(() => ({
     newSession: vi.fn(),
   },
   helpPanelState: {
+    clearDroppedPreferredAgent: vi.fn(),
+    setAutoLaunchEnabled: vi.fn(),
+    requestFocus: vi.fn(),
+    setActiveFigureNumber: vi.fn(),
+    addFigure: vi.fn(),
+    setActiveSlot: vi.fn(),
+    closeSlot: vi.fn(),
+    openSlot: vi.fn(),
+    // #12108: the panel reads its lane pointer; the mocked selectors
+    // above project this same flat object as that lane.
+    activeSlot: 0,
+    sessions: {} as Record<number, unknown>,
     isOpen: true,
     width: 380,
     terminalId: null as string | null,
@@ -141,7 +153,18 @@ vi.mock("@/store/helpPanelStore", () => {
   const store = (selector?: (s: typeof helpPanelState) => unknown) =>
     selector ? selector(helpPanelState) : helpPanelState;
   store.getState = () => helpPanelState;
-  return { useHelpPanelStore: store, HELP_PANEL_MIN_WIDTH: 320, HELP_PANEL_MAX_WIDTH: 800 };
+  return {
+    useHelpPanelStore: store,
+    HELP_PANEL_MIN_WIDTH: 320,
+    HELP_PANEL_MAX_WIDTH: 800,
+    // #12108 selectors. Fixtures stay flat, so these project the same object
+    // as the lane and every existing assertion keeps working.
+    selectSlot: (s) => s,
+    selectActiveSlot: (s) => s,
+    selectOpenSlots: () => [0],
+    selectSlotTerminalIds: (s) => (s.terminalId ? [s.terminalId] : []),
+    selectSlotForTerminal: (s, id) => (s.terminalId === id && id ? 0 : null),
+  };
 });
 
 vi.mock("@/store", () => {

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.autoLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.autoLaunch.test.tsx
@@ -68,6 +68,16 @@ const {
     wake: [] as Array<(sleepDurationMs: number) => void>,
   },
   helpPanelState: {
+    clearDroppedPreferredAgent: vi.fn(),
+    requestFocus: vi.fn(),
+    setActiveFigureNumber: vi.fn(),
+    setActiveSlot: vi.fn(),
+    closeSlot: vi.fn(),
+    openSlot: vi.fn(),
+    // #12108: the panel reads its lane pointer; the mocked selectors
+    // above project this same flat object as that lane.
+    activeSlot: 0,
+    sessions: {} as Record<number, unknown>,
     isOpen: true,
     width: 380,
     terminalId: null as string | null,
@@ -291,6 +301,14 @@ vi.mock("@/store/helpPanelStore", () => {
   store.getState = () => helpPanelState;
   return {
     useHelpPanelStore: store,
+    // #12108 selectors. The fixtures below stay FLAT (terminalId/agentId/…)
+    // and these project that same object as the lane, so every existing
+    // assertion keeps driving the controller unchanged.
+    selectSlot: (s) => s,
+    selectActiveSlot: (s) => s,
+    selectOpenSlots: () => [0],
+    selectSlotTerminalIds: (s) => (s.terminalId ? [s.terminalId] : []),
+    selectSlotForTerminal: (s, id) => (s.terminalId === id && id ? 0 : null),
     HELP_PANEL_MIN_WIDTH: 320,
     HELP_PANEL_MAX_WIDTH: 800,
   };
@@ -930,7 +948,7 @@ describe("HelpPanel — auto-launch (preferredAgentId)", () => {
       }),
       { source: "user" }
     );
-    expect(helpPanelState.setTerminal).toHaveBeenCalledWith("codex-term-1", "codex", "sess-codex");
+    expect(helpPanelState.setTerminal).toHaveBeenCalledWith(0, "codex-term-1", "codex", "sess-codex");
   });
 });
 

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.autoLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.autoLaunch.test.tsx
@@ -957,7 +957,12 @@ describe("HelpPanel — auto-launch (preferredAgentId)", () => {
       }),
       { source: "user" }
     );
-    expect(helpPanelState.setTerminal).toHaveBeenCalledWith(0, "codex-term-1", "codex", "sess-codex");
+    expect(helpPanelState.setTerminal).toHaveBeenCalledWith(
+      0,
+      "codex-term-1",
+      "codex",
+      "sess-codex"
+    );
   });
 });
 

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.autoLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.autoLaunch.test.tsx
@@ -304,11 +304,12 @@ vi.mock("@/store/helpPanelStore", () => {
     // #12108 selectors. The fixtures below stay FLAT (terminalId/agentId/…)
     // and these project that same object as the lane, so every existing
     // assertion keeps driving the controller unchanged.
-    selectSlot: (s) => s,
-    selectActiveSlot: (s) => s,
+    selectSlot: (s: typeof helpPanelState) => s,
+    selectActiveSlot: (s: typeof helpPanelState) => s,
     selectOpenSlots: () => [0],
-    selectSlotTerminalIds: (s) => (s.terminalId ? [s.terminalId] : []),
-    selectSlotForTerminal: (s, id) => (s.terminalId === id && id ? 0 : null),
+    selectSlotTerminalIds: (s: typeof helpPanelState) => (s.terminalId ? [s.terminalId] : []),
+    selectSlotForTerminal: (s: typeof helpPanelState, id: string) =>
+      s.terminalId === id && id ? 0 : null,
     HELP_PANEL_MIN_WIDTH: 320,
     HELP_PANEL_MAX_WIDTH: 800,
   };
@@ -437,6 +438,7 @@ vi.mock("@/types", () => ({
 vi.mock("../FigureRail", () => ({ FigureRail: () => null }));
 
 import { HelpPanel } from "../HelpPanel";
+import { __resetHelpSessionControllersForTests } from "@/controllers/helpSessionControllerRegistry";
 
 // The real `app:view-revealed` bridge fans out to every registered listener;
 // HelpPanel registers the switch-back recovery effect against it (#10739).
@@ -539,6 +541,9 @@ afterEach(() => {
 });
 
 beforeEach(() => {
+  // #12108: controllers live in a per-view registry, not component
+  // state, so they outlive a render and must be reset between tests.
+  __resetHelpSessionControllersForTests();
   vi.clearAllMocks();
   resetState();
 
@@ -755,6 +760,7 @@ describe("HelpPanel — auto-launch (preferredAgentId)", () => {
       projectPath: "/repo",
       agentId: "claude",
       context: {},
+      slot: 0,
     });
     expect(mockDispatch).toHaveBeenCalledWith(
       "agent.launch",
@@ -784,6 +790,7 @@ describe("HelpPanel — auto-launch (preferredAgentId)", () => {
       projectPath: "/late-repo",
       agentId: "claude",
       context: {},
+      slot: 0,
     });
     expect(mockDispatch).toHaveBeenCalledWith(
       "agent.launch",
@@ -812,6 +819,7 @@ describe("HelpPanel — auto-launch (preferredAgentId)", () => {
       projectPath: "/scratches/scratch-1",
       agentId: "claude",
       context: {},
+      slot: 0,
     });
     expect(mockDispatch).toHaveBeenCalledWith(
       "agent.launch",
@@ -935,6 +943,7 @@ describe("HelpPanel — auto-launch (preferredAgentId)", () => {
       projectPath: "/repo",
       agentId: "codex",
       context: {},
+      slot: 0,
     });
     expect(mockDispatch).toHaveBeenCalledWith(
       "agent.launch",

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.emptyStateCustomArgs.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.emptyStateCustomArgs.test.tsx
@@ -67,6 +67,16 @@ const {
     wake: [] as Array<(sleepDurationMs: number) => void>,
   },
   helpPanelState: {
+    clearDroppedPreferredAgent: vi.fn(),
+    requestFocus: vi.fn(),
+    setActiveFigureNumber: vi.fn(),
+    setActiveSlot: vi.fn(),
+    closeSlot: vi.fn(),
+    openSlot: vi.fn(),
+    // #12108: the panel reads its lane pointer; the mocked selectors
+    // above project this same flat object as that lane.
+    activeSlot: 0,
+    sessions: {} as Record<number, unknown>,
     isOpen: true,
     width: 380,
     terminalId: null as string | null,
@@ -287,6 +297,14 @@ vi.mock("@/store/helpPanelStore", () => {
   store.getState = () => helpPanelState;
   return {
     useHelpPanelStore: store,
+    // #12108 selectors. The fixtures below stay FLAT (terminalId/agentId/…)
+    // and these project that same object as the lane, so every existing
+    // assertion keeps driving the controller unchanged.
+    selectSlot: (s) => s,
+    selectActiveSlot: (s) => s,
+    selectOpenSlots: () => [0],
+    selectSlotTerminalIds: (s) => (s.terminalId ? [s.terminalId] : []),
+    selectSlotForTerminal: (s, id) => (s.terminalId === id && id ? 0 : null),
     HELP_PANEL_MIN_WIDTH: 320,
     HELP_PANEL_MAX_WIDTH: 800,
   };
@@ -925,7 +943,7 @@ describe("HelpPanel — customArgs threading", () => {
       expect.not.objectContaining({ agentLaunchFlags: expect.anything() }),
       { source: "user" }
     );
-    expect(helpPanelState.setTerminal).toHaveBeenCalledWith("term-1", "claude", "sess-default");
+    expect(helpPanelState.setTerminal).toHaveBeenCalledWith(0, "term-1", "claude", "sess-default");
   });
 });
 

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.emptyStateCustomArgs.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.emptyStateCustomArgs.test.tsx
@@ -300,11 +300,12 @@ vi.mock("@/store/helpPanelStore", () => {
     // #12108 selectors. The fixtures below stay FLAT (terminalId/agentId/…)
     // and these project that same object as the lane, so every existing
     // assertion keeps driving the controller unchanged.
-    selectSlot: (s) => s,
-    selectActiveSlot: (s) => s,
+    selectSlot: (s: typeof helpPanelState) => s,
+    selectActiveSlot: (s: typeof helpPanelState) => s,
     selectOpenSlots: () => [0],
-    selectSlotTerminalIds: (s) => (s.terminalId ? [s.terminalId] : []),
-    selectSlotForTerminal: (s, id) => (s.terminalId === id && id ? 0 : null),
+    selectSlotTerminalIds: (s: typeof helpPanelState) => (s.terminalId ? [s.terminalId] : []),
+    selectSlotForTerminal: (s: typeof helpPanelState, id: string) =>
+      s.terminalId === id && id ? 0 : null,
     HELP_PANEL_MIN_WIDTH: 320,
     HELP_PANEL_MAX_WIDTH: 800,
   };
@@ -425,6 +426,7 @@ vi.mock("../FigureRail", () => ({ FigureRail: () => null }));
 
 import { HelpPanel } from "../HelpPanel";
 import { useEscapeStack } from "@/hooks/useEscapeStack";
+import { __resetHelpSessionControllersForTests } from "@/controllers/helpSessionControllerRegistry";
 
 // The real `app:view-revealed` bridge fans out to every registered listener;
 // HelpPanel registers the switch-back recovery effect against it (#10739).
@@ -526,6 +528,9 @@ afterEach(() => {
 });
 
 beforeEach(() => {
+  // #12108: controllers live in a per-view registry, not component
+  // state, so they outlive a render and must be reset between tests.
+  __resetHelpSessionControllersForTests();
   vi.clearAllMocks();
   resetState();
 

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.persistenceHibernation.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.persistenceHibernation.test.tsx
@@ -300,11 +300,12 @@ vi.mock("@/store/helpPanelStore", () => {
     // #12108 selectors. The fixtures below stay FLAT (terminalId/agentId/…)
     // and these project that same object as the lane, so every existing
     // assertion keeps driving the controller unchanged.
-    selectSlot: (s) => s,
-    selectActiveSlot: (s) => s,
+    selectSlot: (s: typeof helpPanelState) => s,
+    selectActiveSlot: (s: typeof helpPanelState) => s,
     selectOpenSlots: () => [0],
-    selectSlotTerminalIds: (s) => (s.terminalId ? [s.terminalId] : []),
-    selectSlotForTerminal: (s, id) => (s.terminalId === id && id ? 0 : null),
+    selectSlotTerminalIds: (s: typeof helpPanelState) => (s.terminalId ? [s.terminalId] : []),
+    selectSlotForTerminal: (s: typeof helpPanelState, id: string) =>
+      s.terminalId === id && id ? 0 : null,
     HELP_PANEL_MIN_WIDTH: 320,
     HELP_PANEL_MAX_WIDTH: 800,
   };
@@ -424,6 +425,8 @@ vi.mock("@/types", () => ({
 vi.mock("../FigureRail", () => ({ FigureRail: () => null }));
 
 import { HelpPanel } from "../HelpPanel";
+import { assistantSlotKey as slotKey } from "@shared/config/assistantSlots";
+import { __resetHelpSessionControllersForTests } from "@/controllers/helpSessionControllerRegistry";
 
 // The real `app:view-revealed` bridge fans out to every registered listener;
 // HelpPanel registers the switch-back recovery effect against it (#10739).
@@ -530,6 +533,9 @@ afterEach(() => {
 });
 
 beforeEach(() => {
+  // #12108: controllers live in a per-view registry, not component
+  // state, so they outlive a render and must be reset between tests.
+  __resetHelpSessionControllersForTests();
   vi.clearAllMocks();
   resetState();
 
@@ -1002,8 +1008,8 @@ describe("HelpPanel — resume from main-captured hibernation (eviction recovery
     // observes the entry the controller just merged. Default mock just
     // tracks the call; here we also write through to the in-memory state.
     helpPanelState.setHibernateSession = vi.fn(
-      (projectId: string, entry: { sessionId: string; cwd: string; agentId: string }) => {
-        helpPanelState.hibernateSessions[projectId] = entry;
+      (projectId: string, slot: number, entry: { sessionId: string; cwd: string; agentId: string }) => {
+        helpPanelState.hibernateSessions[slotKey(projectId, slot)] = entry;
       }
     );
     panelStoreState.addPanel.mockResolvedValueOnce("term-resumed");
@@ -1019,9 +1025,13 @@ describe("HelpPanel — resume from main-captured hibernation (eviction recovery
       await Promise.resolve();
     });
 
-    expect(mockTakePendingHibernation).toHaveBeenCalledWith(projectStoreState.currentProject?.id);
+    expect(mockTakePendingHibernation).toHaveBeenCalledWith(
+      projectStoreState.currentProject?.id,
+      0
+    );
     expect(helpPanelState.setHibernateSession).toHaveBeenCalledWith(
       projectStoreState.currentProject?.id,
+      0,
       expect.objectContaining({
         sessionId: "resume-id-from-main",
         agentId: "claude",
@@ -1045,7 +1055,8 @@ describe("HelpPanel — resume from main-captured hibernation (eviction recovery
     );
     // Resume consumes the hibernate entry once committed.
     expect(helpPanelState.clearHibernateSession).toHaveBeenCalledWith(
-      projectStoreState.currentProject?.id
+      projectStoreState.currentProject?.id,
+      0
     );
   });
 
@@ -1068,8 +1079,8 @@ describe("HelpPanel — resume from main-captured hibernation (eviction recovery
       cwd: "/help/session-dir",
     });
     helpPanelState.setHibernateSession = vi.fn(
-      (projectId: string, entry: { sessionId: string; cwd: string; agentId: string }) => {
-        helpPanelState.hibernateSessions[projectId] = entry;
+      (projectId: string, slot: number, entry: { sessionId: string; cwd: string; agentId: string }) => {
+        helpPanelState.hibernateSessions[slotKey(projectId, slot)] = entry;
       }
     );
     panelStoreState.addPanel.mockResolvedValueOnce("term-resumed-latest");
@@ -1087,6 +1098,7 @@ describe("HelpPanel — resume from main-captured hibernation (eviction recovery
 
     expect(helpPanelState.setHibernateSession).toHaveBeenCalledWith(
       projectStoreState.currentProject?.id,
+      0,
       expect.objectContaining({ sessionId: "", agentId: "claude" })
     );
     // Resume-latest spawns through addPanel with the `--continue` flag.

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.persistenceHibernation.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.persistenceHibernation.test.tsx
@@ -1008,7 +1008,11 @@ describe("HelpPanel — resume from main-captured hibernation (eviction recovery
     // observes the entry the controller just merged. Default mock just
     // tracks the call; here we also write through to the in-memory state.
     helpPanelState.setHibernateSession = vi.fn(
-      (projectId: string, slot: number, entry: { sessionId: string; cwd: string; agentId: string }) => {
+      (
+        projectId: string,
+        slot: number,
+        entry: { sessionId: string; cwd: string; agentId: string }
+      ) => {
         helpPanelState.hibernateSessions[slotKey(projectId, slot)] = entry;
       }
     );
@@ -1079,7 +1083,11 @@ describe("HelpPanel — resume from main-captured hibernation (eviction recovery
       cwd: "/help/session-dir",
     });
     helpPanelState.setHibernateSession = vi.fn(
-      (projectId: string, slot: number, entry: { sessionId: string; cwd: string; agentId: string }) => {
+      (
+        projectId: string,
+        slot: number,
+        entry: { sessionId: string; cwd: string; agentId: string }
+      ) => {
         helpPanelState.hibernateSessions[slotKey(projectId, slot)] = entry;
       }
     );

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.persistenceHibernation.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.persistenceHibernation.test.tsx
@@ -67,6 +67,16 @@ const {
     wake: [] as Array<(sleepDurationMs: number) => void>,
   },
   helpPanelState: {
+    clearDroppedPreferredAgent: vi.fn(),
+    requestFocus: vi.fn(),
+    setActiveFigureNumber: vi.fn(),
+    setActiveSlot: vi.fn(),
+    closeSlot: vi.fn(),
+    openSlot: vi.fn(),
+    // #12108: the panel reads its lane pointer; the mocked selectors
+    // above project this same flat object as that lane.
+    activeSlot: 0,
+    sessions: {} as Record<number, unknown>,
     isOpen: true,
     width: 380,
     terminalId: null as string | null,
@@ -287,6 +297,14 @@ vi.mock("@/store/helpPanelStore", () => {
   store.getState = () => helpPanelState;
   return {
     useHelpPanelStore: store,
+    // #12108 selectors. The fixtures below stay FLAT (terminalId/agentId/…)
+    // and these project that same object as the lane, so every existing
+    // assertion keeps driving the controller unchanged.
+    selectSlot: (s) => s,
+    selectActiveSlot: (s) => s,
+    selectOpenSlots: () => [0],
+    selectSlotTerminalIds: (s) => (s.terminalId ? [s.terminalId] : []),
+    selectSlotForTerminal: (s, id) => (s.terminalId === id && id ? 0 : null),
     HELP_PANEL_MIN_WIDTH: 320,
     HELP_PANEL_MAX_WIDTH: 800,
   };

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.runAnywayProvisioning.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.runAnywayProvisioning.test.tsx
@@ -300,11 +300,12 @@ vi.mock("@/store/helpPanelStore", () => {
     // #12108 selectors. The fixtures below stay FLAT (terminalId/agentId/…)
     // and these project that same object as the lane, so every existing
     // assertion keeps driving the controller unchanged.
-    selectSlot: (s) => s,
-    selectActiveSlot: (s) => s,
+    selectSlot: (s: typeof helpPanelState) => s,
+    selectActiveSlot: (s: typeof helpPanelState) => s,
     selectOpenSlots: () => [0],
-    selectSlotTerminalIds: (s) => (s.terminalId ? [s.terminalId] : []),
-    selectSlotForTerminal: (s, id) => (s.terminalId === id && id ? 0 : null),
+    selectSlotTerminalIds: (s: typeof helpPanelState) => (s.terminalId ? [s.terminalId] : []),
+    selectSlotForTerminal: (s: typeof helpPanelState, id: string) =>
+      s.terminalId === id && id ? 0 : null,
     HELP_PANEL_MIN_WIDTH: 320,
     HELP_PANEL_MAX_WIDTH: 800,
   };
@@ -424,6 +425,7 @@ vi.mock("@/types", () => ({
 vi.mock("../FigureRail", () => ({ FigureRail: () => null }));
 
 import { HelpPanel } from "../HelpPanel";
+import { __resetHelpSessionControllersForTests } from "@/controllers/helpSessionControllerRegistry";
 
 // The real `app:view-revealed` bridge fans out to every registered listener;
 // HelpPanel registers the switch-back recovery effect against it (#10739).
@@ -525,6 +527,9 @@ afterEach(() => {
 });
 
 beforeEach(() => {
+  // #12108: controllers live in a per-view registry, not component
+  // state, so they outlive a render and must be reset between tests.
+  __resetHelpSessionControllersForTests();
   vi.clearAllMocks();
   resetState();
 
@@ -890,6 +895,7 @@ describe("HelpPanel — session provisioning", () => {
       projectPath: "/repo",
       agentId: "claude",
       context: {},
+      slot: 0,
     });
     expect(mockDispatch).toHaveBeenCalledWith(
       "agent.launch",

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.runAnywayProvisioning.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.runAnywayProvisioning.test.tsx
@@ -67,6 +67,16 @@ const {
     wake: [] as Array<(sleepDurationMs: number) => void>,
   },
   helpPanelState: {
+    clearDroppedPreferredAgent: vi.fn(),
+    requestFocus: vi.fn(),
+    setActiveFigureNumber: vi.fn(),
+    setActiveSlot: vi.fn(),
+    closeSlot: vi.fn(),
+    openSlot: vi.fn(),
+    // #12108: the panel reads its lane pointer; the mocked selectors
+    // above project this same flat object as that lane.
+    activeSlot: 0,
+    sessions: {} as Record<number, unknown>,
     isOpen: true,
     width: 380,
     terminalId: null as string | null,
@@ -287,6 +297,14 @@ vi.mock("@/store/helpPanelStore", () => {
   store.getState = () => helpPanelState;
   return {
     useHelpPanelStore: store,
+    // #12108 selectors. The fixtures below stay FLAT (terminalId/agentId/…)
+    // and these project that same object as the lane, so every existing
+    // assertion keeps driving the controller unchanged.
+    selectSlot: (s) => s,
+    selectActiveSlot: (s) => s,
+    selectOpenSlots: () => [0],
+    selectSlotTerminalIds: (s) => (s.terminalId ? [s.terminalId] : []),
+    selectSlotForTerminal: (s, id) => (s.terminalId === id && id ? 0 : null),
     HELP_PANEL_MIN_WIDTH: 320,
     HELP_PANEL_MAX_WIDTH: 800,
   };
@@ -640,6 +658,7 @@ describe("HelpPanel — handleRunAnyway", () => {
       { source: "user" }
     );
     expect(helpPanelState.setTerminal).toHaveBeenCalledWith(
+      0,
       "terminal-restarted",
       "claude",
       "sess-default"
@@ -676,6 +695,7 @@ describe("HelpPanel — handleRunAnyway", () => {
     // when dispatch returned !ok — so no second setTerminal call carrying a session id.
     expect(helpPanelState.setTerminal).toHaveBeenCalledTimes(1);
     expect(helpPanelState.setTerminal).toHaveBeenCalledWith(
+      0,
       expect.stringMatching(/^terminal-/),
       "claude",
       null
@@ -724,7 +744,7 @@ describe("HelpPanel — handleRunAnyway", () => {
 
     // setTerminal fired with the pre-generated id while dispatch is still pending.
     expect(capturedRequestedId).toMatch(/^terminal-/);
-    expect(helpPanelState.setTerminal).toHaveBeenCalledWith(capturedRequestedId, "claude", null);
+    expect(helpPanelState.setTerminal).toHaveBeenCalledWith(0, capturedRequestedId, "claude", null);
 
     await act(async () => {
       resolveDispatch({ ok: true, result: { terminalId: capturedRequestedId! } });
@@ -884,7 +904,7 @@ describe("HelpPanel — session provisioning", () => {
       }),
       { source: "user" }
     );
-    expect(helpPanelState.setTerminal).toHaveBeenCalledWith("term-1", "claude", "sess-1");
+    expect(helpPanelState.setTerminal).toHaveBeenCalledWith(0, "term-1", "claude", "sess-1");
   });
 
   it("omits DAINTREE_MCP_URL when mcpUrl is null (daintreeControl=false)", async () => {
@@ -982,6 +1002,7 @@ describe("HelpPanel — hasAutoLaunched stale reset (regression)", () => {
     });
 
     expect(helpPanelState.setTerminal).toHaveBeenCalledWith(
+      0,
       "term-gemini",
       "gemini",
       "sess-default"
@@ -1007,6 +1028,7 @@ describe("HelpPanel — single-supported-agent auto-skip (issue #6612)", () => {
       { source: "user" }
     );
     expect(helpPanelState.setTerminal).toHaveBeenCalledWith(
+      0,
       "auto-skip-term",
       "claude",
       "sess-default"

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.sessionResetStop.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.sessionResetStop.test.tsx
@@ -76,7 +76,10 @@ const {
     // #12108: the panel reads its lane pointer; the mocked selectors
     // above project this same flat object as that lane.
     activeSlot: 0,
-    sessions: {} as Record<number, unknown>,
+    sessions: {} as Record<number, Record<string, unknown>>,
+    // #12108: which lanes the tab strip renders. Stays [0] for every
+    // single-lane case; the parallel-lane suite below widens it.
+    openSlots: [0] as number[],
     isOpen: true,
     width: 380,
     terminalId: null as string | null,
@@ -300,9 +303,12 @@ vi.mock("@/store/helpPanelStore", () => {
     // #12108 selectors. The fixtures below stay FLAT (terminalId/agentId/…)
     // and these project that same object as the lane, so every existing
     // assertion keeps driving the controller unchanged.
-    selectSlot: (s: typeof helpPanelState) => s,
+    // The active lane is the flat fixture; a background lane comes from
+    // `sessions[slot]`, which only the parallel-lane suite populates.
+    selectSlot: (s: typeof helpPanelState, slot: number) =>
+      slot === s.activeSlot ? s : ((s.sessions[slot] as typeof s) ?? s),
     selectActiveSlot: (s: typeof helpPanelState) => s,
-    selectOpenSlots: () => [0],
+    selectOpenSlots: (s: typeof helpPanelState) => s.openSlots,
     selectSlotTerminalIds: (s: typeof helpPanelState) => (s.terminalId ? [s.terminalId] : []),
     selectSlotForTerminal: (s: typeof helpPanelState, id: string) =>
       s.terminalId === id && id ? 0 : null,
@@ -425,7 +431,10 @@ vi.mock("@/types", () => ({
 vi.mock("../FigureRail", () => ({ FigureRail: () => null }));
 
 import { HelpPanel } from "../HelpPanel";
-import { __resetHelpSessionControllersForTests } from "@/controllers/helpSessionControllerRegistry";
+import {
+  __resetHelpSessionControllersForTests,
+  acquireHelpSessionController,
+} from "@/controllers/helpSessionControllerRegistry";
 
 // The real `app:view-revealed` bridge fans out to every registered listener;
 // HelpPanel registers the switch-back recovery effect against it (#10739).
@@ -444,6 +453,11 @@ function resetState() {
   helpPanelState.conversationTouched = false;
   helpPanelState.hibernateSessions = {};
   helpPanelState.figures = [];
+  helpPanelState.sessions = {};
+  helpPanelState.openSlots = [0];
+  helpPanelState.activeSlot = 0;
+  helpPanelState.closeSlot = vi.fn();
+  helpPanelState.openSlot = vi.fn();
   helpPanelState.markConversationStarted = vi.fn();
   helpPanelState.setTerminal = vi.fn();
   helpPanelState.setOpen = vi.fn();
@@ -1143,5 +1157,122 @@ describe("HelpPanel — Stop assistant (end session, #10989)", () => {
       "sess-fresh"
     );
     expect(panelStoreState.removePanel).toHaveBeenCalledWith(reservedId);
+  });
+});
+
+describe("HelpPanel — closing one parallel lane (#12108)", () => {
+  // Two live lanes: slot 0 on screen (the flat fixture) and slot 1 behind the
+  // tab strip. `sessions` is what the close path and the per-lane state marker
+  // read, so both lanes have to appear there.
+  function setupTwoLanes(opts: { backgroundAgentState?: string } = {}) {
+    projectStoreState.currentProject = { id: "proj-1", path: "/repo" };
+    helpPanelState.terminalId = "term-1";
+    helpPanelState.agentId = "claude";
+    helpPanelState.sessionId = "sess-front";
+    helpPanelState.activeSlot = 0;
+    helpPanelState.openSlots = [0, 1];
+    helpPanelState.sessions = {
+      0: {
+        terminalId: "term-1",
+        agentId: "claude",
+        sessionId: "sess-front",
+        conversationTouched: false,
+        figures: [],
+        activeFigureNumber: null,
+      },
+      1: {
+        terminalId: "term-2",
+        agentId: "claude",
+        sessionId: "sess-back",
+        conversationTouched: false,
+        figures: [],
+        activeFigureNumber: null,
+      },
+    };
+    panelStoreState.panelsById = {
+      "term-1": {
+        id: "term-1",
+        kind: "terminal",
+        spawnStatus: "ready",
+        cwd: "/help",
+        title: "Claude",
+        command: "claude",
+        location: "dock",
+        agentState: "idle",
+      },
+      "term-2": {
+        id: "term-2",
+        kind: "terminal",
+        spawnStatus: "ready",
+        cwd: "/help",
+        title: "Claude",
+        command: "claude",
+        location: "dock",
+        agentState: opts.backgroundAgentState ?? "idle",
+      },
+    };
+  }
+
+  function closeButtonFor(container: HTMLElement, label: string): HTMLButtonElement {
+    const button = container.querySelector<HTMLButtonElement>(
+      `button[aria-label="Close ${label}"]`
+    );
+    if (!button) throw new Error(`no close button for ${label}`);
+    return button;
+  }
+
+  it("tears down only the closed lane and leaves the panel open on the survivor", () => {
+    setupTwoLanes();
+    const survivor = acquireHelpSessionController(0);
+    const closing = acquireHelpSessionController(1);
+
+    const { container } = render(<HelpPanel width={380} />);
+    fireEvent.click(closeButtonFor(container, "Session 2"));
+
+    // The closed lane's backend is gone…
+    expect(mockRevokeSession).toHaveBeenCalledWith("sess-back");
+    expect(panelStoreState.removePanel).toHaveBeenCalledWith("term-2");
+    expect(helpPanelState.closeSlot).toHaveBeenCalledWith(1);
+    // …its controller was released, so a later acquire mints a fresh one…
+    expect(acquireHelpSessionController(1)).not.toBe(closing);
+    // …while the surviving lane keeps its running session AND its controller…
+    expect(mockRevokeSession).not.toHaveBeenCalledWith("sess-front");
+    expect(panelStoreState.removePanel).not.toHaveBeenCalledWith("term-1");
+    expect(acquireHelpSessionController(0)).toBe(survivor);
+    // …and the sidebar does not slide shut on it (#12108).
+    expect(helpPanelState.setOpen).not.toHaveBeenCalledWith(false);
+  });
+
+  it("confirms before closing a lane whose agent is working, gated on THAT lane", () => {
+    setupTwoLanes({ backgroundAgentState: "working" });
+
+    const { container, getByTestId } = render(<HelpPanel width={380} />);
+    fireEvent.click(closeButtonFor(container, "Session 2"));
+
+    // Nothing torn down until the user answers.
+    expect(mockRevokeSession).not.toHaveBeenCalled();
+    expect(helpPanelState.closeSlot).not.toHaveBeenCalled();
+    expect(getByTestId("dialog-title").textContent).toBe("Close Session 2?");
+    expect(getByTestId("dialog-confirm").textContent).toBe("Close session");
+    expect(getByTestId("dialog-description").textContent).toContain(
+      "the conversation will be discarded"
+    );
+
+    fireEvent.click(getByTestId("dialog-confirm"));
+    expect(mockRevokeSession).toHaveBeenCalledWith("sess-back");
+    expect(helpPanelState.closeSlot).toHaveBeenCalledWith(1);
+  });
+
+  it("keeps the lane when the close confirm is cancelled", () => {
+    setupTwoLanes({ backgroundAgentState: "working" });
+
+    const { container, getByTestId, queryByTestId } = render(<HelpPanel width={380} />);
+    fireEvent.click(closeButtonFor(container, "Session 2"));
+    fireEvent.click(getByTestId("dialog-cancel"));
+
+    expect(queryByTestId("confirm-dialog")).toBeNull();
+    expect(mockRevokeSession).not.toHaveBeenCalled();
+    expect(panelStoreState.removePanel).not.toHaveBeenCalled();
+    expect(helpPanelState.closeSlot).not.toHaveBeenCalled();
   });
 });

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.sessionResetStop.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.sessionResetStop.test.tsx
@@ -1136,7 +1136,12 @@ describe("HelpPanel — Stop assistant (end session, #10989)", () => {
 
     // The superseded launch bailed: it never bound the fresh session and cleaned
     // up the orphaned terminal instead.
-    expect(helpPanelState.setTerminal).not.toHaveBeenCalledWith(0, reservedId, "claude", "sess-fresh");
+    expect(helpPanelState.setTerminal).not.toHaveBeenCalledWith(
+      0,
+      reservedId,
+      "claude",
+      "sess-fresh"
+    );
     expect(panelStoreState.removePanel).toHaveBeenCalledWith(reservedId);
   });
 });

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.sessionResetStop.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.sessionResetStop.test.tsx
@@ -300,11 +300,12 @@ vi.mock("@/store/helpPanelStore", () => {
     // #12108 selectors. The fixtures below stay FLAT (terminalId/agentId/…)
     // and these project that same object as the lane, so every existing
     // assertion keeps driving the controller unchanged.
-    selectSlot: (s) => s,
-    selectActiveSlot: (s) => s,
+    selectSlot: (s: typeof helpPanelState) => s,
+    selectActiveSlot: (s: typeof helpPanelState) => s,
     selectOpenSlots: () => [0],
-    selectSlotTerminalIds: (s) => (s.terminalId ? [s.terminalId] : []),
-    selectSlotForTerminal: (s, id) => (s.terminalId === id && id ? 0 : null),
+    selectSlotTerminalIds: (s: typeof helpPanelState) => (s.terminalId ? [s.terminalId] : []),
+    selectSlotForTerminal: (s: typeof helpPanelState, id: string) =>
+      s.terminalId === id && id ? 0 : null,
     HELP_PANEL_MIN_WIDTH: 320,
     HELP_PANEL_MAX_WIDTH: 800,
   };
@@ -424,6 +425,7 @@ vi.mock("@/types", () => ({
 vi.mock("../FigureRail", () => ({ FigureRail: () => null }));
 
 import { HelpPanel } from "../HelpPanel";
+import { __resetHelpSessionControllersForTests } from "@/controllers/helpSessionControllerRegistry";
 
 // The real `app:view-revealed` bridge fans out to every registered listener;
 // HelpPanel registers the switch-back recovery effect against it (#10739).
@@ -525,6 +527,9 @@ afterEach(() => {
 });
 
 beforeEach(() => {
+  // #12108: controllers live in a per-view registry, not component
+  // state, so they outlive a render and must be reset between tests.
+  __resetHelpSessionControllersForTests();
   vi.clearAllMocks();
   resetState();
 
@@ -839,7 +844,7 @@ describe("HelpPanel — + New session destructive reset", () => {
     // setTerminal must NOT be called again with a session id.
     const setCalls = (helpPanelState.setTerminal as ReturnType<typeof vi.fn>).mock.calls;
     expect(setCalls.length).toBe(1);
-    expect(setCalls[0]?.[2]).toBeNull();
+    expect(setCalls[0]?.[3]).toBeNull();
     expect(helpPanelState.clearTerminal).toHaveBeenCalled();
     expect(screen.getByTestId("help-launch-error-banner")).toBeTruthy();
     expect(mockNotify).not.toHaveBeenCalled();
@@ -874,7 +879,7 @@ describe("HelpPanel — + New session destructive reset", () => {
 
     helpPanelState.setTerminal = vi
       .fn()
-      .mockImplementation((tId: string, aId: string, sId: string | null) => {
+      .mockImplementation((_slot: number, tId: string, aId: string, sId: string | null) => {
         helpPanelState.terminalId = tId;
         helpPanelState.agentId = aId;
         helpPanelState.sessionId = sId;

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.sessionResetStop.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.sessionResetStop.test.tsx
@@ -67,6 +67,16 @@ const {
     wake: [] as Array<(sleepDurationMs: number) => void>,
   },
   helpPanelState: {
+    clearDroppedPreferredAgent: vi.fn(),
+    requestFocus: vi.fn(),
+    setActiveFigureNumber: vi.fn(),
+    setActiveSlot: vi.fn(),
+    closeSlot: vi.fn(),
+    openSlot: vi.fn(),
+    // #12108: the panel reads its lane pointer; the mocked selectors
+    // above project this same flat object as that lane.
+    activeSlot: 0,
+    sessions: {} as Record<number, unknown>,
     isOpen: true,
     width: 380,
     terminalId: null as string | null,
@@ -287,6 +297,14 @@ vi.mock("@/store/helpPanelStore", () => {
   store.getState = () => helpPanelState;
   return {
     useHelpPanelStore: store,
+    // #12108 selectors. The fixtures below stay FLAT (terminalId/agentId/…)
+    // and these project that same object as the lane, so every existing
+    // assertion keeps driving the controller unchanged.
+    selectSlot: (s) => s,
+    selectActiveSlot: (s) => s,
+    selectOpenSlots: () => [0],
+    selectSlotTerminalIds: (s) => (s.terminalId ? [s.terminalId] : []),
+    selectSlotForTerminal: (s, id) => (s.terminalId === id && id ? 0 : null),
     HELP_PANEL_MIN_WIDTH: 320,
     HELP_PANEL_MAX_WIDTH: 800,
   };
@@ -664,6 +682,7 @@ describe("HelpPanel — + New session destructive reset", () => {
       { source: "user" }
     );
     expect(helpPanelState.setTerminal).toHaveBeenCalledWith(
+      0,
       "terminal-fresh",
       "claude",
       "sess-fresh"
@@ -730,6 +749,7 @@ describe("HelpPanel — + New session destructive reset", () => {
     expect(mockRevokeSession).toHaveBeenCalledWith("sess-bound");
     expect(helpPanelState.clearTerminal).toHaveBeenCalled();
     expect(helpPanelState.setTerminal).toHaveBeenCalledWith(
+      0,
       "terminal-fresh",
       "claude",
       "sess-fresh"
@@ -764,7 +784,7 @@ describe("HelpPanel — + New session destructive reset", () => {
       mockDispatch.mock.calls[0]?.[1] as { requestedId?: string } | undefined
     )?.requestedId;
     expect(capturedRequestedId).toMatch(/^terminal-/);
-    expect(helpPanelState.setTerminal).toHaveBeenCalledWith(capturedRequestedId, "claude", null);
+    expect(helpPanelState.setTerminal).toHaveBeenCalledWith(0, capturedRequestedId, "claude", null);
 
     await act(async () => {
       resolveDispatch({ ok: true, result: { terminalId: capturedRequestedId! } });
@@ -998,7 +1018,7 @@ describe("HelpPanel — Stop assistant (end session, #10989)", () => {
     expect(helpPanelState.clearTerminal).toHaveBeenCalled();
     expect(helpPanelState.clearFigures).toHaveBeenCalled();
     // …the persisted hibernate entry is dropped so a stop can't be resumed…
-    expect(helpPanelState.clearHibernateSession).toHaveBeenCalledWith("proj-1");
+    expect(helpPanelState.clearHibernateSession).toHaveBeenCalledWith("proj-1", 0);
     // …and, unlike + New session, no fresh agent is launched.
     expect(mockDispatch).not.toHaveBeenCalledWith(
       "agent.launch",
@@ -1058,7 +1078,7 @@ describe("HelpPanel — Stop assistant (end session, #10989)", () => {
     expect(panelStoreState.removePanel).toHaveBeenCalledWith("term-1");
     expect(mockRevokeSession).toHaveBeenCalledWith("sess-bound");
     expect(helpPanelState.clearTerminal).toHaveBeenCalled();
-    expect(helpPanelState.clearHibernateSession).toHaveBeenCalledWith("proj-1");
+    expect(helpPanelState.clearHibernateSession).toHaveBeenCalledWith("proj-1", 0);
     expect(mockDispatch).not.toHaveBeenCalledWith(
       "agent.launch",
       expect.anything(),
@@ -1111,7 +1131,7 @@ describe("HelpPanel — Stop assistant (end session, #10989)", () => {
 
     // The superseded launch bailed: it never bound the fresh session and cleaned
     // up the orphaned terminal instead.
-    expect(helpPanelState.setTerminal).not.toHaveBeenCalledWith(reservedId, "claude", "sess-fresh");
+    expect(helpPanelState.setTerminal).not.toHaveBeenCalledWith(0, reservedId, "claude", "sess-fresh");
     expect(panelStoreState.removePanel).toHaveBeenCalledWith(reservedId);
   });
 });

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.versionGateInput.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.versionGateInput.test.tsx
@@ -300,11 +300,12 @@ vi.mock("@/store/helpPanelStore", () => {
     // #12108 selectors. The fixtures below stay FLAT (terminalId/agentId/…)
     // and these project that same object as the lane, so every existing
     // assertion keeps driving the controller unchanged.
-    selectSlot: (s) => s,
-    selectActiveSlot: (s) => s,
+    selectSlot: (s: typeof helpPanelState) => s,
+    selectActiveSlot: (s: typeof helpPanelState) => s,
     selectOpenSlots: () => [0],
-    selectSlotTerminalIds: (s) => (s.terminalId ? [s.terminalId] : []),
-    selectSlotForTerminal: (s, id) => (s.terminalId === id && id ? 0 : null),
+    selectSlotTerminalIds: (s: typeof helpPanelState) => (s.terminalId ? [s.terminalId] : []),
+    selectSlotForTerminal: (s: typeof helpPanelState, id: string) =>
+      s.terminalId === id && id ? 0 : null,
     HELP_PANEL_MIN_WIDTH: 320,
     HELP_PANEL_MAX_WIDTH: 800,
   };
@@ -425,6 +426,7 @@ vi.mock("../FigureRail", () => ({ FigureRail: () => null }));
 
 import { HelpPanel } from "../HelpPanel";
 import { useEscapeStack } from "@/hooks/useEscapeStack";
+import { __resetHelpSessionControllersForTests } from "@/controllers/helpSessionControllerRegistry";
 
 // The real `app:view-revealed` bridge fans out to every registered listener;
 // HelpPanel registers the switch-back recovery effect against it (#10739).
@@ -526,6 +528,9 @@ afterEach(() => {
 });
 
 beforeEach(() => {
+  // #12108: controllers live in a per-view registry, not component
+  // state, so they outlive a render and must be reset between tests.
+  __resetHelpSessionControllersForTests();
   vi.clearAllMocks();
   resetState();
 

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.versionGateInput.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.versionGateInput.test.tsx
@@ -67,6 +67,16 @@ const {
     wake: [] as Array<(sleepDurationMs: number) => void>,
   },
   helpPanelState: {
+    clearDroppedPreferredAgent: vi.fn(),
+    requestFocus: vi.fn(),
+    setActiveFigureNumber: vi.fn(),
+    setActiveSlot: vi.fn(),
+    closeSlot: vi.fn(),
+    openSlot: vi.fn(),
+    // #12108: the panel reads its lane pointer; the mocked selectors
+    // above project this same flat object as that lane.
+    activeSlot: 0,
+    sessions: {} as Record<number, unknown>,
     isOpen: true,
     width: 380,
     terminalId: null as string | null,
@@ -287,6 +297,14 @@ vi.mock("@/store/helpPanelStore", () => {
   store.getState = () => helpPanelState;
   return {
     useHelpPanelStore: store,
+    // #12108 selectors. The fixtures below stay FLAT (terminalId/agentId/…)
+    // and these project that same object as the lane, so every existing
+    // assertion keeps driving the controller unchanged.
+    selectSlot: (s) => s,
+    selectActiveSlot: (s) => s,
+    selectOpenSlots: () => [0],
+    selectSlotTerminalIds: (s) => (s.terminalId ? [s.terminalId] : []),
+    selectSlotForTerminal: (s, id) => (s.terminalId === id && id ? 0 : null),
     HELP_PANEL_MIN_WIDTH: 320,
     HELP_PANEL_MAX_WIDTH: 800,
   };

--- a/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
@@ -266,11 +266,12 @@ vi.mock("@/store/helpPanelStore", () => {
     // #12108 selectors. The fixtures below stay FLAT (terminalId/agentId/…)
     // and these project that same object as the lane, so every existing
     // assertion keeps driving the controller unchanged.
-    selectSlot: (s) => s,
-    selectActiveSlot: (s) => s,
+    selectSlot: (s: typeof helpPanelState) => s,
+    selectActiveSlot: (s: typeof helpPanelState) => s,
     selectOpenSlots: () => [0],
-    selectSlotTerminalIds: (s) => (s.terminalId ? [s.terminalId] : []),
-    selectSlotForTerminal: (s, id) => (s.terminalId === id && id ? 0 : null),
+    selectSlotTerminalIds: (s: typeof helpPanelState) => (s.terminalId ? [s.terminalId] : []),
+    selectSlotForTerminal: (s: typeof helpPanelState, id: string) =>
+      s.terminalId === id && id ? 0 : null,
     HELP_PANEL_MIN_WIDTH: 320,
     HELP_PANEL_MAX_WIDTH: 800,
   };
@@ -405,6 +406,8 @@ vi.mock("@/types", () => ({
 vi.mock("../FigureRail", () => ({ FigureRail: () => null }));
 
 import { HelpPanel } from "../HelpPanel";
+import { assistantSlotKey as slotKey } from "@shared/config/assistantSlots";
+import { __resetHelpSessionControllersForTests } from "@/controllers/helpSessionControllerRegistry";
 
 // Drain the full async chain (pull-on-mount peek → setState → re-render →
 // fire-effect → async launch) by yielding to a macrotask: setTimeout(0) runs
@@ -526,6 +529,9 @@ function resetState() {
 }
 
 beforeEach(() => {
+  // #12108: controllers live in a per-view registry, not component
+  // state, so they outlive a render and must be reset between tests.
+  __resetHelpSessionControllersForTests();
   vi.clearAllMocks();
   resetState();
 
@@ -616,7 +622,7 @@ describe("HelpPanel — resume from hibernated session", () => {
   it("auto-launch resumes via addPanel when hibernateSessions has a matching project + agent entry", async () => {
     helpPanelState.preferredAgentId = "claude";
     helpPanelState.hibernateSessions = {
-      "proj-1": { sessionId: "abc-123", cwd: "/tmp/help/proj-1", agentId: "claude" },
+      [slotKey("proj-1", 0)]: { sessionId: "abc-123", cwd: "/tmp/help/proj-1", agentId: "claude" },
     };
     projectStoreState.currentProject = { id: "proj-1", path: "/tmp/proj-1" };
     mockGetFolderPath.mockResolvedValue("/help");
@@ -665,7 +671,7 @@ describe("HelpPanel — resume from hibernated session", () => {
     helpPanelState.autoLaunchEnabled = false;
     helpPanelState.preferredAgentId = "claude";
     helpPanelState.hibernateSessions = {
-      "proj-1": { sessionId: "abc-123", cwd: "/tmp/help/proj-1", agentId: "claude" },
+      [slotKey("proj-1", 0)]: { sessionId: "abc-123", cwd: "/tmp/help/proj-1", agentId: "claude" },
     };
     projectStoreState.currentProject = { id: "proj-1", path: "/tmp/proj-1" };
     mockGetFolderPath.mockResolvedValue("/help");
@@ -684,7 +690,7 @@ describe("HelpPanel — resume from hibernated session", () => {
   it("renders the resume banner after a successful resume", async () => {
     helpPanelState.preferredAgentId = "claude";
     helpPanelState.hibernateSessions = {
-      "proj-1": { sessionId: "abc-123", cwd: "/tmp/help/proj-1", agentId: "claude" },
+      [slotKey("proj-1", 0)]: { sessionId: "abc-123", cwd: "/tmp/help/proj-1", agentId: "claude" },
     };
     projectStoreState.currentProject = { id: "proj-1", path: "/tmp/proj-1" };
     mockGetFolderPath.mockResolvedValue("/help");
@@ -720,7 +726,7 @@ describe("HelpPanel — resume from hibernated session", () => {
   it("does not resume when the hibernated entry is for a different agent", async () => {
     helpPanelState.preferredAgentId = "claude";
     helpPanelState.hibernateSessions = {
-      "proj-1": { sessionId: "abc-123", cwd: "/tmp/help/proj-1", agentId: "gemini" },
+      [slotKey("proj-1", 0)]: { sessionId: "abc-123", cwd: "/tmp/help/proj-1", agentId: "gemini" },
     };
     projectStoreState.currentProject = { id: "proj-1", path: "/tmp/proj-1" };
     mockGetFolderPath.mockResolvedValue("/help");
@@ -749,7 +755,7 @@ describe("HelpPanel — resume from hibernated session", () => {
   it("does not resume when no hibernated entry exists for the current project", async () => {
     helpPanelState.preferredAgentId = "claude";
     helpPanelState.hibernateSessions = {
-      "other-proj": { sessionId: "xyz", cwd: "/tmp/help/other", agentId: "claude" },
+      [slotKey("other-proj", 0)]: { sessionId: "xyz", cwd: "/tmp/help/other", agentId: "claude" },
     };
     projectStoreState.currentProject = { id: "proj-1", path: "/tmp/proj-1" };
     mockGetFolderPath.mockResolvedValue("/help");
@@ -777,7 +783,7 @@ describe("HelpPanel — resume from hibernated session", () => {
   it("falls through to agent.launch when buildResumeCommand returns undefined", async () => {
     helpPanelState.preferredAgentId = "claude";
     helpPanelState.hibernateSessions = {
-      "proj-1": { sessionId: "abc-123", cwd: "/tmp/help/proj-1", agentId: "claude" },
+      [slotKey("proj-1", 0)]: { sessionId: "abc-123", cwd: "/tmp/help/proj-1", agentId: "claude" },
     };
     projectStoreState.currentProject = { id: "proj-1", path: "/tmp/proj-1" };
     mockGetFolderPath.mockResolvedValue("/help");
@@ -807,7 +813,7 @@ describe("HelpPanel — resume from hibernated session", () => {
   it("falls through to agent.launch when the resumed addPanel returns no id", async () => {
     helpPanelState.preferredAgentId = "claude";
     helpPanelState.hibernateSessions = {
-      "proj-1": { sessionId: "abc-123", cwd: "/tmp/help/proj-1", agentId: "claude" },
+      [slotKey("proj-1", 0)]: { sessionId: "abc-123", cwd: "/tmp/help/proj-1", agentId: "claude" },
     };
     projectStoreState.currentProject = { id: "proj-1", path: "/tmp/proj-1" };
     mockGetFolderPath.mockResolvedValue("/help");
@@ -856,7 +862,7 @@ describe("HelpPanel — Resume affordance for eviction-captured sessions", () =>
     expect(await findByTestId("help-resume-assistant")).toBeTruthy();
     // The Resume CTA replaces the fresh-start primary in the empty state.
     expect(queryByTestId("help-start-assistant")).toBeNull();
-    expect(mockPeekPendingHibernation).toHaveBeenCalledWith("proj-1");
+    expect(mockPeekPendingHibernation).toHaveBeenCalledWith("proj-1", 0);
   });
 
   it("clicking Resume resumes the captured session WITHOUT recording consent (#10699)", async () => {
@@ -865,7 +871,7 @@ describe("HelpPanel — Resume affordance for eviction-captured sessions", () =>
     // reads (setHibernateSession is mocked, so we pre-seed what _seedHibernateFromMain
     // would have written) — this proves the click actually resumes, not just launches.
     helpPanelState.hibernateSessions = {
-      "proj-1": { sessionId: "abc-123", cwd: "/tmp/help/proj-1", agentId: "claude" },
+      [slotKey("proj-1", 0)]: { sessionId: "abc-123", cwd: "/tmp/help/proj-1", agentId: "claude" },
     };
     projectStoreState.currentProject = { id: "proj-1", path: "/tmp/proj-1" };
     mockGetFolderPath.mockResolvedValue("/help");
@@ -1077,7 +1083,7 @@ describe("HelpPanel — cold switch-back auto-resume (#10815)", () => {
     // Seed what _seedHibernateFromMain would have written so the launch actually
     // resumes (mirrors the click-to-resume test).
     helpPanelState.hibernateSessions = {
-      "proj-1": { sessionId: "abc-123", cwd: "/tmp/help/proj-1", agentId: "claude" },
+      [slotKey("proj-1", 0)]: { sessionId: "abc-123", cwd: "/tmp/help/proj-1", agentId: "claude" },
     };
     projectStoreState.currentProject = { id: "proj-1", path: "/tmp/proj-1" };
     mockGetFolderPath.mockResolvedValue("/help");
@@ -1144,7 +1150,7 @@ describe("HelpPanel — cold switch-back auto-resume (#10815)", () => {
       cwd: "/tmp/help/proj-1",
       agentId: "codex",
     };
-    helpPanelState.hibernateSessions = { "proj-1": preExisting };
+    helpPanelState.hibernateSessions = { [slotKey("proj-1", 0)]: preExisting };
     projectStoreState.currentProject = { id: "proj-1", path: "/tmp/proj-1" };
     mockGetFolderPath.mockResolvedValue("/help");
     mockPeekPendingHibernation.mockResolvedValue({
@@ -1166,9 +1172,9 @@ describe("HelpPanel — cold switch-back auto-resume (#10815)", () => {
     });
     await flushAsyncWork();
 
-    expect(mockRestorePendingHibernation).toHaveBeenCalledWith("proj-1", "claim-mismatch");
+    expect(mockRestorePendingHibernation).toHaveBeenCalledWith("proj-1", "claim-mismatch", 0);
     expect(helpPanelState.clearHibernateSession).not.toHaveBeenCalledWith("proj-1", 0);
-    expect(helpPanelState.hibernateSessions["proj-1"]).toEqual(preExisting);
+    expect(helpPanelState.hibernateSessions[slotKey("proj-1", 0)]).toEqual(preExisting);
   });
 
   it("does NOT launch when a live session already exists (DevTools reload guard)", async () => {
@@ -1208,7 +1214,7 @@ describe("HelpPanel — cold switch-back auto-resume (#10815)", () => {
     helpPanelState.autoLaunchEnabled = false;
     helpPanelState.terminalId = null;
     helpPanelState.hibernateSessions = {
-      "proj-1": { sessionId: "abc-123", cwd: "/tmp/help/proj-1", agentId: "claude" },
+      [slotKey("proj-1", 0)]: { sessionId: "abc-123", cwd: "/tmp/help/proj-1", agentId: "claude" },
     };
     projectStoreState.currentProject = { id: "proj-1", path: "/tmp/proj-1" };
     mockGetFolderPath.mockResolvedValue("/help");
@@ -1268,12 +1274,12 @@ describe("HelpPanel — cold switch-back auto-resume (#10815)", () => {
     helpPanelState.terminalId = null;
     helpPanelState.hibernateSessions = {};
     helpPanelState.setHibernateSession = vi.fn(
-      (projectId: string, entry: { sessionId: string; cwd: string; agentId: string }) => {
-        helpPanelState.hibernateSessions[projectId] = entry;
+      (projectId: string, slot: number, entry: { sessionId: string; cwd: string; agentId: string }) => {
+        helpPanelState.hibernateSessions[slotKey(projectId, slot)] = entry;
       }
     );
-    helpPanelState.clearHibernateSession = vi.fn((projectId: string) => {
-      delete helpPanelState.hibernateSessions[projectId];
+    helpPanelState.clearHibernateSession = vi.fn((projectId: string, slot: number) => {
+      delete helpPanelState.hibernateSessions[slotKey(projectId, slot)];
     });
     projectStoreState.currentProject = { id: "proj-1", path: "/tmp/proj-1" };
     mockGetFolderPath.mockResolvedValue("/help");
@@ -1308,8 +1314,8 @@ describe("HelpPanel — cold switch-back auto-resume (#10815)", () => {
 
     // The peek targets the in-view project, and the launch consumes the entry
     // via the atomic take.
-    expect(mockPeekPendingHibernation).toHaveBeenCalledWith("proj-1");
-    expect(mockTakePendingHibernation).toHaveBeenCalledWith("proj-1");
+    expect(mockPeekPendingHibernation).toHaveBeenCalledWith("proj-1", 0);
+    expect(mockTakePendingHibernation).toHaveBeenCalledWith("proj-1", 0);
     // The session is RESUMED (addPanel with the --resume command)...
     expect(panelStoreState.addPanel).toHaveBeenCalledWith(
       expect.objectContaining({ command: "claude --resume abc-123", launchAgentId: "claude" })
@@ -1334,8 +1340,8 @@ describe("HelpPanel — cold switch-back auto-resume (#10815)", () => {
     helpPanelState.terminalId = null;
     helpPanelState.hibernateSessions = {};
     helpPanelState.setHibernateSession = vi.fn(
-      (projectId: string, entry: { sessionId: string; cwd: string; agentId: string }) => {
-        helpPanelState.hibernateSessions[projectId] = entry;
+      (projectId: string, slot: number, entry: { sessionId: string; cwd: string; agentId: string }) => {
+        helpPanelState.hibernateSessions[slotKey(projectId, slot)] = entry;
       }
     );
     projectStoreState.currentProject = { id: "proj-1", path: "/tmp/proj-1" };
@@ -1360,10 +1366,10 @@ describe("HelpPanel — cold switch-back auto-resume (#10815)", () => {
     });
     await flushAsyncWork();
 
-    expect(mockTakePendingHibernation).toHaveBeenCalledWith("proj-1");
+    expect(mockTakePendingHibernation).toHaveBeenCalledWith("proj-1", 0);
     // Quoting the claim main handed out, so the put-back acts on THIS take and
     // not on whatever the project's slot happens to hold by then.
-    expect(mockRestorePendingHibernation).toHaveBeenCalledWith("proj-1", "claim-1");
+    expect(mockRestorePendingHibernation).toHaveBeenCalledWith("proj-1", "claim-1", 0);
     // The renderer's local mirror goes with it: seedFromMain wrote the taken
     // entry into hibernateSessions, and leaving that behind while main hands
     // the entry to another window would let two windows resume one
@@ -1380,12 +1386,12 @@ describe("HelpPanel — cold switch-back auto-resume (#10815)", () => {
     helpPanelState.terminalId = null;
     helpPanelState.hibernateSessions = {};
     helpPanelState.setHibernateSession = vi.fn(
-      (workspaceId: string, entry: { sessionId: string; cwd: string; agentId: string }) => {
-        helpPanelState.hibernateSessions[workspaceId] = entry;
+      (workspaceId: string, slot: number, entry: { sessionId: string; cwd: string; agentId: string }) => {
+        helpPanelState.hibernateSessions[slotKey(workspaceId, slot)] = entry;
       }
     );
-    helpPanelState.clearHibernateSession = vi.fn((workspaceId: string) => {
-      delete helpPanelState.hibernateSessions[workspaceId];
+    helpPanelState.clearHibernateSession = vi.fn((workspaceId: string, slot: number) => {
+      delete helpPanelState.hibernateSessions[slotKey(workspaceId, slot)];
     });
     projectStoreState.currentProject = null;
     scratchStoreState.currentScratch = { id: "scratch-1", path: "/scratches/scratch-1" };
@@ -1417,8 +1423,8 @@ describe("HelpPanel — cold switch-back auto-resume (#10815)", () => {
     });
     await flushAsyncWork();
 
-    expect(mockPeekPendingHibernation).toHaveBeenCalledWith("scratch-1");
-    expect(mockTakePendingHibernation).toHaveBeenCalledWith("scratch-1");
+    expect(mockPeekPendingHibernation).toHaveBeenCalledWith("scratch-1", 0);
+    expect(mockTakePendingHibernation).toHaveBeenCalledWith("scratch-1", 0);
     expect(mockReportPanelOpen).toHaveBeenCalledWith(
       "scratch-1",
       expect.any(Boolean),
@@ -1519,7 +1525,7 @@ describe("HelpPanel — cold switch-back auto-resume (#10815)", () => {
     await flushAsyncWork();
 
     // The losing window armed and attempted the take...
-    expect(mockTakePendingHibernation).toHaveBeenCalledWith("proj-1");
+    expect(mockTakePendingHibernation).toHaveBeenCalledWith("proj-1", 0);
     // ...but nothing is resumed and nothing is fresh-launched.
     expect(panelStoreState.addPanel).not.toHaveBeenCalled();
     expect(mockDispatch).not.toHaveBeenCalledWith(
@@ -1545,7 +1551,7 @@ describe("HelpPanel — cold switch-back auto-resume (#10815)", () => {
     helpPanelState.autoLaunchEnabled = false;
     helpPanelState.terminalId = null;
     helpPanelState.hibernateSessions = {
-      "proj-1": { sessionId: "abc-123", cwd: "/tmp/help/proj-1", agentId: "claude" },
+      [slotKey("proj-1", 0)]: { sessionId: "abc-123", cwd: "/tmp/help/proj-1", agentId: "claude" },
     };
     projectStoreState.currentProject = { id: "proj-1", path: "/tmp/proj-1" };
     mockGetFolderPath.mockResolvedValue("/help");
@@ -1590,7 +1596,7 @@ describe("HelpPanel — cold switch-back auto-resume (#10815)", () => {
     });
     await flushAsyncWork();
 
-    expect(mockPeekPendingHibernation).toHaveBeenCalledWith("proj-1");
+    expect(mockPeekPendingHibernation).toHaveBeenCalledWith("proj-1", 0);
     expect(helpPanelState.setOpen).toHaveBeenCalledWith(true);
     expect(panelStoreState.addPanel).toHaveBeenCalledTimes(1);
     expect(panelStoreState.addPanel).toHaveBeenCalledWith(
@@ -1639,7 +1645,7 @@ describe("HelpPanel — resume preserves user-configured launch flags", () => {
   it("threads customArgs into both buildResumeCommand and addPanel.agentLaunchFlags", async () => {
     helpPanelState.preferredAgentId = "claude";
     helpPanelState.hibernateSessions = {
-      "proj-1": { sessionId: "abc-123", cwd: "/tmp/help/proj-1", agentId: "claude" },
+      [slotKey("proj-1", 0)]: { sessionId: "abc-123", cwd: "/tmp/help/proj-1", agentId: "claude" },
     };
     projectStoreState.currentProject = { id: "proj-1", path: "/tmp/proj-1" };
     mockGetFolderPath.mockResolvedValue("/help");
@@ -1979,7 +1985,7 @@ describe("HelpPanel — idle hibernation timer", () => {
       helpPanelState.agentId = "claude";
       // Pre-existing entry from a previous successful hibernate cycle.
       helpPanelState.hibernateSessions = {
-        "proj-1": { sessionId: "old", cwd: "/help", agentId: "claude" },
+        [slotKey("proj-1", 0)]: { sessionId: "old", cwd: "/help", agentId: "claude" },
       };
       panelStoreState.panelsById = {
         t1: {

--- a/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
@@ -1274,7 +1274,11 @@ describe("HelpPanel — cold switch-back auto-resume (#10815)", () => {
     helpPanelState.terminalId = null;
     helpPanelState.hibernateSessions = {};
     helpPanelState.setHibernateSession = vi.fn(
-      (projectId: string, slot: number, entry: { sessionId: string; cwd: string; agentId: string }) => {
+      (
+        projectId: string,
+        slot: number,
+        entry: { sessionId: string; cwd: string; agentId: string }
+      ) => {
         helpPanelState.hibernateSessions[slotKey(projectId, slot)] = entry;
       }
     );
@@ -1340,7 +1344,11 @@ describe("HelpPanel — cold switch-back auto-resume (#10815)", () => {
     helpPanelState.terminalId = null;
     helpPanelState.hibernateSessions = {};
     helpPanelState.setHibernateSession = vi.fn(
-      (projectId: string, slot: number, entry: { sessionId: string; cwd: string; agentId: string }) => {
+      (
+        projectId: string,
+        slot: number,
+        entry: { sessionId: string; cwd: string; agentId: string }
+      ) => {
         helpPanelState.hibernateSessions[slotKey(projectId, slot)] = entry;
       }
     );
@@ -1386,7 +1394,11 @@ describe("HelpPanel — cold switch-back auto-resume (#10815)", () => {
     helpPanelState.terminalId = null;
     helpPanelState.hibernateSessions = {};
     helpPanelState.setHibernateSession = vi.fn(
-      (workspaceId: string, slot: number, entry: { sessionId: string; cwd: string; agentId: string }) => {
+      (
+        workspaceId: string,
+        slot: number,
+        entry: { sessionId: string; cwd: string; agentId: string }
+      ) => {
         helpPanelState.hibernateSessions[slotKey(workspaceId, slot)] = entry;
       }
     );

--- a/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
@@ -75,6 +75,16 @@ const {
     wake: [] as Array<(sleepDurationMs: number) => void>,
   },
   helpPanelState: {
+    clearDroppedPreferredAgent: vi.fn(),
+    requestFocus: vi.fn(),
+    setActiveFigureNumber: vi.fn(),
+    setActiveSlot: vi.fn(),
+    closeSlot: vi.fn(),
+    openSlot: vi.fn(),
+    // #12108: the panel reads its lane pointer; the mocked selectors
+    // above project this same flat object as that lane.
+    activeSlot: 0,
+    sessions: {} as Record<number, unknown>,
     isOpen: true,
     width: 380,
     terminalId: null as string | null,
@@ -253,6 +263,14 @@ vi.mock("@/store/helpPanelStore", () => {
   store.getState = () => helpPanelState;
   return {
     useHelpPanelStore: store,
+    // #12108 selectors. The fixtures below stay FLAT (terminalId/agentId/…)
+    // and these project that same object as the lane, so every existing
+    // assertion keeps driving the controller unchanged.
+    selectSlot: (s) => s,
+    selectActiveSlot: (s) => s,
+    selectOpenSlots: () => [0],
+    selectSlotTerminalIds: (s) => (s.terminalId ? [s.terminalId] : []),
+    selectSlotForTerminal: (s, id) => (s.terminalId === id && id ? 0 : null),
     HELP_PANEL_MIN_WIDTH: 320,
     HELP_PANEL_MAX_WIDTH: 800,
   };
@@ -632,8 +650,9 @@ describe("HelpPanel — resume from hibernated session", () => {
       expect.anything(),
       expect.anything()
     );
-    expect(helpPanelState.clearHibernateSession).toHaveBeenCalledWith("proj-1");
+    expect(helpPanelState.clearHibernateSession).toHaveBeenCalledWith("proj-1", 0);
     expect(helpPanelState.setTerminal).toHaveBeenCalledWith(
+      0,
       "resumed-term-1",
       "claude",
       "fresh-session"
@@ -777,7 +796,7 @@ describe("HelpPanel — resume from hibernated session", () => {
       render(<HelpPanel width={380} />);
     });
 
-    expect(helpPanelState.clearHibernateSession).toHaveBeenCalledWith("proj-1");
+    expect(helpPanelState.clearHibernateSession).toHaveBeenCalledWith("proj-1", 0);
     expect(mockDispatch).toHaveBeenCalledWith(
       "agent.launch",
       expect.objectContaining({ agentId: "claude" }),
@@ -806,7 +825,7 @@ describe("HelpPanel — resume from hibernated session", () => {
       render(<HelpPanel width={380} />);
     });
 
-    expect(helpPanelState.clearHibernateSession).toHaveBeenCalledWith("proj-1");
+    expect(helpPanelState.clearHibernateSession).toHaveBeenCalledWith("proj-1", 0);
     expect(mockDispatch).toHaveBeenCalledWith(
       "agent.launch",
       expect.objectContaining({ agentId: "claude" }),
@@ -1148,7 +1167,7 @@ describe("HelpPanel — cold switch-back auto-resume (#10815)", () => {
     await flushAsyncWork();
 
     expect(mockRestorePendingHibernation).toHaveBeenCalledWith("proj-1", "claim-mismatch");
-    expect(helpPanelState.clearHibernateSession).not.toHaveBeenCalledWith("proj-1");
+    expect(helpPanelState.clearHibernateSession).not.toHaveBeenCalledWith("proj-1", 0);
     expect(helpPanelState.hibernateSessions["proj-1"]).toEqual(preExisting);
   });
 
@@ -1349,7 +1368,7 @@ describe("HelpPanel — cold switch-back auto-resume (#10815)", () => {
     // entry into hibernateSessions, and leaving that behind while main hands
     // the entry to another window would let two windows resume one
     // conversation — the single-winner invariant the atomic take holds.
-    expect(helpPanelState.clearHibernateSession).toHaveBeenCalledWith("proj-1");
+    expect(helpPanelState.clearHibernateSession).toHaveBeenCalledWith("proj-1", 0);
   });
 
   // #11068: the same cold-resume handoff, but the active workspace is a scratch
@@ -1750,7 +1769,7 @@ describe("HelpPanel — idle hibernation timer", () => {
       });
 
       expect(mockGracefulKill).toHaveBeenCalledWith("t1");
-      expect(helpPanelState.setHibernateSession).toHaveBeenCalledWith("proj-1", {
+      expect(helpPanelState.setHibernateSession).toHaveBeenCalledWith("proj-1", 0, {
         sessionId: "resume-token-xyz",
         cwd: "/help",
         agentId: "claude",
@@ -1798,7 +1817,7 @@ describe("HelpPanel — idle hibernation timer", () => {
       });
 
       expect(mockGracefulKill).toHaveBeenCalledWith("t1");
-      expect(helpPanelState.setHibernateSession).toHaveBeenCalledWith("scratch-1", {
+      expect(helpPanelState.setHibernateSession).toHaveBeenCalledWith("scratch-1", 0, {
         sessionId: "resume-token-scratch",
         cwd: "/scratches/scratch-1",
         agentId: "claude",
@@ -1860,7 +1879,7 @@ describe("HelpPanel — idle hibernation timer", () => {
       });
 
       expect(mockGracefulKill).toHaveBeenCalledWith("t1");
-      expect(helpPanelState.setHibernateSession).toHaveBeenCalledWith("scratch-1", {
+      expect(helpPanelState.setHibernateSession).toHaveBeenCalledWith("scratch-1", 0, {
         sessionId: "resume-token-scratch",
         cwd: "/scratches/scratch-1",
         agentId: "claude",
@@ -1987,7 +2006,7 @@ describe("HelpPanel — idle hibernation timer", () => {
       });
 
       expect(helpPanelState.setHibernateSession).not.toHaveBeenCalled();
-      expect(helpPanelState.clearHibernateSession).toHaveBeenCalledWith("proj-1");
+      expect(helpPanelState.clearHibernateSession).toHaveBeenCalledWith("proj-1", 0);
     } finally {
       vi.useRealTimers();
     }
@@ -2097,6 +2116,6 @@ describe("HelpPanel — + New session clears hibernated entry", () => {
       fireEvent.click(newSessionBtn);
     });
 
-    expect(helpPanelState.clearHibernateSession).toHaveBeenCalledWith("proj-1");
+    expect(helpPanelState.clearHibernateSession).toHaveBeenCalledWith("proj-1", 0);
   });
 });

--- a/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
@@ -11,6 +11,7 @@ const {
   mockPeekPendingHibernation,
   mockTakePendingHibernation,
   mockRestorePendingHibernation,
+  mockListPendingHibernationSlots,
   mockReportPanelOpen,
   mockProvisionSession,
   mockRevokeSession,
@@ -44,6 +45,7 @@ const {
   mockPeekPendingHibernation: vi.fn().mockResolvedValue(null),
   mockTakePendingHibernation: vi.fn().mockResolvedValue(null),
   mockRestorePendingHibernation: vi.fn().mockResolvedValue(false),
+  mockListPendingHibernationSlots: vi.fn().mockResolvedValue([]),
   mockReportPanelOpen: vi.fn().mockResolvedValue(undefined),
   mockProvisionSession: vi.fn().mockResolvedValue(null),
   mockRevokeSession: vi.fn().mockResolvedValue(undefined),
@@ -81,6 +83,7 @@ const {
     setActiveSlot: vi.fn(),
     closeSlot: vi.fn(),
     openSlot: vi.fn(),
+    ensureSlot: vi.fn(),
     // #12108: the panel reads its lane pointer; the mocked selectors
     // above project this same flat object as that lane.
     activeSlot: 0,
@@ -492,6 +495,9 @@ function resetState() {
   mockTakePendingHibernation.mockResolvedValue(null);
   mockRestorePendingHibernation.mockReset();
   mockRestorePendingHibernation.mockResolvedValue(false);
+  mockListPendingHibernationSlots.mockReset();
+  mockListPendingHibernationSlots.mockResolvedValue([]);
+  helpPanelState.ensureSlot = vi.fn();
   mockReportPanelOpen.mockReset();
   mockReportPanelOpen.mockResolvedValue(undefined);
   focusStoreState.gestureAssistantHidden = false;
@@ -570,6 +576,7 @@ beforeEach(() => {
           peekPendingHibernation: mockPeekPendingHibernation,
           takePendingHibernation: mockTakePendingHibernation,
           restorePendingHibernation: mockRestorePendingHibernation,
+          listPendingHibernationSlots: mockListPendingHibernationSlots,
           reportPanelOpen: mockReportPanelOpen,
           provisionSession: mockProvisionSession,
           revokeSession: mockRevokeSession,
@@ -2135,5 +2142,43 @@ describe("HelpPanel — + New session clears hibernated entry", () => {
     });
 
     expect(helpPanelState.clearHibernateSession).toHaveBeenCalledWith("proj-1", 0);
+  });
+});
+
+describe("HelpPanel — cold-view lane restore (#12108)", () => {
+  it("recreates a tab for every lane holding an eviction-captured conversation", async () => {
+    // A cold view knows only slot 0, so lanes 1+ would have no tab to reach
+    // their captured conversations from even though the entries are on disk.
+    helpPanelState.terminalId = null;
+    projectStoreState.currentProject = { id: "proj-1", path: "/tmp/proj-1" };
+    mockListPendingHibernationSlots.mockResolvedValue([0, 2]);
+
+    await act(async () => {
+      render(<HelpPanel width={380} />);
+    });
+    await flushAsyncWork();
+
+    expect(mockListPendingHibernationSlots).toHaveBeenCalledWith("proj-1");
+    expect(helpPanelState.ensureSlot).toHaveBeenCalledWith(0);
+    expect(helpPanelState.ensureSlot).toHaveBeenCalledWith(2);
+    // Recreating a background lane must not start (or bill) it — the restored
+    // tab lands on its own Resume CTA and waits for the user. (Slot 0 is the
+    // visible lane and follows the ordinary auto-launch consent path.)
+    expect(mockProvisionSession).not.toHaveBeenCalledWith(expect.objectContaining({ slot: 2 }));
+  });
+
+  it("does not recreate lanes for a view that already holds a live session", async () => {
+    helpPanelState.terminalId = "term-live";
+    helpPanelState.agentId = "claude";
+    projectStoreState.currentProject = { id: "proj-1", path: "/tmp/proj-1" };
+    mockListPendingHibernationSlots.mockResolvedValue([1]);
+
+    await act(async () => {
+      render(<HelpPanel width={380} />);
+    });
+    await flushAsyncWork();
+
+    expect(mockListPendingHibernationSlots).not.toHaveBeenCalled();
+    expect(helpPanelState.ensureSlot).not.toHaveBeenCalled();
   });
 });

--- a/src/components/HelpPanel/__tests__/HelpPanel.revealBackstop.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.revealBackstop.test.tsx
@@ -14,6 +14,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const { repaintForRevealMock, helpPanelState, panelStoreState } = vi.hoisted(() => ({
   repaintForRevealMock: vi.fn(),
   helpPanelState: {
+    clearDroppedPreferredAgent: vi.fn(),
+    setAutoLaunchEnabled: vi.fn(),
+    requestFocus: vi.fn(),
+    setActiveFigureNumber: vi.fn(),
+    addFigure: vi.fn(),
+    setActiveSlot: vi.fn(),
+    closeSlot: vi.fn(),
+    openSlot: vi.fn(),
+    // #12108: the panel reads its lane pointer; the mocked selectors
+    // above project this same flat object as that lane.
+    activeSlot: 0,
+    sessions: {} as Record<number, unknown>,
     isOpen: true,
     width: 380,
     terminalId: null as string | null,
@@ -151,7 +163,18 @@ vi.mock("@/store/helpPanelStore", () => {
   const store = (selector?: (s: typeof helpPanelState) => unknown) =>
     selector ? selector(helpPanelState) : helpPanelState;
   store.getState = () => helpPanelState;
-  return { useHelpPanelStore: store, HELP_PANEL_MIN_WIDTH: 320, HELP_PANEL_MAX_WIDTH: 800 };
+  return {
+    useHelpPanelStore: store,
+    HELP_PANEL_MIN_WIDTH: 320,
+    HELP_PANEL_MAX_WIDTH: 800,
+    // #12108 selectors. Fixtures stay flat, so these project the same object
+    // as the lane and every existing assertion keeps working.
+    selectSlot: (s) => s,
+    selectActiveSlot: (s) => s,
+    selectOpenSlots: () => [0],
+    selectSlotTerminalIds: (s) => (s.terminalId ? [s.terminalId] : []),
+    selectSlotForTerminal: (s, id) => (s.terminalId === id && id ? 0 : null),
+  };
 });
 
 vi.mock("@/store", () => {

--- a/src/components/HelpPanel/__tests__/HelpPanel.revealBackstop.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.revealBackstop.test.tsx
@@ -169,11 +169,12 @@ vi.mock("@/store/helpPanelStore", () => {
     HELP_PANEL_MAX_WIDTH: 800,
     // #12108 selectors. Fixtures stay flat, so these project the same object
     // as the lane and every existing assertion keeps working.
-    selectSlot: (s) => s,
-    selectActiveSlot: (s) => s,
+    selectSlot: (s: typeof helpPanelState) => s,
+    selectActiveSlot: (s: typeof helpPanelState) => s,
     selectOpenSlots: () => [0],
-    selectSlotTerminalIds: (s) => (s.terminalId ? [s.terminalId] : []),
-    selectSlotForTerminal: (s, id) => (s.terminalId === id && id ? 0 : null),
+    selectSlotTerminalIds: (s: typeof helpPanelState) => (s.terminalId ? [s.terminalId] : []),
+    selectSlotForTerminal: (s: typeof helpPanelState, id: string) =>
+      s.terminalId === id && id ? 0 : null,
   };
 });
 
@@ -242,6 +243,7 @@ vi.mock("@/components/ui/ConfirmDialog", () => ({ ConfirmDialog: () => null }));
 vi.mock("../FigureRail", () => ({ FigureRail: () => null }));
 
 import { HelpPanel } from "../HelpPanel";
+import { __resetHelpSessionControllersForTests } from "@/controllers/helpSessionControllerRegistry";
 
 // rAF mock: drive the bounded reveal poll synchronously per flushed frame.
 const rafQueue = new Map<number, FrameRequestCallback>();
@@ -265,6 +267,9 @@ function setVisibilityState(state: DocumentVisibilityState): void {
 }
 
 beforeEach(() => {
+  // #12108: controllers live in a per-view registry, not component
+  // state, so they outlive a render and must be reset between tests.
+  __resetHelpSessionControllersForTests();
   vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
   rafQueue.clear();
   rafIdCounter = 0;

--- a/src/components/HelpPanel/__tests__/HelpPanel.revealFocusOwnership.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.revealFocusOwnership.test.tsx
@@ -23,6 +23,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const { focusMock, helpPanelState, panelStoreState, hybridHandle } = vi.hoisted(() => ({
   focusMock: vi.fn(),
   helpPanelState: {
+    clearDroppedPreferredAgent: vi.fn(),
+    setAutoLaunchEnabled: vi.fn(),
+    requestFocus: vi.fn(),
+    setActiveFigureNumber: vi.fn(),
+    addFigure: vi.fn(),
+    setActiveSlot: vi.fn(),
+    closeSlot: vi.fn(),
+    openSlot: vi.fn(),
+    // #12108: the panel reads its lane pointer; the mocked selectors
+    // above project this same flat object as that lane.
+    activeSlot: 0,
+    sessions: {} as Record<number, unknown>,
     isOpen: true,
     width: 380,
     terminalId: "t-1" as string | null,
@@ -205,7 +217,18 @@ vi.mock("@/store/helpPanelStore", () => {
   const store = (selector?: (s: typeof helpPanelState) => unknown) =>
     selector ? selector(helpPanelState) : helpPanelState;
   store.getState = () => helpPanelState;
-  return { useHelpPanelStore: store, HELP_PANEL_MIN_WIDTH: 320, HELP_PANEL_MAX_WIDTH: 800 };
+  return {
+    useHelpPanelStore: store,
+    HELP_PANEL_MIN_WIDTH: 320,
+    HELP_PANEL_MAX_WIDTH: 800,
+    // #12108 selectors. Fixtures stay flat, so these project the same object
+    // as the lane and every existing assertion keeps working.
+    selectSlot: (s) => s,
+    selectActiveSlot: (s) => s,
+    selectOpenSlots: () => [0],
+    selectSlotTerminalIds: (s) => (s.terminalId ? [s.terminalId] : []),
+    selectSlotForTerminal: (s, id) => (s.terminalId === id && id ? 0 : null),
+  };
 });
 
 vi.mock("@/store", () => {

--- a/src/components/HelpPanel/__tests__/HelpPanel.revealFocusOwnership.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.revealFocusOwnership.test.tsx
@@ -223,11 +223,12 @@ vi.mock("@/store/helpPanelStore", () => {
     HELP_PANEL_MAX_WIDTH: 800,
     // #12108 selectors. Fixtures stay flat, so these project the same object
     // as the lane and every existing assertion keeps working.
-    selectSlot: (s) => s,
-    selectActiveSlot: (s) => s,
+    selectSlot: (s: typeof helpPanelState) => s,
+    selectActiveSlot: (s: typeof helpPanelState) => s,
     selectOpenSlots: () => [0],
-    selectSlotTerminalIds: (s) => (s.terminalId ? [s.terminalId] : []),
-    selectSlotForTerminal: (s, id) => (s.terminalId === id && id ? 0 : null),
+    selectSlotTerminalIds: (s: typeof helpPanelState) => (s.terminalId ? [s.terminalId] : []),
+    selectSlotForTerminal: (s: typeof helpPanelState, id: string) =>
+      s.terminalId === id && id ? 0 : null,
   };
 });
 
@@ -301,6 +302,7 @@ vi.mock("@/components/ui/ConfirmDialog", () => ({ ConfirmDialog: () => null }));
 vi.mock("../FigureRail", () => ({ FigureRail: () => null }));
 
 import { HelpPanel } from "../HelpPanel";
+import { __resetHelpSessionControllersForTests } from "@/controllers/helpSessionControllerRegistry";
 import {
   _resetForTests as resetTooltipDismissRegistry,
   isTooltipFocusOpenSuppressed,
@@ -352,6 +354,9 @@ function anyFocusWriterCalled(): boolean {
 }
 
 beforeEach(() => {
+  // #12108: controllers live in a per-view registry, not component
+  // state, so they outlive a render and must be reset between tests.
+  __resetHelpSessionControllersForTests();
   resetTooltipDismissRegistry();
   rafQueue.clear();
   rafIdCounter = 0;

--- a/src/components/HelpPanel/__tests__/HelpPanel.webglPin.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.webglPin.test.tsx
@@ -170,11 +170,12 @@ vi.mock("@/store/helpPanelStore", () => {
     HELP_PANEL_MAX_WIDTH: 800,
     // #12108 selectors. Fixtures stay flat, so these project the same object
     // as the lane and every existing assertion keeps working.
-    selectSlot: (s) => s,
-    selectActiveSlot: (s) => s,
+    selectSlot: (s: typeof helpPanelState) => s,
+    selectActiveSlot: (s: typeof helpPanelState) => s,
     selectOpenSlots: () => [0],
-    selectSlotTerminalIds: (s) => (s.terminalId ? [s.terminalId] : []),
-    selectSlotForTerminal: (s, id) => (s.terminalId === id && id ? 0 : null),
+    selectSlotTerminalIds: (s: typeof helpPanelState) => (s.terminalId ? [s.terminalId] : []),
+    selectSlotForTerminal: (s: typeof helpPanelState, id: string) =>
+      s.terminalId === id && id ? 0 : null,
   };
 });
 
@@ -243,6 +244,7 @@ vi.mock("@/components/ui/ConfirmDialog", () => ({ ConfirmDialog: () => null }));
 vi.mock("../FigureRail", () => ({ FigureRail: () => null }));
 
 import { HelpPanel } from "../HelpPanel";
+import { __resetHelpSessionControllersForTests } from "@/controllers/helpSessionControllerRegistry";
 
 function getAside(): HTMLElement {
   const aside = document.getElementById("daintree-assistant-panel");
@@ -256,6 +258,9 @@ function pinCalls(): unknown[][] {
 }
 
 beforeEach(() => {
+  // #12108: controllers live in a per-view registry, not component
+  // state, so they outlive a render and must be reset between tests.
+  __resetHelpSessionControllersForTests();
   setFocusedMock.mockClear();
   focusMock.mockClear();
 

--- a/src/components/HelpPanel/__tests__/HelpPanel.webglPin.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.webglPin.test.tsx
@@ -14,6 +14,18 @@ const { setFocusedMock, focusMock, helpPanelState, panelStoreState } = vi.hoiste
   setFocusedMock: vi.fn(),
   focusMock: vi.fn(),
   helpPanelState: {
+    clearDroppedPreferredAgent: vi.fn(),
+    setAutoLaunchEnabled: vi.fn(),
+    requestFocus: vi.fn(),
+    setActiveFigureNumber: vi.fn(),
+    addFigure: vi.fn(),
+    setActiveSlot: vi.fn(),
+    closeSlot: vi.fn(),
+    openSlot: vi.fn(),
+    // #12108: the panel reads its lane pointer; the mocked selectors
+    // above project this same flat object as that lane.
+    activeSlot: 0,
+    sessions: {} as Record<number, unknown>,
     isOpen: true,
     width: 380,
     terminalId: "t-1" as string | null,
@@ -152,7 +164,18 @@ vi.mock("@/store/helpPanelStore", () => {
   const store = (selector?: (s: typeof helpPanelState) => unknown) =>
     selector ? selector(helpPanelState) : helpPanelState;
   store.getState = () => helpPanelState;
-  return { useHelpPanelStore: store, HELP_PANEL_MIN_WIDTH: 320, HELP_PANEL_MAX_WIDTH: 800 };
+  return {
+    useHelpPanelStore: store,
+    HELP_PANEL_MIN_WIDTH: 320,
+    HELP_PANEL_MAX_WIDTH: 800,
+    // #12108 selectors. Fixtures stay flat, so these project the same object
+    // as the lane and every existing assertion keeps working.
+    selectSlot: (s) => s,
+    selectActiveSlot: (s) => s,
+    selectOpenSlots: () => [0],
+    selectSlotTerminalIds: (s) => (s.terminalId ? [s.terminalId] : []),
+    selectSlotForTerminal: (s, id) => (s.terminalId === id && id ? 0 : null),
+  };
 });
 
 vi.mock("@/store", () => {

--- a/src/components/HelpPanel/__tests__/HelpPanelHeader.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanelHeader.test.tsx
@@ -41,6 +41,8 @@ function renderHeader(overrides: Partial<ComponentProps<typeof HelpPanelHeader>>
       agentState={null}
       canStartNewSession={false}
       canEndSession={false}
+      canOpenParallelSession
+      onOpenParallelSession={vi.fn()}
       onNewSession={vi.fn()}
       onEndSession={vi.fn()}
       onOpenDocs={vi.fn()}

--- a/src/components/HelpPanel/__tests__/McpActivityStrip.test.tsx
+++ b/src/components/HelpPanel/__tests__/McpActivityStrip.test.tsx
@@ -37,6 +37,7 @@ vi.mock("@/components/ui/popover", async () => {
 import { McpActivityStrip } from "../McpActivityStrip";
 import { groupCallsByTurn } from "../RecentCallsPopover";
 import type { McpToolActivityState } from "@/controllers/HelpSessionController";
+import { __resetHelpSessionControllersForTests } from "@/controllers/helpSessionControllerRegistry";
 
 function makeRecord(overrides: Partial<McpAuditRecord> = {}): McpAuditRecord {
   return {
@@ -74,6 +75,9 @@ function makeActivity(overrides: Partial<McpToolActivityState> = {}): McpToolAct
 const getAuditRecords = vi.fn();
 
 beforeEach(() => {
+  // #12108: controllers live in a per-view registry, not component
+  // state, so they outlive a render and must be reset between tests.
+  __resetHelpSessionControllersForTests();
   getAuditRecords.mockReset();
   getAuditRecords.mockResolvedValue([]);
   Object.defineProperty(globalThis, "window", {

--- a/src/components/Layout/ContentDock.tsx
+++ b/src/components/Layout/ContentDock.tsx
@@ -58,7 +58,7 @@ import {
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
 
-import { useHelpPanelStore } from "@/store/helpPanelStore";
+import { useHelpPanelStore, selectSlotTerminalIds } from "@/store/helpPanelStore";
 import { buildDockRenderItems, type DockRenderItem } from "./dockRenderItems";
 import { usePreferencesStore, type DockDensity } from "@/store/preferencesStore";
 
@@ -102,7 +102,9 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
 
   const trashedTerminals = usePanelStore((state) => state.trashedTerminals);
   const storeTabGroups = usePanelStore((state) => state.tabGroups);
-  const helpTerminalId = useHelpPanelStore((s) => s.terminalId);
+  // Every lane, not the focused one (#12108): all assistant terminals render
+  // inside HelpPanel, so all must stay out of the dock.
+  const helpTerminalIdList = useHelpPanelStore(useShallow(selectSlotTerminalIds));
   const setDockDensity = usePreferencesStore((s) => s.setDockDensity);
 
   // Narrow dock subscription (#10908). Subscribing to the whole `panelsById`
@@ -163,14 +165,14 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
     const result: DockPanelData[] = [];
     for (const terminal of dockTerminalsRaw) {
       if (
-        terminal.id !== helpTerminalId &&
+        !helpTerminalIdList.includes(terminal.id) &&
         panelMatchesWorktreeScope(terminal.worktreeId, activeWorktreeId, "dock")
       ) {
         result.push(terminal);
       }
     }
     return result;
-  }, [dockTerminalsRaw, helpTerminalId, activeWorktreeId]);
+  }, [dockTerminalsRaw, helpTerminalIdList, activeWorktreeId]);
 
   // Trashed panels resolved from the store, keyed by id. Values are the actual
   // store panel references (not freshly constructed), so `useShallow` bails

--- a/src/components/Layout/DockPanelOffscreenContainer.tsx
+++ b/src/components/Layout/DockPanelOffscreenContainer.tsx
@@ -16,7 +16,7 @@ import {
   getPanelKindRegistrySnapshot,
 } from "@shared/config/panelKindRegistry";
 import { isDockPanel, isPtyPanel, type DockPanelData } from "@shared/types/panel";
-import { useHelpPanelStore } from "@/store/helpPanelStore";
+import { useHelpPanelStore, selectSlotTerminalIds } from "@/store/helpPanelStore";
 import { DockedPanel } from "@/components/Terminal/DockedPanel";
 import { buildPanelDuplicateOptions } from "@/services/terminal/panelDuplicationService";
 import { logError } from "@/utils/logger";
@@ -98,7 +98,9 @@ export function DockPanelOffscreenContainer({ children }: DockPanelOffscreenCont
 
   const activeWorktreeId = useWorktreeSelectionStore((s) => s.activeWorktreeId);
   const activeDockTerminalId = usePanelStore((s) => s.activeDockTerminalId);
-  const helpTerminalId = useHelpPanelStore((s) => s.terminalId);
+  // All lanes (#12108) — a background assistant is still rendered by HelpPanel
+  // and must not be mirrored into the offscreen dock container too.
+  const helpTerminalIdList = useHelpPanelStore(useShallow(selectSlotTerminalIds));
   const dockTerminals = usePanelStore(
     useShallow((s) => {
       const result: DockPanelData[] = [];
@@ -109,7 +111,7 @@ export function DockPanelOffscreenContainer({ children }: DockPanelOffscreenCont
           isDockPanel(t) &&
           t.location === "dock" &&
           !s.trashedTerminals.has(t.id) &&
-          t.id !== helpTerminalId &&
+          !helpTerminalIdList.includes(t.id) &&
           // Show terminals that match active worktree OR have no worktree (global terminals)
           (t.worktreeId == null || t.worktreeId === activeWorktreeId)
         ) {

--- a/src/components/Layout/ToolbarAssistantButton.tsx
+++ b/src/components/Layout/ToolbarAssistantButton.tsx
@@ -6,7 +6,7 @@ import { useAriaKeyshortcuts, useKeybindingDisplay, useShortcutHintHover } from 
 import { cn } from "@/lib/utils";
 import { DaintreeIcon } from "@/components/icons/DaintreeIcon";
 import { useFocusStore } from "@/store/focusStore";
-import { useHelpPanelStore } from "@/store/helpPanelStore";
+import { useHelpPanelStore, selectSlotTerminalIds } from "@/store/helpPanelStore";
 import { usePanelStore } from "@/store";
 import { isPtyPanel } from "@shared/types/panel";
 import { suppressSidebarResizes } from "@/lib/sidebarToggle";
@@ -88,14 +88,27 @@ export function ToolbarAssistantButton({
   // actually sees.
   const gestureAssistantHidden = useFocusStore((s) => s.gestureAssistantHidden);
   const isVisible = !gestureAssistantHidden && isOpen;
-  // Two-step primitive selectors so the button only re-renders when the
-  // assistant terminal id changes, then when its agentState transitions.
-  // Returning a primitive avoids needing useShallow.
-  const assistantTerminalId = useHelpPanelStore((s) => s.terminalId);
+  // Two-step selectors so the button only re-renders when the set of assistant
+  // terminals changes, then when the reported agentState transitions.
+  // Aggregate across lanes (#12108). The button is the one place a background
+  // assistant can ask for the user, so it reports the most demanding lane
+  // rather than the focused one — surfacing "one of your assistants is
+  // waiting" is the whole point of the pip, and reporting only the active lane
+  // would hide exactly the session the user has navigated away from.
+  const assistantTerminalIds = useHelpPanelStore(useShallow(selectSlotTerminalIds));
   const agentState = usePanelStore((s) => {
-    if (!assistantTerminalId) return null;
-    const p = s.panelsById[assistantTerminalId];
-    return p && isPtyPanel(p) ? (p.agentState ?? null) : null;
+    let best: AgentState | null = null;
+    for (const terminalId of assistantTerminalIds) {
+      const p = s.panelsById[terminalId];
+      if (!p || !isPtyPanel(p)) continue;
+      const state = p.agentState ?? null;
+      if (state === null) continue;
+      // "waiting" outranks everything: it is the only state that is a request
+      // for the user. Otherwise first live lane wins.
+      if (state === "waiting") return state;
+      best ??= state;
+    }
+    return best;
   });
   const mcp = useMcpReadiness();
   const hasAnomaly = useMcpAnomalyStore((s) => s.hasAnomaly);
@@ -112,14 +125,18 @@ export function ToolbarAssistantButton({
   // whatever the user just saw and closing without further change leaves the
   // pip hidden.
   const [lastSeenMarker, setLastSeenMarker] = useState<{
-    terminalId: string | null;
+    terminalKey: string;
     state: AgentState | null;
   } | null>(null);
+  // Identity is the whole set of lanes, not one id (#12108): opening or closing
+  // a session changes what the pip is reporting on, so a marker taken against
+  // the old set must stop counting as "already read".
+  const assistantTerminalKey = assistantTerminalIds.join("\u0000");
   useEffect(() => {
     if (isVisible) {
-      setLastSeenMarker({ terminalId: assistantTerminalId, state: agentState });
+      setLastSeenMarker({ terminalKey: assistantTerminalKey, state: agentState });
     }
-  }, [isVisible, assistantTerminalId, agentState]);
+  }, [isVisible, assistantTerminalKey, agentState]);
 
   const handleClick = useCallback(() => {
     suppressSidebarResizes();
@@ -144,7 +161,7 @@ export function ToolbarAssistantButton({
   // stays quiet until a real state change.
   const isAcknowledged =
     lastSeenMarker !== null &&
-    lastSeenMarker.terminalId === assistantTerminalId &&
+    lastSeenMarker.terminalKey === assistantTerminalKey &&
     lastSeenMarker.state === agentState;
   const showAgentPip = !pip && agentPip !== null && !isVisible && !isAcknowledged;
   // Lowest-precedence ambient signal: an MCP audit anomaly fired (#10022). Only

--- a/src/components/Layout/ToolbarAssistantButton.tsx
+++ b/src/components/Layout/ToolbarAssistantButton.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
+import { useShallow } from "zustand/react/shallow";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { createTooltipContent } from "@/lib/tooltipShortcut";

--- a/src/components/Layout/__tests__/ContentDock.portalKeydown.test.tsx
+++ b/src/components/Layout/__tests__/ContentDock.portalKeydown.test.tsx
@@ -72,6 +72,11 @@ vi.mock("@/store/scratchStore", () => ({
 vi.mock("@/store/helpPanelStore", () => ({
   useHelpPanelStore: (selector: (s: { terminalId: null }) => unknown) =>
     selector({ terminalId: null }),
+  // #12108: the dock filters against every lane, so it reads this selector.
+  selectSlotTerminalIds: () => [],
+  selectSlot: (s: unknown) => s,
+  selectActiveSlot: (s: unknown) => s,
+  selectOpenSlots: () => [0],
 }));
 vi.mock("@/store/agentSettingsStore", () => ({
   useAgentSettingsStore: (selector: (s: { settings: null }) => unknown) =>

--- a/src/components/Layout/__tests__/DockPanelOffscreenContainer.test.tsx
+++ b/src/components/Layout/__tests__/DockPanelOffscreenContainer.test.tsx
@@ -34,6 +34,11 @@ vi.mock("@/store", () => {
 vi.mock("@/store/helpPanelStore", () => ({
   useHelpPanelStore: (selector: (s: { terminalId: string | null }) => unknown) =>
     selector({ terminalId: null }),
+  // #12108: the offscreen container filters against every lane's terminal.
+  selectSlotTerminalIds: () => [],
+  selectSlot: (s: unknown) => s,
+  selectActiveSlot: (s: unknown) => s,
+  selectOpenSlots: () => [0],
 }));
 
 // Mock the panel body but keep it a REAL consumer of DragHandleContext, so the

--- a/src/components/Layout/__tests__/ToolbarAssistantButton.test.tsx
+++ b/src/components/Layout/__tests__/ToolbarAssistantButton.test.tsx
@@ -71,11 +71,28 @@ vi.mock("@/store/focusStore", () => ({
   ),
 }));
 
+/**
+ * Seed the panel with a single assistant lane (#12108). These cases predate
+ * lanes and all describe one session, so they seed slot 0; the aggregate
+ * behaviour across lanes has its own tests below.
+ */
 function setHelpPanel(state: { isOpen: boolean; terminalId: string | null }) {
   useHelpPanelStore.setState({
     isOpen: state.isOpen,
-    terminalId: state.terminalId,
+    sessions: { 0: { ...emptyLane(), terminalId: state.terminalId } },
+    activeSlot: 0,
   });
+}
+
+function emptyLane() {
+  return {
+    terminalId: null,
+    agentId: null,
+    sessionId: null,
+    conversationTouched: false,
+    figures: [],
+    activeFigureNumber: null,
+  };
 }
 
 function setPanel(id: string, agentState: string | undefined): void {
@@ -102,9 +119,8 @@ describe("ToolbarAssistantButton — agent state pip", () => {
     mcpReadinessMock.mockReturnValue({ enabled: true, state: "ready", port: 0, lastError: null });
     useHelpPanelStore.setState({
       isOpen: false,
-      terminalId: null,
-      agentId: null,
-      sessionId: null,
+      sessions: { 0: emptyLane() },
+      activeSlot: 0,
     });
     usePanelStore.setState({ panelsById: {}, panelIds: [] } as never);
     mockGestureAssistantHidden = false;
@@ -286,7 +302,7 @@ describe("ToolbarAssistantButton — agent state pip", () => {
     // The user has not seen *this* session, so the pip should fire.
     act(() => {
       setPanel("t-new", "waiting");
-      useHelpPanelStore.setState({ terminalId: "t-new" });
+      useHelpPanelStore.setState({ sessions: { 0: { ...emptyLane(), terminalId: "t-new" } } });
     });
     const pip = queryByTestId("assistant-working-pip");
     expect(pip?.getAttribute("data-visible")).toBe("true");
@@ -435,7 +451,7 @@ describe("ToolbarAssistantButton — agent state pip", () => {
 describe("ToolbarAssistantButton — MCP anomaly pip (#10022)", () => {
   beforeEach(() => {
     mcpReadinessMock.mockReturnValue({ enabled: true, state: "ready", port: 0, lastError: null });
-    useHelpPanelStore.setState({ isOpen: false, terminalId: null, agentId: null, sessionId: null });
+    useHelpPanelStore.setState({ isOpen: false, sessions: { 0: emptyLane() }, activeSlot: 0 });
     usePanelStore.setState({ panelsById: {}, panelIds: [] } as never);
     mockGestureAssistantHidden = false;
     __resetMcpAnomalyStoreForTesting();

--- a/src/components/Layout/__tests__/dockPanelVisibility.test.ts
+++ b/src/components/Layout/__tests__/dockPanelVisibility.test.ts
@@ -30,7 +30,7 @@ function createScope(overrides: Partial<DockPanelScope> = {}): DockPanelScope {
   return {
     // The store keeps trash as a Map; `has` is all the predicate needs.
     trashedTerminals: new Map<string, unknown>(),
-    helpTerminalId: null,
+    helpTerminalIds: new Set<string>(),
     activeWorktreeId: "wt-a",
     ...overrides,
   };
@@ -66,7 +66,7 @@ describe("isDockPanelRendered", () => {
   });
 
   it("does not render the help panel, which owns its own surface", () => {
-    const scope = createScope({ helpTerminalId: "dock-1" });
+    const scope = createScope({ helpTerminalIds: new Set(["dock-1"]) });
 
     expect(isDockPanelRendered(createDockPanel("dock-1"), scope)).toBe(false);
   });
@@ -112,7 +112,7 @@ describe("selectOpenDockPopoverId", () => {
     };
   }
 
-  const scope = { helpTerminalId: null, activeWorktreeId: "wt-a" };
+  const scope = { helpTerminalIds: new Set<string>(), activeWorktreeId: "wt-a" };
 
   it("returns the id of a dock panel the dock actually renders", () => {
     expect(selectOpenDockPopoverId(createState(), scope)).toBe("dock-1");
@@ -145,7 +145,7 @@ describe("selectOpenDockPopoverId", () => {
 
   it("returns null for the help panel, which owns its own surface", () => {
     expect(
-      selectOpenDockPopoverId(createState(), { ...scope, helpTerminalId: "dock-1" })
+      selectOpenDockPopoverId(createState(), { ...scope, helpTerminalIds: new Set(["dock-1"]) })
     ).toBeNull();
   });
 

--- a/src/components/Layout/__tests__/useOpenDockPopoverId.test.tsx
+++ b/src/components/Layout/__tests__/useOpenDockPopoverId.test.tsx
@@ -44,13 +44,13 @@ function seedVisibleDockPopover() {
 
 function emptyLane() {
   return {
-  terminalId: null,
-  agentId: null,
-  sessionId: null,
-  conversationTouched: false,
-  figures: [],
-  activeFigureNumber: null,
-};
+    terminalId: null,
+    agentId: null,
+    sessionId: null,
+    conversationTouched: false,
+    figures: [],
+    activeFigureNumber: null,
+  };
 }
 
 beforeEach(() => {

--- a/src/components/Layout/__tests__/useOpenDockPopoverId.test.tsx
+++ b/src/components/Layout/__tests__/useOpenDockPopoverId.test.tsx
@@ -39,7 +39,18 @@ function seedVisibleDockPopover() {
     trashedTerminals: new Map(),
   });
   useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-a" });
-  useHelpPanelStore.setState({ terminalId: null });
+  useHelpPanelStore.setState({ sessions: { 0: emptyLane() }, activeSlot: 0 });
+}
+
+function emptyLane() {
+  return {
+  terminalId: null,
+  agentId: null,
+  sessionId: null,
+  conversationTouched: false,
+  figures: [],
+  activeFigureNumber: null,
+};
 }
 
 beforeEach(() => {
@@ -54,7 +65,7 @@ afterEach(() => {
     trashedTerminals: new Map(),
   });
   useWorktreeSelectionStore.setState({ activeWorktreeId: null });
-  useHelpPanelStore.setState({ terminalId: null });
+  useHelpPanelStore.setState({ sessions: { 0: emptyLane() }, activeSlot: 0 });
 });
 
 describe("useOpenDockPopoverId", () => {
@@ -82,7 +93,10 @@ describe("useOpenDockPopoverId", () => {
     expect(result.current).toBe("dock-1");
 
     act(() => {
-      useHelpPanelStore.setState({ terminalId: "dock-1" });
+      useHelpPanelStore.setState({
+        sessions: { 0: { ...emptyLane(), terminalId: "dock-1" } },
+        activeSlot: 0,
+      });
     });
 
     expect(result.current).toBeNull();

--- a/src/components/Layout/dockPanelVisibility.ts
+++ b/src/components/Layout/dockPanelVisibility.ts
@@ -3,7 +3,13 @@ import { isDockPanel, type PanelInstance } from "@shared/types/panel";
 export interface DockPanelScope {
   /** Structural so both the store's trash `Map` and a plain `Set` satisfy it. */
   trashedTerminals: { has: (id: string) => boolean };
-  helpTerminalId: string | null;
+  /**
+   * Every live assistant lane's terminal (#12108). All of them are rendered by
+   * `HelpPanel` rather than the dock, so all of them must be filtered out —
+   * carrying only the focused lane would leak a background assistant into the
+   * dock as a stray chip.
+   */
+  helpTerminalIds: ReadonlySet<string>;
   activeWorktreeId: string | null;
 }
 
@@ -30,12 +36,12 @@ export interface DockPanelScope {
  */
 export function isDockPanelRendered(
   panel: PanelInstance | undefined,
-  { trashedTerminals, helpTerminalId, activeWorktreeId }: DockPanelScope
+  { trashedTerminals, helpTerminalIds, activeWorktreeId }: DockPanelScope
 ): boolean {
   if (!panel || !isDockPanel(panel)) return false;
   if (panel.location !== "dock") return false;
   if (trashedTerminals.has(panel.id)) return false;
-  if (panel.id === helpTerminalId) return false;
+  if (helpTerminalIds.has(panel.id)) return false;
   // Global panels (no worktree) ride along with every worktree.
   return panel.worktreeId == null || panel.worktreeId === activeWorktreeId;
 }
@@ -62,7 +68,7 @@ export interface DockPopoverPointerState {
  */
 export function selectOpenDockPopoverId(
   state: DockPopoverPointerState,
-  { helpTerminalId, activeWorktreeId }: Omit<DockPanelScope, "trashedTerminals">
+  { helpTerminalIds, activeWorktreeId }: Omit<DockPanelScope, "trashedTerminals">
 ): string | null {
   const id = state.activeDockTerminalId;
   if (id === null) return null;
@@ -71,7 +77,7 @@ export function selectOpenDockPopoverId(
   const panel = state.panelIds.includes(id) ? state.panelsById[id] : undefined;
   return isDockPanelRendered(panel, {
     trashedTerminals: state.trashedTerminals,
-    helpTerminalId,
+    helpTerminalIds,
     activeWorktreeId,
   })
     ? id

--- a/src/components/Layout/useOpenDockPopoverId.ts
+++ b/src/components/Layout/useOpenDockPopoverId.ts
@@ -1,8 +1,9 @@
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
+import { useShallow } from "zustand/react/shallow";
 import { usePanelStore } from "@/store/panelStore";
 import { setDockPopoverOpen } from "@/lib/dockPopoverLayer";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
-import { useHelpPanelStore } from "@/store/helpPanelStore";
+import { useHelpPanelStore, selectSlotTerminalIds } from "@/store/helpPanelStore";
 import { selectOpenDockPopoverId } from "./dockPanelVisibility";
 
 /**
@@ -27,9 +28,13 @@ import { selectOpenDockPopoverId } from "./dockPanelVisibility";
  */
 export function useOpenDockPopoverId(): string | null {
   const activeWorktreeId = useWorktreeSelectionStore((state) => state.activeWorktreeId);
-  const helpTerminalId = useHelpPanelStore((state) => state.terminalId);
+  // Shallow-compared array, then a Set: returning a fresh Set straight from
+  // the selector would fail every equality check and re-render on every store
+  // write.
+  const helpTerminalIdList = useHelpPanelStore(useShallow(selectSlotTerminalIds));
+  const helpTerminalIds = useMemo(() => new Set(helpTerminalIdList), [helpTerminalIdList]);
   return usePanelStore((state) =>
-    selectOpenDockPopoverId(state, { helpTerminalId, activeWorktreeId })
+    selectOpenDockPopoverId(state, { helpTerminalIds, activeWorktreeId })
   );
 }
 

--- a/src/components/Settings/DaintreeAssistantSettingsTab.tsx
+++ b/src/components/Settings/DaintreeAssistantSettingsTab.tsx
@@ -44,7 +44,7 @@ import { getAgentConfig, getAssistantSupportedAgentIds } from "@/config/agents";
 import { DEFAULT_DANGEROUS_ARGS } from "@shared/types/agentSettings";
 import { agentCapabilitiesClient } from "@/clients/agentCapabilitiesClient";
 import type { AgentModelConfig } from "@shared/config/agentRegistry";
-import { useHelpPanelStore } from "@/store/helpPanelStore";
+import { useHelpPanelStore, selectActiveSlot } from "@/store/helpPanelStore";
 import type {
   HelpAssistantIdleHibernateMinutes,
   HelpAssistantSettings,
@@ -1520,7 +1520,7 @@ interface SessionLiveStatusCardProps {
 // tier field — covered by #10027); the snapshot refreshes on mount and on any
 // grant-lifecycle event for this session.
 function SessionLiveStatusCard({ configuredTier }: SessionLiveStatusCardProps) {
-  const sessionId = useHelpPanelStore((s) => s.sessionId);
+  const sessionId = useHelpPanelStore((s) => selectActiveSlot(s).sessionId);
   const { connected, tier, activeGrants } = useHelpSessionLiveStatus(sessionId);
   const perToolGrants = activeGrants.filter((g) => g.kind !== "native");
   const nativeGrants = activeGrants.filter((g) => g.kind === "native");

--- a/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
@@ -132,6 +132,9 @@ vi.mock("@/store/helpPanelStore", () => {
   store.getState = () => helpPanelState;
   return {
     useHelpPanelStore: store,
+    // #12108: the live-status card follows the lane on screen. This fixture is
+    // flat and single-lane, so the selector projects it as that lane.
+    selectActiveSlot: (s: typeof helpPanelState) => s,
     HELP_PANEL_MIN_WIDTH: 320,
     HELP_PANEL_MAX_WIDTH: 800,
     HELP_PANEL_DEFAULT_WIDTH: 380,

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -81,7 +81,7 @@ import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
 import { useProjectPresetsStore } from "@/store/projectPresetsStore";
 import { terminalClient } from "@/clients";
 import { logWarn } from "@/utils/logger";
-import { useHelpPanelStore } from "@/store/helpPanelStore";
+import { useHelpPanelStore, selectActiveSlot } from "@/store/helpPanelStore";
 import { openSendToAgentPaletteWithText } from "@/hooks/useSendToAgentPalette";
 import { formatWithBracketedPaste } from "@shared/utils/terminalInputProtocol";
 import { panelKindHasPty } from "@shared/config/panelKindRegistry";
@@ -1130,7 +1130,7 @@ function TerminalPaneComponent({
   // assistant session. It's only offered when the assistant terminal exists
   // and is idle/waiting — writing into a working or directing agent would
   // corrupt its input mid-stream.
-  const helpTerminalId = useHelpPanelStore((s) => s.terminalId);
+  const helpTerminalId = useHelpPanelStore((s) => selectActiveSlot(s).terminalId);
   const helpAgentState = usePanelStore((s) => {
     if (!helpTerminalId) return undefined;
     const p = s.panelsById[helpTerminalId];
@@ -1169,8 +1169,7 @@ function TerminalPaneComponent({
   );
 
   const handleSendToAssistant = useCallback(() => {
-    const help = useHelpPanelStore.getState();
-    const helpTid = help.terminalId;
+    const helpTid = selectActiveSlot(useHelpPanelStore.getState()).terminalId;
     if (!helpTid || helpTid === id) return;
     const state = terminalInstanceService.getAgentState(helpTid);
     if (state !== "idle" && state !== "waiting") return;
@@ -1186,6 +1185,7 @@ function TerminalPaneComponent({
       terminalClient.write(helpTid, formatWithBracketedPaste(text));
     }
     terminalInstanceService.notifyUserInput(helpTid);
+    const help = useHelpPanelStore.getState();
     help.setOpen(true);
     help.requestFocus();
   }, [id]);

--- a/src/controllers/HelpSessionController.ts
+++ b/src/controllers/HelpSessionController.ts
@@ -7,7 +7,8 @@
 
 import { getAgentConfig } from "@/config/agents";
 import { actionService } from "@/services/ActionService";
-import { useHelpPanelStore } from "@/store/helpPanelStore";
+import { useHelpPanelStore, selectSlot } from "@/store/helpPanelStore";
+import { DEFAULT_ASSISTANT_SLOT, assistantSlotKey } from "@shared/config/assistantSlots";
 import { usePanelStore } from "@/store";
 import { logError } from "@/utils/logger";
 import { safeFireAndForget } from "@/utils/safeFireAndForget";
@@ -330,6 +331,24 @@ const INITIAL_SNAPSHOT: HelpSessionSnapshot = Object.freeze({
  *   is committed to the store.
  */
 export class HelpSessionController {
+  /**
+   * The assistant lane this controller drives (#12108). One controller per
+   * lane: each owns its own IPC subscriptions, launch state machine and
+   * hibernation timer, and reads/writes only its own slice of the store.
+   *
+   * Defaults to slot 0 so pre-lane callers and fixtures keep working.
+   */
+  readonly slot: number;
+
+  constructor(slot: number = DEFAULT_ASSISTANT_SLOT) {
+    this.slot = slot;
+  }
+
+  /** This lane's live state — never the panel's, never a sibling's. */
+  private _slotState() {
+    return selectSlot(useHelpPanelStore.getState(), this.slot);
+  }
+
   private _snapshot: HelpSessionSnapshot = INITIAL_SNAPSHOT;
   private _listeners = new Set<() => void>();
   private _started = false;
@@ -375,6 +394,10 @@ export class HelpSessionController {
   private readonly _mcpTracker = new McpActivityTracker({
     getSnapshot: () => this._snapshot,
     patch: (partial) => this._patch(partial),
+    // This lane's session, so every MCP push is matched against the
+    // conversation this controller owns rather than the focused one.
+    getSessionId: () => this._slotState().sessionId,
+    getSlot: () => this.slot,
   });
 
   private readonly _hibernationManager = new HibernationManager({
@@ -382,6 +405,8 @@ export class HelpSessionController {
     patch: (partial) => this._patch(partial),
     resetPhase: () => this._resetPhase(),
     isLaunchCurrent: (gen) => gen === this._launchGen,
+    getSlot: () => this.slot,
+    getSlotState: () => this._slotState(),
   });
 
   // Bound for stable references across StrictMode re-subscribe.
@@ -478,8 +503,7 @@ export class HelpSessionController {
     const { terminalId, terminalExists } = args;
     if (!terminalId || terminalExists) return;
     if (terminalId === this._pendingNewTerminalId) return;
-    const store = useHelpPanelStore.getState();
-    if (store.terminalId !== terminalId) return;
+    if (this._slotState().terminalId !== terminalId) return;
 
     // A controlled hibernate (`_fireHibernate`) can tear this same terminal
     // down while its `gracefulKill` is in flight — the PTY `onExit` removes the
@@ -584,8 +608,7 @@ export class HelpSessionController {
    * commits (#6951).
    */
   newSession(): void {
-    const help = useHelpPanelStore.getState();
-    const { terminalId, agentId } = help;
+    const { terminalId, agentId } = this._slotState();
     if (!terminalId || !agentId) return;
     const reservedId = `terminal-${crypto.randomUUID()}`;
     this.launch({
@@ -633,7 +656,7 @@ export class HelpSessionController {
    */
   handleAgentExited(terminalId: string): void {
     if (this._snapshot.phase === "hibernating") return;
-    if (useHelpPanelStore.getState().terminalId !== terminalId) return;
+    if (this._slotState().terminalId !== terminalId) return;
     this._stopBoundSession();
   }
 
@@ -651,9 +674,7 @@ export class HelpSessionController {
     this._isLaunching = false;
     this._clearLaunchWatchdog();
 
-    const help = useHelpPanelStore.getState();
-    const existingTerminalId = help.terminalId;
-    const previousSessionId = help.sessionId;
+    const { terminalId: existingTerminalId, sessionId: previousSessionId } = this._slotState();
     if (existingTerminalId) {
       this._teardownBoundSession(existingTerminalId, previousSessionId, {
         revokePending: true,
@@ -709,8 +730,7 @@ export class HelpSessionController {
    * `force: true` so the dispatcher bypasses the missing-CLI guard.
    */
   runAnyway(): void {
-    const help = useHelpPanelStore.getState();
-    const { terminalId, agentId } = help;
+    const { terminalId, agentId } = this._slotState();
     if (!terminalId || !agentId) return;
     const reservedId = `terminal-${crypto.randomUUID()}`;
     this.launch({
@@ -782,9 +802,7 @@ export class HelpSessionController {
     let presetEnv: Record<string, string> | undefined;
 
     if (replaceExisting) {
-      const existing = useHelpPanelStore.getState();
-      const existingTerminalId = existing.terminalId;
-      const previousSessionId = existing.sessionId;
+      const { terminalId: existingTerminalId, sessionId: previousSessionId } = this._slotState();
       if (existingTerminalId) {
         const panel = usePanelStore.getState().panelsById[existingTerminalId];
         presetEnv = asStringRecord(panel?.extensionState?.presetEnv);
@@ -798,7 +816,7 @@ export class HelpSessionController {
       // for this launch: in a scratch the project store is null by design, and
       // a live read would strand the scratch's entry (#11068).
       if (reservedId) {
-        useHelpPanelStore.getState().clearHibernateSession(launchProject.id);
+        useHelpPanelStore.getState().clearHibernateSession(launchProject.id, this.slot);
         this._patch({ showResumeBanner: false });
       }
     }
@@ -808,7 +826,7 @@ export class HelpSessionController {
       // dock filter (#6951) sees `helpPanelStore.terminalId === reservedId`
       // the instant `addPanel` commits.
       this._pendingNewTerminalId = reservedId;
-      useHelpPanelStore.getState().setTerminal(reservedId, launchAgentId, null);
+      useHelpPanelStore.getState().setTerminal(this.slot, reservedId, launchAgentId, null);
     }
 
     safeFireAndForget(this._executeLaunch(gen, options, launchProject, presetEnv, launchContext), {
@@ -907,8 +925,8 @@ export class HelpSessionController {
     revokeHelpSession(previousSessionId);
     if (options.revokePending) this._revokePendingSession();
     usePanelStore.getState().removePanel(existingTerminalId);
-    useHelpPanelStore.getState().clearTerminal();
-    useHelpPanelStore.getState().clearFigures();
+    useHelpPanelStore.getState().clearTerminal(this.slot);
+    useHelpPanelStore.getState().clearFigures(this.slot);
     this._mcpTracker.clearActivity();
     this._mcpTracker.clearGrantState();
     this._mcpTracker.clearOutcomeAlert();
@@ -1030,9 +1048,8 @@ export class HelpSessionController {
       // Another launch may have already taken over and overwritten it.
       if (this._pendingNewTerminalId === reservedId) {
         this._pendingNewTerminalId = null;
-        const help = useHelpPanelStore.getState();
-        if (help.terminalId === reservedId) {
-          help.clearTerminal();
+        if (this._slotState().terminalId === reservedId) {
+          useHelpPanelStore.getState().clearTerminal(this.slot);
         }
       }
     }
@@ -1253,7 +1270,10 @@ export class HelpSessionController {
           claimId: string;
         } | null = null;
         try {
-          earlyPending = await window.electron.help.takePendingHibernation(launchProject.id);
+          earlyPending = await window.electron.help.takePendingHibernation(
+            launchProject.id,
+            this.slot
+          );
         } catch (err) {
           logError("HelpPanel: resumeOnly early hibernation take failed", err);
         }
@@ -1276,7 +1296,7 @@ export class HelpSessionController {
           this._abandonInFlightLaunch(reservedId, session, { resetAutoLaunch });
           return;
         }
-        useHelpPanelStore.getState().setHibernateSession(launchProject.id, {
+        useHelpPanelStore.getState().setHibernateSession(launchProject.id, this.slot, {
           sessionId: earlyPending.agentSessionId,
           cwd: earlyPending.cwd,
           agentId: earlyPending.agentId,
@@ -1284,7 +1304,12 @@ export class HelpSessionController {
         if (unreleasedHibernation) unreleasedHibernation.mirrored = true;
       }
 
-      const outcome = await provisionHelpSession(launchProject, launchAgentId, launchContext);
+      const outcome = await provisionHelpSession(
+        launchProject,
+        launchAgentId,
+        launchContext,
+        this.slot
+      );
       if (gen !== this._launchGen) {
         if (outcome.ok) session = outcome.session;
         this._abandonInFlightLaunch(reservedId, session, { resetAutoLaunch });
@@ -1293,7 +1318,7 @@ export class HelpSessionController {
       if (!outcome.ok) {
         if (reservedId) {
           this._pendingNewTerminalId = null;
-          useHelpPanelStore.getState().clearTerminal();
+          useHelpPanelStore.getState().clearTerminal(this.slot);
         } else {
           this._hasAutoLaunched = false;
         }
@@ -1347,7 +1372,10 @@ export class HelpSessionController {
             return;
           }
         }
-        const hibernated = useHelpPanelStore.getState().hibernateSessions[launchProject.id];
+        const hibernated =
+          useHelpPanelStore.getState().hibernateSessions[
+            assistantSlotKey(launchProject.id, this.slot)
+          ];
         if (hibernated && hibernated.agentId === launchAgentId && folderPath) {
           const resumed = await this._spawnResumed(
             launchAgentId,
@@ -1371,10 +1399,10 @@ export class HelpSessionController {
             // both post-spawn checks and is about to go live. Every other exit
             // from here leaves the marker set so the `finally` gives it back.
             unreleasedHibernation = null;
-            useHelpPanelStore.getState().clearHibernateSession(launchProject.id);
+            useHelpPanelStore.getState().clearHibernateSession(launchProject.id, this.slot);
             useHelpPanelStore
               .getState()
-              .setTerminal(resumed.panelId, launchAgentId, session.sessionId);
+              .setTerminal(this.slot, resumed.panelId, launchAgentId, session.sessionId);
             this._pendingSessionId = null;
             window.electron.help.markTerminal(resumed.panelId).catch((err) => {
               logError("Failed to mark help terminal", err);
@@ -1391,7 +1419,7 @@ export class HelpSessionController {
             }
             return;
           }
-          useHelpPanelStore.getState().clearHibernateSession(launchProject.id);
+          useHelpPanelStore.getState().clearHibernateSession(launchProject.id, this.slot);
         }
       }
 
@@ -1475,7 +1503,7 @@ export class HelpSessionController {
       if (!result.ok || !result.result?.terminalId) {
         if (reservedId) {
           this._pendingNewTerminalId = null;
-          useHelpPanelStore.getState().clearTerminal();
+          useHelpPanelStore.getState().clearTerminal(this.slot);
           revokeHelpSession(session?.sessionId ?? null);
           logError(
             options.force
@@ -1498,7 +1526,7 @@ export class HelpSessionController {
         this._pendingNewTerminalId = null;
         useHelpPanelStore
           .getState()
-          .setTerminal(finalTerminalId, launchAgentId, session?.sessionId ?? null);
+          .setTerminal(this.slot, finalTerminalId, launchAgentId, session?.sessionId ?? null);
       } else {
         // Stale-launch guard: handleClose may have revoked the pending
         // session while dispatch was in-flight. Drop the orphan terminal
@@ -1510,7 +1538,7 @@ export class HelpSessionController {
         }
         useHelpPanelStore
           .getState()
-          .setTerminal(finalTerminalId, launchAgentId, session?.sessionId ?? null);
+          .setTerminal(this.slot, finalTerminalId, launchAgentId, session?.sessionId ?? null);
         this._pendingSessionId = null;
       }
       reached = true;

--- a/src/controllers/HelpSessionController.ts
+++ b/src/controllers/HelpSessionController.ts
@@ -512,8 +512,8 @@ export class HelpSessionController {
     // never clear hibernate, close the panel, or suppress relaunch here.
     const hibernating = this._snapshot.phase === "hibernating";
 
-    revokeHelpSession(store.sessionId);
-    store.clearTerminal();
+    revokeHelpSession(this._slotState().sessionId);
+    useHelpPanelStore.getState().clearTerminal(this.slot);
     // The bound session is gone — drop any lingering activity row so the strip
     // doesn't show stale tool calls for a dead session (#9759), clear the
     // grant countdown/notice so they don't outlive the session (#10042), and
@@ -534,7 +534,7 @@ export class HelpSessionController {
     // slide the sidebar out. The user ended the session from inside the
     // terminal, so hide the panel rather than lingering on the empty state.
     this._applyStopSuppression();
-    store.setOpen(false);
+    useHelpPanelStore.getState().setOpen(false);
   }
 
   /**

--- a/src/controllers/HelpSessionController.ts
+++ b/src/controllers/HelpSessionController.ts
@@ -1559,7 +1559,7 @@ export class HelpSessionController {
       if (reservedId) {
         if (ownsGen) {
           this._pendingNewTerminalId = null;
-          useHelpPanelStore.getState().clearTerminal();
+          useHelpPanelStore.getState().clearTerminal(this.slot);
         }
         logError(options.force ? "Help run-anyway failed" : "Help new-session failed", error);
       } else {

--- a/src/controllers/HelpSessionController.ts
+++ b/src/controllers/HelpSessionController.ts
@@ -633,9 +633,16 @@ export class HelpSessionController {
    * starts fresh through the normal launch / auto-launch flow. Safe to call
    * repeatedly: with nothing bound it skips the teardown but still invalidates
    * any in-flight launch and closes, converging on the same stopped state.
+   *
+   * `closePanel: false` is for the parallel-lane close (#12108), where a
+   * sibling lane is still live behind the tab strip and sliding the whole
+   * sidebar out would take a running conversation off screen with it. It stays
+   * true by default — for the last lane the close is load-bearing, not
+   * cosmetic: `closeSlot` recreates an empty slot 0 whose fresh controller has
+   * never auto-launched, and `_maybeAutoLaunch` hard-gates on `isOpen`.
    */
-  endSession(): void {
-    this._stopBoundSession();
+  endSession(options: { closePanel?: boolean } = {}): void {
+    this._stopBoundSession(options.closePanel ?? true);
   }
 
   /**
@@ -657,7 +664,7 @@ export class HelpSessionController {
   handleAgentExited(terminalId: string): void {
     if (this._snapshot.phase === "hibernating") return;
     if (this._slotState().terminalId !== terminalId) return;
-    this._stopBoundSession();
+    this._stopBoundSession(true);
   }
 
   /**
@@ -665,11 +672,11 @@ export class HelpSessionController {
    * self-exit (`handleAgentExited`). Aborts any in-flight launch first (mirrors
    * `cancelLaunch`) so a late-settling provision can't bind a fresh terminal
    * after the stop, tears the bound session down (revoke-before-kill), makes
-   * the stop stick, then slides the sidebar out. The close is unconditional:
-   * both callers end the session outright, so neither leaves the panel behind
-   * on its empty state.
+   * the stop stick, then slides the sidebar out. Both callers end the session
+   * outright, so neither leaves the panel behind on its empty state — except
+   * when `closePanel` is false because another lane is still live (#12108).
    */
-  private _stopBoundSession(): void {
+  private _stopBoundSession(closePanel: boolean): void {
     this._launchGen++;
     this._isLaunching = false;
     this._clearLaunchWatchdog();
@@ -687,7 +694,7 @@ export class HelpSessionController {
 
     this._applyStopSuppression();
 
-    useHelpPanelStore.getState().setOpen(false);
+    if (closePanel) useHelpPanelStore.getState().setOpen(false);
   }
 
   /**

--- a/src/controllers/HelpSessionProvisioner.ts
+++ b/src/controllers/HelpSessionProvisioner.ts
@@ -7,6 +7,7 @@ import { extractHelpSessionErrorCode } from "@/utils/clientHelpSessionError";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import type { ActionContext } from "@shared/types/actions";
 import type { HelpProjectRef, LaunchErrorKind } from "./HelpSessionController";
+import { DEFAULT_ASSISTANT_SLOT } from "@shared/config/assistantSlots";
 
 export interface HelpSessionRef {
   sessionId: string;
@@ -41,13 +42,20 @@ export type ProvisionOutcome =
 export async function provisionHelpSession(
   project: HelpProjectRef,
   agentId: string,
-  context?: ActionContext
+  context?: ActionContext,
+  /**
+   * The assistant lane to provision into (#12108). Main displaces only the
+   * prior session in this lane, so naming it is what lets sibling sessions
+   * survive a launch.
+   */
+  slot: number = DEFAULT_ASSISTANT_SLOT
 ): Promise<ProvisionOutcome> {
   try {
     const result = await window.electron.help.provisionSession({
       projectId: project.id,
       projectPath: project.path,
       agentId,
+      slot,
       ...(context && { context }),
     });
     if (!result) {

--- a/src/controllers/HibernationManager.ts
+++ b/src/controllers/HibernationManager.ts
@@ -27,6 +27,14 @@ export interface HibernationManagerHost {
   resetPhase(): void;
   /** True when `gen` is still the controller's current launch generation. */
   isLaunchCurrent(gen: number): boolean;
+  /**
+   * The assistant lane this manager hibernates and resumes (#12108). A
+   * function because the controller builds this in a class field initializer,
+   * before its own constructor body has assigned the lane.
+   */
+  getSlot(): number;
+  /** This lane's live state, so a sibling's terminal is never mistaken for ours. */
+  getSlotState(): { terminalId: string | null; agentId: string | null; sessionId: string | null };
 }
 
 /**
@@ -87,7 +95,7 @@ export class HibernationManager {
     this.clearTimer();
     this._hibernateArmedFor = null;
     if (projectId) {
-      useHelpPanelStore.getState().clearHibernateSession(projectId);
+      useHelpPanelStore.getState().clearHibernateSession(projectId, this.host.getSlot());
     }
   }
 
@@ -127,7 +135,7 @@ export class HibernationManager {
     // `currentProject` null by design (#11068).
     this._hibernateArmedFor = {
       terminalId,
-      agentId: useHelpPanelStore.getState().agentId,
+      agentId: this.host.getSlotState().agentId,
       projectId: workspaceId,
     };
     const initialTerminalId = terminalId;
@@ -178,9 +186,9 @@ export class HibernationManager {
     this._hibernateTimer = null;
     if (!this._isStillArmedFor(initialTerminalId)) return;
 
-    const helpState = useHelpPanelStore.getState();
+    const helpState = this.host.getSlotState();
     if (helpState.terminalId !== initialTerminalId) return;
-    if (helpState.isOpen) return;
+    if (useHelpPanelStore.getState().isOpen) return;
     if (this._isSystemSuspended) return;
 
     const panelState = usePanelStore.getState();
@@ -218,8 +226,8 @@ export class HibernationManager {
         .gracefulKill(initialTerminalId)
         .then((capturedSessionId) => {
           const after = useHelpPanelStore.getState();
-          if (after.terminalId !== initialTerminalId) {
-            // Another flow took over the slot, or the panel was torn down
+          if (this.host.getSlotState().terminalId !== initialTerminalId) {
+            // Another flow took over the lane, or the panel was torn down
             // (e.g. `handleTerminalPanelMissing` cleared the terminal) while
             // the kill was in flight. If a new launch took over it already
             // wrote its own phase; only when the phase is still "hibernating"
@@ -237,7 +245,7 @@ export class HibernationManager {
             return;
           }
           if (capturedSessionId && projectId && liveAgentId && cwd) {
-            after.setHibernateSession(projectId, {
+            after.setHibernateSession(projectId, this.host.getSlot(), {
               sessionId: capturedSessionId,
               cwd,
               agentId: liveAgentId,
@@ -252,22 +260,21 @@ export class HibernationManager {
             // a sentinel hibernate entry (empty sessionId) so the next panel
             // open hits the `--continue`-style fallback in `_spawnResumed`
             // instead of starting a fresh session (#8787).
-            after.setHibernateSession(projectId, {
+            after.setHibernateSession(projectId, this.host.getSlot(), {
               sessionId: "",
               cwd,
               agentId: liveAgentId,
             });
           } else if (projectId) {
-            after.clearHibernateSession(projectId);
+            after.clearHibernateSession(projectId, this.host.getSlot());
           }
           usePanelStore.getState().removePanel(initialTerminalId);
           revokeHelpSession(sessionToRevoke);
-          useHelpPanelStore.getState().clearTerminal();
+          useHelpPanelStore.getState().clearTerminal(this.host.getSlot());
           this.host.resetPhase();
         })
         .catch((err) => {
-          const after = useHelpPanelStore.getState();
-          if (after.terminalId !== initialTerminalId) {
+          if (this.host.getSlotState().terminalId !== initialTerminalId) {
             // See the `.then()` guard: only reset when this hibernate is still
             // the phase's last writer.
             if (this.host.getSnapshot().phase === "hibernating") this.host.resetPhase();
@@ -279,11 +286,11 @@ export class HibernationManager {
           }
           logError("HelpPanel: gracefulKill during hibernate failed", err);
           if (projectId) {
-            useHelpPanelStore.getState().clearHibernateSession(projectId);
+            useHelpPanelStore.getState().clearHibernateSession(projectId, this.host.getSlot());
           }
           usePanelStore.getState().removePanel(initialTerminalId);
           revokeHelpSession(sessionToRevoke);
-          useHelpPanelStore.getState().clearTerminal();
+          useHelpPanelStore.getState().clearTerminal(this.host.getSlot());
           this.host.resetPhase();
         }),
       { context: "HelpPanel:hibernate gracefulKill" }
@@ -333,7 +340,10 @@ export class HibernationManager {
     // the mirror is ours to drop.
     let mirrored = false;
     try {
-      const pending = await window.electron.help.takePendingHibernation(projectId);
+      const pending = await window.electron.help.takePendingHibernation(
+        projectId,
+        this.host.getSlot()
+      );
       if (!pending) return { status: "empty" };
       claimId = pending.claimId;
       if (!this.host.isLaunchCurrent(gen)) {
@@ -350,7 +360,7 @@ export class HibernationManager {
       // branch — see the comment in `_spawnResumed` and `ResumeSpawnResult`.
       // The root-cause capture race is in main; the fix here is the
       // renderer-side truth-in-trigger only.
-      useHelpPanelStore.getState().setHibernateSession(projectId, {
+      useHelpPanelStore.getState().setHibernateSession(projectId, this.host.getSlot(), {
         sessionId: pending.agentSessionId,
         cwd: pending.cwd,
         agentId: pending.agentId,
@@ -399,9 +409,15 @@ export class HibernationManager {
     reason: string,
     opts: { clearMirror: boolean }
   ): Promise<void> {
-    if (opts.clearMirror) useHelpPanelStore.getState().clearHibernateSession(projectId);
+    if (opts.clearMirror) {
+      useHelpPanelStore.getState().clearHibernateSession(projectId, this.host.getSlot());
+    }
     try {
-      const restored = await window.electron.help.restorePendingHibernation(projectId, claimId);
+      const restored = await window.electron.help.restorePendingHibernation(
+        projectId,
+        claimId,
+        this.host.getSlot()
+      );
       logInfo("HelpPanel: released pending hibernation back to main", {
         projectId,
         reason,

--- a/src/controllers/HibernationManager.ts
+++ b/src/controllers/HibernationManager.ts
@@ -280,7 +280,7 @@ export class HibernationManager {
             if (this.host.getSnapshot().phase === "hibernating") this.host.resetPhase();
             return;
           }
-          if (after.isOpen) {
+          if (useHelpPanelStore.getState().isOpen) {
             this.host.patch({ phase: "live" });
             return;
           }

--- a/src/controllers/McpActivityTracker.ts
+++ b/src/controllers/McpActivityTracker.ts
@@ -17,6 +17,24 @@ const GRANT_ENDED_BANNER_AUTO_DISMISS_MS = 15_000;
 export interface McpActivityTrackerHost {
   getSnapshot(): HelpSessionSnapshot;
   patch(partial: Partial<HelpSessionSnapshot>): void;
+  /**
+   * The MCP session id of the lane this tracker belongs to, or null before one
+   * is bound (#12108).
+   *
+   * Deliberately NOT read off the global store. Every push below is targeted
+   * at a WebContents, and with concurrent lanes all of a project's sessions
+   * share one — so routing can no longer say which lane an event belongs to
+   * and the payload's session id is the only thing that can. Sourcing this
+   * from the host keeps each tracker comparing against ITS OWN session rather
+   * than whichever lane happens to be focused.
+   */
+  getSessionId(): string | null;
+  /**
+   * The lane this tracker writes figures into. A function rather than a value
+   * because the host constructs this tracker in a class field initializer,
+   * which runs before its own constructor body has assigned the lane.
+   */
+  getSlot(): number;
 }
 
 /**
@@ -32,9 +50,24 @@ export class McpActivityTracker {
 
   constructor(private readonly host: McpActivityTrackerHost) {}
 
+  /**
+   * Whether an incoming push belongs to this tracker's lane.
+   *
+   * A live session always commits its id before any tool call — and thus
+   * before any denial, grant or revoke — so a null or mismatched id means the
+   * event is for a sibling lane, or for a torn-down / mid-relaunch session of
+   * our own. Painting either would stomp the lane the user is actually in
+   * (#10017, generalized to lanes in #12108).
+   */
+  private _isMine(sessionId: string | null | undefined): boolean {
+    const mine = this.host.getSessionId();
+    return mine !== null && sessionId === mine;
+  }
+
   /** Arm IPC subscriptions. Idempotency is the caller's responsibility (controller `start()`). */
   start(): void {
     const disposeTier = window.electron.mcpServer.onTierNotPermitted((payload) => {
+      if (!this._isMine(payload.sessionId)) return;
       const projectId = useProjectStore.getState().currentProject?.id ?? null;
       // A fresh denial supersedes any lingering "approval ended" notice — the
       // banner the user is about to re-approve from carries the same signal.
@@ -53,14 +86,7 @@ export class McpActivityTracker {
     this._disposers.push(disposeTier);
 
     const disposeRevoked = window.electron.mcpServer.onSessionRevoked((payload) => {
-      // Only surface a revoke that matches the session this panel currently
-      // holds. A live session always has its id committed to the store before
-      // any tool call (and thus before any denial/revoke), so a null or
-      // mismatched `sessionId` here means the revoke is for a torn-down or
-      // mid-relaunch session — painting its banner would stomp the fresh
-      // launch the user just started to escape it (#10017).
-      const currentSessionId = useHelpPanelStore.getState().sessionId;
-      if (currentSessionId === null || payload.sessionId !== currentSessionId) return;
+      if (!this._isMine(payload.sessionId)) return;
       this.host.patch({
         sessionRevoked: { sessionId: payload.sessionId, denialKind: payload.denialKind },
       });
@@ -68,27 +94,36 @@ export class McpActivityTracker {
     this._disposers.push(disposeRevoked);
 
     const disposeGrant = window.electron.mcpServer.onGrantLifecycle((payload) => {
+      if (!this._isMine(payload.sessionId)) return;
       this._onGrantLifecycle(payload);
     });
     this._disposers.push(disposeGrant);
 
     const disposeToolStarted = window.electron.mcpServer.onToolCallStarted((payload) => {
+      if (!this._isMine(payload.sessionId)) return;
       this._onToolCallStarted(payload);
     });
     const disposeToolSettled = window.electron.mcpServer.onToolCallSettled((payload) => {
+      if (!this._isMine(payload.sessionId)) return;
       this._onToolCallSettled(payload);
     });
     this._disposers.push(disposeToolStarted, disposeToolSettled);
 
     const disposeOutcomeAlert = window.electron.mcpServer.onTurnOutcomeAlert((payload) => {
+      // This channel names the lane with `helpSessionId` rather than
+      // `sessionId`; both are the same public help-session id.
+      if (!this._isMine(payload.helpSessionId)) return;
       this._onTurnOutcomeAlert(payload);
     });
     this._disposers.push(disposeOutcomeAlert);
 
     const disposeDisplayImage = window.electron.mcpServer.onDisplayImage((payload) => {
+      // Gate before writing: figures are per lane, so an unfiltered push would
+      // file a sibling's image under this conversation (#12108).
+      if (!this._isMine(payload.sessionId)) return;
       // The main process already validated the URL and assigned the figure
       // number (#9828); the renderer just records the figure for inline display.
-      useHelpPanelStore.getState().addFigure({
+      useHelpPanelStore.getState().addFigure(this.host.getSlot(), {
         imageId: payload.imageId,
         figureNumber: payload.figureNumber,
         figureLabel: payload.figureLabel,

--- a/src/controllers/__tests__/HelpSessionController.coreLifecycle.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.coreLifecycle.test.ts
@@ -57,6 +57,21 @@ const {
   grantLifecycleListeners: [] as Array<(payload: unknown) => void>,
   outcomeAlertListeners: [] as Array<(payload: unknown) => void>,
   helpPanelState: {
+    clearDroppedPreferredAgent: vi.fn(),
+    dismissIntro: vi.fn(),
+    setAutoLaunchEnabled: vi.fn(),
+    setWidth: vi.fn(),
+    requestFocus: vi.fn(),
+    setActiveFigureNumber: vi.fn(),
+    addFigure: vi.fn(),
+    markConversationStarted: vi.fn(),
+    setActiveSlot: vi.fn(),
+    closeSlot: vi.fn(),
+    openSlot: vi.fn(),
+    // #12108: the panel reads its lane pointer; the mocked selectors
+    // above project this same flat object as that lane.
+    activeSlot: 0,
+    sessions: {} as Record<number, unknown>,
     isOpen: false,
     terminalId: null as string | null,
     agentId: null as string | null,
@@ -97,7 +112,17 @@ vi.mock("@/store/helpPanelStore", () => {
   const store = (selector?: (s: typeof helpPanelState) => unknown) =>
     selector ? selector(helpPanelState) : helpPanelState;
   store.getState = () => helpPanelState;
-  return { useHelpPanelStore: store };
+  return {
+    useHelpPanelStore: store,
+    // #12108 selectors. The fixtures below stay FLAT (terminalId/agentId/…)
+    // and these project that same object as the lane, so every existing
+    // assertion keeps driving the controller unchanged.
+    selectSlot: (s) => s,
+    selectActiveSlot: (s) => s,
+    selectOpenSlots: () => [0],
+    selectSlotTerminalIds: (s) => (s.terminalId ? [s.terminalId] : []),
+    selectSlotForTerminal: (s, id) => (s.terminalId === id && id ? 0 : null),
+  };
 });
 
 vi.mock("@/store", () => {
@@ -392,6 +417,8 @@ describe("HelpSessionController — subscribe / getSnapshot", () => {
   });
 
   it("notifies listeners when state changes via patch", () => {
+    // #12108: pushes are matched against the lane's own session id.
+    helpPanelState.sessionId = "s1";
     const ctrl = new HelpSessionController();
     ctrl.start();
     const listener = vi.fn();
@@ -448,6 +475,7 @@ describe("HelpSessionController — turn-outcome alert pip", () => {
   }
 
   it("surfaces agent-stuck as outcomeAlert and notifies listeners", () => {
+    helpPanelState.sessionId = "help-1";
     const ctrl = new HelpSessionController();
     ctrl.start();
     const listener = vi.fn();
@@ -461,6 +489,7 @@ describe("HelpSessionController — turn-outcome alert pip", () => {
   });
 
   it("surfaces reasoning-loop and clears on user dismiss", () => {
+    helpPanelState.sessionId = "help-1";
     const ctrl = new HelpSessionController();
     ctrl.start();
     fireOutcome({ helpSessionId: "help-1", outcome: "reasoning-loop", turnId: "turn-1" });
@@ -472,6 +501,7 @@ describe("HelpSessionController — turn-outcome alert pip", () => {
   });
 
   it("auto-clears the pip when a tool call from a different turn starts", () => {
+    helpPanelState.sessionId = "help-1";
     const ctrl = new HelpSessionController();
     ctrl.start();
     fireOutcome({ helpSessionId: "help-1", outcome: "reasoning-loop", turnId: "turn-1" });
@@ -488,6 +518,7 @@ describe("HelpSessionController — turn-outcome alert pip", () => {
   });
 
   it("auto-clears an agent-stuck pip (no turn id) on the next turn-stamped call", () => {
+    helpPanelState.sessionId = "help-1";
     const ctrl = new HelpSessionController();
     ctrl.start();
     fireOutcome({ helpSessionId: "help-1", outcome: "agent-stuck" });
@@ -499,6 +530,7 @@ describe("HelpSessionController — turn-outcome alert pip", () => {
   });
 
   it("does not clear the pip for a call with no turn id", () => {
+    helpPanelState.sessionId = "help-1";
     const ctrl = new HelpSessionController();
     ctrl.start();
     fireOutcome({ helpSessionId: "help-1", outcome: "reasoning-loop", turnId: "turn-1" });
@@ -578,7 +610,7 @@ describe("HelpSessionController — endSession (Stop assistant, #10989)", () => 
     expect(helpPanelState.clearFigures).toHaveBeenCalled();
     // Stop is destructive, not pause: the persisted hibernate slot is dropped so
     // the discarded conversation can't resume on next open.
-    expect(helpPanelState.clearHibernateSession).toHaveBeenCalledWith("proj-1");
+    expect(helpPanelState.clearHibernateSession).toHaveBeenCalledWith("proj-1", 0);
     // No fresh terminal is reserved — unlike newSession(), stop does not relaunch.
     expect(helpPanelState.setTerminal).not.toHaveBeenCalled();
     // #11833: Stop slides the sidebar out rather than lingering on the empty
@@ -598,7 +630,7 @@ describe("HelpSessionController — endSession (Stop assistant, #10989)", () => 
 
     ctrl.endSession();
 
-    expect(helpPanelState.clearHibernateSession).toHaveBeenCalledWith("scratch-1");
+    expect(helpPanelState.clearHibernateSession).toHaveBeenCalledWith("scratch-1", 0);
   });
 
   it("revokes the bearer before killing the PTY (revoke-before-kill, #7522)", () => {
@@ -732,7 +764,7 @@ describe("HelpSessionController — terminal PTY exit slides the sidebar out (#1
     expect(window.electron.help.revokeSession).toHaveBeenCalledWith("sess-bound");
     expect(helpPanelState.clearTerminal).toHaveBeenCalled();
     // Full stop: the hibernate slot is dropped and the sidebar slides out.
-    expect(helpPanelState.clearHibernateSession).toHaveBeenCalledWith("proj-1");
+    expect(helpPanelState.clearHibernateSession).toHaveBeenCalledWith("proj-1", 0);
     expect(helpPanelState.setOpen).toHaveBeenCalledWith(false);
     expect(ctrl.getSnapshot().phase).toBe("idle");
   });
@@ -820,7 +852,7 @@ describe("HelpSessionController — handleAgentExited (agent /exit inside a live
     expect(window.electron.help.revokeSession).toHaveBeenCalledWith("sess-bound");
     expect(helpPanelState.clearTerminal).toHaveBeenCalled();
     // Full stop, and the sidebar slides out — same as the Stop button (#11833).
-    expect(helpPanelState.clearHibernateSession).toHaveBeenCalledWith("proj-1");
+    expect(helpPanelState.clearHibernateSession).toHaveBeenCalledWith("proj-1", 0);
     expect(helpPanelState.setOpen).toHaveBeenCalledWith(false);
     expect(ctrl["_hasAutoLaunched"]).toBe(true);
     expect(ctrl.getSnapshot().phase).toBe("idle");

--- a/src/controllers/__tests__/HelpSessionController.coreLifecycle.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.coreLifecycle.test.ts
@@ -117,11 +117,12 @@ vi.mock("@/store/helpPanelStore", () => {
     // #12108 selectors. The fixtures below stay FLAT (terminalId/agentId/…)
     // and these project that same object as the lane, so every existing
     // assertion keeps driving the controller unchanged.
-    selectSlot: (s) => s,
-    selectActiveSlot: (s) => s,
+    selectSlot: (s: typeof helpPanelState) => s,
+    selectActiveSlot: (s: typeof helpPanelState) => s,
     selectOpenSlots: () => [0],
-    selectSlotTerminalIds: (s) => (s.terminalId ? [s.terminalId] : []),
-    selectSlotForTerminal: (s, id) => (s.terminalId === id && id ? 0 : null),
+    selectSlotTerminalIds: (s: typeof helpPanelState) => (s.terminalId ? [s.terminalId] : []),
+    selectSlotForTerminal: (s: typeof helpPanelState, id: string) =>
+      s.terminalId === id && id ? 0 : null,
   };
 });
 
@@ -465,7 +466,9 @@ describe("HelpSessionController — turn-outcome alert pip", () => {
   }
   function fireToolStart(payload: { turnId?: string }) {
     toolStartedListeners[0]!({
-      sessionId: "s1",
+      // Follow whichever session the lane is bound to — since #12108 a push
+      // for another session is correctly ignored.
+      sessionId: helpPanelState.sessionId ?? "s1",
       toolId: "agent.getState",
       argsSummary: "{}",
       startedAt: Date.now(),

--- a/src/controllers/__tests__/HelpSessionController.launchPhaseFsm.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.launchPhaseFsm.test.ts
@@ -117,11 +117,12 @@ vi.mock("@/store/helpPanelStore", () => {
     // #12108 selectors. The fixtures below stay FLAT (terminalId/agentId/…)
     // and these project that same object as the lane, so every existing
     // assertion keeps driving the controller unchanged.
-    selectSlot: (s) => s,
-    selectActiveSlot: (s) => s,
+    selectSlot: (s: typeof helpPanelState) => s,
+    selectActiveSlot: (s: typeof helpPanelState) => s,
     selectOpenSlots: () => [0],
-    selectSlotTerminalIds: (s) => (s.terminalId ? [s.terminalId] : []),
-    selectSlotForTerminal: (s, id) => (s.terminalId === id && id ? 0 : null),
+    selectSlotTerminalIds: (s: typeof helpPanelState) => (s.terminalId ? [s.terminalId] : []),
+    selectSlotForTerminal: (s: typeof helpPanelState, id: string) =>
+      s.terminalId === id && id ? 0 : null,
   };
 });
 
@@ -152,6 +153,7 @@ vi.mock("@/utils/safeFireAndForget", () => ({
 
 import { HelpSessionController } from "../HelpSessionController";
 import { actionService } from "@/services/ActionService";
+import { assistantSlotKey as slotKey } from "@shared/config/assistantSlots";
 
 function resetState() {
   helpPanelState.isOpen = false;
@@ -522,7 +524,7 @@ describe("HelpSessionController — launch phase FSM", () => {
     ctrl.start();
     helpPanelState.preferredAgentId = "claude";
     helpPanelState.hibernateSessions = {
-      proj: { sessionId: "old-sess", agentId: "claude", cwd: "/help" },
+      [slotKey("proj", 0)]: { sessionId: "old-sess", agentId: "claude", cwd: "/help" },
     };
     // Store currentProject drifts away from the launch project after capture.
     projectStoreState.currentProject = { id: "other", path: "/other" };

--- a/src/controllers/__tests__/HelpSessionController.launchPhaseFsm.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.launchPhaseFsm.test.ts
@@ -57,6 +57,21 @@ const {
   grantLifecycleListeners: [] as Array<(payload: unknown) => void>,
   outcomeAlertListeners: [] as Array<(payload: unknown) => void>,
   helpPanelState: {
+    clearDroppedPreferredAgent: vi.fn(),
+    dismissIntro: vi.fn(),
+    setAutoLaunchEnabled: vi.fn(),
+    setWidth: vi.fn(),
+    requestFocus: vi.fn(),
+    setActiveFigureNumber: vi.fn(),
+    addFigure: vi.fn(),
+    markConversationStarted: vi.fn(),
+    setActiveSlot: vi.fn(),
+    closeSlot: vi.fn(),
+    openSlot: vi.fn(),
+    // #12108: the panel reads its lane pointer; the mocked selectors
+    // above project this same flat object as that lane.
+    activeSlot: 0,
+    sessions: {} as Record<number, unknown>,
     isOpen: false,
     terminalId: null as string | null,
     agentId: null as string | null,
@@ -97,7 +112,17 @@ vi.mock("@/store/helpPanelStore", () => {
   const store = (selector?: (s: typeof helpPanelState) => unknown) =>
     selector ? selector(helpPanelState) : helpPanelState;
   store.getState = () => helpPanelState;
-  return { useHelpPanelStore: store };
+  return {
+    useHelpPanelStore: store,
+    // #12108 selectors. The fixtures below stay FLAT (terminalId/agentId/…)
+    // and these project that same object as the lane, so every existing
+    // assertion keeps driving the controller unchanged.
+    selectSlot: (s) => s,
+    selectActiveSlot: (s) => s,
+    selectOpenSlots: () => [0],
+    selectSlotTerminalIds: (s) => (s.terminalId ? [s.terminalId] : []),
+    selectSlotForTerminal: (s, id) => (s.terminalId === id && id ? 0 : null),
+  };
 });
 
 vi.mock("@/store", () => {

--- a/src/controllers/__tests__/HelpSessionController.resumeAndToolActivity.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.resumeAndToolActivity.test.ts
@@ -409,7 +409,11 @@ describe("HelpSessionController — resume-only auto-resume (#10815)", () => {
   // it a pure spy; this writes through to helpPanelState.hibernateSessions.
   const seedThroughSetHibernate = () => {
     helpPanelState.setHibernateSession = vi.fn(
-      (projectId: string, slot: number, entry: { sessionId: string; cwd: string; agentId: string }) => {
+      (
+        projectId: string,
+        slot: number,
+        entry: { sessionId: string; cwd: string; agentId: string }
+      ) => {
         helpPanelState.hibernateSessions[slotKey(projectId, slot)] = entry;
       }
     );

--- a/src/controllers/__tests__/HelpSessionController.resumeAndToolActivity.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.resumeAndToolActivity.test.ts
@@ -117,11 +117,12 @@ vi.mock("@/store/helpPanelStore", () => {
     // #12108 selectors. The fixtures below stay FLAT (terminalId/agentId/…)
     // and these project that same object as the lane, so every existing
     // assertion keeps driving the controller unchanged.
-    selectSlot: (s) => s,
-    selectActiveSlot: (s) => s,
+    selectSlot: (s: typeof helpPanelState) => s,
+    selectActiveSlot: (s: typeof helpPanelState) => s,
     selectOpenSlots: () => [0],
-    selectSlotTerminalIds: (s) => (s.terminalId ? [s.terminalId] : []),
-    selectSlotForTerminal: (s, id) => (s.terminalId === id && id ? 0 : null),
+    selectSlotTerminalIds: (s: typeof helpPanelState) => (s.terminalId ? [s.terminalId] : []),
+    selectSlotForTerminal: (s: typeof helpPanelState, id: string) =>
+      s.terminalId === id && id ? 0 : null,
   };
 });
 
@@ -153,6 +154,7 @@ vi.mock("@/utils/safeFireAndForget", () => ({
 import { HelpSessionController, loadCustomLaunchFlags } from "../HelpSessionController";
 import { actionService } from "@/services/ActionService";
 import { notify } from "@/lib/notify";
+import { assistantSlotKey as slotKey } from "@shared/config/assistantSlots";
 
 function resetState() {
   helpPanelState.isOpen = false;
@@ -347,7 +349,7 @@ describe("HelpSessionController — resume banner gating (#10057)", () => {
     ctrl.start();
     primeResumeInputs(ctrl);
     // Empty sessionId is the sentinel from main's LRU-eviction race.
-    helpPanelState.hibernateSessions["p1"] = {
+    helpPanelState.hibernateSessions[slotKey("p1", 0)] = {
       sessionId: "",
       cwd: "/repo",
       agentId: "claude",
@@ -378,7 +380,7 @@ describe("HelpSessionController — resume banner gating (#10057)", () => {
     const ctrl = new HelpSessionController();
     ctrl.start();
     primeResumeInputs(ctrl);
-    helpPanelState.hibernateSessions["p1"] = {
+    helpPanelState.hibernateSessions[slotKey("p1", 0)] = {
       sessionId: "abc-123",
       cwd: "/repo",
       agentId: "claude",
@@ -407,8 +409,8 @@ describe("HelpSessionController — resume-only auto-resume (#10815)", () => {
   // it a pure spy; this writes through to helpPanelState.hibernateSessions.
   const seedThroughSetHibernate = () => {
     helpPanelState.setHibernateSession = vi.fn(
-      (projectId: string, entry: { sessionId: string; cwd: string; agentId: string }) => {
-        helpPanelState.hibernateSessions[projectId] = entry;
+      (projectId: string, slot: number, entry: { sessionId: string; cwd: string; agentId: string }) => {
+        helpPanelState.hibernateSessions[slotKey(projectId, slot)] = entry;
       }
     );
   };
@@ -463,7 +465,7 @@ describe("HelpSessionController — resume-only auto-resume (#10815)", () => {
     (
       window.electron.help as unknown as { takePendingHibernation: ReturnType<typeof vi.fn> }
     ).takePendingHibernation = vi.fn().mockResolvedValue(null);
-    helpPanelState.hibernateSessions["p1"] = {
+    helpPanelState.hibernateSessions[slotKey("p1", 0)] = {
       sessionId: "stale-123",
       cwd: "/repo",
       agentId: "claude",
@@ -514,7 +516,7 @@ describe("HelpSessionController — resume-only auto-resume (#10815)", () => {
     );
 
     // The take is the gate, and it runs before provisioning displaces anything.
-    expect(takeMock).toHaveBeenCalledWith("p1");
+    expect(takeMock).toHaveBeenCalledWith("p1", 0);
     const takeOrder = takeMock.mock.invocationCallOrder[0];
     const provisionOrder = provisionMock().mock.invocationCallOrder[0];
     expect(takeOrder).toBeDefined();
@@ -656,7 +658,7 @@ describe("HelpSessionController — resume-only auto-resume (#10815)", () => {
     await ctrl["_executeLaunch"](7, { agentId: "claude" }, { id: "p1", path: "/repo" }, undefined);
 
     // _seedHibernateFromMain ran (the take is its only caller on this path).
-    expect(takeMock).toHaveBeenCalledWith("p1");
+    expect(takeMock).toHaveBeenCalledWith("p1", 0);
     expect(panelStoreState.addPanel).toHaveBeenCalled();
     expect(helpPanelState.clearHibernateSession).toHaveBeenCalledWith("p1", 0);
     expect(ctrl.getSnapshot().phase).toBe("live");
@@ -666,6 +668,9 @@ describe("HelpSessionController — resume-only auto-resume (#10815)", () => {
 
 describe("HelpSessionController — MCP tool activity strip (#9759)", () => {
   function startCtrl() {
+    // #12108: every MCP push is matched against the lane's own session id, and
+    // the fixtures below all fire for "s1".
+    helpPanelState.sessionId = "s1";
     const ctrl = new HelpSessionController();
     ctrl.start();
     return ctrl;
@@ -863,7 +868,6 @@ describe("HelpSessionController — MCP tool activity strip (#9759)", () => {
   it("handleTerminalPanelMissing clears the activity row", () => {
     const ctrl = startCtrl();
     helpPanelState.terminalId = "term-1";
-    helpPanelState.sessionId = "sess-1";
     fireStarted({ sessionId: "s1", toolId: "x", argsSummary: "{}", startedAt: 1, danger: false });
     expect(ctrl.getSnapshot().mcpActivity).not.toBeNull();
     ctrl.handleTerminalPanelMissing({ terminalId: "term-1", terminalExists: false });

--- a/src/controllers/__tests__/HelpSessionController.resumeAndToolActivity.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.resumeAndToolActivity.test.ts
@@ -57,6 +57,21 @@ const {
   grantLifecycleListeners: [] as Array<(payload: unknown) => void>,
   outcomeAlertListeners: [] as Array<(payload: unknown) => void>,
   helpPanelState: {
+    clearDroppedPreferredAgent: vi.fn(),
+    dismissIntro: vi.fn(),
+    setAutoLaunchEnabled: vi.fn(),
+    setWidth: vi.fn(),
+    requestFocus: vi.fn(),
+    setActiveFigureNumber: vi.fn(),
+    addFigure: vi.fn(),
+    markConversationStarted: vi.fn(),
+    setActiveSlot: vi.fn(),
+    closeSlot: vi.fn(),
+    openSlot: vi.fn(),
+    // #12108: the panel reads its lane pointer; the mocked selectors
+    // above project this same flat object as that lane.
+    activeSlot: 0,
+    sessions: {} as Record<number, unknown>,
     isOpen: false,
     terminalId: null as string | null,
     agentId: null as string | null,
@@ -97,7 +112,17 @@ vi.mock("@/store/helpPanelStore", () => {
   const store = (selector?: (s: typeof helpPanelState) => unknown) =>
     selector ? selector(helpPanelState) : helpPanelState;
   store.getState = () => helpPanelState;
-  return { useHelpPanelStore: store };
+  return {
+    useHelpPanelStore: store,
+    // #12108 selectors. The fixtures below stay FLAT (terminalId/agentId/…)
+    // and these project that same object as the lane, so every existing
+    // assertion keeps driving the controller unchanged.
+    selectSlot: (s) => s,
+    selectActiveSlot: (s) => s,
+    selectOpenSlots: () => [0],
+    selectSlotTerminalIds: (s) => (s.terminalId ? [s.terminalId] : []),
+    selectSlotForTerminal: (s, id) => (s.terminalId === id && id ? 0 : null),
+  };
 });
 
 vi.mock("@/store", () => {
@@ -341,7 +366,7 @@ describe("HelpSessionController — resume banner gating (#10057)", () => {
     expect(ctrl.getSnapshot().showResumeBanner).toBe(false);
     // The hibernate entry is still consumed so a future auto-launch doesn't
     // loop on the same --continue attempt.
-    expect(helpPanelState.clearHibernateSession).toHaveBeenCalledWith("p1");
+    expect(helpPanelState.clearHibernateSession).toHaveBeenCalledWith("p1", 0);
     // The spawn still happened — the renderer attempted the agent heuristic.
     expect(panelStoreState.addPanel).toHaveBeenCalledWith(
       expect.objectContaining({ kind: "terminal" })
@@ -368,7 +393,7 @@ describe("HelpSessionController — resume banner gating (#10057)", () => {
 
     expect(ctrl.getSnapshot().phase).toBe("live");
     expect(ctrl.getSnapshot().showResumeBanner).toBe(true);
-    expect(helpPanelState.clearHibernateSession).toHaveBeenCalledWith("p1");
+    expect(helpPanelState.clearHibernateSession).toHaveBeenCalledWith("p1", 0);
     ctrl.stop();
   });
 });
@@ -496,7 +521,7 @@ describe("HelpSessionController — resume-only auto-resume (#10815)", () => {
     expect(provisionOrder).toBeDefined();
     expect(takeOrder!).toBeLessThan(provisionOrder!);
     // The taken entry seeds the local store the resume block reads.
-    expect(helpPanelState.setHibernateSession).toHaveBeenCalledWith("p1", {
+    expect(helpPanelState.setHibernateSession).toHaveBeenCalledWith("p1", 0, {
       sessionId: "abc-123",
       cwd: "/repo",
       agentId: "claude",
@@ -509,7 +534,7 @@ describe("HelpSessionController — resume-only auto-resume (#10815)", () => {
       expect.anything(),
       expect.anything()
     );
-    expect(helpPanelState.clearHibernateSession).toHaveBeenCalledWith("p1");
+    expect(helpPanelState.clearHibernateSession).toHaveBeenCalledWith("p1", 0);
     expect(ctrl.getSnapshot().phase).toBe("live");
     ctrl.stop();
   });
@@ -633,7 +658,7 @@ describe("HelpSessionController — resume-only auto-resume (#10815)", () => {
     // _seedHibernateFromMain ran (the take is its only caller on this path).
     expect(takeMock).toHaveBeenCalledWith("p1");
     expect(panelStoreState.addPanel).toHaveBeenCalled();
-    expect(helpPanelState.clearHibernateSession).toHaveBeenCalledWith("p1");
+    expect(helpPanelState.clearHibernateSession).toHaveBeenCalledWith("p1", 0);
     expect(ctrl.getSnapshot().phase).toBe("live");
     ctrl.stop();
   });

--- a/src/controllers/__tests__/HelpSessionController.sessionAndViewRecovery.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.sessionAndViewRecovery.test.ts
@@ -117,11 +117,12 @@ vi.mock("@/store/helpPanelStore", () => {
     // #12108 selectors. The fixtures below stay FLAT (terminalId/agentId/…)
     // and these project that same object as the lane, so every existing
     // assertion keeps driving the controller unchanged.
-    selectSlot: (s) => s,
-    selectActiveSlot: (s) => s,
+    selectSlot: (s: typeof helpPanelState) => s,
+    selectActiveSlot: (s: typeof helpPanelState) => s,
     selectOpenSlots: () => [0],
-    selectSlotTerminalIds: (s) => (s.terminalId ? [s.terminalId] : []),
-    selectSlotForTerminal: (s, id) => (s.terminalId === id && id ? 0 : null),
+    selectSlotTerminalIds: (s: typeof helpPanelState) => (s.terminalId ? [s.terminalId] : []),
+    selectSlotForTerminal: (s: typeof helpPanelState, id: string) =>
+      s.terminalId === id && id ? 0 : null,
   };
 });
 
@@ -343,6 +344,8 @@ describe("HelpSessionController — handleViewRevealed (switch-back recovery #10
   }
 
   it("silently reaps a stranded loading-phase launch and re-drives it (no error surfaced)", () => {
+    // #12108: MCP pushes are matched against the lane's own session id.
+    helpPanelState.sessionId = "s1";
     const ctrl = new HelpSessionController();
     ctrl.start();
     startStuckLaunch(ctrl);
@@ -368,6 +371,8 @@ describe("HelpSessionController — handleViewRevealed (switch-back recovery #10
   });
 
   it("revokes the minted-but-orphaned pending session token when reaping", () => {
+    // #12108: MCP pushes are matched against the lane's own session id.
+    helpPanelState.sessionId = "s1";
     const ctrl = new HelpSessionController();
     ctrl.start();
     startStuckLaunch(ctrl);
@@ -380,6 +385,8 @@ describe("HelpSessionController — handleViewRevealed (switch-back recovery #10
   });
 
   it("is a no-op when a session is already live (no reap, no re-drive)", () => {
+    // #12108: MCP pushes are matched against the lane's own session id.
+    helpPanelState.sessionId = "s1";
     const ctrl = new HelpSessionController();
     ctrl.start();
     ctrl["_patch"]({ phase: "live" });
@@ -393,6 +400,8 @@ describe("HelpSessionController — handleViewRevealed (switch-back recovery #10
   });
 
   it("is a no-op while idle", () => {
+    // #12108: MCP pushes are matched against the lane's own session id.
+    helpPanelState.sessionId = "s1";
     const ctrl = new HelpSessionController();
     ctrl.start();
     const genBefore = ctrl["_launchGen"] as number;
@@ -405,6 +414,8 @@ describe("HelpSessionController — handleViewRevealed (switch-back recovery #10
   });
 
   it("does not reap a hibernating phase (it owns a live terminal mid-shutdown)", () => {
+    // #12108: MCP pushes are matched against the lane's own session id.
+    helpPanelState.sessionId = "s1";
     const ctrl = new HelpSessionController();
     ctrl.start();
     ctrl["_patch"]({ phase: "hibernating" });
@@ -418,6 +429,8 @@ describe("HelpSessionController — handleViewRevealed (switch-back recovery #10
   });
 
   it("does not reap a manual (non-auto) launch — the _hasAutoLaunched guard protects it", () => {
+    // #12108: MCP pushes are matched against the lane's own session id.
+    helpPanelState.sessionId = "s1";
     const ctrl = new HelpSessionController();
     ctrl.start();
     // A manual selectAgent() launch never sets `_hasAutoLaunched`; reaping it
@@ -445,6 +458,8 @@ describe("HelpSessionController — handleViewRevealed (switch-back recovery #10
   });
 
   it("does not surface a launch error when the original hung IPC rejects after the reap", async () => {
+    // #12108: MCP pushes are matched against the lane's own session id.
+    helpPanelState.sessionId = "s1";
     const ctrl = new HelpSessionController();
     ctrl.start();
     helpPanelState.preferredAgentId = "claude";
@@ -486,6 +501,8 @@ describe("HelpSessionController — handleViewRevealed (switch-back recovery #10
   });
 
   it("does not reap a loading phase when a terminal is already bound (reserved-id guard)", () => {
+    // #12108: MCP pushes are matched against the lane's own session id.
+    helpPanelState.sessionId = "s1";
     const ctrl = new HelpSessionController();
     ctrl.start();
     // A newSession/runAnyway launch reserves its terminal slot synchronously, so
@@ -515,6 +532,8 @@ describe("HelpSessionController — handleViewRevealed (switch-back recovery #10
 
 describe("HelpSessionController — tier-mismatch handlers", () => {
   it("approveTierOnce() calls issueGrant (per-tool) and clears banner on success", async () => {
+    // #12108: MCP pushes are matched against the lane's own session id.
+    helpPanelState.sessionId = "s1";
     const ctrl = new HelpSessionController();
     ctrl.start();
     tierListeners[0]?.({
@@ -540,6 +559,8 @@ describe("HelpSessionController — tier-mismatch handlers", () => {
   });
 
   it("approveTierOnce() is a no-op while another approval is in flight", () => {
+    // #12108: MCP pushes are matched against the lane's own session id.
+    helpPanelState.sessionId = "s1";
     const ctrl = new HelpSessionController();
     ctrl.start();
     tierListeners[0]?.({
@@ -556,6 +577,8 @@ describe("HelpSessionController — tier-mismatch handlers", () => {
   });
 
   it("dismissTierMismatch() clears the banner immediately", () => {
+    // #12108: MCP pushes are matched against the lane's own session id.
+    helpPanelState.sessionId = "s1";
     const ctrl = new HelpSessionController();
     ctrl.start();
     tierListeners[0]?.({
@@ -571,6 +594,8 @@ describe("HelpSessionController — tier-mismatch handlers", () => {
   });
 
   it("dismissTierMismatch() resets the denial counter for the dismissed session (#10017)", () => {
+    // #12108: MCP pushes are matched against the lane's own session id.
+    helpPanelState.sessionId = "sess-9";
     const ctrl = new HelpSessionController();
     ctrl.start();
     tierListeners[0]?.({
@@ -587,6 +612,8 @@ describe("HelpSessionController — tier-mismatch handlers", () => {
   });
 
   it("dismissTierMismatch() does not reset denial counts when no banner is showing", () => {
+    // #12108: MCP pushes are matched against the lane's own session id.
+    helpPanelState.sessionId = "s1";
     const ctrl = new HelpSessionController();
     ctrl.start();
     ctrl.dismissTierMismatch();
@@ -595,6 +622,8 @@ describe("HelpSessionController — tier-mismatch handlers", () => {
   });
 
   it("dismissTierMismatch() clears the banner even if the denial-reset IPC rejects", () => {
+    // #12108: MCP pushes are matched against the lane's own session id.
+    helpPanelState.sessionId = "sess-r";
     const ctrl = new HelpSessionController();
     ctrl.start();
     // Fire-and-forget: a rejected reset (e.g. caller-pin mismatch after a view
@@ -615,6 +644,8 @@ describe("HelpSessionController — tier-mismatch handlers", () => {
 
 describe("HelpSessionController — session revoked (#10017)", () => {
   it("start() arms the session-revoked subscription", () => {
+    // #12108: MCP pushes are matched against the lane's own session id.
+    helpPanelState.sessionId = "s1";
     const ctrl = new HelpSessionController();
     ctrl.start();
     expect(mockMcpOnSessionRevoked).toHaveBeenCalledTimes(1);
@@ -622,6 +653,8 @@ describe("HelpSessionController — session revoked (#10017)", () => {
   });
 
   it("a session-revoked push surfaces the recovery banner", () => {
+    // #12108: MCP pushes are matched against the lane's own session id.
+    helpPanelState.sessionId = "s1";
     const ctrl = new HelpSessionController();
     ctrl.start();
     helpPanelState.sessionId = "sess-live";
@@ -634,6 +667,8 @@ describe("HelpSessionController — session revoked (#10017)", () => {
   });
 
   it("ignores a revoke for a session the panel has already replaced", () => {
+    // #12108: MCP pushes are matched against the lane's own session id.
+    helpPanelState.sessionId = "s1";
     const ctrl = new HelpSessionController();
     ctrl.start();
     helpPanelState.sessionId = "sess-current";
@@ -643,6 +678,8 @@ describe("HelpSessionController — session revoked (#10017)", () => {
   });
 
   it("ignores a revoke while no session is pinned (torn-down or mid-relaunch window)", () => {
+    // #12108: MCP pushes are matched against the lane's own session id.
+    helpPanelState.sessionId = "s1";
     const ctrl = new HelpSessionController();
     ctrl.start();
     // A null store sessionId means there is no live session to end — a revoke
@@ -655,6 +692,8 @@ describe("HelpSessionController — session revoked (#10017)", () => {
   });
 
   it("dismissSessionRevoked clears the banner", () => {
+    // #12108: MCP pushes are matched against the lane's own session id.
+    helpPanelState.sessionId = "s1";
     const ctrl = new HelpSessionController();
     ctrl["_patch"]({ sessionRevoked: { sessionId: "sess-1", denialKind: "tierMismatch" } });
     expect(ctrl.getSnapshot().sessionRevoked).not.toBeNull();
@@ -663,6 +702,8 @@ describe("HelpSessionController — session revoked (#10017)", () => {
   });
 
   it("a launch supersedes any standing revoked-session banner", () => {
+    // #12108: MCP pushes are matched against the lane's own session id.
+    helpPanelState.sessionId = "s1";
     const ctrl = new HelpSessionController();
     ctrl.start();
     ctrl["_lastInputs"] = {
@@ -695,6 +736,8 @@ describe("HelpSessionController — grant lifecycle (#10042)", () => {
   }
 
   it("start() arms the grant lifecycle subscription", () => {
+    // #12108: MCP pushes are matched against the lane's own session id.
+    helpPanelState.sessionId = "s1";
     const ctrl = new HelpSessionController();
     ctrl.start();
     expect(mockMcpOnGrantLifecycle).toHaveBeenCalledTimes(1);
@@ -703,6 +746,8 @@ describe("HelpSessionController — grant lifecycle (#10042)", () => {
   });
 
   it("grant.issued sets the active countdown and clears the prompting mismatch", () => {
+    // #12108: MCP pushes are matched against the lane's own session id.
+    helpPanelState.sessionId = "s1";
     const ctrl = new HelpSessionController();
     ctrl.start();
     armMismatch();
@@ -729,6 +774,8 @@ describe("HelpSessionController — grant lifecycle (#10042)", () => {
   });
 
   it("grant.issued without expiresAt is ignored rather than seeding a NaN countdown", () => {
+    // #12108: MCP pushes are matched against the lane's own session id.
+    helpPanelState.sessionId = "s1";
     const ctrl = new HelpSessionController();
     ctrl.start();
     grantLifecycleListeners[0]?.({
@@ -742,6 +789,8 @@ describe("HelpSessionController — grant lifecycle (#10042)", () => {
   });
 
   it("grant.expired retires the active grant and surfaces an 'expired' notice", () => {
+    // #12108: MCP pushes are matched against the lane's own session id.
+    helpPanelState.sessionId = "s1";
     const ctrl = new HelpSessionController();
     ctrl.start();
     grantLifecycleListeners[0]?.({
@@ -763,6 +812,8 @@ describe("HelpSessionController — grant lifecycle (#10042)", () => {
   });
 
   it("grant.revoked with grant-ceiling surfaces a ceiling notice", () => {
+    // #12108: MCP pushes are matched against the lane's own session id.
+    helpPanelState.sessionId = "s1";
     const ctrl = new HelpSessionController();
     ctrl.start();
     grantLifecycleListeners[0]?.({
@@ -787,7 +838,9 @@ describe("HelpSessionController — grant lifecycle (#10042)", () => {
   it.each(["user", "session-ended", "session-idle"] as const)(
     "grant.revoked with reason %s clears the grant silently (no notice)",
     (revokedReason) => {
-      const ctrl = new HelpSessionController();
+      // #12108: MCP pushes are matched against the lane's own session id.
+    helpPanelState.sessionId = "s1";
+    const ctrl = new HelpSessionController();
       ctrl.start();
       grantLifecycleListeners[0]?.({
         type: "grant.issued",
@@ -810,6 +863,8 @@ describe("HelpSessionController — grant lifecycle (#10042)", () => {
   );
 
   it("a lapse for a different tool leaves the on-screen countdown intact", () => {
+    // #12108: MCP pushes are matched against the lane's own session id.
+    helpPanelState.sessionId = "s1";
     const ctrl = new HelpSessionController();
     ctrl.start();
     grantLifecycleListeners[0]?.({
@@ -832,6 +887,8 @@ describe("HelpSessionController — grant lifecycle (#10042)", () => {
   });
 
   it("tier.elevated / tier.decayed do not disturb the per-tool countdown", () => {
+    // #12108: MCP pushes are matched against the lane's own session id.
+    helpPanelState.sessionId = "s1";
     const ctrl = new HelpSessionController();
     ctrl.start();
     grantLifecycleListeners[0]?.({
@@ -859,6 +916,8 @@ describe("HelpSessionController — grant lifecycle (#10042)", () => {
   });
 
   it("a fresh tier denial supersedes a lingering 'approval ended' notice", () => {
+    // #12108: MCP pushes are matched against the lane's own session id.
+    helpPanelState.sessionId = "s1";
     const ctrl = new HelpSessionController();
     ctrl.start();
     grantLifecycleListeners[0]?.({
@@ -892,6 +951,8 @@ describe("HelpSessionController — grant lifecycle (#10042)", () => {
   }
 
   it("revokeGrant() revokes the session's grants and clears the countdown once the IPC settles", async () => {
+    // #12108: MCP pushes are matched against the lane's own session id.
+    helpPanelState.sessionId = "s1";
     const ctrl = new HelpSessionController();
     ctrl.start();
     issueGrant();
@@ -908,6 +969,8 @@ describe("HelpSessionController — grant lifecycle (#10042)", () => {
   });
 
   it("revokeGrant() is a no-op while a revoke is already in flight", () => {
+    // #12108: MCP pushes are matched against the lane's own session id.
+    helpPanelState.sessionId = "s1";
     const ctrl = new HelpSessionController();
     ctrl.start();
     issueGrant();
@@ -925,6 +988,8 @@ describe("HelpSessionController — grant lifecycle (#10042)", () => {
   });
 
   it("revokeGrant() does not wipe a newer grant that arrived before the IPC settled", async () => {
+    // #12108: MCP pushes are matched against the lane's own session id.
+    helpPanelState.sessionId = "s1";
     const ctrl = new HelpSessionController();
     ctrl.start();
     issueGrant();
@@ -954,6 +1019,8 @@ describe("HelpSessionController — grant lifecycle (#10042)", () => {
   });
 
   it("a failed revoke keeps the countdown banner up as the retry surface", async () => {
+    // #12108: MCP pushes are matched against the lane's own session id.
+    helpPanelState.sessionId = "s1";
     const ctrl = new HelpSessionController();
     ctrl.start();
     issueGrant();
@@ -968,6 +1035,8 @@ describe("HelpSessionController — grant lifecycle (#10042)", () => {
   });
 
   it("a teardown mid-revoke does not leak a disabled Revoke button into the next grant", () => {
+    // #12108: MCP pushes are matched against the lane's own session id.
+    helpPanelState.sessionId = "s1";
     const ctrl = new HelpSessionController();
     ctrl.start();
     issueGrant();
@@ -987,6 +1056,8 @@ describe("HelpSessionController — grant lifecycle (#10042)", () => {
   });
 
   it("revokeGrant() is a no-op when there is no active grant", () => {
+    // #12108: MCP pushes are matched against the lane's own session id.
+    helpPanelState.sessionId = "s1";
     const ctrl = new HelpSessionController();
     ctrl.start();
     ctrl.revokeGrant();
@@ -995,6 +1066,8 @@ describe("HelpSessionController — grant lifecycle (#10042)", () => {
   });
 
   it("dismissGrantEnded() clears the notice", () => {
+    // #12108: MCP pushes are matched against the lane's own session id.
+    helpPanelState.sessionId = "s1";
     const ctrl = new HelpSessionController();
     ctrl.start();
     grantLifecycleListeners[0]?.({

--- a/src/controllers/__tests__/HelpSessionController.sessionAndViewRecovery.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.sessionAndViewRecovery.test.ts
@@ -57,6 +57,21 @@ const {
   grantLifecycleListeners: [] as Array<(payload: unknown) => void>,
   outcomeAlertListeners: [] as Array<(payload: unknown) => void>,
   helpPanelState: {
+    clearDroppedPreferredAgent: vi.fn(),
+    dismissIntro: vi.fn(),
+    setAutoLaunchEnabled: vi.fn(),
+    setWidth: vi.fn(),
+    requestFocus: vi.fn(),
+    setActiveFigureNumber: vi.fn(),
+    addFigure: vi.fn(),
+    markConversationStarted: vi.fn(),
+    setActiveSlot: vi.fn(),
+    closeSlot: vi.fn(),
+    openSlot: vi.fn(),
+    // #12108: the panel reads its lane pointer; the mocked selectors
+    // above project this same flat object as that lane.
+    activeSlot: 0,
+    sessions: {} as Record<number, unknown>,
     isOpen: false,
     terminalId: null as string | null,
     agentId: null as string | null,
@@ -97,7 +112,17 @@ vi.mock("@/store/helpPanelStore", () => {
   const store = (selector?: (s: typeof helpPanelState) => unknown) =>
     selector ? selector(helpPanelState) : helpPanelState;
   store.getState = () => helpPanelState;
-  return { useHelpPanelStore: store };
+  return {
+    useHelpPanelStore: store,
+    // #12108 selectors. The fixtures below stay FLAT (terminalId/agentId/…)
+    // and these project that same object as the lane, so every existing
+    // assertion keeps driving the controller unchanged.
+    selectSlot: (s) => s,
+    selectActiveSlot: (s) => s,
+    selectOpenSlots: () => [0],
+    selectSlotTerminalIds: (s) => (s.terminalId ? [s.terminalId] : []),
+    selectSlotForTerminal: (s, id) => (s.terminalId === id && id ? 0 : null),
+  };
 });
 
 vi.mock("@/store", () => {

--- a/src/controllers/__tests__/HelpSessionController.sessionAndViewRecovery.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.sessionAndViewRecovery.test.ts
@@ -839,8 +839,8 @@ describe("HelpSessionController — grant lifecycle (#10042)", () => {
     "grant.revoked with reason %s clears the grant silently (no notice)",
     (revokedReason) => {
       // #12108: MCP pushes are matched against the lane's own session id.
-    helpPanelState.sessionId = "s1";
-    const ctrl = new HelpSessionController();
+      helpPanelState.sessionId = "s1";
+      const ctrl = new HelpSessionController();
       ctrl.start();
       grantLifecycleListeners[0]?.({
         type: "grant.issued",

--- a/src/controllers/__tests__/HelpSessionController.versionAndLaunchErrors.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.versionAndLaunchErrors.test.ts
@@ -117,11 +117,12 @@ vi.mock("@/store/helpPanelStore", () => {
     // #12108 selectors. The fixtures below stay FLAT (terminalId/agentId/…)
     // and these project that same object as the lane, so every existing
     // assertion keeps driving the controller unchanged.
-    selectSlot: (s) => s,
-    selectActiveSlot: (s) => s,
+    selectSlot: (s: typeof helpPanelState) => s,
+    selectActiveSlot: (s: typeof helpPanelState) => s,
     selectOpenSlots: () => [0],
-    selectSlotTerminalIds: (s) => (s.terminalId ? [s.terminalId] : []),
-    selectSlotForTerminal: (s, id) => (s.terminalId === id && id ? 0 : null),
+    selectSlotTerminalIds: (s: typeof helpPanelState) => (s.terminalId ? [s.terminalId] : []),
+    selectSlotForTerminal: (s: typeof helpPanelState, id: string) =>
+      s.terminalId === id && id ? 0 : null,
   };
 });
 

--- a/src/controllers/__tests__/HelpSessionController.versionAndLaunchErrors.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.versionAndLaunchErrors.test.ts
@@ -854,7 +854,12 @@ describe("HelpSessionController — launch error routing", () => {
     // against is the re-eval's launch() being swallowed by the still-held
     // re-entrancy guard, leaving _hasAutoLaunched stuck and codex unlaunched.
     await vi.waitFor(() => {
-      expect(helpPanelState.setTerminal).toHaveBeenCalledWith(0, "term-codex", "codex", "sess-codex");
+      expect(helpPanelState.setTerminal).toHaveBeenCalledWith(
+        0,
+        "term-codex",
+        "codex",
+        "sess-codex"
+      );
     });
     // The superseded claude attempt is cleaned up: orphan terminal removed,
     // stale session token revoked.

--- a/src/controllers/__tests__/HelpSessionController.versionAndLaunchErrors.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.versionAndLaunchErrors.test.ts
@@ -57,6 +57,21 @@ const {
   grantLifecycleListeners: [] as Array<(payload: unknown) => void>,
   outcomeAlertListeners: [] as Array<(payload: unknown) => void>,
   helpPanelState: {
+    clearDroppedPreferredAgent: vi.fn(),
+    dismissIntro: vi.fn(),
+    setAutoLaunchEnabled: vi.fn(),
+    setWidth: vi.fn(),
+    requestFocus: vi.fn(),
+    setActiveFigureNumber: vi.fn(),
+    addFigure: vi.fn(),
+    markConversationStarted: vi.fn(),
+    setActiveSlot: vi.fn(),
+    closeSlot: vi.fn(),
+    openSlot: vi.fn(),
+    // #12108: the panel reads its lane pointer; the mocked selectors
+    // above project this same flat object as that lane.
+    activeSlot: 0,
+    sessions: {} as Record<number, unknown>,
     isOpen: false,
     terminalId: null as string | null,
     agentId: null as string | null,
@@ -97,7 +112,17 @@ vi.mock("@/store/helpPanelStore", () => {
   const store = (selector?: (s: typeof helpPanelState) => unknown) =>
     selector ? selector(helpPanelState) : helpPanelState;
   store.getState = () => helpPanelState;
-  return { useHelpPanelStore: store };
+  return {
+    useHelpPanelStore: store,
+    // #12108 selectors. The fixtures below stay FLAT (terminalId/agentId/…)
+    // and these project that same object as the lane, so every existing
+    // assertion keeps driving the controller unchanged.
+    selectSlot: (s) => s,
+    selectActiveSlot: (s) => s,
+    selectOpenSlots: () => [0],
+    selectSlotTerminalIds: (s) => (s.terminalId ? [s.terminalId] : []),
+    selectSlotForTerminal: (s, id) => (s.terminalId === id && id ? 0 : null),
+  };
 });
 
 vi.mock("@/store", () => {
@@ -828,7 +853,7 @@ describe("HelpSessionController — launch error routing", () => {
     // against is the re-eval's launch() being swallowed by the still-held
     // re-entrancy guard, leaving _hasAutoLaunched stuck and codex unlaunched.
     await vi.waitFor(() => {
-      expect(helpPanelState.setTerminal).toHaveBeenCalledWith("term-codex", "codex", "sess-codex");
+      expect(helpPanelState.setTerminal).toHaveBeenCalledWith(0, "term-codex", "codex", "sess-codex");
     });
     // The superseded claude attempt is cleaned up: orphan terminal removed,
     // stale session token revoked.

--- a/src/controllers/__tests__/McpActivityTracker.laneGating.test.ts
+++ b/src/controllers/__tests__/McpActivityTracker.laneGating.test.ts
@@ -1,0 +1,157 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { McpActivityTracker, type McpActivityTrackerHost } from "../McpActivityTracker";
+import type { HelpSessionSnapshot } from "../HelpSessionController";
+
+const { addFigure, helpPanelState, projectStoreState } = vi.hoisted(() => ({
+  addFigure: vi.fn(),
+  helpPanelState: { sessions: {} as Record<number, unknown>, activeSlot: 0 },
+  projectStoreState: { currentProject: { id: "proj-1", path: "/tmp/proj-1" } },
+}));
+
+vi.mock("@/store/helpPanelStore", () => {
+  const store = (selector?: (s: typeof helpPanelState) => unknown) =>
+    selector ? selector(helpPanelState) : helpPanelState;
+  store.getState = () => ({ ...helpPanelState, addFigure });
+  return { useHelpPanelStore: store };
+});
+
+vi.mock("@/store", () => {
+  const projectStore = (selector?: (s: typeof projectStoreState) => unknown) =>
+    selector ? selector(projectStoreState) : projectStoreState;
+  projectStore.getState = () => projectStoreState;
+  return { useProjectStore: projectStore };
+});
+
+vi.mock("@/clients/projectClient", () => ({ projectClient: {} }));
+vi.mock("@/lib/notify", () => ({ notify: vi.fn() }));
+vi.mock("@/utils/logger", () => ({ logError: vi.fn() }));
+vi.mock("@/utils/safeFireAndForget", () => ({ safeFireAndForget: vi.fn() }));
+
+/** Captures the handler each `on*` subscription registers so tests can fire it. */
+function makeMcpBridge() {
+  const handlers: Record<string, (payload: unknown) => void> = {};
+  const register =
+    (name: string) =>
+    (fn: (payload: unknown) => void): (() => void) => {
+      handlers[name] = fn;
+      return () => delete handlers[name];
+    };
+  return {
+    handlers,
+    bridge: {
+      onTierNotPermitted: register("tier"),
+      onSessionRevoked: register("revoked"),
+      onGrantLifecycle: register("grant"),
+      onToolCallStarted: register("started"),
+      onToolCallSettled: register("settled"),
+      onTurnOutcomeAlert: register("outcome"),
+      onDisplayImage: register("image"),
+    },
+  };
+}
+
+const EMPTY_SNAPSHOT = {
+  mcpActivity: null,
+  tierMismatch: null,
+  sessionRevoked: null,
+  activeGrant: null,
+  grantEnded: null,
+  outcomeAlert: null,
+} as unknown as HelpSessionSnapshot;
+
+/**
+ * #12108. With concurrent lanes every session in a project shares ONE
+ * WebContents, so the transport can no longer say which lane a push belongs
+ * to — the payload's session id is the only thing that can. These tests pin
+ * that every listener family filters on it, because an unfiltered push paints
+ * a sibling lane's banner over the conversation the user is actually in.
+ */
+describe("McpActivityTracker — lane gating (#12108)", () => {
+  let patch: ReturnType<typeof vi.fn>;
+  let host: McpActivityTrackerHost;
+  let mcp: ReturnType<typeof makeMcpBridge>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    patch = vi.fn();
+    mcp = makeMcpBridge();
+    Object.defineProperty(window, "electron", {
+      value: { mcpServer: mcp.bridge },
+      writable: true,
+      configurable: true,
+    });
+    host = {
+      getSnapshot: () => EMPTY_SNAPSHOT,
+      patch,
+      // This tracker belongs to the lane holding "session-mine".
+      getSessionId: () => "session-mine",
+      getSlot: () => 1,
+    };
+    new McpActivityTracker(host).start();
+  });
+
+  it("ignores every push aimed at a sibling lane's session", () => {
+    mcp.handlers.tier!({ sessionId: "session-other", toolId: "git.push", tier: "action" });
+    mcp.handlers.revoked!({ sessionId: "session-other", denialKind: "tier" });
+    mcp.handlers.grant!({
+      type: "grant.issued",
+      sessionId: "session-other",
+      toolId: "git.push",
+      ttlMs: 1000,
+      expiresAt: Date.now() + 1000,
+    });
+    mcp.handlers.started!({ sessionId: "session-other", toolId: "git.push", turnId: "t1" });
+    mcp.handlers.outcome!({ helpSessionId: "session-other", outcome: "agent-stuck" });
+
+    expect(patch).not.toHaveBeenCalled();
+  });
+
+  it("never files a sibling lane's figure into this conversation", () => {
+    mcp.handlers.image!({
+      sessionId: "session-other",
+      imageId: "img-1",
+      figureNumber: 1,
+      figureLabel: "Figure 1",
+      url: "https://daintree.org/a.png",
+    });
+
+    expect(addFigure).not.toHaveBeenCalled();
+  });
+
+  it("accepts a push for its own lane, and writes the figure into its own slot", () => {
+    mcp.handlers.revoked!({ sessionId: "session-mine", denialKind: "tier" });
+    expect(patch).toHaveBeenCalledWith({
+      sessionRevoked: { sessionId: "session-mine", denialKind: "tier" },
+    });
+
+    mcp.handlers.image!({
+      sessionId: "session-mine",
+      imageId: "img-1",
+      figureNumber: 1,
+      figureLabel: "Figure 1",
+      url: "https://daintree.org/a.png",
+    });
+    // Slot 1 — the tracker's own lane, not the store's active one.
+    expect(addFigure).toHaveBeenCalledWith(1, expect.objectContaining({ imageId: "img-1" }));
+  });
+
+  it("drops every push while the lane has no session bound", () => {
+    // A lane mid-relaunch has no id yet. Painting a banner here would stomp
+    // the launch the user just started (#10017, generalized to lanes).
+    patch.mockClear();
+    const unboundHost: McpActivityTrackerHost = { ...host, getSessionId: () => null };
+    const unbound = makeMcpBridge();
+    Object.defineProperty(window, "electron", {
+      value: { mcpServer: unbound.bridge },
+      writable: true,
+      configurable: true,
+    });
+    new McpActivityTracker(unboundHost).start();
+
+    unbound.handlers.revoked!({ sessionId: "session-mine", denialKind: "tier" });
+    unbound.handlers.started!({ sessionId: "session-mine", toolId: "git.push", turnId: "t1" });
+
+    expect(patch).not.toHaveBeenCalled();
+  });
+});

--- a/src/controllers/__tests__/McpActivityTracker.laneGating.test.ts
+++ b/src/controllers/__tests__/McpActivityTracker.laneGating.test.ts
@@ -68,13 +68,13 @@ const EMPTY_SNAPSHOT = {
  * a sibling lane's banner over the conversation the user is actually in.
  */
 describe("McpActivityTracker — lane gating (#12108)", () => {
-  let patch: ReturnType<typeof vi.fn>;
+  let patch: McpActivityTrackerHost["patch"] & ReturnType<typeof vi.fn>;
   let host: McpActivityTrackerHost;
   let mcp: ReturnType<typeof makeMcpBridge>;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    patch = vi.fn();
+    patch = vi.fn() as typeof patch;
     mcp = makeMcpBridge();
     Object.defineProperty(window, "electron", {
       value: { mcpServer: mcp.bridge },

--- a/src/controllers/__tests__/helpSessionControllerRegistry.test.ts
+++ b/src/controllers/__tests__/helpSessionControllerRegistry.test.ts
@@ -8,8 +8,7 @@ import {
 
 vi.mock("@/store/helpPanelStore", () => {
   const state = { sessions: {}, activeSlot: 0 };
-  const store = (selector?: (s: typeof state) => unknown) =>
-    selector ? selector(state) : state;
+  const store = (selector?: (s: typeof state) => unknown) => (selector ? selector(state) : state);
   store.getState = () => state;
   return { useHelpPanelStore: store, selectSlot: (s: typeof state) => s };
 });

--- a/src/controllers/__tests__/helpSessionControllerRegistry.test.ts
+++ b/src/controllers/__tests__/helpSessionControllerRegistry.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  acquireHelpSessionController,
+  releaseHelpSessionController,
+  __resetHelpSessionControllersForTests,
+} from "../helpSessionControllerRegistry";
+
+vi.mock("@/store/helpPanelStore", () => {
+  const state = { sessions: {}, activeSlot: 0 };
+  const store = (selector?: (s: typeof state) => unknown) =>
+    selector ? selector(state) : state;
+  store.getState = () => state;
+  return { useHelpPanelStore: store, selectSlot: (s: typeof state) => s };
+});
+vi.mock("@/store", () => ({
+  usePanelStore: Object.assign(() => ({}), { getState: () => ({}) }),
+  useProjectStore: Object.assign(() => ({}), { getState: () => ({}) }),
+}));
+vi.mock("@/services/ActionService", () => ({ actionService: { dispatch: vi.fn() } }));
+vi.mock("@/clients/projectClient", () => ({ projectClient: {} }));
+vi.mock("@/lib/notify", () => ({ notify: vi.fn() }));
+
+afterEach(() => {
+  __resetHelpSessionControllersForTests();
+});
+
+/**
+ * #12108. The registry exists because a lane's controller must outlive the
+ * component showing it: a background lane still needs its MCP subscriptions to
+ * surface approvals, and its idle timer to hibernate it.
+ */
+describe("helpSessionControllerRegistry", () => {
+  it("hands back the same controller for a lane, and distinct ones across lanes", () => {
+    const first = acquireHelpSessionController(0);
+
+    // Re-acquiring must not mint a second controller: two instances on one lane
+    // would double-arm the IPC listeners and double-count its launch state.
+    expect(acquireHelpSessionController(0)).toBe(first);
+    expect(acquireHelpSessionController(1)).not.toBe(first);
+    expect(first.slot).toBe(0);
+    expect(acquireHelpSessionController(1).slot).toBe(1);
+  });
+
+  it("survives being acquired again after the panel switches away and back", () => {
+    // The bug this pins: an arm/disarm effect keyed on the ACTIVE controller
+    // tore down the outgoing lane on every tab switch. `stop()` is not a
+    // neutral pause — it bumps the launch generation, so an in-flight launch in
+    // the lane the user tabbed away from would silently bail. Identity has to
+    // survive the round trip so the lane keeps whichever launch it had running.
+    const laneZero = acquireHelpSessionController(0);
+    acquireHelpSessionController(1);
+
+    expect(acquireHelpSessionController(0)).toBe(laneZero);
+  });
+
+  it("mints a fresh controller only after the lane is explicitly released", () => {
+    const before = acquireHelpSessionController(2);
+    releaseHelpSessionController(2);
+
+    expect(acquireHelpSessionController(2)).not.toBe(before);
+  });
+
+  it("releasing an unknown lane is a no-op", () => {
+    expect(() => releaseHelpSessionController(2)).not.toThrow();
+  });
+});

--- a/src/controllers/helpSessionControllerRegistry.ts
+++ b/src/controllers/helpSessionControllerRegistry.ts
@@ -1,0 +1,47 @@
+import { HelpSessionController } from "./HelpSessionController";
+
+/**
+ * One live `HelpSessionController` per assistant lane, for the lifetime of the
+ * project view (#12108).
+ *
+ * A registry rather than component state because a background lane still needs
+ * a running controller. Its MCP subscriptions are what surface a tool-call
+ * approval, a tier-mismatch prompt or a session-revoked banner, and its idle
+ * timer is what hibernates it — none of which can happen if the controller is
+ * torn down whenever its tab is not the one on screen. Holding controllers in
+ * `useState` inside the visible body would do exactly that, and switching tabs
+ * would also lose the lane's in-memory launch phase and banners.
+ *
+ * Module scope is per project view: each project gets its own renderer context,
+ * which is the same granularity `helpPanelStore` already has.
+ */
+const controllers = new Map<number, HelpSessionController>();
+
+export function acquireHelpSessionController(slot: number): HelpSessionController {
+  let controller = controllers.get(slot);
+  if (!controller) {
+    controller = new HelpSessionController(slot);
+    controllers.set(slot, controller);
+  }
+  return controller;
+}
+
+/**
+ * Drop a lane's controller once the lane itself is gone.
+ *
+ * Only for a lane the user actually closed. `stop()` deliberately does NOT end
+ * the session — it just disarms listeners — so the caller must have revoked
+ * and killed the backend first; releasing without that would leave a running
+ * agent with nothing listening to it.
+ */
+export function releaseHelpSessionController(slot: number): void {
+  const controller = controllers.get(slot);
+  if (!controller) return;
+  controllers.delete(slot);
+  controller.stop();
+}
+
+export function __resetHelpSessionControllersForTests(): void {
+  for (const controller of controllers.values()) controller.stop();
+  controllers.clear();
+}

--- a/src/lib/__tests__/sidebarToggle.test.ts
+++ b/src/lib/__tests__/sidebarToggle.test.ts
@@ -58,6 +58,10 @@ vi.mock("@/store/worktreeStore", () => ({
 
 vi.mock("@/store/helpPanelStore", () => ({
   useHelpPanelStore: helpPanelStoreMock,
+  // #12108: the reveal repaint follows the lane on screen; resize suppression
+  // covers every lane. The fixture runs one lane, so both project it.
+  selectActiveSlot: (s: HelpPanelFixture) => s,
+  selectSlotTerminalIds: (s: HelpPanelFixture) => (s.terminalId ? [s.terminalId] : []),
 }));
 
 vi.mock("../layoutTransitionLock", () => ({

--- a/src/lib/sidebarToggle.ts
+++ b/src/lib/sidebarToggle.ts
@@ -1,10 +1,6 @@
 import { terminalInstanceService } from "@/services/terminal/TerminalInstanceService";
 import { isDocumentHidden, revealUntilStable } from "@/services/terminal/revealUntilStable";
-import {
-  useHelpPanelStore,
-  selectActiveSlot,
-  selectSlotTerminalIds,
-} from "@/store/helpPanelStore";
+import { useHelpPanelStore, selectActiveSlot, selectSlotTerminalIds } from "@/store/helpPanelStore";
 import { usePanelStore } from "@/store/panelStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { lockSidebarLayoutTransition } from "./layoutTransitionLock";

--- a/src/lib/sidebarToggle.ts
+++ b/src/lib/sidebarToggle.ts
@@ -1,6 +1,10 @@
 import { terminalInstanceService } from "@/services/terminal/TerminalInstanceService";
 import { isDocumentHidden, revealUntilStable } from "@/services/terminal/revealUntilStable";
-import { useHelpPanelStore } from "@/store/helpPanelStore";
+import {
+  useHelpPanelStore,
+  selectActiveSlot,
+  selectSlotTerminalIds,
+} from "@/store/helpPanelStore";
 import { usePanelStore } from "@/store/panelStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { lockSidebarLayoutTransition } from "./layoutTransitionLock";
@@ -37,9 +41,10 @@ export function getSidebarAffectedTerminalIds(): string[] {
       ids.push(panel.id);
     }
   }
-  const assistantTerminalId = useHelpPanelStore.getState().terminalId;
-  if (assistantTerminalId && panelState.panelsById[assistantTerminalId]) {
-    ids.push(assistantTerminalId);
+  // Every lane (#12108): a background assistant's xterm is still mounted and
+  // still needs its resizes suppressed during the transition.
+  for (const assistantTerminalId of selectSlotTerminalIds(useHelpPanelStore.getState())) {
+    if (panelState.panelsById[assistantTerminalId]) ids.push(assistantTerminalId);
   }
   return ids;
 }
@@ -196,14 +201,21 @@ export function createAssistantRevealCoordinator(): AssistantRevealCoordinator {
     start() {
       unsubscribe?.();
       const dispose = useHelpPanelStore.subscribe((state, prev) => {
+        // The ACTIVE lane only (#12108): a reveal repaints what is on screen,
+        // and a background lane has no visible geometry to correct. Switching
+        // tabs runs its own fit, so nothing is dropped by ignoring siblings.
+        const next = selectActiveSlot(state);
+        const previous = selectActiveSlot(prev);
         // sessionId as well as terminalId: a reserved id is finalized in place
         // when provisioning resolves, so the id alone can be edge-less on the
         // retry path after an attach-wait timeout.
-        if (state.terminalId === prev.terminalId && state.sessionId === prev.sessionId) return;
-        if (!state.terminalId || !pending || !visible) return;
+        if (next.terminalId === previous.terminalId && next.sessionId === previous.sessionId) {
+          return;
+        }
+        if (!next.terminalId || !pending || !visible) return;
         // A re-bind supersedes whatever the previous binding was chasing.
         generation++;
-        discharge(state.terminalId);
+        discharge(next.terminalId);
       });
       // Deliberately NOT cancelled on app:view-cached. Yielding the obligation to
       // the switch-back sweep looks tempting, but that sweep only covers the
@@ -239,7 +251,7 @@ export function createAssistantRevealCoordinator(): AssistantRevealCoordinator {
       pending = true;
       inFlight = null;
 
-      const assistantTerminalId = useHelpPanelStore.getState().terminalId;
+      const assistantTerminalId = selectActiveSlot(useHelpPanelStore.getState()).terminalId;
       // No terminal yet (the cold first open — the #11070 case). Hold the
       // obligation; the help-store subscription discharges it once one binds.
       if (!assistantTerminalId) return;

--- a/src/services/VoiceRecordingService.ts
+++ b/src/services/VoiceRecordingService.ts
@@ -1,6 +1,6 @@
 import { useProjectStore } from "@/store/projectStore";
 import { usePanelStore } from "@/store/panelStore";
-import { useHelpPanelStore } from "@/store/helpPanelStore";
+import { useHelpPanelStore, selectActiveSlot } from "@/store/helpPanelStore";
 import { isAssistantFocused } from "@/store/macroFocusStore";
 import { useTerminalInputStore } from "@/store/terminalInputStore";
 import { useVoiceRecordingStore, type VoiceRecordingTarget } from "@/store/voiceRecordingStore";
@@ -1280,7 +1280,9 @@ class VoiceRecordingService {
   }
 
   private getAssistantTarget(): VoiceRecordingTarget | null {
-    const terminalId = useHelpPanelStore.getState().terminalId;
+    // The ACTIVE lane (#12108): dictation is aimed at the session on screen,
+    // not at whichever one happens to be running in the background.
+    const terminalId = selectActiveSlot(useHelpPanelStore.getState()).terminalId;
     if (!terminalId) return null;
 
     // Guard the brief window where the assistant terminal has been trashed (or

--- a/src/services/__tests__/VoiceRecordingService.test.ts
+++ b/src/services/__tests__/VoiceRecordingService.test.ts
@@ -89,6 +89,9 @@ vi.mock("@/store/helpPanelStore", () => {
     isOpen: false,
     terminalId: null as string | null,
   };
+  // #12108: dictation targets the lane on screen. This fixture runs one lane,
+  // so the selector projects the same flat state as that lane.
+  const selectActiveSlot = (s: typeof state) => s;
   const fns = {
     setOpen: vi.fn((open: boolean) => {
       state.isOpen = open;
@@ -98,6 +101,7 @@ vi.mock("@/store/helpPanelStore", () => {
   const getState = () => ({ ...state, ...fns });
   return {
     useHelpPanelStore: Object.assign(getState, { getState }),
+    selectActiveSlot,
     __state: state,
     __fns: fns,
   };

--- a/src/services/actions/definitions/__tests__/helpLaunchAgent.test.ts
+++ b/src/services/actions/definitions/__tests__/helpLaunchAgent.test.ts
@@ -11,6 +11,7 @@ const {
   mockGetProjectState,
   mockGetScratchState,
   mockLogError,
+  mockRemovePanel,
 } = vi.hoisted(() => ({
   mockDispatch: vi.fn().mockResolvedValue({ ok: true }),
   mockGetContext: vi.fn(() => ({})),
@@ -21,6 +22,7 @@ const {
   mockGetProjectState: vi.fn(),
   mockGetScratchState: vi.fn(),
   mockLogError: vi.fn(),
+  mockRemovePanel: vi.fn(),
 }));
 
 vi.mock("@/services/ActionService", () => ({
@@ -47,6 +49,13 @@ vi.mock("@/store/projectStore", () => ({
   useProjectStore: { getState: () => mockGetProjectState() },
 }));
 
+// The launch path tears its own PTY down when the lane it was minted for is
+// closed mid-flight (#12108); the real panel store is far too heavy for this
+// node-environment suite, and only `removePanel` is reached.
+vi.mock("@/store/panelStore", () => ({
+  usePanelStore: { getState: () => ({ removePanel: mockRemovePanel }) },
+}));
+
 // Leaf-path mock, mirroring the projectStore one — the action reads the scratch
 // pointer as its workspace fallback (#11068).
 vi.mock("@/store/scratchStore", () => ({
@@ -62,6 +71,7 @@ vi.mock("@/lib/sidebarToggle", () => ({
 }));
 
 import { registerHelpActions } from "../helpActions";
+import { useHelpPanelStore } from "@/store/helpPanelStore";
 import type { ActionCallbacks, ActionRegistry } from "../../actionTypes";
 import type { ActionContext } from "@shared/types/actions";
 import type { AnyActionDefinition } from "../../actionTypes";
@@ -568,5 +578,49 @@ describe("help.launchAgent", () => {
     await action.run(undefined, stubCtx);
 
     expect(window.electron.help.revokeSession).toHaveBeenCalledWith("sess-fail");
+  });
+
+  it("revokes and removes the terminal when the lane is closed mid-launch (#12108)", async () => {
+    // The lane is read before the provision await and used to bind after the
+    // dispatch. `setTerminal` refuses a lane that is gone, so without an
+    // explicit teardown the spawned PTY would keep a live bearer while
+    // belonging to no lane — and no longer be filtered out of the dock.
+    (window.electron.help.getFolderPath as ReturnType<typeof vi.fn>).mockResolvedValue(
+      "/mock/help"
+    );
+    mockGetProjectState.mockReturnValue({
+      currentProject: { id: "proj-1", path: "/repo" },
+      isBootstrapped: true,
+    });
+    (window.electron.help.provisionSession as ReturnType<typeof vi.fn>).mockResolvedValue({
+      sessionId: "sess-orphan",
+      sessionPath: "/sessions/sess-orphan",
+      token: "tok-orphan",
+      tier: "action",
+      mcpUrl: null,
+      windowId: 1,
+    });
+
+    const lane = useHelpPanelStore.getState().openSlot();
+    expect(lane).toBe(1);
+    // The user hits the tab's close button while provision/dispatch is still
+    // outstanding.
+    mockDispatch.mockImplementation(async () => {
+      useHelpPanelStore.getState().closeSlot(1);
+      return { ok: true, result: { terminalId: "term-orphan" } };
+    });
+
+    try {
+      await action.run(undefined, stubCtx);
+    } finally {
+      mockDispatch.mockReset();
+      useHelpPanelStore.setState({ sessions: { 0: useHelpPanelStore.getState().sessions[0]! } });
+      useHelpPanelStore.getState().setActiveSlot(0);
+    }
+
+    expect(window.electron.help.revokeSession).toHaveBeenCalledWith("sess-orphan");
+    expect(mockRemovePanel).toHaveBeenCalledWith("term-orphan");
+    expect(window.electron.help.markTerminal).not.toHaveBeenCalled();
+    expect(useHelpPanelStore.getState().sessions[1]).toBeUndefined();
   });
 });

--- a/src/services/actions/definitions/__tests__/helpLaunchAgent.test.ts
+++ b/src/services/actions/definitions/__tests__/helpLaunchAgent.test.ts
@@ -345,6 +345,9 @@ describe("help.launchAgent", () => {
       projectPath: "/repo",
       agentId: "claude",
       context: {},
+      // #12108: the action names its lane explicitly rather than letting main
+      // default it, so the session it mints is the one it binds into.
+      slot: 0,
     });
     expect(mockDispatch).toHaveBeenCalledWith(
       "agent.launch",

--- a/src/services/actions/definitions/helpActions.ts
+++ b/src/services/actions/definitions/helpActions.ts
@@ -8,6 +8,7 @@ import { useAgentPreferencesStore } from "@/store/agentPreferencesStore";
 import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
 import { useFocusStore } from "@/store/focusStore";
 import { useHelpPanelStore } from "@/store/helpPanelStore";
+import { usePanelStore } from "@/store/panelStore";
 import { useProjectStore } from "@/store/projectStore";
 import { useScratchStore } from "@/store/scratchStore";
 import { isAssistantFocused } from "@/store/macroFocusStore";
@@ -261,12 +262,25 @@ export function registerHelpActions(actions: ActionRegistry, callbacks: ActionCa
       );
 
       if (result.ok && result.result?.terminalId) {
+        const launchedTerminalId = result.result.terminalId;
+        // The lane can be closed while the provision + dispatch awaits are
+        // outstanding (#12108). `setTerminal` refuses to bind into a lane that
+        // is gone, so binding blind would leave this PTY holding a live bearer,
+        // owned by no lane and no longer filtered out of the dock. Tear it down
+        // instead — revoke before kill, mirroring `_teardownBoundSession`.
+        if (!useHelpPanelStore.getState().sessions[activeSlot]) {
+          window.electron.help.revokeSession(session.sessionId).catch((err) => {
+            logError("Failed to revoke help session for a lane closed mid-launch", err);
+          });
+          usePanelStore.getState().removePanel(launchedTerminalId);
+          return;
+        }
         // Bind into the lane the panel is showing (#12108). The action never
         // picks a lane implicitly: provisioning targeted this same lane above,
         // so binding anywhere else would leave that session unreachable.
         useHelpPanelStore
           .getState()
-          .setTerminal(activeSlot, result.result.terminalId, agentId, session?.sessionId ?? null);
+          .setTerminal(activeSlot, launchedTerminalId, agentId, session?.sessionId ?? null);
         useFocusStore.getState().clearAssistantGesture();
         if (!useHelpPanelStore.getState().isOpen) {
           suppressSidebarResizes();

--- a/src/services/actions/definitions/helpActions.ts
+++ b/src/services/actions/definitions/helpActions.ts
@@ -183,12 +183,19 @@ export function registerHelpActions(actions: ActionRegistry, callbacks: ActionCa
         return;
       }
 
+      // Name the lane explicitly (#12108) rather than letting main default it.
+      // Read once, before the provision, so the lane this session is minted for
+      // is the same one the terminal binds into below even if the user switches
+      // tabs while the await is outstanding.
+      const activeSlot = useHelpPanelStore.getState().activeSlot;
+
       try {
         session = await window.electron.help.provisionSession({
           projectId: workspace.id,
           projectPath: workspace.path,
           agentId,
           context: capturedContext,
+          slot: activeSlot,
         });
       } catch (err) {
         logError("Failed to provision help session", err);
@@ -254,9 +261,12 @@ export function registerHelpActions(actions: ActionRegistry, callbacks: ActionCa
       );
 
       if (result.ok && result.result?.terminalId) {
+        // Bind into the lane the panel is showing (#12108). The action never
+        // picks a lane implicitly: provisioning targeted this same lane above,
+        // so binding anywhere else would leave that session unreachable.
         useHelpPanelStore
           .getState()
-          .setTerminal(result.result.terminalId, agentId, session?.sessionId ?? null);
+          .setTerminal(activeSlot, result.result.terminalId, agentId, session?.sessionId ?? null);
         useFocusStore.getState().clearAssistantGesture();
         if (!useHelpPanelStore.getState().isOpen) {
           suppressSidebarResizes();

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -58,7 +58,11 @@ import { isValidTerminalGeometry, type TerminalGeometry } from "@shared/types/te
 import type { TerminalResizeResult } from "@shared/types/pty-host";
 import { applyXtermReflowFastpath } from "@shared/utils/xtermReflowFastpath";
 import { usePanelStore } from "@/store/panelStore";
-import { useHelpPanelStore } from "@/store/helpPanelStore";
+import {
+  useHelpPanelStore,
+  selectSlot,
+  selectSlotForTerminal,
+} from "@/store/helpPanelStore";
 import { logDebug, logWarn, logError } from "@/utils/logger";
 import { getErrorMessage } from "@/utils/errorContext";
 import { PaintFabricCompositor } from "./paintFabric/PaintFabricCompositor";
@@ -1371,13 +1375,28 @@ class TerminalInstanceService {
     // where the help session owns the figure state (#9830). Gating on the
     // bound help terminal keeps grid terminals that happen to print the token
     // inert, and the provider rebuilds with the rest on tier promotion.
-    if (!managed.imageLinksDisposable && useHelpPanelStore.getState().terminalId === id) {
+    // Resolve the lane at build time, then re-resolve on every read: a terminal
+    // belongs to exactly one lane, but which one can change if the lane is
+    // relaunched, and reading a sibling lane's figures would make `[image #N]`
+    // point at another conversation's picture (#12108).
+    if (
+      !managed.imageLinksDisposable &&
+      selectSlotForTerminal(useHelpPanelStore.getState(), id) !== null
+    ) {
       try {
         managed.imageLinksDisposable = createImageLinksAddon(
           managed.terminal,
-          () => useHelpPanelStore.getState().figures.map((f) => f.figureNumber),
+          () => {
+            const state = useHelpPanelStore.getState();
+            const slot = selectSlotForTerminal(state, id);
+            if (slot === null) return [];
+            return selectSlot(state, slot).figures.map((f) => f.figureNumber);
+          },
           (figureNumber, openLightbox) => {
-            useHelpPanelStore.getState().setActiveFigureNumber(figureNumber);
+            const state = useHelpPanelStore.getState();
+            const slot = selectSlotForTerminal(state, id);
+            if (slot === null) return;
+            state.setActiveFigureNumber(slot, figureNumber);
             // Lightbox open on modified-click lands with the figure rail
             // (#9829); the highlight is the interim affordance until then.
             void openLightbox;

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -58,11 +58,7 @@ import { isValidTerminalGeometry, type TerminalGeometry } from "@shared/types/te
 import type { TerminalResizeResult } from "@shared/types/pty-host";
 import { applyXtermReflowFastpath } from "@shared/utils/xtermReflowFastpath";
 import { usePanelStore } from "@/store/panelStore";
-import {
-  useHelpPanelStore,
-  selectSlot,
-  selectSlotForTerminal,
-} from "@/store/helpPanelStore";
+import { useHelpPanelStore, selectSlot, selectSlotForTerminal } from "@/store/helpPanelStore";
 import { logDebug, logWarn, logError } from "@/utils/logger";
 import { getErrorMessage } from "@/utils/errorContext";
 import { PaintFabricCompositor } from "./paintFabric/PaintFabricCompositor";

--- a/src/store/__tests__/helpPanelStore.test.ts
+++ b/src/store/__tests__/helpPanelStore.test.ts
@@ -1,11 +1,11 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
-import { assistantSlotKey as slotKey } from "../../../shared/config/assistantSlots";
   HELP_PANEL_DEFAULT_WIDTH,
   HELP_PANEL_MAX_WIDTH,
   HELP_PANEL_MIN_WIDTH,
 } from "../helpPanelStore";
+import { assistantSlotKey as slotKey } from "../../../shared/config/assistantSlots";
 
 describe("helpPanelStore persistence migration", () => {
   const STORAGE_KEY = "help-panel-storage";
@@ -788,7 +788,7 @@ describe("helpPanelStore persistence migration", () => {
       const { useHelpPanelStore: store } = await import("../helpPanelStore");
 
       expect(store.getState().hibernateSessions).toEqual({
-        "good-proj": { sessionId: "abc", cwd: "/tmp", agentId: "claude" },
+        [slotKey("good-proj", 0)]: { sessionId: "abc", cwd: "/tmp", agentId: "claude" },
       });
     });
 
@@ -813,7 +813,7 @@ describe("helpPanelStore persistence migration", () => {
       const { useHelpPanelStore: store } = await import("../helpPanelStore");
 
       expect(store.getState().hibernateSessions).toEqual({
-        "resume-latest-proj": { sessionId: "", cwd: "/tmp", agentId: "claude" },
+        [slotKey("resume-latest-proj", 0)]: { sessionId: "", cwd: "/tmp", agentId: "claude" },
       });
     });
 

--- a/src/store/__tests__/helpPanelStore.test.ts
+++ b/src/store/__tests__/helpPanelStore.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+import { assistantSlotKey as slotKey } from "../../../shared/config/assistantSlots";
   HELP_PANEL_DEFAULT_WIDTH,
   HELP_PANEL_MAX_WIDTH,
   HELP_PANEL_MIN_WIDTH,
@@ -146,7 +147,7 @@ describe("helpPanelStore persistence migration", () => {
     const { useHelpPanelStore: store } = await import("../helpPanelStore");
     expect(store.getState().droppedPreferredAgentId).toBe("gemini");
 
-    store.getState().setTerminal("term-1", "claude", null);
+    store.getState().setTerminal(0, "term-1", "claude", null);
     expect(store.getState().droppedPreferredAgentId).toBeNull();
   });
 
@@ -227,7 +228,7 @@ describe("helpPanelStore persistence migration", () => {
           introDismissed: boolean;
         };
       };
-      expect(parsed.version).toBe(5);
+      expect(parsed.version).toBe(6);
       expect(parsed.state.width).toBe(450);
       expect(parsed.state.preferredAgentId).toBeNull();
     } finally {
@@ -295,7 +296,7 @@ describe("helpPanelStore persistence migration", () => {
       expect(written).toBeDefined();
       const parsed: unknown = JSON.parse(written!);
       expect(parsed).toMatchObject({
-        version: 5,
+        version: 6,
         state: { introDismissed: true },
       });
     } finally {
@@ -357,7 +358,7 @@ describe("helpPanelStore persistence migration", () => {
         version: number;
         state: Record<string, unknown>;
       };
-      expect(parsed.version).toBe(5);
+      expect(parsed.version).toBe(6);
       expect(parsed.state).not.toHaveProperty("isOpen");
     } finally {
       vi.useRealTimers();
@@ -377,37 +378,37 @@ describe("helpPanelStore persistence migration", () => {
 
     const { useHelpPanelStore: store } = await import("../helpPanelStore");
 
-    expect(store.getState().conversationTouched).toBe(false);
+    expect(store.getState().sessions[0]!.conversationTouched).toBe(false);
   });
 
   it("markConversationStarted sets conversationTouched to true", async () => {
     installLocalStorage({});
 
     const { useHelpPanelStore: store } = await import("../helpPanelStore");
-    store.getState().markConversationStarted();
+    store.getState().markConversationStarted(0);
 
-    expect(store.getState().conversationTouched).toBe(true);
+    expect(store.getState().sessions[0]!.conversationTouched).toBe(true);
   });
 
   it("markConversationStarted is idempotent (calling twice still yields true)", async () => {
     installLocalStorage({});
 
     const { useHelpPanelStore: store } = await import("../helpPanelStore");
-    store.getState().markConversationStarted();
-    store.getState().markConversationStarted();
+    store.getState().markConversationStarted(0);
+    store.getState().markConversationStarted(0);
 
-    expect(store.getState().conversationTouched).toBe(true);
+    expect(store.getState().sessions[0]!.conversationTouched).toBe(true);
   });
 
   it("setTerminal resets conversationTouched to false", async () => {
     installLocalStorage({});
 
     const { useHelpPanelStore: store } = await import("../helpPanelStore");
-    store.getState().markConversationStarted();
-    expect(store.getState().conversationTouched).toBe(true);
+    store.getState().markConversationStarted(0);
+    expect(store.getState().sessions[0]!.conversationTouched).toBe(true);
 
-    store.getState().setTerminal("term-1", "claude", null);
-    expect(store.getState().conversationTouched).toBe(false);
+    store.getState().setTerminal(0, "term-1", "claude", null);
+    expect(store.getState().sessions[0]!.conversationTouched).toBe(false);
   });
 
   it("setTerminal initializes preferredAgentId from the bound agent when none is set", async () => {
@@ -416,7 +417,7 @@ describe("helpPanelStore persistence migration", () => {
     const { useHelpPanelStore: store } = await import("../helpPanelStore");
     expect(store.getState().preferredAgentId).toBeNull();
 
-    store.getState().setTerminal("term-1", "codex", null);
+    store.getState().setTerminal(0, "term-1", "codex", null);
     expect(store.getState().preferredAgentId).toBe("codex");
   });
 
@@ -428,36 +429,36 @@ describe("helpPanelStore persistence migration", () => {
 
     // A live terminal re-binds (resume/reconnect) to a different agent —
     // the user's explicit choice must survive, not get clobbered.
-    store.getState().setTerminal("term-1", "codex", null);
+    store.getState().setTerminal(0, "term-1", "codex", null);
     expect(store.getState().preferredAgentId).toBe("claude");
-    expect(store.getState().agentId).toBe("codex");
+    expect(store.getState().sessions[0]!.agentId).toBe("codex");
   });
 
   it("clearTerminal resets conversationTouched to false", async () => {
     installLocalStorage({});
 
     const { useHelpPanelStore: store } = await import("../helpPanelStore");
-    store.getState().markConversationStarted();
-    expect(store.getState().conversationTouched).toBe(true);
+    store.getState().markConversationStarted(0);
+    expect(store.getState().sessions[0]!.conversationTouched).toBe(true);
 
-    store.getState().clearTerminal();
-    expect(store.getState().conversationTouched).toBe(false);
+    store.getState().clearTerminal(0);
+    expect(store.getState().sessions[0]!.conversationTouched).toBe(false);
   });
 
   it("clearTerminal drops figures so a crash/hibernate teardown can't leak them into the next session (#9829)", async () => {
     installLocalStorage({});
 
     const { useHelpPanelStore: store } = await import("../helpPanelStore");
-    store.getState().addFigure({
+    store.getState().addFigure(0, {
       imageId: "img-1",
       figureNumber: 1,
       figureLabel: "image #1",
       url: "https://daintree.org/figure-1.png",
     });
-    expect(store.getState().figures).toHaveLength(1);
+    expect(store.getState().sessions[0]!.figures).toHaveLength(1);
 
-    store.getState().clearTerminal();
-    expect(store.getState().figures).toEqual([]);
+    store.getState().clearTerminal(0);
+    expect(store.getState().sessions[0]!.figures).toEqual([]);
   });
 
   it("conversationTouched is NOT persisted", async () => {
@@ -466,7 +467,7 @@ describe("helpPanelStore persistence migration", () => {
       const backing = installLocalStorage({});
 
       const { useHelpPanelStore: store } = await import("../helpPanelStore");
-      store.getState().markConversationStarted();
+      store.getState().markConversationStarted(0);
       vi.advanceTimersByTime(400);
 
       const written = backing.get(STORAGE_KEY);
@@ -478,7 +479,7 @@ describe("helpPanelStore persistence migration", () => {
       // conversationTouched is excluded from the persisted blob
       expect(parsed.state).not.toHaveProperty("conversationTouched");
       // The field is still true in the store
-      expect(store.getState().conversationTouched).toBe(true);
+      expect(store.getState().sessions[0]!.conversationTouched).toBe(true);
     } finally {
       vi.useRealTimers();
     }
@@ -500,7 +501,152 @@ describe("helpPanelStore persistence migration", () => {
 
     const { useHelpPanelStore: store } = await import("../helpPanelStore");
 
-    expect(store.getState().conversationTouched).toBe(false);
+    expect(store.getState().sessions[0]!.conversationTouched).toBe(false);
+  });
+
+  // #12108. The lane axis the pre-lane cases above never had: they all describe
+  // slot 0 and still pass unchanged, so these add what is genuinely new.
+  describe("assistant lanes (#12108)", () => {
+    it("openSlot takes the lowest free lane, focuses it, and refuses past the ceiling", async () => {
+      installLocalStorage({});
+      const { useHelpPanelStore: store, MAX_SLOTS } = await import("../helpPanelStore").then(
+        async (m) => ({
+          useHelpPanelStore: m.useHelpPanelStore,
+          MAX_SLOTS: (await import("../../../shared/config/assistantSlots")).MAX_ASSISTANT_SLOTS,
+        })
+      );
+
+      const opened: Array<number | null> = [];
+      for (let i = 0; i < MAX_SLOTS + 1; i += 1) {
+        opened.push(store.getState().openSlot());
+      }
+
+      // Slot 0 exists from the start, so the first call takes 1.
+      expect(opened.slice(0, MAX_SLOTS - 1)).toEqual([1, 2].slice(0, MAX_SLOTS - 1));
+      // Refuses rather than reusing a lane — reuse would displace a session the
+      // user never named.
+      expect(opened[opened.length - 1]).toBeNull();
+      expect(store.getState().activeSlot).toBe(MAX_SLOTS - 1);
+    });
+
+    it("keeps lanes independent: writing one leaves its sibling untouched", async () => {
+      installLocalStorage({});
+      const { useHelpPanelStore: store } = await import("../helpPanelStore");
+      store.getState().openSlot();
+
+      store.getState().setTerminal(0, "term-0", "claude", "sess-0");
+      store.getState().setTerminal(1, "term-1", "codex", "sess-1");
+
+      expect(store.getState().sessions[0]).toMatchObject({
+        terminalId: "term-0",
+        agentId: "claude",
+        sessionId: "sess-0",
+      });
+      expect(store.getState().sessions[1]).toMatchObject({
+        terminalId: "term-1",
+        agentId: "codex",
+        sessionId: "sess-1",
+      });
+
+      // Clearing one lane must not touch the other's terminal OR its figures.
+      store.getState().addFigure(1, {
+        imageId: "img-1",
+        figureNumber: 1,
+        figureLabel: "Figure 1",
+        url: "https://daintree.org/a.png",
+      });
+      store.getState().clearTerminal(0);
+
+      expect(store.getState().sessions[0]!.terminalId).toBeNull();
+      expect(store.getState().sessions[1]!.terminalId).toBe("term-1");
+      expect(store.getState().sessions[1]!.figures).toHaveLength(1);
+    });
+
+    it("closeSlot drops the lane and falls back to the lowest remaining one", async () => {
+      installLocalStorage({});
+      const { useHelpPanelStore: store } = await import("../helpPanelStore");
+      store.getState().openSlot();
+      store.getState().setTerminal(0, "term-0", "claude", null);
+      store.getState().setActiveSlot(1);
+
+      store.getState().closeSlot(1);
+
+      expect(store.getState().sessions[1]).toBeUndefined();
+      expect(store.getState().activeSlot).toBe(0);
+      expect(store.getState().sessions[0]!.terminalId).toBe("term-0");
+    });
+
+    it("never leaves the panel lane-less: closing the last lane resets slot 0", async () => {
+      installLocalStorage({});
+      const { useHelpPanelStore: store } = await import("../helpPanelStore");
+      store.getState().setTerminal(0, "term-0", "claude", "sess-0");
+
+      store.getState().closeSlot(0);
+
+      // Slot 0 still exists, but empty — the panel has an empty state to show
+      // rather than no lane at all.
+      expect(store.getState().activeSlot).toBe(0);
+      expect(store.getState().sessions[0]).toMatchObject({ terminalId: null, sessionId: null });
+    });
+
+    it("ignores writes to a lane the user already closed", async () => {
+      installLocalStorage({});
+      const { useHelpPanelStore: store } = await import("../helpPanelStore");
+      store.getState().openSlot();
+      store.getState().closeSlot(1);
+
+      // An in-flight launch resolving after its tab was closed must not
+      // resurrect the lane.
+      store.getState().setTerminal(1, "term-late", "claude", "sess-late");
+
+      expect(store.getState().sessions[1]).toBeUndefined();
+    });
+
+    it("keeps each lane's hibernation entry separate", async () => {
+      installLocalStorage({});
+      const { useHelpPanelStore: store } = await import("../helpPanelStore");
+
+      store.getState().setHibernateSession("proj-1", 0, {
+        sessionId: "s0",
+        cwd: "/tmp/a",
+        agentId: "claude",
+      });
+      store.getState().setHibernateSession("proj-1", 1, {
+        sessionId: "s1",
+        cwd: "/tmp/b",
+        agentId: "claude",
+      });
+      store.getState().clearHibernateSession("proj-1", 0);
+
+      expect(store.getState().hibernateSessions).toEqual({
+        [slotKey("proj-1", 1)]: { sessionId: "s1", cwd: "/tmp/b", agentId: "claude" },
+      });
+    });
+
+    it("migrates a v5 bare-projectId hibernation key onto slot 0", async () => {
+      // Without this an upgrading user silently loses every resume token: the
+      // old key would never be looked up again.
+      installLocalStorage({
+        "help-panel-storage": JSON.stringify({
+          version: 5,
+          state: {
+            hibernateSessions: {
+              "proj-legacy": { sessionId: "legacy-id", cwd: "/tmp/legacy", agentId: "claude" },
+            },
+          },
+        }),
+      });
+
+      const { useHelpPanelStore: store } = await import("../helpPanelStore");
+
+      expect(store.getState().hibernateSessions).toEqual({
+        [slotKey("proj-legacy", 0)]: {
+          sessionId: "legacy-id",
+          cwd: "/tmp/legacy",
+          agentId: "claude",
+        },
+      });
+    });
   });
 
   describe("hibernateSessions", () => {
@@ -516,14 +662,14 @@ describe("helpPanelStore persistence migration", () => {
       installLocalStorage({});
 
       const { useHelpPanelStore: store } = await import("../helpPanelStore");
-      store.getState().setHibernateSession("proj-1", {
+      store.getState().setHibernateSession("proj-1", 0, {
         sessionId: "abc-123",
         cwd: "/tmp/help",
         agentId: "claude",
       });
 
       expect(store.getState().hibernateSessions).toEqual({
-        "proj-1": { sessionId: "abc-123", cwd: "/tmp/help", agentId: "claude" },
+        [slotKey("proj-1", 0)]: { sessionId: "abc-123", cwd: "/tmp/help", agentId: "claude" },
       });
     });
 
@@ -531,20 +677,20 @@ describe("helpPanelStore persistence migration", () => {
       installLocalStorage({});
 
       const { useHelpPanelStore: store } = await import("../helpPanelStore");
-      store.getState().setHibernateSession("proj-a", {
+      store.getState().setHibernateSession("proj-a", 0, {
         sessionId: "session-a",
         cwd: "/tmp/a",
         agentId: "claude",
       });
-      store.getState().setHibernateSession("proj-b", {
+      store.getState().setHibernateSession("proj-b", 0, {
         sessionId: "session-b",
         cwd: "/tmp/b",
         agentId: "claude",
       });
 
       expect(store.getState().hibernateSessions).toEqual({
-        "proj-a": { sessionId: "session-a", cwd: "/tmp/a", agentId: "claude" },
-        "proj-b": { sessionId: "session-b", cwd: "/tmp/b", agentId: "claude" },
+        [slotKey("proj-a", 0)]: { sessionId: "session-a", cwd: "/tmp/a", agentId: "claude" },
+        [slotKey("proj-b", 0)]: { sessionId: "session-b", cwd: "/tmp/b", agentId: "claude" },
       });
     });
 
@@ -552,20 +698,20 @@ describe("helpPanelStore persistence migration", () => {
       installLocalStorage({});
 
       const { useHelpPanelStore: store } = await import("../helpPanelStore");
-      store.getState().setHibernateSession("proj-a", {
+      store.getState().setHibernateSession("proj-a", 0, {
         sessionId: "session-a",
         cwd: "/tmp/a",
         agentId: "claude",
       });
-      store.getState().setHibernateSession("proj-b", {
+      store.getState().setHibernateSession("proj-b", 0, {
         sessionId: "session-b",
         cwd: "/tmp/b",
         agentId: "claude",
       });
-      store.getState().clearHibernateSession("proj-a");
+      store.getState().clearHibernateSession("proj-a", 0);
 
       expect(store.getState().hibernateSessions).toEqual({
-        "proj-b": { sessionId: "session-b", cwd: "/tmp/b", agentId: "claude" },
+        [slotKey("proj-b", 0)]: { sessionId: "session-b", cwd: "/tmp/b", agentId: "claude" },
       });
     });
 
@@ -573,15 +719,15 @@ describe("helpPanelStore persistence migration", () => {
       installLocalStorage({});
 
       const { useHelpPanelStore: store } = await import("../helpPanelStore");
-      store.getState().setHibernateSession("proj-a", {
+      store.getState().setHibernateSession("proj-a", 0, {
         sessionId: "session-a",
         cwd: "/tmp/a",
         agentId: "claude",
       });
-      store.getState().clearHibernateSession("proj-unknown");
+      store.getState().clearHibernateSession("proj-unknown", 0);
 
       expect(store.getState().hibernateSessions).toEqual({
-        "proj-a": { sessionId: "session-a", cwd: "/tmp/a", agentId: "claude" },
+        [slotKey("proj-a", 0)]: { sessionId: "session-a", cwd: "/tmp/a", agentId: "claude" },
       });
     });
 
@@ -591,7 +737,7 @@ describe("helpPanelStore persistence migration", () => {
         const backing = installLocalStorage({});
 
         let mod = await import("../helpPanelStore");
-        mod.useHelpPanelStore.getState().setHibernateSession("proj-a", {
+        mod.useHelpPanelStore.getState().setHibernateSession("proj-a", 0, {
           sessionId: "session-a",
           cwd: "/tmp/a",
           agentId: "claude",
@@ -604,16 +750,16 @@ describe("helpPanelStore persistence migration", () => {
           version: number;
           state: { hibernateSessions: Record<string, unknown> };
         };
-        expect(parsed.version).toBe(5);
+        expect(parsed.version).toBe(6);
         expect(parsed.state.hibernateSessions).toEqual({
-          "proj-a": { sessionId: "session-a", cwd: "/tmp/a", agentId: "claude" },
+          [slotKey("proj-a", 0)]: { sessionId: "session-a", cwd: "/tmp/a", agentId: "claude" },
         });
 
         vi.useRealTimers();
         vi.resetModules();
         mod = await import("../helpPanelStore");
         expect(mod.useHelpPanelStore.getState().hibernateSessions).toEqual({
-          "proj-a": { sessionId: "session-a", cwd: "/tmp/a", agentId: "claude" },
+          [slotKey("proj-a", 0)]: { sessionId: "session-a", cwd: "/tmp/a", agentId: "claude" },
         });
       } finally {
         vi.useRealTimers();
@@ -729,7 +875,7 @@ describe("helpPanelStore persistence migration", () => {
         const mod = await import("../helpPanelStore");
 
         // This view captures project A's session and flushes it to the shared partition.
-        mod.useHelpPanelStore.getState().setHibernateSession("proj-a", {
+        mod.useHelpPanelStore.getState().setHibernateSession("proj-a", 0, {
           sessionId: "a1",
           cwd: "/a",
           agentId: "claude",
@@ -737,7 +883,7 @@ describe("helpPanelStore persistence migration", () => {
         vi.advanceTimersByTime(400);
 
         // This (stale) view updates project A again — enqueued, not yet flushed.
-        mod.useHelpPanelStore.getState().setHibernateSession("proj-a", {
+        mod.useHelpPanelStore.getState().setHibernateSession("proj-a", 0, {
           sessionId: "a2",
           cwd: "/a",
           agentId: "claude",
@@ -746,7 +892,7 @@ describe("helpPanelStore persistence migration", () => {
         // A sibling view (project B) writes its own session DURING the debounce
         // window. The flush must read disk at flush time to preserve it.
         const disk = JSON.parse(backing.get(STORAGE_KEY)!) as PersistedBlob;
-        disk.state.hibernateSessions["proj-b"] = {
+        disk.state.hibernateSessions[slotKey("proj-b", 0)] = {
           sessionId: "b1",
           cwd: "/b",
           agentId: "claude",
@@ -757,8 +903,8 @@ describe("helpPanelStore persistence migration", () => {
 
         const written = JSON.parse(backing.get(STORAGE_KEY)!) as PersistedBlob;
         expect(written.state.hibernateSessions).toEqual({
-          "proj-a": { sessionId: "a2", cwd: "/a", agentId: "claude" },
-          "proj-b": { sessionId: "b1", cwd: "/b", agentId: "claude" },
+          [slotKey("proj-a", 0)]: { sessionId: "a2", cwd: "/a", agentId: "claude" },
+          [slotKey("proj-b", 0)]: { sessionId: "b1", cwd: "/b", agentId: "claude" },
         });
       } finally {
         vi.useRealTimers();
@@ -777,14 +923,14 @@ describe("helpPanelStore persistence migration", () => {
         backing.set(
           STORAGE_KEY,
           JSON.stringify({
-            version: 5,
+            version: 6,
             state: {
               width: 500,
               preferredAgentId: null,
               autoLaunchEnabled: true,
               introDismissed: true,
               hibernateSessions: {
-                "proj-b": { sessionId: "b1", cwd: "/b", agentId: "claude" },
+                [slotKey("proj-b", 0)]: { sessionId: "b1", cwd: "/b", agentId: "claude" },
               },
             },
           })
@@ -801,7 +947,7 @@ describe("helpPanelStore persistence migration", () => {
         expect(written.state.autoLaunchEnabled).toBe(true);
         expect(written.state.introDismissed).toBe(true);
         expect(written.state.hibernateSessions).toEqual({
-          "proj-b": { sessionId: "b1", cwd: "/b", agentId: "claude" },
+          [slotKey("proj-b", 0)]: { sessionId: "b1", cwd: "/b", agentId: "claude" },
         });
       } finally {
         vi.useRealTimers();
@@ -816,7 +962,7 @@ describe("helpPanelStore persistence migration", () => {
         // the same clamped value so an unrelated write doesn't read it as an edit.
         const backing = installLocalStorage({
           [STORAGE_KEY]: JSON.stringify({
-            version: 5,
+            version: 6,
             state: {
               width: HELP_PANEL_MAX_WIDTH + 1000,
               preferredAgentId: null,
@@ -836,7 +982,7 @@ describe("helpPanelStore persistence migration", () => {
         backing.set(STORAGE_KEY, JSON.stringify(disk));
 
         // An unrelated write (a hibernate capture) must not clobber the sibling's width.
-        mod.useHelpPanelStore.getState().setHibernateSession("proj-x", {
+        mod.useHelpPanelStore.getState().setHibernateSession("proj-x", 0, {
           sessionId: "x1",
           cwd: "/x",
           agentId: "claude",
@@ -846,7 +992,7 @@ describe("helpPanelStore persistence migration", () => {
         const written = JSON.parse(backing.get(STORAGE_KEY)!) as PersistedBlob;
         expect(written.state.width).toBe(500);
         expect(written.state.hibernateSessions).toEqual({
-          "proj-x": { sessionId: "x1", cwd: "/x", agentId: "claude" },
+          [slotKey("proj-x", 0)]: { sessionId: "x1", cwd: "/x", agentId: "claude" },
         });
       } finally {
         vi.useRealTimers();
@@ -859,15 +1005,15 @@ describe("helpPanelStore persistence migration", () => {
         // Hydrate a blob holding two sessions, so both live in this view's memory.
         const backing = installLocalStorage({
           [STORAGE_KEY]: JSON.stringify({
-            version: 5,
+            version: 6,
             state: {
               width: HELP_PANEL_DEFAULT_WIDTH,
               preferredAgentId: null,
               autoLaunchEnabled: false,
               introDismissed: false,
               hibernateSessions: {
-                "proj-a": { sessionId: "a1", cwd: "/a", agentId: "claude" },
-                "proj-b": { sessionId: "b1", cwd: "/b", agentId: "claude" },
+                [slotKey("proj-a", 0)]: { sessionId: "a1", cwd: "/a", agentId: "claude" },
+                [slotKey("proj-b", 0)]: { sessionId: "b1", cwd: "/b", agentId: "claude" },
               },
             },
           }),
@@ -876,7 +1022,7 @@ describe("helpPanelStore persistence migration", () => {
 
         // A sibling deletes proj-b on disk.
         const disk = JSON.parse(backing.get(STORAGE_KEY)!) as PersistedBlob;
-        delete disk.state.hibernateSessions["proj-b"];
+        delete disk.state.hibernateSessions[slotKey("proj-b", 0)];
         backing.set(STORAGE_KEY, JSON.stringify(disk));
 
         // This view writes an unrelated field; it still carries proj-b in memory,
@@ -886,7 +1032,7 @@ describe("helpPanelStore persistence migration", () => {
 
         const written = JSON.parse(backing.get(STORAGE_KEY)!) as PersistedBlob;
         expect(written.state.hibernateSessions).toEqual({
-          "proj-a": { sessionId: "a1", cwd: "/a", agentId: "claude" },
+          [slotKey("proj-a", 0)]: { sessionId: "a1", cwd: "/a", agentId: "claude" },
         });
         expect(written.state.width).toBe(500);
       } finally {
@@ -904,21 +1050,21 @@ describe("helpPanelStore persistence migration", () => {
         backing.set(
           STORAGE_KEY,
           JSON.stringify({
-            version: 5,
+            version: 6,
             state: {
               width: HELP_PANEL_DEFAULT_WIDTH,
               preferredAgentId: null,
               autoLaunchEnabled: false,
               introDismissed: false,
               hibernateSessions: {
-                "proj-b": { sessionId: "b1", cwd: "/b", agentId: "claude" },
+                [slotKey("proj-b", 0)]: { sessionId: "b1", cwd: "/b", agentId: "claude" },
               },
             },
           })
         );
 
         // This view captures a resume-latest sentinel (empty sessionId) for its project.
-        mod.useHelpPanelStore.getState().setHibernateSession("proj-a", {
+        mod.useHelpPanelStore.getState().setHibernateSession("proj-a", 0, {
           sessionId: "",
           cwd: "/a",
           agentId: "claude",
@@ -927,8 +1073,8 @@ describe("helpPanelStore persistence migration", () => {
 
         const written = JSON.parse(backing.get(STORAGE_KEY)!) as PersistedBlob;
         expect(written.state.hibernateSessions).toEqual({
-          "proj-a": { sessionId: "", cwd: "/a", agentId: "claude" },
-          "proj-b": { sessionId: "b1", cwd: "/b", agentId: "claude" },
+          [slotKey("proj-a", 0)]: { sessionId: "", cwd: "/a", agentId: "claude" },
+          [slotKey("proj-b", 0)]: { sessionId: "b1", cwd: "/b", agentId: "claude" },
         });
       } finally {
         vi.useRealTimers();
@@ -941,7 +1087,7 @@ describe("helpPanelStore persistence migration", () => {
         const backing = installLocalStorage({});
         const mod = await import("../helpPanelStore");
 
-        mod.useHelpPanelStore.getState().setHibernateSession("proj-a", {
+        mod.useHelpPanelStore.getState().setHibernateSession("proj-a", 0, {
           sessionId: "a1",
           cwd: "/a",
           agentId: "claude",
@@ -949,7 +1095,7 @@ describe("helpPanelStore persistence migration", () => {
         vi.advanceTimersByTime(400);
 
         const disk = JSON.parse(backing.get(STORAGE_KEY)!) as PersistedBlob;
-        disk.state.hibernateSessions["proj-b"] = {
+        disk.state.hibernateSessions[slotKey("proj-b", 0)] = {
           sessionId: "b1",
           cwd: "/b",
           agentId: "claude",
@@ -957,12 +1103,12 @@ describe("helpPanelStore persistence migration", () => {
         backing.set(STORAGE_KEY, JSON.stringify(disk));
 
         // Clearing this view's own project must not resurrect it, and must keep B.
-        mod.useHelpPanelStore.getState().clearHibernateSession("proj-a");
+        mod.useHelpPanelStore.getState().clearHibernateSession("proj-a", 0);
         vi.advanceTimersByTime(400);
 
         const written = JSON.parse(backing.get(STORAGE_KEY)!) as PersistedBlob;
         expect(written.state.hibernateSessions).toEqual({
-          "proj-b": { sessionId: "b1", cwd: "/b", agentId: "claude" },
+          [slotKey("proj-b", 0)]: { sessionId: "b1", cwd: "/b", agentId: "claude" },
         });
       } finally {
         vi.useRealTimers();
@@ -1022,7 +1168,7 @@ describe("helpPanelStore persistence migration", () => {
 
     it("preserves autoLaunchEnabled: true from a persisted blob across rehydration", async () => {
       const blob = JSON.stringify({
-        version: 5,
+        version: 6,
         state: { width: 400, preferredAgentId: "claude", autoLaunchEnabled: true },
       });
       installLocalStorage({ [STORAGE_KEY]: blob });
@@ -1034,7 +1180,7 @@ describe("helpPanelStore persistence migration", () => {
 
     it("falls back to false when persisted autoLaunchEnabled has a non-boolean type", async () => {
       const malformed = JSON.stringify({
-        version: 5,
+        version: 6,
         state: { width: 400, preferredAgentId: null, autoLaunchEnabled: "true" },
       });
       installLocalStorage({ [STORAGE_KEY]: malformed });
@@ -1060,7 +1206,7 @@ describe("helpPanelStore persistence migration", () => {
           version: number;
           state: Record<string, unknown>;
         };
-        expect(parsed.version).toBe(5);
+        expect(parsed.version).toBe(6);
         expect(parsed.state.autoLaunchEnabled).toBe(true);
       } finally {
         vi.useRealTimers();
@@ -1069,7 +1215,7 @@ describe("helpPanelStore persistence migration", () => {
 
     it("setAutoLaunchEnabled(false) flips consent back off", async () => {
       const blob = JSON.stringify({
-        version: 5,
+        version: 6,
         state: { width: 400, preferredAgentId: "claude", autoLaunchEnabled: true },
       });
       installLocalStorage({ [STORAGE_KEY]: blob });
@@ -1088,57 +1234,57 @@ describe("helpPanelStore persistence migration", () => {
 
       const { useHelpPanelStore: store } = await import("../helpPanelStore");
 
-      expect(store.getState().activeFigureNumber).toBeNull();
+      expect(store.getState().sessions[0]!.activeFigureNumber).toBeNull();
     });
 
     it("setActiveFigureNumber updates the active figure", async () => {
       installLocalStorage({});
 
       const { useHelpPanelStore: store } = await import("../helpPanelStore");
-      store.getState().setActiveFigureNumber(3);
+      store.getState().setActiveFigureNumber(0, 3);
 
-      expect(store.getState().activeFigureNumber).toBe(3);
+      expect(store.getState().sessions[0]!.activeFigureNumber).toBe(3);
 
-      store.getState().setActiveFigureNumber(null);
-      expect(store.getState().activeFigureNumber).toBeNull();
+      store.getState().setActiveFigureNumber(0, null);
+      expect(store.getState().sessions[0]!.activeFigureNumber).toBeNull();
     });
 
     it("clearFigures resets the active figure alongside the figures list", async () => {
       installLocalStorage({});
 
       const { useHelpPanelStore: store } = await import("../helpPanelStore");
-      store.getState().addFigure({
+      store.getState().addFigure(0, {
         imageId: "img-1",
         figureNumber: 1,
         figureLabel: "image #1",
         url: "https://daintree.org/a.png",
       });
-      store.getState().setActiveFigureNumber(1);
-      expect(store.getState().figures).toHaveLength(1);
-      expect(store.getState().activeFigureNumber).toBe(1);
+      store.getState().setActiveFigureNumber(0, 1);
+      expect(store.getState().sessions[0]!.figures).toHaveLength(1);
+      expect(store.getState().sessions[0]!.activeFigureNumber).toBe(1);
 
-      store.getState().clearFigures();
-      expect(store.getState().figures).toHaveLength(0);
-      expect(store.getState().activeFigureNumber).toBeNull();
+      store.getState().clearFigures(0);
+      expect(store.getState().sessions[0]!.figures).toHaveLength(0);
+      expect(store.getState().sessions[0]!.activeFigureNumber).toBeNull();
     });
 
     it("clearTerminal drops figures and the active figure (session-scoped reset)", async () => {
       installLocalStorage({});
 
       const { useHelpPanelStore: store } = await import("../helpPanelStore");
-      store.getState().addFigure({
+      store.getState().addFigure(0, {
         imageId: "img-1",
         figureNumber: 1,
         figureLabel: "image #1",
         url: "https://daintree.org/a.png",
       });
-      store.getState().setActiveFigureNumber(1);
-      expect(store.getState().figures).toHaveLength(1);
-      expect(store.getState().activeFigureNumber).toBe(1);
+      store.getState().setActiveFigureNumber(0, 1);
+      expect(store.getState().sessions[0]!.figures).toHaveLength(1);
+      expect(store.getState().sessions[0]!.activeFigureNumber).toBe(1);
 
-      store.getState().clearTerminal();
-      expect(store.getState().figures).toHaveLength(0);
-      expect(store.getState().activeFigureNumber).toBeNull();
+      store.getState().clearTerminal(0);
+      expect(store.getState().sessions[0]!.figures).toHaveLength(0);
+      expect(store.getState().sessions[0]!.activeFigureNumber).toBeNull();
     });
 
     it("activeFigureNumber is NOT persisted", async () => {
@@ -1147,7 +1293,7 @@ describe("helpPanelStore persistence migration", () => {
         const backing = installLocalStorage({});
 
         const { useHelpPanelStore: store } = await import("../helpPanelStore");
-        store.getState().setActiveFigureNumber(2);
+        store.getState().setActiveFigureNumber(0, 2);
         vi.advanceTimersByTime(400);
 
         const written = backing.get(STORAGE_KEY);
@@ -1157,7 +1303,7 @@ describe("helpPanelStore persistence migration", () => {
           state: Record<string, unknown>;
         };
         expect(parsed.state).not.toHaveProperty("activeFigureNumber");
-        expect(store.getState().activeFigureNumber).toBe(2);
+        expect(store.getState().sessions[0]!.activeFigureNumber).toBe(2);
       } finally {
         vi.useRealTimers();
       }

--- a/src/store/__tests__/projectStore.adversarial.test.ts
+++ b/src/store/__tests__/projectStore.adversarial.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 // @vitest-environment-options {"url":"http://localhost/"}
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ASSISTANT_SLOTS, assistantSlotKey } from "@shared/config/assistantSlots";
 
 type ProjectShape = {
   id: string;
@@ -551,8 +552,10 @@ describe("projectStore adversarial", () => {
     const { useProjectStore } = await import("../projectStore");
     await useProjectStore.getState().removeProject(projectA.id);
 
-    expect(clearHibernateSessionMock).toHaveBeenCalledTimes(1);
-    expect(clearHibernateSessionMock).toHaveBeenCalledWith(projectA.id);
+    // Once per lane since #12108 — a removed project must not leave a sibling
+    // lane's resume token keyed to an id nothing will look up again.
+    expect(clearHibernateSessionMock).toHaveBeenCalledTimes(ASSISTANT_SLOTS.length);
+    expect(clearHibernateSessionMock).toHaveBeenCalledWith(projectA.id, 0);
   });
 
   it("does not GC the hibernate session when project removal fails", async () => {
@@ -570,7 +573,7 @@ describe("projectStore adversarial", () => {
   it("carries the hibernate session over if locating still changes the id", async () => {
     installProjectApi({});
     installLocalStorage(createStorageMock());
-    hibernateSessionsMock[projectA.id] = {
+    hibernateSessionsMock[assistantSlotKey(projectA.id, 0)] = {
       sessionId: "session-1",
       cwd: "/tmp/project-a",
       agentId: "claude",
@@ -584,12 +587,12 @@ describe("projectStore adversarial", () => {
 
     // Preserved under the new id and repointed at the new folder — the whole
     // point of #11282 is that relocating never costs the user a conversation.
-    expect(setHibernateSessionMock).toHaveBeenCalledWith("project-a-relocated", {
+    expect(setHibernateSessionMock).toHaveBeenCalledWith("project-a-relocated", 0, {
       sessionId: "session-1",
       cwd: "/tmp/project-a-moved",
       agentId: "claude",
     });
-    expect(clearHibernateSessionMock).toHaveBeenCalledWith(projectA.id);
+    expect(clearHibernateSessionMock).toHaveBeenCalledWith(projectA.id, 0);
   });
 
   it("still refreshes the project list when hibernate migration fails", async () => {
@@ -598,7 +601,7 @@ describe("projectStore adversarial", () => {
     setHibernateSessionMock.mockImplementationOnce(() => {
       throw new Error("store unavailable");
     });
-    hibernateSessionsMock[projectA.id] = {
+    hibernateSessionsMock[assistantSlotKey(projectA.id, 0)] = {
       sessionId: "session-1",
       cwd: "/tmp/project-a",
       agentId: "claude",
@@ -649,7 +652,7 @@ describe("projectStore adversarial", () => {
       },
     });
     installLocalStorage(createStorageMock());
-    hibernateSessionsMock[projectA.id] = {
+    hibernateSessionsMock[assistantSlotKey(projectA.id, 0)] = {
       sessionId: "session-1",
       cwd: `${projectA.path}/sub`,
       agentId: "claude",
@@ -662,7 +665,7 @@ describe("projectStore adversarial", () => {
     await vi.dynamicImportSettled();
 
     // Same id, new folder: the resume pointer is repointed in place, never GC'd.
-    expect(setHibernateSessionMock).toHaveBeenCalledWith(projectA.id, {
+    expect(setHibernateSessionMock).toHaveBeenCalledWith(projectA.id, 0, {
       sessionId: "session-1",
       cwd: "/tmp/project-a-moved/sub",
       agentId: "claude",
@@ -679,7 +682,7 @@ describe("projectStore adversarial", () => {
       },
     });
     installLocalStorage(createStorageMock());
-    hibernateSessionsMock[projectA.id] = {
+    hibernateSessionsMock[assistantSlotKey(projectA.id, 0)] = {
       sessionId: "session-1",
       cwd: projectA.path,
       agentId: "claude",

--- a/src/store/__tests__/wakeActiveWorktreeTerminals.test.ts
+++ b/src/store/__tests__/wakeActiveWorktreeTerminals.test.ts
@@ -55,8 +55,7 @@ vi.mock("@/store/helpPanelStore", () => ({
   },
   // #12108: the wake fan-out covers every assistant lane, not just the focused
   // one — a background assistant's xterm still needs waking on view reveal.
-  selectSlotTerminalIds: (s: { terminalId: string | null }) =>
-    s.terminalId ? [s.terminalId] : [],
+  selectSlotTerminalIds: (s: { terminalId: string | null }) => (s.terminalId ? [s.terminalId] : []),
 }));
 
 const { wakeActiveWorktreeTerminals, repaintActiveWorktreeTerminals } =

--- a/src/store/__tests__/wakeActiveWorktreeTerminals.test.ts
+++ b/src/store/__tests__/wakeActiveWorktreeTerminals.test.ts
@@ -53,6 +53,10 @@ vi.mock("@/store/helpPanelStore", () => ({
   useHelpPanelStore: {
     getState: () => ({ terminalId: mockHelpTerminalId }),
   },
+  // #12108: the wake fan-out covers every assistant lane, not just the focused
+  // one — a background assistant's xterm still needs waking on view reveal.
+  selectSlotTerminalIds: (s: { terminalId: string | null }) =>
+    s.terminalId ? [s.terminalId] : [],
 }));
 
 const { wakeActiveWorktreeTerminals, repaintActiveWorktreeTerminals } =

--- a/src/store/helpPanelStore.ts
+++ b/src/store/helpPanelStore.ts
@@ -631,4 +631,3 @@ export function selectSlotTerminalIds(state: HelpPanelState): string[] {
   }
   return ids;
 }
-

--- a/src/store/helpPanelStore.ts
+++ b/src/store/helpPanelStore.ts
@@ -569,7 +569,7 @@ const EMPTY_SLOT: HelpSessionSlotState = Object.freeze({
   agentId: null,
   sessionId: null,
   conversationTouched: false,
-  figures: Object.freeze([]) as HelpFigure[],
+  figures: [] as HelpFigure[],
   activeFigureNumber: null,
 });
 

--- a/src/store/helpPanelStore.ts
+++ b/src/store/helpPanelStore.ts
@@ -146,6 +146,15 @@ interface HelpPanelActions {
    * one, since reuse would displace a session the user never named.
    */
   openSlot: () => number | null;
+  /**
+   * Open one specific lane if it isn't already, leaving the active lane alone.
+   *
+   * The restore half of `openSlot`: a cold view knows only slot 0, so a lane
+   * whose eviction-captured conversation survived on disk has to come back at
+   * its ORIGINAL slot — the persisted entries are keyed by it — and recreating
+   * a background tab must not yank the user off the lane they're looking at.
+   */
+  ensureSlot: (slot: number) => void;
   /** Drop a lane. Never removes the last one: the panel always has slot 0. */
   closeSlot: (slot: number) => void;
   setActiveSlot: (slot: number) => void;
@@ -394,6 +403,13 @@ export const useHelpPanelStore = create<HelpPanelState & HelpPanelActions>()(
         });
         return taken;
       },
+
+      ensureSlot: (slot) =>
+        set((s) =>
+          isValidAssistantSlot(slot) && !s.sessions[slot]
+            ? { sessions: { ...s.sessions, [slot]: emptySlot() } }
+            : s
+        ),
 
       closeSlot: (slot) =>
         set((s) => {

--- a/src/store/helpPanelStore.ts
+++ b/src/store/helpPanelStore.ts
@@ -10,6 +10,12 @@ import {
 import { registerPersistedStore } from "./persistence/persistedStoreRegistry";
 import { getAssistantSupportedAgentIds } from "../../shared/config/agentRegistry";
 import { isBuiltInAgentId } from "../../shared/config/agentIds";
+import {
+  DEFAULT_ASSISTANT_SLOT,
+  MAX_ASSISTANT_SLOTS,
+  assistantSlotKey,
+  isValidAssistantSlot,
+} from "../../shared/config/assistantSlots";
 
 function isAssistantSupportedAgentId(value: unknown): value is string {
   return typeof value === "string" && getAssistantSupportedAgentIds().includes(value);
@@ -50,11 +56,50 @@ export interface HelpFigure {
   altText?: string;
 }
 
+/**
+ * One assistant lane's live state (#12108). Everything here is per-session and
+ * none of it is persisted — a lane's terminal, bearer and figures are all
+ * meaningless across a restart, and the store instance is per project view
+ * anyway. Only `hibernateSessions` outlives the view, and it is keyed by
+ * `assistantSlotKey` so lanes can't overwrite each other.
+ */
+export interface HelpSessionSlotState {
+  terminalId: string | null;
+  agentId: string | null;
+  sessionId: string | null;
+  conversationTouched: boolean;
+  /**
+   * Figures the assistant surfaced via `help.displayImage`, in arrival order
+   * (#9828). Per lane: a figure belongs to the conversation that produced it,
+   * so a sibling lane must never be able to navigate to it.
+   */
+  figures: HelpFigure[];
+  /** The figure a clickable `[image #N]` reference last activated (#9830). */
+  activeFigureNumber: number | null;
+}
+
+function emptySlot(): HelpSessionSlotState {
+  return {
+    terminalId: null,
+    agentId: null,
+    sessionId: null,
+    conversationTouched: false,
+    figures: [],
+    activeFigureNumber: null,
+  };
+}
+
 interface HelpPanelState {
   isOpen: boolean;
   width: number;
-  terminalId: string | null;
-  agentId: string | null;
+  /**
+   * Live assistant lanes, keyed by slot. Slot 0 always exists — the panel is
+   * never session-less, it just shows an empty state. A lane appears when the
+   * user adds a session and disappears when they close it.
+   */
+  sessions: Record<number, HelpSessionSlotState>;
+  /** Which lane the panel body is showing. Always a key of `sessions`. */
+  activeSlot: number;
   preferredAgentId: string | null;
   /**
    * User consent to auto-launch a billed agent session when the panel opens.
@@ -71,82 +116,112 @@ interface HelpPanelState {
    * the silent null-out is explained instead of leaving a blank empty state.
    */
   droppedPreferredAgentId: string | null;
-  sessionId: string | null;
   introDismissed: boolean;
-  conversationTouched: boolean;
   /**
-   * Per-project captured resume sessions, keyed by projectId. helpPanelStore
-   * is shared across all project views (single localStorage partition), so
-   * the assistant session for project A must not leak into project B.
+   * Captured resume sessions, keyed by `assistantSlotKey(projectId, slot)`.
+   * helpPanelStore is shared across all project views (single localStorage
+   * partition), so the assistant session for project A must not leak into
+   * project B — and since #12108, one lane's resume token must not overwrite
+   * a sibling lane's either.
    */
   hibernateSessions: Record<string, HelpHibernateSession>;
   /** Monotonic counter bumped by requestFocus() so repeated Cmd+L presses re-trigger the focus effect. */
   focusRequest: number;
-  /**
-   * Figures the assistant surfaced via `help.displayImage`, in arrival order
-   * (#9828). Session-scoped and never persisted — a new conversation starts
-   * empty, so stale image references can't survive an app restart.
-   */
-  figures: HelpFigure[];
-  /**
-   * The figure a clickable `[image #N]` reference last activated (#9830). The
-   * figure rail (#9829) consumes this to scroll-to and highlight the matching
-   * thumbnail. Session-scoped and never persisted — cleared on session reset.
-   */
-  activeFigureNumber: number | null;
 }
 
 interface HelpPanelActions {
   toggle: () => void;
   setOpen: (open: boolean) => void;
   setWidth: (width: number) => void;
-  setTerminal: (terminalId: string, agentId: string, sessionId: string | null) => void;
-  clearTerminal: () => void;
+  setTerminal: (
+    slot: number,
+    terminalId: string,
+    agentId: string,
+    sessionId: string | null
+  ) => void;
+  clearTerminal: (slot: number) => void;
+  /**
+   * Add an empty lane and focus it. Returns the slot taken, or null when every
+   * lane is occupied — the caller surfaces that rather than silently reusing
+   * one, since reuse would displace a session the user never named.
+   */
+  openSlot: () => number | null;
+  /** Drop a lane. Never removes the last one: the panel always has slot 0. */
+  closeSlot: (slot: number) => void;
+  setActiveSlot: (slot: number) => void;
   setPreferredAgent: (agentId: string | null) => void;
   setAutoLaunchEnabled: (enabled: boolean) => void;
   clearDroppedPreferredAgent: () => void;
   dismissIntro: () => void;
-  markConversationStarted: () => void;
+  markConversationStarted: (slot: number) => void;
   requestFocus: () => void;
   setHibernateSession: (
     projectId: string,
+    slot: number,
     entry: { sessionId: string; cwd: string; agentId: string }
   ) => void;
-  clearHibernateSession: (projectId: string) => void;
+  clearHibernateSession: (projectId: string, slot: number) => void;
   /** Append (or replace by imageId) a figure surfaced by `help.displayImage`. */
-  addFigure: (figure: HelpFigure) => void;
-  /** Drop all figures — called when the conversation/terminal resets. */
-  clearFigures: () => void;
+  addFigure: (slot: number, figure: HelpFigure) => void;
+  /** Drop a lane's figures — called when its conversation/terminal resets. */
+  clearFigures: (slot: number) => void;
   /** Set the figure a clickable `[image #N]` reference activated (#9830). */
-  setActiveFigureNumber: (figureNumber: number | null) => void;
+  setActiveFigureNumber: (slot: number, figureNumber: number | null) => void;
 }
 
 const initialState: HelpPanelState = {
   isOpen: false,
   width: HELP_PANEL_DEFAULT_WIDTH,
-  terminalId: null,
-  agentId: null,
+  sessions: { [DEFAULT_ASSISTANT_SLOT]: emptySlot() },
+  activeSlot: DEFAULT_ASSISTANT_SLOT,
   preferredAgentId: null,
   autoLaunchEnabled: false,
   droppedPreferredAgentId: null,
-  sessionId: null,
   introDismissed: false,
-  conversationTouched: false,
   hibernateSessions: {},
   focusRequest: 0,
-  figures: [],
-  activeFigureNumber: null,
 };
+
+/**
+ * Apply `mutate` to one lane, leaving every sibling's object identity intact so
+ * a lane's subscribers don't rerender when another lane moves. Returns the
+ * state unchanged when the lane isn't open — a late callback from a lane the
+ * user just closed must not resurrect it.
+ */
+function patchSlot(
+  state: HelpPanelState,
+  slot: number,
+  mutate: (entry: HelpSessionSlotState) => HelpSessionSlotState
+): Pick<HelpPanelState, "sessions"> | HelpPanelState {
+  const existing = state.sessions[slot];
+  if (!existing) return state;
+  const next = mutate(existing);
+  if (next === existing) return state;
+  return { sessions: { ...state.sessions, [slot]: next } };
+}
 
 function isRecordOfUnknown(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object";
 }
 
+/**
+ * Normalize persisted hibernation keys AND migrate v5 keys in place.
+ *
+ * Before #12108 the key was a bare project id, which described the one lane
+ * that existed then — slot 0. Doing the migration here rather than in a
+ * `migrate` step matters: this same function canonicalizes the baseline, disk
+ * and incoming blobs for the cross-view write merge, so a sibling view still
+ * on a v5 blob and this view on a v6 one compare like with like instead of
+ * accumulating one entry under each spelling (#11351).
+ */
 function sanitizeHibernateSessions(value: unknown): Record<string, HelpHibernateSession> {
   if (!isRecordOfUnknown(value)) return {};
   const out: Record<string, HelpHibernateSession> = {};
-  for (const [projectId, entry] of Object.entries(value)) {
-    if (!projectId) continue;
+  for (const [rawKey, entry] of Object.entries(value)) {
+    if (!rawKey) continue;
+    const key = rawKey.includes("\u0000")
+      ? rawKey
+      : assistantSlotKey(rawKey, DEFAULT_ASSISTANT_SLOT);
     if (!isRecordOfUnknown(entry)) continue;
     const sessionId = entry.sessionId;
     const cwd = entry.cwd;
@@ -156,7 +231,7 @@ function sanitizeHibernateSessions(value: unknown): Record<string, HelpHibernate
     if (typeof sessionId !== "string") continue;
     if (typeof cwd !== "string" || !cwd) continue;
     if (typeof agentId !== "string" || !agentId) continue;
-    out[projectId] = { sessionId, cwd, agentId };
+    out[key] = { sessionId, cwd, agentId };
   }
   return out;
 }
@@ -264,33 +339,88 @@ export const useHelpPanelStore = create<HelpPanelState & HelpPanelActions>()(
           width: Math.min(Math.max(width, HELP_PANEL_MIN_WIDTH), HELP_PANEL_MAX_WIDTH),
         }),
 
-      setTerminal: (terminalId, agentId, sessionId) =>
-        set((s) => ({
-          terminalId,
-          agentId,
-          sessionId,
-          // Only initialize the preference on first launch. An explicit user
-          // choice (made via Settings) must survive terminal re-binds —
-          // overwriting it here is what made #8353's agent switch a no-op.
-          preferredAgentId: s.preferredAgentId ?? agentId,
-          // A launched session is a successful recovery — drop the stale banner
-          // so it can't resurface if the panel later returns to the empty state.
-          droppedPreferredAgentId: null,
-          conversationTouched: false,
-        })),
-
-      clearTerminal: () =>
-        set({
-          terminalId: null,
-          agentId: null,
-          sessionId: null,
-          conversationTouched: false,
-          // Figures are session-scoped — unbinding the terminal must drop them
-          // (and any active highlight) so a relaunched session can't navigate
-          // to a previous session's image (#9830).
-          figures: [],
-          activeFigureNumber: null,
+      setTerminal: (slot, terminalId, agentId, sessionId) =>
+        set((s) => {
+          // A lane the user closed mid-launch must not come back: bind only
+          // into a lane that is still open.
+          if (!s.sessions[slot]) return s;
+          return {
+            sessions: {
+              ...s.sessions,
+              [slot]: {
+                ...s.sessions[slot],
+                terminalId,
+                agentId,
+                sessionId,
+                conversationTouched: false,
+              },
+            },
+            // Only initialize the preference on first launch. An explicit user
+            // choice (made via Settings) must survive terminal re-binds —
+            // overwriting it here is what made #8353's agent switch a no-op.
+            preferredAgentId: s.preferredAgentId ?? agentId,
+            // A launched session is a successful recovery — drop the stale
+            // banner so it can't resurface if the panel later returns to the
+            // empty state.
+            droppedPreferredAgentId: null,
+          };
         }),
+
+      clearTerminal: (slot) =>
+        set((s) =>
+          patchSlot(s, slot, (entry) => ({
+            ...entry,
+            terminalId: null,
+            agentId: null,
+            sessionId: null,
+            conversationTouched: false,
+            // Figures are session-scoped — unbinding the terminal must drop
+            // them (and any active highlight) so a relaunched session can't
+            // navigate to a previous session's image (#9830).
+            figures: [],
+            activeFigureNumber: null,
+          }))
+        ),
+
+      openSlot: () => {
+        let taken: number | null = null;
+        set((s) => {
+          for (let slot = 0; slot < MAX_ASSISTANT_SLOTS; slot += 1) {
+            if (s.sessions[slot]) continue;
+            taken = slot;
+            return { sessions: { ...s.sessions, [slot]: emptySlot() }, activeSlot: slot };
+          }
+          return s;
+        });
+        return taken;
+      },
+
+      closeSlot: (slot) =>
+        set((s) => {
+          if (!s.sessions[slot]) return s;
+          const remaining = Object.keys(s.sessions)
+            .map(Number)
+            .filter((n) => n !== slot)
+            .sort((a, b) => a - b);
+          // The panel is never lane-less. Closing the only lane resets it to an
+          // empty slot 0 instead, which is what "close this session" means when
+          // there is nothing to fall back to.
+          if (remaining.length === 0) {
+            return {
+              sessions: { [DEFAULT_ASSISTANT_SLOT]: emptySlot() },
+              activeSlot: DEFAULT_ASSISTANT_SLOT,
+            };
+          }
+          const next = { ...s.sessions };
+          delete next[slot];
+          return {
+            sessions: next,
+            activeSlot: s.activeSlot === slot ? remaining[0]! : s.activeSlot,
+          };
+        }),
+
+      setActiveSlot: (slot) =>
+        set((s) => (s.sessions[slot] && s.activeSlot !== slot ? { activeSlot: slot } : s)),
 
       setPreferredAgent: (agentId) =>
         set({ preferredAgentId: agentId, droppedPreferredAgentId: null }),
@@ -301,49 +431,65 @@ export const useHelpPanelStore = create<HelpPanelState & HelpPanelActions>()(
 
       dismissIntro: () => set({ introDismissed: true }),
 
-      markConversationStarted: () => set({ conversationTouched: true }),
+      markConversationStarted: (slot) =>
+        set((s) =>
+          patchSlot(s, slot, (entry) =>
+            entry.conversationTouched ? entry : { ...entry, conversationTouched: true }
+          )
+        ),
 
       requestFocus: () => set((s) => ({ focusRequest: s.focusRequest + 1 })),
 
-      setHibernateSession: (projectId, entry) =>
+      setHibernateSession: (projectId, slot, entry) =>
         set((s) => ({
           hibernateSessions: {
             ...s.hibernateSessions,
-            [projectId]: { sessionId: entry.sessionId, cwd: entry.cwd, agentId: entry.agentId },
+            [assistantSlotKey(projectId, slot)]: {
+              sessionId: entry.sessionId,
+              cwd: entry.cwd,
+              agentId: entry.agentId,
+            },
           },
         })),
 
-      clearHibernateSession: (projectId) =>
+      clearHibernateSession: (projectId, slot) =>
         set((s) => {
-          if (!(projectId in s.hibernateSessions)) return s;
+          const key = assistantSlotKey(projectId, slot);
+          if (!(key in s.hibernateSessions)) return s;
           const next = { ...s.hibernateSessions };
-          delete next[projectId];
+          delete next[key];
           return { hibernateSessions: next };
         }),
 
-      addFigure: (figure) =>
-        set((s) => {
-          const existing = s.figures.findIndex((f) => f.imageId === figure.imageId);
-          if (existing === -1) {
-            return { figures: [...s.figures, figure] };
-          }
-          // Idempotent upsert: a duplicate push (e.g. StrictMode double-mount
-          // replaying the listener) replaces rather than appends.
-          const next = s.figures.slice();
-          next[existing] = figure;
-          return { figures: next };
-        }),
-
-      clearFigures: () =>
+      addFigure: (slot, figure) =>
         set((s) =>
-          s.figures.length === 0 && s.activeFigureNumber === null
-            ? s
-            : { figures: [], activeFigureNumber: null }
+          patchSlot(s, slot, (entry) => {
+            const existing = entry.figures.findIndex((f) => f.imageId === figure.imageId);
+            if (existing === -1) return { ...entry, figures: [...entry.figures, figure] };
+            // Idempotent upsert: a duplicate push (e.g. StrictMode double-mount
+            // replaying the listener) replaces rather than appends.
+            const figures = entry.figures.slice();
+            figures[existing] = figure;
+            return { ...entry, figures };
+          })
         ),
 
-      setActiveFigureNumber: (figureNumber) =>
+      clearFigures: (slot) =>
         set((s) =>
-          s.activeFigureNumber === figureNumber ? s : { activeFigureNumber: figureNumber }
+          patchSlot(s, slot, (entry) =>
+            entry.figures.length === 0 && entry.activeFigureNumber === null
+              ? entry
+              : { ...entry, figures: [], activeFigureNumber: null }
+          )
+        ),
+
+      setActiveFigureNumber: (slot, figureNumber) =>
+        set((s) =>
+          patchSlot(s, slot, (entry) =>
+            entry.activeFigureNumber === figureNumber
+              ? entry
+              : { ...entry, activeFigureNumber: figureNumber }
+          )
         ),
     }),
     {
@@ -351,7 +497,11 @@ export const useHelpPanelStore = create<HelpPanelState & HelpPanelActions>()(
       storage: createDebouncedSafeJSONStorage<HelpPanelPersistedState>(300, {
         mergeOnWrite: mergeHelpPanelPersistedWrite,
       }),
-      version: 5,
+      // v6: `hibernateSessions` is keyed by `assistantSlotKey(projectId, slot)`
+      // instead of bare projectId (#12108). The v5 → v6 key rewrite happens in
+      // `sanitizeHibernateSessions`, which every read path already funnels
+      // through, so no separate migration step can be skipped.
+      version: 6,
       migrate: (persistedState) => persistedState as HelpPanelState & HelpPanelActions,
       partialize: (state): HelpPanelPersistedState => ({
         width: state.width,
@@ -410,3 +560,75 @@ registerPersistedStore({
   persistedStateType:
     "Pick<HelpPanelState, 'width' | 'preferredAgentId' | 'autoLaunchEnabled' | 'introDismissed' | 'hibernateSessions'>",
 });
+
+// Frozen module singleton so the "closed lane" answer keeps a stable identity
+// across reads — a fresh object each call would defeat every `useShallow` and
+// `useSyncExternalStore` equality check that consumes it.
+const EMPTY_SLOT: HelpSessionSlotState = Object.freeze({
+  terminalId: null,
+  agentId: null,
+  sessionId: null,
+  conversationTouched: false,
+  figures: Object.freeze([]) as HelpFigure[],
+  activeFigureNumber: null,
+});
+
+/** Lanes currently open, ascending — the order the tab strip renders in. */
+export function selectOpenSlots(state: HelpPanelState): number[] {
+  return Object.keys(state.sessions)
+    .map(Number)
+    .filter(isValidAssistantSlot)
+    .sort((a, b) => a - b);
+}
+
+/**
+ * A lane's live state, or an empty one when the lane is closed.
+ *
+ * Never returns undefined so callers don't have to branch on a lane that was
+ * closed between render and read; an empty lane and a missing one look the
+ * same to the UI, which is correct — neither has a session.
+ */
+export function selectSlot(state: HelpPanelState, slot: number): HelpSessionSlotState {
+  return state.sessions[slot] ?? EMPTY_SLOT;
+}
+
+/**
+ * The lane the panel is currently showing — what a panel-level caller means by
+ * "the assistant". Correct for anything the user directs at the surface they
+ * are looking at: dictation, "send to assistant", the focus grab.
+ */
+export function selectActiveSlot(state: HelpPanelState): HelpSessionSlotState {
+  return selectSlot(state, state.activeSlot);
+}
+
+/**
+ * Which lane owns `terminalId`, or null when no lane does.
+ *
+ * Terminal-first rather than lane-first because the callers that need it —
+ * xterm addons, per-terminal services — are handed a terminal and must find
+ * the conversation it belongs to.
+ */
+export function selectSlotForTerminal(state: HelpPanelState, terminalId: string): number | null {
+  for (const slot of selectOpenSlots(state)) {
+    if (state.sessions[slot]?.terminalId === terminalId) return slot;
+  }
+  return null;
+}
+
+/**
+ * Every live lane's terminal id.
+ *
+ * The right primitive for infrastructure that has to cover all sessions rather
+ * than the focused one — dock filtering, wake-on-reveal, resize suppression.
+ * Using the active lane there would leave background assistants out of the
+ * very bookkeeping that keeps their terminals painting correctly.
+ */
+export function selectSlotTerminalIds(state: HelpPanelState): string[] {
+  const ids: string[] = [];
+  for (const slot of selectOpenSlots(state)) {
+    const terminalId = state.sessions[slot]?.terminalId;
+    if (terminalId) ids.push(terminalId);
+  }
+  return ids;
+}
+

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -16,6 +16,7 @@ import { logErrorWithContext } from "@/utils/errorContext";
 import { logDebug } from "@/utils/logger";
 import { useUrlHistoryStore } from "./urlHistoryStore";
 import { useHelpPanelStore } from "./helpPanelStore";
+import { ASSISTANT_SLOTS, assistantSlotKey } from "../../shared/config/assistantSlots";
 import { createSafeJSONStorage } from "./persistence/safeStorage";
 import { registerPersistedStore } from "./persistence/persistedStoreRegistry";
 import { panelPersistence, panelToSnapshot } from "./persistence/panelPersistence";
@@ -353,11 +354,16 @@ function cancelProjectReadRequests(): void {
 function migrateHibernateSession(fromProjectId: string, toProjectId: string, newCwd: string): void {
   try {
     const helpPanel = useHelpPanelStore.getState();
-    const orphaned = helpPanel.hibernateSessions?.[fromProjectId];
-    if (orphaned) {
-      helpPanel.setHibernateSession(toProjectId, { ...orphaned, cwd: newCwd });
+    // Every lane (#12108) — the project may have hibernated more than one
+    // conversation, and leaving a sibling keyed to the old project id strands
+    // it under an id nothing will ever look up again.
+    for (const slot of ASSISTANT_SLOTS) {
+      const orphaned = helpPanel.hibernateSessions?.[assistantSlotKey(fromProjectId, slot)];
+      if (orphaned) {
+        helpPanel.setHibernateSession(toProjectId, slot, { ...orphaned, cwd: newCwd });
+      }
+      helpPanel.clearHibernateSession(fromProjectId, slot);
     }
-    helpPanel.clearHibernateSession(fromProjectId);
   } catch (error) {
     logErrorWithContext(error, {
       operation: "migrate_hibernate_session",
@@ -378,11 +384,15 @@ function migrateHibernateSession(fromProjectId: string, toProjectId: string, new
 function rebaseHibernateSessionCwd(projectId: string, oldPath: string, newPath: string): void {
   try {
     const helpPanel = useHelpPanelStore.getState();
-    const session = helpPanel.hibernateSessions?.[projectId];
-    if (!session) return;
-    const nextCwd = rebaseAbsolutePath(session.cwd, oldPath, newPath);
-    if (nextCwd === session.cwd) return;
-    helpPanel.setHibernateSession(projectId, { ...session, cwd: nextCwd });
+    // Each lane captured its own cwd under the old root, so each needs its own
+    // rebase (#12108).
+    for (const slot of ASSISTANT_SLOTS) {
+      const session = helpPanel.hibernateSessions?.[assistantSlotKey(projectId, slot)];
+      if (!session) continue;
+      const nextCwd = rebaseAbsolutePath(session.cwd, oldPath, newPath);
+      if (nextCwd === session.cwd) continue;
+      helpPanel.setHibernateSession(projectId, slot, { ...session, cwd: nextCwd });
+    }
   } catch (error) {
     logErrorWithContext(error, {
       operation: "rebase_hibernate_session_cwd",
@@ -976,7 +986,9 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
         set({ currentProject: null });
       }
       useUrlHistoryStore.getState().removeProjectHistory(id);
-      useHelpPanelStore.getState().clearHibernateSession(id);
+      for (const slot of ASSISTANT_SLOTS) {
+        useHelpPanelStore.getState().clearHibernateSession(id, slot);
+      }
       set({ isLoading: false });
     } catch (error) {
       logErrorWithContext(error, {

--- a/src/store/slices/panelRegistry/__tests__/addPanelSpawnDims.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/addPanelSpawnDims.test.ts
@@ -65,8 +65,11 @@ vi.mock("@/services/TerminalInstanceService", () => ({
 
 vi.mock("@/store/helpPanelStore", () => ({
   useHelpPanelStore: {
-    getState: () => ({ width: 500 }),
+    getState: () => ({ width: 500, sessions: {}, activeSlot: 0 }),
   },
+  // #12108: present so anything reached through this module graph resolves.
+  selectActiveSlot: () => ({ terminalId: null, sessionId: null, agentId: null }),
+  selectSlotTerminalIds: () => [],
 }));
 
 vi.mock("../persistence", async () => {

--- a/src/store/wakeActiveWorktreeTerminals.ts
+++ b/src/store/wakeActiveWorktreeTerminals.ts
@@ -1,6 +1,6 @@
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { isDocumentHidden, revealUntilStable } from "@/services/terminal/revealUntilStable";
-import { useHelpPanelStore } from "@/store/helpPanelStore";
+import { useHelpPanelStore, selectSlotTerminalIds } from "@/store/helpPanelStore";
 import { usePanelStore } from "@/store/panelStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { logWarn } from "@/utils/logger";

--- a/src/store/wakeActiveWorktreeTerminals.ts
+++ b/src/store/wakeActiveWorktreeTerminals.ts
@@ -86,9 +86,10 @@ function collectActiveWorktreeTerminalTargets(): string[] {
   // id straight from the help-panel store and fold it into the same fan-out;
   // the per-terminal methods guard on disposal internally, so a stale id whose
   // panel was cleared on project switch safely misses the lookup.
-  const assistantId = useHelpPanelStore.getState().terminalId;
-  if (assistantId && panelsById[assistantId] && !targets.includes(assistantId)) {
-    targets.push(assistantId);
+  for (const assistantId of selectSlotTerminalIds(useHelpPanelStore.getState())) {
+    if (panelsById[assistantId] && !targets.includes(assistantId)) {
+      targets.push(assistantId);
+    }
   }
 
   return targets;


### PR DESCRIPTION
## Summary

- A project could previously run only one Daintree Assistant session. Each new provision replaced the project's single backend.
- This PR adds up to 3 concurrent sessions, called lanes, each with its own conversation, worktree binding, activity state, and capability approvals.
- A tab strip only appears in the Assistant panel once a second lane is open, so a single-session panel looks exactly like it did before. "Open parallel session" lives in the header overflow menu (the header keeps its 3-icon budget) and is distinct from the existing "+", which restarts the current conversation.

Resolves #12108

## Key design point

The single-backend invariant from #7509 was re-scoped, not dropped. It's now "at most one assistant PTY per (project, slot)".

#7509 was about an orphaned backend that kept dispatching MCP tool calls under a valid bearer token, because renderer cleanup is fire-and-forget and can drop the kill IPC call. The decisive property was that a record leaves `sessionsByToken` before the fire-and-forget kill fires, so a lost kill still leaves an orphan whose bearer 401s. That ordering is untouched here, only the filter narrowed.

As evidence, every existing test in `describe("single-backend invariant (#7509)")` passes unchanged, because they all exercise one project at the default lane. The new `describe("concurrent assistant lanes (#12108)")` adds the orthogonal axis.

## Why slots, not session ids

A lane is a stable integer, not the ephemeral `sessionId`, because Claude Code's per-folder workspace-trust acceptance is keyed by the session directory, and an agent's resume token is keyed by its cwd. Slot 0 keeps the historical bare-hash directory, so an existing install's trust and resume token are untouched. Lanes 1+ get a `<hash>-sN` directory.

## Main process

- Per-lane session directories.
- Provision locks keyed on `(projectId, slot)`, so different lanes provision in parallel while a same-lane re-provision still serializes.
- Hibernation capture, the take/restore compare-and-swap, and pending entries are all keyed by lane.
- `getAssistantBackends` reports every lane, so a dead one can't mask a live sibling (the #11807 reclaim floor).
- `gcStaleSessions` now knows the lane directory naming. This one is load-bearing: GC recursively deletes whatever its predicate rejects.

## Renderer

`helpPanelStore`'s scalar fields moved into per-lane entities plus an `activeSlot` pointer. `HelpSessionController`, `HibernationManager`, and `McpActivityTracker` are all lane-scoped now.

The routing fix the issue calls for: with concurrent lanes, every session in a project shares one WebContents, so transport routing can no longer disambiguate on its own. All seven MCP listener families now gate on the payload's session id against the lane's own, never against the global store. Controllers live in a per-view registry, so a background lane keeps its listeners armed: its approvals still surface, and its idle timer still hibernates it.

## Migrations

The pending-hibernation file migrates v1 to v2, and `helpPanelStore`'s persisted state migrates v5 to v6. Both re-key bare project ids onto slot 0 on read, so an upgrading user keeps every resume token.

## Review findings fixed

Caught in review, not by tests:

- A tab switch used to abort an in-flight launch in the outgoing lane, because `stop()` bumps the launch generation. Lifecycle now belongs to the per-lane runtime instead.
- The assistant-ranking comparator was cyclic: mixing spawn-time ordering and liveness ordering meant the reported assistant depended on terminal listing order. Replaced with a two-stage reduction, spawn time within a lane, then attention across lanes.
- Copilot's `$DAINTREE_MCP_TOKEN` placeholder is no longer stripped from a directory its own live session owns.

## Known limitations

Downgrading to a build without lane support deletes lanes 1+ session directories (its GC doesn't recognize the naming) and its hibernation store rejects the v2 file. Downgrade is lossy for lanes 1+ in both halves. Slot 0 is unaffected.

Also pre-existing and untouched: a second `markTerminalForToken` binding on one record keeps the shared bearer valid, so a dropped kill can still leave an orphan. That predates this change and needs its own issue.

## Explicitly deferred

Worktree-per-session, Ctrl+Tab cycling shortcuts, session-list grouping, configurable N, tab rename/reorder, moving a live session between lanes.

## Testing

- Typecheck clean.
- 16,823 tests pass across the renderer and main-process suites.
- Prettier and eslint clean on all 75 changed files.
- Lint ratchet passes.
- New coverage: concurrent-lane provisioning and displacement, GC lane-directory preservation (including rejecting `-s0` and out-of-range suffixes), out-of-range slot rejection, MCP lane gating across all seven listener families, both key migrations, the ranking cycle, and the controller registry.
