### PR TITLE
fix(actions): let run() see the host confirm attestation

### DIFF
--- a/shared/types/actions.ts
+++ b/shared/types/actions.ts
@@ -142,6 +142,30 @@ export interface ActionContext {
    * Purely descriptive — it grants nothing and gates nothing.
    */
   copyTreeRunSource?: CopyTreeRunSource;
+  /**
+   * Whether the host already attested this dispatch as approved. Set by
+   * `ActionService.dispatch` from {@link ActionDispatchOptions.confirmed}
+   * unconditionally, so — like `dispatchSource` — a caller cannot spoof it by
+   * planting a value on `contextOverride`, and a definition cannot read a stale
+   * one left on a shared context object.
+   *
+   * This is the trusted half of a deliberate pair. An action's own `argsSchema`
+   * may also carry a `confirmed` field; that one is client-settable and only
+   * skips the action's inner gate. This one carries the approval the host
+   * actually obtained — the native ConfirmDialog the MCP bridge raised, or a
+   * host-issued grant — which is why `run()` can trust it to mean the user has
+   * already answered. Without it a `danger:"confirm"` action re-asked after the
+   * host modal was approved, staged a second dialog and changed nothing (#12120).
+   *
+   * Deliberately absent for user-source dispatch, where `options.confirmed` is
+   * unset: the in-app dialog is that surface's own confirmation, and its call
+   * sites re-dispatch with `confirmed: true` in args once the user approves.
+   *
+   * Narrow by design — it attests to THIS dispatch's approval and nothing else.
+   * It is not a capability grant: an action still decides for itself what an
+   * approval permits.
+   */
+  hostConfirmed?: boolean;
 }
 
 export type InferActionArgs<S extends z.ZodTypeAny | undefined> = [S] extends [z.ZodTypeAny]

--- a/src/components/Terminal/XtermAdapter.tsx
+++ b/src/components/Terminal/XtermAdapter.tsx
@@ -28,6 +28,7 @@ import {
   isTerminalClipboardPasteKey,
   isTuiReservedKey,
 } from "@/services/terminalReservedKeys";
