### PR TITLE
fix(mcp): persist the tool call's start time on audit records

### DIFF
--- a/electron/services/mcp-server/__tests__/auditLog.test.ts
+++ b/electron/services/mcp-server/__tests__/auditLog.test.ts
@@ -295,7 +295,7 @@ describe("AuditService.appendRecord — resultMeta (#10014)", () => {
 });
 
 describe("AuditService.appendRecord — startedAt (#12122)", () => {
-  it("persists the caller's startedAt verbatim and round-trips it through getRecords", () => {
+  it("persists the caller's startedAt verbatim and reads it back unchanged", () => {
     const { service } = makeFixture();
     // A real epoch reading, not a small sentinel: the service must not clamp,
     // round, or re-derive it the way it normalises `durationMs`.
@@ -314,29 +314,31 @@ describe("AuditService.appendRecord — startedAt (#12122)", () => {
     expect(record!.startedAt).toBe(startedAt);
   });
 
-  it("records startedAt independently of timestamp and durationMs", () => {
-    // The whole point of the field (#12122): `timestamp` is a fresh clock read
-    // taken inside appendRecord, so `timestamp - durationMs` lands after the
-    // real start. A consumer ordering calls must be able to read the start
-    // directly rather than reconstruct it.
+  it("carries start information that timestamp and durationMs cannot express", () => {
+    // The point of the field (#12122): two calls can settle into identical
+    // `timestamp`/`durationMs` shapes and still have begun at different
+    // moments. Recording distinct starts under an identical duration is what
+    // proves the record now carries ordering information it did not before —
+    // and it fails outright if the field stops being persisted.
     const { service } = makeFixture();
-    const startedAt = 1_767_225_600_000;
-    service.appendRecord({
-      toolId: "worktree.list",
-      sessionId: "sess-1",
-      tier: "action",
-      args: {},
-      durationMs: 250,
-      startedAt,
-      outcome: successOutcome,
-      argsSummary: "{}",
-    });
-    const [record] = service.getRecords();
-    expect(record!.startedAt).toBe(startedAt);
-    // timestamp is "now", far from the fixed historical startedAt above —
-    // proving the field is stored, not derived from the other two.
-    expect(record!.timestamp).not.toBe(startedAt);
-    expect(record!.timestamp - record!.durationMs).not.toBe(startedAt);
+    const first = 1_767_225_600_000;
+    const second = 1_767_225_604_000;
+    for (const startedAt of [first, second]) {
+      service.appendRecord({
+        toolId: "worktree.list",
+        sessionId: "sess-1",
+        tier: "action",
+        args: {},
+        durationMs: 250,
+        startedAt,
+        outcome: successOutcome,
+        argsSummary: "{}",
+      });
+    }
+    const records = service.getRecords();
+    expect(records.map((r) => r.startedAt).sort((a, b) => a! - b!)).toEqual([first, second]);
+    // Same duration on both, so `durationMs` alone orders nothing.
+    expect(new Set(records.map((r) => r.durationMs)).size).toBe(1);
   });
 
   it("keeps startedAt on gate outcomes, which are real dispatch attempts", () => {

--- a/electron/services/mcp-server/__tests__/auditLog.test.ts
+++ b/electron/services/mcp-server/__tests__/auditLog.test.ts
@@ -294,6 +294,99 @@ describe("AuditService.appendRecord — resultMeta (#10014)", () => {
   });
 });
 
+describe("AuditService.appendRecord — startedAt (#12122)", () => {
+  it("persists the caller's startedAt verbatim and round-trips it through getRecords", () => {
+    const { service } = makeFixture();
+    // A real epoch reading, not a small sentinel: the service must not clamp,
+    // round, or re-derive it the way it normalises `durationMs`.
+    const startedAt = 1_767_225_600_123;
+    service.appendRecord({
+      toolId: "worktree.list",
+      sessionId: "sess-1",
+      tier: "action",
+      args: {},
+      durationMs: 40,
+      startedAt,
+      outcome: successOutcome,
+      argsSummary: "{}",
+    });
+    const [record] = service.getRecords();
+    expect(record!.startedAt).toBe(startedAt);
+  });
+
+  it("records startedAt independently of timestamp and durationMs", () => {
+    // The whole point of the field (#12122): `timestamp` is a fresh clock read
+    // taken inside appendRecord, so `timestamp - durationMs` lands after the
+    // real start. A consumer ordering calls must be able to read the start
+    // directly rather than reconstruct it.
+    const { service } = makeFixture();
+    const startedAt = 1_767_225_600_000;
+    service.appendRecord({
+      toolId: "worktree.list",
+      sessionId: "sess-1",
+      tier: "action",
+      args: {},
+      durationMs: 250,
+      startedAt,
+      outcome: successOutcome,
+      argsSummary: "{}",
+    });
+    const [record] = service.getRecords();
+    expect(record!.startedAt).toBe(startedAt);
+    // timestamp is "now", far from the fixed historical startedAt above —
+    // proving the field is stored, not derived from the other two.
+    expect(record!.timestamp).not.toBe(startedAt);
+    expect(record!.timestamp - record!.durationMs).not.toBe(startedAt);
+  });
+
+  it("keeps startedAt on gate outcomes, which are real dispatch attempts", () => {
+    // Unlike `resultMeta`, absence is NOT the right behaviour for gates: an
+    // unauthorized / dedup / collision row is a call the backend actually
+    // issued, so it must count when measuring concurrency.
+    const { service } = makeFixture();
+    const outcomes: AuditOutcome[] = [
+      { kind: "unauthorized" },
+      { kind: "dedup" },
+      { kind: "collision" },
+    ];
+    outcomes.forEach((outcome, i) => {
+      service.appendRecord({
+        toolId: "agent.terminal",
+        sessionId: "sess-1",
+        tier: "action",
+        args: {},
+        durationMs: 0,
+        startedAt: 1_767_225_600_000 + i,
+        outcome,
+        argsSummary: "{}",
+      });
+    });
+    const records = service.getRecords();
+    expect(records).toHaveLength(3);
+    // Newest-first, so the starts run back down the sequence.
+    expect(records.map((r) => r.startedAt).sort((a, b) => a! - b!)).toEqual([
+      1_767_225_600_000, 1_767_225_600_001, 1_767_225_600_002,
+    ]);
+  });
+
+  it("omits startedAt as a key entirely when the caller supplies none", () => {
+    const { service } = makeFixture();
+    service.appendRecord({
+      toolId: "agent.launch",
+      sessionId: "sess-1",
+      tier: "action",
+      args: {},
+      durationMs: 5,
+      outcome: successOutcome,
+      argsSummary: "{}",
+    });
+    const [record] = service.getRecords();
+    // Absent as a key, not present-and-undefined — persisted JSON must not
+    // carry a stray `startedAt: undefined`.
+    expect("startedAt" in record!).toBe(false);
+  });
+});
+
 describe("AuditService.recordAuth401 pre-auth records", () => {
   it("emits a pre-auth record alongside the counter increment", () => {
     const { service } = makeFixture();
@@ -313,6 +406,10 @@ describe("AuditService.recordAuth401 pre-auth records", () => {
     expect(record!.durationMs).toBe(0);
     expect(record!.argsSummary).toBe("pre-auth request rejected");
     expect(record!.repeatCount).toBeUndefined();
+    // A 401 is rejected before any CallTool handler exists, so there is no
+    // start to record — the key must stay absent rather than be invented
+    // from the write time (#12122).
+    expect("startedAt" in record!).toBe(false);
   });
 
   it("coalesces bursts within 1s by incrementing repeatCount", () => {
@@ -408,6 +505,26 @@ describe("AuditService hydrate — backward compat", () => {
     const records = service.getRecords();
     expect(records).toHaveLength(1);
     expect(records[0]!.id).toBe("old-1");
+  });
+
+  it("leaves startedAt absent on rows written before the field existed (#12122)", () => {
+    // hydrate() backfills only schemaVersion/severity. An old row has no start
+    // to recover, and inferring one from `timestamp - durationMs` would be a
+    // fabricated value a concurrency reader would silently trust.
+    const { service } = makeFixture({}, [
+      {
+        id: "old-1",
+        timestamp: 1000,
+        toolId: "agent.terminal",
+        sessionId: "sess-1",
+        tier: "action",
+        argsSummary: "{}",
+        result: "success",
+        durationMs: 5,
+      },
+    ]);
+    const [record] = service.getRecords();
+    expect("startedAt" in record!).toBe(false);
   });
 
   it("backfills schemaVersion and severity on old persisted records", () => {

--- a/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
+++ b/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
@@ -902,6 +902,31 @@ describe("HttpLifecycle", () => {
       expect(persisted.capturedTurnId).toBeUndefined();
     });
 
+    it("passes startedAt through the closure untouched (#12122)", () => {
+      // This hop has no explicit handling for `startedAt` — it survives only on
+      // the `...recordInput` rest spread, which peels off `capturedTurnId` and
+      // keeps everything else. That makes it exactly the kind of silent-drop
+      // risk a future edit to the destructure could reintroduce, so pin it.
+      const deps = fakeDeps();
+      deps.sessionStore.sessionHelpIdMap.set("session-1", "help-session-9");
+      const lc = new HttpLifecycle(deps);
+      const deps_ = buildDeps(lc, "session-1");
+      const startedAt = 1_767_225_600_123;
+      deps_.appendAuditRecord({
+        toolId: "agent.terminal",
+        sessionId: "session-1",
+        tier: "action",
+        args: {},
+        durationMs: 5,
+        startedAt,
+        outcome: { kind: "result", value: { ok: true, result: null } },
+        capturedTurnId: null,
+      });
+      expect(deps.auditService.appendRecord).toHaveBeenCalledWith(
+        expect.objectContaining({ startedAt })
+      );
+    });
+
     it("omits turnId when the captured snapshot is null", () => {
       const deps = fakeDeps();
       deps.sessionStore.sessionHelpIdMap.set("session-1", "help-session-9");

--- a/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
+++ b/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
@@ -37,6 +37,7 @@ import { createHash } from "node:crypto";
 import { HttpLifecycle } from "../httpLifecycle.js";
 import type { HttpLifecycleDeps } from "../httpLifecycle.js";
 import { minimumPermittingTier } from "../shared.js";
+import type { SessionServerDeps } from "../sessionServer.js";
 import { WorkspaceBindingError } from "../rendererBridge.js";
 
 type BearerTestHandle = {
@@ -845,10 +846,11 @@ describe("HttpLifecycle", () => {
   });
 
   describe("buildSessionServerDeps — turnId snapshot stamping (#10067)", () => {
-    type TurnDeps = {
-      getCurrentTurnId?: () => string | null;
-      appendAuditRecord: (input: Record<string, unknown>) => void;
-    };
+    // Picked from the real dep contract rather than a `Record<string, unknown>`
+    // carrier: this block is the only coverage of the closure's
+    // `{ capturedTurnId, ...recordInput }` hop, and a structural stand-in would
+    // let a field the real callers must pass go missing here unnoticed.
+    type TurnDeps = Pick<SessionServerDeps, "getCurrentTurnId" | "appendAuditRecord">;
     const buildDeps = (lc: HttpLifecycle, sessionId: string): TurnDeps =>
       (
         lc as unknown as { buildSessionServerDeps: (id: string) => TurnDeps }
@@ -885,6 +887,7 @@ describe("HttpLifecycle", () => {
         tier: "action",
         args: {},
         durationMs: 5,
+        startedAt: 1_767_225_600_000,
         outcome: { kind: "result", value: { ok: true, result: null } },
         capturedTurnId: "turn-uuid-abc",
       });
@@ -905,8 +908,10 @@ describe("HttpLifecycle", () => {
     it("passes startedAt through the closure untouched (#12122)", () => {
       // This hop has no explicit handling for `startedAt` — it survives only on
       // the `...recordInput` rest spread, which peels off `capturedTurnId` and
-      // keeps everything else. That makes it exactly the kind of silent-drop
-      // risk a future edit to the destructure could reintroduce, so pin it.
+      // keeps everything else. So this asserts a property the closure has
+      // always had rather than one #12122 added; it earns its place as the
+      // guard against a future destructure widening to drop the field, which
+      // would otherwise fail nowhere until a consumer noticed missing starts.
       const deps = fakeDeps();
       deps.sessionStore.sessionHelpIdMap.set("session-1", "help-session-9");
       const lc = new HttpLifecycle(deps);
@@ -938,6 +943,7 @@ describe("HttpLifecycle", () => {
         tier: "action",
         args: {},
         durationMs: 5,
+        startedAt: 1_767_225_600_000,
         outcome: { kind: "result", value: { ok: true, result: null } },
         capturedTurnId: null,
       });
@@ -960,6 +966,7 @@ describe("HttpLifecycle", () => {
         tier: "action",
         args: {},
         durationMs: 5,
+        startedAt: 1_767_225_600_000,
         outcome: { kind: "result", value: { ok: true, result: null } },
         capturedTurnId: null,
       });
@@ -993,6 +1000,7 @@ describe("HttpLifecycle", () => {
         tier: "action",
         args: {},
         durationMs: 5,
+        startedAt: 1_767_225_600_000,
         outcome: { kind: "result", value: { ok: true, result: null } },
         capturedTurnId,
       });

--- a/electron/services/mcp-server/__tests__/sessionServer.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionServer.test.ts
@@ -1179,6 +1179,21 @@ describe("CallTool idempotency dedup", () => {
     );
     expect(outcomes).toContain("dedup");
     expect(outcomes.filter((k) => k === "dedup")).toHaveLength(1);
+
+    // The suppressed duplicate is still a call the backend issued, so its row
+    // carries its own start — that is what makes back-to-back vs. overlapping
+    // dispatch distinguishable downstream (#12122).
+    const calls = appendAuditRecord.mock.calls.map(
+      (call) => call[0] as { outcome: { kind: string }; startedAt: number }
+    );
+    for (const call of calls) {
+      expect(typeof call.startedAt).toBe("number");
+    }
+    const dedupCall = calls.find((c) => c.outcome.kind === "dedup");
+    const dispatchCall = calls.find((c) => c.outcome.kind === "result");
+    // Two separate CallTool handlers, so two distinct start snapshots — the
+    // dedup row must not borrow the original dispatch's start.
+    expect(dedupCall!.startedAt).toBeGreaterThanOrEqual(dispatchCall!.startedAt);
   });
 
   it("treats requestKey:'' as absent (falls through to auto-hash)", async () => {
@@ -1750,6 +1765,14 @@ describe("CallTool live activity notifications (#9759)", () => {
     expect(appendAuditRecord).toHaveBeenCalledWith(
       expect.objectContaining({ capturedTurnId: "turn-xyz" })
     );
+
+    // Same single-snapshot discipline for the dispatch start (#12122): the
+    // audit record must carry the exact value the live started event carries,
+    // not a second Date.now() read that would put the persisted row and the
+    // strip on slightly different starts.
+    const startedAt = (started.mock.calls[0]?.[0] as { startedAt: number }).startedAt;
+    expect(typeof startedAt).toBe("number");
+    expect(appendAuditRecord).toHaveBeenCalledWith(expect.objectContaining({ startedAt }));
   });
 
   it("snapshots the turn id at start so started/settled agree across an FSM clear (#10067)", async () => {
@@ -1789,6 +1812,32 @@ describe("CallTool live activity notifications (#9759)", () => {
 
     expect(started).not.toHaveBeenCalled();
     expect(settled).not.toHaveBeenCalled();
+  });
+
+  it("stamps startedAt on a tier-rejected record that has no live started event (#12122)", async () => {
+    const started = vi.fn();
+    const appendAuditRecord = vi.fn();
+    const deps = fakeDeps({ notifyToolCallStarted: started, appendAuditRecord });
+    const server = createSessionServer("session-U", deps);
+    await server.connect(makeMockTransport());
+
+    const before = Date.now();
+    // worktree.delete is system-tier — denied at the default workbench tier.
+    await callTool(server, { name: "worktree.delete", arguments: {} });
+    const after = Date.now();
+
+    // The gate refuses before anything announces, so the audit row is the only
+    // record of this attempt existing. Without its own start it could never be
+    // ordered against the calls around it.
+    expect(started).not.toHaveBeenCalled();
+    expect(appendAuditRecord).toHaveBeenCalledTimes(1);
+    const input = appendAuditRecord.mock.calls[0]?.[0] as {
+      outcome: { kind: string };
+      startedAt: number;
+    };
+    expect(input.outcome.kind).toBe("unauthorized");
+    expect(input.startedAt).toBeGreaterThanOrEqual(before);
+    expect(input.startedAt).toBeLessThanOrEqual(after);
   });
 
   it('flags danger:"confirm" tools on the started event', async () => {

--- a/electron/services/mcp-server/__tests__/sessionServer.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionServer.test.ts
@@ -899,9 +899,11 @@ describe("CallTool idempotency dedup", () => {
           resolveDispatch = resolve as (envelope: unknown) => void;
         })
     );
+    const appendAuditRecord = vi.fn();
     const deps = fakeDeps({
       sessionStore: fakeSessionStore("system"),
       dispatchAction,
+      appendAuditRecord,
     });
     const server = createSessionServer("dedup-1", deps);
 
@@ -929,6 +931,21 @@ describe("CallTool idempotency dedup", () => {
     expect(dispatchAction).toHaveBeenCalledTimes(1);
     expect(resultA).toEqual(resultB);
     expect((resultA as { content: Array<{ text: string }> }).content[0].text).toContain("t-1");
+
+    // The in-flight dedup row is the case `startedAt` exists for (#12122):
+    // audit-write order and arrival order genuinely disagree here. B's `dedup`
+    // row is written while A is still suspended on the held dispatch, so it
+    // lands FIRST even though A arrived first — a reader ordering by write
+    // time would invert the two. Their starts restore the truth.
+    const calls = appendAuditRecord.mock.calls.map(
+      (call) => call[0] as { outcome: { kind: string }; startedAt: number }
+    );
+    expect(calls.map((c) => c.outcome.kind)).toEqual(["dedup", "result"]);
+    const [dedupCall, dispatchCall] = calls;
+    expect(typeof dedupCall!.startedAt).toBe("number");
+    expect(typeof dispatchCall!.startedAt).toBe("number");
+    // A entered the handler no later than B, despite settling after it.
+    expect(dispatchCall!.startedAt).toBeLessThanOrEqual(dedupCall!.startedAt);
   });
 
   it("returns the cached result for a post-completion duplicate within TTL", async () => {
@@ -1174,25 +1191,26 @@ describe("CallTool idempotency dedup", () => {
     await callTool(server, { name: "terminal.new", arguments: args });
     await callTool(server, { name: "terminal.new", arguments: args });
 
-    const outcomes = appendAuditRecord.mock.calls.map(
-      (call) => (call[0] as { outcome: { kind: string } }).outcome.kind
+    const calls = appendAuditRecord.mock.calls.map(
+      (call) => call[0] as { outcome: { kind: string }; startedAt: number }
     );
-    expect(outcomes).toContain("dedup");
-    expect(outcomes.filter((k) => k === "dedup")).toHaveLength(1);
+    const outcomes = calls.map((c) => c.outcome.kind);
+    // The original's settlement row is written in the dispatch `finally`,
+    // which runs before the first awaited callTool returns — so the order is
+    // fixed, not merely "contains a dedup".
+    expect(outcomes).toEqual(["result", "dedup"]);
 
     // The suppressed duplicate is still a call the backend issued, so its row
     // carries its own start — that is what makes back-to-back vs. overlapping
     // dispatch distinguishable downstream (#12122).
-    const calls = appendAuditRecord.mock.calls.map(
-      (call) => call[0] as { outcome: { kind: string }; startedAt: number }
-    );
     for (const call of calls) {
       expect(typeof call.startedAt).toBe("number");
     }
-    const dedupCall = calls.find((c) => c.outcome.kind === "dedup");
-    const dispatchCall = calls.find((c) => c.outcome.kind === "result");
-    // Two separate CallTool handlers, so two distinct start snapshots — the
-    // dedup row must not borrow the original dispatch's start.
+    const [dispatchCall, dedupCall] = calls;
+    // Two separate CallTool handlers, each taking its own snapshot. They can
+    // legitimately land in the same millisecond, so this asserts ordering, not
+    // distinctness — the guarantee is that the dedup row never reaches back
+    // for a start earlier than the call it duplicated.
     expect(dedupCall!.startedAt).toBeGreaterThanOrEqual(dispatchCall!.startedAt);
   });
 

--- a/electron/services/mcp-server/auditLog.ts
+++ b/electron/services/mcp-server/auditLog.ts
@@ -164,9 +164,11 @@ export class AuditService {
     args: unknown;
     durationMs: number;
     /**
-     * Dispatch-start snapshot from the CallTool handler. Optional here because
-     * `recordAuth401` writes pre-auth rows that never had a handler; the
-     * `SessionServerDeps` carrier makes it required for every real dispatch.
+     * Dispatch-start snapshot from the CallTool handler. Optional only so this
+     * input keeps the same shape as the persisted record, whose field is
+     * optional for rows predating it. Every real dispatch supplies it: the
+     * `SessionServerDeps.appendAuditRecord` carrier upstream makes it required,
+     * so a CallTool site cannot reach here without one.
      */
     startedAt?: number;
     outcome: AuditOutcome;

--- a/electron/services/mcp-server/auditLog.ts
+++ b/electron/services/mcp-server/auditLog.ts
@@ -163,6 +163,12 @@ export class AuditService {
     tier: McpTier;
     args: unknown;
     durationMs: number;
+    /**
+     * Dispatch-start snapshot from the CallTool handler. Optional here because
+     * `recordAuth401` writes pre-auth rows that never had a handler; the
+     * `SessionServerDeps` carrier makes it required for every real dispatch.
+     */
+    startedAt?: number;
     outcome: AuditOutcome;
     confirmationDecision?: McpConfirmationDecision;
     argsSummary: string;
@@ -192,6 +198,12 @@ export class AuditService {
       schemaVersion: MCP_AUDIT_SCHEMA_VERSION,
       severity: computeMcpAuditSeverity(classification.result, classification.errorCode),
     };
+    // Stored verbatim — unlike `durationMs`, which is clamped because a
+    // wall-clock step can make an elapsed interval negative. `startedAt` is an
+    // absolute epoch reading; rounding or flooring it would fabricate.
+    if (input.startedAt !== undefined) {
+      record.startedAt = input.startedAt;
+    }
     if (classification.errorCode !== undefined) {
       record.errorCode = classification.errorCode;
     }

--- a/electron/services/mcp-server/sessionServer.ts
+++ b/electron/services/mcp-server/sessionServer.ts
@@ -308,6 +308,16 @@ export interface SessionServerDeps {
     tier: McpTier;
     args: unknown;
     durationMs: number;
+    /**
+     * The handler's dispatch-start snapshot (#12122), forwarded so the
+     * persisted record carries the same start the live strip's started event
+     * does. Required — the audit record's own `timestamp` is a later clock
+     * read, so a site that omitted this would leave its row unable to be
+     * ordered against its siblings. Every CallTool audit write has it in
+     * scope; making it mandatory here is what stops the next one from
+     * dropping it.
+     */
+    startedAt: number;
     outcome: AuditOutcome;
     confirmationDecision?: import("../../../shared/types/ipc/mcpServer.js").McpConfirmationDecision;
     bannerSuppressed?: boolean;
@@ -860,6 +870,7 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
           tier,
           args,
           durationMs: Date.now() - startedAt,
+          startedAt,
           outcome: { kind: "unauthorized" },
           bannerSuppressed: suppressBanner ? true : undefined,
           capturedTurnId,
@@ -934,6 +945,7 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
             tier,
             args,
             durationMs: Date.now() - startedAt,
+            startedAt,
             outcome: { kind: "throw", error: err },
             capturedTurnId,
           });
@@ -1019,6 +1031,7 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
             tier,
             args,
             durationMs: Date.now() - startedAt,
+            startedAt,
             outcome: { kind: "result", value },
             capturedTurnId,
           });
@@ -1100,6 +1113,7 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
                 tier,
                 args,
                 durationMs: Date.now() - startedAt,
+                startedAt,
                 outcome: { kind: "collision" },
                 capturedTurnId,
               });
@@ -1120,6 +1134,7 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
               tier,
               args,
               durationMs: Date.now() - startedAt,
+              startedAt,
               outcome: { kind: "dedup" },
               capturedTurnId,
             });
@@ -1141,6 +1156,7 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
               tier,
               args,
               durationMs: Date.now() - startedAt,
+              startedAt,
               outcome: { kind: "collision" },
               capturedTurnId,
             });
@@ -1161,6 +1177,7 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
             tier,
             args,
             durationMs: Date.now() - startedAt,
+            startedAt,
             outcome: { kind: "dedup" },
             capturedTurnId,
           });
@@ -1841,6 +1858,7 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
             tier,
             args,
             durationMs,
+            startedAt,
             outcome: settledOutcome,
             confirmationDecision,
             capturedTurnId,

--- a/shared/types/ipc/mcpServer.ts
+++ b/shared/types/ipc/mcpServer.ts
@@ -116,11 +116,11 @@ export interface McpAuditRecord {
   timestamp: number;
   /**
    * Epoch ms snapshotted once at CallTool-handler entry — the same value the
-   * live {@link McpToolCallStartedPayload} carries, never a re-read. Lets a
-   * reader order dispatches by true arrival and compute real overlap
-   * (`startA < endB && startB < endA`) to tell whether an assistant backend
-   * issues MCP calls concurrently or serially, which `durationMs` alone can't
-   * answer (#12122).
+   * live {@link McpToolCallStartedPayload} carries, never a re-read. This is
+   * the authoritative arrival time: it is what lets a reader sort dispatches
+   * by the order the backend actually issued them and tell whether an
+   * assistant issues MCP calls concurrently or serially, which `durationMs`
+   * alone cannot answer (#12122).
    *
    * Present on every CallTool record including the gate outcomes
    * (unauthorized / dedup / collision) — those are real attempts the backend
@@ -128,6 +128,13 @@ export interface McpAuditRecord {
    * underlying action ran; `result` is what says that. Absent on pre-auth
    * rejections (no handler exists yet) and on records written before the
    * field existed.
+   *
+   * Ordering is sound everywhere; treating `startedAt + durationMs` as the
+   * call's end is not. The in-flight dedup row is appended when the duplicate
+   * is *detected*, before the handler awaits the call it duplicated, so its
+   * duration covers detection rather than the caller's real wait — an overlap
+   * test against that row understates it. Finding an in-flight entry is itself
+   * proof the two calls overlapped.
    */
   startedAt?: number;
   toolId: string;

--- a/shared/types/ipc/mcpServer.ts
+++ b/shared/types/ipc/mcpServer.ts
@@ -105,7 +105,31 @@ export function computeMcpAuditSeverity(
 
 export interface McpAuditRecord {
   id: string;
+  /**
+   * When the record was written — the outcome-decision time, not the moment
+   * the caller got its response. For the in-flight dedup gate that is when the
+   * duplicate was detected, before the handler awaits the original promise.
+   * Do not reconstruct the start as `timestamp - durationMs`: the two come
+   * from different clock reads separated by the audit's own summarize/redact
+   * work, so they disagree. Use {@link McpAuditRecord.startedAt} (#12122).
+   */
   timestamp: number;
+  /**
+   * Epoch ms snapshotted once at CallTool-handler entry — the same value the
+   * live {@link McpToolCallStartedPayload} carries, never a re-read. Lets a
+   * reader order dispatches by true arrival and compute real overlap
+   * (`startA < endB && startB < endA`) to tell whether an assistant backend
+   * issues MCP calls concurrently or serially, which `durationMs` alone can't
+   * answer (#12122).
+   *
+   * Present on every CallTool record including the gate outcomes
+   * (unauthorized / dedup / collision) — those are real attempts the backend
+   * made, so they count for concurrency. Presence does NOT imply the
+   * underlying action ran; `result` is what says that. Absent on pre-auth
+   * rejections (no handler exists yet) and on records written before the
+   * field existed.
+   */
+  startedAt?: number;
   toolId: string;
   sessionId: string;
   /**


### PR DESCRIPTION
## Summary

- MCP audit records stored a completion `timestamp` and a `durationMs`, but never the call's actual start time, even though `sessionServer.ts` already snapshots `const startedAt = Date.now()` at handler entry and sends it to the live activity strip. Without it there's no way to tell whether an assistant backend is issuing MCP tool calls concurrently or serially.
- Reconstructing the start as `timestamp - durationMs` doesn't work, and that's the real bug here: `durationMs` is measured at the call site, but `timestamp` is a separate, later `Date.now()` taken inside `appendRecord`, after the record's own summarize-and-redact work (which can walk up to 1500 characters of tool output). The two reads are separated by real work, so the reconstructed start lands after the true start by an unbounded amount.
- The fix: `McpAuditRecord` gains an optional `startedAt`, populated from the same original snapshot rather than a fresh read, following the same discipline used for `capturedTurnId` in #10067.

Resolves #12122

## Changes

- Threaded `startedAt` through all eight audit write sites in the CallTool handler.
- `SessionServerDeps.appendAuditRecord` makes the field required, so any call site that omits it fails to compile instead of silently writing a row that can't be ordered. The persisted record field itself stays optional, to cover rows written before this change.
- Gate outcomes (unauthorized, dedup, collision) carry `startedAt` too. Those are real attempts the backend made, so they should count toward measuring concurrency. Presence of the field doesn't mean the underlying action ran; that's what `result` is for.
- Left `MCP_AUDIT_SCHEMA_VERSION` at 1, matching how every prior additive optional field has landed.
- Didn't touch `httpLifecycle.ts`. Its `{ capturedTurnId, ...recordInput }` rest spread already forwards the field, and that hop is now covered by a compile-checked `Pick<SessionServerDeps, ...>` test view instead of an untyped carrier.

**Known limitation** (already documented in the type, not introduced here): the in-flight dedup row appends its audit record when the duplicate is *detected*, before the handler awaits the call it duplicated, so that row's `durationMs` covers detection time, not the caller's real wait. Ordering by `startedAt` is sound everywhere; treating `startedAt + durationMs` as the call's end isn't, for that one row. Fixing it properly means either moving the append past the awaited promise (which loses the row entirely if that promise rejects) or adding a separate settlement field. Out of scope here.

Also deliberately deferred: an arrival ordinal for same-millisecond tie-breaking. Minting one at write time would just encode settlement order, not arrival order, which defeats the purpose. A real one needs this same dispatch-start plumbing first.

## Testing

- 17 test files / 1063 tests pass locally: the mcp-server suites plus every downstream consumer (turn-outcome log, anomaly store/hooks, audit log viewer, activity strip, forge audit).
- Typecheck clean.
- Prettier and eslint clean on all changed files.