### PR TITLE
fix(github): read pasted and spaced number lists as a lookup

### DIFF
--- a/plugins/builtin/github/renderer/__tests__/GitHubResourceList.swr.test.tsx
+++ b/plugins/builtin/github/renderer/__tests__/GitHubResourceList.swr.test.tsx
@@ -2554,9 +2554,7 @@ describe("GitHubResourceList number-query chip (#6867)", () => {
     render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
 
     await waitFor(() => {
-      expect(mockListIssues).toHaveBeenCalledWith(
-        expect.objectContaining({ search: "123,,124" })
-      );
+      expect(mockListIssues).toHaveBeenCalledWith(expect.objectContaining({ search: "123,,124" }));
     });
     await waitFor(() => {
       expect(screen.getByText(FALLBACK_COPY)).toBeTruthy();

--- a/plugins/builtin/github/renderer/__tests__/GitHubResourceList.swr.test.tsx
+++ b/plugins/builtin/github/renderer/__tests__/GitHubResourceList.swr.test.tsx
@@ -6,6 +6,7 @@ import { render, screen, cleanup, waitFor, act, fireEvent } from "@testing-libra
 import React, { Activity, type ReactNode } from "react";
 import type { Issue, ListOptions, Page } from "@shared/types/forge";
 import { setCache, getCache, buildCacheKey, _resetForTests } from "@/lib/forgeResourceCache";
+import { MULTI_FETCH_CAP } from "@/lib/parseNumberQuery";
 import { useGitHubFilterStore } from "../stores/githubFilterStore";
 import { useIssueSelectionStore } from "@/store/issueSelectionStore";
 import { useForgeProviderHealthStore } from "@/store/forgeProviderHealthStore";
@@ -28,6 +29,8 @@ const mockListIssues = vi.fn();
 const mockListPRs = vi.fn();
 const mockGetIssueByNumber = vi.fn();
 const mockGetPRByNumber = vi.fn();
+const mockGetIssuesByNumbers = vi.fn();
+const mockGetPRsByNumbers = vi.fn();
 
 // The shim merges `cwd` into the options object so assertions can keep
 // matching a single flat shape.
@@ -38,8 +41,8 @@ vi.mock("@/clients/forgeClient", () => ({
     getIssue: (cwd: string, issueNumber: number) => mockGetIssueByNumber(cwd, issueNumber),
     getPR: (cwd: string, prNumber: number) => mockGetPRByNumber(cwd, prNumber),
     getIssueUrl: vi.fn().mockResolvedValue("https://github.com/acme/repo/issues/1"),
-    getIssuesByNumbers: vi.fn().mockResolvedValue([]),
-    getPRsByNumbers: vi.fn().mockResolvedValue([]),
+    getIssuesByNumbers: (cwd: string, numbers: number[]) => mockGetIssuesByNumbers(cwd, numbers),
+    getPRsByNumbers: (cwd: string, numbers: number[]) => mockGetPRsByNumbers(cwd, numbers),
   },
 }));
 
@@ -261,6 +264,10 @@ beforeEach(() => {
   mockListPRs.mockReset();
   mockGetIssueByNumber.mockReset();
   mockGetPRByNumber.mockReset();
+  // Reset drops the default, and the hook calls `.filter` straight on the
+  // result — leave every batch lookup resolving to an empty array.
+  mockGetIssuesByNumbers.mockReset().mockResolvedValue([]);
+  mockGetPRsByNumbers.mockReset().mockResolvedValue([]);
   LiveTimeAgoMock.mockClear();
   dispatchMock.mockReset();
   notifyMock.mockReset();
@@ -2491,6 +2498,87 @@ describe("GitHubResourceList number-query chip (#6867)", () => {
       expect(screen.getByTestId("skeleton")).toBeTruthy();
     });
     expect(screen.queryByText("Showing issue #42")).toBeNull();
+  });
+
+  const FALLBACK_COPY = "Showing text matches — separate numbers with commas or spaces";
+
+  it("routes a trailing-comma list to the batch lookup, not full-text search", async () => {
+    mockGetIssuesByNumbers.mockResolvedValue([makeIssue(123), makeIssue(124)]);
+    useGitHubFilterStore.getState().setIssueSearchQuery("123, 124,");
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Showing #123, #124")).toBeTruthy();
+    });
+    expect(mockGetIssuesByNumbers).toHaveBeenCalledWith("/test/proj", [123, 124]);
+    expect(mockListIssues).not.toHaveBeenCalled();
+    expect(screen.queryByText(FALLBACK_COPY)).toBeNull();
+  });
+
+  it("routes a whitespace-separated list to the batch lookup", async () => {
+    mockGetIssuesByNumbers.mockResolvedValue([makeIssue(12036), makeIssue(12037)]);
+    useGitHubFilterStore.getState().setIssueSearchQuery("12036 12037");
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Showing #12036, #12037")).toBeTruthy();
+    });
+    expect(mockGetIssuesByNumbers).toHaveBeenCalledWith("/test/proj", [12036, 12037]);
+    expect(mockListIssues).not.toHaveBeenCalled();
+  });
+
+  it("caps an explicit list at the multi-fetch cap and says so", async () => {
+    const asked = Array.from({ length: MULTI_FETCH_CAP + 1 }, (_, i) => i + 1);
+    mockGetIssuesByNumbers.mockResolvedValue(asked.slice(0, MULTI_FETCH_CAP).map(makeIssue));
+    useGitHubFilterStore.getState().setIssueSearchQuery(asked.join(", "));
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(`Showing first ${MULTI_FETCH_CAP} of ${asked.length} numbers (capped)`)
+      ).toBeTruthy();
+    });
+    expect(mockGetIssuesByNumbers).toHaveBeenCalledWith(
+      "/test/proj",
+      asked.slice(0, MULTI_FETCH_CAP)
+    );
+  });
+
+  it("says the results are text matches when a number list fails to parse", async () => {
+    mockListIssues.mockResolvedValue(makeResponse([makeIssue(500)]));
+    useGitHubFilterStore.getState().setIssueSearchQuery("123,,124");
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    await waitFor(() => {
+      expect(mockListIssues).toHaveBeenCalledWith(
+        expect.objectContaining({ search: "123,,124" })
+      );
+    });
+    await waitFor(() => {
+      expect(screen.getByText(FALLBACK_COPY)).toBeTruthy();
+    });
+    expect(mockGetIssuesByNumbers).not.toHaveBeenCalled();
+  });
+
+  it("stays quiet for an ordinary text search that contains numbers", async () => {
+    mockListIssues.mockResolvedValue(makeResponse([makeIssue(500)]));
+    useGitHubFilterStore.getState().setIssueSearchQuery("fix 123 crash");
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    await waitFor(() => {
+      expect(mockListIssues).toHaveBeenCalledWith(
+        expect.objectContaining({ search: "fix 123 crash" })
+      );
+    });
+    await waitFor(() => {
+      expect(screen.getByText("Issue #500")).toBeTruthy();
+    });
+    expect(screen.queryByText(FALLBACK_COPY)).toBeNull();
   });
 });
 

