### PR TITLE
fix(worktree): separate the base ahead/behind counts in the sync tooltip

### DIFF
--- a/src/components/Worktree/WorktreeCard/UpstreamSyncBadge.tsx
+++ b/src/components/Worktree/WorktreeCard/UpstreamSyncBadge.tsx
@@ -65,6 +65,8 @@ export function UpstreamSyncBadge({
 }: UpstreamSyncBadgeProps) {
   const hasAhead = aheadCount !== undefined && aheadCount > 0;
   const hasBehind = behindCount !== undefined && behindCount > 0;
+  const hasBaseAhead = baseAheadCount != null && baseAheadCount > 0;
+  const hasBaseBehind = baseBehindCount != null && baseBehindCount > 0;
 
   // The base segment is a *relationship*, not an alarm: it renders whenever we
   // know which branch this one is measured against, and only its glyph and
@@ -92,10 +94,7 @@ export function UpstreamSyncBadge({
   const compareLabel = comparedWithLocalBase
     ? `local ${baseBranchName}`
     : baseCompareRef || baseBranchName;
-  const showBaseDivergence =
-    hasBaseName &&
-    ((baseAheadCount != null && baseAheadCount > 0) ||
-      (baseBehindCount != null && baseBehindCount > 0));
+  const showBaseDivergence = hasBaseName && (hasBaseAhead || hasBaseBehind);
   // Equality has to be measured, not assumed. `BaseDivergence` keeps the base
   // name and nulls a count it could not parse, so a missing count is "we do
   // not know", and the resting form is the one claim we cannot make on a
@@ -142,10 +141,8 @@ export function UpstreamSyncBadge({
   // does.
   const displayedAhead = showUpstreamDelta && hasAhead ? aheadCount : null;
   const displayedBehind = showUpstreamDelta && hasBehind ? behindCount : null;
-  const displayedBaseAhead =
-    showBaseDivergence && baseAheadCount != null && baseAheadCount > 0 ? baseAheadCount : null;
-  const displayedBaseBehind =
-    showBaseDivergence && baseBehindCount != null && baseBehindCount > 0 ? baseBehindCount : null;
+  const displayedBaseAhead = showBaseDivergence && hasBaseAhead ? baseAheadCount : null;
+  const displayedBaseBehind = showBaseDivergence && hasBaseBehind ? baseBehindCount : null;
 
   const prevDisplayedRef = useRef({
     displayedAhead,
@@ -321,10 +318,10 @@ export function UpstreamSyncBadge({
               >
                 {showBaseDivergence ? "Δ" : "≡"} {baseBranchName}
               </span>
-              {baseAheadCount != null && baseAheadCount > 0 && (
+              {hasBaseAhead && (
                 <span className="text-status-success shrink-0">↑{baseAheadCount}</span>
               )}
-              {baseBehindCount != null && baseBehindCount > 0 && (
+              {hasBaseBehind && (
                 <span className="text-status-warning shrink-0">↓{baseBehindCount}</span>
               )}
               {/* Same tier as the branch name it qualifies, so it inherits the
@@ -357,12 +354,13 @@ export function UpstreamSyncBadge({
         )}
         {showBaseDivergence && baseBranchName && (
           <div className="text-text-muted/70 break-words">
-            {baseAheadCount != null && baseAheadCount > 0 && (
+            {hasBaseAhead && (
               <span>
                 {baseAheadCount} ahead of {compareLabel}
               </span>
             )}
-            {baseBehindCount != null && baseBehindCount > 0 && (
+            {hasBaseAhead && hasBaseBehind && <span>, </span>}
+            {hasBaseBehind && (
               <span>
                 {baseBehindCount} behind {compareLabel}
               </span>

--- a/src/components/Worktree/WorktreeCard/__tests__/UpstreamSyncBadge.compareRef.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/UpstreamSyncBadge.compareRef.test.tsx
@@ -276,3 +276,33 @@ describe("UpstreamSyncBadge — the auth-failed tooltip (#12074)", () => {
     expect(document.body.textContent).not.toContain("Compared with");
   });
 });
+
+describe("UpstreamSyncBadge — the base-divergence tooltip line (#12110)", () => {
+  it("separates the two counts when a branch is both ahead of and behind its base", () => {
+    // Without the separator the ref and the next count fuse into
+    // `origin/develop82`, which parses as a branch name before it parses as
+    // two numbers.
+    renderBadge({
+      baseBranchName: "develop",
+      baseCompareRef: "origin/develop",
+      baseAheadCount: 8,
+      baseBehindCount: 82,
+    });
+
+    expect(document.body.textContent).toContain(
+      "8 ahead of origin/develop, 82 behind origin/develop"
+    );
+  });
+
+  it("leaves a single-sided divergence with no trailing separator", () => {
+    renderBadge({
+      baseBranchName: "develop",
+      baseCompareRef: "origin/develop",
+      baseAheadCount: 8,
+      baseBehindCount: 0,
+    });
+
+    expect(document.body.textContent).toContain("8 ahead of origin/develop");
+    expect(document.body.textContent).not.toContain("origin/develop,");
+  });
+});


### PR DESCRIPTION
Closes #12110.

The base-divergence line of the upstream sync tooltip rendered its two clauses back to back, so a worktree that is both ahead of and behind its base read as one run-on string:

```
8 ahead of origin/develop82 behind origin/develop
```

The ref and the next count fuse into `origin/develop82`, which parses as a branch name before it parses as two numbers. The upstream-delta block directly above already emits a `, ` between its ahead and behind spans; this does the same thing one block down.

While in there I folded the four repeated `baseAheadCount != null && baseAheadCount > 0` guards into `hasBaseAhead` / `hasBaseBehind` — the separator needs both conditions anyway, and spelling it out a fifth time wasn't going to make it clearer.

Two regression tests in `UpstreamSyncBadge.compareRef.test.tsx`: the both-sided case gets the separator, the single-sided case doesn't grow a trailing one.

`npm run check` clean (lint warnings down 3, baseline left alone). Full `npm test`: 2447/2448 files pass — the one failure is `scripts/perf/__tests__/scenarioLiveness.test.ts`, which is load-dependent and fails on a different scenario each run; it came in with #12109 and has nothing to do with this diff.