### PR TITLE
fix(viewer): scope Select All to the focused document, not the whole app

### DIFF
--- a/src/components/Markdown/MarkdownDocument.tsx
+++ b/src/components/Markdown/MarkdownDocument.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import ReactMarkdown, { defaultUrlTransform, type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { toJsxRuntime } from "hast-util-to-jsx-runtime";
@@ -11,6 +11,7 @@ import {
 } from "@/components/Worktree/diffRefractor";
 import { dirname, isAbsolute, isPathInside, join, normalize } from "@shared/utils/path";
 import { buildDaintreeFileUrl } from "@/components/FileViewer/filePreviewKinds";
+import { useScopedSelectAll } from "@/hooks/useScopedSelectAll";
 import { actionService } from "@/services/ActionService";
 import { logError } from "@/utils/logger";
 import { cn } from "@/lib/utils";
@@ -132,6 +133,11 @@ export function MarkdownDocument({
     onRendered?.();
   }, [onRendered]);
 
+  // Nothing owns Select All over plain rendered DOM, so the native Edit-menu
+  // command falls back to the whole app (#12135). Claim it for the document.
+  const rootRef = useRef<HTMLDivElement>(null);
+  useScopedSelectAll(rootRef);
+
   const urlTransform = useMemo(() => {
     return (url: string, key: string): string | null | undefined => {
       if (key === "src") {
@@ -215,7 +221,7 @@ export function MarkdownDocument({
   );
 
   return (
-    <div className={cn("markdown-document prose", className)}>
+    <div ref={rootRef} className={cn("markdown-document prose", className)}>
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         urlTransform={urlTransform}

--- a/src/components/Markdown/__tests__/MarkdownDocument.test.tsx
+++ b/src/components/Markdown/__tests__/MarkdownDocument.test.tsx
@@ -294,17 +294,16 @@ describe("MarkdownDocument", () => {
   // webContents.selectAll(). Chromium only scopes that to editable focus, so
   // over the rendered document it used to select the entire app window.
   it("claims Cmd+A for the document instead of the whole app", () => {
-    const { container } = render(<MarkdownDocument {...FIXTURE_PROPS} content="# Spec title" />);
-
-    // Focus lands on the panel root, an ancestor of the document — the shape
-    // ContentPanel produces, and the reason a container listener can't work.
-    const panelRoot = document.createElement("div");
-    panelRoot.tabIndex = -1;
-    const chrome = document.createElement("nav");
-    chrome.textContent = "sidebar chrome";
-    panelRoot.appendChild(chrome);
-    container.parentNode?.insertBefore(panelRoot, container);
-    panelRoot.appendChild(container);
+    // A React-owned pane wrapper, not a re-parented container: RTL only cleans
+    // up a container whose parent is document.body, so moving one leaks it into
+    // the tests that follow. This is the shape ContentPanel renders — focus on
+    // the `data-panel-id` root, an ancestor of the document.
+    const { getByTestId } = render(
+      <div data-testid="pane" data-panel-id="file-1" tabIndex={-1}>
+        <nav>sidebar chrome</nav>
+        <MarkdownDocument {...FIXTURE_PROPS} content={"# Spec title\n\nBody line."} />
+      </div>
+    );
 
     const event = new KeyboardEvent("keydown", {
       key: "a",
@@ -312,16 +311,18 @@ describe("MarkdownDocument", () => {
       bubbles: true,
       cancelable: true,
     });
-    panelRoot.dispatchEvent(event);
+    getByTestId("pane").dispatchEvent(event);
 
     // A prevented event never reaches the native accelerator.
     expect(event.defaultPrevented).toBe(true);
-    const selection = window.getSelection();
-    expect(selection?.getRangeAt(0).commonAncestorContainer).toBe(
-      container.querySelector(".markdown-document")
-    );
-    expect(selection?.toString()).toContain("Spec title");
-    expect(selection?.toString()).not.toContain("sidebar chrome");
-    selection?.removeAllRanges();
+    const document_ = getByTestId("pane").querySelector(".markdown-document")!;
+    const range = window.getSelection()?.getRangeAt(0);
+    // The whole document, not a collapsed range that merely shares its ancestor.
+    expect(range?.commonAncestorContainer).toBe(document_);
+    expect(range?.startOffset).toBe(0);
+    expect(range?.endOffset).toBe(document_.childNodes.length);
+    expect(window.getSelection()?.toString()).toBe(document_.textContent);
+    expect(window.getSelection()?.toString()).not.toContain("sidebar chrome");
+    window.getSelection()?.removeAllRanges();
   });
 });

--- a/src/components/Markdown/__tests__/MarkdownDocument.test.tsx
+++ b/src/components/Markdown/__tests__/MarkdownDocument.test.tsx
@@ -289,4 +289,39 @@ describe("MarkdownDocument", () => {
 
     expect(dispatchMock).not.toHaveBeenCalled();
   });
+
+  // #12135: Select All is a native Edit-menu accelerator ending in
+  // webContents.selectAll(). Chromium only scopes that to editable focus, so
+  // over the rendered document it used to select the entire app window.
+  it("claims Cmd+A for the document instead of the whole app", () => {
+    const { container } = render(<MarkdownDocument {...FIXTURE_PROPS} content="# Spec title" />);
+
+    // Focus lands on the panel root, an ancestor of the document — the shape
+    // ContentPanel produces, and the reason a container listener can't work.
+    const panelRoot = document.createElement("div");
+    panelRoot.tabIndex = -1;
+    const chrome = document.createElement("nav");
+    chrome.textContent = "sidebar chrome";
+    panelRoot.appendChild(chrome);
+    container.parentNode?.insertBefore(panelRoot, container);
+    panelRoot.appendChild(container);
+
+    const event = new KeyboardEvent("keydown", {
+      key: "a",
+      metaKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    panelRoot.dispatchEvent(event);
+
+    // A prevented event never reaches the native accelerator.
+    expect(event.defaultPrevented).toBe(true);
+    const selection = window.getSelection();
+    expect(selection?.getRangeAt(0).commonAncestorContainer).toBe(
+      container.querySelector(".markdown-document")
+    );
+    expect(selection?.toString()).toContain("Spec title");
+    expect(selection?.toString()).not.toContain("sidebar chrome");
+    selection?.removeAllRanges();
+  });
 });

--- a/src/components/Worktree/DiffViewer.tsx
+++ b/src/components/Worktree/DiffViewer.tsx
@@ -10,7 +10,13 @@ import {
   useRef,
   useState,
 } from "react";
-import type { CSSProperties, KeyboardEvent as ReactKeyboardEvent, ReactElement } from "react";
+import type {
+  CSSProperties,
+  KeyboardEvent as ReactKeyboardEvent,
+  ReactElement,
+  Ref,
+  RefCallback,
+} from "react";
 import {
   parseDiff,
   Diff,
@@ -398,17 +404,36 @@ export const DiffViewer = forwardRef<HTMLDivElement, DiffViewerProps>(function D
   ref
 ) {
   // Select All over a diff has no owner, so the native Edit-menu command falls
-  // back to the whole app (#12135). Claim it for the diff body. The root also
-  // carries a forwarded ref, so publish to both.
+  // back to the whole app (#12135). Claim it for whichever body is on screen —
+  // the sentinel branches below take `rootRef` directly, since an error or
+  // "no changes" pane is just as exposed to the fallback as a rendered diff.
   const rootRef = useRef<HTMLDivElement | null>(null);
   useScopedSelectAll(rootRef);
-  const setRoot = useCallback(
-    (node: HTMLDivElement | null) => {
+  // Compose, never replace, and mirror ContentPanel's React 19 handling: a
+  // callback ref may return a cleanup, and React then skips the usual `null`
+  // call — so that cleanup has to be propagated or the caller's teardown never
+  // runs. Only the rendered-diff root publishes outward; the sentinels have no
+  // `.diff-viewer` to hand a host.
+  const externalRef: Ref<HTMLDivElement> = ref;
+  const setRoot = useCallback<RefCallback<HTMLDivElement>>(
+    (node) => {
       rootRef.current = node;
-      if (typeof ref === "function") ref(node);
-      else if (ref) ref.current = node;
+      if (typeof externalRef === "function") {
+        const cleanup = externalRef(node);
+        if (typeof cleanup === "function") {
+          return () => {
+            rootRef.current = null;
+            cleanup();
+          };
+        }
+        return undefined;
+      }
+      if (externalRef) {
+        externalRef.current = node;
+      }
+      return undefined;
     },
-    [ref]
+    [externalRef]
   );
 
   // Keep keystrokes responsive: highlighting re-tokenizes the whole file, so
@@ -489,7 +514,7 @@ export const DiffViewer = forwardRef<HTMLDivElement, DiffViewerProps>(function D
 
   if (!diff || diff === "NO_CHANGES") {
     return (
-      <div className="p-8">
+      <div ref={rootRef} className="p-8">
         <EmptyState
           variant="zero-data"
           scale="canvas"
@@ -503,7 +528,7 @@ export const DiffViewer = forwardRef<HTMLDivElement, DiffViewerProps>(function D
 
   if (diff === "BINARY_FILE") {
     return (
-      <div className="p-8">
+      <div ref={rootRef} className="p-8">
         <EmptyState
           variant="zero-data"
           scale="canvas"
@@ -518,7 +543,7 @@ export const DiffViewer = forwardRef<HTMLDivElement, DiffViewerProps>(function D
 
   if (diff === "FILE_TOO_LARGE") {
     return (
-      <div className="p-8">
+      <div ref={rootRef} className="p-8">
         <EmptyState
           variant="zero-data"
           scale="canvas"
@@ -533,7 +558,7 @@ export const DiffViewer = forwardRef<HTMLDivElement, DiffViewerProps>(function D
 
   if (diff === "ERROR") {
     return (
-      <div className="p-8">
+      <div ref={rootRef} className="p-8">
         <EmptyState
           variant="zero-data"
           scale="canvas"
@@ -558,7 +583,7 @@ export const DiffViewer = forwardRef<HTMLDivElement, DiffViewerProps>(function D
 
   if (files.length === 0) {
     return (
-      <div className="p-8">
+      <div ref={rootRef} className="p-8">
         <EmptyState
           variant="zero-data"
           scale="canvas"

--- a/src/components/Worktree/DiffViewer.tsx
+++ b/src/components/Worktree/DiffViewer.tsx
@@ -48,6 +48,7 @@ import {
 } from "lucide-react";
 import { join } from "@shared/utils/path";
 import { getLanguageForFile } from "@/components/FileViewer/languageUtils";
+import { useScopedSelectAll } from "@/hooks/useScopedSelectAll";
 import { actionService } from "@/services/ActionService";
 import { TruncatedTooltip } from "@/components/ui/TruncatedTooltip";
 import { EmptyState } from "@/components/ui/EmptyState";
@@ -396,6 +397,20 @@ export const DiffViewer = forwardRef<HTMLDivElement, DiffViewerProps>(function D
   },
   ref
 ) {
+  // Select All over a diff has no owner, so the native Edit-menu command falls
+  // back to the whole app (#12135). Claim it for the diff body. The root also
+  // carries a forwarded ref, so publish to both.
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  useScopedSelectAll(rootRef);
+  const setRoot = useCallback(
+    (node: HTMLDivElement | null) => {
+      rootRef.current = node;
+      if (typeof ref === "function") ref(node);
+      else if (ref) ref.current = node;
+    },
+    [ref]
+  );
+
   // Keep keystrokes responsive: highlighting re-tokenizes the whole file, so
   // the query lands as a deferred value and the table catches up after paint.
   const deferredSearchQuery = useDeferredValue(searchQuery ?? "");
@@ -556,7 +571,7 @@ export const DiffViewer = forwardRef<HTMLDivElement, DiffViewerProps>(function D
   }
 
   return (
-    <div ref={ref} className="diff-viewer" data-wrap={wrapLines ? "true" : undefined}>
+    <div ref={setRoot} className="diff-viewer" data-wrap={wrapLines ? "true" : undefined}>
       {files.map((file, index) => (
         <FileDiff
           key={file.newRevision || file.oldRevision || index}

--- a/src/components/Worktree/__tests__/DiffViewer.test.tsx
+++ b/src/components/Worktree/__tests__/DiffViewer.test.tsx
@@ -1202,3 +1202,52 @@ describe("DiffViewer native scroll proxy CSS contract (#12103)", () => {
     expect(shell).not.toMatch(/overflow|contain|transform|filter|perspective/);
   });
 });
+
+// #12135: Select All over a diff had no owner, so the native Edit-menu
+// accelerator (webContents.selectAll(), which Chromium only scopes to editable
+// focus) selected the whole app window instead of the diff.
+describe("DiffViewer scoped Select All (#12135)", () => {
+  afterEach(() => {
+    window.getSelection()?.removeAllRanges();
+  });
+
+  it("claims Cmd+A for the diff body when focus sits on the panel root", () => {
+    const { container } = render(wrap(<DiffViewer diff={SMALL_DIFF} viewType="unified" />));
+
+    // The shape ContentPanel produces: DOM focus on a tabIndex={-1} ancestor,
+    // so the keydown never travels down into the diff body on its own.
+    const panelRoot = document.createElement("div");
+    panelRoot.tabIndex = -1;
+    const chrome = document.createElement("nav");
+    chrome.textContent = "sidebar chrome";
+    panelRoot.appendChild(chrome);
+    container.parentNode?.insertBefore(panelRoot, container);
+    panelRoot.appendChild(container);
+
+    const event = new KeyboardEvent("keydown", {
+      key: "a",
+      metaKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    panelRoot.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+    const selection = window.getSelection();
+    expect(selection?.getRangeAt(0).commonAncestorContainer).toBe(
+      container.querySelector(".diff-viewer")
+    );
+    expect(selection?.toString()).not.toContain("sidebar chrome");
+  });
+
+  it("still hands its root to a forwarding host", () => {
+    const hostRef = React.createRef<HTMLDivElement>();
+    const { container } = render(
+      wrap(<DiffViewer ref={hostRef} diff={SMALL_DIFF} viewType="unified" />)
+    );
+
+    // The scoped-select-all ref is merged with the forwarded one, not swapped
+    // for it — hosts scroll and measure through this.
+    expect(hostRef.current).toBe(container.querySelector(".diff-viewer"));
+  });
+});

--- a/src/components/Worktree/__tests__/DiffViewer.test.tsx
+++ b/src/components/Worktree/__tests__/DiffViewer.test.tsx
@@ -1211,43 +1211,107 @@ describe("DiffViewer scoped Select All (#12135)", () => {
     window.getSelection()?.removeAllRanges();
   });
 
-  it("claims Cmd+A for the diff body when focus sits on the panel root", () => {
-    const { container } = render(wrap(<DiffViewer diff={SMALL_DIFF} viewType="unified" />));
-
-    // The shape ContentPanel produces: DOM focus on a tabIndex={-1} ancestor,
-    // so the keydown never travels down into the diff body on its own.
-    const panelRoot = document.createElement("div");
-    panelRoot.tabIndex = -1;
-    const chrome = document.createElement("nav");
-    chrome.textContent = "sidebar chrome";
-    panelRoot.appendChild(chrome);
-    container.parentNode?.insertBefore(panelRoot, container);
-    panelRoot.appendChild(container);
-
+  function pressSelectAll(target: Element): KeyboardEvent {
     const event = new KeyboardEvent("keydown", {
       key: "a",
       metaKey: true,
       bubbles: true,
       cancelable: true,
     });
-    panelRoot.dispatchEvent(event);
+    target.dispatchEvent(event);
+    return event;
+  }
+
+  // A React-owned pane wrapper, not a re-parented container: RTL only cleans up
+  // a container whose parent is document.body, so moving one leaks it into the
+  // tests that follow.
+  function renderInPane(ui: React.ReactElement) {
+    return render(
+      wrap(
+        <div data-testid="pane" data-panel-id="diff-1" tabIndex={-1}>
+          <nav>sidebar chrome</nav>
+          <button type="button" data-testid="pane-toolbar-button">
+            Refresh
+          </button>
+          {ui}
+        </div>
+      )
+    );
+  }
+
+  it("selects the whole diff body when focus sits on the pane root", () => {
+    const { getByTestId } = renderInPane(<DiffViewer diff={SMALL_DIFF} viewType="unified" />);
+
+    const event = pressSelectAll(getByTestId("pane"));
 
     expect(event.defaultPrevented).toBe(true);
-    const selection = window.getSelection();
-    expect(selection?.getRangeAt(0).commonAncestorContainer).toBe(
-      container.querySelector(".diff-viewer")
-    );
-    expect(selection?.toString()).not.toContain("sidebar chrome");
+    const body = getByTestId("pane").querySelector(".diff-viewer")!;
+    const range = window.getSelection()?.getRangeAt(0);
+    expect(range?.commonAncestorContainer).toBe(body);
+    expect(range?.startOffset).toBe(0);
+    expect(range?.endOffset).toBe(body.childNodes.length);
+    expect(window.getSelection()?.toString()).not.toContain("sidebar chrome");
   });
 
-  it("still hands its root to a forwarding host", () => {
+  // DiffPane's file sidebar and toolbar keep focus beside the diff, not above
+  // or inside it — an ancestor-only ownership rule would miss this.
+  it("claims the chord from a sibling control in the same pane", () => {
+    const { getByTestId } = renderInPane(<DiffViewer diff={SMALL_DIFF} viewType="unified" />);
+
+    const event = pressSelectAll(getByTestId("pane-toolbar-button"));
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(window.getSelection()?.getRangeAt(0).commonAncestorContainer).toBe(
+      getByTestId("pane").querySelector(".diff-viewer")
+    );
+  });
+
+  // "Couldn't load diff" / "File too large" render a sentinel instead of a
+  // diff, and are just as exposed to the whole-document fallback.
+  it("owns the chord in the sentinel branches too", () => {
+    const { getByTestId } = renderInPane(<DiffViewer diff="" viewType="unified" />);
+
+    const event = pressSelectAll(getByTestId("pane"));
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(window.getSelection()?.toString()).not.toContain("sidebar chrome");
+  });
+
+  it("still publishes its root to a forwarding host while scoping selection", () => {
     const hostRef = React.createRef<HTMLDivElement>();
-    const { container } = render(
-      wrap(<DiffViewer ref={hostRef} diff={SMALL_DIFF} viewType="unified" />)
+    const { getByTestId } = renderInPane(
+      <DiffViewer ref={hostRef} diff={SMALL_DIFF} viewType="unified" />
     );
 
-    // The scoped-select-all ref is merged with the forwarded one, not swapped
-    // for it — hosts scroll and measure through this.
-    expect(hostRef.current).toBe(container.querySelector(".diff-viewer"));
+    const body = getByTestId("pane").querySelector(".diff-viewer");
+    // Composed, not swapped: hosts scroll and measure through the forwarded ref
+    // while the internal one drives selection — so exercise both in one render.
+    expect(hostRef.current).toBe(body);
+    expect(pressSelectAll(getByTestId("pane")).defaultPrevented).toBe(true);
+    expect(window.getSelection()?.getRangeAt(0).commonAncestorContainer).toBe(body);
+  });
+
+  it("propagates a callback ref's React 19 cleanup instead of swallowing it", () => {
+    const cleanup = vi.fn();
+    const attached: (HTMLDivElement | null)[] = [];
+    const { unmount } = renderInPane(
+      <DiffViewer
+        ref={(node) => {
+          attached.push(node);
+          return cleanup;
+        }}
+        diff={SMALL_DIFF}
+        viewType="unified"
+      />
+    );
+
+    expect(attached[0]).not.toBeNull();
+    expect(cleanup).not.toHaveBeenCalled();
+
+    unmount();
+
+    // React skips the usual `null` call when a callback ref returns a cleanup,
+    // so a composed ref that drops the cleanup never tears the caller down.
+    expect(cleanup).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/hooks/__tests__/useScopedSelectAll.test.tsx
+++ b/src/hooks/__tests__/useScopedSelectAll.test.tsx
@@ -5,22 +5,26 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useScopedSelectAll } from "../useScopedSelectAll";
 
 /**
- * Mirrors the real shape the hook has to cope with: DOM focus sits on the
- * panel root (`ContentPanel`'s `tabIndex={-1}` div), which is an *ancestor* of
- * the viewer body — so the interception can never be a listener on the body
- * itself. `#chrome` stands in for the sidebar/toolbar the native command
- * wrongly swept into the selection (#12135).
+ * Mirrors the focus topology the hook has to cope with. DOM focus lands on the
+ * pane root (`ContentPanel`'s `tabIndex={-1}` div, keyed by `data-panel-id`),
+ * which is an *ancestor* of the viewer body; or on the tree beside it, which is
+ * a *sibling*; or inside the body itself. `#outside` stands in for the sidebar
+ * the native command wrongly swept into the selection (#12135).
  */
 function Harness({ enabled = true, bodyText = "document text" }) {
   const ref = useRef<HTMLDivElement>(null);
   useScopedSelectAll(ref, enabled);
   return (
-    <div data-testid="panel-root" tabIndex={-1}>
+    <div data-testid="pane" data-panel-id="pane-1" tabIndex={-1}>
       <div data-testid="toolbar">
         <input data-testid="search" />
+        <textarea data-testid="notes" />
         <button type="button" data-testid="toolbar-button">
           Refresh
         </button>
+      </div>
+      <div data-testid="tree" tabIndex={-1}>
+        tree row
       </div>
       <div data-testid="body" ref={ref}>
         <p>{bodyText}</p>
@@ -48,115 +52,178 @@ function selectedText(): string {
   return window.getSelection()?.toString() ?? "";
 }
 
-beforeEach(() => {
+function clearSelection(): void {
   window.getSelection()?.removeAllRanges();
-});
+}
 
+/**
+ * jsdom performs no native Select All, so "nothing was selected" is true of a
+ * hook that never ran at all. Every declining case therefore has to prove the
+ * listener was live and *chose* to decline — otherwise deleting the hook
+ * outright would leave the test green.
+ */
+function expectStillLive(body: Element, pane: Element): void {
+  clearSelection();
+  const control = pressSelectAll(pane);
+  expect(control.defaultPrevented).toBe(true);
+  expect(window.getSelection()?.getRangeAt(0).commonAncestorContainer).toBe(body);
+  clearSelection();
+}
+
+/** The whole region, not a collapsed range that merely shares its ancestor. */
+function expectSelectedWholeOf(container: HTMLElement): void {
+  const range = window.getSelection()?.getRangeAt(0);
+  expect(range?.commonAncestorContainer).toBe(container);
+  expect(range?.startOffset).toBe(0);
+  expect(range?.endOffset).toBe(container.childNodes.length);
+  expect(selectedText()).toBe(container.textContent);
+}
+
+beforeEach(clearSelection);
 afterEach(() => {
   vi.restoreAllMocks();
-  window.getSelection()?.removeAllRanges();
+  clearSelection();
 });
 
 describe("useScopedSelectAll", () => {
-  it("scopes Cmd+A to the region when focus sits on an ancestor panel root", () => {
+  it("selects the whole region when focus sits on the ancestor pane root", () => {
     const { getByTestId } = render(<Harness />);
 
-    const event = pressSelectAll(getByTestId("panel-root"));
+    const event = pressSelectAll(getByTestId("pane"));
 
     // preventDefault is the half that suppresses Electron's native accelerator:
     // AppKit never sees a key the page already handled.
     expect(event.defaultPrevented).toBe(true);
-    const range = window.getSelection()?.getRangeAt(0);
-    expect(range?.commonAncestorContainer).toBe(getByTestId("body"));
+    expectSelectedWholeOf(getByTestId("body"));
     expect(selectedText()).toContain("document text");
     expect(selectedText()).not.toContain("Refresh");
   });
 
-  it("also claims the chord when focus is inside the region", () => {
+  it("claims the chord when focus is inside the region", () => {
     const { getByTestId } = render(<Harness />);
 
     const event = pressSelectAll(getByTestId("doc-link"));
 
     expect(event.defaultPrevented).toBe(true);
-    expect(window.getSelection()?.getRangeAt(0).commonAncestorContainer).toBe(getByTestId("body"));
+    expectSelectedWholeOf(getByTestId("body"));
+  });
+
+  // The file browser focuses its tree root on a row click and leaves it there,
+  // so the preview beside it is a sibling of the focused element — the most
+  // common path into the reported bug, and one an ancestor-only rule misses.
+  it("claims the chord when focus is on a sibling inside the same pane", () => {
+    const { getByTestId } = render(<Harness />);
+
+    const fromTree = pressSelectAll(getByTestId("tree"));
+    expect(fromTree.defaultPrevented).toBe(true);
+    expectSelectedWholeOf(getByTestId("body"));
+
+    clearSelection();
+    const fromToolbar = pressSelectAll(getByTestId("toolbar-button"));
+    expect(fromToolbar.defaultPrevented).toBe(true);
+    expectSelectedWholeOf(getByTestId("body"));
   });
 
   it("treats Ctrl+A the same way, for Windows and Linux", () => {
     const { getByTestId } = render(<Harness />);
 
-    const event = pressSelectAll(getByTestId("panel-root"), { metaKey: false, ctrlKey: true });
+    const event = pressSelectAll(getByTestId("pane"), { metaKey: false, ctrlKey: true });
 
     expect(event.defaultPrevented).toBe(true);
-    expect(selectedText()).toContain("document text");
+    expectSelectedWholeOf(getByTestId("body"));
   });
 
-  it("leaves Cmd+A in a text field alone", () => {
+  // Caps Lock produces "A" with shiftKey false; Shift+Cmd+A is a different
+  // chord and must stay excluded.
+  it("accepts a capitalised key but not the Shift chord", () => {
     const { getByTestId } = render(<Harness />);
 
-    const event = pressSelectAll(getByTestId("search"));
+    expect(pressSelectAll(getByTestId("pane"), { key: "A" }).defaultPrevented).toBe(true);
+    expectSelectedWholeOf(getByTestId("body"));
+
+    clearSelection();
+    expect(pressSelectAll(getByTestId("pane"), { key: "A", shiftKey: true }).defaultPrevented).toBe(
+      false
+    );
+    expect(window.getSelection()?.rangeCount ?? 0).toBe(0);
+  });
+
+  it("leaves Cmd+A in a text field to the field", () => {
+    const { getByTestId } = render(<Harness />);
+
+    for (const id of ["search", "notes"]) {
+      const event = pressSelectAll(getByTestId(id));
+      expect(event.defaultPrevented).toBe(false);
+      expect(window.getSelection()?.rangeCount ?? 0).toBe(0);
+    }
+
+    const editable = document.createElement("div");
+    // jsdom does not derive isContentEditable from the attribute.
+    Object.defineProperty(editable, "isContentEditable", { value: true });
+    getByTestId("toolbar").appendChild(editable);
+    expect(pressSelectAll(editable).defaultPrevented).toBe(false);
+    expect(window.getSelection()?.rangeCount ?? 0).toBe(0);
+
+    expectStillLive(getByTestId("body"), getByTestId("pane"));
+  });
+
+  it("yields to a higher-priority owner that already claimed the chord", () => {
+    const { getByTestId } = render(<Harness />);
+    const pane = getByTestId("pane");
+    // An explicit user keybinding, or an inner editor, handled it first.
+    pane.addEventListener("keydown", (e) => e.preventDefault(), { once: true });
+
+    pressSelectAll(pane);
+
+    expect(window.getSelection()?.rangeCount ?? 0).toBe(0);
+    expectStillLive(getByTestId("body"), pane);
+  });
+
+  it("ignores a keystroke the IME is still composing", () => {
+    const { getByTestId } = render(<Harness />);
+
+    const event = pressSelectAll(getByTestId("pane"), { isComposing: true });
 
     expect(event.defaultPrevented).toBe(false);
     expect(window.getSelection()?.rangeCount ?? 0).toBe(0);
-  });
-
-  it("leaves an event a higher-priority owner already claimed alone", () => {
-    const { getByTestId } = render(<Harness />);
-    const root = getByTestId("panel-root");
-    // An explicit keybinding or an inner editor handled the chord first.
-    root.addEventListener("keydown", (e) => e.preventDefault(), { once: true });
-
-    pressSelectAll(root);
-
-    expect(window.getSelection()?.rangeCount ?? 0).toBe(0);
-  });
-
-  it("ignores the chord when nothing holds focus", () => {
-    render(<Harness />);
-
-    // body is the keydown target when no element is focused, and it contains
-    // every mounted region — treating it as ownership would let them all fire.
-    const event = pressSelectAll(document.body);
-
-    expect(event.defaultPrevented).toBe(false);
-    expect(window.getSelection()?.rangeCount ?? 0).toBe(0);
+    expectStillLive(getByTestId("body"), getByTestId("pane"));
   });
 
   it("ignores modified variants that are not Select All", () => {
     const { getByTestId } = render(<Harness />);
-    const root = getByTestId("panel-root");
+    const pane = getByTestId("pane");
 
-    expect(pressSelectAll(root, { shiftKey: true }).defaultPrevented).toBe(false);
-    expect(pressSelectAll(root, { altKey: true }).defaultPrevented).toBe(false);
-    expect(pressSelectAll(root, { metaKey: false }).defaultPrevented).toBe(false);
-    expect(pressSelectAll(root, { key: "b" }).defaultPrevented).toBe(false);
+    expect(pressSelectAll(pane, { altKey: true }).defaultPrevented).toBe(false);
+    expect(pressSelectAll(pane, { metaKey: false }).defaultPrevented).toBe(false);
+    expect(pressSelectAll(pane, { key: "b" }).defaultPrevented).toBe(false);
     expect(window.getSelection()?.rangeCount ?? 0).toBe(0);
+
+    expectStillLive(getByTestId("body"), pane);
   });
 
-  it("does nothing while disabled, and detaches on unmount", () => {
-    const { getByTestId, rerender, unmount } = render(<Harness enabled={false} />);
-    const root = getByTestId("panel-root");
+  it("declines a target outside its own pane", () => {
+    const { getByTestId } = render(<Harness />);
+    const outsider = document.createElement("div");
+    outsider.textContent = "sidebar";
+    document.body.appendChild(outsider);
 
-    expect(pressSelectAll(root).defaultPrevented).toBe(false);
+    const event = pressSelectAll(outsider);
 
-    rerender(<Harness enabled={true} />);
-    expect(pressSelectAll(root).defaultPrevented).toBe(true);
-
-    const detached = getByTestId("panel-root");
-    unmount();
-    expect(pressSelectAll(detached).defaultPrevented).toBe(false);
+    expect(event.defaultPrevented).toBe(false);
+    expect(window.getSelection()?.rangeCount ?? 0).toBe(0);
+    expectStillLive(getByTestId("body"), getByTestId("pane"));
+    outsider.remove();
   });
 
-  it("lets only the region owning the keydown target act, with two mounted", () => {
+  it("lets only the pane owning the keydown target act, with two mounted", () => {
     const first = render(<Harness bodyText="first document" />);
     const second = render(<Harness bodyText="second document" />);
     // RTL binds queries to document.body, which now holds both harnesses —
     // reach through each render's own container instead.
-    const secondRoot = second.container.querySelector('[data-testid="panel-root"]');
+    const secondPane = second.container.querySelector<HTMLElement>('[data-testid="pane"]')!;
 
-    pressSelectAll(secondRoot!);
+    pressSelectAll(secondPane);
 
-    // The gate is the event target, not a store flag, so the unfocused pane
-    // stays inert even though its listener is live on the same document.
     expect(selectedText()).toContain("second document");
     expect(selectedText()).not.toContain("first document");
 
@@ -164,15 +231,73 @@ describe("useScopedSelectAll", () => {
     second.unmount();
   });
 
-  it("stays inert when focus is in an unrelated region", () => {
-    render(<Harness />);
-    const outsider = document.createElement("div");
-    document.body.appendChild(outsider);
+  // F6 focuses the grid's macro-region wrapper, which encloses every open pane.
+  // An unbounded "is the target an ancestor?" rule would let each mounted
+  // viewer claim that keypress and leave mount order to pick the winner.
+  it("declines when focus is on an ancestor enclosing several panes", () => {
+    const macroRegion = document.createElement("div");
+    macroRegion.tabIndex = -1;
+    document.body.appendChild(macroRegion);
+    const first = render(<Harness bodyText="first document" />, { container: macroRegion });
+    const second = render(<Harness bodyText="second document" />, {
+      container: macroRegion.appendChild(document.createElement("div")),
+    });
 
-    const event = pressSelectAll(outsider);
+    const event = pressSelectAll(macroRegion);
 
     expect(event.defaultPrevented).toBe(false);
     expect(window.getSelection()?.rangeCount ?? 0).toBe(0);
-    outsider.remove();
+
+    // Both listeners were live and both declined — neither pane won a lottery.
+    const firstPane = first.container.querySelector<HTMLElement>('[data-testid="pane"]')!;
+    expectStillLive(firstPane.querySelector<HTMLElement>('[data-testid="body"]')!, firstPane);
+
+    first.unmount();
+    second.unmount();
+    macroRegion.remove();
+  });
+
+  it("attaches, detaches, and re-attaches its listener with `enabled`", () => {
+    const { getByTestId, rerender } = render(<Harness enabled={false} />);
+    const pane = getByTestId("pane");
+
+    expect(pressSelectAll(pane).defaultPrevented).toBe(false);
+
+    rerender(<Harness enabled={true} />);
+    expect(pressSelectAll(pane).defaultPrevented).toBe(true);
+    clearSelection();
+
+    rerender(<Harness enabled={false} />);
+    expect(pressSelectAll(pane).defaultPrevented).toBe(false);
+    expect(window.getSelection()?.rangeCount ?? 0).toBe(0);
+
+    rerender(<Harness enabled={true} />);
+    expect(pressSelectAll(pane).defaultPrevented).toBe(true);
+  });
+
+  it("removes the exact listener it added on unmount", () => {
+    // Unmount also detaches the tree, so a keydown after it can't reach
+    // `document` either way — the only honest proof is handler identity.
+    const added = new Set<EventListenerOrEventListenerObject>();
+    const addSpy = vi
+      .spyOn(document, "addEventListener")
+      .mockImplementation((type, handler, opts) => {
+        if (type === "keydown") added.add(handler);
+        return HTMLDocument.prototype.addEventListener.call(document, type, handler, opts);
+      });
+
+    const { unmount } = render(<Harness />);
+    addSpy.mockRestore();
+    expect(added.size).toBe(1);
+
+    const removed = new Set<EventListenerOrEventListenerObject>();
+    vi.spyOn(document, "removeEventListener").mockImplementation((type, handler, opts) => {
+      if (type === "keydown") removed.add(handler);
+      return HTMLDocument.prototype.removeEventListener.call(document, type, handler, opts);
+    });
+
+    unmount();
+
+    expect([...added].every((handler) => removed.has(handler))).toBe(true);
   });
 });

--- a/src/hooks/__tests__/useScopedSelectAll.test.tsx
+++ b/src/hooks/__tests__/useScopedSelectAll.test.tsx
@@ -1,0 +1,178 @@
+// @vitest-environment jsdom
+import { useRef } from "react";
+import { render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useScopedSelectAll } from "../useScopedSelectAll";
+
+/**
+ * Mirrors the real shape the hook has to cope with: DOM focus sits on the
+ * panel root (`ContentPanel`'s `tabIndex={-1}` div), which is an *ancestor* of
+ * the viewer body — so the interception can never be a listener on the body
+ * itself. `#chrome` stands in for the sidebar/toolbar the native command
+ * wrongly swept into the selection (#12135).
+ */
+function Harness({ enabled = true, bodyText = "document text" }) {
+  const ref = useRef<HTMLDivElement>(null);
+  useScopedSelectAll(ref, enabled);
+  return (
+    <div data-testid="panel-root" tabIndex={-1}>
+      <div data-testid="toolbar">
+        <input data-testid="search" />
+        <button type="button" data-testid="toolbar-button">
+          Refresh
+        </button>
+      </div>
+      <div data-testid="body" ref={ref}>
+        <p>{bodyText}</p>
+        <a href="#x" data-testid="doc-link">
+          link
+        </a>
+      </div>
+    </div>
+  );
+}
+
+function pressSelectAll(target: Element, init: Partial<KeyboardEventInit> = {}): KeyboardEvent {
+  const event = new KeyboardEvent("keydown", {
+    key: "a",
+    metaKey: true,
+    bubbles: true,
+    cancelable: true,
+    ...init,
+  });
+  target.dispatchEvent(event);
+  return event;
+}
+
+function selectedText(): string {
+  return window.getSelection()?.toString() ?? "";
+}
+
+beforeEach(() => {
+  window.getSelection()?.removeAllRanges();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  window.getSelection()?.removeAllRanges();
+});
+
+describe("useScopedSelectAll", () => {
+  it("scopes Cmd+A to the region when focus sits on an ancestor panel root", () => {
+    const { getByTestId } = render(<Harness />);
+
+    const event = pressSelectAll(getByTestId("panel-root"));
+
+    // preventDefault is the half that suppresses Electron's native accelerator:
+    // AppKit never sees a key the page already handled.
+    expect(event.defaultPrevented).toBe(true);
+    const range = window.getSelection()?.getRangeAt(0);
+    expect(range?.commonAncestorContainer).toBe(getByTestId("body"));
+    expect(selectedText()).toContain("document text");
+    expect(selectedText()).not.toContain("Refresh");
+  });
+
+  it("also claims the chord when focus is inside the region", () => {
+    const { getByTestId } = render(<Harness />);
+
+    const event = pressSelectAll(getByTestId("doc-link"));
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(window.getSelection()?.getRangeAt(0).commonAncestorContainer).toBe(getByTestId("body"));
+  });
+
+  it("treats Ctrl+A the same way, for Windows and Linux", () => {
+    const { getByTestId } = render(<Harness />);
+
+    const event = pressSelectAll(getByTestId("panel-root"), { metaKey: false, ctrlKey: true });
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(selectedText()).toContain("document text");
+  });
+
+  it("leaves Cmd+A in a text field alone", () => {
+    const { getByTestId } = render(<Harness />);
+
+    const event = pressSelectAll(getByTestId("search"));
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(window.getSelection()?.rangeCount ?? 0).toBe(0);
+  });
+
+  it("leaves an event a higher-priority owner already claimed alone", () => {
+    const { getByTestId } = render(<Harness />);
+    const root = getByTestId("panel-root");
+    // An explicit keybinding or an inner editor handled the chord first.
+    root.addEventListener("keydown", (e) => e.preventDefault(), { once: true });
+
+    pressSelectAll(root);
+
+    expect(window.getSelection()?.rangeCount ?? 0).toBe(0);
+  });
+
+  it("ignores the chord when nothing holds focus", () => {
+    render(<Harness />);
+
+    // body is the keydown target when no element is focused, and it contains
+    // every mounted region — treating it as ownership would let them all fire.
+    const event = pressSelectAll(document.body);
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(window.getSelection()?.rangeCount ?? 0).toBe(0);
+  });
+
+  it("ignores modified variants that are not Select All", () => {
+    const { getByTestId } = render(<Harness />);
+    const root = getByTestId("panel-root");
+
+    expect(pressSelectAll(root, { shiftKey: true }).defaultPrevented).toBe(false);
+    expect(pressSelectAll(root, { altKey: true }).defaultPrevented).toBe(false);
+    expect(pressSelectAll(root, { metaKey: false }).defaultPrevented).toBe(false);
+    expect(pressSelectAll(root, { key: "b" }).defaultPrevented).toBe(false);
+    expect(window.getSelection()?.rangeCount ?? 0).toBe(0);
+  });
+
+  it("does nothing while disabled, and detaches on unmount", () => {
+    const { getByTestId, rerender, unmount } = render(<Harness enabled={false} />);
+    const root = getByTestId("panel-root");
+
+    expect(pressSelectAll(root).defaultPrevented).toBe(false);
+
+    rerender(<Harness enabled={true} />);
+    expect(pressSelectAll(root).defaultPrevented).toBe(true);
+
+    const detached = getByTestId("panel-root");
+    unmount();
+    expect(pressSelectAll(detached).defaultPrevented).toBe(false);
+  });
+
+  it("lets only the region owning the keydown target act, with two mounted", () => {
+    const first = render(<Harness bodyText="first document" />);
+    const second = render(<Harness bodyText="second document" />);
+    // RTL binds queries to document.body, which now holds both harnesses —
+    // reach through each render's own container instead.
+    const secondRoot = second.container.querySelector('[data-testid="panel-root"]');
+
+    pressSelectAll(secondRoot!);
+
+    // The gate is the event target, not a store flag, so the unfocused pane
+    // stays inert even though its listener is live on the same document.
+    expect(selectedText()).toContain("second document");
+    expect(selectedText()).not.toContain("first document");
+
+    first.unmount();
+    second.unmount();
+  });
+
+  it("stays inert when focus is in an unrelated region", () => {
+    render(<Harness />);
+    const outsider = document.createElement("div");
+    document.body.appendChild(outsider);
+
+    const event = pressSelectAll(outsider);
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(window.getSelection()?.rangeCount ?? 0).toBe(0);
+    outsider.remove();
+  });
+});

--- a/src/hooks/__tests__/useScopedSelectAll.test.tsx
+++ b/src/hooks/__tests__/useScopedSelectAll.test.tsx
@@ -257,6 +257,27 @@ describe("useScopedSelectAll", () => {
     macroRegion.remove();
   });
 
+  // A panel opened as a dialog puts Close and "Open as panel" in the dialog
+  // header — outside the panel root, inside the dialog — and AppDialog focuses
+  // one of them on open, so that is where the first Cmd+A lands.
+  it("claims the chord from the dialog header above its own pane", () => {
+    const { getByTestId } = render(
+      <div role="dialog" data-testid="dialog">
+        <header>
+          <button type="button" data-testid="dialog-close">
+            Close
+          </button>
+        </header>
+        <Harness />
+      </div>
+    );
+
+    const event = pressSelectAll(getByTestId("dialog-close"));
+
+    expect(event.defaultPrevented).toBe(true);
+    expectSelectedWholeOf(getByTestId("body"));
+  });
+
   it("attaches, detaches, and re-attaches its listener with `enabled`", () => {
     const { getByTestId, rerender } = render(<Harness enabled={false} />);
     const pane = getByTestId("pane");

--- a/src/hooks/useScopedSelectAll.ts
+++ b/src/hooks/useScopedSelectAll.ts
@@ -8,6 +8,27 @@ import { useEffect, useEffectEvent, type RefObject } from "react";
 const SELECT_ALL_SCOPE = "[data-panel-id],[role='dialog'],[role='alertdialog']";
 
 /**
+ * Does `target` sit in one of the surfaces enclosing `container`?
+ *
+ * The chain is walked rather than stopped at the nearest match because the two
+ * nest: a panel opened as a dialog puts its Close and "Open as panel" controls
+ * in the dialog header, *outside* the panel root but inside the dialog — and
+ * AppDialog focuses one of them as the dialog opens, so that is where the very
+ * first Cmd+A lands.
+ */
+function isTargetInScope(container: Element, target: Element): boolean {
+  let scope = container.closest(SELECT_ALL_SCOPE);
+  // Unhosted region: fall back to the container, so focus landing inside it
+  // still counts.
+  if (!scope) return container.contains(target);
+  while (scope) {
+    if (scope.contains(target)) return true;
+    scope = scope.parentElement?.closest(SELECT_ALL_SCOPE) ?? null;
+  }
+  return false;
+}
+
+/**
  * Give a read-only rendered region an owner for Select All.
  *
  * The Edit menu's Select All is a native accelerator that ends in
@@ -43,11 +64,11 @@ const SELECT_ALL_SCOPE = "[data-panel-id],[role='dialog'],[role='alertdialog']";
  * the file tree beside the preview, and Select All should mean "the document
  * I'm looking at" in all of them.
  *
- * Bounding it at that scope rather than walking ancestors freely is what keeps
- * the rule single-valued. F6 focuses the grid's macro-region wrapper, which
- * encloses *every* open pane; an unbounded "is the target an ancestor?" test
- * would make each mounted viewer claim that keypress and let mount order pick
- * the winner. Outside its own pane, a viewer declines.
+ * Bounding it at those surfaces rather than walking ancestors freely is what
+ * keeps the rule single-valued. F6 focuses the grid's macro-region wrapper,
+ * which encloses *every* open pane; an unbounded "is the target an ancestor?"
+ * test would make each mounted viewer claim that keypress and let mount order
+ * pick the winner. Outside its own pane or dialog, a viewer declines.
  */
 export function useScopedSelectAll(
   ref: RefObject<HTMLElement | null>,
@@ -76,10 +97,7 @@ export function useScopedSelectAll(
       return;
     }
 
-    // No enclosing pane or dialog: fall back to the region itself, so an
-    // unhosted viewer still owns focus landing inside it.
-    const scope = container.closest(SELECT_ALL_SCOPE) ?? container;
-    if (!scope.contains(target)) return;
+    if (!isTargetInScope(container, target)) return;
 
     event.preventDefault();
     event.stopPropagation();

--- a/src/hooks/useScopedSelectAll.ts
+++ b/src/hooks/useScopedSelectAll.ts
@@ -1,0 +1,81 @@
+import { useEffect, useEffectEvent, type RefObject } from "react";
+
+/**
+ * Give a read-only rendered region an owner for Select All.
+ *
+ * The Edit menu's Select All is a native accelerator that ends in
+ * `webContents.selectAll()` (electron/menu.ts). Chromium only scopes that
+ * command to the focused element when the element is *editable*; with focus on
+ * plain non-editable DOM it falls back to selecting the whole document — the
+ * sidebar, toolbars and tree along with the text the user is actually reading
+ * (#12135). CodeMirror and xterm escape this because both bind the chord
+ * themselves and `preventDefault()` it; a rendered Markdown document or diff
+ * has no such owner.
+ *
+ * `registerAccelerator: false` cannot be the fix: it is a Windows/Linux knob and
+ * a no-op on macOS, where the accelerator always binds as an AppKit key
+ * equivalent. The renderer gets the keydown first, though, and AppKit never
+ * sees a key the page has already handled — so preventing the event here is
+ * what suppresses the native command, on every platform.
+ *
+ * ## Why the listener is on `document`
+ *
+ * A listener on `ref.current` would never fire. Keydown bubbles up from the
+ * focused element, and for a focused pane that element is `ContentPanel`'s
+ * `tabIndex={-1}` root — an *ancestor* of the viewer body, not a descendant.
+ * Hence a document-level listener plus an explicit ownership test.
+ *
+ * ## Ownership
+ *
+ * The keydown target is the focused element, and exactly one element is focused
+ * per document, so the target alone decides which mounted region owns the
+ * chord — no `isFocused` prop, and stacked dialogs sort themselves out. Focus
+ * either sits inside the region (a Markdown link, a diff's focusable rows) or on
+ * an ancestor that wraps it (the panel root, a dialog's focus sink), so both
+ * containment directions count. `body`/`documentElement` are excluded: they are
+ * the target when *nothing* holds focus, and they contain every mounted region,
+ * so treating them as ownership would let every instance claim the key at once.
+ */
+export function useScopedSelectAll(
+  ref: RefObject<HTMLElement | null>,
+  enabled: boolean = true
+): void {
+  const handleKeyDown = useEffectEvent((event: KeyboardEvent) => {
+    if (!(event.metaKey || event.ctrlKey) || event.altKey || event.shiftKey) return;
+    if (event.key !== "a" && event.key !== "A") return;
+    // A higher-priority owner already claimed the chord — an explicit user
+    // keybinding, or an editor that handled it on the way up. Never override.
+    if (event.defaultPrevented) return;
+
+    const container = ref.current;
+    if (!container) return;
+
+    const target = event.target;
+    if (!(target instanceof Element)) return;
+    // Select All inside a text field must stay Select All *of that field*.
+    if (
+      target.tagName === "INPUT" ||
+      target.tagName === "TEXTAREA" ||
+      (target instanceof HTMLElement && target.isContentEditable)
+    ) {
+      return;
+    }
+
+    const doc = container.ownerDocument;
+    if (target === doc.body || target === doc.documentElement) return;
+    if (!container.contains(target) && !target.contains(container)) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+    doc.defaultView?.getSelection()?.selectAllChildren(container);
+  });
+
+  useEffect(() => {
+    if (!enabled) return;
+    const handler = (event: KeyboardEvent) => handleKeyDown(event);
+    // Bubble phase, so anything inside the region that owns the chord for
+    // itself still gets it first.
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [enabled]);
+}

--- a/src/hooks/useScopedSelectAll.ts
+++ b/src/hooks/useScopedSelectAll.ts
@@ -1,6 +1,13 @@
 import { useEffect, useEffectEvent, type RefObject } from "react";
 
 /**
+ * The surfaces that bound a Select All. A viewer body owns the chord for the
+ * pane or dialog it lives in — `ContentPanel`'s root carries `data-panel-id`,
+ * `AppDialog`'s content carries the dialog role — and for nothing outside it.
+ */
+const SELECT_ALL_SCOPE = "[data-panel-id],[role='dialog'],[role='alertdialog']";
+
+/**
  * Give a read-only rendered region an owner for Select All.
  *
  * The Edit menu's Select All is a native accelerator that ends in
@@ -21,20 +28,26 @@ import { useEffect, useEffectEvent, type RefObject } from "react";
  * ## Why the listener is on `document`
  *
  * A listener on `ref.current` would never fire. Keydown bubbles up from the
- * focused element, and for a focused pane that element is `ContentPanel`'s
- * `tabIndex={-1}` root — an *ancestor* of the viewer body, not a descendant.
- * Hence a document-level listener plus an explicit ownership test.
+ * focused element, and that element is rarely inside the viewer body: a focused
+ * pane puts it on `ContentPanel`'s `tabIndex={-1}` root, an *ancestor*, and the
+ * file browser leaves it on the tree root, a *sibling*. Hence a document-level
+ * listener plus an explicit ownership test.
  *
  * ## Ownership
  *
  * The keydown target is the focused element, and exactly one element is focused
  * per document, so the target alone decides which mounted region owns the
- * chord — no `isFocused` prop, and stacked dialogs sort themselves out. Focus
- * either sits inside the region (a Markdown link, a diff's focusable rows) or on
- * an ancestor that wraps it (the panel root, a dialog's focus sink), so both
- * containment directions count. `body`/`documentElement` are excluded: they are
- * the target when *nothing* holds focus, and they contain every mounted region,
- * so treating them as ownership would let every instance claim the key at once.
+ * chord — no `isFocused` prop, and stacked panes and dialogs sort themselves
+ * out. Ownership is the region's *enclosing pane or dialog*, not the region
+ * itself: focus legitimately rests on the pane root, on a toolbar button, or on
+ * the file tree beside the preview, and Select All should mean "the document
+ * I'm looking at" in all of them.
+ *
+ * Bounding it at that scope rather than walking ancestors freely is what keeps
+ * the rule single-valued. F6 focuses the grid's macro-region wrapper, which
+ * encloses *every* open pane; an unbounded "is the target an ancestor?" test
+ * would make each mounted viewer claim that keypress and let mount order pick
+ * the winner. Outside its own pane, a viewer declines.
  */
 export function useScopedSelectAll(
   ref: RefObject<HTMLElement | null>,
@@ -43,6 +56,8 @@ export function useScopedSelectAll(
   const handleKeyDown = useEffectEvent((event: KeyboardEvent) => {
     if (!(event.metaKey || event.ctrlKey) || event.altKey || event.shiftKey) return;
     if (event.key !== "a" && event.key !== "A") return;
+    // Mid-composition the keystroke belongs to the IME, not to us.
+    if (event.isComposing) return;
     // A higher-priority owner already claimed the chord — an explicit user
     // keybinding, or an editor that handled it on the way up. Never override.
     if (event.defaultPrevented) return;
@@ -61,13 +76,14 @@ export function useScopedSelectAll(
       return;
     }
 
-    const doc = container.ownerDocument;
-    if (target === doc.body || target === doc.documentElement) return;
-    if (!container.contains(target) && !target.contains(container)) return;
+    // No enclosing pane or dialog: fall back to the region itself, so an
+    // unhosted viewer still owns focus landing inside it.
+    const scope = container.closest(SELECT_ALL_SCOPE) ?? container;
+    if (!scope.contains(target)) return;
 
     event.preventDefault();
     event.stopPropagation();
-    doc.defaultView?.getSelection()?.selectAllChildren(container);
+    container.ownerDocument.defaultView?.getSelection()?.selectAllChildren(container);
   });
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

- Pressing Cmd+A (or Ctrl+A) in a file viewer selected everything in the app: sidebar, toolbars, file tree, all of it, instead of just the document on screen.
- Root cause is that Edit → Select All is a native Electron accelerator that calls `webContents.selectAll()` (`electron/menu.ts:360-368`). Chromium only scopes that command to the focused element when the element is editable; over plain non-editable DOM it falls back to selecting the whole document. CodeMirror and xterm dodge this because both bind the key combination themselves and call `preventDefault()`. Rendered Markdown and diff views had no such handler.
- `registerAccelerator: false` can't fix this either. That flag only works on Windows and Linux, and is a no-op on macOS, where the renderer sees the keydown before AppKit's key-equivalent fallback runs. Calling `preventDefault()` in the renderer is what actually suppresses the native command, on every platform.

Resolves #12135

## Changes

- New hook, `src/hooks/useScopedSelectAll.ts`: a document-level, bubble-phase Cmd/Ctrl+A interceptor that calls `preventDefault()` and runs `Selection.selectAllChildren` scoped to its own region.
- Wired into `MarkdownDocument` and `DiffViewer`, so every place that hosts either one is covered with no focus props threaded through: the file viewer pane, the file browser preview, the diff pane, and the cross-worktree diff dialog.
- Ownership of the key combination is decided by the keydown event's actual target, which is always the currently focused element, rather than by a store flag. That lets stacked panes and dialogs sort themselves out on their own. A viewer only owns the key combination for its own enclosing pane or dialog, never anything outside it.
- The implementation walks the full chain of ancestor scopes rather than stopping at the first match, because a panel opened as a dialog puts its Close button and "Open as panel" control in the dialog header, outside the panel's own root but still inside the dialog, and that's where `AppDialog` puts initial keyboard focus.
- Deliberately left unchanged: Cmd+A inside an INPUT, TEXTAREA, or contenteditable element; a keydown a user keybinding or inner editor already handled; a keydown mid IME composition; and anything focused outside the viewer's own pane.

**Known limitations:**

- Clicking Edit → Select All with the mouse doesn't generate a renderer keydown at all, so that path still falls through to `webContents.selectAll()`. Scoping the menu item itself needs separate action and IPC plumbing, out of scope here since the issue is specifically about the keyboard shortcut.
- Separate, pre-existing issue in `WorktreeOverviewModal`: its own document-level Cmd+A handler has no containment check and ignores `defaultPrevented`, so it can bulk-select worktrees behind a dialog opened above it. Not caused or worsened by this change, left alone.

## Testing

- `npm test` on all 43 test files covering every changed module: 1141 tests passed.
- `npm run typecheck`: clean.
- `prettier --check` on the six changed files: all formatted correctly.
- `eslint` on the six changed files: zero errors, warning counts per file match the existing baseline exactly (`DiffViewer.tsx` 5 pre-existing warnings, `DiffViewer.test.tsx` 9, the other four files zero).
- Mutation check: disabling the new hook's listener failed 17 of the 18 new tests, confirming the suite isn't vacuous.
- Not run locally, left to CI: the full monorepo `npm test`, `npm run check`, a production build, and end-to-end tests.