### PR TITLE
fix(github): make bulk selection reachable with nothing ticked

### DIFF
--- a/plugins/builtin/github/renderer/__tests__/GitHubDropdownSkeletons.test.tsx
+++ b/plugins/builtin/github/renderer/__tests__/GitHubDropdownSkeletons.test.tsx
@@ -83,6 +83,15 @@ describe("GitHubResourceListSkeleton", () => {
     expect(status?.getAttribute("aria-busy")).toBe("true");
     expect(status?.getAttribute("aria-label")).toBe("Loading GitHub results");
   });
+
+  it("reserves every header icon slot the loaded list renders", () => {
+    // Refresh, sort and bulk-select. One slot short and the search field
+    // jumps narrower the moment real content replaces this.
+    const { container } = render(<GitHubResourceListSkeleton />);
+    const header = container.querySelector(".border-b");
+    const slots = header?.querySelectorAll(".w-8.h-8");
+    expect(slots).toHaveLength(3);
+  });
 });
 
 describe("CommitListSkeleton", () => {

--- a/plugins/builtin/github/renderer/__tests__/GitHubResourceList.swr.test.tsx
+++ b/plugins/builtin/github/renderer/__tests__/GitHubResourceList.swr.test.tsx
@@ -3349,7 +3349,7 @@ describe("GitHubResourceList bulk selection menu (#12124)", () => {
     act(() => {
       button.click();
     });
-    await screen.findByRole("group", { name: "Selection actions" });
+    await screen.findByRole("dialog", { name: "Selection actions" });
     return button;
   };
 
@@ -3373,16 +3373,27 @@ describe("GitHubResourceList bulk selection menu (#12124)", () => {
     expect((mockSelectAll.mock.calls[0]![0] as Issue[]).map((i) => i.number)).toEqual([1, 2, 3]);
   });
 
-  it("keeps the trigger in the header whether or not a selection is live", async () => {
+  it("keeps the trigger in the header's fixed icon row, selection live or not", async () => {
     mockListIssues.mockResolvedValue(makeResponse([makeIssue(1)]));
 
+    // Same parent as Refresh and Sort — that row is the one whose height does
+    // not move, which is the whole point of putting the control there.
+    const sharesTheIconRow = async () => {
+      const row = (await trigger()).parentElement;
+      expect(row?.contains(screen.getByRole("button", { name: /refresh issues/i }))).toBe(true);
+      expect(row?.contains(screen.getByRole("button", { name: /^sort/i }))).toBe(true);
+    };
+
     const view = render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
-    expect(await trigger()).toBeTruthy();
+    await screen.findByTestId("item-1");
+    await sharesTheIconRow();
     view.unmount();
 
     mockIsSelectionActive = true;
+    mockSelectedIds = new Set([1]);
     render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
-    expect(await trigger()).toBeTruthy();
+    await screen.findByTestId("item-1");
+    await sharesTheIconRow();
   });
 
   it("never puts the helpers in a header row of their own", async () => {
@@ -3392,11 +3403,17 @@ describe("GitHubResourceList bulk selection menu (#12124)", () => {
     // is neither, and it must not be on the page until the menu is opened.
     mockListIssues.mockResolvedValue(makeResponse([makeIssue(1)]));
     mockIsSelectionActive = true;
+    mockSelectedIds = new Set([1]);
 
     render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+    await screen.findByTestId("item-1");
 
-    await trigger();
-    expect(screen.queryByRole("group", { name: "Selection actions" })).toBeNull();
+    // The header is the search/icon row plus the state tabs, and stays that
+    // way with a live selection. Nothing about the helpers is on the page
+    // until the menu is opened.
+    const header = (await trigger()).closest(".space-y-2");
+    expect(header?.children).toHaveLength(2);
+    expect(screen.queryByRole("dialog", { name: "Selection actions" })).toBeNull();
   });
 
   it("offers unassigned again, and skips the assigned rows", async () => {
@@ -3492,15 +3509,102 @@ describe("GitHubResourceList bulk selection menu (#12124)", () => {
     expect(mockSelectionClear).toHaveBeenCalledTimes(1);
   });
 
-  it("stays present but disabled when there is nothing to select", async () => {
+  it("stays present but disabled once the list has settled on nothing", async () => {
     mockListIssues.mockResolvedValue(makeResponse([]));
 
     render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
 
-    await waitFor(() => {
-      expect((screen.getByRole("button", { name: "Select issues" }) as HTMLButtonElement).disabled)
-        .toBe(true);
+    // Wait for the settled empty list, or this passes on the first frame —
+    // `data` starts empty whatever the response turns out to be.
+    await screen.findByText("No open issues");
+    expect((await trigger()).hasAttribute("disabled")).toBe(true);
+  });
+
+  it("still offers select all when only some rows are ticked", async () => {
+    mockListIssues.mockResolvedValue(makeResponse([makeIssue(1), makeIssue(2)]));
+    mockSelectedIds = new Set([1]);
+    mockIsSelectionActive = true;
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    await openMenu();
+    expect(screen.getByRole("button", { name: "Select all (2)" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Deselect all" })).toBeNull();
+  });
+
+  it("matches pull requests on prNumber, not on a same-numbered issue worktree", async () => {
+    // The worktree index is built per resource type. An issue worktree that
+    // happens to carry the same number must not make PR #5 look covered.
+    worktreeMap.set("wt-issue-5", { id: "wt-issue-5", issueNumber: 5 });
+    worktreeMap.set("wt-pr-6", { id: "wt-pr-6", prNumber: 6 });
+    mockListPRs.mockResolvedValue(makeResponse([makeIssue(5), makeIssue(6)]));
+
+    render(<GitHubResourceList type="pr" projectPath="/test/proj" />);
+
+    await openMenu("pull requests");
+    const withoutWorktree = screen.getByRole("button", { name: "Select without worktrees (1)" });
+    act(() => {
+      withoutWorktree.click();
     });
+
+    expect((mockSelectAll.mock.calls[0]![0] as Issue[]).map((i) => i.number)).toEqual([5]);
+  });
+
+  it("closes itself once a preset has been applied", async () => {
+    mockListIssues.mockResolvedValue(makeResponse([makeIssue(1)]));
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    const button = await openMenu();
+    act(() => {
+      screen.getByRole("button", { name: "Select all (1)" }).click();
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Selection actions" })).toBeNull();
+    });
+    expect(button.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("closes on Escape without disturbing the selection", async () => {
+    mockListIssues.mockResolvedValue(makeResponse([makeIssue(1)]));
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    const button = await openMenu();
+    const dialog = screen.getByRole("dialog", { name: "Selection actions" });
+    act(() => {
+      fireEvent.keyDown(dialog, { key: "Escape" });
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Selection actions" })).toBeNull();
+    });
+    expect(button.getAttribute("aria-expanded")).toBe("false");
+    expect(mockSelectAll).not.toHaveBeenCalled();
+    expect(mockSelectionClear).not.toHaveBeenCalled();
+  });
+
+  it("does not stand over a list that emptied out from under it", async () => {
+    // A background revalidation keeps the rows and the trigger live, so the
+    // menu can be open when a fresh page comes back with nothing. Left open,
+    // its select-all would replace a live selection with an empty one.
+    mockListIssues.mockResolvedValue(makeResponse([makeIssue(1)]));
+    mockIsSelectionActive = true;
+    mockSelectedIds = new Set([1]);
+
+    const view = render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+    await openMenu();
+
+    mockListIssues.mockResolvedValue(makeResponse([]));
+    await act(async () => {
+      view.rerender(<GitHubResourceList type="issue" projectPath="/other/proj" />);
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Selection actions" })).toBeNull();
+    });
+    expect(mockSelectAll).not.toHaveBeenCalled();
   });
 
   it("closes the menu when the parent dropdown goes away", async () => {
@@ -3523,7 +3627,7 @@ describe("GitHubResourceList bulk selection menu (#12124)", () => {
     );
 
     await waitFor(() => {
-      expect(screen.queryByRole("group", { name: "Selection actions" })).toBeNull();
+      expect(screen.queryByRole("dialog", { name: "Selection actions" })).toBeNull();
     });
   });
 });

--- a/plugins/builtin/github/renderer/__tests__/GitHubResourceList.swr.test.tsx
+++ b/plugins/builtin/github/renderer/__tests__/GitHubResourceList.swr.test.tsx
@@ -89,17 +89,24 @@ const mockSelectionClear = vi.fn();
 // Stable identities — the component memoizes and effects off these.
 const EMPTY_ITEMS = new Map();
 const mockReconcile = vi.fn();
+const mockSelectAll = vi.fn();
+// Seeded per test, so the selection menu's "everything visible is already
+// picked" branch is reachable. Reassigned rather than mutated: the identity
+// still changes only when a test means it to.
+let mockSelectedIds = new Set<number>();
 
 vi.mock("@/hooks/useIssueSelection", () => ({
   useIssueSelection: () => ({
-    selectedIds: new Set<number>(),
+    get selectedIds() {
+      return mockSelectedIds;
+    },
     get isSelectionActive() {
       return mockIsSelectionActive;
     },
     selectedItems: EMPTY_ITEMS,
     toggle: vi.fn(),
     toggleRange: vi.fn(),
-    selectAll: vi.fn(),
+    selectAll: mockSelectAll,
     reconcile: mockReconcile,
     clear: mockSelectionClear,
   }),
@@ -273,6 +280,8 @@ beforeEach(() => {
   notifyMock.mockReset();
   initializeMock.mockClear();
   mockSelectionClear.mockReset();
+  mockSelectAll.mockReset();
+  mockSelectedIds = new Set<number>();
   mockOpenCreateDialog.mockReset();
   mockOpenCreateDialogForPR.mockReset();
   mockSelectWorktree.mockReset();
@@ -3318,5 +3327,203 @@ describe("GitHubResourceList — the keyboard cursor across a refresh", () => {
     view.rerender(<GitHubResourceList type="issue" projectPath="/other/proj" />);
 
     await waitFor(() => expect(activeDescendant()).toBeNull());
+  });
+});
+
+describe("GitHubResourceList bulk selection menu (#12124)", () => {
+  const assigned = (issue: Issue): Issue => ({
+    ...issue,
+    assignees: [{ login: "octocat", avatarUrl: "", rawData: null }],
+  });
+  const closed = (issue: Issue): Issue => ({ ...issue, state: "closed", rawState: "CLOSED" });
+
+  /** The always-present header trigger, by its accessible name. */
+  const trigger = (kind: "issues" | "pull requests" = "issues") =>
+    screen.findByRole("button", { name: `Select ${kind}` });
+
+  const openMenu = async (kind: "issues" | "pull requests" = "issues") => {
+    const button = await trigger(kind);
+    // The trigger is inert until there is something to select, so a click
+    // fired mid-load would silently do nothing.
+    await waitFor(() => expect((button as HTMLButtonElement).disabled).toBe(false));
+    act(() => {
+      button.click();
+    });
+    await screen.findByRole("group", { name: "Selection actions" });
+    return button;
+  };
+
+  it("selects every visible result with no row ticked first", async () => {
+    // The reported workflow: a comma-separated number query, then one press.
+    // Ticking a row to reveal the helper is exactly what must not be needed.
+    useGitHubFilterStore.getState().setIssueSearchQuery("#1, #2, #3");
+    mockGetIssuesByNumbers.mockResolvedValue([makeIssue(1), makeIssue(2), makeIssue(3)]);
+    mockIsSelectionActive = false;
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+    await screen.findByTestId("item-3");
+
+    await openMenu();
+    const selectAll = await screen.findByRole("button", { name: "Select all (3)" });
+    act(() => {
+      selectAll.click();
+    });
+
+    expect(mockSelectAll).toHaveBeenCalledTimes(1);
+    expect((mockSelectAll.mock.calls[0]![0] as Issue[]).map((i) => i.number)).toEqual([1, 2, 3]);
+  });
+
+  it("keeps the trigger in the header whether or not a selection is live", async () => {
+    mockListIssues.mockResolvedValue(makeResponse([makeIssue(1)]));
+
+    const view = render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+    expect(await trigger()).toBeTruthy();
+    view.unmount();
+
+    mockIsSelectionActive = true;
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+    expect(await trigger()).toBeTruthy();
+  });
+
+  it("never puts the helpers in a header row of their own", async () => {
+    // The old row was a whole extra band in a vertically stacked header, so it
+    // could only ever be gated — on selection mode (unreachable) or on the
+    // query (which grew the header on the first keystroke). Inside the menu it
+    // is neither, and it must not be on the page until the menu is opened.
+    mockListIssues.mockResolvedValue(makeResponse([makeIssue(1)]));
+    mockIsSelectionActive = true;
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    await trigger();
+    expect(screen.queryByRole("group", { name: "Selection actions" })).toBeNull();
+  });
+
+  it("offers unassigned again, and skips the assigned rows", async () => {
+    mockListIssues.mockResolvedValue(
+      makeResponse([makeIssue(1), assigned(makeIssue(2)), makeIssue(3)])
+    );
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    await openMenu();
+    const unassigned = await screen.findByRole("button", { name: "Select unassigned (2)" });
+    act(() => {
+      unassigned.click();
+    });
+
+    expect((mockSelectAll.mock.calls[0]![0] as Issue[]).map((i) => i.number)).toEqual([1, 3]);
+  });
+
+  it("does not narrow unassigned to open items the way the worktree preset does", async () => {
+    // Assignment and worktree readiness measure different things. A closed
+    // issue with nobody on it is still unassigned; the worktree preset drops it
+    // because the bulk planner would skip it anyway.
+    useGitHubFilterStore.getState().setIssueFilter("all");
+    mockListIssues.mockResolvedValue(makeResponse([makeIssue(1), closed(makeIssue(2))]));
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    await openMenu();
+    expect(screen.getByRole("button", { name: "Select unassigned (2)" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Select without worktrees (1)" })).toBeTruthy();
+  });
+
+  it("excludes rows that already have a worktree", async () => {
+    worktreeMap.set("wt-2", { id: "wt-2", issueNumber: 2 });
+    mockListIssues.mockResolvedValue(makeResponse([makeIssue(1), makeIssue(2)]));
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    await openMenu();
+    const withoutWorktree = await screen.findByRole("button", {
+      name: "Select without worktrees (1)",
+    });
+    act(() => {
+      withoutWorktree.click();
+    });
+
+    expect((mockSelectAll.mock.calls[0]![0] as Issue[]).map((i) => i.number)).toEqual([1]);
+  });
+
+  it("omits unassigned for pull requests, which carry no assignment model", async () => {
+    mockListPRs.mockResolvedValue(makeResponse([makeIssue(5)]));
+
+    render(<GitHubResourceList type="pr" projectPath="/test/proj" />);
+
+    await openMenu("pull requests");
+    expect(screen.getByRole("button", { name: "Select all (1)" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /select unassigned/i })).toBeNull();
+  });
+
+  it("keeps an empty preset listed but disabled rather than dropping it", async () => {
+    // A menu whose entries come and go between openings has to be re-read every
+    // time, and an empty preset would replace the selection with nothing.
+    worktreeMap.set("wt-1", { id: "wt-1", issueNumber: 1 });
+    mockListIssues.mockResolvedValue(makeResponse([assigned(makeIssue(1))]));
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    await openMenu();
+    const unassigned = screen.getByRole("button", { name: "Select unassigned (0)" });
+    const withoutWorktree = screen.getByRole("button", { name: "Select without worktrees (0)" });
+    expect((unassigned as HTMLButtonElement).disabled).toBe(true);
+    expect((withoutWorktree as HTMLButtonElement).disabled).toBe(true);
+
+    act(() => {
+      unassigned.click();
+    });
+    expect(mockSelectAll).not.toHaveBeenCalled();
+  });
+
+  it("turns the first entry into deselect all once everything visible is picked", async () => {
+    mockListIssues.mockResolvedValue(makeResponse([makeIssue(1), makeIssue(2)]));
+    mockSelectedIds = new Set([1, 2]);
+    mockIsSelectionActive = true;
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    await openMenu();
+    expect(screen.queryByRole("button", { name: /^select all/i })).toBeNull();
+    act(() => {
+      screen.getByRole("button", { name: "Deselect all" }).click();
+    });
+
+    expect(mockSelectionClear).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays present but disabled when there is nothing to select", async () => {
+    mockListIssues.mockResolvedValue(makeResponse([]));
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    await waitFor(() => {
+      expect((screen.getByRole("button", { name: "Select issues" }) as HTMLButtonElement).disabled)
+        .toBe(true);
+    });
+  });
+
+  it("closes the menu when the parent dropdown goes away", async () => {
+    // Nothing of this panel's may stay portaled on document.body after the
+    // toolbar dropdown closes.
+    mockListIssues.mockResolvedValue(makeResponse([makeIssue(1)]));
+
+    const view = render(
+      <FixedDropdownVisibleContext.Provider value={true}>
+        <GitHubResourceList type="issue" projectPath="/test/proj" />
+      </FixedDropdownVisibleContext.Provider>
+    );
+
+    await openMenu();
+
+    view.rerender(
+      <FixedDropdownVisibleContext.Provider value={false}>
+        <GitHubResourceList type="issue" projectPath="/test/proj" />
+      </FixedDropdownVisibleContext.Provider>
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByRole("group", { name: "Selection actions" })).toBeNull();
+    });
   });
 });

--- a/plugins/builtin/github/renderer/__tests__/GitHubResourceList.swr.test.tsx
+++ b/plugins/builtin/github/renderer/__tests__/GitHubResourceList.swr.test.tsx
@@ -3586,19 +3586,49 @@ describe("GitHubResourceList bulk selection menu (#12124)", () => {
   });
 
   it("does not stand over a list that emptied out from under it", async () => {
-    // A background revalidation keeps the rows and the trigger live, so the
-    // menu can be open when a fresh page comes back with nothing. Left open,
-    // its select-all would replace a live selection with an empty one.
-    mockListIssues.mockResolvedValue(makeResponse([makeIssue(1)]));
+    // A background revalidation keeps the cached rows and the trigger live, so
+    // the menu can be open when the fresh page comes back with nothing. Left
+    // open, its select-all would replace a live selection with an empty one.
+    setCache(buildCacheKey("/test/proj", "issue", "open", "created"), {
+      items: [makeIssue(1)],
+      nextCursor: null,
+      hasMore: false,
+      timestamp: Date.now() - 30_000,
+    });
+    let resolveRevalidate: ((page: Page<Issue>) => void) | undefined;
+    mockListIssues.mockImplementation(
+      () =>
+        new Promise<Page<Issue>>((resolve) => {
+          resolveRevalidate = resolve;
+        })
+    );
     mockIsSelectionActive = true;
     mockSelectedIds = new Set([1]);
 
-    const view = render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
     await openMenu();
 
-    mockListIssues.mockResolvedValue(makeResponse([]));
     await act(async () => {
-      view.rerender(<GitHubResourceList type="issue" projectPath="/other/proj" />);
+      resolveRevalidate?.(makeResponse([]));
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Selection actions" })).toBeNull();
+    });
+    expect(mockSelectAll).not.toHaveBeenCalled();
+  });
+
+  it("does not carry an open menu across a project switch", async () => {
+    // The panel survives a project change without remounting, so the presets
+    // would rebind to the new project while still listing the old one's rows.
+    mockListIssues.mockResolvedValue(makeResponse([makeIssue(1)]));
+
+    const view = render(<GitHubResourceList type="issue" projectPath="/test/proj-a" />);
+    await openMenu();
+
+    await act(async () => {
+      view.rerender(<GitHubResourceList type="issue" projectPath="/test/proj-b" />);
     });
 
     await waitFor(() => {

--- a/plugins/builtin/github/renderer/__tests__/GitHubResourceList.swr.test.tsx
+++ b/plugins/builtin/github/renderer/__tests__/GitHubResourceList.swr.test.tsx
@@ -3617,6 +3617,30 @@ describe("GitHubResourceList bulk selection menu (#12124)", () => {
       expect(screen.queryByRole("dialog", { name: "Selection actions" })).toBeNull();
     });
     expect(mockSelectAll).not.toHaveBeenCalled();
+    // The trigger went `disabled` in the same commit that closed the menu, so
+    // Radix's restoring `.focus()` on it is a no-op and focus would land on
+    // `document.body` — every grid key dead until the user clicks back in.
+    expect(document.activeElement).toBe(screen.getByPlaceholderText(/search issues/i));
+  });
+
+  it("hands focus back to the search input when the menu closes", async () => {
+    // The grid keeps DOM focus in the search input so `aria-activedescendant`
+    // is legal; left on the trigger, the arrow keys, Shift+Space and Enter are
+    // all inert until the user tabs back.
+    mockListIssues.mockResolvedValue(makeResponse([makeIssue(1)]));
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    await openMenu();
+    const dialog = screen.getByRole("dialog", { name: "Selection actions" });
+    act(() => {
+      fireEvent.keyDown(dialog, { key: "Escape" });
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Selection actions" })).toBeNull();
+    });
+    expect(document.activeElement).toBe(screen.getByPlaceholderText(/search issues/i));
   });
 
   it("does not carry an open menu across a project switch", async () => {

--- a/plugins/builtin/github/renderer/components/GitHubDropdownSkeletons.tsx
+++ b/plugins/builtin/github/renderer/components/GitHubDropdownSkeletons.tsx
@@ -1,4 +1,5 @@
 import { Search, ExternalLink, Plus, ArrowUpDown, RefreshCw } from "lucide-react";
+import { ListChecks } from "@/components/icons";
 import { cn } from "@/lib/utils";
 import { useSkeletonGate } from "@/hooks/useDeferredLoading";
 
@@ -74,13 +75,16 @@ export function GitHubResourceListSkeleton({
               Search {type === "issue" ? "issues" : "pull requests"}…
             </span>
           </div>
-          {/* Both icon slots, or the search field jumps narrower the moment
+          {/* Every icon slot, or the search field jumps narrower the moment
               real content replaces this. */}
           <div className="flex items-center justify-center w-8 h-8 rounded-[var(--radius-md)] shrink-0 text-text-secondary">
             <RefreshCw className="w-3.5 h-3.5" />
           </div>
           <div className="flex items-center justify-center w-8 h-8 rounded-[var(--radius-md)] shrink-0 text-text-secondary">
             <ArrowUpDown className="w-3.5 h-3.5" />
+          </div>
+          <div className="flex items-center justify-center w-8 h-8 rounded-[var(--radius-md)] shrink-0 text-text-secondary">
+            <ListChecks className="w-3.5 h-3.5" />
           </div>
         </div>
 

--- a/plugins/builtin/github/renderer/components/GitHubResourceList.tsx
+++ b/plugins/builtin/github/renderer/components/GitHubResourceList.tsx
@@ -19,6 +19,7 @@ import {
   ArrowUpDown,
   Clock,
 } from "lucide-react";
+import { ListChecks } from "@/components/icons";
 import { GitHubIcon } from "@/components/icons/brands";
 import { isTokenRelatedError, isTransientNetworkError } from "@/lib/forgeErrors";
 import { Button } from "@/components/ui/button";
@@ -287,6 +288,7 @@ export function GitHubResourceList({
 
   const [activeIndex, setActiveIndex] = useState(-1);
   const [sortPopoverOpen, setSortPopoverOpen] = useState(false);
+  const [selectionMenuOpen, setSelectionMenuOpen] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const virtuosoRef = useRef<VirtuosoHandle>(null);
 
@@ -592,6 +594,7 @@ export function GitHubResourceList({
     if (isDropdownOpen) return;
     // Closing — nothing of ours may stay portaled on `document.body`.
     setSortPopoverOpen(false);
+    setSelectionMenuOpen(false);
     setOpenRowMenuNumber(null);
   }, [isDropdownOpen]);
 
@@ -1220,61 +1223,136 @@ export function GitHubResourceList({
               </div>
             </PopoverContent>
           </Popover>
-        </div>
-
-        {/* Tied to selection mode rather than to a non-empty query: this is a
-            whole extra row in a vertically stacked header, so typing the first
-            character of a search used to grow the header and shove the list
-            down. Entering selection is a deliberate act; typing is not. */}
-        {selection.isSelectionActive &&
-          data.length > 0 &&
-          !loading &&
-          (() => {
-            const allSelected = data.every((item) => selection.selectedIds.has(item.number));
-            // The bulk action these helpers feed is creating worktrees, so the
-            // useful filter is which rows do not have one yet. "Unassigned" was
-            // a proxy for that, and a poor one — plenty of assigned issues have
-            // no local worktree, and picking them selected rows the bulk create
-            // would immediately skip.
-            // Open as well as worktree-less: the bulk planner skips closed
-            // issues and merged PRs outright, so selecting them would walk you
-            // into a dialog with nothing left to create.
-            const withoutWorktree = data.filter(
-              (item) => item.state === "open" && !worktreeIndex.has(item.number)
-            );
-            return (
-              <div
-                className="flex items-center gap-1.5"
-                role="group"
-                aria-label="Selection actions"
-              >
-                <button
-                  type="button"
-                  onClick={() => {
-                    if (allSelected) {
-                      selection.clear();
-                    } else {
-                      selection.selectAll(data);
-                    }
-                  }}
-                  className="text-xs text-text-secondary hover:text-text-primary focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-accent-primary transition-colors duration-150 ease-out px-1 py-0.5 rounded"
-                >
-                  {allSelected ? "Deselect all" : `Select all (${data.length})`}
-                </button>
-                {withoutWorktree.length > 0 && withoutWorktree.length < data.length && (
-                  <button
-                    type="button"
-                    onClick={() => {
-                      selection.selectAll(withoutWorktree);
-                    }}
-                    className="text-xs text-text-secondary hover:text-text-primary focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-accent-primary transition-colors duration-150 ease-out px-1 py-0.5 rounded"
-                  >
-                    {`Select without worktrees (${withoutWorktree.length})`}
-                  </button>
+          {/* The bulk-select entry point lives here, in the fixed icon row,
+              rather than in a row of its own. A helper row keyed to selection
+              mode could only be reached by ticking a row first, and one keyed
+              to the search query grew the stacked header on the first
+              keystroke and shoved the list down. A trigger that is always
+              present at a fixed size is neither. */}
+          <Popover open={selectionMenuOpen} onOpenChange={setSelectionMenuOpen}>
+            <PopoverTrigger asChild>
+              <button
+                type="button"
+                disabled={loading || data.length === 0}
+                aria-label={`Select ${type === "issue" ? "issues" : "pull requests"}`}
+                aria-haspopup="dialog"
+                aria-expanded={selectionMenuOpen}
+                title="Select"
+                className={cn(
+                  "flex items-center justify-center w-8 h-8 rounded-[var(--radius-md)] shrink-0",
+                  "text-text-secondary hover:text-text-primary hover:bg-overlay-medium",
+                  "transition-[background-color,color] duration-150 ease-out",
+                  // No lift while a selection is live: the bulk bar already
+                  // states the count, and a second membership signal here
+                  // would say the same thing twice.
+                  "disabled:cursor-default disabled:opacity-50",
+                  "disabled:hover:bg-transparent disabled:hover:text-text-secondary"
                 )}
+              >
+                <ListChecks className="w-3.5 h-3.5" />
+              </button>
+            </PopoverTrigger>
+            <PopoverContent
+              align="end"
+              sideOffset={8}
+              className="w-56 p-3"
+              onMouseDown={(e: React.MouseEvent) => e.stopPropagation()}
+              onTouchStart={(e: React.TouchEvent) => e.stopPropagation()}
+              onKeyDown={(e: React.KeyboardEvent) => {
+                if (e.key === "Escape") {
+                  e.stopPropagation();
+                  setSelectionMenuOpen(false);
+                }
+              }}
+            >
+              <div className="text-xs font-medium text-text-secondary mb-2">Select</div>
+              <div className="flex flex-col gap-1" role="group" aria-label="Selection actions">
+                {(() => {
+                  const allSelected =
+                    data.length > 0 && data.every((item) => selection.selectedIds.has(item.number));
+                  // Assignment, not worktree readiness — the two measure
+                  // different things, so this one does NOT inherit the open
+                  // filter below. `data` is already scoped by the state tab,
+                  // and a closed issue with nobody on it is still unassigned.
+                  // PRs carry no assignment model at all, so the choice is
+                  // absent for them rather than permanently empty.
+                  const unassigned =
+                    type === "issue"
+                      ? data.filter((item) => (item as Issue).assignees.length === 0)
+                      : null;
+                  // Open as well as worktree-less: the bulk planner skips
+                  // closed issues and merged PRs outright, so selecting them
+                  // would walk you into a dialog with nothing left to create.
+                  const withoutWorktree = data.filter(
+                    (item) => item.state === "open" && !worktreeIndex.has(item.number)
+                  );
+
+                  const options: {
+                    key: string;
+                    label: string;
+                    disabled: boolean;
+                    onSelect: () => void;
+                  }[] = [
+                    allSelected
+                      ? {
+                          key: "deselect-all",
+                          label: "Deselect all",
+                          disabled: false,
+                          onSelect: () => selection.clear(),
+                        }
+                      : {
+                          key: "select-all",
+                          label: `Select all (${data.length})`,
+                          disabled: false,
+                          onSelect: () => selection.selectAll(data),
+                        },
+                  ];
+                  if (unassigned !== null) {
+                    options.push({
+                      key: "select-unassigned",
+                      label: `Select unassigned (${unassigned.length})`,
+                      disabled: unassigned.length === 0,
+                      onSelect: () => selection.selectAll(unassigned),
+                    });
+                  }
+                  options.push({
+                    key: "select-without-worktrees",
+                    label: `Select without worktrees (${withoutWorktree.length})`,
+                    disabled: withoutWorktree.length === 0,
+                    onSelect: () => selection.selectAll(withoutWorktree),
+                  });
+
+                  // Disabled rather than dropped at zero: a menu whose entries
+                  // come and go between openings has to be re-read every time,
+                  // and an empty preset would replace the selection with
+                  // nothing.
+                  return options.map((option) => (
+                    <button
+                      key={option.key}
+                      type="button"
+                      disabled={option.disabled}
+                      onClick={() => {
+                        option.onSelect();
+                        setSelectionMenuOpen(false);
+                      }}
+                      className={cn(
+                        "flex items-center px-2 py-1 text-xs text-start rounded-[var(--radius-sm)]",
+                        "transition-[background-color,color] duration-150 ease-out",
+                        "focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2",
+                        "focus-visible:outline-accent-primary",
+                        "text-text-secondary hover:bg-overlay-medium hover:text-text-primary",
+                        "disabled:cursor-default disabled:opacity-50",
+                        "disabled:hover:bg-transparent disabled:hover:text-text-secondary"
+                      )}
+                    >
+                      {option.label}
+                    </button>
+                  ));
+                })()}
               </div>
-            );
-          })()}
+            </PopoverContent>
+          </Popover>
+        </div>
 
         <div
           className="flex p-0.5 bg-overlay-soft border border-[var(--border-divider)] rounded-[var(--radius-md)]"

--- a/plugins/builtin/github/renderer/components/GitHubResourceList.tsx
+++ b/plugins/builtin/github/renderer/components/GitHubResourceList.tsx
@@ -598,6 +598,23 @@ export function GitHubResourceList({
     setOpenRowMenuNumber(null);
   }, [isDropdownOpen]);
 
+  // The selection menu only ever describes the rows on screen right now, for
+  // the project open right now. It has to close when either goes away. A
+  // background revalidation keeps the list visible and the trigger live, so a
+  // page that comes back empty can otherwise leave the menu standing over
+  // nothing — and a preset there would replace the selection with an empty
+  // one. The panel also survives a project switch without remounting, which
+  // would rebind the presets to the new project while still listing the old
+  // one's rows.
+  useEffect(() => {
+    if (data.length > 0) return;
+    setSelectionMenuOpen(false);
+  }, [data.length]);
+
+  useEffect(() => {
+    setSelectionMenuOpen(false);
+  }, [type, projectPath]);
+
   useEffect(() => {
     const wasOpen = wasDropdownOpenRef.current;
     wasDropdownOpenRef.current = isDropdownOpen;
@@ -1264,9 +1281,13 @@ export function GitHubResourceList({
                   setSelectionMenuOpen(false);
                 }
               }}
+              // Radix gives the content `role="dialog"`, and a dialog that
+              // announces itself as nothing is a dialog a screen-reader user
+              // has to explore to identify.
+              aria-label="Selection actions"
             >
               <div className="text-xs font-medium text-text-secondary mb-2">Select</div>
-              <div className="flex flex-col gap-1" role="group" aria-label="Selection actions">
+              <div className="flex flex-col gap-1">
                 {(() => {
                   const allSelected =
                     data.length > 0 && data.every((item) => selection.selectedIds.has(item.number));
@@ -1303,7 +1324,7 @@ export function GitHubResourceList({
                       : {
                           key: "select-all",
                           label: `Select all (${data.length})`,
-                          disabled: false,
+                          disabled: data.length === 0,
                           onSelect: () => selection.selectAll(data),
                         },
                   ];

--- a/plugins/builtin/github/renderer/components/GitHubResourceList.tsx
+++ b/plugins/builtin/github/renderer/components/GitHubResourceList.tsx
@@ -1281,6 +1281,17 @@ export function GitHubResourceList({
                   setSelectionMenuOpen(false);
                 }
               }}
+              // Radix hands focus back to the trigger, which leaves the grid
+              // inert either way: focus off the search input kills the arrow
+              // keys, Shift+Space and Enter (see the invariant above), and on
+              // the emptied-list close the trigger has gone `disabled` in the
+              // same commit, so its `.focus()` is a no-op and focus falls all
+              // the way to `document.body`. Take the restoration over — same
+              // hand-back the row menus do via `onMenuClose`.
+              onCloseAutoFocus={(event: Event) => {
+                event.preventDefault();
+                focusSearchInput();
+              }}
               // Radix gives the content `role="dialog"`, and a dialog that
               // announces itself as nothing is a dialog a screen-reader user
               // has to explore to identify.

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -38,6 +38,7 @@ export {
   Layers, // worktree overview (multiple worktrees, stacked)
   LayoutPanelTop, // workspace plugin category (panels, notes)
   Link2Off, // detach the issue linked to a worktree
+  ListChecks, // bulk selection of forge rows — the preset picker that selects many issues or PRs at once
   Menu, // the application menu, surfaced in-app where the native menu bar can't render
   Moon, // sleep a project — shut it down the way quitting does, restored on reopen
   Network, // Subagent tree — a parent session's spawned child sessions


### PR DESCRIPTION
## Summary

- The bulk-selection helpers in the GitHub issue/PR dropdown only rendered once `selection.isSelectionActive` was true, so selecting a row was a precondition for the control that selects rows. `Select unassigned` had also quietly disappeared in a prior commit (`02b84c46d`).
- The helper row is gone. The presets now live behind an always-present icon button in the header's fixed icon row, next to Refresh and Sort, so selecting every visible result is one press with nothing ticked, and the stacked header's row count never moves with selection state or keystrokes (the reason the row was gated in the first place).
- `Select unassigned` is back for issues. It filters on assignment alone (a closed issue with nobody on it still counts) which is distinct from `Select without worktrees`, which stays narrowed to open items because the bulk planner can't act on closed ones. Pull requests carry no assignment model, so the option is simply absent there rather than shown disabled.

Resolves #12124

## Changes

- Removed the conditional helper row from `GitHubResourceList.tsx` and replaced it with a bulk-selection icon button that's always present in the header.
- Restored the `Select unassigned` preset for issues.
- Empty presets stay listed but disabled, so the menu doesn't reshape between openings and no preset can stomp a live selection with an empty one.
- The menu closes when the list empties under it (background revalidation keeps the trigger live, so a query returning nothing could otherwise leave select-all standing over zero rows) and when the project switches (the panel survives a switch without remounting).
- `GitHubDropdownSkeletons.tsx` now reserves space for the new icon button, so the search field doesn't visibly narrow the moment real content lands.

## Verified

- `plugins/builtin/github/renderer/__tests__` (`GitHubResourceList.swr`, `GitHubDropdownSkeletons`, `GitHubListItem`, `BulkActionBar`, `forgeRowModel`): 235 pass, including 13 new cases covering the menu.
- `src/config/__tests__` + `src/components/ui/__tests__` (the source-text accent/colour/focus-ring contract suites and the Radix wrapper suites): 1476 pass.
- `prettier --check` and `eslint` on the five changed files: clean, exit 0, no new warnings (the lint ratchet's per-rule counts don't increase; two bare-`rounded` warnings go away with the deleted row).
