### PR TITLE
perf(mcp): trim redundant input schema metadata

### DIFF
--- a/electron/services/mcp-server/__tests__/tierAuth.test.ts
+++ b/electron/services/mcp-server/__tests__/tierAuth.test.ts
@@ -351,6 +351,27 @@ describe("wire/validation schema split", () => {
     expect(findWireStrippedKeywords(wire)).toEqual([]);
   });
 
+  it("omits the redundant top-level schema dialect", () => {
+    const wire = buildToolInputSchema(
+      makeEntry({
+        inputSchema: {
+          $schema: "https://json-schema.org/draft/2020-12/schema",
+          type: "object",
+          properties: {},
+        },
+      })
+    );
+
+    expect(wire["$schema"]).toBeUndefined();
+  });
+
+  it("omits an empty properties map when the tool declares no arguments", () => {
+    expect(buildToolInputSchema(makeEntry({ inputSchema: undefined }))).toEqual({
+      type: "object",
+      additionalProperties: false,
+    });
+  });
+
   it("keeps every argument the schema declares, including keyword-named ones", () => {
     const wire = buildToolInputSchema(
       makeEntry({ inputSchema: structuredClone(CONSTRAINED_SCHEMA) as Record<string, unknown> })

--- a/electron/services/mcp-server/tierAuth.ts
+++ b/electron/services/mcp-server/tierAuth.ts
@@ -924,14 +924,17 @@ export function buildToolInputSchema(entry: ActionManifestEntry): Record<string,
     !Array.isArray(entry.inputSchema) &&
     entry.inputSchema["type"] === "object"
   ) {
-    return {
-      ...(toWireSchema(entry.inputSchema) as Record<string, unknown>),
-      additionalProperties: false,
-    };
+    const { ["$schema"]: _dialect, ...projected } = toWireSchema(entry.inputSchema) as Record<
+      string,
+      unknown
+    >;
+    // MCP already fixes the input schema dialect. Repeating its URI on every
+    // tool adds no instruction or validation, but is billed on every turn.
+    projected["additionalProperties"] = false;
+    return projected;
   }
   return {
     type: "object",
-    properties: {},
     additionalProperties: false,
   };
 }

--- a/src/services/actions/__tests__/helpers/wireSurface.ts
+++ b/src/services/actions/__tests__/helpers/wireSurface.ts
@@ -164,7 +164,7 @@ export async function measureWireSurface(): Promise<WireTool[]> {
       continue;
     }
 
-    const EMPTY_INPUT_SCHEMA = { type: "object", properties: {}, additionalProperties: false };
+    const EMPTY_INPUT_SCHEMA = { type: "object", additionalProperties: false };
     let inputSchema: unknown = EMPTY_INPUT_SCHEMA;
     if (def.argsSchema) {
       const emitted = emitSchema(def.argsSchema, "input");
@@ -176,12 +176,16 @@ export async function measureWireSurface(): Promise<WireTool[]> {
       // `advertisesObjectRootedInput` in the quality suite is what keeps that
       // substitution from firing unnoticed; this keeps the bytes honest if it
       // ever does.
-      inputSchema = isObjectRooted(emitted)
-        ? {
-            ...(toWireSchema(emitted) as Record<string, unknown>),
-            additionalProperties: false,
-          }
-        : EMPTY_INPUT_SCHEMA;
+      if (isObjectRooted(emitted)) {
+        const { ["$schema"]: _dialect, ...projected } = toWireSchema(emitted) as Record<
+          string,
+          unknown
+        >;
+        projected["additionalProperties"] = false;
+        inputSchema = projected;
+      } else {
+        inputSchema = EMPTY_INPUT_SCHEMA;
+      }
     } else if (def.rawInputSchema) {
       inputSchema = isObjectRooted(def.rawInputSchema)
         ? toWireSchema(def.rawInputSchema)


### PR DESCRIPTION
## Summary

- omit redundant root `$schema` URIs from advertised MCP `inputSchema` objects
- omit empty `properties: {}` from no-argument schemas while retaining `type: "object"` and `additionalProperties: false`
- avoid an extra full-object copy, and mirror production projection in the wire-surface test helper

MCP 2025-11-25 defaults an absent `$schema` to JSON Schema 2020-12 and recommends `{ "type": "object", "additionalProperties": false }` for no-argument tools, so validation semantics stay intact.

## Protocol

- champion: `6dd9528c29d253f0d375b337cc59d9b152bd8d0d`; candidate: `93c30a2bda8040e55eff3f8f0d1f7fa97eda9435`
- apparatus SHA-256: `1d64b293f6cf94593ab291e280300bb41bcf1ba5998e9229d88ea5cf1a0a7b41` (162 files)
- smoke; 5 iterations; 2 warmups; 3 interleaved A/B pairs; lower is better; 1% threshold; 2% drift ceiling
- local: `host-02d9f218-darwin-arm64`, Apple M1 Max (10 CPUs, 32 GiB), macOS 26.4 / Darwin 25.4.0, Node 24.20.0, Electron 42.7.1, Git 2.55.0
- process gate: zero active benchmark/build/test processes before and after every arm; `caffeinate -dimsu`; 4 seconds between arms

## PERF-203 — `systemToolPayloadBytes.max`

### Local macOS — `host-02d9f218-darwin-arm64`

| Metric | Before | After | Absolute | Relative | Result |
| --- | ---: | ---: | ---: | ---: | --- |
| target | 230,392 B | 222,347 B | −8,045 B | −3.5% | won 3/3 |
| predicate `surfaceMisses` | 0 | 0 | 0 | — | healthy 5/5 |
| predicate `toolSchemaMisses` | 0 | 0 | 0 | — | healthy 5/5 |
| `manifestEntryCount` | 501 | 501 | 0 | 0.0% | guard OK |
| `registeredActionCount` | 501 | 501 | 0 | 0.0% | guard OK |
| `inputSchemaCount` | 313 | 313 | 0 | 0.0% | guard OK |
| `outputSchemaCount` | 51 | 51 | 0 | 0.0% | guard OK |
| `declaredArgNameCount` | 766 | 766 | 0 | 0.0% | guard OK |
| `workbenchToolCount` | 61 | 61 | 0 | 0.0% | guard OK |
| `externalToolCount` | 28 | 28 | 0 | 0.0% | guard OK |
| `systemToolCount` | 162 | 162 | 0 | 0.0% | guard OK |
| `workbenchToolPayloadBytes` | 103,983 B | 101,121 B | −2,862 B | −2.8% | guard OK |
| `externalToolPayloadBytes` | 50,986 B | 49,636 B | −1,350 B | −2.6% | guard OK |
| `coldManifestMs` | 12.578 ms | 12.461 ms | −0.117 ms | −0.9% | guard OK |
| `warmManifestMs` | 2.411 ms | 2.462 ms | +0.051 ms | +2.1% | guard OK |
| `projectionMs` | 8.269 ms | 7.790 ms | −0.479 ms | −5.8% | guard OK |
| `surfaceHashMs` | 5.345 ms | 4.924 ms | −0.421 ms | −7.9% | guard OK |

```text
Target: metricStats.systemToolPayloadBytes.max on PERF-203 · lower is better
Champion drift D: 0.0% (worst of 3, champ2 v champ3) — same code on both sides, so this is the machine
Drift ceiling (--max-drift): 2.0% (default, 2x threshold)
Worst within-arm spread: 21.3% on champ2

  pair 1: 230392 → 222347  3.5%  WON
  pair 2: 230392 → 222347  3.5%  WON
  pair 3: 230392 → 222347  3.5%  WON

  median arm: 230392 → 222347  improvement 3.5%
  precommitted threshold (--threshold): 1.0%

  guards (cost metrics — up is worse):
    OK      manifestEntryCount  501 → 501  +0.0% better  tolerance 5%
    OK      registeredActionCount  501 → 501  +0.0% better  tolerance 5%
    OK      inputSchemaCount  313 → 313  +0.0% better  tolerance 5%
    OK      outputSchemaCount  51 → 51  +0.0% better  tolerance 5%
    OK      declaredArgNameCount  766 → 766  +0.0% better  tolerance 5%
    OK      workbenchToolCount  61 → 61  +0.0% better  tolerance 5%
    OK      externalToolCount  28 → 28  +0.0% better  tolerance 5%
    OK      systemToolCount  162 → 162  +0.0% better  tolerance 5%
    OK      workbenchToolPayloadBytes  103983 → 101121  -2.8% better  tolerance 5%
    OK      externalToolPayloadBytes  50986 → 49636  -2.6% better  tolerance 5%
    OK      coldManifestMs  12.578 → 12.461  -0.9% better  tolerance 10% (machine-dependent)
    OK      warmManifestMs  2.411 → 2.462  +2.1% worse  tolerance 10% (machine-dependent)
    OK      projectionMs  8.269 → 7.79  -5.8% better  tolerance 10% (machine-dependent)
    OK      surfaceHashMs  5.345 → 4.924  -7.9% better  tolerance 10% (machine-dependent)

  condition 1  PASS  candidate won every index-paired arm — 3/3
  condition 2  PASS  median-to-median improvement 3.5% >= precommitted threshold 1.0%
  condition 3  PASS  improvement 3.5% > champion drift D 0.0%
  condition 4  PASS  no guard outside its precommitted tolerance — 14 checked

VERDICT: CLAIM

CLAIM — all four conditions hold.
```

### Hosted machines

| Machine | Target before | Target after | Absolute | Relative | Predicates | Guards/durations | Verdict |
| --- | ---: | ---: | ---: | ---: | --- | --- | --- |
| Linux (`gh-linux-x64-ab-33531241106.1`) | 230,392 B | 222,347 B | −8,045 B | −3.5% | `surfaceMisses=0`; `toolSchemaMisses=0`, 5/5 every arm | not measured; no hosted durations claimed | CLAIM, won 3/3 |
| Windows (`gh-windows-x64-ab-33531241106.1`) | 230,392 B | 222,347 B | −8,045 B | −3.5% | `surfaceMisses=0`; `toolSchemaMisses=0`, 5/5 every arm | not measured; no hosted durations claimed | CLAIM, won 3/3 |
| macOS (`gh-macos-arm64-ab-33531241106.1`) | 230,392 B | 222,347 B | −8,045 B | −3.5% | `surfaceMisses=0`; `toolSchemaMisses=0`, 5/5 every arm | not measured; no hosted durations claimed | CLAIM, won 3/3 |

Workflow and per-machine verdict blocks: https://github.com/daintreehq/daintree/actions/runs/33531241106

<details><summary>Linux verdict — PERF-203</summary>

```text
Target: metricStats.systemToolPayloadBytes.max on PERF-203 · lower is better
Champion drift D: 0.0% (worst of 3, champ2 v champ3) — same code on both sides, so this is the machine
Drift ceiling (--max-drift): 2.0% (default, 2x threshold)
Worst within-arm spread: 9.5% on champ3

  pair 1: 230392 → 222347  3.5%  WON
  pair 2: 230392 → 222347  3.5%  WON
  pair 3: 230392 → 222347  3.5%  WON

  median arm: 230392 → 222347  improvement 3.5%
  precommitted threshold (--threshold): 1.0%

  condition 1  PASS  candidate won every index-paired arm — 3/3
  condition 2  PASS  median-to-median improvement 3.5% >= precommitted threshold 1.0%
  condition 3  PASS  improvement 3.5% > champion drift D 0.0%
  condition 4  PASS  no guard outside its precommitted tolerance — 0 checked

VERDICT: CLAIM

CLAIM — all four conditions hold.
```
</details>

<details><summary>Windows verdict — PERF-203</summary>

```text
Target: metricStats.systemToolPayloadBytes.max on PERF-203 · lower is better
Champion drift D: 0.0% (worst of 3, champ2 v champ3) — same code on both sides, so this is the machine
Drift ceiling (--max-drift): 2.0% (default, 2x threshold)
Worst within-arm spread: 10.7% on champ3

  pair 1: 230392 → 222347  3.5%  WON
  pair 2: 230392 → 222347  3.5%  WON
  pair 3: 230392 → 222347  3.5%  WON

  median arm: 230392 → 222347  improvement 3.5%
  precommitted threshold (--threshold): 1.0%

  condition 1  PASS  candidate won every index-paired arm — 3/3
  condition 2  PASS  median-to-median improvement 3.5% >= precommitted threshold 1.0%
  condition 3  PASS  improvement 3.5% > champion drift D 0.0%
  condition 4  PASS  no guard outside its precommitted tolerance — 0 checked

VERDICT: CLAIM

CLAIM — all four conditions hold.
```
</details>

<details><summary>macOS verdict — PERF-203</summary>

```text
Target: metricStats.systemToolPayloadBytes.max on PERF-203 · lower is better
Champion drift D: 0.0% (worst of 3, champ2 v champ3) — same code on both sides, so this is the machine
Drift ceiling (--max-drift): 2.0% (default, 2x threshold)
Worst within-arm spread: 36.2% on champ1

  pair 1: 230392 → 222347  3.5%  WON
  pair 2: 230392 → 222347  3.5%  WON
  pair 3: 230392 → 222347  3.5%  WON

  median arm: 230392 → 222347  improvement 3.5%
  precommitted threshold (--threshold): 1.0%

  condition 1  PASS  candidate won every index-paired arm — 3/3
  condition 2  PASS  median-to-median improvement 3.5% >= precommitted threshold 1.0%
  condition 3  PASS  improvement 3.5% > champion drift D 0.0%
  condition 4  PASS  no guard outside its precommitted tolerance — 0 checked

VERDICT: CLAIM

CLAIM — all four conditions hold.
```
</details>

The hosted workflow did not check guards (`0 checked`). Its duration/spread readings are not claimed; the local quiet six-arm runs above are the guard authority.

## PERF-281 — `systemWireBytes.max`

### Local macOS — `host-02d9f218-darwin-arm64`

| Metric | Before | After | Absolute | Relative | Result |
| --- | ---: | ---: | ---: | ---: | --- |
| target | 230,426 B | 222,381 B | −8,045 B | −3.5% | won 3/3 |
| predicate `surfaceMisses` | 0 | 0 | 0 | — | healthy 5/5 |
| `workbenchToolCount` | 61 | 61 | 0 | 0.0% | guard OK |
| `actionToolCount` | 120 | 120 | 0 | 0.0% | guard OK |
| `systemToolCount` | 162 | 162 | 0 | 0.0% | guard OK |
| `externalToolCount` | 28 | 28 | 0 | 0.0% | guard OK |
| `boundExternalToolCount` | 26 | 26 | 0 | 0.0% | guard OK |
| `boundExternalWithheldCount` | 2 | 2 | 0 | 0.0% | guard OK |
| `workbenchWireBytes` | 104,017 B | 101,155 B | −2,862 B | −2.8% | guard OK |
| `actionWireBytes` | 169,683 B | 163,991 B | −5,692 B | −3.4% | guard OK |
| `externalWireBytes` | 51,020 B | 49,670 B | −1,350 B | −2.6% | guard OK |
| `boundExternalWireBytes` | 47,765 B | 46,529 B | −1,236 B | −2.6% | guard OK |
| `jsonRpcEnvelopeBytes` | 34 B | 34 B | 0 | 0.0% | guard OK |
| `withheldByVisibilityCount` | 0 | 0 | 0 | — | guard OK |
| `listMs` | 81.581 ms | 80.431 ms | −1.150 ms | −1.4% | guard OK |

```text
Target: metricStats.systemWireBytes.max on PERF-281 · lower is better
Champion drift D: 0.0% (worst of 3, champ2 v champ3) — same code on both sides, so this is the machine
Drift ceiling (--max-drift): 2.0% (default, 2x threshold)
Worst within-arm spread: 3.1% on champ1

  pair 1: 230426 → 222381  3.5%  WON
  pair 2: 230426 → 222381  3.5%  WON
  pair 3: 230426 → 222381  3.5%  WON

  median arm: 230426 → 222381  improvement 3.5%
  precommitted threshold (--threshold): 1.0%

  guards (cost metrics — up is worse):
    OK      workbenchToolCount  61 → 61  +0.0% better  tolerance 5%
    OK      actionToolCount  120 → 120  +0.0% better  tolerance 5%
    OK      systemToolCount  162 → 162  +0.0% better  tolerance 5%
    OK      externalToolCount  28 → 28  +0.0% better  tolerance 5%
    OK      boundExternalToolCount  26 → 26  +0.0% better  tolerance 5%
    OK      boundExternalWithheldCount  2 → 2  +0.0% better  tolerance 5%
    OK      workbenchWireBytes  104017 → 101155  -2.8% better  tolerance 5%
    OK      actionWireBytes  169683 → 163991  -3.4% better  tolerance 5%
    OK      externalWireBytes  51020 → 49670  -2.6% better  tolerance 5%
    OK      boundExternalWireBytes  47765 → 46529  -2.6% better  tolerance 5%
    OK      jsonRpcEnvelopeBytes  34 → 34  +0.0% better  tolerance 5%
    OK      withheldByVisibilityCount  0 → 0 (champion is zero, so no percentage)
    OK      listMs  81.581 → 80.431  -1.4% better  tolerance 10% (machine-dependent)

  condition 1  PASS  candidate won every index-paired arm — 3/3
  condition 2  PASS  median-to-median improvement 3.5% >= precommitted threshold 1.0%
  condition 3  PASS  improvement 3.5% > champion drift D 0.0%
  condition 4  PASS  no guard outside its precommitted tolerance — 13 checked

VERDICT: CLAIM

CLAIM — all four conditions hold.
```

### Hosted machines

| Machine | Target before | Target after | Absolute | Relative | Predicates | Guards/durations | Verdict |
| --- | ---: | ---: | ---: | ---: | --- | --- | --- |
| Linux (`gh-linux-x64-ab-33531252712.1`) | 230,426 B | 222,381 B | −8,045 B | −3.5% | `surfaceMisses=0`, 5/5 every arm | not measured; no hosted durations claimed | CLAIM, won 3/3 |
| Windows (`gh-windows-x64-ab-33531252712.1`) | 230,426 B | 222,381 B | −8,045 B | −3.5% | `surfaceMisses=0`, 5/5 every arm | not measured; no hosted durations claimed | CLAIM, won 3/3 |
| macOS (`gh-macos-arm64-ab-33531252712.1`) | 230,426 B | 222,381 B | −8,045 B | −3.5% | `surfaceMisses=0`, 5/5 every arm | not measured; no hosted durations claimed | CLAIM, won 3/3 |

Workflow and per-machine verdict blocks: https://github.com/daintreehq/daintree/actions/runs/33531252712

<details><summary>Linux verdict — PERF-281</summary>

```text
Target: metricStats.systemWireBytes.max on PERF-281 · lower is better
Champion drift D: 0.0% (worst of 3, champ2 v champ3) — same code on both sides, so this is the machine
Drift ceiling (--max-drift): 2.0% (default, 2x threshold)
Worst within-arm spread: 3.9% on champ1

  pair 1: 230426 → 222381  3.5%  WON
  pair 2: 230426 → 222381  3.5%  WON
  pair 3: 230426 → 222381  3.5%  WON

  median arm: 230426 → 222381  improvement 3.5%
  precommitted threshold (--threshold): 1.0%

  condition 1  PASS  candidate won every index-paired arm — 3/3
  condition 2  PASS  median-to-median improvement 3.5% >= precommitted threshold 1.0%
  condition 3  PASS  improvement 3.5% > champion drift D 0.0%
  condition 4  PASS  no guard outside its precommitted tolerance — 0 checked

VERDICT: CLAIM

CLAIM — all four conditions hold.
```
</details>

<details><summary>Windows verdict — PERF-281</summary>

```text
Target: metricStats.systemWireBytes.max on PERF-281 · lower is better
Champion drift D: 0.0% (worst of 3, champ2 v champ3) — same code on both sides, so this is the machine
Drift ceiling (--max-drift): 2.0% (default, 2x threshold)
Worst within-arm spread: 6.5% on champ1

  pair 1: 230426 → 222381  3.5%  WON
  pair 2: 230426 → 222381  3.5%  WON
  pair 3: 230426 → 222381  3.5%  WON

  median arm: 230426 → 222381  improvement 3.5%
  precommitted threshold (--threshold): 1.0%

  condition 1  PASS  candidate won every index-paired arm — 3/3
  condition 2  PASS  median-to-median improvement 3.5% >= precommitted threshold 1.0%
  condition 3  PASS  improvement 3.5% > champion drift D 0.0%
  condition 4  PASS  no guard outside its precommitted tolerance — 0 checked

VERDICT: CLAIM

CLAIM — all four conditions hold.
```
</details>

<details><summary>macOS verdict — PERF-281</summary>

```text
Target: metricStats.systemWireBytes.max on PERF-281 · lower is better
Champion drift D: 0.0% (worst of 3, champ2 v champ3) — same code on both sides, so this is the machine
Drift ceiling (--max-drift): 2.0% (default, 2x threshold)
Worst within-arm spread: 24.3% on cand1

  pair 1: 230426 → 222381  3.5%  WON
  pair 2: 230426 → 222381  3.5%  WON
  pair 3: 230426 → 222381  3.5%  WON

  median arm: 230426 → 222381  improvement 3.5%
  precommitted threshold (--threshold): 1.0%

  condition 1  PASS  candidate won every index-paired arm — 3/3
  condition 2  PASS  median-to-median improvement 3.5% >= precommitted threshold 1.0%
  condition 3  PASS  improvement 3.5% > champion drift D 0.0%
  condition 4  PASS  no guard outside its precommitted tolerance — 0 checked

VERDICT: CLAIM

CLAIM — all four conditions hold.
```
</details>

The hosted workflow did not check guards (`0 checked`). Its duration/spread readings are not claimed; the local quiet six-arm runs above are the guard authority.

## Hypothesis ledger

- **KEEP — root dialect omission:** saved 7,581 B on both targets while preserving predicates and structural counts.
- **KEEP — no-argument empty map omission:** saved another 464 B; object type and closed-world validation remain.
- **KEEP — direct projected-object return:** avoids a second full copy. This final form is the only implementation whose strict quiet local A/B passed every runtime guard.
- **REJECT — `delete` implementation:** deterministic bytes improved, but strict PERF-203 regressed `coldManifestMs` 10.6%, `projectionMs` 27.0%, and `surfaceHashMs` 37.9%; no claim.
- **REJECT — rest projection plus another spread:** deterministic bytes improved, but strict PERF-203 regressed `coldManifestMs` 18.1%; no claim.
- **REJECT — sparse annotations:** PERF-203 predicates resolved read-only, idempotent, and destructive hints; omission violates correctness.
- **REJECT — descriptions/field prose:** protected by the context-condensation contract.
- **REJECT — narrower masks, output schemas, or examples:** public validation/usage contracts; removal would optimize the fixture rather than the product.
- **DEFER — `$ref`/`$defs` deduplication:** architecture records it as unresolved; provider prompt-token effects are not established.
- **REJECT — polymorphic tool consolidation:** changes public API, atomicity, and annotation correctness.

Credible avenues in this focused mechanism are exhausted.

## Validation

- focused MCP/schema tests: 212 passed
- `npm run typecheck`: passed
- `npm run check`: passed
- full local `npm test`: three transient failures passed immediately in isolation; the only repeatable failure was PERF-063 liveness (`batcherShortfallCount=1`), which also failed at the exact branch point (`batcherShortfallCount=2`), so it is base-red timing behavior
- final hosted CI: passed — static checks, build, preload-backdoor verification, smoke, all four Vitest shards, and aggregate `ci-ok`: https://github.com/daintreehq/daintree/actions/runs/33531230324
- diff audit: three intended files only; `git diff --check` passed; no `scripts/perf/` changes
- E2E: not run (prohibited unless a human names a spec)

Tracks PERF-203 and PERF-281.
