### PR TITLE
fix(mcp): bar unbounded fan-out tools from native automation grants

### DIFF
--- a/docs/architecture/mcp-server.md
+++ b/docs/architecture/mcp-server.md
@@ -371,6 +371,10 @@ tools/call(actionId, args)
   │      │  nothing; the same held when a per-tool grant had just admitted it.
   │      │  Skipped only for an already-admitted introspection carrier, which
   │      │  can never raise a modal, so a peek would just drain the budget.
+  │      │  Refused outright for a per-resolved-target tool (#12121) —
+  │      │  terminal.killAll / terminal.closeAll act on every target they find,
+  │      │  so no use count bounds them; issuance rejects such a scope and the
+  │      │  peek refuses one minted around it.
   │      ├─ granted → capture grantId (widens the floor AND pre-authorizes
   │      │            confirm; the use is charged later, at commit-to-dispatch)
   │      └─ neither gate 1 nor a grant admitted it → incrementDenial → maybe
@@ -407,6 +411,8 @@ tools/call(actionId, args)
 ```
 
 Gate order is load-bearing: a native grant's use is charged **after** admission and after the workspace-bound confirm ceiling — an unauthorized or refused call must never burn one — but **before** dedup, so a replayed duplicate spends a use without dispatching. The per-call rate limiter that used to sit between admission and dedup was removed in #10764.
+
+One use is also the only cost the charge site can express, and it is charged before dispatch — so a tool whose target set is resolved from live renderer state inside `run()` has no honest count available at the moment it would be billed. Those tools are barred from native grants entirely (`shared/config/nativeGrantUsePolicies.ts`) rather than under-charged: `HttpLifecycle.issueNativeGrant` rejects a scope naming one, and `peekNativeGrant`/`consumeNativeGrantUse` refuse one anyway as defence in depth. **A new destructive fan-out action must be added to that policy** — the default is `per-dispatch`, so an omission fails open.
 
 ### Dedup
 

--- a/electron/services/mcp-server/__tests__/grantCache.test.ts
+++ b/electron/services/mcp-server/__tests__/grantCache.test.ts
@@ -1,7 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { GrantCache } from "../grantCache.js";
 import { minimumPermittingTier } from "../shared.js";
-import { NATIVE_GRANT_USE_POLICY_OVERRIDES } from "../../../../shared/config/nativeGrantUsePolicies.js";
+import {
+  NATIVE_GRANT_USE_POLICY_OVERRIDES,
+  getNativeGrantUsePolicy,
+  isGenericNativeGrantEligible,
+} from "../../../../shared/config/nativeGrantUsePolicies.js";
+import { BUILT_IN_ACTION_IDS } from "../../../../shared/config/actionIds.js";
 import type { McpGrantLifecyclePayload } from "../../../../shared/types/ipc/mcpServer.js";
 
 interface EmittedEvent {
@@ -674,36 +679,49 @@ describe("GrantCache native grants (#10648)", () => {
     cache.dispose();
   });
 
-  it("peekNativeGrant refuses a per-resolved-target tool without consuming or emitting", () => {
-    const { cache, emitted } = newCache();
-    const entry = issue(cache, { allowedTools: ["git.commit", "terminal.killAll"] });
-    emitted.length = 0;
-    expect(cache.peekNativeGrant("s1", "terminal.killAll").granted).toBe(false);
-    expect(emitted).toHaveLength(0);
-    // The refusal is scoped to the tool, not the grant: an eligible sibling in
-    // the same allowlist must still be authorized, with the budget untouched.
-    expect(cache.peekNativeGrant("s1", "git.commit")).toEqual({ granted: true, grantId: entry.id });
-    expect(cache._peekNative(entry.id)?.remainingUses).toBe(3);
-    cache.dispose();
-  });
+  // Both policy ids, not just the destructive one: terminal.closeAll is
+  // `danger: "safe"`, so it exercises the leg where a grant only ever widened
+  // the tier floor and never bought a confirm bypass.
+  it.each(["terminal.killAll", "terminal.closeAll"])(
+    "peekNativeGrant refuses %s without consuming or emitting",
+    (fanOutTool) => {
+      const { cache, emitted } = newCache();
+      const entry = issue(cache, { allowedTools: ["git.commit", fanOutTool] });
+      emitted.length = 0;
+      expect(cache.peekNativeGrant("s1", fanOutTool).granted).toBe(false);
+      expect(emitted).toHaveLength(0);
+      // The refusal is scoped to the tool, not the grant: an eligible sibling in
+      // the same allowlist must still be authorized, with the budget untouched.
+      expect(cache.peekNativeGrant("s1", "git.commit")).toEqual({
+        granted: true,
+        grantId: entry.id,
+      });
+      expect(cache._peekNative(entry.id)?.remainingUses).toBe(3);
+      cache.dispose();
+    }
+  );
 
-  it("consumeNativeGrantUse fails closed for a per-resolved-target tool without decrementing", () => {
-    const { cache, emitted } = newCache();
-    const entry = issue(cache, { allowedTools: ["git.commit", "terminal.killAll"] });
-    emitted.length = 0;
-    expect(cache.consumeNativeGrantUse(entry.id, "terminal.killAll")).toBe(false);
-    expect(emitted).toHaveLength(0);
-    // Nothing was authorized, so nothing was spent — and the grant survives for
-    // the siblings it legitimately covers.
-    expect(cache._peekNative(entry.id)?.remainingUses).toBe(3);
-    expect(cache.consumeNativeGrantUse(entry.id, "git.commit")).toBe(true);
-    cache.dispose();
-  });
+  it.each(["terminal.killAll", "terminal.closeAll"])(
+    "consumeNativeGrantUse fails closed for %s without decrementing",
+    (fanOutTool) => {
+      const { cache, emitted } = newCache();
+      const entry = issue(cache, { allowedTools: ["git.commit", fanOutTool] });
+      emitted.length = 0;
+      expect(cache.consumeNativeGrantUse(entry.id, fanOutTool)).toBe(false);
+      expect(emitted).toHaveLength(0);
+      // Nothing was authorized, so nothing was spent — and the grant survives for
+      // the siblings it legitimately covers.
+      expect(cache._peekNative(entry.id)?.remainingUses).toBe(3);
+      expect(cache.consumeNativeGrantUse(entry.id, "git.commit")).toBe(true);
+      cache.dispose();
+    }
+  );
 
   it("consumeNativeGrantUse reports expiry before refusing a per-resolved-target tool", () => {
-    // Pins the check order: the policy refusal sits AFTER the TTL/ceiling
-    // check, so a caller holding a stale grant id still learns the grant aged
-    // out rather than being told only that the tool was ineligible.
+    // An ORDER-LOCK, not coverage of the refusal itself — every assertion here
+    // also holds without the policy guard. What it catches is the guard being
+    // hoisted above the TTL/ceiling block, which would swallow the eviction and
+    // its `grant.expired` signal for a caller holding a stale id.
     let clock = 0;
     const { cache, emitted } = newCache({ ttlMs: 1000, maxLifetimeMs: 100000, now: () => clock });
     const entry = issue(cache, {
@@ -718,17 +736,41 @@ describe("GrantCache native grants (#10648)", () => {
     cache.dispose();
   });
 
-  it("every per-resolved-target override names a tool a grant could otherwise reach", () => {
+  // Naming the hazardous ids outright rather than asserting over whatever the
+  // map happens to contain: a generic "every entry is well-formed" check stays
+  // green when an entry is DELETED, which is the regression that reopens the
+  // hole. These two must be declared, by id, forever.
+  it.each(["terminal.killAll", "terminal.closeAll"])(
+    "%s is declared per-resolved-target and stays grant-ineligible",
+    (toolId) => {
+      expect(getNativeGrantUsePolicy(toolId)).toBe("per-resolved-target");
+      expect(isGenericNativeGrantEligible(toolId)).toBe(false);
+    }
+  );
+
+  it("every per-resolved-target override names a real tool a grant could otherwise reach", () => {
     // The policy is keyed by tool id and defaults to `per-dispatch`, so a
     // renamed or retired action would silently fall back to being grantable
-    // again — reopening exactly the hole #12121 closed. Fail here instead.
+    // again. `BuiltInActionId` typing does not catch this on its own — it also
+    // admits keybinding-only ids that no action registers.
     const overrides = Object.entries(NATIVE_GRANT_USE_POLICY_OVERRIDES);
     expect(overrides.length).toBeGreaterThan(0);
     for (const [toolId, policy] of overrides) {
       expect(policy).toBe("per-resolved-target");
+      expect(BUILT_IN_ACTION_IDS, `${toolId} is not a registered action id`).toContain(toolId);
       expect(minimumPermittingTier(toolId), `${toolId} is no longer a grantable tool id`).not.toBe(
         null
       );
+    }
+  });
+
+  it("treats a prototype-shaped tool id as an ordinary per-dispatch tool", () => {
+    // The lookup is a Map, not a bare index into an object literal, because
+    // `toolId` arrives from the MCP surface: an object literal would resolve
+    // "toString" to an inherited function and this would not be "per-dispatch".
+    for (const toolId of ["toString", "constructor", "__proto__", "hasOwnProperty"]) {
+      expect(getNativeGrantUsePolicy(toolId)).toBe("per-dispatch");
+      expect(isGenericNativeGrantEligible(toolId)).toBe(true);
     }
   });
 

--- a/electron/services/mcp-server/__tests__/grantCache.test.ts
+++ b/electron/services/mcp-server/__tests__/grantCache.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { GrantCache } from "../grantCache.js";
+import { minimumPermittingTier } from "../shared.js";
+import { NATIVE_GRANT_USE_POLICY_OVERRIDES } from "../../../../shared/config/nativeGrantUsePolicies.js";
 import type { McpGrantLifecyclePayload } from "../../../../shared/types/ipc/mcpServer.js";
 
 interface EmittedEvent {
@@ -670,6 +672,64 @@ describe("GrantCache native grants (#10648)", () => {
     expect(cache.consumeNativeGrantUse(entry.id, "git.commit")).toBe(false);
     expect(cache._peekNative(entry.id)).toBeUndefined();
     cache.dispose();
+  });
+
+  it("peekNativeGrant refuses a per-resolved-target tool without consuming or emitting", () => {
+    const { cache, emitted } = newCache();
+    const entry = issue(cache, { allowedTools: ["git.commit", "terminal.killAll"] });
+    emitted.length = 0;
+    expect(cache.peekNativeGrant("s1", "terminal.killAll").granted).toBe(false);
+    expect(emitted).toHaveLength(0);
+    // The refusal is scoped to the tool, not the grant: an eligible sibling in
+    // the same allowlist must still be authorized, with the budget untouched.
+    expect(cache.peekNativeGrant("s1", "git.commit")).toEqual({ granted: true, grantId: entry.id });
+    expect(cache._peekNative(entry.id)?.remainingUses).toBe(3);
+    cache.dispose();
+  });
+
+  it("consumeNativeGrantUse fails closed for a per-resolved-target tool without decrementing", () => {
+    const { cache, emitted } = newCache();
+    const entry = issue(cache, { allowedTools: ["git.commit", "terminal.killAll"] });
+    emitted.length = 0;
+    expect(cache.consumeNativeGrantUse(entry.id, "terminal.killAll")).toBe(false);
+    expect(emitted).toHaveLength(0);
+    // Nothing was authorized, so nothing was spent — and the grant survives for
+    // the siblings it legitimately covers.
+    expect(cache._peekNative(entry.id)?.remainingUses).toBe(3);
+    expect(cache.consumeNativeGrantUse(entry.id, "git.commit")).toBe(true);
+    cache.dispose();
+  });
+
+  it("consumeNativeGrantUse reports expiry before refusing a per-resolved-target tool", () => {
+    // Pins the check order: the policy refusal sits AFTER the TTL/ceiling
+    // check, so a caller holding a stale grant id still learns the grant aged
+    // out rather than being told only that the tool was ineligible.
+    let clock = 0;
+    const { cache, emitted } = newCache({ ttlMs: 1000, maxLifetimeMs: 100000, now: () => clock });
+    const entry = issue(cache, {
+      allowedTools: ["git.commit", "terminal.killAll"],
+      ttlMs: 1000,
+    });
+    emitted.length = 0;
+    clock = 2000;
+    expect(cache.consumeNativeGrantUse(entry.id, "terminal.killAll")).toBe(false);
+    expect(emitted.some((e) => e.payload.type === "grant.expired")).toBe(true);
+    expect(cache._peekNative(entry.id)).toBeUndefined();
+    cache.dispose();
+  });
+
+  it("every per-resolved-target override names a tool a grant could otherwise reach", () => {
+    // The policy is keyed by tool id and defaults to `per-dispatch`, so a
+    // renamed or retired action would silently fall back to being grantable
+    // again — reopening exactly the hole #12121 closed. Fail here instead.
+    const overrides = Object.entries(NATIVE_GRANT_USE_POLICY_OVERRIDES);
+    expect(overrides.length).toBeGreaterThan(0);
+    for (const [toolId, policy] of overrides) {
+      expect(policy).toBe("per-resolved-target");
+      expect(minimumPermittingTier(toolId), `${toolId} is no longer a grantable tool id`).not.toBe(
+        null
+      );
+    }
   });
 
   it("a grant past the hard ceiling fails closed (peek) and emits grant-ceiling revoke", () => {

--- a/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
+++ b/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
@@ -698,6 +698,33 @@ describe("HttpLifecycle", () => {
       expect(grantCacheOf(deps).issueNativeGrant).not.toHaveBeenCalled();
     });
 
+    it("rejects a fan-out tool a use count cannot bound (#12121)", () => {
+      const deps = fakeDeps();
+      resolverOf(deps).mockReturnValue("transport-1");
+      const lc = new HttpLifecycle(deps);
+      for (const toolId of ["terminal.killAll", "terminal.closeAll"]) {
+        // Both are real, tier-reachable tools — so it is the fan-out policy
+        // refusing them here, not the unknown-tool check above.
+        expect(minimumPermittingTier(toolId)).not.toBe(null);
+        expect(() => lc.issueNativeGrant("help-1", { allowedTools: [toolId] }, 42)).toThrow(
+          /cannot cover/
+        );
+      }
+      expect(grantCacheOf(deps).issueNativeGrant).not.toHaveBeenCalled();
+    });
+
+    it("rejects a mixed scope rather than silently narrowing it (#12121)", () => {
+      const deps = fakeDeps();
+      resolverOf(deps).mockReturnValue("transport-1");
+      const lc = new HttpLifecycle(deps);
+      // The minted scope must be exactly the scope the user approved: dropping
+      // the offender would hand back a grant card that reads as approved-in-full.
+      expect(() =>
+        lc.issueNativeGrant("help-1", { allowedTools: ["git.commit", "terminal.killAll"] }, 42)
+      ).toThrow(/terminal\.killAll/);
+      expect(grantCacheOf(deps).issueNativeGrant).not.toHaveBeenCalled();
+    });
+
     it("rejects an out-of-range maxUses", () => {
       const deps = fakeDeps();
       resolverOf(deps).mockReturnValue("transport-1");

--- a/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
+++ b/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
@@ -709,7 +709,7 @@ describe("HttpLifecycle", () => {
         // Names the offender AND the reason: `/cannot cover/` alone would also
         // pass if the tool had merely fallen out of every tier allowlist.
         expect(() => lc.issueNativeGrant("help-1", { allowedTools: [toolId] }, 42)).toThrow(
-          new RegExp(`cannot cover ${toolId.replace(".", "\\.")}\\b.*every target it finds`)
+          new RegExp(`cannot cover ${toolId.replaceAll(".", "\\.")}\\b.*every target it finds`)
         );
       }
       expect(grantCacheOf(deps).issueNativeGrant).not.toHaveBeenCalled();
@@ -720,10 +720,17 @@ describe("HttpLifecycle", () => {
       resolverOf(deps).mockReturnValue("transport-1");
       const lc = new HttpLifecycle(deps);
       // The minted scope must be exactly the scope the user approved: dropping
-      // the offender would hand back a grant card that reads as approved-in-full.
-      expect(() =>
-        lc.issueNativeGrant("help-1", { allowedTools: ["git.commit", "terminal.killAll"] }, 42)
-      ).toThrow(/cannot cover terminal\.killAll\b/);
+      // the offenders would hand back a grant card that reads as approved-in-full.
+      // Two of them, so this also pins the plural branch of the message — with
+      // one offender the singular wording passes either way.
+      const attempt = () =>
+        lc.issueNativeGrant(
+          "help-1",
+          { allowedTools: ["git.commit", "terminal.killAll", "terminal.closeAll"] },
+          42
+        );
+      expect(attempt).toThrow(/cannot cover terminal\.killAll, terminal\.closeAll\b/);
+      expect(attempt).toThrow(/Remove them\b/);
       expect(grantCacheOf(deps).issueNativeGrant).not.toHaveBeenCalled();
     });
 

--- a/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
+++ b/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
@@ -706,8 +706,10 @@ describe("HttpLifecycle", () => {
         // Both are real, tier-reachable tools — so it is the fan-out policy
         // refusing them here, not the unknown-tool check above.
         expect(minimumPermittingTier(toolId)).not.toBe(null);
+        // Names the offender AND the reason: `/cannot cover/` alone would also
+        // pass if the tool had merely fallen out of every tier allowlist.
         expect(() => lc.issueNativeGrant("help-1", { allowedTools: [toolId] }, 42)).toThrow(
-          /cannot cover/
+          new RegExp(`cannot cover ${toolId.replace(".", "\\.")}\\b.*every target it finds`)
         );
       }
       expect(grantCacheOf(deps).issueNativeGrant).not.toHaveBeenCalled();
@@ -721,7 +723,7 @@ describe("HttpLifecycle", () => {
       // the offender would hand back a grant card that reads as approved-in-full.
       expect(() =>
         lc.issueNativeGrant("help-1", { allowedTools: ["git.commit", "terminal.killAll"] }, 42)
-      ).toThrow(/terminal\.killAll/);
+      ).toThrow(/cannot cover terminal\.killAll\b/);
       expect(grantCacheOf(deps).issueNativeGrant).not.toHaveBeenCalled();
     });
 

--- a/electron/services/mcp-server/__tests__/sessionServer.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionServer.test.ts
@@ -2619,6 +2619,7 @@ describe("sessionServer grant cache fallback (#8442)", () => {
       maxUses: 3,
     });
     const consumeSpy = vi.spyOn(sessionStore.grantCache, "consumeNativeGrantUse");
+    const refreshSpy = vi.spyOn(sessionStore.grantCache, "refreshNativeGrant");
     const dispatchAction = vi.fn().mockResolvedValue({ result: { ok: true, result: { ok: 1 } } });
     const deps = fakeDeps({ sessionStore, dispatchAction });
     const server = createSessionServer("s", deps);
@@ -2635,6 +2636,10 @@ describe("sessionServer grant cache fallback (#8442)", () => {
     expect(dispatchAction).toHaveBeenCalledWith("terminal.killAll", expect.any(Object), false);
     expect(consumeSpy).not.toHaveBeenCalled();
     expect(sessionStore.grantCache._peekNative(grant.id)?.remainingUses).toBe(3);
+    // An untouched budget alone would not prove the grant was left alone: the
+    // post-dispatch refresh slides `expiresAt`, so a refused tool must not
+    // extend the window its eligible siblings are still running on.
+    expect(refreshSpy).not.toHaveBeenCalled();
     sessionStore.grantCache.dispose();
   });
 
@@ -2658,9 +2663,12 @@ describe("sessionServer grant cache fallback (#8442)", () => {
     const result = (await callTool(server, {
       name: "terminal.killAll",
       arguments: {},
-    })) as { isError?: boolean };
+    })) as { isError?: boolean; content: Array<{ type: string; text: string }> };
 
     expect(result.isError).toBe(true);
+    // The specific code matters: this must read as an authorization denial the
+    // caller can act on, not a generic dispatch failure.
+    expect(JSON.parse(result.content[0]!.text)).toMatchObject({ code: TIER_NOT_PERMITTED_CODE });
     expect(dispatchAction).not.toHaveBeenCalled();
     expect(sessionStore.grantCache._peekNative(grant.id)?.remainingUses).toBe(3);
     sessionStore.grantCache.dispose();
@@ -4404,6 +4412,32 @@ describe("sessionServer introspection tier filtering", () => {
       expect(payload<{ actions: ActionManifestEntry[] }>(res).actions.map((a) => a.id)).toEqual([
         "git.push",
         "git.commit",
+      ]);
+
+      deps.sessionStore.grantCache.dispose();
+    });
+
+    it("does not surface a per-resolved-target tool a native grant cannot admit (#12121)", async () => {
+      // The mirror of the test above. `peekNativeGrant` refuses terminal.killAll,
+      // so listing it here would produce the discoverable-but-uncallable state
+      // #11585 rejects: the agent finds the tool, calls it, and is told
+      // TIER_NOT_PERMITTED. The eligible sibling proves the grant is otherwise
+      // live, so the omission is the policy and not a dead grant.
+      const deps = introspectionDeps("workbench", {
+        actions: [entry("git.push"), entry("terminal.killAll"), entry("terminal.closeAll")],
+      });
+      const server = createSessionServer("s1", deps);
+      deps.sessionStore.grantCache.issueNativeGrant({
+        sessionId: "s1",
+        actorId: "test-actor",
+        actorType: "help-session",
+        allowedTools: ["git.push", "terminal.killAll", "terminal.closeAll"],
+        maxUses: 5,
+      });
+
+      const res = await callTool(server, { name: "actions.list" });
+      expect(payload<{ actions: ActionManifestEntry[] }>(res).actions.map((a) => a.id)).toEqual([
+        "git.push",
       ]);
 
       deps.sessionStore.grantCache.dispose();

--- a/electron/services/mcp-server/__tests__/sessionServer.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionServer.test.ts
@@ -2603,6 +2603,69 @@ describe("sessionServer grant cache fallback (#8442)", () => {
     sessionStore.grantCache.dispose();
   });
 
+  it("terminal.killAll cannot ride a native grant past the confirm modal (#12121)", async () => {
+    // Issuance refuses a scope naming a fan-out tool, so this grant is minted
+    // through the cache directly — the stale/hand-rolled state the peek and
+    // consume guards exist to catch. The floor already admits terminal.killAll
+    // at the system tier, so the call must still run; what it must NOT do is
+    // arrive pre-confirmed or spend a use, because `maxUses` cannot express
+    // "every terminal in the project".
+    const sessionStore = fakeSessionStore("system");
+    const grant = sessionStore.grantCache.issueNativeGrant({
+      sessionId: "s",
+      actorId: "help-1",
+      actorType: "help-session",
+      allowedTools: ["terminal.killAll"],
+      maxUses: 3,
+    });
+    const consumeSpy = vi.spyOn(sessionStore.grantCache, "consumeNativeGrantUse");
+    const dispatchAction = vi.fn().mockResolvedValue({ result: { ok: true, result: { ok: 1 } } });
+    const deps = fakeDeps({ sessionStore, dispatchAction });
+    const server = createSessionServer("s", deps);
+    await server.connect(makeMockTransport());
+
+    const result = (await callTool(server, {
+      name: "terminal.killAll",
+      arguments: {},
+    })) as { isError?: boolean };
+
+    expect(result.isError).not.toBe(true);
+    // Dispatched, but unconfirmed — the renderer's modal decides, exactly as it
+    // would with no grant at all.
+    expect(dispatchAction).toHaveBeenCalledWith("terminal.killAll", expect.any(Object), false);
+    expect(consumeSpy).not.toHaveBeenCalled();
+    expect(sessionStore.grantCache._peekNative(grant.id)?.remainingUses).toBe(3);
+    sessionStore.grantCache.dispose();
+  });
+
+  it("a native grant cannot admit terminal.killAll below the tier floor (#12121)", async () => {
+    // The other leg: at workbench tier nothing else admits the call, so a grant
+    // that covered it would be the authorization itself. It must fail closed
+    // rather than fall through to an unauthorized dispatch.
+    const sessionStore = fakeSessionStore("workbench");
+    const grant = sessionStore.grantCache.issueNativeGrant({
+      sessionId: "s",
+      actorId: "help-1",
+      actorType: "help-session",
+      allowedTools: ["terminal.killAll"],
+      maxUses: 3,
+    });
+    const dispatchAction = vi.fn().mockResolvedValue({ result: { ok: true, result: { ok: 1 } } });
+    const deps = fakeDeps({ sessionStore, dispatchAction });
+    const server = createSessionServer("s", deps);
+    await server.connect(makeMockTransport());
+
+    const result = (await callTool(server, {
+      name: "terminal.killAll",
+      arguments: {},
+    })) as { isError?: boolean };
+
+    expect(result.isError).toBe(true);
+    expect(dispatchAction).not.toHaveBeenCalled();
+    expect(sessionStore.grantCache._peekNative(grant.id)?.remainingUses).toBe(3);
+    sessionStore.grantCache.dispose();
+  });
+
   it("an already-admitted introspection carrier does not spend a native use (#11878)", async () => {
     // actions.search can never raise a confirm modal, so once the floor has
     // admitted it a grant buys it nothing — peeking would only drain the

--- a/electron/services/mcp-server/__tests__/tierAuth.test.ts
+++ b/electron/services/mcp-server/__tests__/tierAuth.test.ts
@@ -1389,6 +1389,27 @@ describe("filterIntrospectionResultForSession", () => {
         expect(perToolGranted.requiresConfirmation).toBe(true);
       });
 
+      it("keeps requiresConfirmation set for a per-resolved-target tool (#12121)", () => {
+        // `peekNativeGrant` refuses terminal.killAll, so a grant listing it
+        // buys no bypass. Reading the allowlist alone would advertise one the
+        // dispatch gate will not honour.
+        // System tier so the floor admits the call on its own — this isolates
+        // the confirmation axis instead of collapsing the whole record.
+        const policy = policyOf(
+          lookup(makeEntry({ id: "terminal.killAll", danger: "confirm" }), {
+            permittedActionIds: new Set([...permitted, "terminal.killAll"]),
+            policySnapshot: snapshot({
+              tier: "system",
+              nativeGrantedActionIds: new Set(["terminal.killAll"]),
+            }),
+          })
+        );
+
+        expect(policy.danger).toBe("confirm");
+        expect(policy.requiresConfirmation).toBe(true);
+        expect(policy.authorizedBy).toBe("tier");
+      });
+
       it("reports the flat external tier rather than a rung the caller cannot climb", () => {
         const policy = policyOf(
           lookup(makeEntry({ id: "terminal.list" }), {

--- a/electron/services/mcp-server/grantCache.ts
+++ b/electron/services/mcp-server/grantCache.ts
@@ -5,6 +5,7 @@ import type {
   McpGrantRecordType,
   McpGrantRevokedReason,
 } from "../../../shared/types/ipc/mcpServer.js";
+import { isGenericNativeGrantEligible } from "../../../shared/config/nativeGrantUsePolicies.js";
 import {
   MCP_DENIAL_SILENCE_THRESHOLD,
   MCP_GRANT_MAX_LIFETIME_MS,
@@ -446,8 +447,15 @@ export class GrantCache {
    * tool. Expired / ceiling-past grants are lazily evicted (emitting the same
    * `grant.expired`/`grant.revoked` signals as the per-tool path) before being
    * skipped — eviction is hygiene, not use-consumption, so it is safe here.
+   *
+   * A tool whose cost is per-resolved-target (#12121) is refused outright,
+   * before any grant is examined: no grant can cover it, so walking the map
+   * could only evict entries on a call that was never going to be authorized.
+   * Issuance already rejects these tools, so reaching here means a grant was
+   * minted through the cache directly — defence in depth, not the main gate.
    */
   peekNativeGrant(sessionId: string, toolId: string): NativeGrantCheckResult {
+    if (!isGenericNativeGrantEligible(toolId)) return { granted: false };
     const now = this.now();
     for (const entry of this.nativeGrants.values()) {
       if (entry.sessionId !== sessionId) continue;
@@ -483,6 +491,12 @@ export class GrantCache {
    * natural terminal state, distinct from a forced revoke). Returns false and
    * fails closed when the grant is gone or has aged past its TTL/ceiling since
    * the peek — the caller must reject the dispatch in that case.
+   *
+   * Also fails closed for a per-resolved-target tool (#12121), after the
+   * TTL/ceiling checks so a caller holding a stale id still learns the grant
+   * aged out. A policy refusal leaves `remainingUses` untouched and emits no
+   * usage record — nothing was authorized, so nothing was spent — and does not
+   * delete the grant, which may still cover eligible siblings.
    */
   consumeNativeGrantUse(grantId: string, toolId: string): boolean {
     const entry = this.nativeGrants.get(grantId);
@@ -500,6 +514,7 @@ export class GrantCache {
       );
       return false;
     }
+    if (!isGenericNativeGrantEligible(toolId)) return false;
     if (entry.remainingUses <= 0) {
       this.nativeGrants.delete(grantId);
       return false;

--- a/electron/services/mcp-server/httpLifecycle.ts
+++ b/electron/services/mcp-server/httpLifecycle.ts
@@ -2107,8 +2107,10 @@ export class HttpLifecycle {
     const fanOut = allowedTools.filter((t) => !isGenericNativeGrantEligible(t));
     if (fanOut.length > 0) {
       throw new Error(
-        `A native grant cannot cover ${fanOut.join(", ")}: each call acts on every ` +
-          `target it finds, so a use count can't bound it. Remove it and approve those calls individually.`
+        `A native grant cannot cover ${fanOut.join(", ")}: each call acts on every target it ` +
+          `finds, so a use ceiling bounds how many calls run, never how much they affect. ` +
+          `Remove ${fanOut.length > 1 ? "them" : "it"} — those calls still run under the ` +
+          `session's normal tier and confirmation rules.`
       );
     }
 

