### PR TITLE
perf(switching): reduce layout delta payload and capture cost

### DIFF
--- a/electron/ipc/handlers/projectCrud/switch.ts
+++ b/electron/ipc/handlers/projectCrud/switch.ts
@@ -27,7 +27,11 @@ import {
   TERMINAL_FIELD_LEVEL_MERGE,
 } from "../terminalLayout.js";
 import { sanitizeTabGroups } from "../../../schemas/index.js";
-import { mergeIdArray, mergeRecord } from "../../../../shared/utils/layoutMerge.js";
+import {
+  decodeIdArrayDelta,
+  mergeIdArray,
+  mergeRecord,
+} from "../../../../shared/utils/layoutMerge.js";
 import type { HandlerDependencies, IpcContext } from "../../types.js";
 import type { Project } from "../../../types/index.js";
 import type { ProjectSwitchOutgoingState } from "../../../../shared/types/ipc/project.js";
@@ -362,6 +366,14 @@ async function persistOutgoingProjectState(
   await projectStore.enqueueProjectStateUpdate(previousProjectId, (existing) => {
     const terminalDelta = outgoingState.terminalDelta;
     const tabGroupDelta = outgoingState.tabGroupDelta;
+    const decodedTerminalDelta =
+      terminalDelta && outgoingState.terminals
+        ? decodeIdArrayDelta(terminalDelta, outgoingState.terminals)
+        : undefined;
+    const decodedTabGroupDelta =
+      tabGroupDelta && outgoingState.tabGroups
+        ? decodeIdArrayDelta(tabGroupDelta, outgoingState.tabGroups)
+        : undefined;
     // With a delta, merge by id so a stale outgoing snapshot only affects the
     // entries this window actually changed, preserving a sibling window's
     // concurrent additions/moves/deletions (#11350). Without one, fall back to
@@ -369,30 +381,30 @@ async function persistOutgoingProjectState(
     const mergedTerminals =
       validTerminals === undefined
         ? undefined
-        : terminalDelta
+        : decodedTerminalDelta
           ? mergeIdArray(
               existing?.terminals ?? [],
               validTerminals,
-              terminalDelta.changedIds,
-              terminalDelta.removedIds,
+              decodedTerminalDelta.changedIds,
+              decodedTerminalDelta.removedIds,
               {
                 // Same out-of-band-field policy as the setTerminals handler: a
                 // stale outgoing snapshot must not erase a session id Main
                 // captured on shutdown (#11461).
                 fieldLevelMerge: TERMINAL_FIELD_LEVEL_MERGE,
-                fieldEdits: sanitizeFieldEdits(terminalDelta.fieldEdits),
+                fieldEdits: sanitizeFieldEdits(decodedTerminalDelta.fieldEdits),
               }
             )
           : validTerminals;
     const mergedTabGroups =
       validTabGroups === undefined
         ? undefined
-        : tabGroupDelta
+        : decodedTabGroupDelta
           ? mergeIdArray(
               existing?.tabGroups ?? [],
               validTabGroups,
-              tabGroupDelta.changedIds,
-              tabGroupDelta.removedIds
+              decodedTabGroupDelta.changedIds,
+              decodedTabGroupDelta.removedIds
             )
           : validTabGroups;
     // Sizes carry no delta metadata, so a full replace would drop the entries a

--- a/shared/types/ipc/project.ts
+++ b/shared/types/ipc/project.ts
@@ -1,7 +1,7 @@
 import type { Project, TerminalSnapshot } from "../project.js";
 import type { TabGroup } from "../panel.js";
 import type { AgentState, WaitingReason } from "../agent.js";
-import type { IdArrayDelta } from "../../utils/layoutMerge.js";
+import type { IdArrayDelta, IdArrayDeltaWire } from "../../utils/layoutMerge.js";
 import type { HydrateResult } from "./app.js";
 
 /**
@@ -64,8 +64,8 @@ export interface ProjectSwitchOutgoingState {
    * doesn't clobber that window's concurrent layout changes (#11350). Absent =
    * legacy full replace.
    */
-  terminalDelta?: IdArrayDelta;
-  tabGroupDelta?: IdArrayDelta;
+  terminalDelta?: IdArrayDeltaWire;
+  tabGroupDelta?: IdArrayDeltaWire;
   /**
    * What this window changed in `draftInputs` relative to its last-persisted
    * baseline (`changedIds`/`removedIds` are terminal ids). When present, Main

--- a/shared/utils/__tests__/layoutMerge.test.ts
+++ b/shared/utils/__tests__/layoutMerge.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   computeIdArrayDelta,
+  decodeIdArrayDelta,
   mergeIdArray,
   deepEqualIgnoringUndefined,
   computeRecordDelta,
@@ -43,6 +44,37 @@ describe("deepEqualIgnoringUndefined", () => {
   it("does not conflate a real key with an undefined-valued one of a different name", () => {
     expect(deepEqualIgnoringUndefined({ id: "p", a: undefined }, { id: "p", b: 1 })).toBe(false);
   });
+
+  it("matches JSON semantics for omitted object values and null-like array values", () => {
+    expect(
+      deepEqualIgnoringUndefined(
+        { id: "p", ignored: () => undefined, alsoIgnored: Symbol("x") },
+        { id: "p" }
+      )
+    ).toBe(true);
+    expect(deepEqualIgnoringUndefined([undefined, Number.NaN, Infinity], [null, null, null])).toBe(
+      true
+    );
+  });
+
+  it("ignores object key order without ignoring array order", () => {
+    expect(
+      deepEqualIgnoringUndefined(
+        { id: "p", nested: { b: 2, a: 1 } },
+        { nested: { a: 1, b: 2 }, id: "p" }
+      )
+    ).toBe(true);
+    expect(deepEqualIgnoringUndefined(["a", "b"], ["b", "a"])).toBe(false);
+  });
+
+  it("treats non-serializable nested values as changed", () => {
+    expect(deepEqualIgnoringUndefined({ id: "p", value: 1n }, { id: "p", value: 1n })).toBe(false);
+    const left: { id: string; self?: unknown } = { id: "p" };
+    const right: { id: string; self?: unknown } = { id: "p" };
+    left.self = left;
+    right.self = right;
+    expect(deepEqualIgnoringUndefined(left, right)).toBe(false);
+  });
 });
 
 describe("computeIdArrayDelta with JSON-round-trip equality", () => {
@@ -56,6 +88,29 @@ describe("computeIdArrayDelta with JSON-round-trip equality", () => {
 });
 
 describe("computeIdArrayDelta", () => {
+  it("round-trips the compact switch wire shape without repeating changed ids", () => {
+    const base = [
+      { id: "unchanged", v: "a" },
+      { id: "long-changed-panel-id", v: "b" },
+      { id: "removed", v: "c" },
+    ];
+    const current = [
+      { id: "unchanged", v: "a" },
+      { id: "long-changed-panel-id", v: "new" },
+    ];
+    const delta = computeIdArrayDelta(base, current, eq);
+
+    expect(delta.changedIds).toEqual(["long-changed-panel-id"]);
+    expect(delta.removedIds).toEqual(["removed"]);
+    expect(JSON.stringify(delta)).not.toContain("long-changed-panel-id");
+
+    const wire = structuredClone(delta);
+    expect(decodeIdArrayDelta(wire, current)).toEqual({
+      changedIds: ["long-changed-panel-id"],
+      removedIds: ["removed"],
+    });
+  });
+
   it("reports added ids as changed", () => {
     const delta = computeIdArrayDelta([{ id: "1" }], [{ id: "1" }, { id: "2" }], eq);
     expect(delta.changedIds).toEqual(["2"]);

--- a/shared/utils/layoutMerge.ts
+++ b/shared/utils/layoutMerge.ts
@@ -73,6 +73,24 @@ export interface IdArrayDelta {
   fieldEdits?: IdArrayFieldEdit[];
 }
 
+type CompactFieldEdit = readonly [currentIndex: number, fields: readonly string[]];
+
+/**
+ * Structured-clone representation used on project-switch IPC. Changed entries
+ * already exist in the accompanying current array, so their positions carry
+ * the same authority without repeating every id on the wire. Removals retain
+ * ids because the removed entries are necessarily absent from that array.
+ */
+export type IdArrayDeltaWire =
+  | IdArrayDelta
+  | readonly [
+      changedIndices: readonly number[],
+      removedIds: readonly string[],
+      fieldEdits?: readonly CompactFieldEdit[],
+    ];
+
+type CompactIdArrayDelta = IdArrayDelta & Exclude<IdArrayDeltaWire, IdArrayDelta>;
+
 function hasStringId(entry: unknown): entry is { id: string } {
   return (
     typeof entry === "object" &&
@@ -82,27 +100,142 @@ function hasStringId(entry: unknown): entry is { id: string } {
   );
 }
 
-/**
- * Recursively rewrite a value into the exact shape JSON serialization would
- * produce: `undefined`-valued object keys are dropped, `undefined`/hole array
- * elements and non-finite numbers become `null`, and object keys are sorted so
- * ordering never matters. Functions/symbols are dropped by JSON downstream.
- */
-function canonicalizeForJson(value: unknown): unknown {
-  if (value === null || typeof value !== "object") {
-    return value;
+function compactIdArrayDelta<T extends { id: string }>(
+  current: readonly T[],
+  changedIndices: number[],
+  removedIds: string[],
+  fieldEdits: CompactFieldEdit[]
+): CompactIdArrayDelta {
+  const wire: unknown[] =
+    fieldEdits.length > 0 ? [changedIndices, removedIds, fieldEdits] : [changedIndices, removedIds];
+  Object.defineProperties(wire, {
+    changedIds: {
+      get: () =>
+        changedIndices.flatMap((index) => {
+          const entry = current[index];
+          return hasStringId(entry) ? [entry.id] : [];
+        }),
+    },
+    removedIds: { get: () => removedIds },
+    fieldEdits: {
+      get: () =>
+        fieldEdits.length > 0
+          ? fieldEdits.map(([index, fields]) => ({ id: current[index]!.id, fields: [...fields] }))
+          : undefined,
+    },
+  });
+  return wire as unknown as CompactIdArrayDelta;
+}
+
+/** Expand either the compact switch wire shape or the legacy object shape. */
+export function decodeIdArrayDelta<T extends { id: string }>(
+  delta: IdArrayDeltaWire,
+  current: readonly T[]
+): IdArrayDelta {
+  if (!Array.isArray(delta)) return delta as IdArrayDelta;
+
+  const changedIndices = Array.isArray(delta[0]) ? delta[0] : [];
+  const removedIds = Array.isArray(delta[1])
+    ? delta[1].filter((id): id is string => typeof id === "string" && id.length > 0)
+    : [];
+  const changedIds = changedIndices.flatMap((index) => {
+    if (typeof index !== "number" || !Number.isInteger(index) || index < 0) return [];
+    const entry = current[index];
+    return hasStringId(entry) ? [entry.id] : [];
+  });
+  const rawFieldEdits = Array.isArray(delta[2]) ? delta[2] : [];
+  const fieldEdits = rawFieldEdits.flatMap((edit): IdArrayFieldEdit[] => {
+    if (!Array.isArray(edit)) return [];
+    const index = edit[0];
+    if (typeof index !== "number" || !Number.isInteger(index) || index < 0) return [];
+    const entry = current[index];
+    if (!hasStringId(entry) || !Array.isArray(edit[1])) return [];
+    const fields = edit[1].filter(
+      (field): field is string => typeof field === "string" && field.length > 0
+    );
+    return fields.length > 0 ? [{ id: entry.id, fields }] : [];
+  });
+
+  return fieldEdits.length > 0
+    ? { changedIds, removedIds, fieldEdits }
+    : { changedIds, removedIds };
+}
+
+const OMITTED_JSON_VALUE = Symbol("omitted-json-value");
+
+function normalizeJsonScalar(value: unknown, arraySlot: boolean): unknown {
+  if (typeof value === "bigint") throw new TypeError("BigInt is not JSON-serializable");
+  if (typeof value === "number" && !Number.isFinite(value)) return null;
+  if (value === undefined || typeof value === "function" || typeof value === "symbol") {
+    return arraySlot ? null : OMITTED_JSON_VALUE;
   }
-  if (Array.isArray(value)) {
-    return value.map((element) => (element === undefined ? null : canonicalizeForJson(element)));
+  return value;
+}
+
+function jsonObjectKeys(record: Record<string, unknown>): string[] {
+  return Object.keys(record).filter((key) => {
+    const value = record[key];
+    return value !== undefined && typeof value !== "function" && typeof value !== "symbol";
+  });
+}
+
+function jsonValuesEqual(
+  leftValue: unknown,
+  rightValue: unknown,
+  arraySlot: boolean,
+  activeLeft: Set<object>,
+  activeRight: Set<object>
+): boolean {
+  const left = normalizeJsonScalar(leftValue, arraySlot);
+  const right = normalizeJsonScalar(rightValue, arraySlot);
+  if (left === right && (left === null || typeof left !== "object")) return true;
+  if (left === OMITTED_JSON_VALUE || right === OMITTED_JSON_VALUE) return false;
+  if (left === null || right === null || typeof left !== "object" || typeof right !== "object") {
+    return false;
   }
-  const record = value as Record<string, unknown>;
-  const out: Record<string, unknown> = {};
-  for (const key of Object.keys(record).sort()) {
-    if (record[key] !== undefined) {
-      out[key] = canonicalizeForJson(record[key]);
+
+  const leftIsArray = Array.isArray(left);
+  if (leftIsArray !== Array.isArray(right)) return false;
+  if (activeLeft.has(left) || activeRight.has(right)) return false;
+  activeLeft.add(left);
+  activeRight.add(right);
+  try {
+    if (leftIsArray) {
+      const leftArray = left as unknown[];
+      const rightArray = right as unknown[];
+      if (leftArray.length !== rightArray.length) return false;
+      for (let index = 0; index < leftArray.length; index += 1) {
+        if (!jsonValuesEqual(leftArray[index], rightArray[index], true, activeLeft, activeRight)) {
+          return false;
+        }
+      }
+      return true;
     }
+
+    const leftRecord = left as Record<string, unknown>;
+    const rightRecord = right as Record<string, unknown>;
+    const leftKeys = jsonObjectKeys(leftRecord);
+    const rightKeys = jsonObjectKeys(rightRecord);
+    if (leftKeys.length !== rightKeys.length) return false;
+    for (const key of leftKeys) {
+      if (!Object.prototype.hasOwnProperty.call(rightRecord, key)) return false;
+      const rightEntry = rightRecord[key];
+      if (
+        rightEntry === undefined ||
+        typeof rightEntry === "function" ||
+        typeof rightEntry === "symbol"
+      ) {
+        return false;
+      }
+      if (!jsonValuesEqual(leftRecord[key], rightEntry, false, activeLeft, activeRight)) {
+        return false;
+      }
+    }
+    return true;
+  } finally {
+    activeLeft.delete(left);
+    activeRight.delete(right);
   }
-  return out;
 }
 
 /**
@@ -118,7 +251,7 @@ function canonicalizeForJson(value: unknown): unknown {
 export function deepEqualIgnoringUndefined(left: unknown, right: unknown): boolean {
   if (left === right) return true;
   try {
-    return JSON.stringify(canonicalizeForJson(left)) === JSON.stringify(canonicalizeForJson(right));
+    return jsonValuesEqual(left, right, false, new Set(), new Set());
   } catch {
     // Non-serializable input (BigInt, circular): treat as changed so the entry
     // is sent rather than silently dropped from the delta.
@@ -150,34 +283,35 @@ export function computeIdArrayDelta<T extends { id: string }>(
   current: readonly T[],
   equals: (a: T, b: T) => boolean,
   trackedFields?: readonly (keyof T & string)[]
-): IdArrayDelta {
+): CompactIdArrayDelta {
   const baseById = new Map<string, T>();
   for (const entry of base) {
     if (hasStringId(entry)) baseById.set(entry.id, entry);
   }
 
-  const changedIds: string[] = [];
+  const changedIndices: number[] = [];
   const changedSeen = new Set<string>();
-  const fieldEdits: IdArrayFieldEdit[] = [];
+  const fieldEdits: CompactFieldEdit[] = [];
   const currentIds = new Set<string>();
-  for (const entry of current) {
+  for (let index = 0; index < current.length; index += 1) {
+    const entry = current[index];
     if (!hasStringId(entry)) continue;
     currentIds.add(entry.id);
     const prev = baseById.get(entry.id);
     if (prev === undefined || !equals(prev, entry)) {
       changedSeen.add(entry.id);
-      changedIds.push(entry.id);
+      changedIndices.push(index);
     }
     if (trackedFields === undefined || prev === undefined) continue;
     const edited = trackedFields.filter((field) => prev[field] !== entry[field]);
     if (edited.length === 0) continue;
-    fieldEdits.push({ id: entry.id, fields: [...edited] });
+    fieldEdits.push([index, [...edited]]);
     // A claim is only honoured for an entry the writer is allowed to touch, so
     // keep the two lists consistent even if a caller-supplied `equals` ignores
     // the tracked field.
     if (!changedSeen.has(entry.id)) {
       changedSeen.add(entry.id);
-      changedIds.push(entry.id);
+      changedIndices.push(index);
     }
   }
 
@@ -188,10 +322,7 @@ export function computeIdArrayDelta<T extends { id: string }>(
     }
   }
 
-  // Omitted when empty so the common delta keeps its historical shape.
-  return fieldEdits.length > 0
-    ? { changedIds, removedIds, fieldEdits }
-    : { changedIds, removedIds };
+  return compactIdArrayDelta(current, changedIndices, removedIds, fieldEdits);
 }
 
 export interface IdArrayMergeOptions<T> {


### PR DESCRIPTION
## Summary

- encode project-switch terminal and tab-group deltas as compact changed-index tuples on the IPC wire, while preserving removed IDs and exact field authority
- decode those tuples before Main sanitization can shift indices; keep the local object API compatible for existing callers
- replace recursive canonicalize/sort/stringify equality with a direct comparison that preserves the existing JSON-roundtrip semantics
- add regression coverage for wire shape, merge behavior, and the non-JSON values handled by the comparator

## Results

The portable payload measurements are identical on the hosted Linux, Windows, and macOS runners. Absolute deltas are bytes; negative is better.

| OS / runner | Benchmark | Before | After | Absolute | Improvement | Verdict |
| --- | --- | ---: | ---: | ---: | ---: | --- |
| Linux (GitHub) | PERF-070 `payloadBytes.max` | 24,082 B | 23,805 B | -277 B | 1.15% | claim |
| Linux (GitHub) | PERF-071 `payloadBytes.max` | 35,802 B | 35,433 B | -369 B | 1.03% | claim |
| Linux (GitHub) | PERF-072 `payloadBytes.max` | 55,034 B | 54,515 B | -519 B | 0.94% | measured, no claim |
| Windows (GitHub) | PERF-070 `payloadBytes.max` | 24,082 B | 23,805 B | -277 B | 1.15% | claim |
| Windows (GitHub) | PERF-071 `payloadBytes.max` | 35,802 B | 35,433 B | -369 B | 1.03% | claim |
| Windows (GitHub) | PERF-072 `payloadBytes.max` | 55,034 B | 54,515 B | -519 B | 0.94% | measured, no claim |
| macOS (GitHub) | PERF-070 `payloadBytes.max` | 24,082 B | 23,805 B | -277 B | 1.15% | claim |
| macOS (GitHub) | PERF-071 `payloadBytes.max` | 35,802 B | 35,433 B | -369 B | 1.03% | claim |
| macOS (GitHub) | PERF-072 `payloadBytes.max` | 55,034 B | 54,515 B | -519 B | 0.94% | measured, no claim |
| macOS M1 Max (local) | PERF-012 `captureMs.mean`, median arm | 6.918 ms | 3.770 ms | -3.148 ms | 45.5% | claim |

Hosted receipts: [PERF-070](https://github.com/daintreehq/daintree/actions/runs/33508321594), [PERF-071](https://github.com/daintreehq/daintree/actions/runs/33508838842), and [PERF-072](https://github.com/daintreehq/daintree/actions/runs/33509327465).

## Methodology and guards

- branch-point champion: `a208c0e197168c2ace15ad6782e9783ba7e6a320`; candidate: `c84a7a2a77e284b8f351e7266a5295c0fec83a2a`
- payload runs used immutable precommit records, five measured iterations and two warmups, the complete 23-predicate scenario set, and a locked 1% claim threshold; `deepEqualCalls` remained `276 -> 276` for PERF-071
- each hosted workflow used fresh six-arm alternating measurements on one runner per OS and compared the exact same champion/candidate commits; payload byte/count evidence is portable, so hosted durations are intentionally not compared across machines
- the local duration claim used six alternating 40-iteration arms with three warmups, median-of-three, a precommitted 10.1% threshold, and a 10% within-arm CV ceiling; all three pairs won, worst CV was 7.1%, and same-code champion drift was 2.0%
- all ten delta/merge/equality miss predicates were zero for all 40 iterations of every duration arm; all eight non-target guards passed
- the host was shared by several concurrent benchmark worktrees. Contaminated duration interleaves were rejected whole; no arm substitution was used. The accepted run increased iterations only through a fresh immutable protocol recorded before any new arm was measured
- PERF-072 is a real 519-byte reduction, but 0.94% is below the locked 1% threshold, so it is reported without a performance claim
- diff audit: no `scripts/perf/**` files changed. The switch benchmark's production subject lives in `shared/utils/layoutMerge.ts` and `electron/ipc/handlers/projectCrud/switch.ts`; those shared/IPC paths are not currently listed in Area D's ownership catalog and should be added there

## Correctness

- deliberate discovery-break probes made terminal/tab delta and merge misses, single-change misses, and equality-probe misses nonzero before baseline measurement, proving those predicates could fail
- a 576-pair diagnostic found zero semantic differences between the old canonical JSON comparator and the direct comparator
- `shared/utils/__tests__/layoutMerge.test.ts`: 56/56 passed
- `npm run typecheck`: passed
- `npm test`: 54,189 passed, 7 skipped, 1 todo; the sole failing file was `scenarioLiveness.test.ts`, whose exact PERF-053/054/055/056/074/075/076/077/080, 320–325, 340–343, and 391 runtime-unavailable set reproduces on the untouched branch point
- focused PERF-371 rerun on the final candidate: 32/32 passed
- `npm run check`: passed, including typecheck, IPC/API-surface ratchets, lint, and formatting
- [GitHub CI](https://github.com/daintreehq/daintree/actions/runs/33510628133): passed repository check, build, all four unit-test shards, and required `ci-ok`
- E2E was not run, per repository and optimize workflow policy
