### PR TITLE
fix(help): make the tier grant buttons describe what they grant

### DIFF
--- a/electron/ipc/handlers/terminal/lifecycle.ts
+++ b/electron/ipc/handlers/terminal/lifecycle.ts
@@ -488,7 +488,10 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
       // `--dangerously-skip-permissions` flag (no DEFAULT_DANGEROUS_ARGS entry).
       // For it, the user's "bypass permissions" preference maps to skipping the
       // assistant's OWN per-action confirm sheet, which the CLI reads from this
-      // env var at startup. The capability tier remains the only safeguard.
+      // env var at startup. The capability tier is then the main safeguard, but
+      // not the only one: `danger: "confirm"` actions still open the host
+      // confirmation dialog unless a native automation grant covers them
+      // (#12119).
       if (launchAgentId === "daintree-assistant" && bypassPermissions) {
         spawnEnv = { ...(spawnEnv ?? {}), DAINTREE_ASSISTANT_AUTO_APPROVE: "1" };
       }

--- a/electron/services/mcp-server/httpLifecycle.ts
+++ b/electron/services/mcp-server/httpLifecycle.ts
@@ -1892,7 +1892,9 @@ export class HttpLifecycle {
   }
 
   /**
-   * Promote a help-session's tier in-memory (Approve once). Refuses downgrades
+   * Promote a help-session's tier in-memory — the tier-mismatch banner's "Set
+   * project default", never its per-tool "Allow this tool" grant. Refuses
+   * downgrades
    * — a malicious renderer cannot drop its own privileges. When `callerWcId`
    * is supplied, also requires the caller to be the WebContents the session
    * was pinned to at handshake (cross-window forgery defence). Returns the
@@ -1948,7 +1950,8 @@ export class HttpLifecycle {
     // Bound the renderer-approved elevation: after MCP_TIER_ELEVATION_TTL_MS
     // of awake time the session silently decays back to its token-resolved
     // baseline (`current`, the pre-elevation tier) so a stale "Always allow"
-    // can't outlive the user's intent (#8462). Each accepted approval
+    // can't outlive the user's intent (#8462) — which is why the banner no
+    // longer labels this "always". Each accepted approval
     // refreshes the window from now; a chained re-elevation preserves the
     // original baseline.
     this.deps.sessionStore.armTierElevationTimer(sessionId, tier, current);

--- a/electron/services/mcp-server/httpLifecycle.ts
+++ b/electron/services/mcp-server/httpLifecycle.ts
@@ -1948,10 +1948,12 @@ export class HttpLifecycle {
     }
     this.deps.sessionStore.sessionTierMap.set(sessionId, tier);
     // Bound the renderer-approved elevation: after MCP_TIER_ELEVATION_TTL_MS
-    // of awake time the session silently decays back to its token-resolved
-    // baseline (`current`, the pre-elevation tier) so a stale "Always allow"
-    // can't outlive the user's intent (#8462) — which is why the banner no
-    // longer labels this "always". Each accepted approval
+    // of awake time the session silently decays back to its pre-elevation
+    // baseline. `current` is only the candidate — on a chained elevation
+    // `armTierElevationTimer` keeps the baseline the first one captured, so
+    // workbench→action→system still decays all the way to workbench. A stale
+    // elevation therefore can't outlive the user's intent (#8462), which is
+    // why the banner no longer labels this "always" (#12119). Each approval
     // refreshes the window from now; a chained re-elevation preserves the
     // original baseline.
     this.deps.sessionStore.armTierElevationTimer(sessionId, tier, current);

--- a/electron/services/mcp-server/sessionServer.ts
+++ b/electron/services/mcp-server/sessionServer.ts
@@ -342,8 +342,9 @@ export interface SessionServerDeps {
     toolId: string;
     tier: McpTier;
     /**
-     * Minimum tier that permits the denied tool, or `null` if no tier permits
-     * it (unknown tool). The renderer's "Set project default" elevates to it
+     * Minimum tier that permits the denied tool, or `null` if no non-external
+     * help tier permits it — an unknown id, or a deliberately non-grantable
+     * one. The renderer's "Set project default" elevates to it
      * via `setSessionTier`; its "Allow this tool" issues a per-tool grant for
      * the denied tool without changing the session tier at all. A `null`
      * withholds both affordances — the denial isn't actionable.

--- a/electron/services/mcp-server/sessionServer.ts
+++ b/electron/services/mcp-server/sessionServer.ts
@@ -343,9 +343,10 @@ export interface SessionServerDeps {
     tier: McpTier;
     /**
      * Minimum tier that permits the denied tool, or `null` if no tier permits
-     * it (unknown tool). The renderer uses this to label the elevation buttons
-     * — "Allow Action tier" / "Allow System tier" — and to drive the
-     * `setSessionTier` call.
+     * it (unknown tool). The renderer's "Set project default" elevates to it
+     * via `setSessionTier`; its "Allow this tool" issues a per-tool grant for
+     * the denied tool without changing the session tier at all. A `null`
+     * withholds both affordances — the denial isn't actionable.
      */
     targetTier: "workbench" | "action" | "system" | null;
   }) => void;