--- a/electron/services/mcp-server/httpLifecycle.ts
+++ b/electron/services/mcp-server/httpLifecycle.ts
@@ -49,6 +49,7 @@ import type { AuditService } from "./auditLog.js";
 import { classifyMcpDispatchResult } from "./auditLog.js";
 import { computeMcpAuditSeverity } from "../../../shared/types/ipc/mcpServer.js";
 import { buildMcpClientConfig } from "../../../shared/config/mcpClientConfigs.js";
+import { isGenericNativeGrantEligible } from "../../../shared/config/nativeGrantUsePolicies.js";
 import type { TurnOutcomeService } from "./turnOutcomeLog.js";
 import type { AbusePolicy } from "./abusePolicy.js";
 import {
@@ -2096,6 +2097,19 @@ export class HttpLifecycle {
     const ungrantable = allowedTools.filter((t) => minimumPermittingTier(t) === null);
     if (ungrantable.length > 0) {
       throw new Error(`Unknown or non-grantable tool(s): ${ungrantable.join(", ")}`);
+    }
+    // A grant's `maxUses` is what the Settings card shows the user, so it has
+    // to mean something. For a tool that fans out across every target it
+    // resolves at dispatch time it cannot: the count isn't known when the use
+    // is charged, so "10 uses" would authorize ten unbounded sweeps (#12121).
+    // Reject the whole request rather than quietly dropping the offender —
+    // the minted scope must be exactly the scope the user approved.
+    const fanOut = allowedTools.filter((t) => !isGenericNativeGrantEligible(t));
+    if (fanOut.length > 0) {
+      throw new Error(
+        `A native grant cannot cover ${fanOut.join(", ")}: each call acts on every ` +
+          `target it finds, so a use count can't bound it. Remove it and approve those calls individually.`
+      );
     }
 
     const maxUses = params.maxUses ?? MCP_NATIVE_GRANT_DEFAULT_MAX_USES;

--- a/electron/services/mcp-server/sessionServer.ts
+++ b/electron/services/mcp-server/sessionServer.ts
@@ -1048,6 +1048,14 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
     // extend a confirm-gated sibling's bypass window (bounded by the hard
     // lifetime ceiling), and because this site precedes dedup, a replayed
     // duplicate spends a use without dispatching.
+    //
+    // One use is also the ONLY cost this site can express, which is why a tool
+    // that fans out across every target it resolves at dispatch time is barred
+    // from native grants entirely rather than charged here (#12121). Learning
+    // that count would mean reaching into the renderer before the charge — the
+    // async dependency the paragraph above rules out — so `peekNativeGrant`
+    // never hands one back a grant id and `nativeGrantId` stays undefined:
+    // no bypass, no use, and the confirm modal decides as it normally would.
     if (nativeGrantId !== undefined) {
       const consumed = sessionStore.grantCache.consumeNativeGrantUse(nativeGrantId, actionId);
       if (!consumed) {

--- a/electron/services/mcp-server/sessionServer.ts
+++ b/electron/services/mcp-server/sessionServer.ts
@@ -15,6 +15,7 @@ import {
   ErrorCode,
 } from "@modelcontextprotocol/sdk/types.js";
 import { dispatchCarriesRecipeId } from "../../../shared/utils/dispatchRecipeId.js";
+import { isGenericNativeGrantEligible } from "../../../shared/config/nativeGrantUsePolicies.js";
 import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
 import { getAgentAvailabilityStore } from "../AgentAvailabilityStore.js";
 import { events } from "../events.js";
@@ -674,10 +675,17 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
           const perToolGrantedActionIds = new Set<string>(
             sessionStore.grantCache.getLiveGrants(sessionId).map((grant) => grant.toolId)
           );
+          // Filtered to what the dispatch gate would actually honour: a grant
+          // listing a per-resolved-target tool buys nothing, because
+          // `peekNativeGrant` refuses it (#12121). Naming it here would produce
+          // the discoverable-but-uncallable state #11585 rejects — an agent
+          // would find `terminal.killAll` in `actions.search`, then be told
+          // TIER_NOT_PERMITTED when it called it.
           const nativeGrantedActionIds = new Set<string>(
             sessionStore.grantCache
               .getLiveNativeGrants(sessionId)
               .flatMap((grant) => [...grant.allowedTools])
+              .filter((toolId) => isGenericNativeGrantEligible(toolId))
           );
           return {
             permittedActionIds: new Set<string>([

--- a/electron/services/mcp-server/tierAuth.ts
+++ b/electron/services/mcp-server/tierAuth.ts
@@ -12,6 +12,7 @@ import {
   ACTIONS_SEARCH_DEFAULT_LIMIT,
   ACTIONS_SEARCH_MAX_LIMIT,
 } from "../../../shared/config/mcpIntrospection.js";
+import { isGenericNativeGrantEligible } from "../../../shared/config/nativeGrantUsePolicies.js";
 import { canonicalJson, toCompatibilityShape } from "./compatibilityHash.js";
 import type { McpTargetPolicy, McpTargetTier } from "../../../shared/types/mcpTargetPolicy.js";
 
@@ -400,7 +401,14 @@ export function buildTargetPolicy(
   // the one the dispatch gate would reach.
   const grantsReachable = snapshot.rendererOwnedOrigin;
   const perToolGranted = grantsReachable && snapshot.perToolGrantedActionIds.has(id);
-  const nativeGranted = grantsReachable && snapshot.nativeGrantedActionIds.has(id);
+  // Membership in a grant's allowlist is not the same question the gate asks:
+  // `peekNativeGrant` refuses a per-resolved-target tool outright (#12121), so
+  // reading the allowlist alone would promise a confirmation bypass the gate
+  // will not honour. Issuance already rejects such a scope, which makes this
+  // unreachable in practice — but the record has to agree with the gate by
+  // construction, not by relying on the mint path to stay closed.
+  const nativeGranted =
+    grantsReachable && snapshot.nativeGrantedActionIds.has(id) && isGenericNativeGrantEligible(id);
 
   // The caller's own ladder, never a rung it cannot climb. An external
   // allowlist is a flat peer of the in-app ladder, so `minimumPermittingTier` —

--- a/shared/config/nativeGrantUsePolicies.ts
+++ b/shared/config/nativeGrantUsePolicies.ts
@@ -30,12 +30,17 @@ export type NativeGrantUsePolicy = "per-dispatch" | "per-resolved-target";
  * dispatch. A `maxUses: 10` grant therefore reads as "ten careful approvals"
  * while authorizing ten unbounded sweeps.
  *
- * **A new destructive fan-out action must be added here.** The default is
- * deliberately permissive so ordinary single-target tools need no declaration,
- * which means an omission fails open. The batch terminal kill in #12123 is the
- * next tool that belongs in this map: it takes explicit ids rather than a live
- * query, but its blast radius is still per-target, so it gets one bulk human
- * confirmation rather than a generic grant's blanket pre-authorization.
+ * **A new action of this shape must be added here**, judged by what one call
+ * costs the user rather than by its `danger` field — `terminal.closeAll` is
+ * declared `danger: "safe"` and still belongs, because a single call discards
+ * every panel set to remove on exit. The default is deliberately permissive so
+ * ordinary single-target tools need no declaration, which means an omission
+ * fails open.
+ *
+ * The batch terminal kill in #12123 is the next tool that belongs here: it
+ * takes explicit ids rather than a live query, but its blast radius is still
+ * per-target, so it gets one bulk human confirmation rather than a generic
+ * grant's blanket pre-authorization.
  */
 export const NATIVE_GRANT_USE_POLICY_OVERRIDES: Readonly<
   Partial<Record<BuiltInActionId, NativeGrantUsePolicy>>

--- a/shared/config/nativeGrantUsePolicies.ts
+++ b/shared/config/nativeGrantUsePolicies.ts
@@ -8,9 +8,16 @@ import type { BuiltInActionId } from "../types/actions.js";
  *   The budget the Settings card presents ("N of M uses left") is a truthful
  *   count of what the grant still authorizes. This is the default.
  * - `per-resolved-target` — one call fans out across every target it resolves
- *   at dispatch time. A use count cannot bound it, because the target set is
- *   not known when the use is charged, so these tools are not eligible for a
+ *   at dispatch time, and losing those targets is what the user is being asked
+ *   to approve. A use count cannot bound it, because the target set is not
+ *   known when the use is charged, so these tools are not eligible for a
  *   generic native grant at all.
+ *
+ * Fan-out alone does not qualify a tool. `git.stageAll` touches every changed
+ * file in one call and stays `per-dispatch`, because the budget is not
+ * misrepresenting anything a user would count: staging is reversible and
+ * carries no per-file consequence to weigh. What earns the stricter policy is
+ * a call whose blast radius is both unbounded and the thing being approved.
  */
 export type NativeGrantUsePolicy = "per-dispatch" | "per-resolved-target";
 

--- a/shared/config/nativeGrantUsePolicies.ts
+++ b/shared/config/nativeGrantUsePolicies.ts
@@ -1,0 +1,61 @@
+import type { BuiltInActionId } from "../types/actions.js";
+
+/**
+ * How a native automation grant's use budget (#10648) relates to what a single
+ * call actually does (#12121).
+ *
+ * - `per-dispatch` — one call affects one thing, so one call costs one use.
+ *   The budget the Settings card presents ("N of M uses left") is a truthful
+ *   count of what the grant still authorizes. This is the default.
+ * - `per-resolved-target` — one call fans out across every target it resolves
+ *   at dispatch time. A use count cannot bound it, because the target set is
+ *   not known when the use is charged, so these tools are not eligible for a
+ *   generic native grant at all.
+ */
+export type NativeGrantUsePolicy = "per-dispatch" | "per-resolved-target";
+
+/**
+ * Tools whose cost is NOT one-per-call. Everything unlisted is `per-dispatch`.
+ *
+ * `terminal.killAll` and `terminal.closeAll` both resolve their target set from
+ * live renderer state inside `run()` — there is no target list in `args` and no
+ * way for the main process to learn the count before the call is committed to
+ * dispatch. A `maxUses: 10` grant therefore reads as "ten careful approvals"
+ * while authorizing ten unbounded sweeps.
+ *
+ * **A new destructive fan-out action must be added here.** The default is
+ * deliberately permissive so ordinary single-target tools need no declaration,
+ * which means an omission fails open. The batch terminal kill in #12123 is the
+ * next tool that belongs in this map: it takes explicit ids rather than a live
+ * query, but its blast radius is still per-target, so it gets one bulk human
+ * confirmation rather than a generic grant's blanket pre-authorization.
+ */
+export const NATIVE_GRANT_USE_POLICY_OVERRIDES: Readonly<
+  Partial<Record<BuiltInActionId, NativeGrantUsePolicy>>
+> = {
+  "terminal.closeAll": "per-resolved-target",
+  "terminal.killAll": "per-resolved-target",
+};
+
+// Keyed lookup rather than a bare index into the literal above: `toolId` is
+// caller-supplied from the MCP surface, and a plain object inherits
+// `Object.prototype`, so `"toString"` would resolve to a function.
+const POLICY_BY_TOOL_ID: ReadonlyMap<string, NativeGrantUsePolicy> = new Map(
+  Object.entries(NATIVE_GRANT_USE_POLICY_OVERRIDES).filter(
+    (entry): entry is [string, NativeGrantUsePolicy] => entry[1] !== undefined
+  )
+);
+
+export function getNativeGrantUsePolicy(toolId: string): NativeGrantUsePolicy {
+  return POLICY_BY_TOOL_ID.get(toolId) ?? "per-dispatch";
+}
+
+/**
+ * Whether a native automation grant may cover `toolId` at all. False for a
+ * fan-out tool whose per-call cost a use count cannot express — such a call
+ * still runs, it just never rides a grant's pre-authorization and never spends
+ * a use.
+ */
+export function isGenericNativeGrantEligible(toolId: string): boolean {
+  return getNativeGrantUsePolicy(toolId) === "per-dispatch";
+}


### PR DESCRIPTION
## Summary

- A native MCP automation grant is bounded by `maxUses`, and a use is charged once per dispatched tool call. The Settings card presents that as a budget of N individual approvals.
- `terminal.killAll` and `terminal.closeAll` resolve their target sets from live renderer state inside `run()`. There's no target list in the call args, so a `maxUses: 10` grant reads as "ten careful approvals" while actually authorizing ten unbounded sweeps, each of which can hit any number of panels.
- The use charge fires before dispatch, after the admission check and the workspace-bound confirm ceiling but before dedup (the ordering established by #11878), so the real target count isn't knowable at the moment the use gets billed. Rather than charge a guessed or caller-declared number, this makes these fan-out tools ineligible for native grants entirely, the first option from the issue, scoped narrowly to tools whose fan-out can't be bounded before dispatch.

Resolves #12121

## Changes

- New `shared/config/nativeGrantUsePolicies.ts` declares a `NativeGrantUsePolicy` type of either `per-dispatch` or `per-resolved-target`, with an override map defaulting to `per-dispatch`. `terminal.killAll` and `terminal.closeAll` are marked `per-resolved-target`. The lookup is Map-based so a caller-supplied tool id can't resolve through `Object.prototype`.
- `httpLifecycle.issueNativeGrant` rejects a scope naming one of these tools atomically, so the minted scope is always exactly what the user approved and never silently narrowed.
- `grantCache.peekNativeGrant` refuses it before the grant loop runs. `consumeNativeGrantUse` refuses it after the TTL and ceiling check but before the decrement, so a stale grant id still learns it's expired and the budget plus sibling eligible tools stay untouched.
- `sessionServer.ts` filters the introspection snapshot's native-grant tool ids through the same check, so `actions.list` and `actions.search` can't list a tool that dispatch will actually answer with `TIER_NOT_PERMITTED`.
- `tierAuth.buildTargetPolicy` gates the `nativeGranted` flag on the same check, so the client-facing `actions.getSchema` record can't advertise a confirmation bypass the gate won't honor.
- `docs/architecture/mcp-server.md` gets a small update to the gate diagram, which previously implied any allowlisted tool passes the native-grant check.

Net effect: these calls still run, they just never ride a grant's pre-authorization and never spend a use, so the confirm modal decides as normal. Per-tool one-off approve grants are unaffected since `GrantEntry` has no use counter. #12123, covering batch terminal kill, is the next tool that needs to declare itself in this policy, and the new module's doc comment says so explicitly.

## Testing

- Ran the `mcp-server` test suite and the `mcp` adversarial test suite locally: 1181 tests passing.
- Ran `eslint` and `prettier --check` on all changed files, both clean.
- Three review passes on the change, two adversarial and one confirmation, with all findings addressed.
