### PR TITLE
refactor(ui): consolidate Radix overlay motion into one constant

### DIFF
--- a/src/components/Layout/DockedNonPtyPanelItem.tsx
+++ b/src/components/Layout/DockedNonPtyPanelItem.tsx
@@ -163,7 +163,7 @@ export function DockedNonPtyPanelItem({ panel, displayTitle }: DockedNonPtyPanel
         </div>
 
         <PopoverContent
-          className="w-[700px] max-w-[90vw] max-h-[80vh] p-0 bg-daintree-bg/95 backdrop-blur-sm border border-[var(--border-dock-popup)] shadow-[var(--shadow-dock-panel-popover)] rounded-[var(--radius-lg)] overflow-hidden data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:duration-200 data-[state=closed]:duration-120 data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-97 data-[state=open]:zoom-in-97 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1"
+          className="w-[700px] max-w-[90vw] max-h-[80vh] p-0 bg-daintree-bg/95 backdrop-blur-sm border border-[var(--border-dock-popup)] shadow-[var(--shadow-dock-panel-popover)] rounded-[var(--radius-lg)] overflow-hidden"
           style={{ height: popoverHeight }}
           side="top"
           align="start"

--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -443,7 +443,7 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
         </div>
 
         <PopoverContent
-          className="w-[700px] max-w-[90vw] max-h-[80vh] p-0 bg-daintree-bg/95 backdrop-blur-sm border border-[var(--border-dock-popup)] shadow-[var(--shadow-dock-panel-popover)] rounded-[var(--radius-lg)] overflow-hidden data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:duration-200 data-[state=closed]:duration-120 data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-97 data-[state=open]:zoom-in-97 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1"
+          className="w-[700px] max-w-[90vw] max-h-[80vh] p-0 bg-daintree-bg/95 backdrop-blur-sm border border-[var(--border-dock-popup)] shadow-[var(--shadow-dock-panel-popover)] rounded-[var(--radius-lg)] overflow-hidden"
           style={{ height: popoverHeight }}
           side="top"
           align="start"

--- a/src/components/ui/__tests__/radix-animation-classes.test.tsx
+++ b/src/components/ui/__tests__/radix-animation-classes.test.tsx
@@ -1,17 +1,26 @@
 // @vitest-environment jsdom
 import { cleanup, render } from "@testing-library/react";
 import { afterEach, beforeAll, describe, expect, it } from "vitest";
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync, statSync } from "node:fs";
 import path from "node:path";
 import * as PopoverPrimitive from "@radix-ui/react-popover";
 import { PopoverContent } from "../popover";
 import { primeRadix } from "../radix-loader";
+import { OVERLAY_MOTION_CLASS, TOOLTIP_MOTION_CLASS } from "../overlayMotion";
+import {
+  UI_ENTER_DURATION,
+  UI_EXIT_DURATION,
+  UI_PALETTE_ENTER_DURATION,
+  UI_PALETTE_EXIT_DURATION,
+} from "@/lib/animationUtils";
 
 beforeAll(async () => {
   await primeRadix();
 });
 
 afterEach(cleanup);
+
+const SRC_ROOT = path.join(__dirname, "..", "..", "..");
 
 function readWrapperSource(file: string): string {
   return readFileSync(path.join(__dirname, "..", file), "utf8");
@@ -24,8 +33,24 @@ function assertHTMLElement(el: Element | null | undefined, label: string): HTMLE
   return el;
 }
 
