### PR TITLE
feat(markdown): add a reading text-size control to rendered documents

### DIFF
--- a/shared/theme/__tests__/builtInThemes.test.ts
+++ b/shared/theme/__tests__/builtInThemes.test.ts
@@ -677,10 +677,18 @@ const NON_EXTENSION_VAR_NAMES = new Set<string>([
   "radius-xl",
   // Stock Tailwind type steps, consumed by name where a size has to be written as
   // a value rather than a utility class (CodeMirror theme objects, the diff
-  // text-size preference). The steps below them (--text-2xs/3xs/4xs) are declared
-  // in src/index.css, so the `declared` half of the scan already covers those.
+  // text-size preference, the rendered-markdown reading size). The steps below
+  // them (--text-2xs/3xs/4xs) are declared in src/index.css, so the `declared`
+  // half of the scan already covers those. Stock Tailwind variables are not
+  // theme hooks — registering one as an extension key would instead assert it
+  // is themable, which Direction A would then hold the palettes to.
   "text-xs",
   "text-sm",
+  "text-base",
+  "text-lg",
+  "text-xl",
+  "text-2xl",
+  "text-3xl",
   "chart-1",
   "chart-2",
   "chart-3",

--- a/src/components/Markdown/MarkdownDocument.css
+++ b/src/components/Markdown/MarkdownDocument.css
@@ -30,8 +30,13 @@
 
   /* Document scale: prose sizes are em-based, so one font-size tunes the
      whole hierarchy to the app's 14px reading surfaces. The measure caps
-     line length for comfortable reading in maximized panels and dialogs. */
-  font-size: var(--text-sm);
+     line length for comfortable reading in maximized panels and dialogs.
+
+     Set per-surface by the reading text-size control, which declares
+     `--markdown-font-size` on this element as a rung of the shared type scale
+     (#12134). The fallback is what every surface rendered before it existed,
+     so a document mounted without the prop is unchanged. */
+  font-size: var(--markdown-font-size, var(--text-sm));
   max-width: 48rem;
   margin-inline: auto;
 }

--- a/src/components/Markdown/MarkdownDocument.tsx
+++ b/src/components/Markdown/MarkdownDocument.tsx
@@ -19,12 +19,13 @@ import type { MarkdownFontSize } from "@/store/preferencesStore";
 import "./MarkdownDocument.css";
 
 /**
- * Each reading rung resolved to the shared type scale, spelled out rather than
- * interpolated so a rung without a matching token is a type error instead of an
- * unresolved `var()`. Same shape as `DIFF_FONT_SIZE` — the preference names a
+ * Each reading rung resolved to the shared type scale. Spelled out rather than
+ * interpolated so the map is greppable, but typed against the rung name so a
+ * mismatched pair is a compile error rather than an unresolved `var()` that
+ * silently falls back. Same shape as `DIFF_FONT_SIZE` — the preference names a
  * step of the app's scale, so it keeps tracking the scale when the scale moves.
  */
-const MARKDOWN_FONT_SIZE_TOKEN: Record<MarkdownFontSize, string> = {
+const MARKDOWN_FONT_SIZE_TOKEN: { [K in MarkdownFontSize]: `var(--text-${K})` } = {
   "2xs": "var(--text-2xs)",
   xs: "var(--text-xs)",
   sm: "var(--text-sm)",

--- a/src/components/Markdown/MarkdownDocument.tsx
+++ b/src/components/Markdown/MarkdownDocument.tsx
@@ -19,13 +19,18 @@ import type { MarkdownFontSize } from "@/store/preferencesStore";
 import "./MarkdownDocument.css";
 
 /**
- * Each reading rung resolved to the shared type scale. Spelled out rather than
- * interpolated so the map is greppable, but typed against the rung name so a
- * mismatched pair is a compile error rather than an unresolved `var()` that
- * silently falls back. Same shape as `DIFF_FONT_SIZE` — the preference names a
- * step of the app's scale, so it keeps tracking the scale when the scale moves.
+ * Each reading rung resolved to the shared type scale — the same stock Tailwind
+ * steps the diff text-size preference names, so the reading size keeps tracking
+ * the scale when the scale moves. Same shape as `DIFF_FONT_SIZE`.
+ *
+ * Spelled out rather than interpolated, and beware of writing one of these
+ * references into prose: `builtInThemes.test.ts` scans every non-test renderer
+ * file — comments included — for CSS variable references, and reads an
+ * interpolated one as a variable named after the part before the placeholder.
+ * `satisfies` keeps the set exhaustive; that each rung names its own step is
+ * pinned in MarkdownDocument.test.ts, which that scan skips.
  */
-const MARKDOWN_FONT_SIZE_TOKEN: { [K in MarkdownFontSize]: `var(--text-${K})` } = {
+export const MARKDOWN_FONT_SIZE_TOKEN = {
   "2xs": "var(--text-2xs)",
   xs: "var(--text-xs)",
   sm: "var(--text-sm)",
@@ -34,7 +39,7 @@ const MARKDOWN_FONT_SIZE_TOKEN: { [K in MarkdownFontSize]: `var(--text-${K})` } 
   xl: "var(--text-xl)",
   "2xl": "var(--text-2xl)",
   "3xl": "var(--text-3xl)",
-};
+} satisfies Record<MarkdownFontSize, string>;
 
 /** `MarkdownDocument.css` reads this; declaring it here is what applies the rung. */
 type MarkdownFontStyle = CSSProperties & Record<"--markdown-font-size", string>;

--- a/src/components/Markdown/MarkdownDocument.tsx
+++ b/src/components/Markdown/MarkdownDocument.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { useEffect, useMemo, useRef, useState, type CSSProperties, type ReactNode } from "react";
 import ReactMarkdown, { defaultUrlTransform, type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { toJsxRuntime } from "hast-util-to-jsx-runtime";
@@ -15,7 +15,28 @@ import { useScopedSelectAll } from "@/hooks/useScopedSelectAll";
 import { actionService } from "@/services/ActionService";
 import { logError } from "@/utils/logger";
 import { cn } from "@/lib/utils";
+import type { MarkdownFontSize } from "@/store/preferencesStore";
 import "./MarkdownDocument.css";
+
+/**
+ * Each reading rung resolved to the shared type scale, spelled out rather than
+ * interpolated so a rung without a matching token is a type error instead of an
+ * unresolved `var()`. Same shape as `DIFF_FONT_SIZE` — the preference names a
+ * step of the app's scale, so it keeps tracking the scale when the scale moves.
+ */
+const MARKDOWN_FONT_SIZE_TOKEN: Record<MarkdownFontSize, string> = {
+  "2xs": "var(--text-2xs)",
+  xs: "var(--text-xs)",
+  sm: "var(--text-sm)",
+  base: "var(--text-base)",
+  lg: "var(--text-lg)",
+  xl: "var(--text-xl)",
+  "2xl": "var(--text-2xl)",
+  "3xl": "var(--text-3xl)",
+};
+
+/** `MarkdownDocument.css` reads this; declaring it here is what applies the rung. */
+type MarkdownFontStyle = CSSProperties & Record<"--markdown-font-size", string>;
 
 export interface MarkdownDocumentProps {
   /** Markdown source text */
@@ -33,6 +54,12 @@ export interface MarkdownDocumentProps {
    */
   cacheBust?: string;
   className?: string;
+  /**
+   * Reading scale for this document, as a rung of the shared type scale. Absent
+   * leaves the CSS fallback in charge, which is the size every surface rendered
+   * at before the control existed (#12134).
+   */
+  fontSize?: MarkdownFontSize;
   /**
    * Fired once the document has committed. Hosts that pinned their height
    * across the swap into rendered mode use this to release the pin (#11255).
@@ -123,6 +150,7 @@ export function MarkdownDocument({
   rootPath,
   cacheBust,
   className,
+  fontSize,
   onRendered,
 }: MarkdownDocumentProps) {
   // Runs after the first commit, which is the point the host's height pin can
@@ -220,8 +248,13 @@ export function MarkdownDocument({
     [handleLinkActivate]
   );
 
+  const fontStyle: MarkdownFontStyle | undefined =
+    fontSize === undefined
+      ? undefined
+      : { "--markdown-font-size": MARKDOWN_FONT_SIZE_TOKEN[fontSize] };
+
   return (
-    <div ref={rootRef} className={cn("markdown-document prose", className)}>
+    <div ref={rootRef} className={cn("markdown-document prose", className)} style={fontStyle}>
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         urlTransform={urlTransform}

--- a/src/components/Markdown/MarkdownTextSizeControl.tsx
+++ b/src/components/Markdown/MarkdownTextSizeControl.tsx
@@ -1,6 +1,7 @@
 import { useCallback } from "react";
 import { ALargeSmall, Minus, Plus } from "lucide-react";
 import { TOOLBAR_ICON_CLASS } from "@/components/FileViewer/FileViewerToolbar";
+import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -26,8 +27,25 @@ const STEP_LABEL: Record<MarkdownFontSize, string> = {
   "3xl": "30",
 };
 
-const stepAt = (value: MarkdownFontSize, delta: number): MarkdownFontSize | undefined =>
-  MARKDOWN_FONT_SIZE_STEPS[MARKDOWN_FONT_SIZE_STEPS.indexOf(value) + delta];
+const stepAt = (value: MarkdownFontSize, delta: number): MarkdownFontSize | undefined => {
+  const index = MARKDOWN_FONT_SIZE_STEPS.indexOf(value);
+  // A value off the ladder can only arrive from a corrupt store, but -1 + 1
+  // would land on the smallest rung and read as a deliberate step.
+  if (index < 0) return undefined;
+  return MARKDOWN_FONT_SIZE_STEPS[index + delta];
+};
+
+/**
+ * Ends of the ladder are announced, not removed. The native `disabled`
+ * attribute drops focus the moment the attribute lands, so stepping up to the
+ * last rung would blur the very button that was just activated — and a focusout
+ * inside a Radix popover is exactly what dismisses it. `aria-disabled` says the
+ * same thing to a screen reader while the button stays where the user left it.
+ */
+const inertProps = (inert: boolean) => ({
+  "aria-disabled": inert || undefined,
+  className: inert ? "opacity-50" : undefined,
+});
 
 export interface MarkdownTextSizeControlProps {
   value: MarkdownFontSize;
@@ -115,7 +133,7 @@ export function MarkdownTextSizeControl({
             variant="ghost"
             size="icon-xs"
             aria-label="Decrease text size"
-            disabled={smaller === undefined}
+            {...inertProps(smaller === undefined)}
             onClick={() => smaller && onValueChange(smaller)}
             data-testid="markdown-text-size-decrease"
           >
@@ -136,7 +154,7 @@ export function MarkdownTextSizeControl({
             variant="ghost"
             size="icon-xs"
             aria-label="Increase text size"
-            disabled={larger === undefined}
+            {...inertProps(larger === undefined)}
             onClick={() => larger && onValueChange(larger)}
             data-testid="markdown-text-size-increase"
           >
@@ -146,9 +164,16 @@ export function MarkdownTextSizeControl({
         <Button
           variant="ghost"
           size="xs"
-          className="mt-1 w-full justify-center"
-          disabled={value === DEFAULT_MARKDOWN_FONT_SIZE}
-          onClick={() => onValueChange(DEFAULT_MARKDOWN_FONT_SIZE)}
+          className={cn(
+            "mt-1 w-full justify-center",
+            value === DEFAULT_MARKDOWN_FONT_SIZE && "opacity-50"
+          )}
+          // Same reason as the steppers: Reset disables itself by succeeding,
+          // so a native `disabled` would blur the button under the pointer.
+          aria-disabled={value === DEFAULT_MARKDOWN_FONT_SIZE || undefined}
+          onClick={() =>
+            value !== DEFAULT_MARKDOWN_FONT_SIZE && onValueChange(DEFAULT_MARKDOWN_FONT_SIZE)
+          }
           data-testid="markdown-text-size-reset"
         >
           Reset

--- a/src/components/Markdown/MarkdownTextSizeControl.tsx
+++ b/src/components/Markdown/MarkdownTextSizeControl.tsx
@@ -1,0 +1,159 @@
+import { useCallback } from "react";
+import { ALargeSmall, Minus, Plus } from "lucide-react";
+import { TOOLBAR_ICON_CLASS } from "@/components/FileViewer/FileViewerToolbar";
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import {
+  DEFAULT_MARKDOWN_FONT_SIZE,
+  MARKDOWN_FONT_SIZE_STEPS,
+  type MarkdownFontSize,
+} from "@/store/preferencesStore";
+
+/**
+ * What each rung measures at the app's 16px root, for the readout. Labels only:
+ * the value that reaches the document is the type-scale token, never this
+ * number — see `MARKDOWN_FONT_SIZE_TOKEN` in `MarkdownDocument.tsx`.
+ */
+const STEP_LABEL: Record<MarkdownFontSize, string> = {
+  "2xs": "11",
+  xs: "12",
+  sm: "14",
+  base: "16",
+  lg: "18",
+  xl: "20",
+  "2xl": "24",
+  "3xl": "30",
+};
+
+const stepAt = (value: MarkdownFontSize, delta: number): MarkdownFontSize | undefined =>
+  MARKDOWN_FONT_SIZE_STEPS[MARKDOWN_FONT_SIZE_STEPS.indexOf(value) + delta];
+
+export interface MarkdownTextSizeControlProps {
+  value: MarkdownFontSize;
+  onValueChange: (value: MarkdownFontSize) => void;
+  "data-testid"?: string;
+}
+
+/**
+ * Reading scale for rendered markdown, in the shape reading surfaces have
+ * settled on (Safari Reader, Apple Books, Kindle): an "Aa" trigger in the
+ * toolbar opening a stepper, rather than a second toolbar row that would cost
+ * vertical space in every layout to serve one occasional adjustment (#12134).
+ *
+ * A `Popover` rather than the `DropdownMenu` its neighbour `FileBrowserViewOptions`
+ * uses, because a stepper is a widget and not a menu: `role="menuitem"` on a
+ * minus button claims a semantic that isn't true, and Radix's menu roving focus
+ * is vertical-only, so a horizontally laid-out pair would be walked with
+ * Up/Down. Inside a popover the three buttons are plain tab stops and the
+ * arrow/+/- keys are free to mean what they say. Close-time focus and tooltip
+ * restoration are the primitive's job either way (`overlay-focus-restore.ts`).
+ *
+ * The size is one app-level preference, so the control is stateless — it steps
+ * whatever the store holds and both hosts show the same number.
+ */
+export function MarkdownTextSizeControl({
+  value,
+  onValueChange,
+  "data-testid": testId,
+}: MarkdownTextSizeControlProps) {
+  const smaller = stepAt(value, -1);
+  const larger = stepAt(value, 1);
+  const label = STEP_LABEL[value];
+
+  // The stepper's own accelerators, live only while the popover is open. There
+  // is no global combo to reach for: Cmd+= / Cmd+- / Cmd+0 are whole-window
+  // zoom and Cmd+Alt+= cycles workspaces, so a document-scale binding would
+  // either collide or land on a combo nobody would find.
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent) => {
+      const next =
+        event.key === "ArrowUp" || event.key === "+" || event.key === "="
+          ? stepAt(value, 1)
+          : event.key === "ArrowDown" || event.key === "-"
+            ? stepAt(value, -1)
+            : undefined;
+      if (next === undefined) return;
+      event.preventDefault();
+      onValueChange(next);
+    },
+    [value, onValueChange]
+  );
+
+  return (
+    <Popover>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              // Same footprint as its neighbours in the row; the armed chip
+              // `toolbar-icon-button` paints on `data-state="open"` carries the
+              // only state this trigger has.
+              className="toolbar-icon-button shrink-0 rounded-lg p-1.5 text-text-secondary"
+              // Carries the current size, so a screen reader hears where the
+              // document already is before opening anything.
+              aria-label={`Text size, ${label} pixels`}
+              data-testid={testId}
+            >
+              <ALargeSmall className={TOOLBAR_ICON_CLASS} aria-hidden="true" />
+            </button>
+          </PopoverTrigger>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">Text size</TooltipContent>
+      </Tooltip>
+      <PopoverContent
+        align="end"
+        sideOffset={6}
+        collisionPadding={8}
+        className="w-auto p-2"
+        aria-label="Text size"
+        onKeyDown={handleKeyDown}
+      >
+        <div className="flex items-center gap-1">
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            aria-label="Decrease text size"
+            disabled={smaller === undefined}
+            onClick={() => smaller && onValueChange(smaller)}
+            data-testid="markdown-text-size-decrease"
+          >
+            <Minus aria-hidden="true" />
+          </Button>
+          {/* A live region rather than a static readout: the popover stays open
+              across a run of adjustments, so the value has to announce itself
+              each time or the stepping is silent. */}
+          <output
+            aria-live="polite"
+            aria-atomic="true"
+            className="w-14 text-center text-xs tabular-nums text-text-primary"
+            data-testid="markdown-text-size-value"
+          >
+            {label} px
+          </output>
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            aria-label="Increase text size"
+            disabled={larger === undefined}
+            onClick={() => larger && onValueChange(larger)}
+            data-testid="markdown-text-size-increase"
+          >
+            <Plus aria-hidden="true" />
+          </Button>
+        </div>
+        <Button
+          variant="ghost"
+          size="xs"
+          className="mt-1 w-full justify-center"
+          disabled={value === DEFAULT_MARKDOWN_FONT_SIZE}
+          onClick={() => onValueChange(DEFAULT_MARKDOWN_FONT_SIZE)}
+          data-testid="markdown-text-size-reset"
+        >
+          Reset
+        </Button>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/components/Markdown/MarkdownViewer.tsx
+++ b/src/components/Markdown/MarkdownViewer.tsx
@@ -3,6 +3,7 @@ import type { FileRenderMode } from "@shared/types/panel";
 import { CodeViewer, type CodeViewerHandle } from "@/components/FileViewer/CodeViewer";
 import { Skeleton, SkeletonText } from "@/components/ui/Skeleton";
 import { cn } from "@/lib/utils";
+import type { MarkdownFontSize } from "@/store/preferencesStore";
 
 // The rendered document pulls react-markdown + remark-gfm; keep that weight
 // out of the first-paint chunk (FilePane is a firstRenderRestore seed).
@@ -33,6 +34,12 @@ export interface MarkdownViewerProps {
    * image to bust — hosts only pass this where they render the document.
    */
   cacheBust?: string;
+  /**
+   * Rendered-mode only: the reading scale, as a rung of the shared type scale.
+   * Source mode is CodeMirror, which has its own sizing and no prose hierarchy
+   * to tune, so this deliberately never reaches it (#12134).
+   */
+  fontSize?: MarkdownFontSize;
   className?: string;
   /**
    * Rendered-mode only: fired once the rendered document has committed. Hosts
@@ -57,6 +64,7 @@ export const MarkdownViewer = forwardRef<MarkdownViewerHandle, MarkdownViewerPro
       initialLine,
       wrapLines,
       cacheBust,
+      fontSize,
       className,
       onRendered,
     },
@@ -100,6 +108,7 @@ export const MarkdownViewer = forwardRef<MarkdownViewerHandle, MarkdownViewerPro
           filePath={filePath}
           rootPath={rootPath}
           cacheBust={cacheBust}
+          fontSize={fontSize}
           className={cn("px-6 py-5", className)}
           onRendered={onRendered}
         />

--- a/src/components/Markdown/__tests__/MarkdownDocument.test.tsx
+++ b/src/components/Markdown/__tests__/MarkdownDocument.test.tsx
@@ -338,28 +338,32 @@ describe("MarkdownDocument", () => {
  * source instead, which is what actually ships in the lazy markdown chunk.
  */
 describe("MarkdownDocument.css document scale (#12134)", () => {
-  const css = fs.readFileSync(
-    path.join(path.dirname(fileURLToPath(import.meta.url)), "../MarkdownDocument.css"),
-    "utf8"
-  );
+  // Comments go first throughout: the file's header explains both rules below
+  // by quoting the very things they forbid, so a raw scan reads its own prose.
+  const rules = fs
+    .readFileSync(
+      path.join(path.dirname(fileURLToPath(import.meta.url)), "../MarkdownDocument.css"),
+      "utf8"
+    )
+    .replace(/\/\*[\s\S]*?\*\//g, "");
+
+  /** The `.markdown-document` rule's own body, not a descendant's. */
+  const rootBlock = /(?:^|\n)\.markdown-document\s*\{([^}]*)\}/.exec(rules)?.[1] ?? "";
 
   it("sizes the document from --markdown-font-size, falling back to the type scale", () => {
-    const declarations = [...css.matchAll(/(?:^|[^-\w])font-size\s*:\s*([^;}\n]+)/g)].map(
+    expect(rootBlock).not.toBe("");
+    const declarations = [...rootBlock.matchAll(/(?:^|[^-\w])font-size\s*:\s*([^;}\n]+)/g)].map(
       (match) => match[1]?.trim()
     );
 
-    // The root rule's own declaration, not one of the descendant overrides.
-    expect(declarations).toContain("var(--markdown-font-size, var(--text-sm))");
     // The fallback is load-bearing: a document mounted without the prop, and
     // every surface that predates the control, still renders at 14px.
-    expect(declarations).not.toContain("var(--markdown-font-size)");
+    expect(declarations).toEqual(["var(--markdown-font-size, var(--text-sm))"]);
   });
 
   it("keeps the scale unlayered, where it still outranks the typography plugin", () => {
     // Wrapping this file in @layer hands the prose rules back to the plugin's
-    // light-theme defaults — the regression the file header records. Comments
-    // go first: the header explains the rule by naming the at-rule it forbids.
-    const rules = css.replace(/\/\*[\s\S]*?\*\//g, "");
+    // light-theme defaults — the regression the file header records.
     expect(rules).not.toMatch(/@layer/);
   });
 });

--- a/src/components/Markdown/__tests__/MarkdownDocument.test.tsx
+++ b/src/components/Markdown/__tests__/MarkdownDocument.test.tsx
@@ -1,4 +1,7 @@
 // @vitest-environment jsdom
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 
@@ -324,5 +327,39 @@ describe("MarkdownDocument", () => {
     expect(window.getSelection()?.toString()).toBe(document_.textContent);
     expect(window.getSelection()?.toString()).not.toContain("sidebar chrome");
     window.getSelection()?.removeAllRanges();
+  });
+});
+
+/**
+ * The stylesheet is the half of the size control that no render test can see:
+ * jsdom applies no author styles, so the whole feature — store, stepper,
+ * forwarding, the inline custom property — stays green while the declaration
+ * that consumes it is reverted and the type never moves (#12134). Read the
+ * source instead, which is what actually ships in the lazy markdown chunk.
+ */
+describe("MarkdownDocument.css document scale (#12134)", () => {
+  const css = fs.readFileSync(
+    path.join(path.dirname(fileURLToPath(import.meta.url)), "../MarkdownDocument.css"),
+    "utf8"
+  );
+
+  it("sizes the document from --markdown-font-size, falling back to the type scale", () => {
+    const declarations = [...css.matchAll(/(?:^|[^-\w])font-size\s*:\s*([^;}\n]+)/g)].map(
+      (match) => match[1]?.trim()
+    );
+
+    // The root rule's own declaration, not one of the descendant overrides.
+    expect(declarations).toContain("var(--markdown-font-size, var(--text-sm))");
+    // The fallback is load-bearing: a document mounted without the prop, and
+    // every surface that predates the control, still renders at 14px.
+    expect(declarations).not.toContain("var(--markdown-font-size)");
+  });
+
+  it("keeps the scale unlayered, where it still outranks the typography plugin", () => {
+    // Wrapping this file in @layer hands the prose rules back to the plugin's
+    // light-theme defaults — the regression the file header records. Comments
+    // go first: the header explains the rule by naming the at-rule it forbids.
+    const rules = css.replace(/\/\*[\s\S]*?\*\//g, "");
+    expect(rules).not.toMatch(/@layer/);
   });
 });

--- a/src/components/Markdown/__tests__/MarkdownDocument.test.tsx
+++ b/src/components/Markdown/__tests__/MarkdownDocument.test.tsx
@@ -10,7 +10,8 @@ vi.mock("@/services/ActionService", () => ({
   actionService: { dispatch: dispatchMock },
 }));
 
-import { MarkdownDocument } from "../MarkdownDocument";
+import { MarkdownDocument, MARKDOWN_FONT_SIZE_TOKEN } from "../MarkdownDocument";
+import { MARKDOWN_FONT_SIZE_STEPS } from "@/store/preferencesStore";
 
 const FIXTURE_PROPS = {
   filePath: "/repo/docs/spec.md",
@@ -365,5 +366,24 @@ describe("MarkdownDocument.css document scale (#12134)", () => {
     // Wrapping this file in @layer hands the prose rules back to the plugin's
     // light-theme defaults — the regression the file header records.
     expect(rules).not.toMatch(/@layer/);
+  });
+});
+
+/**
+ * The type can only hold the map exhaustive, not correct: `satisfies
+ * Record<MarkdownFontSize, string>` accepts a rung mapped to the wrong step, or
+ * to a variable that does not exist. Expressing the correlation as a template
+ * literal type instead would put `var(--text-` in a type position, where
+ * `builtInThemes.test.ts`'s renderer scan reads it as a consumer named `text-`
+ * — so the correlation is pinned here, in a file that scan skips.
+ */
+describe("MARKDOWN_FONT_SIZE_TOKEN (#12134)", () => {
+  it("resolves every rung to its own step of the shared type scale", () => {
+    expect(Object.keys(MARKDOWN_FONT_SIZE_TOKEN).sort()).toEqual(
+      [...MARKDOWN_FONT_SIZE_STEPS].sort()
+    );
+    for (const step of MARKDOWN_FONT_SIZE_STEPS) {
+      expect(MARKDOWN_FONT_SIZE_TOKEN[step]).toBe(`var(--text-${step})`);
+    }
   });
 });

--- a/src/components/Markdown/__tests__/MarkdownTextSizeControl.test.tsx
+++ b/src/components/Markdown/__tests__/MarkdownTextSizeControl.test.tsx
@@ -1,0 +1,125 @@
+// @vitest-environment jsdom
+import { useState, type ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { MarkdownFontSize } from "@/store/preferencesStore";
+
+// Radix opens on a pointer sequence and portals its content, neither of which
+// jsdom drives faithfully. Render the panel inline and keep its keydown handler
+// wired — what this suite owns is the stepping, not Radix's choreography. Same
+// shape as the dropdown mock in FileBrowserViewOptions.test.tsx.
+vi.mock("@/components/ui/popover", () => ({
+  Popover: ({ children }: { children: ReactNode }) => <>{children}</>,
+  PopoverTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  PopoverContent: ({
+    children,
+    onKeyDown,
+    "aria-label": label,
+  }: {
+    children: ReactNode;
+    onKeyDown?: (event: React.KeyboardEvent) => void;
+    "aria-label"?: string;
+  }) => (
+    <div role="dialog" aria-label={label} onKeyDown={onKeyDown}>
+      {children}
+    </div>
+  ),
+}));
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+}));
+
+import { MarkdownTextSizeControl } from "../MarkdownTextSizeControl";
+
+/** Drives the control the way a host does — it owns no state of its own. */
+function Harness({ initial = "sm" as MarkdownFontSize }) {
+  const [value, setValue] = useState<MarkdownFontSize>(initial);
+  return <MarkdownTextSizeControl value={value} onValueChange={setValue} />;
+}
+
+const readout = () => screen.getByTestId("markdown-text-size-value");
+const decrease = () => screen.getByTestId("markdown-text-size-decrease");
+const increase = () => screen.getByTestId("markdown-text-size-increase");
+const reset = () => screen.getByTestId("markdown-text-size-reset");
+
+afterEach(cleanup);
+
+describe("MarkdownTextSizeControl (#12134)", () => {
+  it("steps up and down the ladder, including its widening top end", () => {
+    render(<Harness initial="lg" />);
+    expect(readout().textContent).toBe("18 px");
+
+    fireEvent.click(increase());
+    expect(readout().textContent).toBe("20 px");
+
+    // 20 → 24 → 30: the top of the ladder widens on purpose, so a step there
+    // is worth taking rather than imperceptible.
+    fireEvent.click(increase());
+    expect(readout().textContent).toBe("24 px");
+
+    fireEvent.click(decrease());
+    expect(readout().textContent).toBe("20 px");
+  });
+
+  it("stops at each end of the ladder rather than wrapping", () => {
+    render(<Harness initial="2xs" />);
+    expect(readout().textContent).toBe("11 px");
+    expect((decrease() as HTMLButtonElement).disabled).toBe(true);
+    expect((increase() as HTMLButtonElement).disabled).toBe(false);
+
+    cleanup();
+    render(<Harness initial="3xl" />);
+    expect(readout().textContent).toBe("30 px");
+    expect((increase() as HTMLButtonElement).disabled).toBe(true);
+    expect((decrease() as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it("returns to the default and cannot promise a no-op while already there", () => {
+    render(<Harness initial="2xl" />);
+    expect((reset() as HTMLButtonElement).disabled).toBe(false);
+
+    fireEvent.click(reset());
+    expect(readout().textContent).toBe("14 px");
+    expect((reset() as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  // The popover is the only interface: every discoverable zoom combo is already
+  // bound to whole-window zoom, so these keys are what "accelerator" means here.
+  it("steps from the keyboard while the panel is open", () => {
+    render(<Harness />);
+    const panel = screen.getByRole("dialog", { name: "Text size" });
+
+    fireEvent.keyDown(panel, { key: "ArrowUp" });
+    expect(readout().textContent).toBe("16 px");
+
+    fireEvent.keyDown(panel, { key: "+" });
+    expect(readout().textContent).toBe("18 px");
+
+    fireEvent.keyDown(panel, { key: "ArrowDown" });
+    expect(readout().textContent).toBe("16 px");
+
+    fireEvent.keyDown(panel, { key: "-" });
+    expect(readout().textContent).toBe("14 px");
+
+    // An unrelated key must fall through to whatever else is listening.
+    fireEvent.keyDown(panel, { key: "a" });
+    expect(readout().textContent).toBe("14 px");
+  });
+
+  it("announces the size on the trigger and again on every adjustment", () => {
+    render(<Harness />);
+    // Entering the control says where the document already is...
+    expect(screen.getByLabelText("Text size, 14 pixels")).not.toBeNull();
+
+    // ...and the panel stays open across a run of steps, so the readout has to
+    // say each one or the stepping is silent.
+    expect(readout().getAttribute("aria-live")).toBe("polite");
+    expect(readout().getAttribute("aria-atomic")).toBe("true");
+
+    fireEvent.click(increase());
+    expect(readout().textContent).toBe("16 px");
+    expect(screen.getByLabelText("Text size, 16 pixels")).not.toBeNull();
+  });
+});

--- a/src/components/Markdown/__tests__/MarkdownTextSizeControl.test.tsx
+++ b/src/components/Markdown/__tests__/MarkdownTextSizeControl.test.tsx
@@ -63,26 +63,61 @@ describe("MarkdownTextSizeControl (#12134)", () => {
     expect(readout().textContent).toBe("20 px");
   });
 
+  it("walks every rung of the ladder, and each one reads out its own size", () => {
+    render(<Harness initial="2xs" />);
+    // The whole ladder, so a rung added without a label — or a label left
+    // empty — cannot pass by being the one nobody asserts.
+    const climb = ["11 px", "12 px", "14 px", "16 px", "18 px", "20 px", "24 px", "30 px"];
+    expect(readout().textContent).toBe(climb[0]);
+    for (const expected of climb.slice(1)) {
+      fireEvent.click(increase());
+      expect(readout().textContent).toBe(expected);
+    }
+  });
+
   it("stops at each end of the ladder rather than wrapping", () => {
     render(<Harness initial="2xs" />);
+    expect(decrease().getAttribute("aria-disabled")).toBe("true");
+    expect(increase().getAttribute("aria-disabled")).toBeNull();
+    fireEvent.click(decrease());
     expect(readout().textContent).toBe("11 px");
-    expect((decrease() as HTMLButtonElement).disabled).toBe(true);
-    expect((increase() as HTMLButtonElement).disabled).toBe(false);
 
     cleanup();
     render(<Harness initial="3xl" />);
+    expect(increase().getAttribute("aria-disabled")).toBe("true");
+    expect(decrease().getAttribute("aria-disabled")).toBeNull();
+    fireEvent.click(increase());
     expect(readout().textContent).toBe("30 px");
-    expect((increase() as HTMLButtonElement).disabled).toBe(true);
-    expect((decrease() as HTMLButtonElement).disabled).toBe(false);
   });
 
-  it("returns to the default and cannot promise a no-op while already there", () => {
+  // The ends are announced, never removed: a native `disabled` lands while the
+  // button still holds focus, and a focusout inside a Radix popover is what
+  // dismisses it — so stepping to the last rung would close the panel.
+  it("keeps the button that just reached an end focusable and focused", () => {
     render(<Harness initial="2xl" />);
-    expect((reset() as HTMLButtonElement).disabled).toBe(false);
+    increase().focus();
+    expect(document.activeElement).toBe(increase());
 
+    fireEvent.click(increase());
+    expect(readout().textContent).toBe("30 px");
+    expect(increase().getAttribute("aria-disabled")).toBe("true");
+    expect((increase() as HTMLButtonElement).disabled).toBe(false);
+    expect(document.activeElement).toBe(increase());
+  });
+
+  it("returns to the default and refuses to act once already there", () => {
+    render(<Harness initial="2xl" />);
+    expect(reset().getAttribute("aria-disabled")).toBeNull();
+
+    reset().focus();
     fireEvent.click(reset());
     expect(readout().textContent).toBe("14 px");
-    expect((reset() as HTMLButtonElement).disabled).toBe(true);
+    expect(reset().getAttribute("aria-disabled")).toBe("true");
+    expect(document.activeElement).toBe(reset());
+
+    // Activating it again must not step anything — it says it is inert.
+    fireEvent.click(reset());
+    expect(readout().textContent).toBe("14 px");
   });
 
   // The popover is the only interface: every discoverable zoom combo is already

--- a/src/components/Markdown/__tests__/MarkdownTextSizeControl.test.tsx
+++ b/src/components/Markdown/__tests__/MarkdownTextSizeControl.test.tsx
@@ -101,7 +101,7 @@ describe("MarkdownTextSizeControl (#12134)", () => {
     fireEvent.click(increase());
     expect(readout().textContent).toBe("30 px");
     expect(increase().getAttribute("aria-disabled")).toBe("true");
-    expect((increase() as HTMLButtonElement).disabled).toBe(false);
+    expect(increase().hasAttribute("disabled")).toBe(false);
     expect(document.activeElement).toBe(increase());
   });
 

--- a/src/components/Markdown/__tests__/MarkdownViewer.test.tsx
+++ b/src/components/Markdown/__tests__/MarkdownViewer.test.tsx
@@ -55,11 +55,46 @@ describe("MarkdownViewer", () => {
     expect(new URL(img.getAttribute("src") ?? "").searchParams.get("v")).toBe("rev-7");
   });
 
+  // #12134: the reading size is a rung of the shared type scale, resolved to a
+  // token on the document root. Pinning the token rather than a pixel value is
+  // the point — a raw size would stop tracking the scale.
+  it("declares the chosen rung as a type-scale token on the document root", async () => {
+    const { container } = render(
+      <MarkdownViewer {...FIXTURE_PROPS} viewMode="rendered" fontSize="2xl" />
+    );
+
+    await screen.findByRole("heading", { level: 1 });
+    const root = container.querySelector<HTMLElement>(".markdown-document");
+    expect(root).not.toBeNull();
+    expect(root!.style.getPropertyValue("--markdown-font-size")).toBe("var(--text-2xl)");
+  });
+
+  it("leaves the property absent without a size, so the stylesheet keeps the default", async () => {
+    const { container } = render(<MarkdownViewer {...FIXTURE_PROPS} viewMode="rendered" />);
+
+    await screen.findByRole("heading", { level: 1 });
+    const root = container.querySelector<HTMLElement>(".markdown-document");
+    expect(root!.style.getPropertyValue("--markdown-font-size")).toBe("");
+  });
+
   it("stays silent in source mode, which has no chunk to wait on", () => {
     const onRendered = vi.fn();
-    render(<MarkdownViewer {...FIXTURE_PROPS} viewMode="source" onRendered={onRendered} />);
+    const { container } = render(
+      <MarkdownViewer
+        {...FIXTURE_PROPS}
+        viewMode="source"
+        fontSize="2xl"
+        onRendered={onRendered}
+      />
+    );
 
     expect(screen.getByTestId("code-viewer-mock")).toBeDefined();
     expect(onRendered).not.toHaveBeenCalled();
+    // Source is CodeMirror, which this scale does not reach: the rung must not
+    // leak onto the editor as an inherited custom property.
+    expect(container.querySelector(".markdown-document")).toBeNull();
+    expect(
+      container.querySelector<HTMLElement>("[style*='--markdown-font-size']")
+    ).toBeNull();
   });
 });

--- a/src/components/Markdown/__tests__/MarkdownViewer.test.tsx
+++ b/src/components/Markdown/__tests__/MarkdownViewer.test.tsx
@@ -80,12 +80,7 @@ describe("MarkdownViewer", () => {
   it("stays silent in source mode, which has no chunk to wait on", () => {
     const onRendered = vi.fn();
     const { container } = render(
-      <MarkdownViewer
-        {...FIXTURE_PROPS}
-        viewMode="source"
-        fontSize="2xl"
-        onRendered={onRendered}
-      />
+      <MarkdownViewer {...FIXTURE_PROPS} viewMode="source" fontSize="2xl" onRendered={onRendered} />
     );
 
     expect(screen.getByTestId("code-viewer-mock")).toBeDefined();
@@ -93,8 +88,6 @@ describe("MarkdownViewer", () => {
     // Source is CodeMirror, which this scale does not reach: the rung must not
     // leak onto the editor as an inherited custom property.
     expect(container.querySelector(".markdown-document")).toBeNull();
-    expect(
-      container.querySelector<HTMLElement>("[style*='--markdown-font-size']")
-    ).toBeNull();
+    expect(container.querySelector<HTMLElement>("[style*='--markdown-font-size']")).toBeNull();
   });
 });

--- a/src/panels/file-browser/FileBrowserViewer.tsx
+++ b/src/panels/file-browser/FileBrowserViewer.tsx
@@ -32,6 +32,7 @@ import {
 } from "@/components/FileViewer/filePreviewKinds";
 import { MarkdownViewer } from "@/components/Markdown/MarkdownViewer";
 import { isMarkdownFilePath } from "@/components/Markdown/isMarkdownFile";
+import { MarkdownTextSizeControl } from "@/components/Markdown/MarkdownTextSizeControl";
 import { HtmlViewer } from "@/components/Html/HtmlViewer";
 import { isHtmlFilePath } from "@/components/Html/isHtmlFile";
 import {
@@ -42,6 +43,7 @@ import { EmptyState } from "@/components/ui/EmptyState";
 import { Skeleton, SkeletonBone, SkeletonText } from "@/components/ui/Skeleton";
 import { SegmentedToggle } from "@/components/ui/SegmentedToggle";
 import { useDohertyGate } from "@/hooks/useDeferredLoading";
+import { usePreferencesStore } from "@/store/preferencesStore";
 import { FolderListingView } from "./FolderListingView";
 import { FileBrowserViewOptions } from "./FileBrowserViewOptions";
 import { FileBrowserHiddenStrip } from "./FileBrowserHiddenStrip";
@@ -231,6 +233,10 @@ export function FileBrowserViewer({
   // per-panel mode also survives a file swap). Non-markdown files simply hide
   // the toggle, so a stale "source" never applies where it can't be honoured.
   const [markdownMode, setMarkdownMode] = useState<FileRenderMode>("rendered");
+  // The same app-level reading size the file panel shows, so a document is the
+  // size the reader last chose in whichever surface they opened it (#12134).
+  const markdownFontSize = usePreferencesStore((state) => state.markdownFontSize);
+  const setMarkdownFontSize = usePreferencesStore((state) => state.setMarkdownFontSize);
   // Bumped on every load so `HtmlViewer` re-navigates its sandboxed frame when
   // an agent rewrites the file underneath it.
   const [reloadNonce, setReloadNonce] = useState(0);
@@ -505,6 +511,17 @@ export function FileBrowserViewer({
               onCollapseAll={onCollapseAll}
               canCollapseAll={canCollapseAll}
               data-testid="file-browser-view-options"
+            />
+          )}
+          {/* Rendered markdown only: source is CodeMirror, which this scale
+              does not reach, and every other preview kind has no prose to
+              tune. Sits ahead of the file actions so the controls that change
+              what you are looking at stay left of the ones that leave. */}
+          {filePath !== null && isMarkdownFilePath(filePath) && markdownMode === "rendered" && (
+            <MarkdownTextSizeControl
+              value={markdownFontSize}
+              onValueChange={setMarkdownFontSize}
+              data-testid="file-browser-text-size"
             />
           )}
           {filePath && (
@@ -888,6 +905,7 @@ export function FileBrowserViewer({
               filePath={filePath}
               rootPath={rootPath}
               viewMode={markdownMode}
+              fontSize={markdownFontSize}
               cacheBust={revision}
               className="min-h-full"
             />

--- a/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
@@ -48,10 +48,7 @@ vi.mock("@/store/preferencesStore", () => ({
 // A Popover, whose open/close choreography jsdom does not drive. Its own
 // behaviour is covered in MarkdownTextSizeControl.test.tsx.
 vi.mock("@/components/Markdown/MarkdownTextSizeControl", () => ({
-  MarkdownTextSizeControl: (props: {
-    value: string;
-    onValueChange: (next: string) => void;
-  }) => (
+  MarkdownTextSizeControl: (props: { value: string; onValueChange: (next: string) => void }) => (
     <button
       type="button"
       data-testid="markdown-text-size-mock"

--- a/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
@@ -38,15 +38,26 @@ vi.mock("@/components/Markdown/MarkdownViewer", () => ({
 }));
 // The reading size is one app-level preference shared with the file panel; this
 // suite owns the toolbar gate and the forwarding, not the store's persistence.
+const { setMarkdownFontSizeMock } = vi.hoisted(() => ({
+  setMarkdownFontSizeMock: vi.fn(),
+}));
 vi.mock("@/store/preferencesStore", () => ({
   usePreferencesStore: (selector: (state: unknown) => unknown) =>
-    selector({ markdownFontSize: "xl", setMarkdownFontSize: vi.fn() }),
+    selector({ markdownFontSize: "xl", setMarkdownFontSize: setMarkdownFontSizeMock }),
 }));
 // A Popover, whose open/close choreography jsdom does not drive. Its own
 // behaviour is covered in MarkdownTextSizeControl.test.tsx.
 vi.mock("@/components/Markdown/MarkdownTextSizeControl", () => ({
-  MarkdownTextSizeControl: (props: { value: string }) => (
-    <div data-testid="markdown-text-size-mock" data-value={props.value} />
+  MarkdownTextSizeControl: (props: {
+    value: string;
+    onValueChange: (next: string) => void;
+  }) => (
+    <button
+      type="button"
+      data-testid="markdown-text-size-mock"
+      data-value={props.value}
+      onClick={() => props.onValueChange("2xl")}
+    />
   ),
 }));
 vi.mock("@/components/FileViewer/CodeViewer", () => ({
@@ -294,6 +305,7 @@ function currentFontSize(): string | null {
 beforeEach(() => {
   readMock.mockReset();
   readMock.mockResolvedValue({ content: "# hello" });
+  setMarkdownFontSizeMock.mockReset();
   dispatchMock.mockReset();
   dispatchMock.mockResolvedValue({ ok: true, result: undefined });
   // SegmentedToggle's motion hook (and InlineStatusBanner) read matchMedia at
@@ -375,6 +387,12 @@ describe("FileBrowserViewer rendered-markdown text size (#12134)", () => {
     // reader last chose, whichever surface they opened it in.
     expect(control.getAttribute("data-value")).toBe("xl");
     expect(currentFontSize()).toBe("xl");
+
+    // And the choice reaches the shared preference, not a local no-op.
+    await act(async () => {
+      control.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(setMarkdownFontSizeMock).toHaveBeenCalledWith("2xl");
   });
 
   it("withdraws it in Source, where the scale reaches nothing", async () => {

--- a/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
@@ -27,12 +27,26 @@ vi.mock("@/services/ActionService", () => ({
 // observable — without it the mode plumbing could be deleted and stay green.
 // cacheBust rides along for the same reason (#11587).
 vi.mock("@/components/Markdown/MarkdownViewer", () => ({
-  MarkdownViewer: (props: Pick<MarkdownViewerProps, "viewMode" | "cacheBust">) => (
+  MarkdownViewer: (props: Pick<MarkdownViewerProps, "viewMode" | "cacheBust" | "fontSize">) => (
     <div
       data-testid="markdown-viewer-mock"
       data-view-mode={props.viewMode}
       data-cache-bust={props.cacheBust ?? ""}
+      data-font-size={props.fontSize ?? ""}
     />
+  ),
+}));
+// The reading size is one app-level preference shared with the file panel; this
+// suite owns the toolbar gate and the forwarding, not the store's persistence.
+vi.mock("@/store/preferencesStore", () => ({
+  usePreferencesStore: (selector: (state: unknown) => unknown) =>
+    selector({ markdownFontSize: "xl", setMarkdownFontSize: vi.fn() }),
+}));
+// A Popover, whose open/close choreography jsdom does not drive. Its own
+// behaviour is covered in MarkdownTextSizeControl.test.tsx.
+vi.mock("@/components/Markdown/MarkdownTextSizeControl", () => ({
+  MarkdownTextSizeControl: (props: { value: string }) => (
+    <div data-testid="markdown-text-size-mock" data-value={props.value} />
   ),
 }));
 vi.mock("@/components/FileViewer/CodeViewer", () => ({
@@ -273,6 +287,10 @@ function currentCacheBust(): string | null {
   return screen.getByTestId("markdown-viewer-mock").getAttribute("data-cache-bust");
 }
 
+function currentFontSize(): string | null {
+  return screen.getByTestId("markdown-viewer-mock").getAttribute("data-font-size");
+}
+
 beforeEach(() => {
   readMock.mockReset();
   readMock.mockResolvedValue({ content: "# hello" });
@@ -344,6 +362,39 @@ describe("FileBrowserViewer markdown Source/Rendered toggle (#11319)", () => {
     expect(screen.queryByRole("button", { name: "Source" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Rendered" })).toBeNull();
     expect(screen.queryByTestId("markdown-viewer-mock")).toBeNull();
+  });
+});
+
+describe("FileBrowserViewer rendered-markdown text size (#12134)", () => {
+  it("offers the control and carries the shared size into the rendered document", async () => {
+    renderViewer("/repo/docs/spec.md");
+    await waitFor(() => expect(currentViewMode()).toBe("rendered"));
+
+    const control = await screen.findByTestId("markdown-text-size-mock");
+    // The same global value the file panel reads — a document is the size the
+    // reader last chose, whichever surface they opened it in.
+    expect(control.getAttribute("data-value")).toBe("xl");
+    expect(currentFontSize()).toBe("xl");
+  });
+
+  it("withdraws it in Source, where the scale reaches nothing", async () => {
+    renderViewer("/repo/docs/spec.md");
+    await waitFor(() => expect(currentViewMode()).toBe("rendered"));
+
+    await clickMode("Source");
+    await waitFor(() => expect(currentViewMode()).toBe("source"));
+    expect(screen.queryByTestId("markdown-text-size-mock")).toBeNull();
+    // The rung must not follow the mode switch into CodeMirror.
+    expect(currentFontSize()).toBe("");
+  });
+
+  it("withdraws it for a non-markdown file, which has no prose to tune", async () => {
+    const { rerender } = renderViewer("/repo/docs/spec.md");
+    await screen.findByTestId("markdown-text-size-mock");
+
+    rerender(viewerJsx("/repo/src/notes.txt"));
+    await screen.findByTestId("code-viewer-mock");
+    expect(screen.queryByTestId("markdown-text-size-mock")).toBeNull();
   });
 });
 

--- a/src/panels/file/FilePane.tsx
+++ b/src/panels/file/FilePane.tsx
@@ -21,6 +21,7 @@ import { FolderOpen, FolderTree } from "@/components/icons";
 import type { TabInfo } from "@/components/Panel/TabButton";
 import { MarkdownViewer, type MarkdownViewerHandle } from "@/components/Markdown/MarkdownViewer";
 import { isMarkdownFilePath } from "@/components/Markdown/isMarkdownFile";
+import { MarkdownTextSizeControl } from "@/components/Markdown/MarkdownTextSizeControl";
 import { HtmlViewer } from "@/components/Html/HtmlViewer";
 import { isHtmlFilePath } from "@/components/Html/isHtmlFile";
 import { CodeViewer, type CodeViewerHandle } from "@/components/FileViewer/CodeViewer";
@@ -266,6 +267,10 @@ export function FilePane({
   const setFilePanelPath = usePanelStore((state) => state.setFilePanelPath);
   const markdownWrapLines = usePreferencesStore((state) => state.markdownWrapLines);
   const setMarkdownWrapLines = usePreferencesStore((state) => state.setMarkdownWrapLines);
+  // Global, like wrap: a reading size that reset per panel or per file would
+  // make paging through documents feel unstable (#12134).
+  const markdownFontSize = usePreferencesStore((state) => state.markdownFontSize);
+  const setMarkdownFontSize = usePreferencesStore((state) => state.setMarkdownFontSize);
   // Shared with the diff panel so a user's split/unified and wrap choices carry
   // across every surface that shows a diff.
   const diffViewType = usePreferencesStore((state) => state.diffViewType);
@@ -1021,6 +1026,16 @@ export function FilePane({
         )}
         <FileViewerToolbar.Path path={displayPath} copied={pathCopied} onCopy={handleCopyPath} />
         <FileViewerToolbar.Actions>
+          {/* The mirror of Wrap below it: each owns the slot in the mode it
+              applies to, so rendered and source both carry exactly one
+              markdown-specific control rather than a row that grows. */}
+          {isMarkdown && viewMode === "rendered" && (
+            <MarkdownTextSizeControl
+              value={markdownFontSize}
+              onValueChange={setMarkdownFontSize}
+              data-testid="file-pane-text-size"
+            />
+          )}
           {isMarkdown && viewMode === "source" && (
             <FileViewerToolbar.IconButton
               label="Wrap long lines"
@@ -1320,6 +1335,7 @@ export function FilePane({
               rootPath={effectiveRootPath}
               viewMode="rendered"
               wrapLines={markdownWrapLines}
+              fontSize={markdownFontSize}
               cacheBust={String(reloadNonce)}
               onRendered={heightHold.handleRendered}
             />

--- a/src/panels/file/__tests__/FilePane.test.tsx
+++ b/src/panels/file/__tests__/FilePane.test.tsx
@@ -931,6 +931,12 @@ describe("FilePane show in file browser (#11483)", () => {
 // #11191: HTML files get the same Source/Rendered toggle as Markdown; rendered
 // HTML routes to the sandboxed-iframe HtmlViewer.
 describe("FilePane HTML Source/Rendered (#11191)", () => {
+  // Hoisted, so its call history would otherwise carry across tests and let a
+  // later assertion pass on an earlier test's click.
+  beforeEach(() => {
+    setMarkdownFontSizeMock.mockReset();
+  });
+
   function renderPane(filePath: string, fileViewMode?: "source" | "rendered") {
     panelsById["file-1"] = { id: "file-1", kind: "file", filePath, fileViewMode };
     return render(

--- a/src/panels/file/__tests__/FilePane.test.tsx
+++ b/src/panels/file/__tests__/FilePane.test.tsx
@@ -82,13 +82,16 @@ vi.mock("@/lib/viewCacheState", () => ({
 vi.mock("@/store/projectStore", () => ({
   useProjectStore: (selector: (state: unknown) => unknown) => selector({ currentProject: null }),
 }));
+const { setMarkdownFontSizeMock } = vi.hoisted(() => ({
+  setMarkdownFontSizeMock: vi.fn(),
+}));
 vi.mock("@/store/preferencesStore", () => ({
   usePreferencesStore: (selector: (state: unknown) => unknown) =>
     selector({
       markdownWrapLines: false,
       setMarkdownWrapLines: vi.fn(),
       markdownFontSize: "lg",
-      setMarkdownFontSize: vi.fn(),
+      setMarkdownFontSize: setMarkdownFontSizeMock,
       diffViewType: "unified",
       diffWrapLines: false,
       diffIgnoreWhitespace: false,
@@ -176,8 +179,16 @@ vi.mock("@/components/Markdown/MarkdownViewer", () => ({
 // drive; what this suite owns is which modes it appears in and the value it is
 // handed. Its own behaviour is covered in MarkdownTextSizeControl.test.tsx.
 vi.mock("@/components/Markdown/MarkdownTextSizeControl", () => ({
-  MarkdownTextSizeControl: (props: { value: string }) => (
-    <div data-testid="markdown-text-size-mock" data-value={props.value} />
+  MarkdownTextSizeControl: (props: {
+    value: string;
+    onValueChange: (next: string) => void;
+  }) => (
+    <button
+      type="button"
+      data-testid="markdown-text-size-mock"
+      data-value={props.value}
+      onClick={() => props.onValueChange("2xl")}
+    />
   ),
 }));
 vi.mock("@/components/FileViewer/CodeViewer", () => ({
@@ -1006,6 +1017,13 @@ describe("FilePane HTML Source/Rendered (#11191)", () => {
     expect(screen.queryByRole("button", { name: "Wrap long lines" })).toBeNull();
 
     await waitFor(() => expect(markdownViewerProps.current?.fontSize).toBe("lg"));
+
+    // And the control's choice reaches the preference rather than a local
+    // no-op: without this the host could hand it any type-correct callback.
+    await act(async () => {
+      control.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(setMarkdownFontSizeMock).toHaveBeenCalledWith("2xl");
   });
 
   it("hides it in Markdown Source, where the scale reaches nothing", async () => {

--- a/src/panels/file/__tests__/FilePane.test.tsx
+++ b/src/panels/file/__tests__/FilePane.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import type { ReactNode } from "react";
-import { render, act, screen, waitFor, fireEvent } from "@testing-library/react";
+import { render, act, cleanup, screen, waitFor, fireEvent } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { GitStatus } from "@shared/types/git";
 // Type-only: erased before the vi.mock factory runs, so it cannot pull the real
@@ -87,6 +87,8 @@ vi.mock("@/store/preferencesStore", () => ({
     selector({
       markdownWrapLines: false,
       setMarkdownWrapLines: vi.fn(),
+      markdownFontSize: "lg",
+      setMarkdownFontSize: vi.fn(),
       diffViewType: "unified",
       diffWrapLines: false,
       diffIgnoreWhitespace: false,
@@ -158,15 +160,25 @@ vi.mock("@/lib/notify", () => ({ notify: notifyMock }));
 // a byte-identical daintree-file:// src and never refetches. Picked off the real
 // prop type rather than hand-written, so renaming either prop fails here instead
 // of silently capturing undefined forever.
-type CapturedMarkdownProps = Pick<MarkdownViewerProps, "onRendered" | "cacheBust">;
+type CapturedMarkdownProps = Pick<MarkdownViewerProps, "onRendered" | "cacheBust" | "fontSize">;
 const markdownViewerProps = vi.hoisted(() => ({
-  current: null as { onRendered?: () => void; cacheBust?: string } | null,
+  current: null as
+    | { onRendered?: () => void; cacheBust?: string; fontSize?: string }
+    | null,
 }));
 vi.mock("@/components/Markdown/MarkdownViewer", () => ({
   MarkdownViewer: (props: CapturedMarkdownProps) => {
     markdownViewerProps.current = props;
     return <div data-testid="markdown-viewer-mock" />;
   },
+}));
+// The real control is a Popover, whose open/close choreography jsdom does not
+// drive; what this suite owns is which modes it appears in and the value it is
+// handed. Its own behaviour is covered in MarkdownTextSizeControl.test.tsx.
+vi.mock("@/components/Markdown/MarkdownTextSizeControl", () => ({
+  MarkdownTextSizeControl: (props: { value: string }) => (
+    <div data-testid="markdown-text-size-mock" data-value={props.value} />
+  ),
 }));
 vi.mock("@/components/FileViewer/CodeViewer", () => ({
   // Surfaces `content` so a re-read's result is observable — the only way to
@@ -983,6 +995,38 @@ describe("FilePane HTML Source/Rendered (#11191)", () => {
     renderPane("/repo/docs/spec.md", "rendered");
     expect(await screen.findByTestId("markdown-viewer-mock")).toBeTruthy();
     expect(screen.queryByTestId("html-viewer-mock")).toBeNull();
+  });
+
+  // #12134: the reading control is the mirror of Wrap — each owns the toolbar
+  // slot in the mode it applies to, so neither surfaces where it does nothing.
+  it("offers the text-size control for rendered Markdown only, carrying the global size", async () => {
+    renderPane("/repo/docs/spec.md", "rendered");
+    const control = await screen.findByTestId("markdown-text-size-mock");
+    expect(control.getAttribute("data-value")).toBe("lg");
+    expect(screen.queryByRole("button", { name: "Wrap long lines" })).toBeNull();
+
+    await waitFor(() => expect(markdownViewerProps.current?.fontSize).toBe("lg"));
+  });
+
+  it("hides it in Markdown Source, where the scale reaches nothing", async () => {
+    renderPane("/repo/docs/spec.md", "source");
+    await screen.findByTestId("markdown-viewer-mock");
+
+    expect(screen.queryByTestId("markdown-text-size-mock")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Wrap long lines" })).not.toBeNull();
+    // The rung must not reach CodeMirror through the shared viewer either.
+    expect(markdownViewerProps.current?.fontSize).toBeUndefined();
+  });
+
+  it("hides it for rendered HTML and for a plain file, which have no prose to tune", async () => {
+    renderPane("/repo/docs/page.html", "rendered");
+    await screen.findByTestId("html-viewer-mock");
+    expect(screen.queryByTestId("markdown-text-size-mock")).toBeNull();
+
+    cleanup();
+    renderPane("/repo/src/index.css", "source");
+    await screen.findByTestId("code-viewer-mock");
+    expect(screen.queryByTestId("markdown-text-size-mock")).toBeNull();
   });
 
   // #11587: images embedded in the document resolve to daintree-file:// URLs

--- a/src/panels/file/__tests__/FilePane.test.tsx
+++ b/src/panels/file/__tests__/FilePane.test.tsx
@@ -165,9 +165,7 @@ vi.mock("@/lib/notify", () => ({ notify: notifyMock }));
 // of silently capturing undefined forever.
 type CapturedMarkdownProps = Pick<MarkdownViewerProps, "onRendered" | "cacheBust" | "fontSize">;
 const markdownViewerProps = vi.hoisted(() => ({
-  current: null as
-    | { onRendered?: () => void; cacheBust?: string; fontSize?: string }
-    | null,
+  current: null as { onRendered?: () => void; cacheBust?: string; fontSize?: string } | null,
 }));
 vi.mock("@/components/Markdown/MarkdownViewer", () => ({
   MarkdownViewer: (props: CapturedMarkdownProps) => {
@@ -179,10 +177,7 @@ vi.mock("@/components/Markdown/MarkdownViewer", () => ({
 // drive; what this suite owns is which modes it appears in and the value it is
 // handed. Its own behaviour is covered in MarkdownTextSizeControl.test.tsx.
 vi.mock("@/components/Markdown/MarkdownTextSizeControl", () => ({
-  MarkdownTextSizeControl: (props: {
-    value: string;
-    onValueChange: (next: string) => void;
-  }) => (
+  MarkdownTextSizeControl: (props: { value: string; onValueChange: (next: string) => void }) => (
     <button
       type="button"
       data-testid="markdown-text-size-mock"

--- a/src/store/__tests__/preferencesStore.crossViewMerge.test.ts
+++ b/src/store/__tests__/preferencesStore.crossViewMerge.test.ts
@@ -322,6 +322,42 @@ describe("preferencesStore cross-view write merge (#11351)", () => {
   // is not pushed across views — an already-hydrated view can still show the
   // hint once before it reloads. What must not happen is that view's write
   // erasing the record, sending the hint back to every view on next launch.
+  // The reading size is one global value shared by every project view, so a
+  // stale view writing any other preference must not hand it back (#12134).
+  it("keeps a sibling's reading size through an unrelated preference write", async () => {
+    const backing = installLocalStorage({});
+    const { usePreferencesStore: store } = await import("../preferencesStore");
+
+    store.getState().setDockDensity("compact");
+
+    const disk = readBlob(backing);
+    disk.state.markdownFontSize = "2xl";
+    backing.set(STORAGE_KEY, JSON.stringify(disk));
+
+    store.getState().setShowProjectPulse(false);
+
+    const written = readBlob(backing);
+    expect(written.state.markdownFontSize).toBe("2xl");
+    expect(written.state.showProjectPulse).toBe(false);
+  });
+
+  it("carries this view's reading size while keeping a sibling's unrelated scalar", async () => {
+    const backing = installLocalStorage({});
+    const { usePreferencesStore: store } = await import("../preferencesStore");
+
+    store.getState().setDockDensity("compact");
+
+    const disk = readBlob(backing);
+    disk.state.reduceAnimations = true;
+    backing.set(STORAGE_KEY, JSON.stringify(disk));
+
+    store.getState().setMarkdownFontSize("lg");
+
+    const written = readBlob(backing);
+    expect(written.state.markdownFontSize).toBe("lg");
+    expect(written.state.reduceAnimations).toBe(true);
+  });
+
   it("keeps a sibling's spent prefix hint on disk through an unrelated write", async () => {
     const backing = installLocalStorage({});
     const { usePreferencesStore: store } = await import("../preferencesStore");

--- a/src/store/__tests__/preferencesStore.test.ts
+++ b/src/store/__tests__/preferencesStore.test.ts
@@ -726,6 +726,10 @@ describe("preferencesStore migration", () => {
 
       expect(migrated.markdownFontSize).toBe("sm");
       expect(migrated.dockDensity).toBe("compact");
+      // Pin the bump too: `migrate` only runs for a blob below the configured
+      // version, so leaving it at 17 would skip the branch above entirely and
+      // hydration's sanitizer would quietly supply the same default.
+      expect(store.persist.getOptions().version).toBe(18);
     });
 
     it("leaves an already-valid rung alone when migrating", async () => {

--- a/src/store/__tests__/preferencesStore.test.ts
+++ b/src/store/__tests__/preferencesStore.test.ts
@@ -710,6 +710,62 @@ describe("preferencesStore migration", () => {
     });
   });
 
+  describe("markdownFontSize (#12134)", () => {
+    it("defaults to the rung rendered markdown has always used", async () => {
+      const store = await loadStore();
+      expect(store.getState().markdownFontSize).toBe("sm");
+    });
+
+    it("migrates pre-v18 state to the default rather than leaving it undefined", async () => {
+      // Drive `migrate` directly: hydration's sanitizer would supply the same
+      // default, so a store-level assertion passes with the v18 branch deleted.
+      const store = await loadStore();
+      const migrated = store.persist
+        .getOptions()
+        .migrate?.({ dockDensity: "compact" }, 17) as Record<string, unknown>;
+
+      expect(migrated.markdownFontSize).toBe("sm");
+      expect(migrated.dockDensity).toBe("compact");
+    });
+
+    it("leaves an already-valid rung alone when migrating", async () => {
+      const store = await loadStore();
+      const migrated = store.persist
+        .getOptions()
+        .migrate?.({ markdownFontSize: "2xl" }, 17) as Record<string, unknown>;
+
+      expect(migrated.markdownFontSize).toBe("2xl");
+    });
+
+    it("replaces a value that is not a rung, including a plausible pixel number", async () => {
+      // The persisted value names a step of the type scale, never a size. A
+      // blob carrying 18 came from somewhere else and must not reach the
+      // token lookup, which would resolve to `var(--text-18)`.
+      for (const corrupt of [18, "18px", "huge", null]) {
+        vi.resetModules();
+        _resetPersistedStoreRegistryForTests();
+        setStoredState({ diffViewType: "split", markdownFontSize: corrupt }, 18);
+        const store = await loadStore();
+        expect(store.getState().markdownFontSize).toBe("sm");
+      }
+    });
+
+    it("keeps an explicit rung across a reload and persists it", async () => {
+      let store = await loadStore();
+      store.getState().setMarkdownFontSize("lg");
+      await vi.waitFor(() => {
+        const persisted = storageMock.getItem(STORAGE_KEY);
+        expect(persisted).not.toBeNull();
+        expect(JSON.parse(persisted!).state.markdownFontSize).toBe("lg");
+      });
+
+      vi.resetModules();
+      _resetPersistedStoreRegistryForTests();
+      store = await loadStore();
+      expect(store.getState().markdownFontSize).toBe("lg");
+    });
+  });
+
   describe("fileBrowserAlwaysHiddenPatterns", () => {
     it("is a non-empty curated default list on a fresh install", async () => {
       const store = await loadStore();

--- a/src/store/__tests__/preferencesStore.test.ts
+++ b/src/store/__tests__/preferencesStore.test.ts
@@ -720,12 +720,9 @@ describe("preferencesStore migration", () => {
       // Drive `migrate` directly: hydration's sanitizer would supply the same
       // default, so a store-level assertion passes with the v18 branch deleted.
       const store = await loadStore();
-      const migrated = store.persist
-        .getOptions()
-        .migrate?.({ dockDensity: "compact" }, 17) as Record<string, unknown>;
+      const migrated = store.persist.getOptions().migrate?.({ dockDensity: "compact" }, 17);
 
-      expect(migrated.markdownFontSize).toBe("sm");
-      expect(migrated.dockDensity).toBe("compact");
+      expect(migrated).toMatchObject({ markdownFontSize: "sm", dockDensity: "compact" });
       // Pin the bump too: `migrate` only runs for a blob below the configured
       // version, so leaving it at 17 would skip the branch above entirely and
       // hydration's sanitizer would quietly supply the same default.
@@ -734,11 +731,9 @@ describe("preferencesStore migration", () => {
 
     it("leaves an already-valid rung alone when migrating", async () => {
       const store = await loadStore();
-      const migrated = store.persist
-        .getOptions()
-        .migrate?.({ markdownFontSize: "2xl" }, 17) as Record<string, unknown>;
+      const migrated = store.persist.getOptions().migrate?.({ markdownFontSize: "2xl" }, 17);
 
-      expect(migrated.markdownFontSize).toBe("2xl");
+      expect(migrated).toMatchObject({ markdownFontSize: "2xl" });
     });
 
     it("replaces a value that is not a rung, including a plausible pixel number", async () => {

--- a/src/store/preferencesStore.ts
+++ b/src/store/preferencesStore.ts
@@ -23,21 +23,16 @@ export type DiffViewType = "split" | "unified";
 export type DiffFontSize = "s" | "m" | "l";
 
 /**
- * Reading scale for rendered markdown, named by the rung of the shared type
- * scale it selects rather than by a pixel value. Same reasoning as
- * `DIFF_FONT_SIZE`'s S/M/L: a preference that stores its own number stops
- * tracking the scale the moment the scale moves, and a stored index changes
- * meaning the moment a rung is inserted. A rung name survives both.
+ * Reading scale for rendered markdown, in reading order. The stepper walks this
+ * and the persistence guard checks against it, and the type below is DERIVED
+ * from it so the ladder is the single place a rung is declared — a rung added
+ * to the type alone would be inert, accepted by nothing and reachable by no
+ * step.
+ *
+ * Denser near the 14px base where a reader adjusts by feel, wider at the top
+ * where a step has to be worth taking: 11 · 12 · 14 · 16 · 18 · 20 · 24 · 30.
  */
-export type MarkdownFontSize = "2xs" | "xs" | "sm" | "base" | "lg" | "xl" | "2xl" | "3xl";
-
-/**
- * The rungs in reading order — the stepper walks this, and it is also the
- * closed set the persistence guard checks against. Denser near the 14px base
- * where a reader adjusts by feel, wider at the top where each step has to be
- * worth taking: 11 · 12 · 14 · 16 · 18 · 20 · 24 · 30.
- */
-export const MARKDOWN_FONT_SIZE_STEPS: readonly MarkdownFontSize[] = [
+export const MARKDOWN_FONT_SIZE_STEPS = [
   "2xs",
   "xs",
   "sm",
@@ -46,7 +41,15 @@ export const MARKDOWN_FONT_SIZE_STEPS: readonly MarkdownFontSize[] = [
   "xl",
   "2xl",
   "3xl",
-];
+] as const;
+
+/**
+ * A rung of the shared type scale, named rather than measured. Same reasoning
+ * as `DIFF_FONT_SIZE`'s S/M/L: a preference that stores its own number stops
+ * tracking the scale the moment the scale moves, and a stored index changes
+ * meaning the moment a rung is inserted. A rung name survives both.
+ */
+export type MarkdownFontSize = (typeof MARKDOWN_FONT_SIZE_STEPS)[number];
 
 /** Today's rendered-markdown scale, so an upgrade changes nothing until asked. */
 export const DEFAULT_MARKDOWN_FONT_SIZE: MarkdownFontSize = "sm";

--- a/src/store/preferencesStore.ts
+++ b/src/store/preferencesStore.ts
@@ -22,6 +22,35 @@ export type DiffViewType = "split" | "unified";
 
 export type DiffFontSize = "s" | "m" | "l";
 
+/**
+ * Reading scale for rendered markdown, named by the rung of the shared type
+ * scale it selects rather than by a pixel value. Same reasoning as
+ * `DIFF_FONT_SIZE`'s S/M/L: a preference that stores its own number stops
+ * tracking the scale the moment the scale moves, and a stored index changes
+ * meaning the moment a rung is inserted. A rung name survives both.
+ */
+export type MarkdownFontSize = "2xs" | "xs" | "sm" | "base" | "lg" | "xl" | "2xl" | "3xl";
+
+/**
+ * The rungs in reading order — the stepper walks this, and it is also the
+ * closed set the persistence guard checks against. Denser near the 14px base
+ * where a reader adjusts by feel, wider at the top where each step has to be
+ * worth taking: 11 · 12 · 14 · 16 · 18 · 20 · 24 · 30.
+ */
+export const MARKDOWN_FONT_SIZE_STEPS: readonly MarkdownFontSize[] = [
+  "2xs",
+  "xs",
+  "sm",
+  "base",
+  "lg",
+  "xl",
+  "2xl",
+  "3xl",
+];
+
+/** Today's rendered-markdown scale, so an upgrade changes nothing until asked. */
+export const DEFAULT_MARKDOWN_FONT_SIZE: MarkdownFontSize = "sm";
+
 /** Seconds before a deleted worktree's surviving terminals auto-close (0 = never). */
 export type DeletedWorktreeCleanupSeconds = 0 | 30 | 60 | 300;
 
@@ -110,6 +139,13 @@ interface PreferencesState {
   /** Soft-wrap long lines in markdown Source view (panel + file viewer). */
   markdownWrapLines: boolean;
   setMarkdownWrapLines: (value: boolean) => void;
+  /**
+   * Reading scale for RENDERED markdown, shared by every surface that shows a
+   * document (file panel, file browser). One app-level value on purpose: a
+   * per-file or per-panel size makes paging through documents feel unstable.
+   */
+  markdownFontSize: MarkdownFontSize;
+  setMarkdownFontSize: (value: MarkdownFontSize) => void;
   lastSelectedWorktreeRecipeIdByProject: Record<string, string | null | undefined>;
   setLastSelectedWorktreeRecipeIdByProject: (
     projectId: string,
@@ -212,6 +248,10 @@ function isDiffFontSize(value: unknown): value is DiffFontSize {
   return value === "s" || value === "m" || value === "l";
 }
 
+function isMarkdownFontSize(value: unknown): value is MarkdownFontSize {
+  return MARKDOWN_FONT_SIZE_STEPS.includes(value as MarkdownFontSize);
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object";
 }
@@ -244,6 +284,9 @@ function sanitizePersistedPreferences(
   if (typeof sanitized.diffFullFile !== "boolean") sanitized.diffFullFile = false;
   if (!isDiffFontSize(sanitized.diffFontSize)) sanitized.diffFontSize = "m";
   if (typeof sanitized.markdownWrapLines !== "boolean") sanitized.markdownWrapLines = true;
+  if (!isMarkdownFontSize(sanitized.markdownFontSize)) {
+    sanitized.markdownFontSize = DEFAULT_MARKDOWN_FONT_SIZE;
+  }
   if (typeof sanitized.showAgentTaskTitles !== "boolean") sanitized.showAgentTaskTitles = true;
   if (!isDeletedWorktreeCleanupSeconds(sanitized.deletedWorktreeCleanupSeconds)) {
     sanitized.deletedWorktreeCleanupSeconds = DELETED_WORKTREE_CLEANUP_DEFAULT;
@@ -300,6 +343,7 @@ type PreferencesPersistedState = Pick<
   | "diffFullFile"
   | "diffFontSize"
   | "markdownWrapLines"
+  | "markdownFontSize"
   | "deletedWorktreeCleanupSeconds"
   | "projectSwitcherOtherSortMode"
   | "projectSwitcherCollapsedBands"
@@ -326,6 +370,7 @@ const PREFERENCES_PERSISTED_DEFAULTS: PreferencesPersistedState = {
   diffFullFile: false,
   diffFontSize: "m",
   markdownWrapLines: true,
+  markdownFontSize: DEFAULT_MARKDOWN_FONT_SIZE,
   deletedWorktreeCleanupSeconds: DELETED_WORKTREE_CLEANUP_DEFAULT,
   projectSwitcherOtherSortMode: DEFAULT_OTHER_PROJECTS_SORT_MODE,
   projectSwitcherCollapsedBands: {},
@@ -453,6 +498,9 @@ function toPreferencesPersisted(
     diffFullFile: coerceBool(raw.diffFullFile, d.diffFullFile),
     diffFontSize: isDiffFontSize(raw.diffFontSize) ? raw.diffFontSize : d.diffFontSize,
     markdownWrapLines: coerceBool(raw.markdownWrapLines, d.markdownWrapLines),
+    markdownFontSize: isMarkdownFontSize(raw.markdownFontSize)
+      ? raw.markdownFontSize
+      : d.markdownFontSize,
     deletedWorktreeCleanupSeconds: isDeletedWorktreeCleanupSeconds(
       raw.deletedWorktreeCleanupSeconds
     )
@@ -563,6 +611,11 @@ function mergePreferencesPersistedWrite({
         inc.markdownWrapLines,
         disk.markdownWrapLines
       ),
+      markdownFontSize: pickFieldByWriterDelta(
+        base.markdownFontSize,
+        inc.markdownFontSize,
+        disk.markdownFontSize
+      ),
       deletedWorktreeCleanupSeconds: pickFieldByWriterDelta(
         base.deletedWorktreeCleanupSeconds,
         inc.deletedWorktreeCleanupSeconds,
@@ -648,6 +701,8 @@ export const usePreferencesStore = create<PreferencesState>()(
       setDiffFontSize: (value) => set({ diffFontSize: value }),
       markdownWrapLines: true,
       setMarkdownWrapLines: (value) => set({ markdownWrapLines: value }),
+      markdownFontSize: DEFAULT_MARKDOWN_FONT_SIZE,
+      setMarkdownFontSize: (value) => set({ markdownFontSize: value }),
       lastSelectedWorktreeRecipeIdByProject: {},
       setLastSelectedWorktreeRecipeIdByProject: (projectId, id) =>
         set((state) => ({
@@ -737,7 +792,7 @@ export const usePreferencesStore = create<PreferencesState>()(
       storage: createSafeJSONStorage<PreferencesPersistedState>({
         mergeOnWrite: mergePreferencesPersistedWrite,
       }),
-      version: 17,
+      version: 18,
       // Explicit persisted subset — matches the pre-existing default (setters are
       // dropped by JSON serialization); named so the write merge (#11351) has a
       // typed persisted shape to reconcile.
@@ -757,6 +812,7 @@ export const usePreferencesStore = create<PreferencesState>()(
         diffFullFile: state.diffFullFile,
         diffFontSize: state.diffFontSize,
         markdownWrapLines: state.markdownWrapLines,
+        markdownFontSize: state.markdownFontSize,
         deletedWorktreeCleanupSeconds: state.deletedWorktreeCleanupSeconds,
         projectSwitcherOtherSortMode: state.projectSwitcherOtherSortMode,
         projectSwitcherCollapsedBands: state.projectSwitcherCollapsedBands,
@@ -901,6 +957,13 @@ export const usePreferencesStore = create<PreferencesState>()(
             persisted.projectSwitcherCollapsedBands = {};
           }
         }
+        if (version < 18 && isRecord(persisted)) {
+          // Rendered markdown had no reading control before this shipped, so
+          // everyone starts on the rung it has always rendered at (#12134).
+          if (!isMarkdownFontSize(persisted.markdownFontSize)) {
+            persisted.markdownFontSize = DEFAULT_MARKDOWN_FONT_SIZE;
+          }
+        }
         return persisted as PreferencesState;
       },
     }
@@ -911,5 +974,5 @@ registerPersistedStore({
   storeId: "preferencesStore",
   store: usePreferencesStore,
   persistedStateType:
-    "{ showProjectPulse: boolean; showDeveloperTools: boolean; showGridAgentHighlights: boolean; showDockAgentHighlights: boolean; showAgentTaskTitles: boolean; dockDensity: DockDensity; assignWorktreeToSelf: boolean; reduceAnimations: boolean; diffViewType: DiffViewType; diffWrapLines: boolean; diffIgnoreWhitespace: boolean; diffShowFileList: boolean; diffFullFile: boolean; diffFontSize: DiffFontSize; markdownWrapLines: boolean; lastSelectedWorktreeRecipeIdByProject: Record<string, string | null | undefined>; skipPushConfirmByWorktreePath: Record<string, boolean>; deletedWorktreeCleanupSeconds: DeletedWorktreeCleanupSeconds; projectSwitcherOtherSortMode: OtherProjectsSortMode; projectSwitcherCollapsedBands: Record<string, boolean>; fileBrowserAlwaysHiddenPatterns: string[]; hasSeenActionPalettePrefixHint: boolean; keyboardLayoutConfirmationsByBinding: Record<string, number> }",
+    "{ showProjectPulse: boolean; showDeveloperTools: boolean; showGridAgentHighlights: boolean; showDockAgentHighlights: boolean; showAgentTaskTitles: boolean; dockDensity: DockDensity; assignWorktreeToSelf: boolean; reduceAnimations: boolean; diffViewType: DiffViewType; diffWrapLines: boolean; diffIgnoreWhitespace: boolean; diffShowFileList: boolean; diffFullFile: boolean; diffFontSize: DiffFontSize; markdownWrapLines: boolean; markdownFontSize: MarkdownFontSize; lastSelectedWorktreeRecipeIdByProject: Record<string, string | null | undefined>; skipPushConfirmByWorktreePath: Record<string, boolean>; deletedWorktreeCleanupSeconds: DeletedWorktreeCleanupSeconds; projectSwitcherOtherSortMode: OtherProjectsSortMode; projectSwitcherCollapsedBands: Record<string, boolean>; fileBrowserAlwaysHiddenPatterns: string[]; hasSeenActionPalettePrefixHint: boolean; keyboardLayoutConfirmationsByBinding: Record<string, number> }",
 });

--- a/src/store/preferencesStore.ts
+++ b/src/store/preferencesStore.ts
@@ -252,7 +252,9 @@ function isDiffFontSize(value: unknown): value is DiffFontSize {
 }
 
 function isMarkdownFontSize(value: unknown): value is MarkdownFontSize {
-  return MARKDOWN_FONT_SIZE_STEPS.includes(value as MarkdownFontSize);
+  // `some` rather than `includes`: the latter narrows its argument to the
+  // tuple's own type, so it would need an assertion here to accept `unknown`.
+  return MARKDOWN_FONT_SIZE_STEPS.some((step) => step === value);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {


### PR DESCRIPTION
## Summary

- Rendered Markdown had no reading controls: the toolbar carried only a Source/Rendered toggle, a path pill, and a few icon buttons. This adds an `Aa` text-size control, gated to rendered mode, to the toolbar of both hosts of the shared `MarkdownViewer`: the file panel (`src/panels/file/FilePane.tsx`) and the file browser's viewer (`src/panels/file-browser/FileBrowserViewer.tsx`).
- The only zoom that existed before was `window.zoomIn`/`zoomOut`, which scales the entire app window, chrome, terminals, sidebars and all. Resizing one document's reading text is a different gesture from that.

Resolves #12134

## How it works

`.markdown-document` sets a single `font-size`, and every prose size below it is `em`-based, so one value tunes the whole hierarchy. That declaration now reads:

```css
font-size: var(--markdown-font-size, var(--text-sm));
```

`MarkdownDocument` sets that custom property on its root element from a new rendered-only `fontSize` prop, threaded through `MarkdownViewer`. Source mode is CodeMirror and never receives it.

## The preference stores a rung, not a pixel value

The preference stores a rung of the app's shared type scale, never a raw pixel number:

```ts
'2xs' | 'xs' | 'sm' | 'base' | 'lg' | 'xl' | '2xl' | '3xl'
```

Those measure 11, 12, 14, 16, 18, 20, 24, 30px. Default is `sm` (14px), exactly what rendered markdown has always used.

This follows `DIFF_FONT_SIZE` in `src/panels/diff/DiffPane.tsx`, which maps its own S/M/L sizes to `var(--text-*)` tokens for the same reason: a preference that stores its own number stops tracking the scale the moment the scale moves, and a stored index changes meaning the moment a rung gets inserted. The union type is derived from the step tuple, so the ladder has exactly one place a rung gets declared. It also keeps this change clear of `src/config/__tests__/numericScales.contract.test.ts`, which flags fixed lengths anywhere in a font-size chain under `src/`.

## Persistence

One app-level value in `preferencesStore`, not per-file or per-panel, matching VS Code, Obsidian, and Zed. A size that resets as you page between documents feels unstable. This bumped the preferences schema from version 17 to 18, with a migration.

## Keyboard support (a deliberate deviation from the issue)

The issue asks for a keyboard accelerator alongside the popover. There's no coherent cross-platform combo left to take: `Cmd+=`, `Cmd+Shift+=`, `Cmd+-`, and `Cmd+0` are already bound at scope `global`, priority 0, to `window.zoomIn`/`zoomOut`/`zoomReset` in `shared/config/defaultKeybindings.ts`, and `Cmd+Alt+=` is `project.mruCycleOlder`, so the `Cmd+Alt` triad is already broken. `Cmd+Ctrl` collapses to `Ctrl+Ctrl` on Windows.

Rather than squat on a colliding or platform-broken binding, the popover itself is fully keyboard-operable: Tab moves across minus/plus/reset, and `ArrowUp`/`ArrowDown`/`+`/`-` step the size while it's open. A global accelerator can come later as its own binding-design change, using the existing `find.inFocusedPanel` custom-event pattern.

## Design note: Popover, not DropdownMenu

The control is a `Popover` rather than the `DropdownMenu` its neighbour `FileBrowserViewOptions` uses. A minus/plus stepper is a widget, not a menu: `role="menuitem"` on a minus button would claim a semantic that isn't true, and Radix's menu roving focus is vertical-only, so a horizontally laid-out pair would get walked with up/down arrows.

The ladder's ends are announced with `aria-disabled` rather than the native `disabled` attribute. Native disabling drops focus the instant it lands, and a focusout inside a Radix popover is what dismisses it, so stepping to the last rung would have closed the panel.

## Out of scope

Per the issue: colour inversion, sepia, or any reading-mode polarity override.

## Testing

409 tests green locally across the touched modules:

- `preferencesStore`: defaults, the v17 to v18 migration, corrupt-value rejection (including a plausible pixel number), persistence round-trip
- `preferencesStore` cross-view write merge
- New `MarkdownTextSizeControl` suite: full ladder walk, both ends, focus retention at the ends, reset, keyboard stepping, a11y announcements
- `MarkdownViewer`: the token lands on the document root, is absent without the prop, and never leaks into source mode
- A stylesheet source contract pinning the `var()` fallback and confirming the file stays unlayered
- Both host suites: gating per mode, prop forwarding, and that each host routes the control's choice to the preference setter

Typecheck clean. `lint:ratchet` exits 0 with no baseline widened. Prettier clean.
