### PR TITLE
perf(copytree): parallelize repository discovery

### DIFF
--- a/electron/services/CopyTreeService.ts
+++ b/electron/services/CopyTreeService.ts
@@ -65,12 +65,12 @@ const TEST_CONFIG_FAILED_MESSAGE = "Failed to test context settings";
 const FILE_TREE_FAILED_MESSAGE = "Failed to read the project files";
 
 /**
- * The defaults-only config is immutable and project-independent (`userConfig`
- * is off, so nothing outside the packaged defaults feeds it), and loading one
- * parses every config file and compiles a JSON schema. Cache the promise per
- * isolate: the context listing runs a dry run per directory, and paying that
- * cost on every expansion is pure waste. Failures are evicted so a later call
- * retries rather than inheriting a dead config.
+ * The defaults-only config is project-independent (`userConfig` is off, so
+ * nothing outside the packaged defaults feeds it), and loading one parses every
+ * config file and compiles a JSON schema. Cache the promise per isolate: the
+ * context listing runs a dry run per directory, and paying that cost on every
+ * expansion is pure waste. Failures are evicted so a later call retries rather
+ * than inheriting a dead config.
  */
 let _configPromise: Promise<SdkConfigManager> | null = null;
 
@@ -585,6 +585,11 @@ class CopyTreeService {
         if (!config.isDefaultsLoaded) {
           throw new Error("CopyTree default configuration is missing");
         }
+
+        // CopyTree's default walker is sequential. Daintree routinely scans a
+        // whole repository, so use its bounded parallel walker; the canonical
+        // sort still runs after discovery and before any budget is applied.
+        config.set("copytree.discovery.parallelEnabled", true);
         return config;
       })().catch((error: unknown) => {
         _configPromise = null;

--- a/electron/services/__tests__/CopyTreeService.adversarial.test.ts
+++ b/electron/services/__tests__/CopyTreeService.adversarial.test.ts
@@ -26,7 +26,7 @@ describe("CopyTreeService adversarial", () => {
     // that stubs a config failure would otherwise inherit a previous test's
     // successful load (or leak its own failure forward).
     _resetConfigCacheForTests();
-    configCreateMock.mockResolvedValue({ isDefaultsLoaded: true });
+    configCreateMock.mockResolvedValue({ isDefaultsLoaded: true, set: vi.fn() });
   });
 
   afterEach(async () => {

--- a/electron/services/__tests__/CopyTreeService.fileTree.test.ts
+++ b/electron/services/__tests__/CopyTreeService.fileTree.test.ts
@@ -72,7 +72,7 @@ describe("CopyTreeService.getFileTree", () => {
     vi.clearAllMocks();
     _resetConfigCacheForTests();
     _resetBaseRealpathCacheForTests();
-    configCreateMock.mockResolvedValue({ isDefaultsLoaded: true });
+    configCreateMock.mockResolvedValue({ isDefaultsLoaded: true, set: vi.fn() });
     copyMock.mockResolvedValue(dryRunResult([]));
   });
 
@@ -423,9 +423,15 @@ describe("CopyTreeService.getFileTree", () => {
   it("shares one config load across concurrent operations without cross-cancelling them", async () => {
     // The cache is a shared promise, so a cancel landing while another caller
     // awaits it must not take that caller down with it.
-    let releaseConfig!: (value: { isDefaultsLoaded: boolean }) => void;
+    let releaseConfig!: (value: {
+      isDefaultsLoaded: boolean;
+      set: (path: string, value: unknown) => void;
+    }) => void;
     configCreateMock.mockReturnValue(
-      new Promise<{ isDefaultsLoaded: boolean }>((resolve) => {
+      new Promise<{
+        isDefaultsLoaded: boolean;
+        set: (path: string, value: unknown) => void;
+      }>((resolve) => {
         releaseConfig = resolve;
       })
     );
@@ -440,7 +446,7 @@ describe("CopyTreeService.getFileTree", () => {
     await vi.waitFor(() => expect(configCreateMock).toHaveBeenCalledTimes(1));
 
     copyTreeService.cancel("op-listing");
-    releaseConfig({ isDefaultsLoaded: true });
+    releaseConfig({ isDefaultsLoaded: true, set: vi.fn() });
 
     await expect(listing).rejects.toThrow("Context generation cancelled");
     // The survivor is unaffected: it got the shared config and ran to completion.
@@ -520,7 +526,7 @@ describe("CopyTreeService.getFileTree", () => {
       "Context configuration couldn't be loaded"
     );
 
-    configCreateMock.mockResolvedValue({ isDefaultsLoaded: true });
+    configCreateMock.mockResolvedValue({ isDefaultsLoaded: true, set: vi.fn() });
     await expect(copyTreeService.getFileTree(tempDir)).resolves.toEqual([]);
     expect(configCreateMock).toHaveBeenCalledTimes(2);
   });

--- a/electron/services/__tests__/CopyTreeService.lazy-import.test.ts
+++ b/electron/services/__tests__/CopyTreeService.lazy-import.test.ts
@@ -9,7 +9,9 @@ function mockCopytreeModule() {
       output: "<context />",
       stats: { totalFiles: 1, totalSize: 10, duration: 5 },
     }),
-    ConfigManager: { create: vi.fn().mockResolvedValue({ isDefaultsLoaded: true }) },
+    ConfigManager: {
+      create: vi.fn().mockResolvedValue({ isDefaultsLoaded: true, set: vi.fn() }),
+    },
   };
 }
 
@@ -102,7 +104,9 @@ describe("CopyTreeService lazy copytree import", () => {
       await gate;
       return {
         copy: copyMock,
-        ConfigManager: { create: vi.fn().mockResolvedValue({ isDefaultsLoaded: true }) },
+        ConfigManager: {
+          create: vi.fn().mockResolvedValue({ isDefaultsLoaded: true, set: vi.fn() }),
+        },
       };
     });
 

--- a/electron/services/__tests__/CopyTreeService.stream.test.ts
+++ b/electron/services/__tests__/CopyTreeService.stream.test.ts
@@ -68,7 +68,7 @@ describe("CopyTreeService streaming to a file", () => {
     outputPath = path.join(tempDir, "bundle.xml");
     vi.clearAllMocks();
     _resetConfigCacheForTests();
-    configCreateMock.mockResolvedValue({ isDefaultsLoaded: true });
+    configCreateMock.mockResolvedValue({ isDefaultsLoaded: true, set: vi.fn() });
   });
 
   afterEach(async () => {

--- a/electron/services/__tests__/CopyTreeService.test.ts
+++ b/electron/services/__tests__/CopyTreeService.test.ts
@@ -5,6 +5,7 @@ import path from "path";
 
 const copyMock = vi.hoisted(() => vi.fn());
 const configCreateMock = vi.hoisted(() => vi.fn());
+const configSetMock = vi.hoisted(() => vi.fn());
 
 vi.mock("copytree", () => ({
   copy: copyMock,
@@ -25,7 +26,7 @@ describe("CopyTreeService", () => {
     // that stubs a config failure would otherwise inherit a previous test's
     // successful load (or leak its own failure forward).
     _resetConfigCacheForTests();
-    configCreateMock.mockResolvedValue({ isDefaultsLoaded: true });
+    configCreateMock.mockResolvedValue({ isDefaultsLoaded: true, set: configSetMock });
     copyMock.mockResolvedValue({
       output: "<context />",
       outputFormatVersion: "copytree-xml@1",
@@ -358,12 +359,18 @@ describe("CopyTreeService", () => {
     );
 
     it("proceeds when the defaults did load", async () => {
-      configCreateMock.mockResolvedValue({ isDefaultsLoaded: true });
+      configCreateMock.mockResolvedValue({ isDefaultsLoaded: true, set: configSetMock });
 
       const result = await copyTreeService.generate(tempDir);
 
       expect(copyMock).toHaveBeenCalledTimes(1);
       expect(result.error).toBeUndefined();
+    });
+
+    it("enables bounded parallel discovery on the shared SDK config", async () => {
+      await copyTreeService.generate(tempDir);
+
+      expect(configSetMock).toHaveBeenCalledWith("copytree.discovery.parallelEnabled", true);
     });
   });
 


### PR DESCRIPTION
## Summary

- enable CopyTree's bounded parallel directory walker for Daintree's defaults-only SDK configuration
- retain CopyTree's canonical post-discovery sort, so file selection, output order, budgets, cancellation, and streamed-file semantics stay unchanged
- update focused service mocks and add a configuration contract test for the parallel-discovery setting

## Performance result

Final results come only from fresh branch-point-versus-final six-arm interleaves on `host-02d9f218-darwin-arm64` (Apple M1 Max, macOS/arm64). Each arm used smoke mode, 20 iterations, 1 warmup, and the order `champ1 → cand1 → cand2 → champ2 → champ3 → cand3`.

| Benchmark | Metric | Before | After | Absolute | Change | Threshold | Drift | Pair results | Verdict |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- |
| PERF-390 | `largeMs.mean` | 280.279 ms | 264.523 ms | -15.755 ms | -5.6% | 5.0% | 2.4% | 7.6%, 7.8%, 5.4% | CLAIM |
| PERF-392 | `streamMs.mean` | 271.622 ms | 250.109 ms | -21.513 ms | -7.9% | 7.0% | 1.5% | 9.2%, 8.1%, 7.2% | CLAIM |

PERF-390 verdict:

```text
VERDICT: CLAIM

CLAIM — all four conditions hold.
```

PERF-392 verdict:

```text
VERDICT: CLAIM

CLAIM — all four conditions hold.
```

### Correctness predicates

Every predicate was emitted in every iteration of every arm (`count 20/20`, `min 0`, `max 0`).

| Benchmark | Predicates |
| --- | --- |
| PERF-390 | `bundleFileCountMisses`, `generateErrorMisses`, `outputSizeMisses`, `partialFileMisses`, `progressMonotonicityMisses`, `progressTerminalMisses`, `reportedFileCountMisses`, `sentinelContentMisses` |
| PERF-392 | `budgetFitMisses`, `bundleFileCountMisses`, `generateErrorMisses`, `outputSizeMisses`, `partialFileMisses`, `previewMisses`, `reportedFileCountMisses`, `reservedPathMisses`, `sentinelContentMisses` |

### PERF-390 guards

All 16 precommitted guards passed.

| Guard | Before | After | Change | Gate |
| --- | ---: | ---: | ---: | --- |
| `largeBundleBytes` | 1,885,937 | 1,885,937 | 0.0% | OK |
| `largeFiles` | 2,200 | 2,200 | 0.0% | OK |
| `largeMsPerKFile` | 127.399 ms | 120.238 ms | -5.6% | OK |
| `largeProgressEvents` | 6 | 6 | 0.0% | OK |
| `mediumBundleBytes` | 598,816 | 598,816 | 0.0% | OK |
| `mediumFiles` | 700 | 700 | 0.0% | OK |
| `mediumMs` | 92.078 ms | 85.800 ms | -6.8% | OK |
| `mediumProgressEvents` | 5 | 5 | 0.0% | OK |
| `progressEventCount` | 21 | 21 | 0.0% | OK |
| `scopeNarrowingMs` | 249.484 ms | 233.958 ms | -6.2% | OK |
| `scopedFiles` | 200 | 200 | 0.0% | OK |
| `scopedMs` | 31.511 ms | 29.245 ms | -7.2% | OK |
| `smallBundleBytes` | 102,668 | 102,668 | 0.0% | OK |
| `smallFiles` | 120 | 120 | 0.0% | OK |
| `smallMs` | 18.700 ms | 18.003 ms | -3.7% | OK |
| `smallProgressEvents` | 5 | 5 | 0.0% | OK |

### PERF-392 guards

All nine precommitted guards passed. `inMemoryChars` was classified as noise because it was identical; no guard breached tolerance.

| Guard | Before | After | Change | Gate |
| --- | ---: | ---: | ---: | --- |
| `budgetFitMs` | 0.118 ms | 0.120 ms | +2.0% | OK |
| `bundleBytes` | 1,885,937 | 1,885,937 | 0.0% | OK |
| `inMemoryChars` | 1,867,859 | 1,867,859 | 0.0% | NOISE |
| `inMemoryMs` | 134.829 ms | 114.738 ms | -14.9% | OK |
| `previewMs` | 0.253 ms | 0.258 ms | +2.2% | OK |
| `reserveMs` | 0.551 ms | 0.354 ms | -35.9% | OK |
| `serializedResultBytes` | 34,248 | 34,248 | 0.0% | OK |
| `streamOverheadRatio` | 2.028 | 2.181 | +7.6% | OK |
| `streamThroughputMbPerSec` | 6.625 | 7.199 | +8.7% | OK |

## Protocol and provenance

- branch point: `2cb30c5c79349d69e43efb68d9ea68630f954484`
- final tree: `5c7b6b4d8a402382ab1468246ab895233fc79e8b`
- apparatus digest: `1d64b293f6cf9459…` over 162 files; no `scripts/perf/**` changes
- Node 22.23.2, git 2.55.0, Electron 42.7.1
- final worst within-arm CV: 8.5% for PERF-390 and 8.4% for PERF-392, both below the locked 10% ceiling
- partial interleaves were discarded whenever another perf/test/typecheck process appeared; one complete PERF-392 set was refused at 10.8% within-arm CV and remeasured unchanged after cooling

These are local macOS duration claims only. Linux and Windows were not measured: GitHub-hosted duration claims are prohibited by the performance protocol, and no physical Linux or Windows machine was reachable. Deterministic output counts and byte sizes remained identical correctness guards, so there was no portable deterministic improvement to dispatch through `perf-ab.yml`.

## Rejected hypotheses

| Hypothesis | Result |
| --- | --- |
| coalesce SDK chunks into 64 KiB stream batches | +4.9% regression |
| byte-mode `Readable.from` at the original branch point | -1.6%, below the then-locked 13% threshold |
| 256 KiB source high-water mark | -1.7%, below threshold |
| 256 KiB destination high-water mark | +9.8% regression |
| defer chunk encoding to the writable | +1.5% regression |
| scale discovery concurrency from 5 to host parallelism | 251.736 → 251.742 ms, no movement |
| direct per-chunk `FileHandle.write` | +39.3% regression |
| bounded 64 KiB / 64-vector `writev` | -0.5%, no movement |
| bounded 256 KiB / 256-vector `writev` | -0.4%, no movement |
| byte-mode source combined with parallel discovery | +1.4% regression |
| raise discovery result high-water mark to 256 | +0.3% regression |

## Verification

- focused CopyTree service suite: 188 passed
- `npm run typecheck`: passed
- `npm test`: 2,476 files passed; 54,737 passed, 7 skipped, 1 todo, 0 failed
- `npm run check`: passed (type/generated/API/registry checks, lint ratchet, Prettier)
- E2E not run, per the optimization protocol