--- a/electron/services/mcp-server/sessionStore.ts
+++ b/electron/services/mcp-server/sessionStore.ts
@@ -137,7 +137,8 @@ export class SessionStore {
   // Tier-elevation decay timers, keyed by sessionId (unique across SSE and
   // HTTP). A renderer-approved "Always allow" elevation is bounded to
   // MCP_TIER_ELEVATION_TTL_MS; on expiry the session silently decays to the
-  // `workbench` baseline (#8462). `tierElevationStartedAt` drives the same
+  // baseline captured before the first elevation in the chain — not to a
+  // hardcoded `workbench` (#8462). `tierElevationStartedAt` drives the same
   // awake-time correction as the idle reaper; `tierElevationToken` records
   // the tier captured when the timer was armed so a fresh re-elevation
   // between arm and fire is never wiped (#2243 stale-token guard). Stored

--- a/electron/services/mcp-server/shared.ts
+++ b/electron/services/mcp-server/shared.ts
@@ -705,8 +705,8 @@ export const MCP_DEDUP_MAX_ENTRIES_PER_SESSION = 256;
  * TIER_NOT_PERMITTED denial. Both banner affordances target this tier rather
  * than blanket-elevating to `system`: "Set project default" elevates to it,
  * and "Allow this tool" mints a grant for the one tool that needed it without
- * elevating the tier at all. Returns `null` if the tool isn't permitted at any
- * tier (unknown tool).
+ * elevating the tier at all. Returns `null` when no non-external tier permits
+ * the tool — an unknown id, or a deliberately non-grantable one.
  *
  * The `external` tier is intentionally excluded because it's a peer of the
  * help-session tiers (api-key sessions only) and is never the right target

--- a/electron/services/mcp-server/shared.ts
+++ b/electron/services/mcp-server/shared.ts
@@ -104,10 +104,12 @@ export const MAX_PORT_RETRIES = 10;
 export const MCP_SSE_IDLE_TIMEOUT_MS = 30 * 60 * 1000;
 
 /**
- * Lifetime of a renderer-approved session-tier elevation ("Always allow"
- * via {@link minimumPermittingTier}). After this window the session silently
- * decays back to the `workbench` baseline so a stale "Always allow" can't
- * outlive the user's intent across hibernate/wake and project switches
+ * Lifetime of a renderer-approved session-tier elevation (the tier-mismatch
+ * banner's "Set project default", via {@link minimumPermittingTier}). After
+ * this window the session silently decays back to its pre-elevation baseline
+ * — the tier it held when the elevation was accepted, not the newly-saved
+ * project default — so a stale elevation can't outlive the user's intent
+ * across hibernate/wake and project switches
  * (#8462). The next out-of-baseline tool call re-triggers the tier-mismatch
  * banner — there is no separate decay notification. The window is awake-time
  * corrected via {@link SystemSleepService.getAwakeTimeSince} so suspend time
@@ -118,7 +120,8 @@ export const MCP_SSE_IDLE_TIMEOUT_MS = 30 * 60 * 1000;
 export const MCP_TIER_ELEVATION_TTL_MS = 30 * 60 * 1000;
 
 /**
- * Sliding-TTL window for per-tool grants minted via "Approve once". A grant
+ * Sliding-TTL window for per-tool grants minted via the tier-mismatch
+ * banner's "Allow this tool". A grant
  * issued for `(sessionId, toolId)` permits that exact tool for this session
  * for the duration, and any successful dispatch through the grant refreshes
  * the window. Sized comfortably below `MCP_SSE_IDLE_TIMEOUT_MS` so the
@@ -699,9 +702,11 @@ export const MCP_DEDUP_MAX_ENTRIES_PER_SESSION = 256;
 /**
  * Compute the minimum non-external tier that permits the given tool. Used to
  * tell the renderer how to elevate the session in response to a
- * TIER_NOT_PERMITTED denial: "Approve once" / "Always allow" both target this
- * tier rather than blanket-elevating to `system`. Returns `null` if the tool
- * isn't permitted at any tier (unknown tool).
+ * TIER_NOT_PERMITTED denial. Both banner affordances target this tier rather
+ * than blanket-elevating to `system`: "Set project default" elevates to it,
+ * and "Allow this tool" mints a grant for the one tool that needed it without
+ * elevating the tier at all. Returns `null` if the tool isn't permitted at any
+ * tier (unknown tool).
  *
  * The `external` tier is intentionally excluded because it's a peer of the
  * help-session tiers (api-key sessions only) and is never the right target

--- a/shared/config/helpAssistantTierAllowlists.ts
+++ b/shared/config/helpAssistantTierAllowlists.ts
@@ -260,8 +260,8 @@ export const HELP_TIER_INCREMENTAL: Record<HelpAssistantTier, readonly string[]>
 };
 
 /**
- * Cumulative allow-list per tier — every tool the assistant can call
- * without prompting at that tier.
+ * Cumulative allow-list per tier — every tool the assistant can call at that
+ * tier.
  */
 export const HELP_TIER_CUMULATIVE: Record<HelpAssistantTier, readonly string[]> = {
   workbench: WORKBENCH_TIER_TOOLS,

--- a/shared/config/helpAssistantTierAllowlists.ts
+++ b/shared/config/helpAssistantTierAllowlists.ts
@@ -260,8 +260,8 @@ export const HELP_TIER_INCREMENTAL: Record<HelpAssistantTier, readonly string[]>
 };
 
 /**
- * Cumulative allow-list per tier — every tool the assistant can call at that
- * tier.
+ * Cumulative static allow-list per tier — every tool that tier permits before
+ * a live grant widens the session.
  */
 export const HELP_TIER_CUMULATIVE: Record<HelpAssistantTier, readonly string[]> = {
   workbench: WORKBENCH_TIER_TOOLS,

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -2394,7 +2394,7 @@ export interface HelpAssistantSettings {
   daintreeControl: boolean;
   /**
    * MCP capability tier the help assistant runs at — controls which Daintree
-   * actions the assistant can call without prompting. Defaults to `"action"`.
+   * actions the assistant can call. Defaults to `"action"`.
    */
   tier: HelpAssistantTier;
   /**

--- a/src/components/HelpPanel/HelpPanelBanners.tsx
+++ b/src/components/HelpPanel/HelpPanelBanners.tsx
@@ -298,8 +298,9 @@ export function HelpPanelBanners({
               </p>
               {tierMismatch.targetTier && (
                 <p className="mt-1 text-text-secondary">
-                  Allowing the tool covers repeat calls for up to 30 minutes. The project default
-                  applies to new sessions and raises this session for 30 minutes.
+                  Allowing the tool covers repeat calls for 15 minutes after the last one, 30 at
+                  most. The project default applies to agents launched in this project, and raises
+                  this session for 30 minutes.
                 </p>
               )}
             </div>

--- a/src/components/HelpPanel/HelpPanelBanners.tsx
+++ b/src/components/HelpPanel/HelpPanelBanners.tsx
@@ -35,8 +35,9 @@ function computeRemainingSeconds(expiresAt: number): number {
 }
 
 /**
- * Ambient countdown for a live "Approve once" grant (#10042). Tier 1 — a
- * non-blocking pane-chrome state, not a toast. The countdown derives from the
+ * Ambient countdown for a live per-tool grant (#10042), minted by the
+ * tier-mismatch banner's "Allow this tool". Tier 1 — a non-blocking
+ * pane-chrome state, not a toast. The countdown derives from the
  * grant's `expiresAt` with a component-local 1s tick; the timestamp is the
  * source of truth, so a missed tick can't drift the displayed value (and the
  * interval is keyed on `expiresAt`, restarting cleanly under StrictMode's
@@ -295,6 +296,12 @@ export function HelpPanelBanners({
                   ? `${tierMismatch.toolId} needs ${tierMismatch.targetTier} tier access.`
                   : `${tierMismatch.toolId} isn't available at any project tier.`}
               </p>
+              {tierMismatch.targetTier && (
+                <p className="mt-1 text-text-secondary">
+                  Allowing the tool covers repeat calls for up to 30 minutes. The project default
+                  applies to new sessions and raises this session for 30 minutes.
+                </p>
+              )}
             </div>
             <button
               type="button"
@@ -306,6 +313,15 @@ export function HelpPanelBanners({
             </button>
           </div>
           {tierMismatch.targetTier && (
+            // Labels name the scope; the body above carries the windows. These
+            // read "Approve once" and "Always allow for this project" before
+            // #12119 and both overstated their mechanism. `onApproveOnce` mints
+            // a *reusable* per-tool grant (15min sliding, 30min ceiling), so it
+            // was never once. `onAlwaysAllow` does persist a project default for
+            // new sessions, but lifts *this* session for only 30min of awake
+            // time, so it was never always. Handler names and the main-process
+            // comments keep the original spelling as the flow names (#8442,
+            // #10042); this is the anchor that maps them to the shipped labels.
             <div className="flex items-center gap-2 flex-wrap pl-5">
               <button
                 type="button"
@@ -318,7 +334,7 @@ export function HelpPanelBanners({
                   "focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent-primary focus-visible:outline-offset-2"
                 )}
               >
-                Approve once
+                Allow this tool
               </button>
               <button
                 type="button"
@@ -331,7 +347,7 @@ export function HelpPanelBanners({
                   "focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent-primary focus-visible:outline-offset-2"
                 )}
               >
-                Always allow for this project
+                Set project default
               </button>
               <button
                 type="button"

--- a/src/components/HelpPanel/HelpPanelBanners.tsx
+++ b/src/components/HelpPanel/HelpPanelBanners.tsx
@@ -299,8 +299,8 @@ export function HelpPanelBanners({
               {tierMismatch.targetTier && (
                 <p className="mt-1 text-text-secondary">
                   Allowing the tool covers repeat calls for 15 minutes after the last one, 30 at
-                  most. The project default applies to agents launched in this project, and raises
-                  this session for 30 minutes.
+                  most. The project default applies to Claude Code and Daintree Assistant panes
+                  launched in this project, and raises this session for 30 minutes.
                 </p>
               )}
             </div>
@@ -319,8 +319,9 @@ export function HelpPanelBanners({
             // #12119 and both overstated their mechanism. `onApproveOnce` mints
             // a *reusable* per-tool grant (15min sliding, 30min ceiling), so it
             // was never once. `onAlwaysAllow` does persist a project default for
-            // new sessions, but lifts *this* session for only 30min of awake
-            // time, so it was never always. Handler names and the main-process
+            // the project's own agent panes — never for new help sessions, which
+            // provision from the global settings tier — but lifts *this* session
+            // for only 30min of awake time, so it was never always. Handler names and the main-process
             // comments keep the original spelling as the flow names (#8442,
             // #10042); this is the anchor that maps them to the shipped labels.
             <div className="flex items-center gap-2 flex-wrap pl-5">

--- a/src/components/HelpPanel/__tests__/HelpPanelBanners.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanelBanners.test.tsx
@@ -469,7 +469,8 @@ describe("HelpPanelBanners — grant ended notice (#10042)", () => {
 
 // #12119: the two affordances shipped as "Approve once" / "Always allow for
 // this project" and neither matched its mechanism — the first mints a reusable
-// per-tool grant, the second only lifts the running session for 30 minutes.
+// per-tool grant; the second persists a project default AND lifts the running
+// help session for 30 minutes.
 // Both labels overstated the grant, which is the wrong direction to be wrong in
 // for a control that widens an agent's authority, so the copy is pinned here.
 describe("HelpPanelBanners — tier mismatch (#12119)", () => {
@@ -512,10 +513,15 @@ describe("HelpPanelBanners — tier mismatch (#12119)", () => {
     );
     const text = getByTestId("help-tier-mismatch-banner").textContent ?? "";
     expect(text).toContain("terminal.new needs action tier access.");
-    // The per-tool grant is reusable up to its 30-minute ceiling...
-    expect(text).toContain("repeat calls for up to 30 minutes");
-    // ...and the project write persists while the session lift does not.
-    expect(text).toContain("applies to new sessions");
+    // The grant is reusable on a 15-minute sliding window under a 30-minute
+    // ceiling — stating only the ceiling would overstate an idle grant's life.
+    expect(text).toContain("repeat calls for 15 minutes after the last one, 30 at most");
+    // The project write feeds agents launched in the project; new *help*
+    // sessions provision from the global settings tier, so the copy must not
+    // promise them anything (HelpSessionService.doProvision).
+    expect(text).toContain("applies to agents launched in this project");
+    expect(text).not.toContain("new sessions");
+    // The session lift is the half that lapses.
     expect(text).toContain("raises this session for 30 minutes");
   });
 
@@ -542,15 +548,37 @@ describe("HelpPanelBanners — tier mismatch (#12119)", () => {
     expect(onDismissTierMismatch).toHaveBeenCalledTimes(1);
   });
 
+  it("disables every action while an approval is in flight", () => {
+    const { getByTestId } = render(
+      <HelpPanelBanners {...baseProps()} tierMismatch={tierMismatch} isApprovingTier />
+    );
+    const actionRow = getByTestId("help-tier-mismatch-banner").querySelector(
+      ".flex.items-center.gap-2.flex-wrap.pl-5"
+    );
+    const buttons = Array.from(actionRow!.querySelectorAll("button"));
+    expect(buttons.length).toBe(3);
+    // Cancel is disabled too: dismissing mid-flight would strand the in-flight
+    // grant with no banner to report its outcome.
+    expect(buttons.every((b) => (b as HTMLButtonElement).disabled)).toBe(true);
+  });
+
+  // `targetTier: null` means no tier permits the tool at all, so neither
+  // affordance can help — an unknown id, never an action-tier tool like
+  // `terminal.new`.
   it("withholds the actions and the window copy when no tier would permit the tool", () => {
     const { getByTestId, queryByText } = render(
-      <HelpPanelBanners {...baseProps()} tierMismatch={{ ...tierMismatch, targetTier: null }} />
+      <HelpPanelBanners
+        {...baseProps()}
+        tierMismatch={{ ...tierMismatch, toolId: "unknown.tool", targetTier: null }}
+      />
     );
     const banner = getByTestId("help-tier-mismatch-banner");
-    expect(banner.textContent).toContain("terminal.new isn't available at any project tier.");
-    // Nothing to grant, so the duration copy must not appear either — it would
-    // describe affordances that aren't rendered.
-    expect(banner.textContent).not.toContain("30 minutes");
+    expect(banner.textContent).toContain("unknown.tool isn't available at any project tier.");
+    // Nothing to grant, so the details paragraph must not render at all —
+    // asserting on its semantic openings rather than one duration phrase, so a
+    // reworded body can't leak back into this branch unnoticed.
+    expect(banner.textContent).not.toContain("Allowing the tool");
+    expect(banner.textContent).not.toContain("The project default");
     expect(queryByText("Allow this tool")).toBeNull();
     expect(queryByText("Set project default")).toBeNull();
   });

--- a/src/components/HelpPanel/__tests__/HelpPanelBanners.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanelBanners.test.tsx
@@ -519,7 +519,11 @@ describe("HelpPanelBanners — tier mismatch (#12119)", () => {
     // The project write feeds agents launched in the project; new *help*
     // sessions provision from the global settings tier, so the copy must not
     // promise them anything (HelpSessionService.doProvision).
-    expect(text).toContain("applies to agents launched in this project");
+    expect(text).toContain(
+      "applies to Claude Code and Daintree Assistant panes launched in this project"
+    );
+    // Deliberately broad: nothing in a denied-tool banner has any business
+    // promising "new sessions" anything, and that promise was the bug.
     expect(text).not.toContain("new sessions");
     // The session lift is the half that lapses.
     expect(text).toContain("raises this session for 30 minutes");

--- a/src/components/HelpPanel/__tests__/HelpPanelBanners.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanelBanners.test.tsx
@@ -466,3 +466,92 @@ describe("HelpPanelBanners — grant ended notice (#10042)", () => {
     expect(onDismissGrantEnded).toHaveBeenCalledTimes(1);
   });
 });
+
+// #12119: the two affordances shipped as "Approve once" / "Always allow for
+// this project" and neither matched its mechanism — the first mints a reusable
+// per-tool grant, the second only lifts the running session for 30 minutes.
+// Both labels overstated the grant, which is the wrong direction to be wrong in
+// for a control that widens an agent's authority, so the copy is pinned here.
+describe("HelpPanelBanners — tier mismatch (#12119)", () => {
+  const tierMismatch = {
+    sessionId: "sess-1",
+    toolId: "terminal.new",
+    tier: "workbench",
+    targetTier: "action" as const,
+    projectId: "proj-1",
+  };
+
+  it("renders the exact action row (label + order) for an actionable denial", () => {
+    const { getByTestId } = render(
+      <HelpPanelBanners {...baseProps()} tierMismatch={tierMismatch} />
+    );
+
+    const banner = getByTestId("help-tier-mismatch-banner");
+    expect(banner.getAttribute("role")).toBe("alert");
+
+    const actionRow = banner.querySelector(".flex.items-center.gap-2.flex-wrap.pl-5");
+    expect(actionRow).not.toBeNull();
+    const labels = Array.from(actionRow!.querySelectorAll("button")).map(
+      (b) => b.textContent?.trim() ?? ""
+    );
+    expect(labels).toEqual(["Allow this tool", "Set project default", "Cancel"]);
+  });
+
+  it("never claims the grant is one call or the elevation permanent", () => {
+    const { getByTestId } = render(
+      <HelpPanelBanners {...baseProps()} tierMismatch={tierMismatch} />
+    );
+    const text = getByTestId("help-tier-mismatch-banner").textContent ?? "";
+    expect(text).not.toMatch(/\bonce\b/i);
+    expect(text).not.toMatch(/\balways\b/i);
+  });
+
+  it("discloses both bounded windows in the body", () => {
+    const { getByTestId } = render(
+      <HelpPanelBanners {...baseProps()} tierMismatch={tierMismatch} />
+    );
+    const text = getByTestId("help-tier-mismatch-banner").textContent ?? "";
+    expect(text).toContain("terminal.new needs action tier access.");
+    // The per-tool grant is reusable up to its 30-minute ceiling...
+    expect(text).toContain("repeat calls for up to 30 minutes");
+    // ...and the project write persists while the session lift does not.
+    expect(text).toContain("applies to new sessions");
+    expect(text).toContain("raises this session for 30 minutes");
+  });
+
+  it("routes each button to its own handler", () => {
+    const onApproveOnce = vi.fn();
+    const onAlwaysAllow = vi.fn();
+    const onDismissTierMismatch = vi.fn();
+    const { getByText } = render(
+      <HelpPanelBanners
+        {...baseProps()}
+        tierMismatch={tierMismatch}
+        onApproveOnce={onApproveOnce}
+        onAlwaysAllow={onAlwaysAllow}
+        onDismissTierMismatch={onDismissTierMismatch}
+      />
+    );
+
+    fireEvent.click(getByText("Allow this tool"));
+    fireEvent.click(getByText("Set project default"));
+    fireEvent.click(getByText("Cancel"));
+
+    expect(onApproveOnce).toHaveBeenCalledTimes(1);
+    expect(onAlwaysAllow).toHaveBeenCalledTimes(1);
+    expect(onDismissTierMismatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("withholds the actions and the window copy when no tier would permit the tool", () => {
+    const { getByTestId, queryByText } = render(
+      <HelpPanelBanners {...baseProps()} tierMismatch={{ ...tierMismatch, targetTier: null }} />
+    );
+    const banner = getByTestId("help-tier-mismatch-banner");
+    expect(banner.textContent).toContain("terminal.new isn't available at any project tier.");
+    // Nothing to grant, so the duration copy must not appear either — it would
+    // describe affordances that aren't rendered.
+    expect(banner.textContent).not.toContain("30 minutes");
+    expect(queryByText("Allow this tool")).toBeNull();
+    expect(queryByText("Set project default")).toBeNull();
+  });
+});

--- a/src/components/Settings/DaintreeAssistantSettingsTab.tsx
+++ b/src/components/Settings/DaintreeAssistantSettingsTab.tsx
@@ -173,8 +173,8 @@ interface BypassCopy {
 // Scoped to new sessions because both the tier and the bypass preference are
 // provision-time snapshots — a session already running keeps the tier it was
 // minted with, which the live-status card reports.
-const tierIsMainSafeguard = (tier: HelpAssistantTier): string =>
-  `New sessions run at the ${TIER_SHORT_LABEL[tier]} capability tier, which is the main remaining safeguard for Daintree actions. The ones that need confirmation still raise Daintree's own prompt unless an automation grant covers them.`;
+const tierBoundsNewSessions = (tier: HelpAssistantTier): string =>
+  `New sessions are limited to the Daintree actions the ${TIER_SHORT_LABEL[tier]} capability tier allows. Actions that need confirmation still open Daintree's own prompt unless an automation grant covers them.`;
 
 /**
  * Per-agent wording for the one stored `bypassPermissions` preference. The
@@ -198,7 +198,7 @@ const BYPASS_COPY: Record<string, Omit<BypassCopy, "subtitle"> & { effect: strin
     effect: "Skip Codex's approval prompts and run tools unsandboxed",
     ariaLabel: "Bypass Codex approvals and sandbox during help sessions",
     warning:
-      "With this on, Codex runs every tool without approval and outside its sandbox, so it reaches anywhere the process can.",
+      "With this on, Codex runs every tool without its own approval prompts and outside its sandbox, so it reaches anywhere the process can.",
   },
 };
 
@@ -213,7 +213,7 @@ const BYPASS_COPY: Record<string, Omit<BypassCopy, "subtitle"> & { effect: strin
 function getBypassCopy(agentId: string | null, tier: HelpAssistantTier): BypassCopy | null {
   if (!agentId) return null;
 
-  const safeguard = tierIsMainSafeguard(tier);
+  const safeguard = tierBoundsNewSessions(tier);
 
   // The assistant has no CLI flag: bypass skips its own confirm sheet via
   // DAINTREE_ASSISTANT_AUTO_APPROVE, which is why it carries no
@@ -223,7 +223,7 @@ function getBypassCopy(agentId: string | null, tier: HelpAssistantTier): BypassC
       title: "Auto-approve assistant actions",
       subtitle: "Skip the assistant's own per-action confirmation sheet",
       ariaLabel: "Auto-approve Daintree Assistant actions during help sessions",
-      warning: `With this on, the assistant acts without asking — no confirmation sheet for anything it does. ${safeguard}`,
+      warning: `With this on, the assistant acts without asking — it skips its own confirmation sheet for everything it does. ${safeguard}`,
     };
   }
 
@@ -243,7 +243,7 @@ function getBypassCopy(agentId: string | null, tier: HelpAssistantTier): BypassC
     title: `Bypass ${agentName} permission prompts`,
     subtitle: `Skip ${agentName}'s confirmation gate (passes ${flag})`,
     ariaLabel: `Bypass ${agentName} permission prompts during help sessions`,
-    warning: `With this on, ${agentName} runs every tool without asking. ${safeguard}`,
+    warning: `With this on, ${agentName} skips its own confirmation gate for every tool. ${safeguard}`,
   };
 }
 
@@ -1023,7 +1023,7 @@ export function DaintreeAssistantSettingsTab() {
       <SettingsSection
         icon={ShieldAlert}
         title="Security"
-        description="Pick how much the assistant can do without prompting, and whether to bypass the agent's own confirmation gate."
+        description="Pick how much of Daintree the assistant can reach, and whether to bypass the agent's own confirmation gate."
       >
         <SettingsSelect
           label="Capability tier"
@@ -1332,7 +1332,7 @@ function BlastRadiusPreview({ tier, isOpen, onToggle }: BlastRadiusPreviewProps)
             )}
           />
           <span>
-            {totalCount} actions allowed without prompting
+            {totalCount} actions available at this tier
             {tier !== "workbench" && (
               <span className="text-text-secondary"> ({newAtTier} new at this tier)</span>
             )}

--- a/src/components/Settings/DaintreeAssistantSettingsTab.tsx
+++ b/src/components/Settings/DaintreeAssistantSettingsTab.tsx
@@ -163,12 +163,18 @@ interface BypassCopy {
 }
 
 // Names the tier rather than pointing at "the selector above" (#11907): with
-// the gate off, the tier is the entire remaining boundary, so the warning has
-// to say which one. Scoped to new sessions because both the tier and the
-// bypass preference are provision-time snapshots — a session already running
-// keeps the tier it was minted with, which the live-status card reports.
-const tierIsLastSafeguard = (tier: HelpAssistantTier): string =>
-  `New sessions run at the ${TIER_SHORT_LABEL[tier]} capability tier, which is the only remaining safeguard for Daintree actions.`;
+// the gate off, the tier carries most of the remaining boundary, so the
+// warning has to say which one. It isn't the *entire* boundary though, and
+// claiming so was the #12119 overclaim: a `danger: "confirm"` action still
+// opens the host confirmation dialog no matter the tier or the bypass flag
+// (`tierAuth.ts` — `requiresConfirmation: danger === "confirm" &&
+// !nativeGranted`), and only a native automation grant pre-authorizes it. So
+// the second sentence names that exception instead of dropping the warning.
+// Scoped to new sessions because both the tier and the bypass preference are
+// provision-time snapshots — a session already running keeps the tier it was
+// minted with, which the live-status card reports.
+const tierIsMainSafeguard = (tier: HelpAssistantTier): string =>
+  `New sessions run at the ${TIER_SHORT_LABEL[tier]} capability tier, which is the main remaining safeguard for Daintree actions. The ones that need confirmation still raise Daintree's own prompt unless an automation grant covers them.`;
 
 /**
  * Per-agent wording for the one stored `bypassPermissions` preference. The
@@ -178,7 +184,7 @@ const tierIsLastSafeguard = (tier: HelpAssistantTier): string =>
  * same failure as labelling every agent with Claude's flag.
  */
 // `warning` carries the agent-specific half only; `getBypassCopy` appends the
-// tier-naming safeguard sentence so every branch names the same effective tier.
+// tier-naming safeguard sentences so every branch names the same effective tier.
 const BYPASS_COPY: Record<string, Omit<BypassCopy, "subtitle"> & { effect: string }> = {
   claude: {
     title: "Bypass Claude permission prompts",
@@ -207,7 +213,7 @@ const BYPASS_COPY: Record<string, Omit<BypassCopy, "subtitle"> & { effect: strin
 function getBypassCopy(agentId: string | null, tier: HelpAssistantTier): BypassCopy | null {
   if (!agentId) return null;
 
-  const safeguard = tierIsLastSafeguard(tier);
+  const safeguard = tierIsMainSafeguard(tier);
 
   // The assistant has no CLI flag: bypass skips its own confirm sheet via
   // DAINTREE_ASSISTANT_AUTO_APPROVE, which is why it carries no

--- a/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
@@ -380,12 +380,12 @@ describe("DaintreeAssistantSettingsTab", () => {
     );
     await waitForContent(container, "Bypass Claude permission prompts");
 
-    expect(container.textContent).not.toContain("only remaining safeguard");
+    expect(container.textContent).not.toContain("unless an automation grant covers them");
 
     const toggle = screen.getByLabelText("Bypass Claude permission prompts during help sessions");
     fireEvent.click(toggle);
 
-    await waitForContent(container, "only remaining safeguard");
+    await waitForContent(container, "unless an automation grant covers them");
     expect(window.electron.helpAssistant.setSettings).toHaveBeenCalledWith({
       bypassPermissions: true,
     });
@@ -444,10 +444,12 @@ describe("DaintreeAssistantSettingsTab", () => {
     });
   });
 
-  // #11907: with the confirmation sheet off, the tier is the entire remaining
-  // boundary, so the warning has to name it — and keep naming the right one
-  // when the selector moves (a missing memo dependency would freeze the old
-  // tier in the copy while the selector reads the new one).
+  // #11907: with the confirmation sheet off, the tier carries most of the
+  // remaining boundary, so the warning has to name it — and keep naming the
+  // right one when the selector moves (a missing memo dependency would freeze
+  // the old tier in the copy while the selector reads the new one). #12119
+  // stopped it claiming to be the *entire* boundary, so the assertions below
+  // pin the corrected "main remaining safeguard" wording.
   it("names the configured tier in the auto-approve warning and follows the selector", async () => {
     mockGetAssistantSupportedAgentIds.mockReturnValue(["claude", "codex", "daintree-assistant"]);
     helpPanelState.preferredAgentId = "daintree-assistant";
@@ -472,14 +474,14 @@ describe("DaintreeAssistantSettingsTab", () => {
 
     await waitForContent(
       container,
-      "New sessions run at the Action capability tier, which is the only remaining safeguard"
+      "New sessions run at the Action capability tier, which is the main remaining safeguard"
     );
 
     fireEvent.change(screen.getByLabelText("Capability tier"), { target: { value: "system" } });
 
     await waitForContent(
       container,
-      "New sessions run at the System capability tier, which is the only remaining safeguard"
+      "New sessions run at the System capability tier, which is the main remaining safeguard"
     );
     expect(container.textContent).not.toContain("the Action capability tier");
   });
@@ -561,7 +563,7 @@ describe("DaintreeAssistantSettingsTab", () => {
     await waitForContent(container, "Capability tier");
 
     expect(screen.queryByRole("switch", { name: /bypass|auto-approve/i })).toBeNull();
-    expect(container.textContent).not.toContain("only remaining safeguard");
+    expect(container.textContent).not.toContain("unless an automation grant covers them");
   });
 
   it("renders exactly the model catalog the resolver returns", async () => {

--- a/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
@@ -416,6 +416,9 @@ describe("DaintreeAssistantSettingsTab", () => {
     // confirmation gate, and understating that is the bug being fixed.
     await waitForContent(container, "outside its sandbox");
     expect(container.textContent).not.toContain("built-in (Bash, Write)");
+    // Scoped to Codex's OWN approvals (#12119): an unqualified "without
+    // approval" contradicts the host-confirmation exception appended below it.
+    expect(container.textContent).toContain("without its own approval prompts");
   });
 
   it("describes the Daintree Assistant's env-var bypass, not a CLI flag", async () => {
@@ -439,6 +442,9 @@ describe("DaintreeAssistantSettingsTab", () => {
     fireEvent.click(toggle);
 
     await waitForContent(container, "acts without asking");
+    // Same #12119 scoping: the sheet it skips is its own, not Daintree's host
+    // confirmation, which still fires for confirmation-required actions.
+    expect(container.textContent).toContain("it skips its own confirmation sheet for everything");
     expect(window.electron.helpAssistant.setSettings).toHaveBeenCalledWith({
       bypassPermissions: true,
     });

--- a/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
@@ -449,7 +449,7 @@ describe("DaintreeAssistantSettingsTab", () => {
   // right one when the selector moves (a missing memo dependency would freeze
   // the old tier in the copy while the selector reads the new one). #12119
   // stopped it claiming to be the *entire* boundary, so the assertions below
-  // pin the corrected "main remaining safeguard" wording.
+  // pin both halves: the tier-named limit and the confirmation exception.
   it("names the configured tier in the auto-approve warning and follows the selector", async () => {
     mockGetAssistantSupportedAgentIds.mockReturnValue(["claude", "codex", "daintree-assistant"]);
     helpPanelState.preferredAgentId = "daintree-assistant";
@@ -474,14 +474,14 @@ describe("DaintreeAssistantSettingsTab", () => {
 
     await waitForContent(
       container,
-      "New sessions run at the Action capability tier, which is the main remaining safeguard"
+      "New sessions are limited to the Daintree actions the Action capability tier allows"
     );
 
     fireEvent.change(screen.getByLabelText("Capability tier"), { target: { value: "system" } });
 
     await waitForContent(
       container,
-      "New sessions run at the System capability tier, which is the main remaining safeguard"
+      "New sessions are limited to the Daintree actions the System capability tier allows"
     );
     expect(container.textContent).not.toContain("the Action capability tier");
   });

--- a/src/controllers/McpActivityTracker.ts
+++ b/src/controllers/McpActivityTracker.ts
@@ -176,7 +176,7 @@ export class McpActivityTracker {
   }
 
   /**
-   * End the live "Approve once" grant early (#10042). Revokes every grant on
+   * End the live per-tool grant early (#10042). Revokes every grant on
    * the session — the help session only ever holds one per-tool grant at a
    * time, so this maps to the single banner the user sees. Normally the
    * `grant.revoked` lifecycle event (reason `user`) clears the banner first;
@@ -226,10 +226,10 @@ export class McpActivityTracker {
     this.host.patch({ isApprovingTier: true });
     safeFireAndForget(
       window.electron.mcpServer
-        // "Approve once" mints a per-tool, time-bounded grant for this
-        // session — it does NOT elevate the session tier. The "Always
-        // allow" path is the only remaining caller of `setSessionTier`
-        // (#8442).
+        // The banner's "Allow this tool" mints a per-tool, time-bounded
+        // grant for this session — it does NOT elevate the session tier. The
+        // "Set project default" path is the only remaining caller of
+        // `setSessionTier` (#8442).
         .issueGrant({ sessionId, toolId })
         .then(() => {
           this._clearTierMismatchIfStillCurrent(sessionId, toolId);


### PR DESCRIPTION
The tier-mismatch banner in the assistant panel offered "Approve once" and "Always allow for this project", and neither label matched its mechanism. Both overstated the grant, which is the wrong direction to be wrong in for a control that widens an agent's authority.

**What was actually happening**
- "Approve once" mints a per-`(sessionId, toolId)` grant that is reusable — `MCP_GRANT_TTL_MS` is a 15-minute sliding window refreshed by every successful dispatch, under a 30-minute `MCP_GRANT_MAX_LIFETIME_MS` ceiling. It never elevates the tier.
- "Always allow for this project" writes a persisted `daintreeMcpTier` default AND elevates the live session, which decays back to its pre-elevation baseline after 30 minutes of awake time. Silently — there is no decay notification, the banner just reappears.
- The assistant settings tab called the capability tier "the only remaining safeguard for Daintree actions". False for `danger: "confirm"` actions, which open the host confirmation dialog at any tier; only a native automation grant pre-authorizes that.

**What changed**
- Labels are now `Allow this tool` and `Set project default`, with the real windows disclosed in the banner body rather than implied by the labels.
- The settings sentence states the limit the tier actually imposes and names the confirmation exception, instead of ranking itself as the "only" safeguard.
- The per-agent bypass lead-ins are scoped to each agent's own gate — an unqualified "runs every tool without asking" contradicted the host-confirmation sentence appended right after it.
- Two more "without prompting" tier claims in the same tab are gone; confirmation-required actions have always falsified them.
- Corrected the main-process comments carrying the same misdescriptions: a hardcoded-`workbench` decay claim in `sessionStore`, two button labels in `sessionServer` that never shipped, and `minimumPermittingTier`'s `null` described as only ever an unknown tool.

**One correction worth calling out.** My first pass said the project default "applies to new sessions". It does not — `HelpSessionService.doProvision` provisions every help session from the global `HelpAssistantSettings.tier`; `daintreeMcpTier` is read only by Claude Code and Daintree Assistant *pane* launches in the project. Caught in review and fixed; the copy now names those two consumers.

No behavior changes — copy, comments and tests only.

**Testing**
The tier-mismatch branch had zero coverage, so it has a suite now: exact labels and order, callback routing, both disclosed windows, the in-flight disabled state, and the `targetTier: null` branch that withholds both affordances. The five existing `only remaining safeguard` assertions moved in lockstep, and the newly scoped Codex/assistant lead-in clauses are pinned so an unqualified "without approval" can't come back.

Local: 4,184 tests across HelpPanel, Settings, controllers, config contract suites, mcp-server, terminal handlers and shared config — all passing after rebase. prettier + eslint clean on changed files (0 errors; the 43 warnings are pre-existing legacy-token ones on untouched lines).

**Left out deliberately**
- `McpActivityTracker.alwaysAllowTier` writes the project setting before elevating the session; if the second step fails the write persists while the toast says "Couldn't save permission". Real, but a control-flow fix rather than copy.
- `GeneralTab.tsx:576` says only Claude Code agents consume the project tier setting — Daintree Assistant panes do too.
- `docs/architecture/mcp-server.md:338` repeats the false hardcoded-`workbench` decay.

Resolves #12119