### PR TITLE
perf(sidebar): compute facet counts in one pass

### DIFF
--- a/src/lib/__tests__/worktreeFilters.test.ts
+++ b/src/lib/__tests__/worktreeFilters.test.ts
@@ -1782,4 +1782,28 @@ describe("computeChipCounts — dev-server counts", () => {
     expect(counts.devServer.running).toBe(0);
     expect(counts.devServer.hasDevServer).toBe(0);
   });
+
+  it("excludes only the counted facet when type and dev-server filters intersect", () => {
+    const worktrees = [
+      createMockWorktree({ id: "w1", branch: "feature/a" }),
+      createMockWorktree({ id: "w2", branch: "bugfix/b" }),
+      createMockWorktree({ id: "w3", branch: "feature/c" }),
+    ];
+    const sessions: Record<string, DevPreviewSessionState> = {
+      w1: makeDevSession("running", { worktreeId: "w1" }),
+      w2: makeDevSession("error", { worktreeId: "w2" }),
+      w3: makeDevSession("stopped", { worktreeId: "w3" }),
+    };
+    const filters = createEmptyFilters();
+    filters.typeFilters.add("feature");
+    filters.devServerFilters.add("error");
+
+    const counts = computeChipCounts(worktrees, new Map(), null, filters, sessions);
+
+    expect(counts.branchType.bugfix).toBe(1);
+    expect(counts.branchType.feature).toBe(0);
+    expect(counts.devServer.running).toBe(1);
+    expect(counts.devServer.hasDevServer).toBe(1);
+    expect(counts.devServer.error).toBe(0);
+  });
 });

--- a/src/lib/worktreeFilters.ts
+++ b/src/lib/worktreeFilters.ts
@@ -561,9 +561,12 @@ const DEFAULT_DERIVED_META: DerivedWorktreeMeta = {
   chipState: null,
 };
 
