### PR TITLE
perf: reduce idle process polling and recover git watchers

### DIFF
--- a/electron/services/ProcessTreeCache.ts
+++ b/electron/services/ProcessTreeCache.ts
@@ -1,9 +1,24 @@
-import { execFile } from "child_process";
+import { execFile, type ExecFileOptionsWithStringEncoding } from "child_process";
 import os from "node:os";
-import { promisify } from "util";
 import { logDebug } from "../utils/logger.js";
 
-const execFileAsync = promisify(execFile);
+function execProbe(
+  file: string,
+  args: string[],
+  options: ExecFileOptionsWithStringEncoding
+): Promise<{ stdout: string; pid: number | null }> {
+  return new Promise((resolve, reject) => {
+    const child = execFile(file, args, options, (error, stdout) => {
+      // Native callbacks are asynchronous, but deferring also keeps this safe
+      // under unit-test doubles that invoke the callback synchronously before
+      // `execFile` has returned its ChildProcess.
+      queueMicrotask(() => {
+        if (error) reject(error);
+        else resolve({ stdout, pid: child?.pid ?? null });
+      });
+    });
+  });
+}
 
 const BACKOFF_MULTIPLIER = 1.5;
 const BACKOFF_CEILING_MS = 15_000;
@@ -194,11 +209,16 @@ export class ProcessTreeCache {
     // Include %cpu for activity detection. execFile avoids the shell fork that
     // exec() introduces — ps takes no shell features, so the intermediate
     // /bin/sh -c is pure overhead on every poll.
-    const { stdout } = await execFileAsync("ps", ["-eo", "pid,ppid,%cpu,rss,comm,command"], {
-      timeout: 5000,
-      maxBuffer: 10 * 1024 * 1024,
-      env: { ...process.env, LC_ALL: process.platform === "darwin" ? "en_US.UTF-8" : "C.UTF-8" },
-    });
+    const { stdout, pid: probePid } = await execProbe(
+      "ps",
+      ["-eo", "pid,ppid,%cpu,rss,comm,command"],
+      {
+        timeout: 5000,
+        maxBuffer: 10 * 1024 * 1024,
+        encoding: "utf-8",
+        env: { ...process.env, LC_ALL: process.platform === "darwin" ? "en_US.UTF-8" : "C.UTF-8" },
+      }
+    );
 
     const newCache = new Map<number, ProcessInfo>();
     const newChildrenMap = new Map<number, number[]>();
@@ -210,7 +230,10 @@ export class ProcessTreeCache {
       if (!line) continue;
 
       const parsed = this.parseUnixLine(line);
-      if (parsed) {
+      // The probe appears in the census it produces. Retaining that short-lived
+      // PID makes every otherwise-identical snapshot look changed and prevents
+      // the idle backoff from ever advancing.
+      if (parsed && parsed.pid !== probePid) {
         newCache.set(parsed.pid, parsed);
 
         const children = newChildrenMap.get(parsed.ppid) || [];
@@ -284,13 +307,14 @@ export class ProcessTreeCache {
     // (#12042). Spawning powershell directly removes the cmd hop entirely and
     // puts windowsHide on the process that actually has a console. argv form
     // also means the script no longer needs a layer of cmd-level quoting.
-    const { stdout } = await execFileAsync(
+    const { stdout, pid: probePid } = await execProbe(
       "powershell.exe",
       ["-NoProfile", "-NonInteractive", "-NoLogo", "-Command", psScript],
       {
         timeout: 10000,
         maxBuffer: 10 * 1024 * 1024,
         windowsHide: true,
+        encoding: "utf-8",
       }
     );
 
@@ -325,7 +349,7 @@ export class ProcessTreeCache {
       const pid = parseInt(String(p?.ProcessId), 10);
       const ppid = parseInt(String(p?.ParentProcessId), 10);
 
-      if (!Number.isInteger(pid) || !Number.isInteger(ppid) || pid <= 0) {
+      if (!Number.isInteger(pid) || !Number.isInteger(ppid) || pid <= 0 || pid === probePid) {
         continue;
       }
 

--- a/electron/services/ProcessTreeCache.ts
+++ b/electron/services/ProcessTreeCache.ts
@@ -242,7 +242,7 @@ export class ProcessTreeCache {
       }
     }
 
-    const changed = this.hasPidSetChanged(this.cache, newCache);
+    const changed = this.hasOwnedTreeChanged(this.childrenMap, newChildrenMap);
 
     this.cache = newCache;
     this.childrenMap = newChildrenMap;
@@ -410,7 +410,7 @@ export class ProcessTreeCache {
       }
     }
 
-    const changed = this.hasPidSetChanged(this.cache, newCache);
+    const changed = this.hasOwnedTreeChanged(this.childrenMap, newChildrenMap);
 
     this.cache = newCache;
     this.childrenMap = newChildrenMap;
@@ -423,13 +423,29 @@ export class ProcessTreeCache {
     return changed;
   }
 
-  private hasPidSetChanged(
-    oldCache: Map<number, ProcessInfo>,
-    newCache: Map<number, ProcessInfo>
+  private hasOwnedTreeChanged(
+    oldChildrenMap: Map<number, number[]>,
+    newChildrenMap: Map<number, number[]>
   ): boolean {
-    if (oldCache.size !== newCache.size) return true;
-    for (const pid of newCache.keys()) {
-      if (!oldCache.has(pid)) return true;
+    const collectDescendants = (childrenMap: Map<number, number[]>): Set<number> => {
+      const descendants = new Set<number>();
+      const pending = [...(childrenMap.get(process.pid) ?? [])];
+
+      while (pending.length > 0) {
+        const pid = pending.pop()!;
+        if (descendants.has(pid)) continue;
+        descendants.add(pid);
+        pending.push(...(childrenMap.get(pid) ?? []));
+      }
+
+      return descendants;
+    };
+
+    const oldPids = collectDescendants(oldChildrenMap);
+    const newPids = collectDescendants(newChildrenMap);
+    if (oldPids.size !== newPids.size) return true;
+    for (const pid of newPids) {
+      if (!oldPids.has(pid)) return true;
     }
     return false;
   }

--- a/electron/services/__tests__/ProcessTreeCache.test.ts
+++ b/electron/services/__tests__/ProcessTreeCache.test.ts
@@ -564,12 +564,10 @@ describe("ProcessTreeCache command/env construction", () => {
         _file: string,
         _args: unknown,
         _opts: unknown,
-        cb: (err: null, result: { stdout: string; stderr: string }) => void
+        cb: (err: null, stdout: string, stderr: string) => void
       ) => {
-        cb(null, {
-          stdout: "  PID  PPID %CPU   RSS COMM COMMAND\n    1    0  0.0  1000 init  init",
-          stderr: "",
-        });
+        cb(null, "  PID  PPID %CPU   RSS COMM COMMAND\n    1    0  0.0  1000 init  init", "");
+        return { pid: 999 };
       }
     );
 
@@ -589,16 +587,60 @@ describe("ProcessTreeCache command/env construction", () => {
     expect(callOpts.env!.LANG).toBe(process.env.LANG);
   });
 
+  it("omits the ps probe from the snapshot it produced", async () => {
+    mockExecFile
+      .mockImplementationOnce(
+        (
+          _file: string,
+          _args: unknown,
+          _opts: unknown,
+          cb: (err: null, stdout: string, stderr: string) => void
+        ) => {
+          cb(
+            null,
+            `  PID  PPID %CPU RSS COMM COMMAND\n    1    0 0.0 1000 init init\n  991 ${process.pid} 0.0 1000 ps ps -eo pid,ppid,%cpu,rss,comm,command`,
+            ""
+          );
+          return { pid: 991 };
+        }
+      )
+      .mockImplementationOnce(
+        (
+          _file: string,
+          _args: unknown,
+          _opts: unknown,
+          cb: (err: null, stdout: string, stderr: string) => void
+        ) => {
+          cb(
+            null,
+            `  PID  PPID %CPU RSS COMM COMMAND\n    1    0 0.0 1000 init init\n  992 ${process.pid} 0.0 1000 ps ps -eo pid,ppid,%cpu,rss,comm,command`,
+            ""
+          );
+          return { pid: 992 };
+        }
+      );
+
+    const cache = new ProcessTreeCache(2500);
+    const internals = cache as unknown as { refreshUnix: () => Promise<boolean> };
+
+    expect(await internals.refreshUnix()).toBe(true);
+    expect(await internals.refreshUnix()).toBe(false);
+    expect(cache.getProcess(991)).toBeUndefined();
+    expect(cache.getProcess(992)).toBeUndefined();
+    expect(cache.getProcess(1)?.comm).toBe("init");
+  });
+
   describe("Windows refresh", () => {
-    function mockPowerShellOutput(stdout: string): void {
+    function mockPowerShellOutput(stdout: string, pid: number = 999): void {
       mockExecFile.mockImplementation(
         (
           _file: string,
           _args: string[],
           _opts: unknown,
-          cb: (err: null, result: { stdout: string; stderr: string }) => void
+          cb: (err: null, stdout: string, stderr: string) => void
         ) => {
-          cb(null, { stdout, stderr: "" });
+          cb(null, stdout, "");
+          return { pid };
         }
       );
     }
@@ -687,6 +729,39 @@ describe("ProcessTreeCache command/env construction", () => {
 
       expect(cache.getChildPids(100)).toEqual([200]);
       expect(cache.getProcess(200)?.command).toContain("git status");
+    });
+
+    it("omits the PowerShell probe from the snapshot it produced", async () => {
+      mockPowerShellOutput(
+        JSON.stringify([
+          {
+            ProcessId: 999,
+            ParentProcessId: process.pid,
+            Name: "powershell.exe",
+            CommandLine: "powershell.exe -NoProfile -Command Get-CimInstance Win32_Process",
+            KernelModeTime: "0",
+            UserModeTime: "0",
+            WorkingSetSize: "1048576",
+            CreationDate: null,
+          },
+          {
+            ProcessId: 100,
+            ParentProcessId: 1,
+            Name: "node.exe",
+            CommandLine: "node server.js",
+            KernelModeTime: "0",
+            UserModeTime: "0",
+            WorkingSetSize: "1048576",
+            CreationDate: null,
+          },
+        ]),
+        999
+      );
+
+      const cache = await runWindowsRefresh();
+
+      expect(cache.getProcess(999)).toBeUndefined();
+      expect(cache.getProcess(100)?.comm).toBe("node");
     });
   });
 });

--- a/electron/services/__tests__/ProcessTreeCache.test.ts
+++ b/electron/services/__tests__/ProcessTreeCache.test.ts
@@ -623,11 +623,88 @@ describe("ProcessTreeCache command/env construction", () => {
     const cache = new ProcessTreeCache(2500);
     const internals = cache as unknown as { refreshUnix: () => Promise<boolean> };
 
-    expect(await internals.refreshUnix()).toBe(true);
+    expect(await internals.refreshUnix()).toBe(false);
     expect(await internals.refreshUnix()).toBe(false);
     expect(cache.getProcess(991)).toBeUndefined();
     expect(cache.getProcess(992)).toBeUndefined();
     expect(cache.getProcess(1)?.comm).toBe("init");
+  });
+
+  it("ignores unrelated machine churn when deciding whether to reset backoff", async () => {
+    mockExecFile
+      .mockImplementationOnce(
+        (
+          _file: string,
+          _args: unknown,
+          _opts: unknown,
+          cb: (err: null, stdout: string, stderr: string) => void
+        ) => {
+          cb(
+            null,
+            `  PID  PPID %CPU RSS COMM COMMAND\n  100    1 0.0 1000 runner runner\n  200 ${process.pid} 0.0 1000 zsh zsh`,
+            ""
+          );
+          return { pid: 991 };
+        }
+      )
+      .mockImplementationOnce(
+        (
+          _file: string,
+          _args: unknown,
+          _opts: unknown,
+          cb: (err: null, stdout: string, stderr: string) => void
+        ) => {
+          cb(
+            null,
+            `  PID  PPID %CPU RSS COMM COMMAND\n  101    1 0.0 1000 runner runner\n  200 ${process.pid} 0.0 1000 zsh zsh`,
+            ""
+          );
+          return { pid: 992 };
+        }
+      );
+
+    const cache = new ProcessTreeCache(2500);
+    const internals = cache as unknown as { refreshUnix: () => Promise<boolean> };
+
+    expect(await internals.refreshUnix()).toBe(true);
+    expect(await internals.refreshUnix()).toBe(false);
+    expect(cache.getProcess(101)?.comm).toBe("runner");
+  });
+
+  it("resets backoff when the owned terminal tree changes", async () => {
+    mockExecFile
+      .mockImplementationOnce(
+        (
+          _file: string,
+          _args: unknown,
+          _opts: unknown,
+          cb: (err: null, stdout: string, stderr: string) => void
+        ) => {
+          cb(null, `  PID  PPID %CPU RSS COMM COMMAND\n  200 ${process.pid} 0.0 1000 zsh zsh`, "");
+          return { pid: 991 };
+        }
+      )
+      .mockImplementationOnce(
+        (
+          _file: string,
+          _args: unknown,
+          _opts: unknown,
+          cb: (err: null, stdout: string, stderr: string) => void
+        ) => {
+          cb(
+            null,
+            `  PID  PPID %CPU RSS COMM COMMAND\n  200 ${process.pid} 0.0 1000 zsh zsh\n  201  200 0.0 1000 node node agent.js`,
+            ""
+          );
+          return { pid: 992 };
+        }
+      );
+
+    const cache = new ProcessTreeCache(2500);
+    const internals = cache as unknown as { refreshUnix: () => Promise<boolean> };
+
+    expect(await internals.refreshUnix()).toBe(true);
+    expect(await internals.refreshUnix()).toBe(true);
   });
 
   describe("Windows refresh", () => {

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -12,6 +12,7 @@ import type {
 import type { CIStatusState } from "../../shared/types/forge.js";
 import type { WorktreeSnapshot, WorkspaceFetchResult } from "../../shared/types/workspace-host.js";
 import { invalidateGitStatusCache, getWorktreeChangesWithStats } from "../utils/git.js";
+import { clearGitDirCache } from "../utils/gitUtils.js";
 import { AdaptivePollingStrategy, NoteFileReader } from "../services/worktree/index.js";
 import { deriveIssueTitleFromBranch } from "../services/issueExtractor.js";
 import { FetchScheduler, type FetchSchedulerHost } from "./FetchScheduler.js";
@@ -1530,6 +1531,10 @@ export class WorktreeMonitor {
     if (this.isElevated && this.gitWatchEnabled) {
       const budgetReset = this.watcherController.resetRetryBudget();
       if (budgetReset) {
+        // A manual refresh is the recovery escape hatch for a dark watcher.
+        // Drop a transient negative resolution before re-arming, otherwise the
+        // retry simply replays the cached failure against a repo that has healed.
+        clearGitDirCache(this.path);
         this.watcherController.update();
       }
     }

--- a/electron/workspace-host/__tests__/WorktreeMonitor.watcher.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeMonitor.watcher.test.ts
@@ -152,7 +152,7 @@ vi.mock("../../services/worktree/index.js", () => ({
 
 import { WorktreeMonitor } from "../WorktreeMonitor.js";
 import type { WorktreeMonitorConfig, WorktreeMonitorCallbacks } from "../WorktreeMonitor.js";
-import { getGitDir } from "../../utils/gitUtils.js";
+import { clearGitDirCache, getGitDir } from "../../utils/gitUtils.js";
 
 const TEST_WORKTREE: Worktree = {
   id: "/test/worktree",
@@ -728,6 +728,7 @@ describe("WorktreeMonitor", () => {
       // stop(false) + start("recursive") [fails] + start("git-only") [succeeds].
       await monitor.refresh();
       expect(watcherStartCallCount).toBe(startsAtExhaustion + 2);
+      expect(clearGitDirCache).toHaveBeenCalledWith(ACTIVE_WORKTREE.path);
 
       // Recursive still fails — should schedule a retry with fresh budget.
       await vi.advanceTimersByTimeAsync(30_000);
@@ -757,6 +758,7 @@ describe("WorktreeMonitor", () => {
       // refresh() when budget is zero no-ops — no extra watcher churn.
       await monitor.refresh();
       expect(watcherStartCallCount).toBe(startsBeforeRefresh);
+      expect(clearGitDirCache).not.toHaveBeenCalled();
 
       monitor.stop();
     });


### PR DESCRIPTION
## Summary

This reduces the idle process-tree polling tax and fixes watcher recovery after a transient repository failure:

- exclude the `ps` / PowerShell probe from its own census, then base adaptive-backoff resets on descendants of Daintree's pty host instead of unrelated whole-machine PID churn;
- keep the full process census for terminal discovery and reset immediately when an owned descendant changes;
- when manual refresh actually resets a failed watcher's retry budget, invalidate the transient negative git-dir cache before re-arming it.

The benchmark apparatus is unchanged. Production changes are covered by focused Unix/Windows process-tree tests and watcher-recovery tests.

## Portable count results

`PERF-092 idleProbeSpawns.max` is the headline improvement. Each hosted value is the median of three interleaved branch-point/candidate pairs on the same runner; each arm uses one warmup and five measured iterations.

| OS | Before | After | Absolute | Improvement | Predicates |
| --- | ---: | ---: | ---: | ---: | --- |
| Linux | 9 | 3 | -6 | 66.7% | all zero |
| Windows | 7 | 3 | -4 | 57.1% | all zero |
| macOS | 9 | 3 | -6 | 66.7% | all zero |
| Local macOS (M1 Max) | 9 | 3 | -6 | 66.7% | all zero |

The three independently observed counts—probe spawns, subprocess spawns, and refresh callbacks—move identically. Hosted predicates are `discoveryMisses`, `refreshMisses`, and `spawnObserverMisses`; every predicate is zero in every arm. [Exact final cross-OS run](https://github.com/daintreehq/daintree/actions/runs/33503838371).

`PERF-101 spawnsPerWorktreeN50.max`, the requested entry target, was already at its correctness-preserving floor: one forced refresh spawns one `git status` per worktree. The candidate preserves that floor and both required predicates.

| OS | Before | After | Absolute | Improvement | Predicates |
| --- | ---: | ---: | ---: | ---: | --- |
| Linux | 1 | 1 | 0 | 0% (floor) | all zero |
| Windows | 1 | 1 | 0 | 0% (floor) | all zero |
| macOS | 1 | 1 | 0 | 0% (floor) | all zero |
| Local macOS (M1 Max) | 1 | 1 | 0 | 0% (floor) | all zero |

Linux/Windows evidence: [exact-final run](https://github.com/daintreehq/daintree/actions/runs/33505377091). That run's macOS fixture failed at `git add -A` before measurement, so its value was not inferred; [the exact-final replacement leg](https://github.com/daintreehq/daintree/actions/runs/33506473453) measured all six arms at 1 with both predicates zero throughout. Exit 4 is the gate's expected `NO CLAIM` result at the semantic floor.

## Correctness and controls

- PERF-106 exposes the repaired watcher path. Its branch-point arm is invalid for a percentage claim: all five runs miss watcher arming and report 16 idle git spawns / 4 status passes. The final tree is healthy: zero idle git, status, non-git, and residual spawns; all five predicates are zero in 5/5 runs; mean detection is 60.56 ms.
- PERF-105 remains a healthy negative control: zero idle/residual spawns, all predicates zero in 5/5, mean detection 59.23 ms.
- A new owned terminal descendant still resets process-tree backoff; unrelated machine PID churn no longer does.
- Healthy watcher refreshes do not clear the git-dir cache; only a refresh that resets non-zero recovery state does.

## Methodology and caveats

- Baseline: branch point `a208c0e197168c2ace15ad6782e9783ba7e6a320`; candidate: exact final SHA `4c7ee2b85f319b4d162b8953d72d9a37e738b585`.
- Counts/ratios are the portable evidence. No hosted duration claim is made. Local measurements ran amid many concurrent worktrees, so CPU/ELU readings are descriptive only.
- Local PERF-092 CPU per idle second was 2.637→0.749 ms (-71.6%) and ELU 0.259%→0.152% (-41.1%), but neither is used as the headline claim.
- The intended adaptive backoff raises local injected-child discovery mean from 0.530 s to 3.515 s (max 3.569 s), within the predeclared 25 s correctness bound; refresh and discovery predicates remain healthy.
- An initial direct-probe-only version held on Linux but not Windows/macOS because unrelated runner PID churn still reset backoff. The retained implementation addresses that demonstrated portability failure.
- PERF-101 alternatives that skip an explicit refresh or hide child work under an observer-visible wrapper were rejected as correctness violations / measurement gaming.
- `electron/workspace-host/**` is required for the watcher-recovery fix but is absent from the Area A ownership table; that is a partition gap, not a benchmark apparatus change.

## Validation

- `npm run typecheck`
- `npm run check`
- focused ProcessTreeCache suite: 49/49
- focused WorktreeMonitor watcher suite: 27/27
- full `npm test` repeated three times on the exact final SHA; failures vary outside the touched code, and PERF-063's `batcherShortfallCount=1` reproduces unchanged on the branch point. Focused suites and the repository's required PR checks provide the isolated verdict.
- required PR CI is green at the exact final SHA: build/smoke, static analysis, all four Vitest shards, and aggregate `ci-ok`
- diff audit and `git diff --check`; no changes under `scripts/perf/**`
