### PR TITLE
perf(persistence): reuse SQLite run statements

### DIFF
--- a/electron/services/persistence/__tests__/sqliteRunStatementCache.test.ts
+++ b/electron/services/persistence/__tests__/sqliteRunStatementCache.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
 import Database from "better-sqlite3";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { installSqliteRunStatementCache } from "../sqliteRunStatementCache.js";
 
 class FakeStatement {
@@ -37,6 +40,8 @@ class FakeDatabase {
     return statement;
   }
 }
+
+const distinctSql = (n: number) => `insert into t${n} values (?)`;
 
 installSqliteRunStatementCache(FakeDatabase as unknown as typeof Database);
 installSqliteRunStatementCache(Database);
@@ -114,9 +119,105 @@ describe("SQLite run statement cache", () => {
     const db = new FakeDatabase();
     expect(() => db.prepare("invalid")).toThrow("invalid SQL");
   });
+
+  it("holds exactly 128 statements per connection", () => {
+    const db = new FakeDatabase();
+    for (let i = 0; i < 128; i += 1) db.prepare(distinctSql(i)).run();
+    expect(db.prepared).toHaveLength(128);
+
+    // Replaying all 128 compiles nothing new, so none of them was evicted early.
+    for (let i = 0; i < 128; i += 1) db.prepare(distinctSql(i)).run();
+    expect(db.prepared).toHaveLength(128);
+
+    // The 129th pushes the cache over the bound and drops the oldest entry.
+    db.prepare(distinctSql(128)).run();
+    expect(db.prepared).toHaveLength(129);
+
+    db.prepare(distinctSql(1)).run();
+    expect(db.prepared).toHaveLength(129);
+
+    db.prepare(distinctSql(0)).run();
+    expect(db.prepared).toHaveLength(130);
+  });
+
+  it("evicts the least recently run statement, not the oldest compiled one", () => {
+    const db = new FakeDatabase();
+    for (let i = 0; i < 128; i += 1) db.prepare(distinctSql(i)).run();
+
+    // Reuse promotes the first statement, so overflowing must drop the second.
+    db.prepare(distinctSql(0)).run();
+    db.prepare(distinctSql(128)).run();
+    expect(db.prepared).toHaveLength(129);
+
+    db.prepare(distinctSql(0)).run();
+    expect(db.prepared).toHaveLength(129);
+
+    db.prepare(distinctSql(1)).run();
+    expect(db.prepared).toHaveLength(130);
+  });
 });
 
 describe("SQLite run statement cache native compatibility", () => {
+  it("never lends one connection's cached statement to another", () => {
+    const first = new Database(":memory:");
+    const second = new Database(":memory:");
+    try {
+      for (const db of [first, second]) {
+        db.exec("CREATE TABLE items (id INTEGER PRIMARY KEY, tag TEXT NOT NULL)");
+      }
+
+      const insert = "INSERT INTO items (id, tag) VALUES (?, ?)";
+      first.prepare(insert).run(1, "first");
+      second.prepare(insert).run(2, "second");
+
+      expect(first.prepare("SELECT id, tag FROM items").raw().all()).toEqual([[1, "first"]]);
+      expect(second.prepare("SELECT id, tag FROM items").raw().all()).toEqual([[2, "second"]]);
+    } finally {
+      first.close();
+      second.close();
+    }
+  });
+
+  it("keys the cache by handle even when two handles share one file", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "daintree-run-statement-cache-"));
+    const first = new Database(path.join(dir, "shared.db"));
+    const second = new Database(path.join(dir, "shared.db"));
+    try {
+      // A temp table is private to its connection, so a statement that leaked
+      // across handles writes into the wrong database and shows up here.
+      for (const db of [first, second]) {
+        db.exec("CREATE TEMP TABLE staged (tag TEXT NOT NULL)");
+      }
+
+      const insert = "INSERT INTO staged (tag) VALUES (?)";
+      first.prepare(insert).run("first");
+      second.prepare(insert).run("second");
+
+      expect(first.prepare("SELECT tag FROM staged").pluck().all()).toEqual(["first"]);
+      expect(second.prepare("SELECT tag FROM staged").pluck().all()).toEqual(["second"]);
+    } finally {
+      first.close();
+      second.close();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("still writes correctly once distinct SQL overflows the cache", () => {
+    const db = new Database(":memory:");
+    try {
+      db.exec("CREATE TABLE items (id INTEGER PRIMARY KEY, tag TEXT NOT NULL)");
+      for (let i = 0; i < 200; i += 1) {
+        db.prepare(`INSERT INTO items (id, tag) VALUES (?, 'tag-${i}')`).run(i);
+      }
+
+      expect(db.prepare("SELECT COUNT(*) FROM items").pluck().get()).toBe(200);
+      expect(db.prepare("SELECT tag FROM items WHERE id = 0").pluck().get()).toBe("tag-0");
+      expect(db.prepare("SELECT tag FROM items WHERE id = 199").pluck().get()).toBe("tag-199");
+    } finally {
+      db.close();
+    }
+  });
+
   it("keeps late binding isolated from an already cached statement", () => {
     const db = new Database(":memory:");
     try {

--- a/electron/services/persistence/__tests__/sqliteRunStatementCache.test.ts
+++ b/electron/services/persistence/__tests__/sqliteRunStatementCache.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+import Database from "better-sqlite3";
+import { installSqliteRunStatementCache } from "../sqliteRunStatementCache.js";
+
+class FakeStatement {
+  busy = false;
+  readonly = false;
+  reader = false;
+  source: string;
+  database: FakeDatabase;
+  configured = false;
+  runs = 0;
+
+  constructor(database: FakeDatabase, source: string) {
+    this.database = database;
+    this.source = source;
+  }
+
+  run(): Database.RunResult {
+    this.runs += 1;
+    return { changes: 1, lastInsertRowid: this.runs };
+  }
+
+  raw(): this {
+    this.configured = true;
+    return this;
+  }
+}
+
+class FakeDatabase {
+  prepared: FakeStatement[] = [];
+
+  prepare(source: string): FakeStatement {
+    if (source === "invalid") throw new Error("invalid SQL");
+    const statement = new FakeStatement(this, source);
+    this.prepared.push(statement);
+    return statement;
+  }
+}
+
+installSqliteRunStatementCache(FakeDatabase as unknown as typeof Database);
+installSqliteRunStatementCache(Database);
+
+describe("SQLite run statement cache", () => {
+  it("compiles identical direct run statements once", () => {
+    const db = new FakeDatabase();
+
+    db.prepare("insert into projects values (?)").run();
+    db.prepare("insert into projects values (?)").run();
+
+    expect(db.prepared).toHaveLength(1);
+    expect(db.prepared[0].runs).toBe(2);
+  });
+
+  it("isolates configured statements from the cached run statement", () => {
+    const db = new FakeDatabase();
+    db.prepare("update projects set name = ?").run();
+
+    const configured = db.prepare("update projects set name = ?").raw();
+    configured.run();
+    db.prepare("update projects set name = ?").run();
+
+    expect(db.prepared).toHaveLength(2);
+    expect(db.prepared[0].configured).toBe(false);
+    expect(db.prepared[0].runs).toBe(2);
+    expect(db.prepared[1].configured).toBe(true);
+    expect(db.prepared[1].runs).toBe(1);
+  });
+
+  it("does not share a statement until its first direct run", () => {
+    const db = new FakeDatabase();
+    const configured = db.prepare("insert into projects values (?)");
+    const direct = db.prepare("insert into projects values (?)");
+
+    configured.raw().run();
+    direct.run();
+
+    expect(db.prepared).toHaveLength(2);
+    expect(db.prepared[0].configured).toBe(true);
+    expect(db.prepared[0].runs).toBe(1);
+    expect(db.prepared[1].configured).toBe(false);
+    expect(db.prepared[1].runs).toBe(1);
+  });
+
+  it("isolates configuration added after a statement has entered the cache", () => {
+    const db = new FakeDatabase();
+    const first = db.prepare("update projects set name = ?");
+    first.run();
+    const second = db.prepare("update projects set name = ?");
+
+    first.raw().run();
+    second.run();
+
+    expect(db.prepared).toHaveLength(2);
+    expect(db.prepared[0].configured).toBe(false);
+    expect(db.prepared[0].runs).toBe(2);
+    expect(db.prepared[1].configured).toBe(true);
+    expect(db.prepared[1].runs).toBe(1);
+  });
+
+  it("uses a fresh statement when the cached one is busy", () => {
+    const db = new FakeDatabase();
+    db.prepare("delete from projects where id = ?").run();
+    db.prepared[0].busy = true;
+
+    db.prepare("delete from projects where id = ?").run();
+
+    expect(db.prepared).toHaveLength(2);
+    expect(db.prepared[0].runs).toBe(1);
+    expect(db.prepared[1].runs).toBe(1);
+  });
+
+  it("still validates new SQL during prepare", () => {
+    const db = new FakeDatabase();
+    expect(() => db.prepare("invalid")).toThrow("invalid SQL");
+  });
+});
+
+describe("SQLite run statement cache native compatibility", () => {
+  it("keeps late binding isolated from an already cached statement", () => {
+    const db = new Database(":memory:");
+    try {
+      db.exec("CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT NOT NULL)");
+      const first = db.prepare("INSERT INTO items (id, name) VALUES (?, ?)");
+      first.run(1, "first");
+      const cached = db.prepare("INSERT INTO items (id, name) VALUES (?, ?)");
+
+      first.bind(2, "second").run();
+      cached.run(3, "third");
+
+      expect(db.prepare("SELECT id, name FROM items ORDER BY id").raw().all()).toEqual([
+        [1, "first"],
+        [2, "second"],
+        [3, "third"],
+      ]);
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/electron/services/persistence/__tests__/sqliteRunStatementCacheInstall.test.ts
+++ b/electron/services/persistence/__tests__/sqliteRunStatementCacheInstall.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from "vitest";
+
+const { installSpy } = vi.hoisted(() => ({ installSpy: vi.fn() }));
+
+vi.mock("electron", () => ({
+  app: {
+    getPath: () => "/fake/userData",
+    isPackaged: false,
+    getAppPath: () => "/fake/appPath",
+  },
+}));
+
+vi.mock("../sqliteRunStatementCache.js", () => ({
+  installSqliteRunStatementCache: installSpy,
+}));
+
+import "../db.js";
+
+describe("SQLite run statement cache install site", () => {
+  // db.ts owns every connection Daintree opens. Installing from anywhere else —
+  // schema.ts, say, which drizzle-kit also loads — can be silently undone by a
+  // later `import type`, with no other test noticing.
+  it("installs the cache when the database module loads", () => {
+    expect(installSpy).toHaveBeenCalled();
+  });
+});

--- a/electron/services/persistence/db.ts
+++ b/electron/services/persistence/db.ts
@@ -8,10 +8,17 @@ import path from "path";
 import { getWritesSuppressed } from "../diskPressureState.js";
 import { tightenFilePermissionsSync, OWNER_RW_FILE_MODE } from "../../utils/fs.js";
 import * as schema from "./schema.js";
+import { installSqliteRunStatementCache } from "./sqliteRunStatementCache.js";
 import type { DatabaseRecovery } from "../../../shared/types/ipc/app.js";
 import type { DbProbeResult } from "./dbWorkerProtocol.js";
 
 export type AppDb = ReturnType<typeof drizzle<typeof schema>>;
+
+// Every Daintree SQLite connection is opened from this module, so patching
+// better-sqlite3's prototype here — rather than from the declarative schema
+// drizzle-kit also loads — keeps the optimisation on the connection path and
+// off the migration tooling. Idempotent.
+installSqliteRunStatementCache();
 
 let sharedInstance: { sqlite: Database.Database; db: AppDb } | null = null;
 

--- a/electron/services/persistence/schema.ts
+++ b/electron/services/persistence/schema.ts
@@ -1,10 +1,4 @@
 import { sqliteTable, text, integer, real, index } from "drizzle-orm/sqlite-core";
-import { installSqliteRunStatementCache } from "./sqliteRunStatementCache.js";
-
-// `schema` is the shared bootstrap imported before Daintree's Drizzle
-// connections are created. Install once on better-sqlite3's prototype so every
-// connection gets the same bounded write-statement reuse.
-installSqliteRunStatementCache();
 
 export const projects = sqliteTable(
   "projects",

--- a/electron/services/persistence/schema.ts
+++ b/electron/services/persistence/schema.ts
@@ -1,4 +1,10 @@
 import { sqliteTable, text, integer, real, index } from "drizzle-orm/sqlite-core";
+import { installSqliteRunStatementCache } from "./sqliteRunStatementCache.js";
+
+// `schema` is the shared bootstrap imported before Daintree's Drizzle
+// connections are created. Install once on better-sqlite3's prototype so every
+// connection gets the same bounded write-statement reuse.
+installSqliteRunStatementCache();
 
 export const projects = sqliteTable(
   "projects",

--- a/electron/services/persistence/sqliteRunStatementCache.ts
+++ b/electron/services/persistence/sqliteRunStatementCache.ts
@@ -1,0 +1,102 @@
+import Database from "better-sqlite3";
+
+const INSTALL_MARK = Symbol.for("daintree.sqliteRunStatementCache.installed");
+const MAX_CACHED_RUN_STATEMENTS = 128;
+
+type AnyStatement = Database.Statement<unknown[]>;
+type DatabasePrototype = Database.Database & { [INSTALL_MARK]?: true };
+
+const statementCaches = new WeakMap<Database.Database, Map<string, AnyStatement>>();
+
+function touchCachedStatement(
+  db: Database.Database,
+  source: string,
+  statement: AnyStatement
+): void {
+  let cache = statementCaches.get(db);
+  if (!cache) {
+    cache = new Map();
+    statementCaches.set(db, cache);
+  }
+
+  cache.delete(source);
+  cache.set(source, statement);
+
+  if (cache.size > MAX_CACHED_RUN_STATEMENTS) {
+    const oldestSource = cache.keys().next().value;
+    if (oldestSource !== undefined) cache.delete(oldestSource);
+  }
+}
+
+/**
+ * Reuse native prepared statements for the unconfigured `.run()` path.
+ *
+ * Drizzle creates a new query builder and calls `Database.prepare()` for every
+ * synchronous insert/update/delete, even when the parameterised SQL is
+ * identical. Compiling that SQL over and over is pure overhead. Read and
+ * configured statements cannot be shared because methods such as `pluck()`,
+ * `raw()`, `safeIntegers()` and `bind()` mutate the Statement instance, so the
+ * proxy below isolates every path except a direct `.run()`.
+ *
+ * The cache is per connection, bounded, and weakly owned. A busy statement can
+ * occur through a re-entrant SQLite callback; that call gets a fresh statement
+ * rather than changing better-sqlite3's normal re-entrancy behaviour.
+ */
+export function installSqliteRunStatementCache(
+  DatabaseConstructor: typeof Database = Database
+): void {
+  const prototype = DatabaseConstructor.prototype as DatabasePrototype;
+  if (prototype[INSTALL_MARK]) return;
+
+  const originalPrepare = prototype.prepare;
+
+  prototype.prepare = function cachedPrepare<
+    BindParameters extends unknown[] | Record<string, unknown> = unknown[],
+    Result = unknown,
+  >(this: Database.Database, source: string): Database.Statement<BindParameters, Result> {
+    const cache = statementCaches.get(this);
+    const cached = cache?.get(source);
+    const runStatement = cached ?? (originalPrepare.call(this, source) as AnyStatement);
+    const wasCached = cached !== undefined;
+
+    let isolatedStatement: AnyStatement | undefined;
+    let runClaimed = false;
+    const isolate = (): AnyStatement => {
+      if (isolatedStatement) return isolatedStatement;
+
+      if (!wasCached && !runClaimed) {
+        // A statement is not shared until its first direct `.run()`. A caller
+        // that uses any other API first therefore owns the native statement.
+        isolatedStatement = runStatement;
+      } else {
+        // Once `.run` has been claimed, this proxy may outlive other proxies
+        // using the cached statement. Isolate late configuration too: bind(),
+        // raw(), pluck() and safeIntegers() all mutate native Statement state.
+        isolatedStatement = originalPrepare.call(this, source) as AnyStatement;
+      }
+      return isolatedStatement;
+    };
+
+    return new Proxy(runStatement, {
+      get: (_target, property) => {
+        if (property === "run" && !isolatedStatement) {
+          runClaimed = true;
+          return (...params: unknown[]) => {
+            const statement = runStatement.busy
+              ? (originalPrepare.call(this, source) as AnyStatement)
+              : runStatement;
+            const result = statement.run(...params);
+            touchCachedStatement(this, source, runStatement);
+            return result;
+          };
+        }
+
+        const statement = isolate();
+        const value = Reflect.get(statement, property, statement);
+        return typeof value === "function" ? value.bind(statement) : value;
+      },
+    }) as Database.Statement<BindParameters, Result>;
+  } as Database.Database["prepare"];
+
+  Object.defineProperty(prototype, INSTALL_MARK, { value: true });
+}


### PR DESCRIPTION
## What changed

Reuse identical better-sqlite3 prepared statements for the direct `.run()` path that Drizzle uses for synchronous inserts, updates, and deletes.

The cache is per connection, weakly owned, and capped at 128 SQL strings. Statements only enter it after a successful direct run. Read/configuration APIs such as `bind()`, `raw()`, `pluck()`, and `safeIntegers()` always receive an isolated native statement, as does a re-entrant call while the cached statement is busy.

## PERF-053 `p50Ms` — `host-02d9f218-darwin-arm64`

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| `p50Ms` | 31.554 ms | 26.167 ms | −17.1% |
| `rowMisses` | 0 | 0 | ok |
| `perRowMs` | 19.146 ms | 16.378 ms | −14.5% |
| `txnMs` | 12.538 ms | 10.020 ms | −20.1% |
| `perRowStatementCount` | 200 | 200 | unchanged |
| `txnStatementCount` | 200 | 200 | unchanged |
| `perRowTransactionCount` | 200 | 200 | unchanged |
| `txnTransactionCount` | 1 | 1 | unchanged |
| `batchSpeedupRatio` | 1.524 | 1.638 | +7.5% cost, within 10% guard |
| `rowsChangedCount` | 400 | 400 | unchanged |
| `walKB` | 4161.473 | 4161.473 | unchanged |
| `walGrowthKB` | 8.047 | 8.047 | unchanged |

Machine: `host-02d9f218-darwin-arm64` (darwin/arm64, Apple M1 Max) · smoke mode · 20 iterations · 1 warmup  
Trees: `2cb30c5c79349d69e43efb68d9ea68630f954484` → `55ee3cef9174b901ee123d73e5c43f32ea71dc41` · git 2.55.0 · Electron 42.7.1 · Node 22.23.2  
Statistic: median arm · precommitted threshold 8.8% · measured drift D 0.8%

```text
Target: p50Ms on PERF-053 · lower is better
Champion drift D: 0.8% (worst of 3, champ2 v champ3) — same code on both sides, so this is the machine
Drift ceiling (--max-drift): 17.6% (default, 2x threshold)
Worst within-arm spread: 4.1% on cand3 · ceiling 10%

  pair 1: 31.554 → 26.273  16.7%  WON
  pair 2: 31.596 → 26.167  17.2%  WON
  pair 3: 31.359 → 26.002  17.1%  WON

  median arm: 31.554 → 26.167  improvement 17.1%
  precommitted threshold (--threshold): 8.8%

  guards (cost metrics — up is worse):
    OK      perRowMs  19.146 → 16.378  -14.5% better  tolerance 10% (machine-dependent)
    OK      txnMs  12.538 → 10.02  -20.1% better  tolerance 10% (machine-dependent)
    OK      perRowStatementCount  200 → 200  +0.0% better  tolerance 5%
    OK      txnStatementCount  200 → 200  +0.0% better  tolerance 5%
    OK      perRowTransactionCount  200 → 200  +0.0% better  tolerance 5%
    OK      txnTransactionCount  1 → 1  +0.0% better  tolerance 5%
    OK      batchSpeedupRatio  1.524 → 1.638  +7.5% worse  tolerance 10% (machine-dependent)
    OK      rowsChangedCount  400 → 400  +0.0% better  tolerance 5%
    OK      walKB  4161.473 → 4161.473  +0.0% better  tolerance 5%
    OK      walGrowthKB  8.047 → 8.047  +0.0% better  tolerance 5%

  condition 1  PASS  candidate won every index-paired arm — 3/3
  condition 2  PASS  median-to-median improvement 17.1% >= precommitted threshold 8.8%
  condition 3  PASS  improvement 17.1% > champion drift D 0.8%
  condition 4  PASS  no guard outside its precommitted tolerance — 10 checked

VERDICT: CLAIM

CLAIM — all four conditions hold.
```

`rowMisses` was healthy on every arm: count 20/20, min 0, max 0.

## Hypothesis ledger

- Kept: cache the repeated unconfigured native `.run()` statement per connection and SQL string. The final fresh branch-point headline shows a 17.1% p50 improvement.
- Hardened before final measurement: delay sharing until a successful direct run, isolate late native statement configuration, and use a fresh statement for re-entrant busy calls.
- Rejected: drop or merge required indexes; the indexes serve separate production query shapes.
- Rejected: convert the projects table to `WITHOUT ROWID`; there is no supported generated-migration path for that rewrite here.
- Rejected: pragma changes; the protected production-shaped fixture already fixes the relevant connection pragmas.
- Rejected: ProjectStore batching; PERF-053 deliberately measures the engine-level Drizzle/better-sqlite3 path outside ProjectStore.
- Rejected: omit legitimate upsert columns or share configured statements; either would make the workload easier or violate better-sqlite3's mutable Statement contract.

## Checks and limits

- `npm run typecheck` — pass
- `npm test` — pass: 2,477 files, 54,743 tests (7 skipped, 1 todo)
- `npm run check` — pass
- Focused persistence/perf regressions — pass: 3 files, 31 tests
- Diff audit — three Area D persistence files only; no changes under `scripts/perf/`
- Cross-OS hosted duration — not measured: `p50Ms` is machine-dependent and hosted runners are not valid duration evidence. All deterministic count and WAL guards were unchanged, so there was no changed cross-OS count/size/ratio leg to dispatch.
- E2E — not run; only a human names an E2E spec or bucket.
