### PR TITLE
perf(workspace-host): compact untracked config replays

### DIFF
--- a/electron/services/WorkspaceHostProcess.ts
+++ b/electron/services/WorkspaceHostProcess.ts
@@ -33,6 +33,10 @@ const RESTART_FLOOR_MS = 100;
 const RESTART_CAP_BASE_MS = 1_000;
 const RESTART_CAP_MAX_MS = 10_000;
 
+// Monitor-config pushes are fire-and-forget, so no broker entry ever owns the
+// response. Keep the required protocol field compact instead of minting an ID.
+const UNTRACKED_MONITOR_CONFIG_REQUEST_ID = "";
+
 // Time-windowed crash-loop guard. Mirrors the constants in PtyHostLifecycle
 // and CrashLoopGuardService so the three guards follow the same policy: three
 // crashes within the window trip the cap, and crashes spread further apart
@@ -320,7 +324,7 @@ export class WorkspaceHostProcess extends EventEmitter {
     if (this.isInitialized && this.child) {
       this.send({
         type: "update-monitor-config",
-        requestId: this.generateRequestId(),
+        requestId: UNTRACKED_MONITOR_CONFIG_REQUEST_ID,
         config,
       });
     }
@@ -956,7 +960,7 @@ export class WorkspaceHostProcess extends EventEmitter {
         if (this.monitorConfigCache !== null) {
           this.send({
             type: "update-monitor-config",
-            requestId: this.generateRequestId(),
+            requestId: UNTRACKED_MONITOR_CONFIG_REQUEST_ID,
             config: this.monitorConfigCache,
           });
         }


### PR DESCRIPTION
## What changed

Monitor-config pushes are fire-and-forget: they do not create a broker entry and nothing consumes their response ID. Use the shortest protocol-valid request ID for the immediate push and ready-time replay instead of minting a timestamp/counter ID.

Supervision, restart policy, replay ordering, message count, and the served round trip are unchanged.

## Measurement contract

- Branch point: `6dd9528c29d253f0d375b337cc59d9b152bd8d0d`
- Candidate: `41d9b4969a74bb961ad77117360ba257c8c56b13`
- Protocol: smoke, 5 measured iterations, 1 warmup, 1% precommitted threshold, lower is better
- Apparatus: `1d64b293f6cf9459…` across 162 files, unchanged between trees
- Local machine: `host-02d9f218-darwin-arm64` (`studio-04`), Apple M1 Max, macOS 26.4.1 arm64, Node 22.13.0, Electron 42.7.1, git 2.55.0

Hosted results below claim only deterministic counts and sizes. No hosted-runner duration is quoted or claimed.

## PERF-260 `metricStats.hostForkCount.max` — local macOS

| Metric | Before | After | Absolute / percentage change |
| --- | ---: | ---: | ---: |
| `hostForkCount.max` | 32 | 32 | 0 / 0.0% |
| `recoveryMisses` predicate | 0, count 5/5 | 0, count 5/5 | ok |
| `firstCrashMisses` predicate | 0, count 5/5 | 0, count 5/5 | ok |
| `giveUpMisses` predicate | 0, count 5/5 | 0, count 5/5 | ok |
| `manualRecoveryMisses` predicate | 0, count 5/5 | 0, count 5/5 | ok |
| `backoffMisses` predicate | 0, count 5/5 | 0, count 5/5 | ok |
| p50 duration guard | 24.612 ms | 25.064 ms | +0.452 ms / +1.8% |
| `supervisorCount` | 4 | 4 | 0 / 0.0% |
| `restartsAttempted` | 16 | 16 | 0 / 0.0% |
| `crashesSurvivedCount` | 16 | 16 | 0 / 0.0% |
| Workspace / PTY / plugin / watchdog restarts before give-up | 2 / 2 / 2 / 2 | 2 / 2 / 2 / 2 | unchanged |
| `backoffTimersArmedCount` | 12 | 12 | 0 / 0.0% |
| Backoff floor sum | 900 ms | 900 ms | 0 / 0.0% |
| Workspace / PTY / plugin / watchdog backoff ceilings | 5998 / 5998 / 0 / 7998 ms | same | unchanged |
| `residualChildCount` | 0 | 0 | ok |

Verdict: **NO CLAIM**. All predicates had `count === runs`, `min === 0`, and `max === 0`. Thirty-two forks are the exact structural floor imposed by the exercised recovery ladder.

## PERF-261 `metricStats.replayBytes.max` — local macOS

| Metric | Before | After | Absolute / percentage change |
| --- | ---: | ---: | ---: |
| `replayBytes.max` | 1,811 B | 1,786 B | **−25 B / −1.4%** |
| `replayMisses` predicate | 0, count 5/5 | 0, count 5/5 | ok |
| `serveMisses` predicate | 0, count 5/5 | 0, count 5/5 | ok |
| Replay messages | 6 | 6 | 0 / 0.0% |
| Served round trips | 1 | 1 | 0 / 0.0% |
| Respawn-to-serving mean guard | 5.3875 ms | 5.1931 ms | −0.1944 ms / −3.6% |
| p50 duration guard | 5.543 ms | 5.152 ms | −0.391 ms / −7.1% |
| `residualChildCount` | 0 | 0 | ok |

Verdict: **CLAIM**. Both predicates had `count === runs`, `min === 0`, and `max === 0`; the deterministic pair gate passed against the branch point.

## PERF-260 — hosted Linux

| Metric | Before | After | Absolute / percentage change |
| --- | ---: | ---: | ---: |
| `hostForkCount.max` median arm | 32 | 32 | 0 / 0.0% |
| Five predicates, each of 3 arms | count 5/5, min 0, max 0 | count 5/5, min 0, max 0 | ok |
| Hosted guard gate | 0 eligible guards checked | 0 eligible guards checked | pass |

Verdict: **NO CLAIM**; 0/3 paired wins, 0.0% champion drift.

## PERF-260 — hosted Windows

| Metric | Before | After | Absolute / percentage change |
| --- | ---: | ---: | ---: |
| `hostForkCount.max` median arm | 32 | 32 | 0 / 0.0% |
| Five predicates, each of 3 arms | count 5/5, min 0, max 0 | count 5/5, min 0, max 0 | ok |
| Hosted guard gate | 0 eligible guards checked | 0 eligible guards checked | pass |

Verdict: **NO CLAIM**; 0/3 paired wins, 0.0% champion drift.

## PERF-260 — hosted macOS

| Metric | Before | After | Absolute / percentage change |
| --- | ---: | ---: | ---: |
| `hostForkCount.max` median arm | 32 | 32 | 0 / 0.0% |
| Five predicates, each of 3 arms | count 5/5, min 0, max 0 | count 5/5, min 0, max 0 | ok |
| Hosted guard gate | 0 eligible guards checked | 0 eligible guards checked | pass |

Verdict: **NO CLAIM**; 0/3 paired wins, 0.0% champion drift.

## PERF-261 — hosted Linux

| Metric | Before | After | Absolute / percentage change |
| --- | ---: | ---: | ---: |
| `replayBytes.max` median arm | 1,811 B | 1,786 B | **−25 B / −1.4%** |
| Two predicates, each of 3 arms | count 5/5, min 0, max 0 | count 5/5, min 0, max 0 | ok |
| Hosted guard gate | 0 eligible guards checked | 0 eligible guards checked | pass |

Verdict: **CLAIM**; 3/3 paired wins, 1.4% improvement > 0.0% champion drift.

## PERF-261 — hosted Windows

| Metric | Before | After | Absolute / percentage change |
| --- | ---: | ---: | ---: |
| `replayBytes.max` median arm | 1,814 B | 1,789 B | **−25 B / −1.4%** |
| Two predicates, each of 3 arms | count 5/5, min 0, max 0 | count 5/5, min 0, max 0 | ok |
| Hosted guard gate | 0 eligible guards checked | 0 eligible guards checked | pass |

Verdict: **CLAIM**; 3/3 paired wins, 1.4% improvement > 0.0% champion drift.

## PERF-261 — hosted macOS

| Metric | Before | After | Absolute / percentage change |
| --- | ---: | ---: | ---: |
| `replayBytes.max` median arm | 1,811 B | 1,786 B | **−25 B / −1.4%** |
| Two predicates, each of 3 arms | count 5/5, min 0, max 0 | count 5/5, min 0, max 0 | ok |
| Hosted guard gate | 0 eligible guards checked | 0 eligible guards checked | pass |

Verdict: **CLAIM**; 3/3 paired wins, 1.4% improvement > 0.0% champion drift.

Cross-OS runs: [PERF-260](https://github.com/daintreehq/daintree/actions/runs/33524675304), [PERF-261](https://github.com/daintreehq/daintree/actions/runs/33525144544).

## Hypothesis ledger

- **Kept:** replace generated, unregistered monitor-config request IDs with an empty string. Every measured arm removed 25 replay bytes without moving message count, served round trips, predicates, or deterministic guards.
- **Exhausted:** the other five replay messages and their payload fields are required field-for-field by `replayMisses`; removing them would break replay rather than optimize it.
- **PERF-260 floor:** no honest count-reduction hypothesis remains. The 32 forks are four supervisors × two jitter passes × the initial fork, two predicate-required automatic recoveries, and one predicate-required manual recovery.
- **Rejected adjacent scenarios:** PERF-046/224 do not exercise production supervision/replay; PERF-262 measures classification; PERF-263 measures watchdog policy; PERF-264 measures PTY replay.

## Checks and limits

- Required PR CI [run 33528463398](https://github.com/daintreehq/daintree/actions/runs/33528463398): **green**. Build, preload stripping, packaged smoke, consolidated typecheck/lint/format, four full Vitest shards, and aggregate `ci-ok` passed.
- Full CI Vitest result: 2,476 files; 54,734 passed; 9 skipped; 1 todo.
- Local `npm run typecheck`: pass on Node 22.13.0.
- Local `npm run check`: pass on Node 22.13.0/npm 10.9.2 after clearing the outer launcher-only `npm_config_call` value.
- Scoped monitor-config tests: 3/3 pass.
- Local full-suite diagnostics found only `scenarioLiveness` failures that reproduce unchanged on `origin/develop`: the original Node 22.13.0 runtime lacks APIs used by newer scenarios, and the supported Node 24 run's PERF-063 batcher shortfall reproduces on current `origin/develop` `2cb30c5c79349d69e43efb68d9ea68630f954484`. Required CI is green on the candidate.
- Diff audit: one production file changed; `git diff --check` passes; nothing under `scripts/perf/` changed.
- No E2E was run, per repository policy. No hosted-runner duration was claimed.

Ownership finding: `AREAS.md` does not list `electron/services/WorkspaceHostProcess.ts` under Area D even though it owns the production supervisor measured by PERF-260/261. This PR does not widen scope to alter the ownership partition.