-function withoutGroup<K extends keyof FilterState>(filters: FilterState, group: K): FilterState {
-  return { ...filters, [group]: new Set() };
-}
+const STATUS_FACET = 1 << 0;
+const TYPE_FACET = 1 << 1;
+const PR_ISSUE_FACET = 1 << 2;
+const SESSION_FACET = 1 << 3;
+const ACTIVITY_FACET = 1 << 4;
+const DEV_SERVER_FACET = 1 << 5;
 
 export function computeChipCounts(
   worktrees: readonly (Worktree | WorktreeState)[],
@@ -574,70 +577,128 @@ export function computeChipCounts(
 ): ChipCounts {
   const counts = emptyChipCounts();
   const now = Date.now();
+  const hasQuery = filters.query.length > 0;
+  const exactQuery = hasQuery ? parseExactNumber(filters.query) : null;
 
-  const baseIsActive = (w: (typeof worktrees)[number]) => w.id === activeWorktreeId;
-  const getDerived = (id: string) => derivedMetaMap.get(id) ?? DEFAULT_DERIVED_META;
-  const matchesGroup = (w: (typeof worktrees)[number], groupFilters: FilterState) =>
-    matchesFilters(w, groupFilters, getDerived(w.id), baseIsActive(w), sessionsByWorktreeId);
-
-  // Build base set per group — filtered by all OTHER groups + query. The
-  // group-excluded filter variants depend only on `filters`, so hoist them out
-  // of the per-worktree callbacks.
-  const statusVariant = withoutGroup(filters, "statusFilters");
-  const typeVariant = withoutGroup(filters, "typeFilters");
-  const prIssueVariant = withoutGroup(filters, "prIssueFilters");
-  const sessionsVariant = withoutGroup(filters, "sessionFilters");
-  const activityVariant = withoutGroup(filters, "activityFilters");
-  const devServerVariant = withoutGroup(filters, "devServerFilters");
-
-  const statusBase = worktrees.filter((w) => matchesGroup(w, statusVariant));
-  const typeBase = worktrees.filter((w) => matchesGroup(w, typeVariant));
-  const prIssueBase = worktrees.filter((w) => matchesGroup(w, prIssueVariant));
-  const sessionsBase = worktrees.filter((w) => matchesGroup(w, sessionsVariant));
-  const activityBase = worktrees.filter((w) => matchesGroup(w, activityVariant));
-  const devServerBase = worktrees.filter((w) => matchesGroup(w, devServerVariant));
-
-  for (const w of statusBase) {
-    const statuses = computeStatus(w, baseIsActive(w));
-    for (const status of statuses) counts.status[status]++;
-  }
-
-  for (const w of typeBase) {
-    counts.branchType[getWorktreeType(w)]++;
-  }
-
-  for (const w of prIssueBase) {
-    if (w.issueNumber) counts.prIssue.hasIssue++;
-    if (w.linked?.pr) counts.prIssue.hasPR++;
-    if (w.linked?.pr?.state === "open") counts.prIssue.prOpen++;
-    if (w.linked?.pr?.state === "merged") counts.prIssue.prMerged++;
-    if (w.linked?.pr?.state === "closed" || w.linked?.pr?.state === "declined")
-      counts.prIssue.prClosed++;
-  }
-
-  for (const w of sessionsBase) {
-    const meta = getDerived(w.id);
-    if (meta.terminalCount > 0) counts.sessions.hasTerminals++;
-    if (meta.hasWorkingAgent) counts.sessions.working++;
-    if (meta.hasWaitingAgent) counts.sessions.waiting++;
-    if (meta.hasCompletedAgent) counts.sessions.completed++;
-    if (meta.hasExitedAgent) counts.sessions.exited++;
-  }
-
-  for (const w of activityBase) {
-    const lastActivity = w.lastActivityTimestamp;
-    if (!isValidPastTimestamp(lastActivity, now)) continue;
-    const elapsed = now - lastActivity;
-    for (const key of ACTIVITY_KEYS) {
-      if (elapsed < ACTIVITY_WINDOW_MS[key]) counts.activity[key]++;
+  for (const worktree of worktrees) {
+    if (hasQuery) {
+      const matchesQuery =
+        exactQuery === null
+          ? scoreWorktree(worktree, filters.query) > 0
+          : worktree.issueNumber === exactQuery || worktree.linked?.pr?.ref.number === exactQuery;
+      if (!matchesQuery) continue;
     }
-  }
 
-  for (const w of devServerBase) {
-    const session = sessionsByWorktreeId?.[w.id];
-    if (!session) continue;
-    for (const key of DEV_SERVER_KEYS) {
-      if (matchesDevServerFilter(key, session)) counts.devServer[key]++;
+    const isActive = worktree.id === activeWorktreeId;
+    const derived = derivedMetaMap.get(worktree.id) ?? DEFAULT_DERIVED_META;
+    const session = sessionsByWorktreeId?.[worktree.id];
+    const lastActivity = worktree.lastActivityTimestamp;
+    const activityElapsed = isValidPastTimestamp(lastActivity, now) ? now - lastActivity : null;
+    let statuses: StatusFilter[] | undefined;
+    let type: WorktreeTypeId | undefined;
+    let failedFacets = 0;
+
+    // A row contributes to a facet when every other active facet passed. One
+    // failure therefore admits it only to that facet; multiple failures admit
+    // it to none. This preserves the six disjunctive bases without six sweeps.
+    if (filters.statusFilters.size > 0) {
+      statuses = computeStatus(worktree, isActive);
+      if (!statuses.some((status) => filters.statusFilters.has(status))) {
+        failedFacets |= STATUS_FACET;
+      }
+    }
+
+    if (filters.typeFilters.size > 0) {
+      type = getWorktreeType(worktree);
+      if (!filters.typeFilters.has(type)) failedFacets |= TYPE_FACET;
+    }
+
+    if (filters.prIssueFilters.size > 0) {
+      const prState = worktree.linked?.pr?.state;
+      const matchesPrIssue =
+        (filters.prIssueFilters.has("hasIssue") && Boolean(worktree.issueNumber)) ||
+        (filters.prIssueFilters.has("hasPR") && Boolean(worktree.linked?.pr)) ||
+        (filters.prIssueFilters.has("prOpen") && prState === "open") ||
+        (filters.prIssueFilters.has("prMerged") && prState === "merged") ||
+        (filters.prIssueFilters.has("prClosed") &&
+          (prState === "closed" || prState === "declined"));
+      if (!matchesPrIssue) failedFacets |= PR_ISSUE_FACET;
+    }
+
+    if (filters.sessionFilters.size > 0) {
+      const matchesSession =
+        (filters.sessionFilters.has("hasTerminals") && derived.terminalCount > 0) ||
+        (filters.sessionFilters.has("working") && derived.hasWorkingAgent) ||
+        (filters.sessionFilters.has("waiting") && derived.hasWaitingAgent) ||
+        (filters.sessionFilters.has("completed") && derived.hasCompletedAgent) ||
+        (filters.sessionFilters.has("exited") && derived.hasExitedAgent);
+      if (!matchesSession) failedFacets |= SESSION_FACET;
+    }
+
+    if (filters.activityFilters.size > 0) {
+      let matchesActivity = false;
+      if (activityElapsed !== null) {
+        for (const key of filters.activityFilters) {
+          if (activityElapsed < ACTIVITY_WINDOW_MS[key]) {
+            matchesActivity = true;
+            break;
+          }
+        }
+      }
+      if (!matchesActivity) failedFacets |= ACTIVITY_FACET;
+    }
+
+    if (filters.devServerFilters.size > 0) {
+      let matchesDevServer = false;
+      for (const key of filters.devServerFilters) {
+        if (matchesDevServerFilter(key, session)) {
+          matchesDevServer = true;
+          break;
+        }
+      }
+      if (!matchesDevServer) failedFacets |= DEV_SERVER_FACET;
+    }
+
+    if (failedFacets === 0 || failedFacets === STATUS_FACET) {
+      statuses ??= computeStatus(worktree, isActive);
+      for (const status of statuses) counts.status[status]++;
+    }
+
+    if (failedFacets === 0 || failedFacets === TYPE_FACET) {
+      type ??= getWorktreeType(worktree);
+      counts.branchType[type]++;
+    }
+
+    if (failedFacets === 0 || failedFacets === PR_ISSUE_FACET) {
+      if (worktree.issueNumber) counts.prIssue.hasIssue++;
+      if (worktree.linked?.pr) counts.prIssue.hasPR++;
+      if (worktree.linked?.pr?.state === "open") counts.prIssue.prOpen++;
+      if (worktree.linked?.pr?.state === "merged") counts.prIssue.prMerged++;
+      if (worktree.linked?.pr?.state === "closed" || worktree.linked?.pr?.state === "declined") {
+        counts.prIssue.prClosed++;
+      }
+    }
+
+    if (failedFacets === 0 || failedFacets === SESSION_FACET) {
+      if (derived.terminalCount > 0) counts.sessions.hasTerminals++;
+      if (derived.hasWorkingAgent) counts.sessions.working++;
+      if (derived.hasWaitingAgent) counts.sessions.waiting++;
+      if (derived.hasCompletedAgent) counts.sessions.completed++;
+      if (derived.hasExitedAgent) counts.sessions.exited++;
+    }
+
+    if (failedFacets === 0 || failedFacets === ACTIVITY_FACET) {
+      if (activityElapsed !== null) {
+        for (const key of ACTIVITY_KEYS) {
+          if (activityElapsed < ACTIVITY_WINDOW_MS[key]) counts.activity[key]++;
+        }
+      }
+    }
+
+    if ((failedFacets === 0 || failedFacets === DEV_SERVER_FACET) && session) {
+      for (const key of DEV_SERVER_KEYS) {
+        if (matchesDevServerFilter(key, session)) counts.devServer[key]++;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- replace six whole-array `matchesFilters` passes in `computeChipCounts` with one worktree pass and a six-bit failed-facet mask
- derive reusable worktree/session/activity facts once per row while preserving each facet's group-excluded base semantics
- snapshot `now` once so activity filtering and activity chip counts use a coherent boundary
- add a regression test for intersecting type and dev-server filters

## Performance

PERF-402 is the primary claim. Values are median arms from three interleaved A/B pairs (`champ,cand / cand,champ / champ,cand`), 20 iterations and 20 warmups per arm, against branch point `a208c0e` and final tree `1868cb6`.

| OS / machine | PERF-402 `chipCountsMs.mean` | Absolute | Change | PERF-402 whole-sweep `p50Ms` |
| --- | ---: | ---: | ---: | ---: |
| macOS, local M1 Max | 3.652 → 0.799 ms | -2.853 ms | **-78.1%** | 4.547 → 1.674 ms on PERF-401 (**-63.2%**) |
| Linux, GitHub hosted | 5.456 → 1.305 ms | -4.151 ms | -76.1%* | 6.697 → 2.495 ms (-62.7%)* |
| Windows, GitHub hosted | 6.214 → 1.486 ms | -4.728 ms | -76.1%* | 7.578 → 3.009 ms (-60.3%)* |
| macOS, GitHub hosted | 4.744 → 1.530 ms | -3.214 ms | -67.8%* | 5.905 → 3.041 ms (-48.5%)* |

The local PERF-402 claim won all three pairs (78.5%, 78.1%, 77.9%), exceeded the precommitted 5% threshold and 2.2% champion drift, and stayed below the 10% within-arm CV ceiling (worst 8.5%). PERF-401 also won all three pairs (62.9%, 63.5%, 64.7%), with 4.4% drift and worst CV 8.0%.

PERF-400's raw local median was 1.183 → 0.415 ms, but the optimized path is below the reliable timing floor: its single allowed retry still reached 20.0% within-arm CV against the locked 10% ceiling. That value is descriptive only; this PR makes no PERF-400 percentage claim.

\* Hosted runner durations are corroborating values, not deterministic claims. Shared GitHub runners vary materially; the local paired macOS measurements are the evidence for the performance claim. [Cross-OS run 33499694446](https://github.com/daintreehq/daintree/actions/runs/33499694446) measured and uploaded all six arms on all three OSes.

## Correctness and methodology

- Precommitted PERF-402 target, direction, 5% threshold, full four-way predicate, guards, 20/20 protocol, branch point, and apparatus hash before baseline measurement.
- `keptMisses`, `chipCountMisses`, `sortMisses`, and `groupMisses`: 20/20 samples present with min/max 0 in every local and cross-OS arm.
- Negative control that skipped `computeChipCounts` produced `chipCountMisses=472` on every proof run, demonstrating the predicate catches the tempting fast-but-wrong implementation.
- Stable guards: pass count 18, kept rows 711, worktrees 200; neighboring filter/sort/group timing guards remained within tolerance.
- Explored and rejected two separate PERF-403 switcher-ranking hypotheses because they did not clear the locked noise threshold; no unrelated switcher change is included.

The cross-OS workflow gates only machine-independent targets, so it used unchanged `metricStats.passCount.mean` (18 → 18) to execute and predicate-check the duration benchmark. Its expected `NO CLAIM` exit 4 is displayed as a failed job because the existing workflow shell inherits `-e` and exits before its documented case statement handles code 4. The uploaded arms and logs are complete, and all correctness predicates pass; this PR does not change benchmark infrastructure.

## Validation

- `npm run typecheck` — pass
- `npm run check` — pass
- focused worktree-filter tests — 191 pass
- full `npm test` — run twice; transient worker/timeouts passed narrowly. The remaining local `scenarioLiveness` miss (PERF-053..056, 074..077, 080, 320..325, 340..343, 391) reproduces identically on untouched `origin/develop`/`a208c0e`; clean-runner PR CI passed the scenario coverage.
- PR CI — green: build/smoke, combined typecheck/lint/format, and all four Vitest shards. Shard 2 initially had one PERF-080 timeout after 12,452 passing tests and passed on the fresh-worker retry.
- `git diff --check` — pass
- no `scripts/perf/` changes

The companion test path `src/lib/__tests__/worktreeFilters.test.ts` is not explicitly named in the Area E ownership list even though its subject `src/lib/worktreeFilters.ts` is; this is a documented partition gap rather than an unreported scope expansion.