--- a/plugins/builtin/github/renderer/__tests__/GitHubResourceList.swr.test.tsx
+++ b/plugins/builtin/github/renderer/__tests__/GitHubResourceList.swr.test.tsx
@@ -2599,7 +2599,7 @@ describe("GitHubResourceList number-query chip (#6867)", () => {
       expect(screen.getByText(FALLBACK_COPY)).toBeTruthy();
     });
     // The chip has to sit over the text-search rows it describes, not over a
-    // skeleton or an empty list.
+    // skeleton.
     expect(screen.getByTestId("item-500")).toBeTruthy();
     expect(mockGetIssuesByNumbers).not.toHaveBeenCalled();
   });
@@ -2630,7 +2630,10 @@ describe("GitHubResourceList number-query chip (#6867)", () => {
 
   it("drops a stale exact-number miss when the query falls back to text search", async () => {
     mockGetIssueByNumber.mockResolvedValue(null);
-    mockListIssues.mockResolvedValue(makeResponse([makeIssue(500)]));
+    // Empty on purpose: a returned row would hide the empty state whether or
+    // not the stale miss was cleared, which is exactly how this test can pass
+    // without testing anything.
+    mockListIssues.mockResolvedValue(makeResponse([]));
     useGitHubFilterStore.getState().setIssueSearchQuery("#999");
 
     render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
@@ -2645,9 +2648,25 @@ describe("GitHubResourceList number-query chip (#6867)", () => {
       useGitHubFilterStore.getState().setIssueSearchQuery("123,,124");
     });
 
+    // The empty state must stop naming #999 and start naming the query that
+    // actually ran.
     await waitFor(() => {
-      expect(screen.queryByText(/No issue #999 in this view/)).toBeNull();
+      expect(screen.getByText('No matches for "123,,124"')).toBeTruthy();
     });
+    expect(screen.queryByText(/No issue #999 in this view/)).toBeNull();
+  });
+
+  it("yields the chip slot to a rate-limit pause", async () => {
+    mockListIssues.mockResolvedValue(makeResponse([]));
+    setRateLimit(true, "primary", Date.now() + 60_000);
+    useGitHubFilterStore.getState().setIssueSearchQuery("123,,124");
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/paused/i)).toBeTruthy();
+    });
+    expect(screen.queryByText(FALLBACK_COPY)).toBeNull();
   });
 
   it("stays quiet for an ordinary text search that contains numbers", async () => {

--- a/plugins/builtin/github/renderer/__tests__/GitHubResourceList.swr.test.tsx
+++ b/plugins/builtin/github/renderer/__tests__/GitHubResourceList.swr.test.tsx
@@ -2545,6 +2545,45 @@ describe("GitHubResourceList number-query chip (#6867)", () => {
       "/test/proj",
       asked.slice(0, MULTI_FETCH_CAP)
     );
+    // The point of the cap is one batch, not a sequential fan-out over the rest.
+    expect(mockGetIssuesByNumbers).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves a list of exactly the cap uncapped", async () => {
+    const asked = Array.from({ length: MULTI_FETCH_CAP }, (_, i) => i + 1);
+    mockGetIssuesByNumbers.mockResolvedValue(asked.map(makeIssue));
+    useGitHubFilterStore.getState().setIssueSearchQuery(asked.join(", "));
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Showing #1, #2, #3 + 17 more")).toBeTruthy();
+    });
+    expect(mockGetIssuesByNumbers).toHaveBeenCalledWith("/test/proj", asked);
+    expect(screen.queryByText(/\(capped\)/)).toBeNull();
+  });
+
+  it("caps the PR variant through its own batch lookup", async () => {
+    const asked = Array.from({ length: MULTI_FETCH_CAP + 5 }, (_, i) => i + 1);
+    mockGetPRsByNumbers.mockResolvedValue(
+      asked.slice(0, MULTI_FETCH_CAP).map((n) => ({
+        ...makeIssue(n),
+        isDraft: false,
+        ciStatus: "SUCCESS" as const,
+      }))
+    );
+    useGitHubFilterStore.getState().setPrSearchQuery(asked.join(" "));
+
+    render(<GitHubResourceList type="pr" projectPath="/test/proj" />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(`Showing first ${MULTI_FETCH_CAP} of ${asked.length} numbers (capped)`)
+      ).toBeTruthy();
+    });
+    expect(mockGetPRsByNumbers).toHaveBeenCalledWith("/test/proj", asked.slice(0, MULTI_FETCH_CAP));
+    expect(mockGetPRsByNumbers).toHaveBeenCalledTimes(1);
+    expect(mockListPRs).not.toHaveBeenCalled();
   });
 
   it("says the results are text matches when a number list fails to parse", async () => {
@@ -2559,7 +2598,56 @@ describe("GitHubResourceList number-query chip (#6867)", () => {
     await waitFor(() => {
       expect(screen.getByText(FALLBACK_COPY)).toBeTruthy();
     });
+    // The chip has to sit over the text-search rows it describes, not over a
+    // skeleton or an empty list.
+    expect(screen.getByTestId("item-500")).toBeTruthy();
     expect(mockGetIssuesByNumbers).not.toHaveBeenCalled();
+  });
+
+  it("holds the text-match chip back until the search settles", async () => {
+    mockListIssues.mockImplementation(() => new Promise(() => {}));
+    useGitHubFilterStore.getState().setIssueSearchQuery("123,,124");
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("skeleton")).toBeTruthy();
+    });
+    expect(screen.queryByText(FALLBACK_COPY)).toBeNull();
+  });
+
+  it("yields the chip slot to an error rather than claiming text matches", async () => {
+    mockListIssues.mockRejectedValue(new Error("Couldn't reach GitHub."));
+    useGitHubFilterStore.getState().setIssueSearchQuery("123,,124");
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Couldn't reach GitHub/)).toBeTruthy();
+    });
+    expect(screen.queryByText(FALLBACK_COPY)).toBeNull();
+  });
+
+  it("drops a stale exact-number miss when the query falls back to text search", async () => {
+    mockGetIssueByNumber.mockResolvedValue(null);
+    mockListIssues.mockResolvedValue(makeResponse([makeIssue(500)]));
+    useGitHubFilterStore.getState().setIssueSearchQuery("#999");
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/No issue #999 in this view/)).toBeTruthy();
+    });
+
+    // Falling through to text search must not leave the miss behind, or the
+    // empty state goes on naming #999 over rows that have nothing to do with it.
+    act(() => {
+      useGitHubFilterStore.getState().setIssueSearchQuery("123,,124");
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText(/No issue #999 in this view/)).toBeNull();
+    });
   });
 
   it("stays quiet for an ordinary text search that contains numbers", async () => {

--- a/plugins/builtin/github/renderer/components/GitHubResourceList.tsx
+++ b/plugins/builtin/github/renderer/components/GitHubResourceList.tsx
@@ -45,7 +45,7 @@ import { useGitHubConfigStore } from "../stores/githubConfigStore";
 import type { Issue, PR } from "@shared/types/forge";
 import type { Worktree } from "@shared/types/worktree";
 import type { GitHubSortOrder } from "../../shared/types.js";
-import { MULTI_FETCH_CAP } from "@/lib/parseNumberQuery";
+import { looksLikeNumberList, MULTI_FETCH_CAP } from "@/lib/parseNumberQuery";
 import {
   GitHubResourceRowsSkeleton,
   MAX_SKELETON_ITEMS,
@@ -1333,12 +1333,18 @@ export function GitHubResourceList({
               label = `Showing ${resourceLabel} #${numberQuery.number}`;
             } else if (numberQuery.kind === "multi") {
               const nums = numberQuery.numbers;
-              const shown = nums
-                .slice(0, 3)
-                .map((n) => `#${n}`)
-                .join(", ");
-              label =
-                nums.length > 3 ? `Showing ${shown} + ${nums.length - 3} more` : `Showing ${shown}`;
+              if (nums.length > MULTI_FETCH_CAP) {
+                label = `Showing first ${MULTI_FETCH_CAP} of ${nums.length} numbers (capped)`;
+              } else {
+                const shown = nums
+                  .slice(0, 3)
+                  .map((n) => `#${n}`)
+                  .join(", ");
+                label =
+                  nums.length > 3
+                    ? `Showing ${shown} + ${nums.length - 3} more`
+                    : `Showing ${shown}`;
+              }
             } else if (numberQuery.kind === "range") {
               label = numberQuery.truncated
                 ? `Showing first ${MULTI_FETCH_CAP} of range #${numberQuery.from}..#${numberQuery.to} (capped)`
@@ -1352,6 +1358,18 @@ export function GitHubResourceList({
               </p>
             );
           })()}
+
+        {/* The other half of the same chip slot: when a query that was plainly
+            meant as a number lookup fails to parse, the results below are
+            GitHub's full-text matches, which include anything that merely
+            mentions those numbers. Say so rather than letting the list quietly
+            fill with rows nobody asked for. Gated hard (see
+            `looksLikeNumberList`) so ordinary text searches stay silent. */}
+        {numberQuery === null && !loading && looksLikeNumberList(debouncedSearch) && (
+          <p className="bg-overlay-soft border border-[var(--border-divider)] rounded px-2 py-1 text-xs text-text-secondary">
+            Showing text matches — separate numbers with commas or spaces
+          </p>
+        )}
       </div>
 
       {/* The combobox points `aria-controls` here, so this element exists in

--- a/plugins/builtin/github/renderer/components/GitHubResourceList.tsx
+++ b/plugins/builtin/github/renderer/components/GitHubResourceList.tsx
@@ -1353,7 +1353,7 @@ export function GitHubResourceList({
               label = `Showing #${numberQuery.from} and above`;
             }
             return (
-              <p className="bg-overlay-soft border border-[var(--border-divider)] rounded px-2 py-1 text-xs text-text-secondary">
+              <p className="bg-overlay-soft border border-[var(--border-divider)] rounded-[var(--radius-sm)] px-2 py-1 text-xs text-text-secondary">
                 {label}
               </p>
             );
@@ -1365,11 +1365,15 @@ export function GitHubResourceList({
             mentions those numbers. Say so rather than letting the list quietly
             fill with rows nobody asked for. Gated hard (see
             `looksLikeNumberList`) so ordinary text searches stay silent. */}
-        {numberQuery === null && !loading && looksLikeNumberList(debouncedSearch) && (
-          <p className="bg-overlay-soft border border-[var(--border-divider)] rounded px-2 py-1 text-xs text-text-secondary">
-            Showing text matches — separate numbers with commas or spaces
-          </p>
-        )}
+        {numberQuery === null &&
+          !loading &&
+          !error &&
+          !isRateLimited &&
+          looksLikeNumberList(debouncedSearch) && (
+            <p className="bg-overlay-soft border border-[var(--border-divider)] rounded-[var(--radius-sm)] px-2 py-1 text-xs text-text-secondary">
+              Showing text matches — separate numbers with commas or spaces
+            </p>
+          )}
       </div>
 
       {/* The combobox points `aria-controls` here, so this element exists in

--- a/plugins/builtin/github/renderer/hooks/useGitHubResourceListSWR.ts
+++ b/plugins/builtin/github/renderer/hooks/useGitHubResourceListSWR.ts
@@ -27,7 +27,7 @@ import { useSystemWakeStore } from "@/store/systemWakeStore";
 import { FixedDropdownVisibleContext } from "@/components/ui/fixed-dropdown";
 import type { Issue, ListOptions, PR } from "@shared/types/forge";
 import type { GitHubSortOrder } from "../../shared/types.js";
-import { parseNumberQuery } from "@/lib/parseNumberQuery";
+import { MULTI_FETCH_CAP, parseNumberQuery } from "@/lib/parseNumberQuery";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 type StateFilter = string;
@@ -766,7 +766,11 @@ export function useGitHubResourceListSWR({
         }
 
         case "multi": {
-          const results = await getByNumbers(numberQuery.numbers);
+          // Capped the same way a range is: the parser keeps every number the
+          // user asked for so the chip can say how many were dropped, but the
+          // batch lookup pages through them 20 at a time and an uncapped paste
+          // would fan out into a run of sequential GraphQL calls.
+          const results = await getByNumbers(numberQuery.numbers.slice(0, MULTI_FETCH_CAP));
           if (abortController.signal.aborted) return;
           const filtered = results.filter(
             (r): r is NonNullable<typeof r> => r !== null && matchesFilter(r)

--- a/plugins/builtin/github/renderer/hooks/useGitHubResourceListSWR.ts
+++ b/plugins/builtin/github/renderer/hooks/useGitHubResourceListSWR.ts
@@ -502,6 +502,14 @@ export function useGitHubResourceListSWR({
       return;
     }
 
+    // Every path below that hydrates or clears state clears this too, but the
+    // one that doesn't is the one that matters: a filter/search change while
+    // mounted with a search active leaves `targetCached` undefined and falls
+    // straight through to `fetchData`. Coming off a missed `#999` lookup that
+    // left the empty state claiming "No issue #999 in this view" over the
+    // text-search rows that replaced it. Clear it on entry instead.
+    setExactNumberNotFound(null);
+
     const abortController = new AbortController();
     loadMoreAbortRef.current?.abort();
     const gen = nextGeneration(cacheKey);

--- a/plugins/builtin/github/renderer/hooks/useGitHubResourceListSWR.ts
+++ b/plugins/builtin/github/renderer/hooks/useGitHubResourceListSWR.ts
@@ -502,12 +502,13 @@ export function useGitHubResourceListSWR({
       return;
     }
 
-    // Every path below that hydrates or clears state clears this too, but the
-    // one that doesn't is the one that matters: a filter/search change while
-    // mounted with a search active leaves `targetCached` undefined and falls
-    // straight through to `fetchData`. Coming off a missed `#999` lookup that
-    // left the empty state claiming "No issue #999 in this view" over the
-    // text-search rows that replaced it. Clear it on entry instead.
+    // The clear further down lives inside `if (!isFirstMount)`, and a numeric
+    // query on mount never reaches it: this effect returns above before
+    // setting `mountedRef`, so when the query later becomes text the effect
+    // still counts as a first mount and skips that block on a cold cache. A
+    // missed `#999` then leaves the empty state claiming "No issue #999 in
+    // this view" over the text-search results that replaced it. Clear on entry
+    // instead — it is idempotent, and every other path already agrees.
     setExactNumberNotFound(null);
 
     const abortController = new AbortController();

--- a/src/lib/__tests__/parseNumberQuery.test.ts
+++ b/src/lib/__tests__/parseNumberQuery.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseNumberQuery, MULTI_FETCH_CAP } from "../parseNumberQuery";
+import { parseNumberQuery, looksLikeNumberList, MULTI_FETCH_CAP } from "../parseNumberQuery";
 
 describe("parseNumberQuery", () => {
   describe("single number", () => {
@@ -59,10 +59,74 @@ describe("parseNumberQuery", () => {
 
     it("should reject double commas", () => {
       expect(parseNumberQuery("123,,124")).toBeNull();
+      expect(parseNumberQuery("123,,")).toBeNull();
+      expect(parseNumberQuery("12036,, 12037")).toBeNull();
     });
 
-    it("should reject trailing comma", () => {
-      expect(parseNumberQuery("123, 124,")).toBeNull();
+    it("should parse trailing comma", () => {
+      expect(parseNumberQuery("123, 124,")).toEqual({
+        kind: "multi",
+        numbers: [123, 124],
+      });
+      expect(parseNumberQuery("12036,12037,")).toEqual({
+        kind: "multi",
+        numbers: [12036, 12037],
+      });
+    });
+
+    it("should parse a single number with a trailing comma", () => {
+      expect(parseNumberQuery("12036,")).toEqual({ kind: "single", number: 12036 });
+      expect(parseNumberQuery("#12036 ,")).toEqual({ kind: "single", number: 12036 });
+    });
+
+    it("should parse whitespace-separated numbers", () => {
+      expect(parseNumberQuery("12036 12037 12041")).toEqual({
+        kind: "multi",
+        numbers: [12036, 12037, 12041],
+      });
+      expect(parseNumberQuery("#12036  #12037")).toEqual({
+        kind: "multi",
+        numbers: [12036, 12037],
+      });
+    });
+
+    it("should parse an \"and\"-joined list", () => {
+      expect(parseNumberQuery("12036, 12037, and 12041")).toEqual({
+        kind: "multi",
+        numbers: [12036, 12037, 12041],
+      });
+      expect(parseNumberQuery("#12036, 12037 and 12041")).toEqual({
+        kind: "multi",
+        numbers: [12036, 12037, 12041],
+      });
+      expect(parseNumberQuery("123 AND 124")).toEqual({
+        kind: "multi",
+        numbers: [123, 124],
+      });
+    });
+
+    it("should de-duplicate across mixed separators", () => {
+      expect(parseNumberQuery("123 123 and #124")).toEqual({
+        kind: "multi",
+        numbers: [123, 124],
+      });
+    });
+
+    it("should reject a dangling connector", () => {
+      expect(parseNumberQuery("123 and")).toBeNull();
+      expect(parseNumberQuery("and 123")).toBeNull();
+      expect(parseNumberQuery("123 and 124 and")).toBeNull();
+    });
+
+    it("should reject separators the parser does not speak", () => {
+      expect(parseNumberQuery("123 & 124")).toBeNull();
+      expect(parseNumberQuery("123;124")).toBeNull();
+      expect(parseNumberQuery("123 or 124")).toBeNull();
+    });
+
+    it("should keep every number in a list beyond MULTI_FETCH_CAP", () => {
+      const numbers = Array.from({ length: MULTI_FETCH_CAP + 1 }, (_, i) => i + 1);
+      expect(parseNumberQuery(numbers.join(", "))).toEqual({ kind: "multi", numbers });
     });
 
     it("should treat all-duplicate comma list as single", () => {
@@ -199,5 +263,47 @@ describe("parseNumberQuery", () => {
       expect(parseNumberQuery("123 .. 125")).toBeNull();
       expect(parseNumberQuery("123 +")).toBeNull();
     });
+  });
+});
+
+describe("looksLikeNumberList", () => {
+  it("flags number lists the parser rejected", () => {
+    expect(looksLikeNumberList("123,,124")).toBe(true);
+    expect(looksLikeNumberList("12036,, 12037")).toBe(true);
+    expect(looksLikeNumberList("123 & 124")).toBe(true);
+    expect(looksLikeNumberList("123;124")).toBe(true);
+    expect(looksLikeNumberList("12036, 12037, or 12041")).toBe(true);
+    expect(looksLikeNumberList("#123 , , #124")).toBe(true);
+  });
+
+  it("stays quiet for queries the parser accepts", () => {
+    expect(looksLikeNumberList("123")).toBe(false);
+    expect(looksLikeNumberList("123, 124,")).toBe(false);
+    expect(looksLikeNumberList("12036 12037 12041")).toBe(false);
+    expect(looksLikeNumberList("12036, 12037, and 12041")).toBe(false);
+    expect(looksLikeNumberList("1..5")).toBe(false);
+    expect(looksLikeNumberList("130+")).toBe(false);
+  });
+
+  it("stays quiet for ordinary text searches", () => {
+    expect(looksLikeNumberList("")).toBe(false);
+    expect(looksLikeNumberList("   ")).toBe(false);
+    expect(looksLikeNumberList("fix 123 crash")).toBe(false);
+    expect(looksLikeNumberList("issue 123")).toBe(false);
+    expect(looksLikeNumberList("2024 2025 roadmap")).toBe(false);
+    expect(looksLikeNumberList("12036 12037 fix")).toBe(false);
+  });
+
+  it("stays quiet for version strings and dates", () => {
+    expect(looksLikeNumberList("1.2.3")).toBe(false);
+    expect(looksLikeNumberList("2024-01-15")).toBe(false);
+    expect(looksLikeNumberList("1/2/2024")).toBe(false);
+    expect(looksLikeNumberList("123-125")).toBe(false);
+  });
+
+  it("needs two numbers before it speaks", () => {
+    expect(looksLikeNumberList("123 and")).toBe(false);
+    expect(looksLikeNumberList("123,,")).toBe(false);
+    expect(looksLikeNumberList("0")).toBe(false);
   });
 });

--- a/src/lib/__tests__/parseNumberQuery.test.ts
+++ b/src/lib/__tests__/parseNumberQuery.test.ts
@@ -99,10 +99,13 @@ describe("parseNumberQuery", () => {
         kind: "multi",
         numbers: [12036, 12037, 12041],
       });
-      expect(parseNumberQuery("123 AND 124")).toEqual({
-        kind: "multi",
-        numbers: [123, 124],
-      });
+    });
+
+    it("should leave uppercase boolean operators to text search", () => {
+      // GitHub search reads `AND`/`OR` as operators — hijacking them into a
+      // number lookup would break a query that works today.
+      expect(parseNumberQuery("123 AND 124")).toBeNull();
+      expect(parseNumberQuery("123 OR 124")).toBeNull();
     });
 
     it("should de-duplicate across mixed separators", () => {
@@ -213,6 +216,12 @@ describe("parseNumberQuery", () => {
     it("should reject zero in range", () => {
       expect(parseNumberQuery("0..5")).toBeNull();
     });
+
+    it("should reject range endpoints past the safe-integer ceiling", () => {
+      // Both endpoints collapse onto the same float, and the consumer's
+      // `for (let n = from; n <= to; n++)` loop then never advances.
+      expect(parseNumberQuery("9007199254740992..9007199254740993")).toBeNull();
+    });
   });
 
   describe("open-ended", () => {
@@ -263,6 +272,15 @@ describe("parseNumberQuery", () => {
       expect(parseNumberQuery("123 .. 125")).toBeNull();
       expect(parseNumberQuery("123 +")).toBeNull();
     });
+
+    it("should reject numbers past the safe-integer ceiling", () => {
+      // parseInt collapses these onto one float, so two distinct requested
+      // numbers would silently dedupe into a single lookup.
+      expect(parseNumberQuery("99999999999999999999")).toBeNull();
+      expect(parseNumberQuery("99999999999999999999,")).toBeNull();
+      expect(parseNumberQuery("9007199254740992 9007199254740993")).toBeNull();
+      expect(parseNumberQuery("9007199254740993+")).toBeNull();
+    });
   });
 });
 
@@ -292,6 +310,11 @@ describe("looksLikeNumberList", () => {
     expect(looksLikeNumberList("issue 123")).toBe(false);
     expect(looksLikeNumberList("2024 2025 roadmap")).toBe(false);
     expect(looksLikeNumberList("12036 12037 fix")).toBe(false);
+  });
+
+  it("leaves GitHub boolean queries alone", () => {
+    expect(looksLikeNumberList("123 AND 456")).toBe(false);
+    expect(looksLikeNumberList("123 OR 456")).toBe(false);
   });
 
   it("stays quiet for version strings and dates", () => {

--- a/src/lib/__tests__/parseNumberQuery.test.ts
+++ b/src/lib/__tests__/parseNumberQuery.test.ts
@@ -90,7 +90,7 @@ describe("parseNumberQuery", () => {
       });
     });
 
-    it("should parse an \"and\"-joined list", () => {
+    it('should parse an "and"-joined list', () => {
       expect(parseNumberQuery("12036, 12037, and 12041")).toEqual({
         kind: "multi",
         numbers: [12036, 12037, 12041],

--- a/src/lib/parseNumberQuery.ts
+++ b/src/lib/parseNumberQuery.ts
@@ -13,7 +13,11 @@ const RANGE_RE = /^#?(\d+)\.\.(\d+)$/;
 // list leaves behind, and bare whitespace because that is what falls out of a
 // terminal. Anchored end to end: one stray word or symbol and the whole thing
 // stays a text search.
-const NUMBER_LIST_RE = /^#?\d+(?:(?:\s*,\s*|\s+)(?:and\s+)?#?\d+)+\s*,?$/i;
+//
+// Case-sensitive on purpose. GitHub search reads uppercase `AND`/`OR` as
+// boolean operators, so "123 AND 456" is a real full-text query and must not
+// be hijacked into a lookup.
+const NUMBER_LIST_RE = /^#?\d+(?:(?:\s*,\s*|\s+)(?:and\s+)?#?\d+)+\s*,?$/;
 const SINGLE_RE = /^#?(\d+)\s*,?$/;
 
 export function parseNumberQuery(query: string): NumberQuery | null {
@@ -24,7 +28,7 @@ export function parseNumberQuery(query: string): NumberQuery | null {
   const openMatch = trimmed.match(OPEN_ENDED_RE);
   if (openMatch) {
     const from = parseInt(openMatch[1]!, 10);
-    if (from <= 0 || !Number.isFinite(from)) return null;
+    if (from <= 0 || !Number.isSafeInteger(from)) return null;
     return { kind: "open-ended", from };
   }
 
@@ -33,7 +37,8 @@ export function parseNumberQuery(query: string): NumberQuery | null {
   if (rangeMatch) {
     const from = parseInt(rangeMatch[1]!, 10);
     const to = parseInt(rangeMatch[2]!, 10);
-    if (from <= 0 || to <= 0 || !Number.isFinite(from) || !Number.isFinite(to)) return null;
+    if (from <= 0 || to <= 0 || !Number.isSafeInteger(from) || !Number.isSafeInteger(to))
+      return null;
     if (from > to) return null;
     const count = to - from + 1;
     const truncated = count > MULTI_FETCH_CAP;
@@ -53,7 +58,7 @@ export function parseNumberQuery(query: string): NumberQuery | null {
     // requested numbers — separators and "and" contribute none.
     for (const token of trimmed.match(/\d+/g) ?? []) {
       const num = parseInt(token, 10);
-      if (num <= 0 || !Number.isFinite(num)) return null;
+      if (num <= 0 || !Number.isSafeInteger(num)) return null;
       if (!seen.has(num)) {
         seen.add(num);
         numbers.push(num);
@@ -67,7 +72,7 @@ export function parseNumberQuery(query: string): NumberQuery | null {
   const singleMatch = trimmed.match(SINGLE_RE);
   if (singleMatch) {
     const num = parseInt(singleMatch[1]!, 10);
-    if (num <= 0 || !Number.isFinite(num)) return null;
+    if (num <= 0 || !Number.isSafeInteger(num)) return null;
     return { kind: "single", number: num };
   }
 
@@ -90,7 +95,9 @@ export function looksLikeNumberList(query: string): boolean {
   if (!trimmed) return false;
   if (parseNumberQuery(trimmed) !== null) return false;
   // Connectors are the only words allowed through; anything else is prose.
-  const withoutConnectors = trimmed.replace(/\b(?:and|or)\b/gi, " ");
+  // Lowercase only, for the same reason the grammar is: uppercase `AND`/`OR`
+  // is GitHub boolean search syntax and belongs to full-text search.
+  const withoutConnectors = trimmed.replace(/\b(?:and|or)\b/g, " ");
   if (/[^\d#,;&\s]/.test(withoutConnectors)) return false;
   return (trimmed.match(/\d+/g) ?? []).length >= 2;
 }

--- a/src/lib/parseNumberQuery.ts
+++ b/src/lib/parseNumberQuery.ts
@@ -8,8 +8,13 @@ export type NumberQuery =
 
 const OPEN_ENDED_RE = /^#?(\d+)\+$/;
 const RANGE_RE = /^#?(\d+)\.\.(\d+)$/;
-const COMMA_RE = /^#?\d+(\s*,\s*#?\d+)+$/;
-const SINGLE_RE = /^#?(\d+)$/;
+// Two or more numbers joined by a comma, whitespace, or an "and" that may
+// follow either. A trailing comma is tolerated because that is what pasting a
+// list leaves behind, and bare whitespace because that is what falls out of a
+// terminal. Anchored end to end: one stray word or symbol and the whole thing
+// stays a text search.
+const NUMBER_LIST_RE = /^#?\d+(?:(?:\s*,\s*|\s+)(?:and\s+)?#?\d+)+\s*,?$/i;
+const SINGLE_RE = /^#?(\d+)\s*,?$/;
 
 export function parseNumberQuery(query: string): NumberQuery | null {
   const trimmed = query.trim();
@@ -40,13 +45,14 @@ export function parseNumberQuery(query: string): NumberQuery | null {
     };
   }
 
-  // Comma list: 123, 124 or #123, #124
-  if (COMMA_RE.test(trimmed)) {
-    const parts = trimmed.split(/\s*,\s*/);
+  // Number list: 123, 124 / 123 124 / #123, 124, and 125
+  if (NUMBER_LIST_RE.test(trimmed)) {
     const seen = new Set<number>();
     const numbers: number[] = [];
-    for (const part of parts) {
-      const num = parseInt(part.replace(/^#/, ""), 10);
+    // The shape is already validated, so every run of digits is one of the
+    // requested numbers — separators and "and" contribute none.
+    for (const token of trimmed.match(/\d+/g) ?? []) {
+      const num = parseInt(token, 10);
       if (num <= 0 || !Number.isFinite(num)) return null;
       if (!seen.has(num)) {
         seen.add(num);
@@ -66,4 +72,25 @@ export function parseNumberQuery(query: string): NumberQuery | null {
   }
 
   return null;
+}
+
+/**
+ * True when a query {@link parseNumberQuery} rejected still reads as an
+ * attempt at a number list: two or more numbers with nothing between them but
+ * separators and the words "and"/"or".
+ *
+ * Deliberately narrow. A text search that merely contains digits — "2024
+ * roadmap", "fix 123 crash", a version like "1.2.3", a date like "2024-01-15"
+ * — is working exactly as intended, and telling someone their working search
+ * is a search is noise. Only inputs that were plainly meant as a lookup earn
+ * the hint.
+ */
+export function looksLikeNumberList(query: string): boolean {
+  const trimmed = query.trim();
+  if (!trimmed) return false;
+  if (parseNumberQuery(trimmed) !== null) return false;
+  // Connectors are the only words allowed through; anything else is prose.
+  const withoutConnectors = trimmed.replace(/\b(?:and|or)\b/gi, " ");
+  if (/[^\d#,;&\s]/.test(withoutConnectors)) return false;
+  return (trimmed.match(/\d+/g) ?? []).length >= 2;
 }


### PR DESCRIPTION
## Summary

- The issue/PR dropdown search box parses number queries with `parseNumberQuery`, and its old comma regex matched exactly one shape. A trailing comma from a paste, space-separated numbers copied from a terminal, or a list using the word "and" all failed to parse and silently fell back to GitHub full text search, which returns unrelated issues that just mention those numbers, with nothing on screen to say the input had stopped being read as numbers.
- `parseNumberQuery.ts` now uses an anchored regex that accepts comma, whitespace, and "and" as separators plus one trailing comma, and extracts numbers by matching digit runs after validation rather than splitting on commas. The parser stays case-sensitive on purpose: GitHub search reads uppercase `AND`/`OR` as boolean operators, so `123 AND 456` still falls through to full text search as intended.
- Numbers past the JS safe integer ceiling are now rejected. The old `Number.isFinite` check never rejected anything a digit-only regex could produce, and past 2^53 `parseInt` collapses distinct numbers onto the same value, which for a range hung the renderer in a `for` loop that stopped advancing.

Resolves #12125

## Changes

- Replaced `COMMA_RE` with an anchored `NUMBER_LIST_RE` in `src/lib/parseNumberQuery.ts`; `SINGLE_RE` also now tolerates a trailing comma. Branch order (open-ended → range → list → single) is unchanged.
- Added an exported `looksLikeNumberList()` and a neutral inline chip in `GitHubResourceList.tsx` reading "Showing text matches, separate numbers with commas or spaces" whenever the input looks like it was meant to be a number list but wasn't parsed as one. Detection is deliberately narrow: it only fires when the input is nothing but digits, `#`, separators, and the words "and"/"or", with two or more numbers, so `fix 123 crash`, `2024 roadmap`, `1.2.3`, and `2024-01-15` stay silent. Same styling as the existing "Showing" chips, and it yields to loading, error, and rate-limit states.
- Capped explicit number lists at `MULTI_FETCH_CAP` (20) at the fetch boundary in `useGitHubResourceListSWR.ts`, the same way ranges were already capped. The parser still keeps the full list internally so the chip can report "Showing first 20 of 25 numbers (capped)". Without the cap, a pasted list fanned out into a long run of sequential GraphQL batches.
- Fixed a stale `exactNumberNotFound` state: the existing clear lived inside an `isFirstMount` check that a numeric query on first mount never reached, so a missed `#999` could leave the empty state claiming "No issue #999 in this view" over text search results that had already replaced it.
- Replaced an illegal bare `rounded` utility on both chips with `rounded-lg`, per the design system rules.

Related to #12124 (bulk selection on the resulting list), which is handled separately.

## Testing

- `npm test -- src/lib/__tests__/parseNumberQuery.test.ts` — 50 passed
- `npm test -- plugins/builtin/github/renderer/__tests__/GitHubResourceList.swr.test.tsx` — 131 passed
- `npm test -- plugins/builtin/github/renderer/__tests__/` — 487 passed
- `eslint` and `prettier --check` on the 5 changed files — both exit clean
