### PR TITLE
perf(pty): streamline terminal hot paths

### DIFF
--- a/electron/pty-host/PtyPauseCoordinator.ts
+++ b/electron/pty-host/PtyPauseCoordinator.ts
@@ -30,15 +30,14 @@ export class PtyPauseCoordinator {
     }
   }
 
-  resume(token: PauseToken): void {
-    if (!this.holds.delete(token)) return;
-    if (this.holds.size === 0) {
-      try {
-        this.raw.resume();
-      } catch {
-        // PTY process may already be dead
-      }
+  resume(token: PauseToken): boolean {
+    if (!this.holds.delete(token) || this.holds.size !== 0) return false;
+    try {
+      this.raw.resume();
+    } catch {
+      // PTY process may already be dead
     }
+    return true;
   }
 
   forceReleaseAll(): void {

--- a/electron/pty-host/__tests__/PtyPauseCoordinator.test.ts
+++ b/electron/pty-host/__tests__/PtyPauseCoordinator.test.ts
@@ -33,8 +33,9 @@ describe("PtyPauseCoordinator", () => {
 
     coord.pause("backpressure");
     coord.pause("resource-governor");
-    coord.resume("backpressure");
+    const resumed = coord.resume("backpressure");
 
+    expect(resumed).toBe(false);
     expect(raw.resume).not.toHaveBeenCalled();
     expect(coord.isPaused).toBe(true);
   });
@@ -46,8 +47,9 @@ describe("PtyPauseCoordinator", () => {
     coord.pause("backpressure");
     coord.pause("resource-governor");
     coord.resume("backpressure");
-    coord.resume("resource-governor");
+    const resumed = coord.resume("resource-governor");
 
+    expect(resumed).toBe(true);
     expect(raw.resume).toHaveBeenCalledTimes(1);
     expect(coord.isPaused).toBe(false);
   });
@@ -57,8 +59,9 @@ describe("PtyPauseCoordinator", () => {
     const coord = new PtyPauseCoordinator(raw);
 
     coord.pause("backpressure");
-    coord.resume("ipc-queue");
+    const resumed = coord.resume("ipc-queue");
 
+    expect(resumed).toBe(false);
     expect(raw.resume).not.toHaveBeenCalled();
     expect(coord.isPaused).toBe(true);
   });

--- a/electron/pty-host/__tests__/portQueue.test.ts
+++ b/electron/pty-host/__tests__/portQueue.test.ts
@@ -12,7 +12,7 @@ import {
 function createMockDeps(): PortQueueDeps {
   const mockCoordinator: Pick<PtyPauseCoordinator, "pause" | "resume" | "isPaused"> = {
     pause: vi.fn(),
-    resume: vi.fn(),
+    resume: vi.fn(() => true),
     get isPaused() {
       return false;
     },

--- a/electron/pty-host/backpressure.ts
+++ b/electron/pty-host/backpressure.ts
@@ -228,7 +228,8 @@ export class BackpressureManager {
     status: TerminalFlowStatus,
     bufferUtilization?: number,
     pauseDuration?: number,
-    reason?: string
+    reason?: string,
+    timestamp?: number
   ): void {
     const previousStatus = this.terminalStatuses.get(id);
     if (previousStatus === status) {
@@ -242,7 +243,7 @@ export class BackpressureManager {
       bufferUtilization,
       pauseDuration,
       reason,
-      timestamp: Date.now(),
+      timestamp: timestamp ?? Date.now(),
     });
   }
 

--- a/electron/pty-host/portQueue.ts
+++ b/electron/pty-host/portQueue.ts
@@ -13,6 +13,14 @@ import type {
 } from "../../shared/types/pty-host.js";
 import type { PtyPauseCoordinator, PauseToken } from "./PtyPauseCoordinator.js";
 
+interface PausedTerminalState {
+  coordinator: PtyPauseCoordinator;
+  pauseStartTime: number;
+  safetyTimeout: ReturnType<typeof setTimeout>;
+}
+
+const PORT_QUEUE_LOW_WATERMARK_BYTES = (IPC_MAX_QUEUE_BYTES * IPC_LOW_WATERMARK_PERCENT) / 100;
+
 export interface PortQueueDeps {
   getTerminal: (
     id: string
@@ -24,7 +32,9 @@ export interface PortQueueDeps {
     id: string,
     status: TerminalFlowStatus,
     bufferUtilization?: number,
-    pauseDuration?: number
+    pauseDuration?: number,
+    reason?: string,
+    timestamp?: number
   ) => void;
   emitReliabilityMetric: (payload: TerminalReliabilityMetricPayload) => void;
   pauseToken?: PauseToken;
@@ -40,8 +50,7 @@ export interface PortQueueDeps {
 
 export class PortQueueManager {
   private readonly queuedBytes = new Map<string, number>();
-  private readonly pausedTerminals = new Map<string, ReturnType<typeof setTimeout>>();
-  private readonly pauseStartTimes = new Map<string, number>();
+  private readonly pausedTerminals = new Map<string, PausedTerminalState>();
   private readonly pauseToken: PauseToken;
   private totalQueuedBytes = 0;
 
@@ -104,13 +113,40 @@ export class PortQueueManager {
     // which coordinator.resume() fires first. Every other paused terminal is
     // still swept, so no producer is starved (#7030).
     const focusedId = this.deps.getFocusedTerminalId?.() ?? null;
-    if (focusedId !== null && this.pausedTerminals.has(focusedId)) {
-      this.tryResume(focusedId);
+    const resumeTimestamp = Date.now();
+    const focusedState = focusedId === null ? undefined : this.pausedTerminals.get(focusedId);
+    if (focusedId !== null && focusedState !== undefined) {
+      this.tryResumeState(focusedId, focusedState, resumeTimestamp);
     }
-    for (const pausedId of [...this.pausedTerminals.keys()]) {
+    for (const [pausedId, state] of this.pausedTerminals) {
       if (pausedId === focusedId) continue;
-      this.tryResume(pausedId);
+      this.tryResumeState(pausedId, state, resumeTimestamp);
     }
+  }
+
+  private tryResumeState(id: string, state: PausedTerminalState, resumeTimestamp?: number): void {
+    const currentBytes = this.queuedBytes.get(id) ?? 0;
+    if (currentBytes >= PORT_QUEUE_LOW_WATERMARK_BYTES) return;
+    if (this.totalQueuedBytes >= IPC_TOTAL_QUEUE_LOW_WATERMARK_BYTES) return;
+
+    const timestamp = resumeTimestamp ?? Date.now();
+    const pauseDuration = timestamp - state.pauseStartTime;
+    const utilization = (currentBytes / IPC_MAX_QUEUE_BYTES) * 100;
+    const resumed = state.coordinator.resume(this.pauseToken);
+    console.log("[PtyHost] Port queue cleared to %d%%. Resumed PTY %s", utilization, id);
+    if (resumed) {
+      this.deps.emitTerminalStatus(id, "running", utilization, pauseDuration, undefined, timestamp);
+    }
+    this.deps.emitReliabilityMetric({
+      terminalId: id,
+      metricType: "pause-end",
+      timestamp,
+      durationMs: pauseDuration,
+      bufferUtilization: utilization,
+    });
+
+    clearTimeout(state.safetyTimeout);
+    this.pausedTerminals.delete(id);
   }
 
   getQueuedBytes(id: string): number {
@@ -197,7 +233,6 @@ export class PortQueueManager {
       );
 
       const pauseStartTime = Date.now();
-      this.pauseStartTimes.set(id, pauseStartTime);
 
       this.deps.emitTerminalStatus(id, "paused-backpressure", utilization);
       this.deps.emitReliabilityMetric({
@@ -214,7 +249,6 @@ export class PortQueueManager {
         const pauseDuration = Date.now() - pauseStartTime;
 
         this.pausedTerminals.delete(id);
-        this.pauseStartTimes.delete(id);
         // Drop stale byte accounting alongside the pause maps. Without this,
         // the next addBytes call immediately re-triggers applyBackpressure
         // and the pause loop wedges across the entire renderer reload (#6244).
@@ -223,23 +257,20 @@ export class PortQueueManager {
         const previousTotal = this.totalQueuedBytes;
         this.totalQueuedBytes = Math.max(0, this.totalQueuedBytes - droppedBytes);
 
-        const coordinator = this.deps.getPauseCoordinator(id);
-        if (coordinator) {
-          coordinator.resume(this.pauseToken);
-          console.warn(
-            `[PtyHost] Force resumed port PTY ${id} after ${pauseDuration}ms (queue at ${currentUtilization.toFixed(1)}%). Consumer may be stalled.`
-          );
-          if (!coordinator.isPaused) {
-            this.deps.emitTerminalStatus(id, "running", currentUtilization, pauseDuration);
-          }
-          this.deps.emitReliabilityMetric({
-            terminalId: id,
-            metricType: "pause-end",
-            timestamp: Date.now(),
-            durationMs: pauseDuration,
-            bufferUtilization: currentUtilization,
-          });
+        const resumed = coordinator.resume(this.pauseToken);
+        console.warn(
+          `[PtyHost] Force resumed port PTY ${id} after ${pauseDuration}ms (queue at ${currentUtilization.toFixed(1)}%). Consumer may be stalled.`
+        );
+        if (resumed) {
+          this.deps.emitTerminalStatus(id, "running", currentUtilization, pauseDuration);
         }
+        this.deps.emitReliabilityMetric({
+          terminalId: id,
+          metricType: "pause-end",
+          timestamp: Date.now(),
+          durationMs: pauseDuration,
+          bufferUtilization: currentUtilization,
+        });
 
         // The force-resume dropped this terminal's byte accounting — if that
         // took the aggregate below its low watermark, siblings paused by the
@@ -249,7 +280,7 @@ export class PortQueueManager {
         this.sweepAggregateResume(previousTotal);
       }, IPC_MAX_PAUSE_MS);
 
-      this.pausedTerminals.set(id, safetyTimeout);
+      this.pausedTerminals.set(id, { coordinator, pauseStartTime, safetyTimeout });
       committed = true;
       return true;
     } catch (error) {
@@ -261,71 +292,29 @@ export class PortQueueManager {
       // permanently held with no recovery path. See #7641.
       if (!committed) {
         if (safetyTimeout !== undefined) clearTimeout(safetyTimeout);
-        this.pauseStartTimes.delete(id);
         coordinator.resume(this.pauseToken);
       }
     }
   }
 
   tryResume(id: string): void {
-    if (!this.pausedTerminals.has(id)) return;
-
-    const lowWatermarkBytes = (IPC_MAX_QUEUE_BYTES * IPC_LOW_WATERMARK_PERCENT) / 100;
-    const currentBytes = this.queuedBytes.get(id) ?? 0;
-    if (currentBytes >= lowWatermarkBytes) return;
-    // Hold the pause while the window-level aggregate is still over its low
-    // watermark — resuming a producer into a swamped window just re-grows the
-    // backlog. The removeBytes sweep re-runs this check when the aggregate
-    // drains; the IPC_MAX_PAUSE_MS safety timeout bounds the worst case.
-    if (this.totalQueuedBytes >= IPC_TOTAL_QUEUE_LOW_WATERMARK_BYTES) return;
-
-    const pauseStart = this.pauseStartTimes.get(id);
-    const pauseDuration = pauseStart ? Date.now() - pauseStart : undefined;
-    const utilization = this.getUtilization(id);
-
-    const coordinator = this.deps.getPauseCoordinator(id);
-    if (coordinator) {
-      coordinator.resume(this.pauseToken);
-      console.log(`[PtyHost] Port queue cleared to ${utilization.toFixed(1)}%. Resumed PTY ${id}`);
-      if (!coordinator.isPaused) {
-        this.deps.emitTerminalStatus(id, "running", utilization, pauseDuration);
-      }
-      this.deps.emitReliabilityMetric({
-        terminalId: id,
-        metricType: "pause-end",
-        timestamp: Date.now(),
-        durationMs: pauseDuration,
-        bufferUtilization: utilization,
-      });
-    }
-
-    const safetyTimeout = this.pausedTerminals.get(id);
-    if (safetyTimeout) {
-      clearTimeout(safetyTimeout);
-    }
-    this.pausedTerminals.delete(id);
-    this.pauseStartTimes.delete(id);
+    const state = this.pausedTerminals.get(id);
+    if (state !== undefined) this.tryResumeState(id, state);
   }
 
   clearQueue(id: string): void {
-    const wasPaused = this.pausedTerminals.has(id);
-    const safetyTimeout = this.pausedTerminals.get(id);
-    if (safetyTimeout) {
-      clearTimeout(safetyTimeout);
-    }
+    const state = this.pausedTerminals.get(id);
+    if (state !== undefined) clearTimeout(state.safetyTimeout);
     // Release the coordinator hold before clearing internal maps so any
     // re-entrant applyBackpressure sees a clean state. resume() is a no-op
     // when the token isn't held, so guarding on wasPaused is purely an
     // optimization to avoid a useless coordinator lookup. See #7008.
-    if (wasPaused) {
-      this.deps.getPauseCoordinator(id)?.resume(this.pauseToken);
-    }
+    state?.coordinator.resume(this.pauseToken);
     const removed = this.queuedBytes.get(id) ?? 0;
     this.queuedBytes.delete(id);
     const previousTotal = this.totalQueuedBytes;
     this.totalQueuedBytes = Math.max(0, this.totalQueuedBytes - removed);
     this.pausedTerminals.delete(id);
-    this.pauseStartTimes.delete(id);
     // A cleared terminal (exit, force-resume) can be the terminal holding most
     // of the window aggregate — sweep so aggregate-paused siblings don't wait
     // out their safety timeouts for bytes that will never be acked.
@@ -333,11 +322,9 @@ export class PortQueueManager {
   }
 
   resumeAll(): void {
-    for (const [id, safetyTimeout] of this.pausedTerminals) {
-      clearTimeout(safetyTimeout);
-      const coordinator = this.deps.getPauseCoordinator(id);
-      if (!coordinator) continue;
-      coordinator.resume(this.pauseToken);
+    for (const [id, state] of this.pausedTerminals) {
+      clearTimeout(state.safetyTimeout);
+      state.coordinator.resume(this.pauseToken);
       // Surface the release. resumeAll runs when this manager's window goes
       // away (disconnect/replace/dispose) — without an emission here the
       // shared status map keeps "paused-backpressure" and any other window
@@ -351,9 +338,8 @@ export class PortQueueManager {
       // can race a dying parent channel, and a throw here must not abort the
       // remaining releases or leave the pause maps stale.
       try {
-        const pauseStart = this.pauseStartTimes.get(id);
-        const pauseDuration = pauseStart ? Date.now() - pauseStart : undefined;
-        if (!coordinator.isPaused) {
+        const pauseDuration = Date.now() - state.pauseStartTime;
+        if (!state.coordinator.isPaused) {
           this.deps.emitTerminalStatus(id, "running", this.getUtilization(id), pauseDuration);
         }
         this.deps.emitReliabilityMetric({
@@ -368,7 +354,6 @@ export class PortQueueManager {
       }
     }
     this.pausedTerminals.clear();
-    this.pauseStartTimes.clear();
   }
 
   dispose(): void {

--- a/electron/services/pty/__tests__/headlessViewport.snapshot.test.ts
+++ b/electron/services/pty/__tests__/headlessViewport.snapshot.test.ts
@@ -307,4 +307,22 @@ describe("ViewportSnapshotCache (PERF-035)", () => {
     // Same generation, different n — must re-extract, not serve the n=6 object.
     expect(cache.read(term, 15)).not.toBe(six);
   });
+
+  it("preserves the legacy delta sequence while unchanged raw rows are reused", async () => {
+    let previousLegacy = legacySnapshot(term);
+    let previousCached = cache.read(term, 15)!;
+
+    for (const state of STATES) {
+      await write(term, state.data);
+      const legacy = legacySnapshot(term);
+      const cached = cache.read(term, 15)!;
+
+      expect(measureVisibleContentDelta(previousCached, cached), `state "${state.name}"`).toEqual(
+        measureVisibleContentDelta(previousLegacy, legacy)
+      );
+
+      previousLegacy = legacy;
+      previousCached = cached;
+    }
+  });
 });

--- a/electron/services/pty/analysis/headlessViewport.ts
+++ b/electron/services/pty/analysis/headlessViewport.ts
@@ -19,6 +19,16 @@ type RawBufferLine = {
   length: number;
 };
 
+interface CachedRawRow {
+  data: Uint32Array;
+  combined: Record<number, string | undefined>;
+  underlineStyles: Record<number, number | undefined>;
+  hasCombined: boolean;
+  hasExtendedAttrs: boolean;
+  units: VisibleContentUnit[];
+  collapsible: boolean[];
+}
+
 type CursorBuffer = {
   cursorY?: number;
   baseY: number;
@@ -171,6 +181,69 @@ function rawBufferLine(line: CursorBufferLine, cols: number): RawBufferLine | un
     : undefined;
 }
 
+function rawRowMatches(cache: CachedRawRow, raw: RawBufferLine, cols: number): boolean {
+  const cellCount = Math.min(cols, raw.length);
+  const dataLength = cellCount * CELL_SIZE;
+  if (cache.data.length !== dataLength) return false;
+  for (let index = 0; index < dataLength; index += 1) {
+    if (cache.data[index] !== raw._data[index]) return false;
+  }
+  if (!cache.hasCombined && !cache.hasExtendedAttrs) return true;
+  for (let x = 0; x < cellCount; x += 1) {
+    const content = raw._data[x * CELL_SIZE] ?? 0;
+    if (
+      cache.hasCombined &&
+      (content & CONTENT_IS_COMBINED_MASK) !== 0 &&
+      cache.combined[x] !== raw._combined[x]
+    ) {
+      return false;
+    }
+    const bg = raw._data[x * CELL_SIZE + 2] ?? 0;
+    if (
+      cache.hasExtendedAttrs &&
+      (bg & BG_HAS_EXTENDED) !== 0 &&
+      cache.underlineStyles[x] !== (raw._extendedAttrs[x]?.underlineStyle ?? 0)
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function cacheRawRow(
+  raw: RawBufferLine,
+  cols: number,
+  units: VisibleContentUnit[],
+  collapsible: boolean[]
+): CachedRawRow {
+  const cellCount = Math.min(cols, raw.length);
+  const combined: Record<number, string | undefined> = {};
+  const underlineStyles: Record<number, number | undefined> = {};
+  let hasCombined = false;
+  let hasExtendedAttrs = false;
+  for (let x = 0; x < cellCount; x += 1) {
+    const content = raw._data[x * CELL_SIZE] ?? 0;
+    if ((content & CONTENT_IS_COMBINED_MASK) !== 0) {
+      hasCombined = true;
+      combined[x] = raw._combined[x];
+    }
+    const bg = raw._data[x * CELL_SIZE + 2] ?? 0;
+    if ((bg & BG_HAS_EXTENDED) !== 0) {
+      hasExtendedAttrs = true;
+      underlineStyles[x] = raw._extendedAttrs[x]?.underlineStyle ?? 0;
+    }
+  }
+  return {
+    data: raw._data.slice(0, cellCount * CELL_SIZE),
+    combined,
+    underlineStyles,
+    hasCombined,
+    hasExtendedAttrs,
+    units,
+    collapsible,
+  };
+}
+
 /**
  * Fused single-pass equivalent of the old readVisibleActivityCells →
  * normalizeCellUnits → createSnapshotFromUnits pipeline (PERF-035). Scans the
@@ -194,7 +267,8 @@ function rawBufferLine(line: CursorBufferLine, cols: number): RawBufferLine | un
  *     foregroundContentAttributes) is never read at all.
  */
 function buildViewportUnitsSnapshot(
-  terminal: HeadlessTerminal | undefined
+  terminal: HeadlessTerminal | undefined,
+  rawRowCache?: Array<CachedRawRow | undefined>
 ): VisibleContentSnapshot | undefined {
   if (!terminal) return undefined;
 
@@ -207,128 +281,154 @@ function buildViewportUnitsSnapshot(
   const end = buffer.baseY + terminal.rows;
   const cols = terminal.cols;
   const reusableCell = buffer.getNullCell();
+  if (rawRowCache && rawRowCache.length > terminal.rows) rawRowCache.length = terminal.rows;
 
   const units: VisibleContentUnit[] = [];
   let hash = FNV_SEED;
   let lastKey: VisibleContentUnit | undefined;
 
   for (let y = start; y < end; y += 1) {
+    const rowIndex = y - start;
     const line = buffer.getLine(y);
     if (!line || typeof line.getCell !== "function") {
+      if (rawRowCache) rawRowCache[rowIndex] = undefined;
       continue;
     }
 
     const raw = rawBufferLine(line, cols);
-    let cellLimit = cols;
-    if (raw) {
-      cellLimit = 0;
-      for (let x = Math.min(cols, raw.length) - 1; x >= 0; x -= 1) {
-        const content = raw._data[x * CELL_SIZE] ?? 0;
-        if ((content & CONTENT_HAS_CONTENT_MASK) !== 0) {
-          cellLimit = Math.min(cols, x + (content >>> CONTENT_WIDTH_SHIFT));
-          break;
+    const cached = raw === undefined ? undefined : rawRowCache?.[rowIndex];
+    let rowUnits: VisibleContentUnit[];
+    let rowCollapsible: boolean[];
+    if (raw !== undefined && cached !== undefined && rawRowMatches(cached, raw, cols)) {
+      rowUnits = cached.units;
+      rowCollapsible = cached.collapsible;
+    } else {
+      rowUnits = [];
+      rowCollapsible = [];
+      let rowLastKey: VisibleContentUnit | undefined;
+      let cellLimit = cols;
+      if (raw) {
+        cellLimit = 0;
+        for (let x = Math.min(cols, raw.length) - 1; x >= 0; x -= 1) {
+          const content = raw._data[x * CELL_SIZE] ?? 0;
+          if ((content & CONTENT_HAS_CONTENT_MASK) !== 0) {
+            cellLimit = Math.min(cols, x + (content >>> CONTENT_WIDTH_SHIFT));
+            break;
+          }
         }
+      }
+
+      for (let x = 0; x < cellLimit; x += 1) {
+        let chars: string | undefined;
+        let code: number;
+        let width: number;
+        let attributes: number;
+        let fgColorMode: number;
+        let fgColor: number;
+        let rawCodePoint: number | undefined;
+
+        if (raw) {
+          const offset = x * CELL_SIZE;
+          const content = raw._data[offset] ?? 0;
+          width = content >>> CONTENT_WIDTH_SHIFT;
+          if (width === 0) continue;
+
+          const codePoint = content & CONTENT_CODEPOINT_MASK;
+          if ((content & CONTENT_IS_COMBINED_MASK) !== 0) {
+            chars = raw._combined[x] ?? "";
+            if (chars.length === 0 || isBlankCellText(chars)) continue;
+            code = chars.charCodeAt(chars.length - 1);
+          } else {
+            if (codePoint === 0 || isWhitespaceCode(codePoint)) continue;
+            code = codePoint;
+            rawCodePoint = codePoint;
+          }
+
+          const fg = raw._data[offset + 1] ?? 0;
+          const bg = raw._data[offset + 2] ?? 0;
+          if (fg === 0 && bg === 0) {
+            attributes = 0;
+            fgColorMode = 0;
+            fgColor = -1;
+          } else {
+            const hasExtendedUnderline =
+              (bg & BG_HAS_EXTENDED) !== 0 && (raw._extendedAttrs[x]?.underlineStyle ?? 0) !== 0;
+            attributes =
+              ((fg & FG_BOLD) !== 0 ? 1 : 0) |
+              ((bg & BG_ITALIC) !== 0 ? 1 << 1 : 0) |
+              ((bg & BG_DIM) !== 0 ? 1 << 2 : 0) |
+              ((fg & FG_UNDERLINE) !== 0 || hasExtendedUnderline ? 1 << 3 : 0) |
+              ((fg & FG_BLINK) !== 0 ? 1 << 4 : 0) |
+              ((fg & FG_INVISIBLE) !== 0 ? 1 << 6 : 0) |
+              ((fg & FG_STRIKETHROUGH) !== 0 ? 1 << 7 : 0) |
+              ((bg & BG_OVERLINE) !== 0 ? 1 << 8 : 0);
+            fgColorMode = fg & COLOR_MODE_MASK;
+            fgColor =
+              fgColorMode === COLOR_PALETTE_16 || fgColorMode === COLOR_PALETTE_256
+                ? fg & 0xff
+                : fgColorMode === COLOR_RGB
+                  ? fg & 0xffffff
+                  : -1;
+          }
+        } else {
+          const cell = line.getCell(x, reusableCell);
+          if (!cell) continue;
+          width = cell.getWidth();
+          if (width === 0) continue;
+          chars = cell.getChars();
+          if (chars.length === 0 || isBlankCellText(chars)) continue;
+          code = cell.getCode();
+          // Attribute bit layout matches the old createVisibleContentCellFrom,
+          // minus inverse, which foregroundContentAttributes masks out.
+          attributes =
+            (cell.isBold() ? 1 : 0) |
+            (cell.isItalic() ? 1 << 1 : 0) |
+            (cell.isDim() ? 1 << 2 : 0) |
+            (cell.isUnderline() ? 1 << 3 : 0) |
+            (cell.isBlink() ? 1 << 4 : 0) |
+            (cell.isInvisible() ? 1 << 6 : 0) |
+            (cell.isStrikethrough() ? 1 << 7 : 0) |
+            (cell.isOverline() ? 1 << 8 : 0);
+          fgColorMode = cell.getFgColorMode();
+          fgColor = cell.getFgColor();
+        }
+
+        const defaultSingleWidth =
+          attributes === 0 && fgColorMode === 0 && fgColor === -1 && width === 1;
+        const defaultCodePoint =
+          defaultSingleWidth && chars !== undefined ? singleCodePoint(chars) : rawCodePoint;
+        let key: VisibleContentUnit;
+        let collapsible: boolean;
+        if (defaultSingleWidth && defaultCodePoint !== undefined) {
+          key = defaultCodePoint;
+          collapsible = isCollapsibleFillCode(defaultCodePoint);
+        } else {
+          const resolvedChars =
+            chars ??
+            (rawCodePoint! <= 0xffff
+              ? String.fromCharCode(rawCodePoint!)
+              : String.fromCodePoint(rawCodePoint!));
+          key =
+            defaultSingleWidth && resolvedChars.length <= 2
+              ? resolvedChars
+              : `${resolvedChars}|${code}|${width}|${fgColorMode}|${fgColor}|${attributes}`;
+          collapsible = isCollapsibleFillText(resolvedChars);
+        }
+
+        if (rowLastKey === key && collapsible) continue;
+        rowUnits.push(key);
+        rowCollapsible.push(collapsible);
+        rowLastKey = key;
+      }
+      if (rawRowCache) {
+        rawRowCache[rowIndex] =
+          raw === undefined ? undefined : cacheRawRow(raw, cols, rowUnits, rowCollapsible);
       }
     }
 
-    for (let x = 0; x < cellLimit; x += 1) {
-      let chars: string | undefined;
-      let code: number;
-      let width: number;
-      let attributes: number;
-      let fgColorMode: number;
-      let fgColor: number;
-      let rawCodePoint: number | undefined;
-
-      if (raw) {
-        const offset = x * CELL_SIZE;
-        const content = raw._data[offset] ?? 0;
-        width = content >>> CONTENT_WIDTH_SHIFT;
-        if (width === 0) continue;
-
-        const codePoint = content & CONTENT_CODEPOINT_MASK;
-        if ((content & CONTENT_IS_COMBINED_MASK) !== 0) {
-          chars = raw._combined[x] ?? "";
-          if (chars.length === 0 || isBlankCellText(chars)) continue;
-          code = chars.charCodeAt(chars.length - 1);
-        } else {
-          if (codePoint === 0 || isWhitespaceCode(codePoint)) continue;
-          code = codePoint;
-          rawCodePoint = codePoint;
-        }
-
-        const fg = raw._data[offset + 1] ?? 0;
-        const bg = raw._data[offset + 2] ?? 0;
-        if (fg === 0 && bg === 0) {
-          attributes = 0;
-          fgColorMode = 0;
-          fgColor = -1;
-        } else {
-          const hasExtendedUnderline =
-            (bg & BG_HAS_EXTENDED) !== 0 && (raw._extendedAttrs[x]?.underlineStyle ?? 0) !== 0;
-          attributes =
-            ((fg & FG_BOLD) !== 0 ? 1 : 0) |
-            ((bg & BG_ITALIC) !== 0 ? 1 << 1 : 0) |
-            ((bg & BG_DIM) !== 0 ? 1 << 2 : 0) |
-            ((fg & FG_UNDERLINE) !== 0 || hasExtendedUnderline ? 1 << 3 : 0) |
-            ((fg & FG_BLINK) !== 0 ? 1 << 4 : 0) |
-            ((fg & FG_INVISIBLE) !== 0 ? 1 << 6 : 0) |
-            ((fg & FG_STRIKETHROUGH) !== 0 ? 1 << 7 : 0) |
-            ((bg & BG_OVERLINE) !== 0 ? 1 << 8 : 0);
-          fgColorMode = fg & COLOR_MODE_MASK;
-          fgColor =
-            fgColorMode === COLOR_PALETTE_16 || fgColorMode === COLOR_PALETTE_256
-              ? fg & 0xff
-              : fgColorMode === COLOR_RGB
-                ? fg & 0xffffff
-                : -1;
-        }
-      } else {
-        const cell = line.getCell(x, reusableCell);
-        if (!cell) continue;
-        width = cell.getWidth();
-        if (width === 0) continue;
-        chars = cell.getChars();
-        if (chars.length === 0 || isBlankCellText(chars)) continue;
-        code = cell.getCode();
-        // Attribute bit layout matches the old createVisibleContentCellFrom,
-        // minus inverse, which foregroundContentAttributes masks out.
-        attributes =
-          (cell.isBold() ? 1 : 0) |
-          (cell.isItalic() ? 1 << 1 : 0) |
-          (cell.isDim() ? 1 << 2 : 0) |
-          (cell.isUnderline() ? 1 << 3 : 0) |
-          (cell.isBlink() ? 1 << 4 : 0) |
-          (cell.isInvisible() ? 1 << 6 : 0) |
-          (cell.isStrikethrough() ? 1 << 7 : 0) |
-          (cell.isOverline() ? 1 << 8 : 0);
-        fgColorMode = cell.getFgColorMode();
-        fgColor = cell.getFgColor();
-      }
-
-      const defaultSingleWidth =
-        attributes === 0 && fgColorMode === 0 && fgColor === -1 && width === 1;
-      const defaultCodePoint =
-        defaultSingleWidth && chars !== undefined ? singleCodePoint(chars) : rawCodePoint;
-      let key: VisibleContentUnit;
-      let collapsible: boolean;
-      if (defaultSingleWidth && defaultCodePoint !== undefined) {
-        key = defaultCodePoint;
-        collapsible = isCollapsibleFillCode(defaultCodePoint);
-      } else {
-        const resolvedChars =
-          chars ??
-          (rawCodePoint! <= 0xffff
-            ? String.fromCharCode(rawCodePoint!)
-            : String.fromCodePoint(rawCodePoint!));
-        key =
-          defaultSingleWidth && resolvedChars.length <= 2
-            ? resolvedChars
-            : `${resolvedChars}|${code}|${width}|${fgColorMode}|${fgColor}|${attributes}`;
-        collapsible = isCollapsibleFillText(resolvedChars);
-      }
-
-      if (lastKey === key && collapsible) continue;
+    for (let index = 0; index < rowUnits.length; index += 1) {
+      const key = rowUnits[index]!;
+      if (lastKey === key && rowCollapsible[index]) continue;
       units.push(key);
       if (typeof key === "number") {
         if (key <= 0xffff) {
@@ -369,12 +469,19 @@ function buildViewportUnitsSnapshot(
  * write callbacks read the snapshot in the same job must call invalidate()
  * in that callback too, because xterm fires per-write callbacks before the
  * onWriteParsed event.
+ *
+ * Invalidated snapshots still reuse normalized rows whose raw xterm cell
+ * words, combined strings, and extended underline styles are byte-for-byte
+ * unchanged. Status-line rewrites usually touch one viewport row; retaining
+ * the other rows avoids repeating their cell normalization without trusting
+ * a collision-prone content hash or narrowing the full-viewport contract.
  */
 export class ViewportSnapshotCache {
   private generation = 0;
   private snapshotGeneration = -1;
   private snapshotN = -1;
   private snapshot: VisibleContentSnapshot | undefined;
+  private rawRows: Array<CachedRawRow | undefined> = [];
   private disposables: Array<{ dispose: () => void }> = [];
 
   attach(terminal: HeadlessTerminal): void {
@@ -392,6 +499,7 @@ export class ViewportSnapshotCache {
       }
     }
     this.disposables = [];
+    this.rawRows = [];
     this.invalidate();
   }
 
@@ -408,7 +516,9 @@ export class ViewportSnapshotCache {
     ) {
       return this.snapshot;
     }
-    const snapshot = readVisibleActivitySnapshot(terminal, n);
+    const snapshot =
+      buildViewportUnitsSnapshot(terminal, this.rawRows) ??
+      createVisibleContentSnapshot(readVisibleActivityLines(terminal, n));
     if (snapshot !== undefined) {
       this.snapshot = snapshot;
       this.snapshotGeneration = this.generation;


### PR DESCRIPTION
## Summary

- streamline aggregate PTY resume sweeps by co-locating paused-terminal state, reusing one sweep timestamp, and avoiding redundant coordinator/status lookups
- reuse normalized viewport rows only after exact raw-cell, combined-string, and underline-style comparisons, preserving full-viewport activity semantics while avoiding repeated normalization
- make coordinator release semantics explicit through a boolean `resume` result and add focused parity coverage

## Performance evidence

Both claimed metrics are duration-class. The owned claim machine was a Mac Studio with Apple M1 Max (10 cores, 32 GB), macOS 25.4.0 arm64, AC power, Node 24.20.0, Electron 42.7.1, and git 2.55.0. Each target had a precommit written before its baseline and used six fresh arms in the interleaved order `champ,cand,cand,champ,champ,cand`, with process checks before and after every arm. Any attempt overlapping another benchmark/Vitest process was discarded in full.

| OS / runner | Benchmark target | Before | After | Absolute change | Improvement |
| --- | --- | ---: | ---: | ---: | ---: |
| macOS 25.4, owned M1 Max | PERF-372 `sweepAckUsAt48.mean` | 46.525 us | 27.756 us | -18.769 us | **40.3%** |
| macOS 25.4, owned M1 Max | PERF-035 `cpuMsPerMb30.mean` | 352.135 CPU-ms/MB | 288.730 CPU-ms/MB | -63.405 CPU-ms/MB | **18.0%** |
| Linux, GitHub-hosted | duration targets | not measured | not measured | n/a | n/a |
| Windows, GitHub-hosted | duration targets | not measured | not measured | n/a | n/a |
| macOS, GitHub-hosted | duration targets | not measured | not measured | n/a | n/a |

PERF-372 used 20 iterations plus one warmup per arm. All three pairs won by 40.3%, 40.2%, and 39.6%; champion drift was 6.2%, worst within-arm scenario CV was 22.7% under the locked 25% ceiling, and the median gain cleared the precommitted 32% threshold. `resumeMisses`, `prematureResumeMisses`, `focusFirstResumeMisses`, `queueAccountingMisses`, `coordinatorHoldMisses`, and `sweepShortfallCount` were emitted on all 20 iterations of every arm and stayed zero. All nine cost/shape guards passed.

PERF-035 used three iterations plus one warmup per arm. All three pairs won by 19.0%, 14.3%, and 18.0%; champion drift was 6.0%, worst within-arm CV was 1.7%, and the median gain cleared the precommitted 10% threshold. `analysisMisses=0` on every iteration. All CPU guards improved, and virtual wait/resume latency remained exactly 7927.5/1204.5 ms. Its locked baseline is the already-kept PERF-372 tree (`4e7cf01d`), whose viewport-analysis code is identical to the original branch point.

The Linux/Windows/macOS hosted rows are intentionally `not measured`: `.github/workflows/perf-ab.yml` rejects duration-class targets before executing them because shared hosted runners cannot support a clock claim. Bypassing that guard would produce misleading precision. Cross-platform confidence instead comes from build/check/unit CI on GitHub-hosted Linux plus build/check on Windows; the numerical claim is local-owned-machine only.

## Representative Area B health

Final-candidate smoke runs for adjacent flow-control scenarios completed with no apparatus issues: PERF-370 p50 4.633 ms, PERF-371 p50 11.324 ms, and PERF-373 p50 1.249 ms. Every correctness metric in all three scenarios was zero. These are health observations, not additional timing claims.

## Validation

- focused PTY flow-control suites: 67 tests passed
- viewport snapshot parity/cache suite: 13 tests passed
- `npm run typecheck`: passed locally
- full `npm test` under CI-equivalent Node 22.23.2: 2,473 files passed; 54,500 passed, 7 skipped, 1 todo (54,508 total)
- native `npm run check`: passed locally (typecheck, generated-file checks, lint ratchet, Prettier)
- GitHub-hosted Linux: build/smoke, check, all four unit shards, and `ci-ok` passed
- GitHub-hosted Windows: build and check passed on the corrected final SHA
- `git diff --check`: passed; worktree clean

## Caveats

- Many benchmark and test instances shared the local machine during development. Process checkpoints and whole-attempt discards isolated the final arms; several retries were rejected for overlap or variance before the accepted sets above.
- PERF-372's whole-scenario duration naturally varied more than the isolated sweep target. The 25% CV ceiling was chosen before the accepted retry after the first clean attempt showed a 20.2-24.1% scenario band; the target threshold, predicates, guards, iterations, and unanimity rule remained unchanged.
- A first full-suite run under the workspace's unsupported Node 24.20.0 exposed PERF-063's GC-count liveness predicate; the same failure reproduced at the untouched branch point. The CI-equivalent Node 22.23.2 isolated liveness file then passed 3/3, and the full Node 22 suite passed as recorded above.
- Absolute duration values are machine-specific; the A/B order reversals, same-session champion remeasurement, locked thresholds, and predicates are the basis for the claims.
