### PR TITLE
feat(file-viewer): add a copy file contents button

### DIFF
--- a/src/components/FileViewer/FileViewerToolbar.tsx
+++ b/src/components/FileViewer/FileViewerToolbar.tsx
@@ -1,6 +1,6 @@
-import { useLayoutEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { useToolbarRoving } from "@/hooks/useToolbarRoving";
-import { Check, FileText } from "lucide-react";
+import { Check, Copy, FileText } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
@@ -247,4 +247,89 @@ function IconButton({
   );
 }
 
-export const FileViewerToolbar = { Root, Path, Actions, IconButton };
+/**
+ * How long a copy confirmation stays on screen. One value for the one shared
+ * button, rather than a prop: the two panes' own path pills already flash for
+ * different durations, and handing this control the same seam is how the next
+ * divergence would get in.
+ */
+const COPY_FEEDBACK_MS = 2000;
+
+/**
+ * Copies the file's raw text — the bytes the source view shows, whichever view
+ * mode is on screen, so rendered markdown and rendered HTML copy their source
+ * rather than the DOM they produced.
+ *
+ * Stateful where the rest of this namespace is chrome, and deliberately so:
+ * both file viewers need this action and neither should be able to grow it
+ * without the other (#12136). Owning the copied flag, the timer and the
+ * clipboard call here is what makes that structural rather than a convention
+ * two large panes have to keep. `Actions` stays a plain slot — DiffPane renders
+ * one too and holds diff hunks, not raw file text.
+ *
+ * `contents === null` renders nothing: a read still in flight, an image, an SVG
+ * (both viewers keep only sanitized markup), or a read that failed as binary,
+ * oversized or an LFS pointer. An empty file is `""` and stays copyable, so the
+ * gate is a null check and never a truthiness one.
+ */
+function CopyContentsButton({ contents }: { contents: string | null }) {
+  const [copied, setCopied] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Invalidates a write still in flight when the contents change underneath it
+  // or the button unmounts, so a late resolution can't flash a checkmark for
+  // text that is no longer what a click would copy. Same guard as
+  // DiagnosticCopyButton, which faces the same race.
+  const generationRef = useRef(0);
+
+  useEffect(() => {
+    generationRef.current += 1;
+    setCopied(false);
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+  }, [contents]);
+
+  useEffect(() => {
+    return () => {
+      generationRef.current += 1;
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, []);
+
+  const handleClick = useCallback(() => {
+    if (contents === null) return;
+    if (!navigator.clipboard?.writeText) return;
+    const generation = generationRef.current;
+    void navigator.clipboard.writeText(contents).then(
+      () => {
+        if (generation !== generationRef.current) return;
+        if (timeoutRef.current) clearTimeout(timeoutRef.current);
+        setCopied(true);
+        timeoutRef.current = setTimeout(() => {
+          setCopied(false);
+          timeoutRef.current = null;
+        }, COPY_FEEDBACK_MS);
+      },
+      () => {
+        // Clipboard unavailable or refused. Silent, exactly like the path pill
+        // above: the checkmark simply never appears, and a toast for a gesture
+        // whose whole feedback is on the button would be the louder tier.
+      }
+    );
+  }, [contents]);
+
+  if (contents === null) return null;
+
+  return (
+    <IconButton label="Copy file contents" onClick={handleClick}>
+      {copied ? (
+        <Check className={cn(TOOLBAR_ICON_CLASS, "text-status-success")} />
+      ) : (
+        <Copy className={TOOLBAR_ICON_CLASS} />
+      )}
+    </IconButton>
+  );
+}
+
+export const FileViewerToolbar = { Root, Path, Actions, IconButton, CopyContentsButton };

--- a/src/components/FileViewer/FileViewerToolbar.tsx
+++ b/src/components/FileViewer/FileViewerToolbar.tsx
@@ -273,26 +273,22 @@ const COPY_FEEDBACK_MS = 2000;
  * gate is a null check and never a truthiness one.
  */
 function CopyContentsButton({ contents }: { contents: string | null }) {
-  const [copied, setCopied] = useState(false);
+  // The text the clipboard was last confirmed to hold, not a boolean. The
+  // checkmark then belongs to a value rather than to a moment: new contents
+  // retire it in the very commit that paints them instead of a frame later via
+  // an effect, and a write that resolves late can only ever confirm the text it
+  // actually wrote. That is one piece of state doing what a flag plus a reset
+  // effect plus a generation counter were doing before.
+  const [copiedContents, setCopiedContents] = useState<string | null>(null);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  // Invalidates a write still in flight when the contents change underneath it
-  // or the button unmounts, so a late resolution can't flash a checkmark for
-  // text that is no longer what a click would copy. Same guard as
-  // DiagnosticCopyButton, which faces the same race.
-  const generationRef = useRef(0);
+  // Only unmount needs a ref: a resolution arriving after teardown would
+  // otherwise schedule a timer nothing is left to clear.
+  const mountedRef = useRef(true);
 
   useEffect(() => {
-    generationRef.current += 1;
-    setCopied(false);
-    if (timeoutRef.current) {
-      clearTimeout(timeoutRef.current);
-      timeoutRef.current = null;
-    }
-  }, [contents]);
-
-  useEffect(() => {
+    mountedRef.current = true;
     return () => {
-      generationRef.current += 1;
+      mountedRef.current = false;
       if (timeoutRef.current) clearTimeout(timeoutRef.current);
     };
   }, []);
@@ -300,14 +296,13 @@ function CopyContentsButton({ contents }: { contents: string | null }) {
   const handleClick = useCallback(() => {
     if (contents === null) return;
     if (!navigator.clipboard?.writeText) return;
-    const generation = generationRef.current;
     void navigator.clipboard.writeText(contents).then(
       () => {
-        if (generation !== generationRef.current) return;
+        if (!mountedRef.current) return;
         if (timeoutRef.current) clearTimeout(timeoutRef.current);
-        setCopied(true);
+        setCopiedContents(contents);
         timeoutRef.current = setTimeout(() => {
-          setCopied(false);
+          setCopiedContents(null);
           timeoutRef.current = null;
         }, COPY_FEEDBACK_MS);
       },
@@ -320,6 +315,8 @@ function CopyContentsButton({ contents }: { contents: string | null }) {
   }, [contents]);
 
   if (contents === null) return null;
+
+  const copied = copiedContents === contents;
 
   return (
     <IconButton label="Copy file contents" onClick={handleClick}>

--- a/src/components/FileViewer/__tests__/FileViewerToolbar.test.tsx
+++ b/src/components/FileViewer/__tests__/FileViewerToolbar.test.tsx
@@ -434,7 +434,19 @@ describe("FileViewerToolbar.CopyContentsButton", () => {
     expect(checkIcon()).toBeNull();
   });
 
-  it("schedules nothing after unmount", async () => {
+  it("clears the running flash timer on unmount", async () => {
+    const { unmount } = render(<FileViewerToolbar.CopyContentsButton contents="x" />);
+    await clickCopy();
+    // Prove there is something to clean up — without this the assertion below
+    // holds even with the cleanup deleted.
+    expect(vi.getTimerCount()).toBe(1);
+
+    unmount();
+
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("schedules nothing when a write resolves after unmount", async () => {
     let resolveWrite: (() => void) | undefined;
     writeText.mockReturnValueOnce(
       new Promise<void>((resolve) => {
@@ -443,6 +455,9 @@ describe("FileViewerToolbar.CopyContentsButton", () => {
     );
     const { unmount } = render(<FileViewerToolbar.CopyContentsButton contents="x" />);
     fireEvent.click(button());
+    // The click has to have reached the clipboard, or the timer count below is
+    // zero for the wrong reason.
+    expect(writeText).toHaveBeenCalledTimes(1);
 
     unmount();
     await act(async () => {

--- a/src/components/FileViewer/__tests__/FileViewerToolbar.test.tsx
+++ b/src/components/FileViewer/__tests__/FileViewerToolbar.test.tsx
@@ -291,3 +291,165 @@ describe("FileViewerToolbar.IconButton", () => {
     expect(button.hasAttribute("data-sidebar-toggle")).toBe(false);
   });
 });
+
+describe("FileViewerToolbar.CopyContentsButton", () => {
+  const writeText = vi.fn<(text: string) => Promise<void>>(() => Promise.resolve());
+  const button = () => screen.getByRole("button", { name: "Copy file contents" });
+  const copyIcon = () => document.querySelector(".lucide-copy");
+  const checkIcon = () => document.querySelector(".lucide-check");
+  /** Click, then flush the clipboard promise's continuation. */
+  const clickCopy = async () => {
+    fireEvent.click(button());
+    await act(async () => {});
+  };
+
+  beforeEach(() => {
+    // Fake timers only in this block: the Path suite above measures rather than
+    // waits, and taking its clock over would buy nothing.
+    vi.useFakeTimers();
+    writeText.mockReset();
+    writeText.mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", { configurable: true, value: { writeText } });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders nothing when there is no text to copy", () => {
+    render(<FileViewerToolbar.CopyContentsButton contents={null} />);
+
+    // Null is every state without raw text: a read in flight, an image, an SVG,
+    // or a read that failed as binary/oversized/an LFS pointer.
+    expect(screen.queryByRole("button", { name: "Copy file contents" })).toBeNull();
+  });
+
+  it("stays available for an empty file", async () => {
+    render(<FileViewerToolbar.CopyContentsButton contents="" />);
+
+    await clickCopy();
+
+    // "" is a real file's real contents. A truthiness gate would hide the
+    // button here and read as the control being broken.
+    expect(writeText).toHaveBeenCalledWith("");
+  });
+
+  it("writes the exact text and swaps the icon for a checkmark", async () => {
+    const contents = "line one\nline two\n";
+    render(<FileViewerToolbar.CopyContentsButton contents={contents} />);
+    expect(copyIcon()).not.toBeNull();
+
+    await clickCopy();
+
+    expect(writeText).toHaveBeenCalledWith(contents);
+    expect(checkIcon()).not.toBeNull();
+    expect(copyIcon()).toBeNull();
+  });
+
+  it("keeps a stable accessible name while showing copied feedback", async () => {
+    render(<FileViewerToolbar.CopyContentsButton contents="x" />);
+
+    await clickCopy();
+
+    // Same contract the Path pill is held to: the feedback rides the icon, never
+    // the name, so the control stays findable exactly while it is confirming.
+    expect(button()).toBeTruthy();
+  });
+
+  it("clears the checkmark when the flash times out", async () => {
+    render(<FileViewerToolbar.CopyContentsButton contents="x" />);
+    await clickCopy();
+    expect(checkIcon()).not.toBeNull();
+
+    act(() => void vi.advanceTimersByTime(2000));
+
+    expect(checkIcon()).toBeNull();
+    expect(copyIcon()).not.toBeNull();
+  });
+
+  it("restarts the flash on a second copy instead of letting the first timer end it early", async () => {
+    render(<FileViewerToolbar.CopyContentsButton contents="x" />);
+    await clickCopy();
+    act(() => void vi.advanceTimersByTime(1500));
+
+    await clickCopy();
+
+    // The first click's timer would fire here; the second click must have
+    // cleared it, or the confirmation dies 500ms into its own window.
+    act(() => void vi.advanceTimersByTime(1000));
+    expect(checkIcon()).not.toBeNull();
+
+    act(() => void vi.advanceTimersByTime(1000));
+    expect(checkIcon()).toBeNull();
+  });
+
+  it("stays silent when the clipboard rejects", async () => {
+    writeText.mockRejectedValueOnce(new Error("denied"));
+    render(<FileViewerToolbar.CopyContentsButton contents="x" />);
+
+    await clickCopy();
+
+    // No toast and no checkmark: matching the path controls, a copy whose whole
+    // feedback lives on the button says nothing when it didn't happen.
+    expect(checkIcon()).toBeNull();
+    expect(copyIcon()).not.toBeNull();
+  });
+
+  it("does nothing when the clipboard API is unavailable", () => {
+    Object.defineProperty(navigator, "clipboard", { configurable: true, value: undefined });
+    render(<FileViewerToolbar.CopyContentsButton contents="x" />);
+
+    fireEvent.click(button());
+
+    expect(checkIcon()).toBeNull();
+  });
+
+  it("drops the checkmark when the file's contents change", async () => {
+    const { rerender } = render(<FileViewerToolbar.CopyContentsButton contents="old" />);
+    await clickCopy();
+    expect(checkIcon()).not.toBeNull();
+
+    rerender(<FileViewerToolbar.CopyContentsButton contents="new" />);
+
+    // The confirmation was for text the button no longer offers.
+    expect(checkIcon()).toBeNull();
+  });
+
+  it("ignores a write that resolves after the contents changed underneath it", async () => {
+    let resolveWrite: (() => void) | undefined;
+    writeText.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        resolveWrite = () => resolve();
+      })
+    );
+    const { rerender } = render(<FileViewerToolbar.CopyContentsButton contents="old" />);
+    fireEvent.click(button());
+
+    rerender(<FileViewerToolbar.CopyContentsButton contents="new" />);
+    await act(async () => {
+      resolveWrite?.();
+    });
+
+    // Confirming here would claim the clipboard holds "new" when it holds "old".
+    expect(checkIcon()).toBeNull();
+  });
+
+  it("schedules nothing after unmount", async () => {
+    let resolveWrite: (() => void) | undefined;
+    writeText.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        resolveWrite = () => resolve();
+      })
+    );
+    const { unmount } = render(<FileViewerToolbar.CopyContentsButton contents="x" />);
+    fireEvent.click(button());
+
+    unmount();
+    await act(async () => {
+      resolveWrite?.();
+    });
+
+    // A surviving setTimeout would fire a setState into an unmounted tree.
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/src/components/FileViewer/__tests__/filePreviewKinds.test.ts
+++ b/src/components/FileViewer/__tests__/filePreviewKinds.test.ts
@@ -3,6 +3,7 @@ import {
   buildDaintreeFileUrl,
   buildDaintreePdfUrl,
   isAudioFilePath,
+  isFileContentsCopyCandidate,
   isImageFilePath,
   isPdfFilePath,
   isSvgFilePath,
@@ -217,6 +218,57 @@ describe("filePreviewKinds", () => {
     it("encodes path and root as query params", () => {
       const url = buildDaintreeFileUrl("/a dir/clip.mp4", "/a dir");
       expect(url).toBe("daintree-file://load?path=%2Fa%20dir%2Fclip.mp4&root=%2Fa%20dir");
+    });
+  });
+
+  describe("isFileContentsCopyCandidate", () => {
+    it.each([
+      "/repo/logo.png",
+      "/repo/photo.JPEG",
+      "/repo/icon.svg",
+      "/repo/clip.mp4",
+      "/repo/clip.mov",
+      "/repo/track.mp3",
+      "/repo/track.wma",
+      "/repo/spec.pdf",
+    ])("refuses %s", (filePath) => {
+      expect(isFileContentsCopyCandidate(filePath)).toBe(false);
+    });
+
+    it.each([
+      "/repo/index.ts",
+      "/repo/README.md",
+      "/repo/page.html",
+      "/repo/Makefile",
+      "/repo/.env",
+    ])("offers %s", (filePath) => {
+      expect(isFileContentsCopyCandidate(filePath)).toBe(true);
+    });
+
+    it("is optimistic for formats it doesn't recognise", () => {
+      // The predicate runs before anything has read the file, so a positive is
+      // only "nothing here rules it out". `files:read` is what actually rejects
+      // a binary, and pinning that here stops a later change from quietly
+      // promoting this to a completeness claim it can't make.
+      expect(isFileContentsCopyCandidate("/repo/archive.zip")).toBe(true);
+    });
+
+    it("refuses every kind the two viewers classify as non-text", () => {
+      // The gate must stay the exact complement of the preview classifiers: a
+      // new media kind added there without being composed in here would offer
+      // "copy contents" for a file the viewer never shows as text.
+      const nonText = ["/a.png", "/a.svg", "/a.webm", "/a.mkv", "/a.flac", "/a.aiff", "/a.pdf"];
+      for (const filePath of nonText) {
+        const classified =
+          isImageFilePath(filePath) ||
+          isVideoFilePath(filePath) ||
+          isUnsupportedVideoFilePath(filePath) ||
+          isAudioFilePath(filePath) ||
+          isUnsupportedAudioFilePath(filePath) ||
+          isPdfFilePath(filePath);
+        expect(classified).toBe(true);
+        expect(isFileContentsCopyCandidate(filePath)).toBe(false);
+      }
     });
   });
 

--- a/src/components/FileViewer/filePreviewKinds.ts
+++ b/src/components/FileViewer/filePreviewKinds.ts
@@ -100,6 +100,30 @@ export const UNSUPPORTED_AUDIO_MESSAGE =
   "Can't play this audio format — only MP3, WAV, FLAC, Ogg, Opus, M4A, and AAC are supported";
 
 /**
+ * Whether a path is worth offering "copy contents" for, judged on extension
+ * alone — the answer a surface needs *before* reading anything.
+ *
+ * "Candidate" rather than "isText": the negative is authoritative (a `.png` has
+ * no text to copy and never will), while the positive only says nothing here
+ * rules it out. An extensionless binary still reads as a candidate and is
+ * caught at read time, where `files:read` already reports BINARY_FILE.
+ *
+ * Surfaces that have already loaded the file must gate on their own load state
+ * instead: that knows about binary detection, the 512KiB cap and LFS pointers,
+ * none of which an extension can see.
+ */
+export function isFileContentsCopyCandidate(filePath: string): boolean {
+  return !(
+    isImageFilePath(filePath) ||
+    isVideoFilePath(filePath) ||
+    isUnsupportedVideoFilePath(filePath) ||
+    isAudioFilePath(filePath) ||
+    isUnsupportedAudioFilePath(filePath) ||
+    isPdfFilePath(filePath)
+  );
+}
+
+/**
  * URL for the custom `daintree-file://` protocol, which serves a file from
  * inside a known root. Used as an `<img>` src so raster images never round-trip
  * through a base64 IPC read.

--- a/src/config/__tests__/statusSuccessInventory.ts
+++ b/src/config/__tests__/statusSuccessInventory.ts
@@ -258,8 +258,16 @@ export const STATUS_SUCCESS_INVENTORY = {
     {
       category: "transient",
       signature: "text-status-success",
+      anchor: 'aria-label="Copy file path"',
       expectedOccurrences: 1,
       rationale: "Copy-path confirmation; resets when the copy flash times out",
+    },
+    {
+      category: "transient",
+      signature: "text-status-success",
+      anchor: 'label="Copy file contents"',
+      expectedOccurrences: 1,
+      rationale: "Copy-file-contents confirmation; resets when the copy flash times out",
     },
   ],
   "src/components/FileViewer/diffChangeSet.ts": [
@@ -1041,5 +1049,5 @@ export const STATUS_SUCCESS_INVENTORY = {
  * another added) still trips the per-site checks, and these catch the case
  * where a whole file moves without either check firing.
  */
-export const EXPECTED_STATUS_SUCCESS_SITES = 125;
-export const EXPECTED_STATUS_SUCCESS_OCCURRENCES = 146;
+export const EXPECTED_STATUS_SUCCESS_SITES = 126;
+export const EXPECTED_STATUS_SUCCESS_OCCURRENCES = 147;

--- a/src/hooks/__tests__/useFileRowMenuItems.test.tsx
+++ b/src/hooks/__tests__/useFileRowMenuItems.test.tsx
@@ -81,6 +81,11 @@ import {
 
 const WORKTREE = "/repo";
 
+// Typed at the declaration rather than cast at each use: `navigator.clipboard`
+// is `Clipboard`, so reading `.mock` off it needs an assertion that the ratchet
+// counts. One typed double serves every assertion here.
+const writeTextMock = vi.fn<(text: string) => Promise<void>>(() => Promise.resolve());
+
 function target(overrides: Partial<FileRowMenuTarget> = {}): FileRowMenuTarget {
   return {
     absolutePath: "/repo/src/index.ts",
@@ -145,9 +150,9 @@ beforeEach(() => {
   copyContextMock.mockClear();
   itemsRef.current = [];
   insertRef.current = { canInsert: true, insert: vi.fn(() => true) };
-  Object.assign(navigator, {
-    clipboard: { writeText: vi.fn(() => Promise.resolve()) },
-  });
+  writeTextMock.mockReset();
+  writeTextMock.mockResolvedValue(undefined);
+  Object.assign(navigator, { clipboard: { writeText: writeTextMock } });
 });
 
 afterEach(() => cleanup());
@@ -165,6 +170,7 @@ describe("useFileRowMenuItems — canonical order", () => {
       "Copy path",
       "Copy relative path",
       "Copy file name",
+      "Copy file contents",
       "Reveal in Finder",
     ]);
   });
@@ -312,6 +318,101 @@ describe("useFileRowMenuItems — path semantics", () => {
     writeText.mockClear();
     payload.action!.onClick();
     await waitFor(() => expect(writeText).toHaveBeenCalledWith("/repo/src/index.ts"));
+  });
+});
+
+describe("useFileRowMenuItems — Copy file contents", () => {
+  it("reads through the contained file.read action and writes exactly what came back", async () => {
+    dispatchMock.mockImplementation((id) =>
+      id === "file.read"
+        ? Promise.resolve({ ok: true, result: { content: "raw\nsource\n" } })
+        : Promise.resolve({ ok: true, result: undefined })
+    );
+    const menu = await openMenu();
+
+    fireEvent.click(within(menu).getByRole("menuitem", { name: "Copy file contents" }));
+
+    await waitFor(() => {
+      const call = dispatchMock.mock.calls.find(([id]) => id === "file.read");
+      expect(call).toBeDefined();
+      // filesClient.read would skip the action's containment check, which is
+      // what keeps this off arbitrary paths outside the project.
+      expect(call![1]).toEqual({ path: "/repo/src/index.ts" });
+      expect(call![2]).toEqual({ source: "context-menu" });
+    });
+    await waitFor(() => expect(writeTextMock).toHaveBeenCalledWith("raw\nsource\n"));
+    expect(notifyMock).not.toHaveBeenCalled();
+  });
+
+  it("raises a retryable toast when the read fails, and writes nothing", async () => {
+    dispatchMock.mockImplementation((id) =>
+      id === "file.read"
+        ? Promise.resolve({ ok: false, error: { message: "Binary file — cannot display" } })
+        : Promise.resolve({ ok: true, result: undefined })
+    );
+    const menu = await openMenu();
+
+    fireEvent.click(within(menu).getByRole("menuitem", { name: "Copy file contents" }));
+
+    await waitFor(() => expect(notifyMock).toHaveBeenCalledTimes(1));
+    const [payload] = notifyMock.mock.calls[0]!;
+    expect(payload.type).toBe("error");
+    expect(payload.title).toBe("Couldn't copy file contents");
+    // The reason has to survive: extension gating can't see a binary with a
+    // text-like name, so this toast is where the user learns why.
+    expect(payload.message).toBe("Binary file — cannot display");
+    // Clobbering the clipboard with nothing would lose whatever was in it.
+    expect(writeTextMock).not.toHaveBeenCalled();
+
+    payload.action!.onClick();
+    await waitFor(() =>
+      expect(dispatchMock.mock.calls.filter(([id]) => id === "file.read").length).toBe(2)
+    );
+  });
+
+  it("retries the clipboard write without re-reading the file", async () => {
+    writeTextMock.mockRejectedValueOnce(new Error("nope"));
+    dispatchMock.mockImplementation((id) =>
+      id === "file.read"
+        ? Promise.resolve({ ok: true, result: { content: "raw" } })
+        : Promise.resolve({ ok: true, result: undefined })
+    );
+    const menu = await openMenu();
+
+    fireEvent.click(within(menu).getByRole("menuitem", { name: "Copy file contents" }));
+
+    await waitFor(() => expect(notifyMock).toHaveBeenCalledTimes(1));
+    const [payload] = notifyMock.mock.calls[0]!;
+    expect(payload.title).toBe("Couldn't copy file contents");
+
+    writeTextMock.mockClear();
+    payload.action!.onClick();
+
+    await waitFor(() => expect(writeTextMock).toHaveBeenCalledWith("raw"));
+    // The bytes are already in hand; a second read would be a wasted IPC round
+    // trip against a file that may have changed underneath the first one.
+    expect(dispatchMock.mock.calls.filter(([id]) => id === "file.read").length).toBe(1);
+  });
+
+  it.each([
+    ["a directory", { isDirectory: true, name: "src", relativePath: "src", status: null }],
+    ["a deleted file", { status: "deleted" as const }],
+    ["an image", { absolutePath: "/repo/logo.png", name: "logo.png" }],
+    ["an SVG", { absolutePath: "/repo/icon.svg", name: "icon.svg" }],
+    ["a video", { absolutePath: "/repo/clip.mp4", name: "clip.mp4" }],
+    ["an unplayable video", { absolutePath: "/repo/clip.mov", name: "clip.mov" }],
+    ["audio", { absolutePath: "/repo/track.mp3", name: "track.mp3" }],
+    ["a PDF", { absolutePath: "/repo/spec.pdf", name: "spec.pdf" }],
+  ])("hides the item for %s", async (_case, row) => {
+    const menu = await openMenu({ row });
+    expect(labels(menu)).not.toContain("Copy file contents");
+  });
+
+  it("keeps the item for an extension it doesn't recognise", async () => {
+    // Optimistic by design: the read is the real gate, and hiding everything
+    // unfamiliar would drop the item for perfectly ordinary text files.
+    const menu = await openMenu({ row: { absolutePath: "/repo/Makefile", name: "Makefile" } });
+    expect(labels(menu)).toContain("Copy file contents");
   });
 });
 

--- a/src/hooks/__tests__/useFileRowMenuItems.test.tsx
+++ b/src/hooks/__tests__/useFileRowMenuItems.test.tsx
@@ -408,6 +408,21 @@ describe("useFileRowMenuItems — Copy file contents", () => {
     expect(labels(menu)).not.toContain("Copy file contents");
   });
 
+  it("copies an empty file as the empty string", async () => {
+    dispatchMock.mockImplementation((id) =>
+      id === "file.read"
+        ? Promise.resolve({ ok: true, result: { content: "" } })
+        : Promise.resolve({ ok: true, result: undefined })
+    );
+    const menu = await openMenu();
+
+    fireEvent.click(within(menu).getByRole("menuitem", { name: "Copy file contents" }));
+
+    // A truthiness gate on the read result would silently write nothing here.
+    await waitFor(() => expect(writeTextMock).toHaveBeenCalledWith(""));
+    expect(notifyMock).not.toHaveBeenCalled();
+  });
+
   it("keeps the item for an extension it doesn't recognise", async () => {
     // Optimistic by design: the read is the real gate, and hiding everything
     // unfamiliar would drop the item for perfectly ordinary text files.

--- a/src/hooks/useFileRowMenuItems.tsx
+++ b/src/hooks/useFileRowMenuItems.tsx
@@ -13,14 +13,53 @@ import { usePluginContextMenuItems } from "@/hooks/usePluginContextMenuItems";
 import { useInsertFileReference } from "@/hooks/useInsertFileReference";
 import { copyContextWithFeedback } from "@/hooks/useWorktreeActions";
 import { revealCopy } from "@/components/FileViewer/revealCopy";
+import { isFileContentsCopyCandidate } from "@/components/FileViewer/filePreviewKinds";
 import { INSERT_FILE_REFERENCE_COMBO } from "@/panels/file-browser/fileReference";
 import { comboToAriaKeyshortcuts } from "@/lib/kbdShortcut";
 import { isMac } from "@/lib/platform";
 import { notify } from "@/lib/notify";
 import { actionService } from "@/services/ActionService";
+import type { BuiltInRuntimeActionId } from "@shared/config/actionIds";
 import type { CopyTreeRunSource, GitStatus } from "@shared/types";
 
 const ICON_CLASS = "w-3.5 h-3.5 mr-2";
+
+/**
+ * Dispatch an action for the clicked row and, if it fails, say so with a Retry
+ * that re-runs the same call.
+ *
+ * Shared rather than written per handler because the failure mode is shared:
+ * the menu has already closed by the time a dispatch settles, so anything that
+ * goes wrong here is invisible without a toast — the entry was deleted between
+ * listing and click, the file turned out to be binary. A second copy of this
+ * shape is how one of these handlers ends up silently swallowing its errors.
+ *
+ * Module scope, not a `useCallback`: it closes over nothing from the hook, so
+ * the handlers below can depend on it without a memo of its own.
+ */
+function runRowAction<Result>(
+  actionId: BuiltInRuntimeActionId,
+  args: Record<string, string>,
+  errorTitle: string,
+  onSuccess?: (result: Result) => void
+): void {
+  const run = async () => {
+    const result = await actionService.dispatch<Result>(actionId, args, {
+      source: "context-menu",
+    });
+    if (!result.ok) {
+      notify({
+        type: "error",
+        title: errorTitle,
+        message: result.error.message,
+        action: { label: "Retry", onClick: () => void run() },
+      });
+      return;
+    }
+    onSuccess?.(result.result);
+  };
+  void run();
+}
 
 /**
  * The file a row's context menu acts on. Every path is passed in rather than
@@ -175,28 +214,28 @@ export function useFileRowMenuItems(surface: FileRowMenuSurface): FileRowMenuCon
     void write();
   }, []);
 
+  const handleCopyFileContents = useCallback(
+    (absolutePath: string) =>
+      // `file.read`, not filesClient: the action resolves the path against the
+      // project and its worktrees and refuses anything outside them, and reports
+      // binary, oversized and LFS-pointer files as named failures rather than
+      // handing back partial text. The extension gate on the item only hides
+      // what it can recognise, so this is the check that actually holds.
+      runRowAction<{ content: string }>(
+        "file.read",
+        { path: absolutePath },
+        "Couldn't copy file contents",
+        // Written straight off the read: clipboard writes want a fresh
+        // transient activation, and parking the text in state first would put a
+        // render between the gesture and the write for no gain.
+        (result) => copyToClipboard(result.content, "Couldn't copy file contents")
+      ),
+    [copyToClipboard]
+  );
+
   const handleReveal = useCallback(
-    (absolutePath: string) => {
-      const run = async () => {
-        const result = await actionService.dispatch(
-          "file.showItemInFolder",
-          { path: absolutePath },
-          { source: "context-menu" }
-        );
-        // The menu has already closed by the time this settles, so a failure
-        // here is invisible without a toast — e.g. the entry was deleted
-        // between listing and click.
-        if (!result.ok) {
-          notify({
-            type: "error",
-            title: reveal.errorTitle,
-            message: result.error.message,
-            action: { label: "Retry", onClick: () => void run() },
-          });
-        }
-      };
-      void run();
-    },
+    (absolutePath: string) =>
+      runRowAction("file.showItemInFolder", { path: absolutePath }, reveal.errorTitle),
     [reveal]
   );
 
@@ -232,6 +271,11 @@ export function useFileRowMenuItems(surface: FileRowMenuSurface): FileRowMenuCon
       // exactly what the user wants here and stays. Same call the file browser
       // already makes for its viewer selection (`isSelectedChangedFile`).
       const showOpenCurrent = !isDirectory && status !== "deleted";
+      // Rides the same "there is a current file on disk" gate, then drops the
+      // kinds with no text to put on a clipboard. Extension-only by necessity —
+      // nothing here has read the file — so an unfamiliar binary still shows
+      // the item and fails at the read with a reason.
+      const showCopyFileContents = showOpenCurrent && isFileContentsCopyCandidate(absolutePath);
 
       return (
         <>
@@ -305,6 +349,12 @@ export function useFileRowMenuItems(surface: FileRowMenuSurface): FileRowMenuCon
             <Copy className={ICON_CLASS} />
             Copy file name
           </ContextMenuItem>
+          {showCopyFileContents && (
+            <ContextMenuItem onSelect={() => handleCopyFileContents(absolutePath)}>
+              <Copy className={ICON_CLASS} />
+              Copy file contents
+            </ContextMenuItem>
+          )}
           <ContextMenuSeparator />
           <ContextMenuItem onSelect={() => handleReveal(absolutePath)}>
             <FolderOpen className={ICON_CLASS} />
@@ -335,6 +385,7 @@ export function useFileRowMenuItems(surface: FileRowMenuSurface): FileRowMenuCon
       reveal,
       copyToClipboard,
       handleCopyContext,
+      handleCopyFileContents,
       handleReveal,
     ]
   );

--- a/src/panels/file-browser/FileBrowserViewer.tsx
+++ b/src/panels/file-browser/FileBrowserViewer.tsx
@@ -509,6 +509,14 @@ export function FileBrowserViewer({
           )}
           {filePath && (
             <>
+              {/* Same control, same order as FilePane's action group. Raw text
+                  only: `svg` keeps sanitized markup rather than the source it
+                  was built from, and every media/error state carries none at
+                  all, so both fall through to `null` and render nothing. */}
+              <FileViewerToolbar.CopyContentsButton
+                key={filePath}
+                contents={state.status === "text" || state.status === "html" ? state.content : null}
+              />
               <FileViewerToolbar.IconButton
                 label={reveal.label}
                 onClick={() => void handleExternalAction("reveal")}

--- a/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
@@ -156,6 +156,9 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import type { GitStatus } from "@shared/types/git";
 import type { WorkingTreeFileChange } from "@/lib/workingTreeDiff";
 import { NO_HIDDEN_ROWS } from "../fileBrowserTree";
+import { ClientAppError } from "@/utils/clientAppError";
+import { FILE_READ_ERROR_MESSAGES } from "@/components/FileViewer/fileReadErrors";
+import { revealCopy } from "@/components/FileViewer/revealCopy";
 import type {
   FileBrowserSortOrder,
   FileEntryLike,
@@ -977,26 +980,72 @@ describe("FileBrowserViewer copy file contents (#12136)", () => {
     expect(copyButton()).toBeNull();
   });
 
+  it("offers the control for an empty file and copies the empty string", async () => {
+    readMock.mockResolvedValue({ content: "" });
+    renderViewer("/repo/src/empty.ts");
+
+    fireEvent.click(await screen.findByRole("button", { name: "Copy file contents" }));
+
+    // A `content || null` gate would hide the button here while the toolbar's
+    // own unit test stayed green.
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(""));
+  });
+
   it.each([
-    ["an image", "/repo/logo.png"],
-    ["an SVG", "/repo/icon.svg"],
-    ["a PDF", "/repo/docs/spec.pdf"],
-  ])("withholds the control for %s", async (_case, filePath) => {
-    renderViewer(filePath);
-    await act(async () => {});
+    ["an image", "/repo/logo.png", "img"],
+    ["a video", "/repo/media/demo.webm", "video"],
+    ["audio", "/repo/media/track.mp3", "audio"],
+    ["a PDF", "/repo/docs/spec.pdf", "iframe"],
+  ])("withholds the control for %s", async (_case, filePath, selector) => {
+    // The media previews fetch their bytes into a blob URL; without the stub the
+    // element never mounts and the absence assertion below would pass for the
+    // wrong reason. Mirrors this file's own video/audio describes.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        blob: () => Promise.resolve(new Blob(["x"])),
+      })
+    );
+    URL.createObjectURL = vi.fn(() => "blob:app://daintree/preview");
+    URL.revokeObjectURL = vi.fn();
+    const { container } = renderViewer(filePath);
 
-    // SVG is read as text but only its sanitized markup is kept, so there is no
-    // raw source left to hand back — same answer as the binary previews.
+    await waitFor(() => expect(container.querySelector(selector)).not.toBeNull());
+    expect(copyButton()).toBeNull();
+    vi.unstubAllGlobals();
+  });
+
+  it("withholds the control for an SVG, whose raw source the viewer discards", async () => {
+    // Valid SVG on purpose: this suite's shared default read is `# hello`, which
+    // the sanitizer rejects — so without real markup this would assert absence
+    // from the error state rather than the svg state it means to cover.
+    readMock.mockResolvedValue({
+      content: '<svg xmlns="http://www.w3.org/2000/svg"><rect /></svg>',
+    });
+    const { container } = renderViewer("/repo/icon.svg");
+
+    await waitFor(() => expect(container.querySelector("svg")).not.toBeNull());
+    // Read as text, but only the sanitized markup is kept — there is no raw
+    // source left to hand back.
     expect(copyButton()).toBeNull();
   });
 
-  it("withholds the control when the read failed", async () => {
-    readMock.mockRejectedValue(Object.assign(new Error("binary"), { code: "BINARY_FILE" }));
-    renderViewer("/repo/src/blob.bin");
-    await act(async () => {});
+  it.each(["BINARY_FILE", "FILE_TOO_LARGE", "LFS_POINTER"] as const)(
+    "withholds the control when the read failed with %s",
+    async (code) => {
+      // A real ClientAppError, not `Object.assign(new Error(), { code })`:
+      // `isClientAppError` keys off `name === "AppError"`, so a plain Error
+      // falls into the generic branch and never exercises this mapping.
+      readMock.mockRejectedValue(new ClientAppError(code, code));
+      renderViewer("/repo/src/blob.bin");
 
-    expect(copyButton()).toBeNull();
-  });
+      expect(await screen.findByText(FILE_READ_ERROR_MESSAGES[code])).toBeTruthy();
+      expect(copyButton()).toBeNull();
+    }
+  );
 
   it("sits ahead of Reveal and Open in editor, the same suffix FilePane renders", async () => {
     readMock.mockResolvedValue({ content: "x" });
@@ -1006,8 +1055,9 @@ describe("FileBrowserViewer copy file contents (#12136)", () => {
     const buttons = Array.from(screen.getByRole("toolbar").querySelectorAll("button")).map((b) =>
       b.getAttribute("aria-label")
     );
-    // The reveal label is platform-worded, so pin the shape rather than the
-    // word: Copy contents, then reveal, then open.
-    expect(buttons.indexOf("Open in editor") - buttons.indexOf("Copy file contents")).toBe(2);
+    // The exact tail, not index arithmetic: a difference of 2 also holds with an
+    // unrelated control wedged between them. FilePane's suite asserts the
+    // identical suffix — that parity is what #12136 asked for.
+    expect(buttons.slice(-3)).toEqual(["Copy file contents", revealCopy().label, "Open in editor"]);
   });
 });

--- a/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
@@ -991,46 +991,67 @@ describe("FileBrowserViewer copy file contents (#12136)", () => {
     await waitFor(() => expect(writeText).toHaveBeenCalledWith(""));
   });
 
-  it.each([
-    ["an image", "/repo/logo.png", "img"],
-    ["a video", "/repo/media/demo.webm", "video"],
-    ["audio", "/repo/media/track.mp3", "audio"],
-    ["a PDF", "/repo/docs/spec.pdf", "iframe"],
-  ])("withholds the control for %s", async (_case, filePath, selector) => {
-    // The media previews fetch their bytes into a blob URL; without the stub the
-    // element never mounts and the absence assertion below would pass for the
-    // wrong reason. Mirrors this file's own video/audio describes.
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue({
-        ok: true,
-        status: 200,
-        headers: new Headers(),
-        blob: () => Promise.resolve(new Blob(["x"])),
-      })
-    );
-    URL.createObjectURL = vi.fn(() => "blob:app://daintree/preview");
-    URL.revokeObjectURL = vi.fn();
-    const { container } = renderViewer(filePath);
+  // Video and audio fetch their bytes into a blob URL; without the stub the
+  // element never mounts and the absence assertions below would pass for the
+  // wrong reason. Restored one global at a time rather than through
+  // `vi.unstubAllGlobals()`: vitest.setup.ts installs ResizeObserver and rAF
+  // once at module load, so a blanket unstub here would strip them from every
+  // test that runs after this block.
+  describe("non-text previews", () => {
+    const realFetch = globalThis.fetch;
+    const realCreateObjectURL = URL.createObjectURL;
+    const realRevokeObjectURL = URL.revokeObjectURL;
 
-    await waitFor(() => expect(container.querySelector(selector)).not.toBeNull());
-    expect(copyButton()).toBeNull();
-    vi.unstubAllGlobals();
-  });
-
-  it("withholds the control for an SVG, whose raw source the viewer discards", async () => {
-    // Valid SVG on purpose: this suite's shared default read is `# hello`, which
-    // the sanitizer rejects — so without real markup this would assert absence
-    // from the error state rather than the svg state it means to cover.
-    readMock.mockResolvedValue({
-      content: '<svg xmlns="http://www.w3.org/2000/svg"><rect /></svg>',
+    beforeEach(() => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: true,
+          status: 200,
+          headers: new Headers(),
+          blob: () => Promise.resolve(new Blob(["x"])),
+        })
+      );
+      URL.createObjectURL = vi.fn(() => "blob:app://daintree/media-preview");
+      URL.revokeObjectURL = vi.fn();
     });
-    const { container } = renderViewer("/repo/icon.svg");
 
-    await waitFor(() => expect(container.querySelector("svg")).not.toBeNull());
-    // Read as text, but only the sanitized markup is kept — there is no raw
-    // source left to hand back.
-    expect(copyButton()).toBeNull();
+    afterEach(() => {
+      vi.stubGlobal("fetch", realFetch);
+      URL.createObjectURL = realCreateObjectURL;
+      URL.revokeObjectURL = realRevokeObjectURL;
+    });
+
+    it.each([
+      ["an image", "/repo/logo.png", "img"],
+      ["a video", "/repo/media/demo.webm", "video"],
+      ["audio", "/repo/media/track.mp3", "audio"],
+      ["a PDF", "/repo/docs/spec.pdf", "iframe"],
+    ])("withholds the control for %s", async (_case, filePath, selector) => {
+      const { container } = renderViewer(filePath);
+
+      await waitFor(() => expect(container.querySelector(selector)).not.toBeNull());
+      expect(copyButton()).toBeNull();
+    });
+
+    it("withholds the control for an SVG, whose raw source the viewer discards", async () => {
+      // Valid SVG on purpose: this suite's shared default read is `# hello`,
+      // which the sanitizer rejects — so without real markup this would assert
+      // absence from the error state rather than the svg state it means to cover.
+      readMock.mockResolvedValue({
+        content: '<svg xmlns="http://www.w3.org/2000/svg"><rect /></svg>',
+      });
+      const { container } = renderViewer("/repo/icon.svg");
+
+      // `[role="img"]` and not `"svg"`: every lucide icon in the toolbar is an
+      // <svg>, so the loose selector would match one of those and pass without
+      // the SVG branch ever rendering. FileImagePreview paints that role only
+      // when it has sanitized markup, which is exactly the state under test.
+      await waitFor(() => expect(container.querySelector('[role="img"]')).not.toBeNull());
+      // Read as text, but only the sanitized markup is kept — there is no raw
+      // source left to hand back.
+      expect(copyButton()).toBeNull();
+    });
   });
 
   it.each(["BINARY_FILE", "FILE_TOO_LARGE", "LFS_POINTER"] as const)(

--- a/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
@@ -923,3 +923,91 @@ describe("view options ownership (#11620, consolidated)", () => {
     expect(screen.getByTestId("file-browser-view-options")).toBeTruthy();
   });
 });
+
+describe("FileBrowserViewer copy file contents (#12136)", () => {
+  const writeText = vi.fn<(text: string) => Promise<void>>(() => Promise.resolve());
+  const copyButton = () => screen.queryByRole("button", { name: "Copy file contents" });
+
+  beforeEach(() => {
+    writeText.mockReset();
+    writeText.mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", { configurable: true, value: { writeText } });
+  });
+
+  it("copies the raw source of a text file", async () => {
+    readMock.mockResolvedValue({ content: "const a = 1;\n" });
+    renderViewer("/repo/src/notes.txt");
+
+    const button = await screen.findByRole("button", { name: "Copy file contents" });
+    fireEvent.click(button);
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith("const a = 1;\n"));
+  });
+
+  it("copies markdown source while the rendered view is showing", async () => {
+    readMock.mockResolvedValue({ content: "# hello\n\nbody\n" });
+    renderViewer("/repo/docs/spec.md");
+    await waitFor(() => expect(currentViewMode()).toBe("rendered"));
+
+    fireEvent.click(await screen.findByRole("button", { name: "Copy file contents" }));
+
+    // The raw markdown, not the HTML the renderer produced from it — the whole
+    // point of the control is that the view mode doesn't change what it yields.
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith("# hello\n\nbody\n"));
+  });
+
+  it("copies HTML source rather than the sandboxed preview", async () => {
+    readMock.mockResolvedValue({
+      content: "<h1>hi</h1>\n",
+      htmlPreviewUrl: "daintree-html://preview/1",
+    });
+    renderViewer("/repo/page.html");
+
+    fireEvent.click(await screen.findByRole("button", { name: "Copy file contents" }));
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith("<h1>hi</h1>\n"));
+  });
+
+  it("withholds the control until the read settles", async () => {
+    readMock.mockReturnValue(new Promise(() => {}));
+    renderViewer("/repo/src/notes.txt");
+    await act(async () => {});
+
+    // `loading` carries no content; offering the button here would copy nothing.
+    expect(copyButton()).toBeNull();
+  });
+
+  it.each([
+    ["an image", "/repo/logo.png"],
+    ["an SVG", "/repo/icon.svg"],
+    ["a PDF", "/repo/docs/spec.pdf"],
+  ])("withholds the control for %s", async (_case, filePath) => {
+    renderViewer(filePath);
+    await act(async () => {});
+
+    // SVG is read as text but only its sanitized markup is kept, so there is no
+    // raw source left to hand back — same answer as the binary previews.
+    expect(copyButton()).toBeNull();
+  });
+
+  it("withholds the control when the read failed", async () => {
+    readMock.mockRejectedValue(Object.assign(new Error("binary"), { code: "BINARY_FILE" }));
+    renderViewer("/repo/src/blob.bin");
+    await act(async () => {});
+
+    expect(copyButton()).toBeNull();
+  });
+
+  it("sits ahead of Reveal and Open in editor, the same suffix FilePane renders", async () => {
+    readMock.mockResolvedValue({ content: "x" });
+    renderViewer("/repo/src/notes.txt");
+    await screen.findByRole("button", { name: "Copy file contents" });
+
+    const buttons = Array.from(screen.getByRole("toolbar").querySelectorAll("button")).map((b) =>
+      b.getAttribute("aria-label")
+    );
+    // The reveal label is platform-worded, so pin the shape rather than the
+    // word: Copy contents, then reveal, then open.
+    expect(buttons.indexOf("Open in editor") - buttons.indexOf("Copy file contents")).toBe(2);
+  });
+});

--- a/src/panels/file/FilePane.tsx
+++ b/src/panels/file/FilePane.tsx
@@ -1039,6 +1039,18 @@ export function FilePane({
               className={TOOLBAR_ICON_CLASS}
             />
           </FileViewerToolbar.IconButton>
+          {/* The raw file text, whichever view mode is showing: rendered
+              markdown and the diff view both copy the source, never what they
+              drew from it. `content` only ever holds a settled read, so the
+              button is absent while one is in flight and for every state that
+              has no text — image, SVG, media, PDF, and reads that failed as
+              binary, oversized or an LFS pointer. Keyed on the path so the
+              confirmation resets when a file is swapped for one whose contents
+              happen to be identical. */}
+          <FileViewerToolbar.CopyContentsButton
+            key={filePath}
+            contents={loadState === "loaded" ? content : null}
+          />
           {/* Reveal is always offered, even for a file the viewer can't render
               (oversized, unsupported video) — the OS file manager is then the
               only way forward. */}

--- a/src/panels/file/__tests__/FilePane.test.tsx
+++ b/src/panels/file/__tests__/FilePane.test.tsx
@@ -2999,50 +2999,67 @@ describe("FilePane copy file contents (#12136)", () => {
     }
   );
 
-  it.each([
-    ["an image", "/repo/logo.png", "img"],
-    ["a video", "/repo/media/demo.webm", "video"],
-    ["audio", "/repo/media/track.mp3", "audio"],
-    ["a PDF", "/repo/docs/spec.pdf", "iframe"],
-  ])("withholds the control for %s", async (_case, filePath, selector) => {
-    // Video and audio fetch their bytes into a blob URL; without the stub the
-    // element never mounts and the absence assertion would pass for the wrong
-    // reason. Mirrors this file's own media describes.
+  // Video and audio fetch their bytes into a blob URL; without the stub the
+  // element never mounts and the absence assertions below would pass for the
+  // wrong reason. Restored one global at a time rather than through
+  // `vi.unstubAllGlobals()`: vitest.setup.ts installs ResizeObserver and rAF
+  // once at module load, so a blanket unstub here would strip them from every
+  // test that runs after this block.
+  describe("non-text previews", () => {
+    const realFetch = globalThis.fetch;
     const realCreateObjectURL = URL.createObjectURL;
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue({
-        ok: true,
-        status: 200,
-        headers: new Headers(),
-        blob: () => Promise.resolve(new Blob(["x"])),
-      })
-    );
-    URL.createObjectURL = vi.fn(() => "blob:app://daintree/media-preview");
-    try {
+    const realRevokeObjectURL = URL.revokeObjectURL;
+
+    beforeEach(() => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: true,
+          status: 200,
+          headers: new Headers(),
+          blob: () => Promise.resolve(new Blob(["x"])),
+        })
+      );
+      URL.createObjectURL = vi.fn(() => "blob:app://daintree/media-preview");
+      URL.revokeObjectURL = vi.fn();
+    });
+
+    afterEach(() => {
+      vi.stubGlobal("fetch", realFetch);
+      URL.createObjectURL = realCreateObjectURL;
+      URL.revokeObjectURL = realRevokeObjectURL;
+    });
+
+    it.each([
+      ["an image", "/repo/logo.png", "img"],
+      ["a video", "/repo/media/demo.webm", "video"],
+      ["audio", "/repo/media/track.mp3", "audio"],
+      ["a PDF", "/repo/docs/spec.pdf", "iframe"],
+    ])("withholds the control for %s", async (_case, filePath, selector) => {
       const { container } = await renderPane(filePath);
 
       // Anchored to the preview element: asserting absence on a pane that never
       // reached its terminal state would pass for the wrong reason.
       await waitFor(() => expect(container.querySelector(selector)).not.toBeNull());
       expect(copyButton()).toBeNull();
-    } finally {
-      vi.unstubAllGlobals();
-      URL.createObjectURL = realCreateObjectURL;
-    }
-  });
-
-  it("withholds the control for an SVG, whose raw source the pane discards", async () => {
-    // Valid SVG on purpose: the shared default read is not, so the sanitizer
-    // would reject it and this would assert absence from the error state
-    // instead of from the svg state it is meant to cover.
-    readMock.mockResolvedValue({
-      content: '<svg xmlns="http://www.w3.org/2000/svg"><rect /></svg>',
     });
-    const { container } = await renderPane("/repo/icon.svg");
 
-    await waitFor(() => expect(container.querySelector("svg")).not.toBeNull());
-    expect(copyButton()).toBeNull();
+    it("withholds the control for an SVG, whose raw source the pane discards", async () => {
+      // Valid SVG on purpose: the shared default read is not, so the sanitizer
+      // would reject it and this would assert absence from the error state
+      // instead of from the svg state it is meant to cover.
+      readMock.mockResolvedValue({
+        content: '<svg xmlns="http://www.w3.org/2000/svg"><rect /></svg>',
+      });
+      const { container } = await renderPane("/repo/icon.svg");
+
+      // `[role="img"]` and not `"svg"`: every lucide icon in the toolbar is an
+      // <svg>, so the loose selector would match one of those and pass without
+      // the SVG branch ever rendering. FileImagePreview paints that role only
+      // when it has sanitized markup, which is exactly the state under test.
+      await waitFor(() => expect(container.querySelector('[role="img"]')).not.toBeNull());
+      expect(copyButton()).toBeNull();
+    });
   });
 
   it("retires the control when the file it was offered for turns into media", async () => {

--- a/src/panels/file/__tests__/FilePane.test.tsx
+++ b/src/panels/file/__tests__/FilePane.test.tsx
@@ -213,6 +213,7 @@ import { FilePane } from "../FilePane";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { FILE_READ_ERROR_MESSAGES } from "@/components/FileViewer/fileReadErrors";
 import { revealCopy } from "@/components/FileViewer/revealCopy";
+import { ClientAppError } from "@/utils/clientAppError";
 
 function lastContentPanelProps(): Record<string, unknown> {
   const props = contentPanelProps.at(-1);
@@ -2918,10 +2919,37 @@ describe("FilePane copy file contents (#12136)", () => {
   it("copies markdown source while the rendered view is showing", async () => {
     readMock.mockResolvedValue({ content: "# title\n\nbody\n" });
     await renderPane("/repo/docs/spec.md", "rendered");
+    // Anchor the claim: a fall back to source would copy the same string and
+    // leave this green without ever exercising the rendered branch.
+    expect(await screen.findByTestId("markdown-viewer-mock")).toBeTruthy();
 
     await copy();
 
     await waitFor(() => expect(writeText).toHaveBeenCalledWith("# title\n\nbody\n"));
+  });
+
+  it("copies HTML source while the sandboxed preview is showing", async () => {
+    readMock.mockResolvedValue({
+      content: "<h1>hi</h1>\n",
+      htmlPreviewUrl: "daintree-html://tok/report.html",
+    });
+    await renderPane("/repo/dist/report.html", "rendered");
+    expect(await screen.findByTestId("html-viewer-mock")).toBeTruthy();
+
+    await copy();
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith("<h1>hi</h1>\n"));
+  });
+
+  it("offers the control for an empty file and copies the empty string", async () => {
+    readMock.mockResolvedValue({ content: "" });
+    await renderPane("/repo/src/empty.ts");
+
+    await copy();
+
+    // A `content || null` gate would hide the button here while the toolbar's
+    // own unit test stayed green.
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(""));
   });
 
   it("copies the file, not the diff, while the diff view is showing", async () => {
@@ -2939,6 +2967,7 @@ describe("FilePane copy file contents (#12136)", () => {
       worktreeChanges: { changes: [{ path: "/repo/src/index.ts", status: "modified" }] },
     });
     await renderPane("/repo/src/index.ts", "diff", "wt-1");
+    expect(await screen.findByTestId("diff-viewer-mock")).toBeTruthy();
 
     await copy();
 
@@ -2952,23 +2981,89 @@ describe("FilePane copy file contents (#12136)", () => {
     expect(copyButton()).toBeNull();
   });
 
-  it("withholds the control when the read failed as binary", async () => {
-    readMock.mockRejectedValue(Object.assign(new Error("binary"), { code: "BINARY_FILE" }));
-    await renderPane("/repo/src/blob.bin");
+  it.each(["BINARY_FILE", "FILE_TOO_LARGE", "LFS_POINTER"] as const)(
+    "withholds the control when the read failed with %s",
+    async (code) => {
+      // A real ClientAppError, not `Object.assign(new Error(), { code })`:
+      // `isClientAppError` keys off `name === "AppError"`, so the plain Error
+      // lands in the INVALID_PATH branch and never exercises this code at all.
+      readMock.mockRejectedValue(new ClientAppError(code, code));
+      await renderPane("/repo/src/blob.bin");
 
-    // The extension says nothing here; the read is what knows, and its failure
-    // is what has to keep the button away.
+      // Prove the pane actually settled into the matching error, or the absence
+      // below could just be a frame that never rendered.
+      expect(await screen.findByText(FILE_READ_ERROR_MESSAGES[code])).toBeTruthy();
+      // The extension says nothing here; the read is what knows, and its failure
+      // is what has to keep the button away.
+      expect(copyButton()).toBeNull();
+    }
+  );
+
+  it.each([
+    ["an image", "/repo/logo.png", "img"],
+    ["a video", "/repo/media/demo.webm", "video"],
+    ["audio", "/repo/media/track.mp3", "audio"],
+    ["a PDF", "/repo/docs/spec.pdf", "iframe"],
+  ])("withholds the control for %s", async (_case, filePath, selector) => {
+    // Video and audio fetch their bytes into a blob URL; without the stub the
+    // element never mounts and the absence assertion would pass for the wrong
+    // reason. Mirrors this file's own media describes.
+    const realCreateObjectURL = URL.createObjectURL;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        blob: () => Promise.resolve(new Blob(["x"])),
+      })
+    );
+    URL.createObjectURL = vi.fn(() => "blob:app://daintree/media-preview");
+    try {
+      const { container } = await renderPane(filePath);
+
+      // Anchored to the preview element: asserting absence on a pane that never
+      // reached its terminal state would pass for the wrong reason.
+      await waitFor(() => expect(container.querySelector(selector)).not.toBeNull());
+      expect(copyButton()).toBeNull();
+    } finally {
+      vi.unstubAllGlobals();
+      URL.createObjectURL = realCreateObjectURL;
+    }
+  });
+
+  it("withholds the control for an SVG, whose raw source the pane discards", async () => {
+    // Valid SVG on purpose: the shared default read is not, so the sanitizer
+    // would reject it and this would assert absence from the error state
+    // instead of from the svg state it is meant to cover.
+    readMock.mockResolvedValue({
+      content: '<svg xmlns="http://www.w3.org/2000/svg"><rect /></svg>',
+    });
+    const { container } = await renderPane("/repo/icon.svg");
+
+    await waitFor(() => expect(container.querySelector("svg")).not.toBeNull());
     expect(copyButton()).toBeNull();
   });
 
-  it.each([
-    ["an image", "/repo/logo.png"],
-    ["an SVG", "/repo/icon.svg"],
-    ["a video", "/repo/media/demo.webm"],
-    ["audio", "/repo/media/track.mp3"],
-    ["a PDF", "/repo/docs/spec.pdf"],
-  ])("withholds the control for %s", async (_case, filePath) => {
-    await renderPane(filePath);
+  it("retires the control when the file it was offered for turns into media", async () => {
+    readMock.mockResolvedValue({ content: "x" });
+    const { rerender } = await renderPane("/repo/src/index.ts");
+    await screen.findByRole("button", { name: "Copy file contents" });
+
+    panelsById["file-1"] = { id: "file-1", kind: "file", filePath: "/repo/logo.png" };
+    rerender(
+      <TooltipProvider>
+        <FilePane
+          id="file-1"
+          title="logo.png"
+          isFocused={false}
+          location="grid"
+          onFocus={() => {}}
+          onClose={() => {}}
+        />
+      </TooltipProvider>
+    );
+    await act(async () => {});
 
     expect(copyButton()).toBeNull();
   });
@@ -2981,9 +3076,10 @@ describe("FilePane copy file contents (#12136)", () => {
     const buttons = Array.from(screen.getByRole("toolbar").querySelectorAll("button")).map((b) =>
       b.getAttribute("aria-label")
     );
-    // The reveal label is platform-worded, so pin the shape rather than the
-    // word: Copy contents, then reveal, then open. FileBrowserViewer's suite
-    // asserts the identical suffix — that parity is what #12136 asked for.
-    expect(buttons.indexOf("Open in editor") - buttons.indexOf("Copy file contents")).toBe(2);
+    // The exact tail, not index arithmetic: a difference of 2 also holds with an
+    // unrelated control wedged between them. The reveal label is platform-worded,
+    // so take it from the same helper the component uses. FileBrowserViewer's
+    // suite asserts the identical suffix — that parity is what #12136 asked for.
+    expect(buttons.slice(-3)).toEqual(["Copy file contents", revealCopy().label, "Open in editor"]);
   });
 });

--- a/src/panels/file/__tests__/FilePane.test.tsx
+++ b/src/panels/file/__tests__/FilePane.test.tsx
@@ -2869,3 +2869,121 @@ describe("FilePane re-reads when the project view is revealed (#11588)", () => {
     });
   });
 });
+
+// #12136: one shared toolbar control puts the file's raw text on the clipboard.
+// What this suite owns is the data FilePane selects for it and where it sits;
+// the flash timing and cleanup belong to FileViewerToolbar's own suite.
+describe("FilePane copy file contents (#12136)", () => {
+  const writeText = vi.fn<(text: string) => Promise<void>>(() => Promise.resolve());
+  const copyButton = () => screen.queryByRole("button", { name: "Copy file contents" });
+
+  beforeEach(() => {
+    writeText.mockReset();
+    writeText.mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", { configurable: true, value: { writeText } });
+  });
+
+  async function renderPane(filePath: string, fileViewMode?: string, worktreeId?: string) {
+    panelsById["file-1"] = { id: "file-1", kind: "file", filePath, fileViewMode, worktreeId };
+    const view = render(
+      <TooltipProvider>
+        <FilePane
+          id="file-1"
+          title={filePath.split("/").pop() ?? filePath}
+          isFocused={false}
+          location="grid"
+          onFocus={() => {}}
+          onClose={() => {}}
+        />
+      </TooltipProvider>
+    );
+    // Can't wait on readMock — the media branches short-circuit before it.
+    await act(async () => {});
+    return view;
+  }
+
+  async function copy() {
+    fireEvent.click(await screen.findByRole("button", { name: "Copy file contents" }));
+  }
+
+  it("copies the text of a loaded file", async () => {
+    readMock.mockResolvedValue({ content: "const a = 1;\n" });
+    await renderPane("/repo/src/index.ts");
+
+    await copy();
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith("const a = 1;\n"));
+  });
+
+  it("copies markdown source while the rendered view is showing", async () => {
+    readMock.mockResolvedValue({ content: "# title\n\nbody\n" });
+    await renderPane("/repo/docs/spec.md", "rendered");
+
+    await copy();
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith("# title\n\nbody\n"));
+  });
+
+  it("copies the file, not the diff, while the diff view is showing", async () => {
+    // Deliberately different strings: the pane holds both at once, and a gate on
+    // the wrong one would still look right in every other mode.
+    readMock.mockResolvedValue({ content: "the whole file\n" });
+    useDiffContentMock.mockReturnValue({
+      content: "@@ -1 +1 @@\n-old\n+new\n",
+      stale: false,
+      retry: vi.fn(),
+    });
+    worktreeState.worktrees.set("wt-1", {
+      id: "wt-1",
+      path: "/repo",
+      worktreeChanges: { changes: [{ path: "/repo/src/index.ts", status: "modified" }] },
+    });
+    await renderPane("/repo/src/index.ts", "diff", "wt-1");
+
+    await copy();
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith("the whole file\n"));
+  });
+
+  it("withholds the control until the read settles", async () => {
+    readMock.mockReturnValue(new Promise(() => {}));
+    await renderPane("/repo/src/index.ts");
+
+    expect(copyButton()).toBeNull();
+  });
+
+  it("withholds the control when the read failed as binary", async () => {
+    readMock.mockRejectedValue(Object.assign(new Error("binary"), { code: "BINARY_FILE" }));
+    await renderPane("/repo/src/blob.bin");
+
+    // The extension says nothing here; the read is what knows, and its failure
+    // is what has to keep the button away.
+    expect(copyButton()).toBeNull();
+  });
+
+  it.each([
+    ["an image", "/repo/logo.png"],
+    ["an SVG", "/repo/icon.svg"],
+    ["a video", "/repo/media/demo.webm"],
+    ["audio", "/repo/media/track.mp3"],
+    ["a PDF", "/repo/docs/spec.pdf"],
+  ])("withholds the control for %s", async (_case, filePath) => {
+    await renderPane(filePath);
+
+    expect(copyButton()).toBeNull();
+  });
+
+  it("sits ahead of Reveal and Open in editor", async () => {
+    readMock.mockResolvedValue({ content: "x" });
+    await renderPane("/repo/src/index.ts");
+    await screen.findByRole("button", { name: "Copy file contents" });
+
+    const buttons = Array.from(screen.getByRole("toolbar").querySelectorAll("button")).map((b) =>
+      b.getAttribute("aria-label")
+    );
+    // The reveal label is platform-worded, so pin the shape rather than the
+    // word: Copy contents, then reveal, then open. FileBrowserViewer's suite
+    // asserts the identical suffix — that parity is what #12136 asked for.
+    expect(buttons.indexOf("Open in editor") - buttons.indexOf("Copy file contents")).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a "Copy file contents" action to the file viewer toolbar and to the file row context menu.
- The button is a new shared `FileViewerToolbar.CopyContentsButton` (`src/components/FileViewer/FileViewerToolbar.tsx`) rather than something each pane hand rolls. It owns the clipboard write, the Copy/Check icon swap, and its own flash timer and cleanup, so `FilePane` and `FileBrowserViewer` can't drift apart on it, which is exactly what the issue asked for. `Actions` stays a plain slot, so `DiffPane` (which renders diff hunks rather than raw file text) is untouched by construction.
- Copies the raw file text in every view mode: rendered markdown, rendered HTML, and the diff view all yield the file's source, never the rendered output.

Resolves #12136

## Changes

- Confirmation is a brief checkmark on the button, no toast, matching the existing path pill behavior.
- The button is withheld wherever there's no raw text to copy: images, SVG (both viewers only keep sanitized markup), video, audio, PDFs, and reads that failed as binary, oversized, or an LFS pointer. It's gated on the panes' already-computed load state rather than the file extension, which is strictly better since it also catches a binary file with a text-like name. An empty file is `""` and stays copyable.
- The context menu item reads through the existing `file.read` action (path containment against the project and its worktrees, plus the 512KB preview cap) and writes straight off its resolution, so the clipboard's transient user activation stays as fresh as possible. Failures raise a retryable toast.
- Extracted a `runRowAction` helper in `useFileRowMenuItems.tsx` so the reveal and copy contents handlers share one dispatch-and-retry-toast path instead of duplicating it.
- No new IPC, no new dependency, no new size guard.

### Known limitation

While the diff view is showing, `FilePane`'s `content` is whatever the last source read returned. The pane deliberately doesn't re-read source on worktree ticks during a diff (see the comment near `FilePane.tsx:791`), so a copy taken in diff mode can predate a change the diff itself is showing. This matches what the source view displays the instant you leave diff mode, at which point it re-reads. Making it strictly fresher would need either extra IPC on every worktree tick during a diff, or an async read inside a synchronous shared component, both out of proportion here, so it's flagged rather than fixed.

## Testing

- 582 tests pass across the 12 affected files (`FileViewerToolbar`, `filePreviewKinds`, `FilePane`, `FileBrowserViewer`, `useFileRowMenuItems`, `statusSuccessGuard` contract, `DiffPane`, `FileBrowserPane`).
- `npm run typecheck` is clean.
- `npm run lint:ratchet` passes with warnings down 6, since the `runRowAction` extraction and typed test mocks removed more warnings than the change added.
- Reviewed by Codex over three passes, with fixes applied for a paint timing window in the confirmation state and for several false green tests: SVG cases that asserted absence from the error state rather than the svg state, read failure doubles that `isClientAppError` didn't recognize and so never exercised `BINARY_FILE`, media exclusions not anchored to their rendered preview, and a global restore leak that made later tests in the file order dependent.