### PR TITLE
perf: reduce secret scrubber and forge relay tax

### DIFF
--- a/electron/services/__tests__/forgeProviderRegistry.test.ts
+++ b/electron/services/__tests__/forgeProviderRegistry.test.ts
@@ -11,6 +11,7 @@ import {
   getForgeProviderImpl,
   getRegisteredForgeProviders,
   listMatchingProviders,
+  onForgeProviderMatchersChanged,
   registerForgeProviderImpl,
   registerForgeProviders,
   unregisterForgeProviderImpl,
@@ -341,6 +342,25 @@ describe("forgeProviderRegistry — getActiveProvider", () => {
 });
 
 describe("forgeProviderRegistry — implementation registry", () => {
+  it("does not report impl-only changes as matcher-table changes", () => {
+    let matcherChanges = 0;
+    const unsubscribe = onForgeProviderMatchersChanged(() => {
+      matcherChanges += 1;
+    });
+
+    try {
+      registerForgeProviderImpl("acme", "github", makeImpl("x"));
+      unregisterForgeProviderImpl("acme", "github");
+      expect(matcherChanges).toBe(0);
+
+      registerForgeProviders("acme", [makeContribution("github", ["github.com"])]);
+      unregisterForgeProviders("acme");
+      expect(matcherChanges).toBe(2);
+    } finally {
+      unsubscribe();
+    }
+  });
+
   it("stores and retrieves an impl by namespaced id", () => {
     const impl = makeImpl("primary");
     registerForgeProviderImpl("acme", "github", impl);

--- a/electron/services/forgeMatcherRelay.ts
+++ b/electron/services/forgeMatcherRelay.ts
@@ -7,7 +7,7 @@
  */
 import {
   listForgeProviderMatchers,
-  onForgeProviderRegistryChanged,
+  onForgeProviderMatchersChanged,
 } from "./forgeProviderRegistry.js";
 
 let initialized = false;
@@ -25,7 +25,7 @@ async function pushMatchersToWorkspaceHosts(): Promise<void> {
 export function initForgeMatcherRelay(): void {
   if (initialized) return;
   initialized = true;
-  onForgeProviderRegistryChanged(() => {
+  onForgeProviderMatchersChanged(() => {
     void pushMatchersToWorkspaceHosts();
   });
   // Initial push covers providers registered before the relay was wired.

--- a/electron/services/forgeProviderRegistry.ts
+++ b/electron/services/forgeProviderRegistry.ts
@@ -22,6 +22,7 @@ export type { ForgeProviderMatcher } from "../../shared/utils/forgeHostnames.js"
  * the hostname table) without those services polling the registry.
  */
 const REGISTRY_CHANGE_LISTENERS = new Set<() => void>();
+const MATCHER_CHANGE_LISTENERS = new Set<() => void>();
 
 export function onForgeProviderRegistryChanged(listener: () => void): () => void {
   REGISTRY_CHANGE_LISTENERS.add(listener);
@@ -30,8 +31,30 @@ export function onForgeProviderRegistryChanged(listener: () => void): () => void
   };
 }
 
+/**
+ * Subscribe only to descriptor-table changes that can alter hostname routing.
+ * Runtime impl binding is intentionally excluded: it changes health/RPC
+ * availability, but cannot change the manifest-owned matcher table.
+ */
+export function onForgeProviderMatchersChanged(listener: () => void): () => void {
+  MATCHER_CHANGE_LISTENERS.add(listener);
+  return () => {
+    MATCHER_CHANGE_LISTENERS.delete(listener);
+  };
+}
+
 function notifyRegistryChanged(): void {
   for (const listener of [...REGISTRY_CHANGE_LISTENERS]) {
+    try {
+      listener();
+    } catch {
+      // A throwing listener must not break registration or other listeners.
+    }
+  }
+}
+
+function notifyMatchersChanged(): void {
+  for (const listener of [...MATCHER_CHANGE_LISTENERS]) {
     try {
       listener();
     } catch {
@@ -73,10 +96,12 @@ export function registerForgeProviders(
   if (!Array.isArray(contributions) || contributions.length === 0) {
     PLUGIN_FORGE_PROVIDERS.delete(pluginId);
     notifyRegistryChanged();
+    notifyMatchersChanged();
     return;
   }
   PLUGIN_FORGE_PROVIDERS.set(pluginId, contributions.map(freezeContribution));
   notifyRegistryChanged();
+  notifyMatchersChanged();
 }
 
 function freezeContribution(c: ForgeProviderContribution): ForgeProviderContribution {
@@ -99,11 +124,13 @@ export function unregisterForgeProviders(pluginId: string): void {
   if (typeof pluginId !== "string" || pluginId.length === 0) return;
   PLUGIN_FORGE_PROVIDERS.delete(pluginId);
   notifyRegistryChanged();
+  notifyMatchersChanged();
 }
 
 export function clearForgeProviderRegistry(): void {
   PLUGIN_FORGE_PROVIDERS.clear();
   notifyRegistryChanged();
+  notifyMatchersChanged();
 }
 
 /**

--- a/shared/utils/secretScrubber.ts
+++ b/shared/utils/secretScrubber.ts
@@ -511,6 +511,14 @@ const CASE_INSENSITIVE_PROBE = buildProbe(
   "im"
 );
 
+const PATTERN_PROBES = PATTERNS.map((pattern) => ({
+  pattern,
+  probe: new RegExp(
+    pattern.probe ?? pattern.regex.source,
+    pattern.regex.flags.replace(/[gy]/g, "")
+  ),
+}));
+
 /**
  * Scrubs known secret sigils from free text. Idempotent — calling twice yields
  * the same result, because the `[REDACTED]` token contains no secret sigil.
@@ -534,8 +542,9 @@ export function scrubSecrets(value: string): string {
   }
 
   let out = value;
-  for (const { regex, replacement } of PATTERNS) {
-    out = out.replace(regex, replacement);
+  for (const { pattern, probe } of PATTERN_PROBES) {
+    if (!probe.test(out)) continue;
+    out = out.replace(pattern.regex, pattern.replacement);
   }
 
   return out;


### PR DESCRIPTION
## Summary

- Skip each full secret regex replacement when a compiled pattern-specific necessary probe cannot match.
- Split forge descriptor/matcher notifications from runtime implementation notifications, so bind, rebind, and unbind events still reconcile health subscriptions without reserializing an unchanged hostname table.

## Before / after

### Local macOS duration and count

| Scenario / target | Before | After | Absolute | Change |
| --- | ---: | ---: | ---: | ---: |
| PERF-382 perEntryUsProbeHit, µs | 25.268 | 17.466 | -7.802 µs | -30.9% |
| PERF-343 matcherPushCount | 6 | 1 | -5 pushes | -83.3% |

Machine: Mac Studio, Apple M1 Max, 10 cores, 32 GB, Darwin arm64, Node 24.20.0, Electron 42.7.1, AC power.

PERF-382 used smoke mode, 100 iterations and 2 warmups per arm, with a six-arm A/B/B/A/A/B interleave against the branch point. All three pairs won: 25.853 → 17.511, 25.268 → 17.466, and 24.965 → 17.157 µs. Champion drift D was 3.4%, worst within-arm CV was 7.7%, and the precommitted threshold was 5%.

PERF-343 used smoke mode, 5 iterations and 2 warmups. It is a deterministic count target; the final clean pair reproduced 6 → 1 with every count, byte, subscription, and broadcast guard unchanged.

### Hosted cross-OS count verification

| OS | matcherPushCount before | after | Absolute | Change | Verdict |
| --- | ---: | ---: | ---: | ---: | --- |
| Windows | 6 | 1 | -5 | -83.3% | claim, 3/3 pairs |
| Linux | 6 | 1 | -5 | -83.3% | claim, 3/3 pairs |
| macOS | 6 | 1 | -5 | -83.3% | claim, 3/3 pairs |

Workflow: https://github.com/daintreehq/daintree/actions/runs/33503879184

Each hosted leg measured both trees on one runner with the same 5/2 protocol. The workflow accepts count, size, and structural-ratio targets only. Hosted duration values are intentionally not claimed because shared runner clocks are not stable enough for that conclusion.

## Correctness and security

PERF-382 kept all 11 declared predicates at zero on every arm across 600 measured iterations. In particular:

- secretSurvivalMisses = 0: no planted secret survived.
- markerSurvivalMisses = 0: every planted non-secret marker survived.
- redactionCountDelta = 0: redaction cardinality stayed exact.

The predicate was proven live before optimization: an identity scrubber produced 1,909 secret-survival misses and signed redaction delta +1,800 per iteration; a redact-everything scrubber produced 1,628 marker-survival misses and signed delta +200 per iteration.

PERF-343 kept healthDeliveryMisses, staleBroadcastMisses, resetBroadcastMisses, and matcherRelayMisses at zero on every local and hosted arm. Broadcast bytes/counts, health subscriptions/disposals, and throttle relays were unchanged.

No scripts/perf file changed; the locked apparatus hash remained unchanged.

## Hypotheses tried

- Kept: per-pattern secret probes, final local gain 30.9%.
- Kept: descriptor-only matcher relay notifications, 6 → 1 pushes on every OS.
- Rejected: inline bigint replacement in the IPC byte gate; PERF-361 regressed 2.9%.
- Rejected: shallow/native JSON preinspection; PERF-360 regressed 2.5% and worsened its scaling ratio 9.5%.
- Not claimed: agent pattern memoization screened at -62.8%, but two complete interleaves failed the fixed 10% stability ceiling because this sub-millisecond scenario ran at 14–32% CV. No cache change is included.

## Validation

- npm run typecheck: pass.
- npm run check: pass.
- Focused secret scrubber suite: 291 tests pass.
- Focused forge suites: 77 tests pass.
- Full npm test: 54,498 tests passed. PERF-063 liveness reports batcherShortfallCount=2 on both this branch and origin/develop; narrow reproduction confirms the same pre-existing base failure. Two contention-shaped failures from the concurrent full run reproduced cleanly when run serially, including terminalGetOutputAction at 18/18.
- E2E was not run; the repository optimize contract requires an explicitly named spec.

Scope-map note: shared/utils/secretScrubber.ts is the production path PERF-382 necessarily measures, but the Area C owned-path list currently omits it. No unrelated source path was changed.