+import { isStagedConfirmation } from "@/services/actions/confirmationStaged";
 
 export interface XtermAdapterProps {
   terminalId: string;
@@ -505,7 +506,12 @@ export function XtermAdapter({
                     }
                   )
                   .then((dispatchResult) => {
-                    if (!dispatchResult.ok) {
+                    // A destructive action that parked a confirmation reports
+                    // CONFIRMATION_REQUIRED rather than a silent ok (#12120).
+                    // terminal.kill/restart are bound by default and land here
+                    // when the terminal has focus, so logging that as a failure
+                    // would fire on the normal "the dialog opened" path.
+                    if (!dispatchResult.ok && !isStagedConfirmation(dispatchResult.error)) {
                       logError(
                         `[XtermKeybinding] Action "${result.match!.actionId}" failed`,
                         undefined,

--- a/src/hooks/__tests__/useActionPalette.test.tsx
+++ b/src/hooks/__tests__/useActionPalette.test.tsx
@@ -48,6 +48,7 @@ import { useActionMruStore } from "@/store/actionMruStore";
 import { useActionPrefsStore } from "@/store/actionPrefsStore";
 import { useActionPalette } from "../useActionPalette";
 import { getActionCategoryLabel, orderActionCategories } from "@/config/actionCategoryOrder";
+import { ConfirmationStagedError } from "@/services/actions/confirmationStaged";
 
 function makeEntry(
   id: string,
@@ -554,7 +555,7 @@ describe("useActionPalette", () => {
   async function runFailingPaletteAction(
     entry: ReturnType<typeof makeEntry> & { pluginId?: string; paletteRedirectTo?: string },
     query: string,
-    error: { code: string; message: string }
+    error: { code: string; message: string; details?: unknown }
   ): Promise<void> {
     dispatchMock.mockResolvedValue({ ok: false, error });
     listMock.mockReturnValue([entry]);
@@ -589,6 +590,28 @@ describe("useActionPalette", () => {
     expect(notifyMock).toHaveBeenCalledWith(
       expect.objectContaining({ type: "error", title: "Couldn't run 'Acmething'" })
     );
+  });
+
+  // A destructive action that parked a confirmation reports CONFIRMATION_REQUIRED
+  // so an agent can't read the no-op as a completed kill (#12120). The dialog it
+  // opened is the user's feedback, so the palette must not toast over it — but
+  // only for that sentinel: the outer gate emits the same code to mean a genuine
+  // refusal, which still needs reporting.
+  it("suppresses the palette toast when the action parked a confirmation", async () => {
+    await runFailingPaletteAction(makeEntry("terminal.kill", "Killterminal"), "killterminal", {
+      code: "CONFIRMATION_REQUIRED",
+      message: "Killing this terminal was not performed",
+      details: new ConfirmationStagedError("Killing this terminal was not performed"),
+    });
+    expect(notifyMock).not.toHaveBeenCalled();
+  });
+
+  it("still toasts a CONFIRMATION_REQUIRED that did not come from a parked confirmation", async () => {
+    await runFailingPaletteAction(makeEntry("terminal.kill", "Killterminal"), "killterminal", {
+      code: "CONFIRMATION_REQUIRED",
+      message: "requires explicit confirmation",
+    });
+    expect(notifyMock).toHaveBeenCalledTimes(1);
   });
 
   it("still toasts a built-in action EXECUTION_ERROR (no pluginId, doesn't self-notify)", async () => {

--- a/src/hooks/useActionPalette.ts
+++ b/src/hooks/useActionPalette.ts
@@ -12,6 +12,7 @@ import { getActionCategoryLabel, orderActionCategories } from "@/config/actionCa
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { isPanelLimitError } from "@/services/actions/definitions/panelLimitError";
 import { useSearchablePalette } from "./useSearchablePalette";
+import { isStagedConfirmation } from "@/services/actions/confirmationStaged";
 
 export interface ActionPaletteItem {
   id: string;
@@ -384,6 +385,13 @@ export function useActionPalette(): UseActionPaletteReturn {
           if (result.ok) return;
           // DISABLED is already visible on the originating surface (#8814).
           if (result.error.code === "DISABLED") return;
+          // Same idea: a destructive action that parked a confirmation reports
+          // CONFIRMATION_REQUIRED so an agent can't read the no-op as done
+          // (#12120). Here the dialog it opened IS the feedback — toasting
+          // "couldn't run" over a confirm the user is being asked to answer
+          // would contradict it. Matched by sentinel, not by code, so a genuine
+          // refusal from the outer gate still toasts.
+          if (isStagedConfirmation(result.error)) return;
           // Two kinds of action own their failure toast, and only for a failure
           // thrown out of run() (EXECUTION_ERROR): a plugin action, whose
           // synthetic run() self-notifies in usePluginActions, and a built-in

--- a/src/hooks/useCommandHud.ts
+++ b/src/hooks/useCommandHud.ts
@@ -5,6 +5,7 @@ import { combosFieldsEqual, keybindingService } from "@/services/KeybindingServi
 import { notify } from "@/lib/notify";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { COMMAND_HUD_PREFIX, usePendingChord } from "./useGlobalKeybindings";
+import { isStagedConfirmation } from "@/services/actions/confirmationStaged";
 
 /** A single entry in the curated Cmd+K power-command layer. */
 export interface CommandHudItem {
@@ -161,6 +162,10 @@ export function useCommandHud(): UseCommandHudReturn {
         if (result.ok) return;
         // DISABLED is already visible on the originating surface.
         if (result.error.code === "DISABLED") return;
+        // So is a parked confirmation: the action reports CONFIRMATION_REQUIRED
+        // rather than a silent no-op (#12120), but the dialog it just opened is
+        // what the user should be answering — not an error toast over it.
+        if (isStagedConfirmation(result.error)) return;
         // eslint-disable-next-line no-restricted-syntax -- notify-no-action: ok
         notify({
           type: "error",

--- a/src/hooks/useGlobalKeybindings.ts
+++ b/src/hooks/useGlobalKeybindings.ts
@@ -11,6 +11,7 @@ import { ESCAPE_BACKSTOP_DIALOG_ATTR } from "@/lib/dialogEscapeBackstop";
 import { isTerminalReservedKey } from "@/services/terminalReservedKeys";
 import { buildKeybindingWhenContext } from "@/services/keybindingWhenContext";
 import { usePaletteStore, usePanelStore } from "../store";
+import { isStagedConfirmation } from "@/services/actions/confirmationStaged";
 
 /**
  * Canonical first-step combo of every chord (they all begin `Cmd+K`). Opening
@@ -297,7 +298,12 @@ export function useGlobalKeybindings(enabled: boolean = true): void {
               source: "keybinding",
             })
             .then((dispatchResult) => {
-              if (!dispatchResult.ok) {
+              // `terminal.kill`/`restart`/`restartAll` are bound by default and
+              // park a confirmation when an agent is mid-work. That now reports
+              // CONFIRMATION_REQUIRED instead of a silent ok (#12120), but the
+              // shortcut did exactly what it should — the dialog is up — so it
+              // must not be logged as a failure.
+              if (!dispatchResult.ok && !isStagedConfirmation(dispatchResult.error)) {
                 logError(
                   `[GlobalKeybinding] Action "${result.match!.actionId}" failed`,
                   undefined,

--- a/src/hooks/useMenuActions.ts
+++ b/src/hooks/useMenuActions.ts
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { isElectronAvailable } from "./useElectron";
 import { actionService } from "@/services/ActionService";
 import { logError } from "@/utils/logger";
+import { isStagedConfirmation } from "@/services/actions/confirmationStaged";
 
 export function useMenuActions(): void {
   useEffect(() => {
@@ -18,7 +19,11 @@ export function useMenuActions(): void {
         const result = await actionService.dispatch(payload.actionId, payload.args, {
           source: "menu",
         });
-        if (!result.ok) {
+        // A destructive action that parked a confirmation reports
+        // CONFIRMATION_REQUIRED rather than resolving ok on a no-op (#12120).
+        // From a menu that is the intended outcome — the dialog is open — so it
+        // is not a failure to log.
+        if (!result.ok && !isStagedConfirmation(result.error)) {
           logError(`[Menu] Action "${payload.actionId}" failed`, undefined, {
             error: result.error,
           });

--- a/src/services/ActionService.ts
+++ b/src/services/ActionService.ts
@@ -18,6 +18,7 @@ import { useUIStore } from "@/store/uiStore";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { isClientAppError } from "@/utils/clientAppError";
 import { PartialSuccessError } from "@shared/utils/partialSuccess";
+import { ConfirmationStagedError } from "./actions/confirmationStaged";
 import {
   WORKBENCH_TIER_TOOLS,
   ACTION_TIER_ADDONS,
@@ -585,6 +586,14 @@ export class ActionService {
         // is, and a definition must not be able to read a stale one left on a
         // shared context object.
         copyTreeRunSource: options?.copyTreeRunSource,
+        // Stamped for the same reason, and this one is load-bearing: it is the
+        // ONLY way `run()` can see the attestation the gate above already
+        // required. Without it a confirm-gated action could only consult the
+        // client-settable `confirmed` on its own args, so it re-asked after the
+        // host modal was approved — staging a second dialog and changing
+        // nothing (#12120). Unconditional, so a `contextOverride` cannot claim
+        // an approval the host never made.
+        hostConfirmed: options?.confirmed,
       };
       const result = await definition.run(validatedArgs, runContext);
       // Enforce the action's own result contract. Zod objects strip unknown
@@ -664,7 +673,20 @@ export class ActionService {
         // sound here because the throw and this catch are the same realm; an
         // upstream forge/git rejection reaching this line is an ordinary
         // `EXECUTION_ERROR` however its message happens to read.
-        code: err instanceof PartialSuccessError ? "PARTIAL_SUCCESS" : "EXECUTION_ERROR",
+        // `ConfirmationStagedError` is the other class-authenticated throw: an
+        // action that parked a confirmation instead of acting. It reuses the
+        // existing `CONFIRMATION_REQUIRED` rather than widening the union
+        // (`panelLimitError`'s rule — the union is the plugin-facing contract),
+        // and that code already means what happened: the dispatch did not
+        // proceed because it needs an approval it does not have. What it must
+        // NOT be is `ok` — an agent read a staged kill as a completed one
+        // (#12120).
+        code:
+          err instanceof ConfirmationStagedError
+            ? "CONFIRMATION_REQUIRED"
+            : err instanceof PartialSuccessError
+              ? "PARTIAL_SUCCESS"
+              : "EXECUTION_ERROR",
         message,
         details: err,
       };

--- a/src/services/__tests__/ActionService.test.ts
+++ b/src/services/__tests__/ActionService.test.ts
@@ -854,7 +854,10 @@ describe("ActionService", () => {
     // `confirmed` on the action's own args, so a confirm-gated action re-asked
     // after the host modal was approved and returned `ok` having done nothing.
     describe("host-attested confirmation reaches run() (#12120)", () => {
-      function confirmAction(run: ReturnType<typeof vi.fn>): ActionDefinition {
+      // Typed as the definition's own `run`, not `ReturnType<typeof vi.fn>` —
+      // that resolves to `Mock<Procedure | Constructable>`, whose Constructable
+      // arm carries no call signature and so satisfies no function type.
+      function confirmAction(run: ActionDefinition["run"]): ActionDefinition {
         return {
           id: "actions.list" as ActionId,
           title: "Test Action",

--- a/src/services/__tests__/ActionService.test.ts
+++ b/src/services/__tests__/ActionService.test.ts
@@ -34,6 +34,7 @@ vi.mock("@/lib/notify", () => ({ notify: notifyMock }));
 import { ActionService } from "../ActionService";
 import { useUIStore } from "@/store/uiStore";
 import type { ActionDefinition, ActionId } from "@shared/types/actions";
+import { ConfirmationStagedError } from "../actions/confirmationStaged";
 
 describe("ActionService", () => {
   let service: ActionService;
@@ -846,6 +847,86 @@ describe("ActionService", () => {
         expect(result.error.message).toBe(expected);
         expect(result.error.code).toBe("EXECUTION_ERROR");
       }
+    });
+
+    // #12120: the confirm gate above already required a host attestation for
+    // agent dispatch, but run() could not see it — it only had the client-settable
+    // `confirmed` on the action's own args, so a confirm-gated action re-asked
+    // after the host modal was approved and returned `ok` having done nothing.
+    describe("host-attested confirmation reaches run() (#12120)", () => {
+      function confirmAction(run: ReturnType<typeof vi.fn>): ActionDefinition {
+        return {
+          id: "actions.list" as ActionId,
+          title: "Test Action",
+          description: "A test action",
+          category: "test",
+          kind: "command",
+          danger: "confirm",
+          scope: "renderer",
+          run,
+        };
+      }
+
+      it("stamps ctx.hostConfirmed from the dispatch options", async () => {
+        const mockRun = vi.fn().mockResolvedValue(undefined);
+        service.register(confirmAction(mockRun));
+
+        await service.dispatch("actions.list", undefined, { source: "agent", confirmed: true });
+
+        expect(mockRun).toHaveBeenCalledWith(
+          undefined,
+          expect.objectContaining({ hostConfirmed: true })
+        );
+      });
+
+      it("leaves ctx.hostConfirmed unset when the host attested nothing", async () => {
+        const mockRun = vi.fn().mockResolvedValue(undefined);
+        service.register(confirmAction(mockRun));
+
+        await service.dispatch("actions.list", undefined, { source: "user" });
+
+        expect(mockRun).toHaveBeenCalledWith(
+          undefined,
+          expect.objectContaining({ hostConfirmed: undefined })
+        );
+      });
+
+      // The whole point of putting it on the context rather than in args: a
+      // caller cannot plant it. Same property that makes `dispatchSource`
+      // trustworthy — the stamp is unconditional and overwrites the override.
+      it("overwrites a contextOverride that claims an approval the host never made", async () => {
+        const mockRun = vi.fn().mockResolvedValue(undefined);
+        service.register(confirmAction(mockRun));
+
+        const result = await service.dispatch("actions.list", undefined, {
+          source: "user",
+          contextOverride: { hostConfirmed: true },
+        });
+
+        expect(result.ok).toBe(true);
+        expect(mockRun).toHaveBeenCalledWith(
+          undefined,
+          expect.objectContaining({ hostConfirmed: undefined })
+        );
+      });
+
+      it("maps a staged confirmation to CONFIRMATION_REQUIRED rather than resolving ok", async () => {
+        const mockRun = vi
+          .fn()
+          .mockRejectedValue(new ConfirmationStagedError("Killing it did not happen"));
+        service.register(confirmAction(mockRun));
+
+        const result = await service.dispatch("actions.list", undefined, {
+          source: "agent",
+          confirmed: true,
+        });
+
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+          expect(result.error.code).toBe("CONFIRMATION_REQUIRED");
+          expect(result.error.message).toContain("did not happen");
+        }
+      });
     });
 
     it("returns BINDING_STALE when contextOverride projectId differs from live context (#8432)", async () => {

--- a/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
+++ b/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
@@ -4807,7 +4807,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "terminal",
     "danger": "confirm",
     "dangerRationale": "Permanently kills the PTY process. Scrollback and session state are lost.",
-    "description": "Permanently destroy a panel and its process, with no trash step and no recovery. Not limited to terminals: whatever the id names is removed. A panel running an agent session is untouched unless the call is marked confirmed, so read back its state rather than assume it went. Identify it explicitly: an automated caller cannot see what the user focused. Close it instead when recovery matters.",
+    "description": "Permanently destroy a panel and its process, with no trash step and no recovery. Not limited to terminals: whatever the id names is removed. A panel running an agent session is untouched unless the call is confirmed, and an untouched call fails rather than reporting it went. Identify it explicitly: an automated caller cannot see what the user focused. Close it instead when recovery matters.",
     "examples": undefined,
     "id": "terminal.kill",
     "keywords": [
@@ -4824,7 +4824,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "terminal",
     "danger": "confirm",
     "dangerRationale": "Permanently kills every user-facing terminal. All scrollback and session state are lost.",
-    "description": "Permanently destroy every panel in the project, across all worktrees and kinds, including trashed and backgrounded, with no trash step and no recovery. It takes the user's own shells and other agents' work with it; only tooling-internal and dialog-hosted panels are spared. While an agent session runs it destroys nothing unless the call is marked confirmed. Automated callers should never need this.",
+    "description": "Permanently destroy every panel in the project, across all worktrees and kinds, including trashed and backgrounded, with no trash step and no recovery. It takes the user's own shells and other agents' work with it; only tooling-internal and dialog-hosted panels are spared. While an agent session runs it destroys nothing unless the call is confirmed. Automated callers should never need this.",
     "examples": undefined,
     "id": "terminal.killAll",
     "keywords": [
@@ -5083,7 +5083,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "terminal",
     "danger": "confirm",
     "dangerRationale": "Restarts the terminal process. Scrollback is lost and the process is re-spawned.",
-    "description": "Restart a terminal's process in place, keeping the pane. This returns before the restart finishes, so it is not ready when it does; watch its status before sending anything. A terminal running an agent session is left untouched unless the call is marked confirmed; otherwise whatever was running is terminated and unsaved state is lost. A panel with no process is ignored, not an error.",
+    "description": "Restart a terminal's process in place, keeping the pane. This returns before the restart finishes, so it is not ready when it does; watch its status before sending anything. A terminal running an agent session is left untouched unless the call is confirmed; otherwise whatever was running is terminated and unsaved state is lost. A panel with no process is ignored, not an error.",
     "examples": undefined,
     "id": "terminal.restart",
     "keywords": [

--- a/src/services/actions/__tests__/confirmationStaged.test.ts
+++ b/src/services/actions/__tests__/confirmationStaged.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ConfirmationStagedError,
+  confirmationStagedMessage,
+  isStagedConfirmation,
+} from "../confirmationStaged";
+
+// The predicate five generic dispatchers rely on to tell "a dialog just opened"
+// from "this really failed" (#12120). Matching the code alone would swallow the
+// outer gate's genuine refusal, which those surfaces must still report.
+describe("isStagedConfirmation", () => {
+  it("matches a staged confirmation carrying the sentinel", () => {
+    expect(
+      isStagedConfirmation({
+        code: "CONFIRMATION_REQUIRED",
+        details: new ConfirmationStagedError(confirmationStagedMessage("Killing this terminal")),
+      })
+    ).toBe(true);
+  });
+
+  it("rejects the outer gate's refusal, which uses the same code without the sentinel", () => {
+    expect(
+      isStagedConfirmation({
+        code: "CONFIRMATION_REQUIRED",
+        details: new Error("requires explicit confirmation from agent sources"),
+      })
+    ).toBe(false);
+  });
+
+  it("rejects the same code with no details at all", () => {
+    expect(isStagedConfirmation({ code: "CONFIRMATION_REQUIRED" })).toBe(false);
+  });
+
+  // The sentinel is only meaningful together with the code ActionService maps
+  // it to; a different code means something else produced this failure.
+  it("rejects another code even when the sentinel is attached", () => {
+    expect(
+      isStagedConfirmation({
+        code: "EXECUTION_ERROR",
+        details: new ConfirmationStagedError("staged"),
+      })
+    ).toBe(false);
+  });
+});
+
+describe("confirmationStagedMessage", () => {
+  it("leads with what did not happen, so a model cannot read it as done", () => {
+    const message = confirmationStagedMessage("Killing this terminal");
+    expect(message).toContain("Killing this terminal was not performed");
+    expect(message).toContain("Nothing changed.");
+  });
+});

--- a/src/services/actions/confirmationStaged.ts
+++ b/src/services/actions/confirmationStaged.ts
@@ -1,0 +1,32 @@
+/**
+ * Thrown by an action whose `run()` staged a confirmation instead of acting.
+ *
+ * The class is the authentication, exactly as {@link PartialSuccessError} is:
+ * only code in this repo can construct it, and `ActionService.dispatch` maps it
+ * to the existing `CONFIRMATION_REQUIRED` code. Reusing that code rather than
+ * widening `ActionErrorCode` follows `panelLimitError`'s rule — the union is the
+ * plugin-facing error contract — and it already means what this outcome is.
+ *
+ * It exists because staging must not resolve `ok`. A destructive action that
+ * parked a dialog and returned normally reported success on a terminal that is
+ * still alive, and an agent reading `ok` moved on (#12120, same shape as #8814).
+ *
+ * Lives in its own leaf module so `ActionService` can recognise it without
+ * importing the action-definitions graph.
+ */
+export class ConfirmationStagedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ConfirmationStagedError";
+  }
+}
+
+/**
+ * The message an MCP caller reads when its dispatch staged rather than acted.
+ *
+ * Says what did NOT happen first: the failure mode this guards against is a
+ * model treating a staged destructive call as done.
+ */
+export function confirmationStagedMessage(what: string): string {
+  return `${what} was not performed — it needs confirmation, and one is now waiting for the user. Nothing changed.`;
+}

--- a/src/services/actions/confirmationStaged.ts
+++ b/src/services/actions/confirmationStaged.ts
@@ -30,3 +30,18 @@ export class ConfirmationStagedError extends Error {
 export function confirmationStagedMessage(what: string): string {
   return `${what} was not performed — it needs confirmation, and one is now waiting for the user. Nothing changed.`;
 }
+
+/**
+ * Did this failed dispatch park a confirmation, rather than actually fail?
+ *
+ * `CONFIRMATION_REQUIRED` has two producers: `ActionService`'s outer gate,
+ * which refuses an unattested agent or plugin dispatch, and this sentinel,
+ * which means a dialog is now open for the user to answer. Only the second is a
+ * normal outcome an interactive surface should stay quiet about — so match the
+ * class, which `ActionService` passes through as `error.details`, rather than
+ * the code alone. A surface that suppressed the code would also swallow a real
+ * refusal it ought to report.
+ */
+export function isStagedConfirmation(error: { code: string; details?: unknown }): boolean {
+  return error.code === "CONFIRMATION_REQUIRED" && error.details instanceof ConfirmationStagedError;
+}

--- a/src/services/actions/definitions/__tests__/terminalLifecycleActions.test.ts
+++ b/src/services/actions/definitions/__tests__/terminalLifecycleActions.test.ts
@@ -389,7 +389,7 @@ describe("terminal.kill confirm gate", () => {
     expect(pendingDestructiveStoreMock.state.request).not.toHaveBeenCalled();
   });
 
-  it("does not kill when an agent is mid-work without confirmed:true — requests confirmation instead", async () => {
+  it("does not kill when an agent is mid-work without confirmed:true — requests confirmation and fails", async () => {
     const { removePanel } = setRichPanelState({
       focusedId: "p1",
       panels: [
@@ -403,7 +403,7 @@ describe("terminal.kill confirm gate", () => {
     });
     const run = setupActions();
 
-    await run("terminal.kill", { terminalId: "p1" });
+    await expect(run("terminal.kill", { terminalId: "p1" })).rejects.toThrow(/needs confirmation/);
 
     expect(removePanel).not.toHaveBeenCalled();
     expect(pendingDestructiveStoreMock.state.request).toHaveBeenCalledWith({
@@ -463,7 +463,9 @@ describe("terminal.restart confirm gate", () => {
     });
     const run = setupActions();
 
-    await run("terminal.restart", { terminalId: "p1" });
+    await expect(run("terminal.restart", { terminalId: "p1" })).rejects.toThrow(
+      /needs confirmation/
+    );
 
     expect(restartTerminal).not.toHaveBeenCalled();
     expect(pendingDestructiveStoreMock.state.request).toHaveBeenCalledWith({
@@ -544,7 +546,7 @@ describe("terminal.killAll confirm gate", () => {
     });
     const run = setupActions();
 
-    await run("terminal.killAll");
+    await expect(run("terminal.killAll")).rejects.toThrow(/needs confirmation/);
 
     expect(removePanel).not.toHaveBeenCalled();
     expect(pendingDestructiveStoreMock.state.request).toHaveBeenCalledWith({
@@ -603,7 +605,7 @@ describe("terminal.restartAll confirm gate", () => {
     });
     const run = setupActions();
 
-    await run("terminal.restartAll");
+    await expect(run("terminal.restartAll")).rejects.toThrow(/needs confirmation/);
 
     expect(bulkRestartAll).not.toHaveBeenCalled();
     expect(pendingDestructiveStoreMock.state.request).toHaveBeenCalledWith({
@@ -994,7 +996,12 @@ describe("agent dispatch target binding (#11532)", () => {
     }));
     const run = setupActions();
 
-    await run("terminal.kill", { terminalId: "explicit-panel" }, { dispatchSource: "agent" });
+    // Agent source alone is NOT approval — only a host-attested `hostConfirmed`
+    // is (#12120). An agent that reached run() without one still stages, and now
+    // fails rather than reporting a kill it did not perform.
+    await expect(
+      run("terminal.kill", { terminalId: "explicit-panel" }, { dispatchSource: "agent" })
+    ).rejects.toThrow(/needs confirmation/);
 
     expect(spies.requestConfirm).toHaveBeenCalledWith(
       expect.objectContaining({ kind: "kill", terminalId: "explicit-panel" })
@@ -1085,5 +1092,116 @@ describe("agent dispatch target binding (#11532)", () => {
         "No terminal selected"
       );
     });
+  });
+});
+
+// #12120: the MCP bridge sets the approval in the dispatch OPTIONS and leaves
+// the model's args alone, so `run()` could only see the client-settable
+// `args.confirmed` — it re-asked after the host modal was already approved,
+// staged a second dialog, and returned `ok` on a terminal that was still alive.
+// `ctx.hostConfirmed` is the attestation ActionService stamps from those options.
+describe("host-attested confirmation (#12120)", () => {
+  const WORKING_AGENT = {
+    location: "grid" as const,
+    detectedAgentId: "claude",
+    agentState: "working",
+  };
+
+  it("kills a running-agent terminal without staging a second confirmation", async () => {
+    const { removePanel } = setRichPanelState({
+      focusedId: "p1",
+      panels: [{ id: "p1", ...WORKING_AGENT }],
+    });
+    const run = setupActions();
+
+    await run("terminal.kill", { terminalId: "p1" }, { hostConfirmed: true });
+
+    expect(removePanel).toHaveBeenCalledWith("p1");
+    expect(pendingDestructiveStoreMock.state.request).not.toHaveBeenCalled();
+  });
+
+  it("restarts a running-agent terminal without staging a second confirmation", async () => {
+    const { restartTerminal } = setRichPanelState({
+      focusedId: "p1",
+      panels: [{ id: "p1", ...WORKING_AGENT }],
+    });
+    const run = setupActions();
+
+    await run("terminal.restart", { terminalId: "p1" }, { hostConfirmed: true });
+
+    expect(restartTerminal).toHaveBeenCalledWith("p1");
+    expect(pendingDestructiveStoreMock.state.request).not.toHaveBeenCalled();
+  });
+
+  // killAll/restartAll took no `ctx` at all before this fix, so they could not
+  // have read the attestation even if it existed.
+  it("kills all without staging a second confirmation", async () => {
+    const { removePanel } = setRichPanelState({
+      panels: [
+        { id: "p1", location: "grid" },
+        { id: "p2", ...WORKING_AGENT },
+      ],
+    });
+    const run = setupActions();
+
+    await run("terminal.killAll", undefined, { hostConfirmed: true });
+
+    expect(removePanel).toHaveBeenCalledWith("p1");
+    expect(removePanel).toHaveBeenCalledWith("p2");
+    expect(pendingDestructiveStoreMock.state.request).not.toHaveBeenCalled();
+  });
+
+  it("restarts all without staging a second confirmation", async () => {
+    const { bulkRestartAll } = setRichPanelState({
+      panels: [
+        { id: "p1", location: "grid" },
+        { id: "p2", ...WORKING_AGENT },
+      ],
+    });
+    const run = setupActions();
+
+    await run("terminal.restartAll", undefined, { hostConfirmed: true });
+
+    expect(bulkRestartAll).toHaveBeenCalled();
+    expect(pendingDestructiveStoreMock.state.request).not.toHaveBeenCalled();
+  });
+
+  // Only `true` attests. A stray falsy/garbage value must fall through to the
+  // confirmation rather than be read as approval.
+  it.each([[false], [undefined], ["true"]])(
+    "does not treat hostConfirmed=%p as approval",
+    async (hostConfirmed) => {
+      const { removePanel } = setRichPanelState({
+        focusedId: "p1",
+        panels: [{ id: "p1", ...WORKING_AGENT }],
+      });
+      const run = setupActions();
+
+      await expect(run("terminal.kill", { terminalId: "p1" }, { hostConfirmed })).rejects.toThrow(
+        /needs confirmation/
+      );
+
+      expect(removePanel).not.toHaveBeenCalled();
+      expect(pendingDestructiveStoreMock.state.request).toHaveBeenCalled();
+    }
+  );
+
+  // The user-facing dialog re-dispatches with args.confirmed; a host-attested
+  // dispatch arrives with neither that nor any pending entry of its own. Both
+  // paths must clear a parked confirmation so it can't outlive the kill.
+  it("clears a parked confirmation when the host attested instead", async () => {
+    const { removePanel } = setRichPanelState({
+      focusedId: "p1",
+      panels: [{ id: "p1", ...WORKING_AGENT }],
+    });
+    const run = setupActions();
+
+    await expect(run("terminal.kill", { terminalId: "p1" })).rejects.toThrow();
+    expect(pendingDestructiveStoreMock.state.pending).toMatchObject({ kind: "kill" });
+
+    await run("terminal.kill", { terminalId: "p1" }, { hostConfirmed: true });
+
+    expect(removePanel).toHaveBeenCalledWith("p1");
+    expect(pendingDestructiveStoreMock.state.clear).toHaveBeenCalled();
   });
 });

--- a/src/services/actions/definitions/terminalLifecycleActions.ts
+++ b/src/services/actions/definitions/terminalLifecycleActions.ts
@@ -1,5 +1,9 @@
 import type { ActionCallbacks, ActionRegistry } from "../actionTypes";
-import type { ActionSource } from "@shared/types/actions";
+import type { ActionContext, ActionSource } from "@shared/types/actions";
+import {
+  ConfirmationStagedError,
+  confirmationStagedMessage,
+} from "@/services/actions/confirmationStaged";
 import { z } from "zod";
 import { terminalClient } from "@/clients";
 import { terminalInstanceService } from "@/services/terminal/TerminalInstanceService";
@@ -10,6 +14,7 @@ import { isPtyPanel } from "@shared/types/panel";
 import {
   useTerminalPendingDestructiveActionStore,
   type TerminalPendingDestructiveActionKind,
+  type TerminalPendingDestructiveActionSnapshot,
 } from "@/store/terminalPendingDestructiveActionStore";
 import {
   collectRunningAgentTerminals,
@@ -22,6 +27,46 @@ import { isForegroundDispatch } from "./dispatchSource";
 function parseConfirmed(args: unknown): boolean {
   if (!args || typeof args !== "object") return false;
   return (args as { confirmed?: unknown }).confirmed === true;
+}
+
+/**
+ * Has this dispatch's destructive step already been approved?
+ *
+ * Two independent surfaces, deliberately. `args.confirmed` is how the in-app
+ * dialogs re-dispatch after the user clicks through: client-settable, which is
+ * harmless because it only skips the gate below — `ActionService` still made an
+ * agent clear the host modal to get here at all. `ctx.hostConfirmed` is that
+ * host attestation itself, stamped by `ActionService.dispatch` and unspoofable.
+ *
+ * Reading only the first is what made an MCP kill ask twice and kill nothing
+ * (#12120): the bridge sets the attestation in the dispatch options and leaves
+ * the model's args alone, so the approval the user had already given was
+ * invisible here.
+ *
+ * Deliberately NOT `ctx.dispatchSource === "agent"`. That reads as the same
+ * thing only for a statically `danger:"confirm"` action; where the tier is
+ * escalated from the args (`resolveEffectiveActionDanger`), an agent reaches
+ * `run()` with no approval at all and the inference becomes a silent bypass.
+ */
+function isConfirmed(args: unknown, ctx: ActionContext | undefined): boolean {
+  return parseConfirmed(args) || ctx?.hostConfirmed === true;
+}
+
+/**
+ * Park a confirmation for the user, and refuse the dispatch.
+ *
+ * Never returns — staging is not success. Returning normally here resolved the
+ * dispatch as `ok` while the terminal was still running, so an agent read a
+ * staged kill as a completed one and moved on (#12120). Same shape as the
+ * panel-limit refusal (#8814): a `run()` that declines to act must throw, or
+ * `dispatch` reports success for nothing happening.
+ */
+function stageConfirmation(
+  snapshot: TerminalPendingDestructiveActionSnapshot,
+  what: string
+): never {
+  useTerminalPendingDestructiveActionStore.getState().request(snapshot);
+  throw new ConfirmationStagedError(confirmationStagedMessage(what));
 }
 
 function clearPendingIf(kind: TerminalPendingDestructiveActionKind): void {
@@ -244,7 +289,7 @@ export function registerTerminalLifecycleActions(
     id: "terminal.kill",
     title: "Kill Terminal",
     description:
-      "Permanently destroy a panel and its process, with no trash step and no recovery. Not limited to terminals: whatever the id names is removed. A panel running an agent session is untouched unless the call is marked confirmed, so read back its state rather than assume it went. Identify it explicitly: an automated caller cannot see what the user focused. Close it instead when recovery matters.",
+      "Permanently destroy a panel and its process, with no trash step and no recovery. Not limited to terminals: whatever the id names is removed. A panel running an agent session is untouched unless the call is confirmed, and an untouched call fails rather than reporting it went. Identify it explicitly: an automated caller cannot see what the user focused. Close it instead when recovery matters.",
     category: "terminal",
     kind: "command",
     danger: "confirm",
@@ -257,7 +302,7 @@ export function registerTerminalLifecycleActions(
         .boolean()
         .optional()
         .describe(
-          "Acknowledges losing a running agent session. Without it, a panel running an agent is left alone and a confirmation is staged for the user instead, so the call returns having changed nothing."
+          "Acknowledges losing a running agent session. Redundant once the host has prompted for approval. Without either, the panel is left alone, a confirmation is staged, and the call fails rather than reporting success."
         ),
     }),
     run: async (args: unknown, ctx) => {
@@ -273,14 +318,11 @@ export function registerTerminalLifecycleActions(
       // Bare PTY stays D0 — only confirm when an agent session would lose
       // in-flight work. Mid-work is "working"; "waiting"/"directing" are
       // paused states where stopping is non-disruptive.
-      if (!parseConfirmed(args) && terminalHasRunningAgentSession(terminal)) {
-        useTerminalPendingDestructiveActionStore.getState().request({
-          kind: "kill",
-          targetCount: 1,
-          runningAgentCount: 1,
-          terminalId: targetId,
-        });
-        return;
+      if (!isConfirmed(args, ctx) && terminalHasRunningAgentSession(terminal)) {
+        stageConfirmation(
+          { kind: "kill", targetCount: 1, runningAgentCount: 1, terminalId: targetId },
+          "Killing this terminal"
+        );
       }
       clearPendingIf("kill");
       state.removePanel(targetId);
@@ -291,7 +333,7 @@ export function registerTerminalLifecycleActions(
     id: "terminal.restart",
     title: "Restart Terminal",
     description:
-      "Restart a terminal's process in place, keeping the pane. This returns before the restart finishes, so it is not ready when it does; watch its status before sending anything. A terminal running an agent session is left untouched unless the call is marked confirmed; otherwise whatever was running is terminated and unsaved state is lost. A panel with no process is ignored, not an error.",
+      "Restart a terminal's process in place, keeping the pane. This returns before the restart finishes, so it is not ready when it does; watch its status before sending anything. A terminal running an agent session is left untouched unless the call is confirmed; otherwise whatever was running is terminated and unsaved state is lost. A panel with no process is ignored, not an error.",
     category: "terminal",
     kind: "command",
     danger: "confirm",
@@ -305,7 +347,7 @@ export function registerTerminalLifecycleActions(
         .boolean()
         .optional()
         .describe(
-          "Acknowledges interrupting a running agent session. Without it, a terminal running an agent is left alone and a confirmation is staged for the user instead, so the call returns having changed nothing."
+          "Acknowledges interrupting a running agent session. Redundant once the host has prompted for approval. Without either, the terminal is left alone, a confirmation is staged, and the call fails rather than reporting success."
         ),
     }),
     run: async (args: unknown, ctx) => {
@@ -316,14 +358,11 @@ export function registerTerminalLifecycleActions(
       const targetId = terminalId ?? state.focusedId;
       if (!targetId) return;
       const terminal = state.panelsById[targetId];
-      if (!parseConfirmed(args) && terminalHasRunningAgentSession(terminal)) {
-        useTerminalPendingDestructiveActionStore.getState().request({
-          kind: "restart",
-          targetCount: 1,
-          runningAgentCount: 1,
-          terminalId: targetId,
-        });
-        return;
+      if (!isConfirmed(args, ctx) && terminalHasRunningAgentSession(terminal)) {
+        stageConfirmation(
+          { kind: "restart", targetCount: 1, runningAgentCount: 1, terminalId: targetId },
+          "Restarting this terminal"
+        );
       }
       clearPendingIf("restart");
       state.restartTerminal(targetId);
@@ -611,7 +650,7 @@ export function registerTerminalLifecycleActions(
     id: "terminal.killAll",
     title: "Kill All Terminals",
     description:
-      "Permanently destroy every panel in the project, across all worktrees and kinds, including trashed and backgrounded, with no trash step and no recovery. It takes the user's own shells and other agents' work with it; only tooling-internal and dialog-hosted panels are spared. While an agent session runs it destroys nothing unless the call is marked confirmed. Automated callers should never need this.",
+      "Permanently destroy every panel in the project, across all worktrees and kinds, including trashed and backgrounded, with no trash step and no recovery. It takes the user's own shells and other agents' work with it; only tooling-internal and dialog-hosted panels are spared. While an agent session runs it destroys nothing unless the call is confirmed. Automated callers should never need this.",
     category: "terminal",
     kind: "command",
     danger: "confirm",
@@ -625,11 +664,11 @@ export function registerTerminalLifecycleActions(
           .boolean()
           .optional()
           .describe(
-            "Acknowledges losing every running agent session. Without it, nothing is destroyed while any agent is running — a confirmation is staged for the user and the call returns having changed nothing."
+            "Acknowledges losing every running agent session. Redundant once the host has prompted for approval. Without either, nothing is destroyed, a confirmation is staged, and the call fails rather than reporting success."
           ),
       })
       .optional(),
-    run: async (args: unknown) => {
+    run: async (args: unknown, ctx) => {
       // Don't reuse bulkCloseAll() — it indiscriminately removes every panel,
       // including the tooling-internal assistant terminal. Filter those out
       // before issuing per-panel removes.
@@ -642,13 +681,15 @@ export function registerTerminalLifecycleActions(
         });
       if (targets.length === 0) return;
       const runningAgents = collectRunningAgentTerminals(targets);
-      if (!parseConfirmed(args) && runningAgents.length > 0) {
-        useTerminalPendingDestructiveActionStore.getState().request({
-          kind: "killAll",
-          targetCount: targets.length,
-          runningAgentCount: runningAgents.length,
-        });
-        return;
+      if (!isConfirmed(args, ctx) && runningAgents.length > 0) {
+        stageConfirmation(
+          {
+            kind: "killAll",
+            targetCount: targets.length,
+            runningAgentCount: runningAgents.length,
+          },
+          "Killing every terminal"
+        );
       }
       clearPendingIf("killAll");
       targets.forEach((t) => state.removePanel(t.id));
@@ -667,7 +708,7 @@ export function registerTerminalLifecycleActions(
       "Restarts every non-trash terminal. All scrollback is lost across all terminals.",
     keywords: ["relaunch", "reset", "rerun", "processes"],
     argsSchema: z.object({ confirmed: z.boolean().optional() }).optional(),
-    run: async (args: unknown) => {
+    run: async (args: unknown, ctx) => {
       const state = usePanelStore.getState();
       // Location-only, deliberately narrower than `isEphemeralPanel`: this list
       // must match what `bulkRestartAll` actually restarts, and that still
@@ -681,13 +722,15 @@ export function registerTerminalLifecycleActions(
         );
       if (targets.length === 0) return;
       const runningAgents = collectRunningAgentTerminals(targets);
-      if (!parseConfirmed(args) && runningAgents.length > 0) {
-        useTerminalPendingDestructiveActionStore.getState().request({
-          kind: "restartAll",
-          targetCount: targets.length,
-          runningAgentCount: runningAgents.length,
-        });
-        return;
+      if (!isConfirmed(args, ctx) && runningAgents.length > 0) {
+        stageConfirmation(
+          {
+            kind: "restartAll",
+            targetCount: targets.length,
+            runningAgentCount: runningAgents.length,
+          },
+          "Restarting every terminal"
+        );
       }
       clearPendingIf("restartAll");
       await state.bulkRestartAll();


### PR DESCRIPTION
## Summary

`terminal.kill` is `danger: "confirm"`. The MCP bridge sets the host attestation in the dispatch OPTIONS (`options.confirmed`) after the user approves the native ConfirmDialog, and passes the model's args through unchanged. But `run()` only checked `parseConfirmed(args)`, the client-settable `confirmed` field on the action's own argsSchema. So after the user approved the host modal, `run()` asked again: it staged a second confirmation in `useTerminalPendingDestructiveActionStore` and returned.

Because it returned normally, dispatch resolved `{ok: true}` on a terminal that was still alive, so the model read a no-op as a completed kill.

Resolves #12120

## The fix

Two halves.

1. A new `ActionContext.hostConfirmed` optional boolean, stamped by `ActionService.dispatch` from `ActionDispatchOptions.confirmed` alongside `dispatchSource` and `copyTreeRunSource`. It's stamped unconditionally, so a `contextOverride` can't claim an approval the host never made. It isn't added to `ActionContextSchema`, since it's renderer-internal, the same treatment as `copyTreeRunSource`, so no IPC codegen is needed.
2. Staging now throws a new `ConfirmationStagedError` (new leaf module `src/services/actions/confirmationStaged.ts`), which `ActionService` maps by a same-realm `instanceof` check to the existing `CONFIRMATION_REQUIRED` code, mirroring how `PartialSuccessError` already maps to `PARTIAL_SUCCESS`. A dispatch that changed nothing no longer resolves ok. This deliberately reuses the existing code rather than widening `ActionErrorCode`, which is a plugin-facing contract per `panelLimitError`'s documented rule.

Applied to all four sibling actions: `terminal.kill`, `terminal.restart`, `terminal.killAll`, `terminal.restartAll`. The latter two didn't take a `ctx` parameter before; now they do.

### Why not `ctx.dispatchSource === "agent"`

That's the pattern three prior fixes used, in `worktreeSessionActions.ts` and `gitActions.ts`, and it would have been the simpler change here. The issue explicitly ruled it out, and it's unsound as a general primitive: it only reads as "already approved" for an action that is *statically* `danger: "confirm"`. Where a confirmation is decided inside `run()` from live state — `fleet.reject` at 5 targets, `fleet.interrupt` at 3, the portal close-escalations — `resolveEffectiveActionDanger` never sees it (it elevates only an agent-sourced safe action carrying a `recipeId`), so nothing forces host approval before `run()`, and `dispatchSource === "agent"` would read as approval that was never given. Those actions are not MCP-exposed today, so the existing shortcuts are safe where they stand; the point is that the inference doesn't generalise, and this fix is the prerequisite for a single-dialog batch kill. Carrying the actual attestation is correct at every tier.

### Knock-on caught in review

The new throw reaches four generic dispatchers that inspect the dispatch result, and `terminal.kill`/`restart`/`restartAll` are bound by default and reachable from the palette, command HUD, and app menu, so a parked confirmation would otherwise have shown an error toast or logged a failure on an entirely normal path. `useActionPalette`, `useCommandHud`, `useMenuActions`, and `useGlobalKeybindings` now skip that one outcome alongside their existing `DISABLED` early-return, matched via a new `isStagedConfirmation()` helper rather than the raw code, because `CONFIRMATION_REQUIRED` has a second producer (the outer gate's own refusal) that still needs to be reported.

## Out of scope

- `fleet.*` and `portal.*` share the same `parseConfirmed`-only inner gate and are worth a follow-up; their runtime danger escalation makes the source-inference pattern especially unsafe there.
- The MCP confirm modal still shows no "an agent is mid-work" preview for `terminal.kill` (no entry in `resolveMcpConfirmPreviewTarget`), though it does carry the action's `dangerRationale`.

## Testing

560 tests pass across the 18 affected suites: `terminalLifecycleActions`, `ActionService` (plus its adversarial and e2eGate suites), `actionDefinitions.quality`, `mcpWireBudget`, `mcpExternalBaseManifest`, `resultSchemaHygiene`, `worktreeSessionActions`, `useActionPalette`, `useMenuActions`, `useGlobalKeybindings`, `useMcpBridge`, `TerminalContextMenu`, `TerminalDestructiveActionConfirmDialog` (x2). Prettier clean, eslint 0 errors.

One snapshot line was regenerated for the corrected MCP tool description prose, and all tool descriptions were reverified under the 400-byte cap (393/379/393), with the MCP wire budget rechecked rather than widened.