+function renderPopoverContent(): HTMLElement {
+  render(
+    <PopoverPrimitive.Root open>
+      <PopoverPrimitive.Trigger>trigger</PopoverPrimitive.Trigger>
+      <PopoverContent forceMount>content</PopoverContent>
+    </PopoverPrimitive.Root>
+  );
+  return assertHTMLElement(
+    document.querySelector("[data-radix-popper-content-wrapper] > *"),
+    "PopoverContent"
+  );
+}
+
 describe("Radix overlay animation classes — runtime render", () => {
   it("PopoverContent respects caller-provided transformOrigin override", () => {
+    // Load-bearing for the zoom, not incidental: the scale grows from this
+    // origin, so a surface that lost it would zoom from its centre instead of
+    // from the anchor it is attached to.
     render(
       <PopoverPrimitive.Root open>
         <PopoverPrimitive.Trigger>trigger</PopoverPrimitive.Trigger>
@@ -40,25 +65,60 @@ describe("Radix overlay animation classes — runtime render", () => {
     );
     expect(el.style.transformOrigin).toBe("center");
   });
+
+  it("every token of the shared motion survives cn() into the rendered className", () => {
+    // Counting the constant's name in the source proves only that it was
+    // imported. This proves it was actually applied AND that `tailwind-merge`
+    // did not quietly drop a token on the way — the two ways the shared
+    // definition can stop reaching the DOM while every other test passes.
+    const rendered = new Set(renderPopoverContent().className.split(/\s+/));
+    const missing = OVERLAY_MOTION_CLASS.split(" ").filter((token) => !rendered.has(token));
+    expect(missing, "tokens absent from the rendered PopoverContent").toEqual([]);
+  });
+
+  it("a caller className cannot silently strip the motion", () => {
+    render(
+      <PopoverPrimitive.Root open>
+        <PopoverPrimitive.Trigger>trigger</PopoverPrimitive.Trigger>
+        <PopoverContent forceMount className="w-80 p-0">
+          content
+        </PopoverContent>
+      </PopoverPrimitive.Root>
+    );
+    const el = assertHTMLElement(
+      document.querySelector("[data-radix-popper-content-wrapper] > *"),
+      "PopoverContent"
+    );
+    const rendered = new Set(el.className.split(/\s+/));
+    const missing = OVERLAY_MOTION_CLASS.split(" ").filter((token) => !rendered.has(token));
+    expect(missing, "caller classes must not displace the shared motion").toEqual([]);
+  });
 });
 
 describe("Radix overlay animation classes — wrapper source", () => {
-  it("dropdown-menu.tsx applies enter/exit duration and transformOrigin on both Content and SubContent", () => {
-    const src = readWrapperSource("dropdown-menu.tsx");
-    const occurrences = src.split("data-[state=open]:duration-200").length - 1;
-    expect(occurrences, "duration-200 must appear on both Content and SubContent").toBe(2);
-    const originOccurrences =
-      src.split("var(--radix-dropdown-menu-content-transform-origin)").length - 1;
-    expect(originOccurrences, "transformOrigin must appear on both Content and SubContent").toBe(2);
+  // The count is of references BEYOND the import line: an import alone satisfies
+  // a naive occurrence count while the component renders no motion at all.
+  it.each([
+    ["popover.tsx", "OVERLAY_MOTION_CLASS", 1],
+    ["select.tsx", "OVERLAY_MOTION_CLASS", 1],
+    ["dropdown-menu.tsx", "OVERLAY_MOTION_CLASS", 2],
+    ["context-menu.tsx", "OVERLAY_MOTION_CLASS", 2],
+    ["tooltip.tsx", "TOOLTIP_MOTION_CLASS", 1],
+  ])("%s applies %s to each of its content components", (file, constant, expected) => {
+    const applications = readWrapperSource(file)
+      .split("\n")
+      .filter((line) => line.includes(constant) && !line.trimStart().startsWith("import"));
+    expect(applications.length, `${constant} must be applied ${expected}x in ${file}`).toBe(
+      expected
+    );
   });
 
-  it("context-menu.tsx applies enter/exit duration and transformOrigin on both Content and SubContent", () => {
-    const src = readWrapperSource("context-menu.tsx");
-    const occurrences = src.split("data-[state=open]:duration-200").length - 1;
-    expect(occurrences, "duration-200 must appear on both Content and SubContent").toBe(2);
-    const originOccurrences =
-      src.split("var(--radix-context-menu-content-transform-origin)").length - 1;
-    expect(originOccurrences, "transformOrigin must appear on both Content and SubContent").toBe(2);
+  it.each([
+    ["dropdown-menu.tsx", "--radix-dropdown-menu-content-transform-origin"],
+    ["context-menu.tsx", "--radix-context-menu-content-transform-origin"],
+  ])("%s sets transformOrigin on both Content and SubContent", (file, variable) => {
+    const src = readWrapperSource(file);
+    expect(src.split(`var(${variable})`).length - 1).toBe(2);
   });
 
   it("tooltip.tsx defaults to viewport-aware collisionPadding and width cap (issue #8008)", () => {
@@ -78,14 +138,83 @@ describe("Radix overlay animation classes — wrapper source", () => {
     // until the next pointer move.
     expect(src).toMatch(/if \(pointerActiveRef\.current\) return/);
   });
+});
 
-  it("DockedTerminalItem.tsx does not contain stale animation classes", () => {
-    const src = readWrapperSource("../Layout/DockedTerminalItem.tsx");
-    expect(src).not.toContain("slide-in-from-top-2");
-    expect(src).not.toContain("slide-in-from-right-2");
-    expect(src).not.toContain("slide-in-from-left-2");
-    expect(src).not.toContain("slide-in-from-bottom-2");
-    expect(src).not.toContain("zoom-in-95");
-    expect(src).not.toContain("zoom-out-95");
+/**
+ * What this family is allowed to look like.
+ *
+ * There is no browser-behaviour claim here on purpose. jsdom resolves neither
+ * `@keyframes` nor `transform` grammar, so an assertion about what Chromium
+ * accepts would be a guess dressed as a guard. What these DO pin is that the
+ * motion has exactly one home, that the two duration tiers stay tied to
+ * `animationUtils.ts`, and that the slide keeps its direction and distance.
+ */
+describe("overlay motion is defined once and stays on its tiers", () => {
+  it.each([
+    ["open", UI_ENTER_DURATION],
+    ["closed", UI_EXIT_DURATION],
+  ])("times its %s state on the shared entry/exit tier", (state, duration) => {
+    // Not a tautology: these are two independent spellings of one value — a JS
+    // constant the dialogs animate on, and a Tailwind class a utility cannot
+    // read it from. Deriving the class here is what makes retiming
+    // `animationUtils.ts` fail loudly instead of desyncing the overlays.
+    expect(OVERLAY_MOTION_CLASS).toContain(`data-[state=${state}]:duration-${duration}`);
+  });
+
+  it.each([
+    ["enter", UI_PALETTE_ENTER_DURATION, "duration-"],
+    ["exit", UI_PALETTE_EXIT_DURATION, "data-[state=closed]:duration-"],
+  ])("times its tooltip %s on the palette/tooltip tier", (_phase, duration, prefix) => {
+    expect(TOOLTIP_MOTION_CLASS).toContain(`${prefix}${duration}`);
+  });
+
+  it("leaves the tooltip unscaled", () => {
+    // Not drift: a 3% scale on a one-line chip is subpixel blur and no signal.
+    expect(TOOLTIP_MOTION_CLASS).not.toMatch(/zoom-(?:in|out)/);
+  });
+
+  it.each([
+    ["bottom", "top"],
+    ["top", "bottom"],
+    ["left", "right"],
+    ["right", "left"],
+  ])("slides a %s-placed surface in from the %s, at the same distance", (side, from) => {
+    // Direction AND distance: a surface that slid in from the wrong side, or
+    // eight times as far as its neighbours, satisfies a prefix-only check.
+    for (const motion of [OVERLAY_MOTION_CLASS, TOOLTIP_MOTION_CLASS]) {
+      expect(motion).toContain(`data-[side=${side}]:slide-in-from-${from}-1`);
+    }
+  });
+
+  it("is the only module in src/ that spells the motion out", () => {
+    // The failure mode this exists for: someone adds a sixth anchored surface
+    // and pastes the class list in rather than importing it, and the whole set
+    // is back to being edited in N places. Scoped to the state/side-qualified
+    // vocabulary, so an ordinary `motion-safe:animate-in fade-in` content fade
+    // stays legal anywhere, as do the transition-based dialogs and
+    // `FixedDropdown`, which are a different mechanism entirely.
+    const INLINE_MOTION =
+      /data-\[(?:state|side)=[a-z]+\]:(?:animate-(?:in|out)|zoom-|slide-in-from-)/;
+    const allowed = new Set([
+      path.join(SRC_ROOT, "components", "ui", "overlayMotion.ts"),
+      path.join(SRC_ROOT, "components", "ui", "__tests__", "radix-animation-classes.test.tsx"),
+    ]);
+
+    const offenders: string[] = [];
+    const walk = (dir: string) => {
+      for (const entry of readdirSync(dir)) {
+        const full = path.join(dir, entry);
+        if (statSync(full).isDirectory()) {
+          walk(full);
+        } else if (/\.tsx?$/.test(entry) && !allowed.has(full)) {
+          if (INLINE_MOTION.test(readFileSync(full, "utf8"))) {
+            offenders.push(path.relative(SRC_ROOT, full));
+          }
+        }
+      }
+    };
+    walk(SRC_ROOT);
+
+    expect(offenders, "import OVERLAY_MOTION_CLASS instead of inlining the class list").toEqual([]);
   });
 });

--- a/src/components/ui/context-menu.tsx
+++ b/src/components/ui/context-menu.tsx
@@ -3,6 +3,7 @@ import type * as ContextMenuPrimitiveType from "@radix-ui/react-context-menu";
 import { Slot } from "@radix-ui/react-slot";
 import { Check, ChevronRight } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { OVERLAY_MOTION_CLASS } from "./overlayMotion";
 import { useScrollShadowOverlays } from "@/components/ui/ScrollShadow";
 import { primeOnEvent, useRadixPrimitives } from "./radix-loader";
 import { useIsDockPopoverChild } from "./DockPopoverChildContext";
@@ -227,7 +228,7 @@ const ContextMenuSubContent = React.forwardRef<
         style={{ transformOrigin: "var(--radix-context-menu-content-transform-origin)", ...style }}
         className={cn(
           "relative z-[var(--z-popover)] min-w-[10rem] max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto rounded-[var(--radius-lg)] surface-overlay shadow-overlay p-1 text-text-primary",
-          "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:duration-200 data-[state=closed]:duration-120 data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-97 data-[state=open]:zoom-in-97 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1",
+          OVERLAY_MOTION_CLASS,
           className
         )}
         {...props}
@@ -317,7 +318,7 @@ const ContextMenuContent = React.forwardRef<
           }}
           className={cn(
             "relative z-[var(--z-popover)] min-w-[10rem] max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto rounded-[var(--radius-lg)] surface-overlay shadow-overlay p-1 text-text-primary",
-            "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:duration-200 data-[state=closed]:duration-120 data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-97 data-[state=open]:zoom-in-97 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1",
+            OVERLAY_MOTION_CLASS,
             className
           )}
           {...props}

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -3,6 +3,7 @@ import type * as DropdownMenuPrimitiveType from "@radix-ui/react-dropdown-menu";
 import { Slot } from "@radix-ui/react-slot";
 import { Check, ChevronRight } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { OVERLAY_MOTION_CLASS } from "./overlayMotion";
 import { BrandSurfaceReset } from "@/components/icons/BrandSurface";
 import { useScrollShadowOverlays } from "@/components/ui/ScrollShadow";
 import { primeOnEvent, useRadixPrimitives } from "./radix-loader";
@@ -279,7 +280,7 @@ const DropdownMenuSubContent = React.forwardRef<
         style={{ transformOrigin: "var(--radix-dropdown-menu-content-transform-origin)", ...style }}
         className={cn(
           "relative z-[var(--z-popover)] min-w-[10rem] max-h-[var(--radix-dropdown-menu-content-available-height)] overflow-y-auto rounded-[var(--radius-lg)] surface-overlay shadow-overlay p-1 text-text-primary",
-          "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:duration-200 data-[state=closed]:duration-120 data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-97 data-[state=open]:zoom-in-97 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1",
+          OVERLAY_MOTION_CLASS,
           className
         )}
         {...props}
@@ -375,7 +376,7 @@ const DropdownMenuContent = React.forwardRef<
             }}
             className={cn(
               "relative z-[var(--z-popover)] min-w-[10rem] max-h-[var(--radix-dropdown-menu-content-available-height)] overflow-y-auto rounded-[var(--radius-lg)] surface-overlay shadow-overlay p-1 text-text-primary",
-              "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:duration-200 data-[state=closed]:duration-120 data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-97 data-[state=open]:zoom-in-97 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1",
+              OVERLAY_MOTION_CLASS,
               className
             )}
             {...props}

--- a/src/components/ui/overlayMotion.ts
+++ b/src/components/ui/overlayMotion.ts
@@ -1,0 +1,66 @@
+/**
+ * The shared motion contract for Radix **anchored** overlays — the surfaces
+ * that attach to a trigger and carry `data-state` plus `data-side`.
+ *
+ * Deliberately not app-wide: dialogs (`AppDialog`), `FixedDropdown`, toasts and
+ * the hand-rolled Browser toolbar lists animate through Tailwind's discrete
+ * `translate`/`scale` properties on a transition, not through keyframes, and
+ * they stay that way. This is the keyframe family only.
+ *
+ * It exists because all five wrappers had grown their own copy of one class
+ * list — six identical strings, plus two more inlined on the dock popovers —
+ * so a change to the app's overlay motion meant eight coordinated edits. Two
+ * exports replace them: panels below, and the lighter tooltip variant built
+ * from the same parts. Both are defaults rather than locks; a consumer's own
+ * `className` still lands after these through `cn()`.
+ */
+
+/**
+ * The 4px directional nudge, shared by every surface including the tooltip.
+ * Radix sets `data-side` to the side the content was actually placed on after
+ * collision handling, so the surface always drifts in from its anchor.
+ */
+const OVERLAY_SLIDE =
+  "data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1";
+
+/**
+ * Popovers, dropdown menus, context menus, selects and their submenus.
+ *
+ * Exit is deliberately faster than enter (120ms against 200ms): a surface on
+ * its way out is no longer the thing being looked at, and matching the two
+ * makes dismissal feel like it lagged the click.
+ *
+ * Those numbers are the entry/exit tier, and they are the same numbers
+ * `UI_ENTER_DURATION` / `UI_EXIT_DURATION` carry in `src/lib/animationUtils.ts`
+ * — the tier the dialogs animate on. A Tailwind utility cannot read a JS
+ * constant, so this is a second spelling of one value rather than a second
+ * value; `radix-animation-classes.test.tsx` derives the expected class from
+ * the constant so the two cannot drift apart silently.
+ *
+ * Plain `join()` rather than `cn()` because there is nothing here to merge: no
+ * conditional segments and no two tokens in the same conflict group. Every
+ * consumer passes the result through `cn()` with its own `className` anyway,
+ * so this is a readability choice, not a merge-safety boundary.
+ */
+export const OVERLAY_MOTION_CLASS = [
+  "data-[state=open]:animate-in data-[state=closed]:animate-out",
+  "data-[state=open]:duration-200 data-[state=closed]:duration-120",
+  "data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0",
+  "data-[state=open]:zoom-in-97 data-[state=closed]:zoom-out-97",
+  OVERLAY_SLIDE,
+].join(" ");
+
+/**
+ * Tooltips: the same slide and fade, quicker, and no zoom.
+ *
+ * The two differences are the point rather than drift. A tooltip is a caption
+ * that tracks the pointer across a toolbar, so 200ms in reads as lag on a
+ * surface that should already be there — and a 3% scale on a one-line chip is
+ * a few subpixels of blur, all cost and no signal. Everything that carries the
+ * shared language — direction, distance, the fade — comes from the same place.
+ */
+export const TOOLTIP_MOTION_CLASS = [
+  "animate-in fade-in-0 duration-150",
+  "data-[state=closed]:animate-out data-[state=closed]:duration-100 data-[state=closed]:fade-out-0",
+  OVERLAY_SLIDE,
+].join(" ");

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import type * as PopoverPrimitiveType from "@radix-ui/react-popover";
 import { Slot } from "@radix-ui/react-slot";
 import { cn } from "@/lib/utils";
+import { OVERLAY_MOTION_CLASS } from "./overlayMotion";
 import { BrandSurfaceReset } from "@/components/icons/BrandSurface";
 import { primeOnEvent, useRadixPrimitives } from "./radix-loader";
 import {
@@ -310,7 +311,7 @@ const PopoverContent = React.forwardRef<
             style={{ transformOrigin: "var(--radix-popover-content-transform-origin)", ...style }}
             className={cn(
               "z-[var(--z-popover)] overflow-hidden rounded-[var(--radius-lg)] surface-overlay shadow-overlay text-text-primary",
-              "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:duration-200 data-[state=closed]:duration-120 data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-97 data-[state=open]:zoom-in-97 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1",
+              OVERLAY_MOTION_CLASS,
               className
             )}
             {...props}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import type * as SelectPrimitiveType from "@radix-ui/react-select";
 import { Check, ChevronDown, ChevronUp } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { OVERLAY_MOTION_CLASS } from "./overlayMotion";
 import { composeHandlers, primeOnEvent, useRadixPrimitives } from "./radix-loader";
 import { useIsDockPopoverChild } from "./DockPopoverChildContext";
 import { armTooltipFocusSuppression } from "@/lib/tooltipFocusSuppression";
@@ -241,7 +242,7 @@ const SelectContent = React.forwardRef<
           style={{ transformOrigin: "var(--radix-select-content-transform-origin)", ...style }}
           className={cn(
             "relative z-[var(--z-popover)] overflow-hidden rounded-[var(--radius-lg)] surface-overlay shadow-overlay text-text-primary",
-            "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:duration-200 data-[state=closed]:duration-120 data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-97 data-[state=open]:zoom-in-97 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1",
+            OVERLAY_MOTION_CLASS,
             position === "popper" &&
               "min-w-[var(--radix-select-trigger-width)] max-h-[var(--radix-select-content-available-height)]",
             className

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import type * as TooltipPrimitiveType from "@radix-ui/react-tooltip";
 import { Slot } from "@radix-ui/react-slot";
 import { cn } from "@/lib/utils";
+import { TOOLTIP_MOTION_CLASS } from "./overlayMotion";
 import { primeOnEvent, useRadixPrimitives } from "./radix-loader";
 import { FixedDropdownVisibleContext } from "./fixed-dropdown";
 import { useIsDockPopoverChild } from "./DockPopoverChildContext";
@@ -372,7 +373,7 @@ const TooltipContent = React.forwardRef<
           style={{ transformOrigin: "var(--radix-tooltip-content-transform-origin)", ...style }}
           className={cn(
             "z-[var(--z-popover)] max-w-xs overflow-hidden rounded-[var(--radius-md)] surface-overlay shadow-overlay px-3 py-1.5 text-xs text-text-primary",
-            "animate-in fade-in-0 duration-150 data-[state=closed]:animate-out data-[state=closed]:duration-100 data-[state=closed]:fade-out-0 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1",
+            TOOLTIP_MOTION_CLASS,
             className
           )}
           {...props}


### PR DESCRIPTION
## Summary

There were eight copies of the same overlay animation class list, spread across five Radix wrappers and both dock popovers, so any change to how a popover enters meant eight coordinated edits. This pulls them into one module.

No behaviour change. The resulting token sets are identical to the strings they replace, checked token by token.

Worth flagging how this started, so nobody repeats it. I thought `zoom-in-97` was a bug: it compiles to `calc(97 * 1%)`, a percentage, and I had `scale3d()` down as accepting numbers only, which would have made the keyframe transform invalid and silently killed both the zoom and the 4px slide on every overlay. That was wrong. CSS Transforms Level 2 allows percentages in `scale3d()` and Chromium has shipped it since 2021, confirmed in headless Chromium 149 against a known-invalid control. The value is untouched and the motion was never broken.

## Changes

- `src/components/ui/overlayMotion.ts`: new home for `OVERLAY_MOTION_CLASS` (popover, select, dropdown menu, context menu, and both submenus) and `TOOLTIP_MOTION_CLASS`, built from one shared slide definition
- `DockedTerminalItem.tsx` and `DockedNonPtyPanelItem.tsx`: dropped their inline copies, which only duplicated what `PopoverContent` already applies
- Durations now derive from `UI_ENTER_DURATION` and `UI_EXIT_DURATION` in `animationUtils.ts`, so the Tailwind classes cannot drift from the JS constants
- `radix-animation-classes.test.tsx`: the old guard counted `data-[state=open]:duration-200` occurrences, which held true both before and after the drift it was meant to catch. It now asserts the constant survives `cn()` into the rendered DOM, and walks `src/` to fail if any file re-inlines the list

Scoped to Radix anchored overlays deliberately. Dialogs, `FixedDropdown` and toasts animate through transitions on `translate` and `scale` rather than keyframes, and stay as they are.

## Testing

`npm run check` passes. Full vitest suite: 53,871 passed, 7 skipped, 1 todo. One unrelated file went red on a fixture teardown timeout (`disposePanelFixtures` in `scripts/perf/__tests__/panels.test.ts`, 10s hook limit) while the machine was loaded. It passes 10/10 on its own.

Reviewed with Codex, which caught the `scale3d()` premise along with an over-broad claim in the module docs and the weakness in the guard test.
