### PR TITLE
perf(notifications): reduce routing store work

### DIFF
--- a/electron/services/AgentNotificationService.ts
+++ b/electron/services/AgentNotificationService.ts
@@ -42,6 +42,7 @@ const SPAWN_GRACE_PERIOD_MS = 5_000;
 const BOOT_GRACE_PERIOD_MS = 8_000;
 
 type TerminalSnapshot = StoreSchema["appState"]["terminals"];
+type TerminalSnapshotEntry = TerminalSnapshot[number];
 
 interface PendingNotification {
   title: string;
@@ -87,8 +88,10 @@ class AgentNotificationService {
    * a minutes-later escalation fires, the live index no longer knows the owner.
    */
   private lastOwnerByPanel = new Map<string, NotificationOwnerId>();
+  private terminalIndexById = new Map<string, number>();
   private hasEverGoneWorking = false;
   private peakConcurrentWorking = 0;
+  private activeTerminalIds = new Set<string>();
   private allClearTimer: NodeJS.Timeout | null = null;
 
   private waitingBurstBuffer: BurstWaitingEntry[] = [];
@@ -224,6 +227,15 @@ class AgentNotificationService {
     if (this.unsubscribers.length > 0) return;
 
     this.initializedAt = Date.now();
+    const initialTerminals = store.get("appState")?.terminals ?? [];
+    this.rebuildTerminalIndex(initialTerminals);
+    this.activeTerminalIds = new Set(
+      initialTerminals
+        .filter((terminal) =>
+          terminal.agentState ? ACTIVE_AGENT_STATES.has(terminal.agentState) : false
+        )
+        .map((terminal) => terminal.id)
+    );
 
     const unsubStateChanged = events.on("agent:state-changed", (payload) => {
       this.handleStateChanged(payload);
@@ -264,6 +276,8 @@ class AgentNotificationService {
     const unsubExited = events.on("agent:exited", (payload) => {
       if (payload.terminalId) {
         this.agentSpawnTimestamps.delete(payload.terminalId);
+        this.activeTerminalIds.delete(payload.terminalId);
+        this.terminalIndexById.delete(payload.terminalId);
         // Bound the routing hint's lifetime to the agent's. A re-watch of the
         // same panel repopulates it; notifications already in flight captured
         // their owner when the event fired.
@@ -277,6 +291,8 @@ class AgentNotificationService {
     const unsubKilled = events.on("agent:killed", (payload) => {
       if (payload.terminalId) {
         this.agentSpawnTimestamps.delete(payload.terminalId);
+        this.activeTerminalIds.delete(payload.terminalId);
+        this.terminalIndexById.delete(payload.terminalId);
         this.forgetPanelOwnership(payload.terminalId);
       }
     });
@@ -319,13 +335,22 @@ class AgentNotificationService {
    * gesture; that is acceptable because the fallback (undefined) simply means
    * notifications aren't suppressed, not that they fire wrongly.
    */
-  private resolveWorktreeIdForTerminal(
-    terminals: TerminalSnapshot,
-    terminalId?: string
-  ): string | undefined {
+  private rebuildTerminalIndex(terminals: TerminalSnapshot): void {
+    this.terminalIndexById.clear();
+    terminals.forEach((terminal, index) => this.terminalIndexById.set(terminal.id, index));
+  }
+
+  private getTerminalSnapshot(terminalId?: string): TerminalSnapshotEntry | undefined {
     if (!terminalId) return undefined;
-    const entry = terminals.find((t) => t.id === terminalId);
-    return entry?.worktreeId;
+    const terminals = store.get("appState").terminals;
+    const index = this.terminalIndexById.get(terminalId);
+    if (index !== undefined) {
+      const terminal = terminals[index];
+      if (terminal?.id === terminalId) return terminal;
+    }
+
+    this.rebuildTerminalIndex(terminals);
+    return terminals.find((terminal) => terminal.id === terminalId);
   }
 
   private handleStateChanged(payload: {
@@ -338,15 +363,17 @@ class AgentNotificationService {
     waitingReason?: string;
   }): void {
     const { state, previousState, terminalId, agentId } = payload;
-    // Snapshot store-backed state once — each store.get() re-reads the full
-    // store file from disk, so the helpers below take these as parameters.
-    const terminals = store.get("appState").terminals;
+    this.checkAllClear(state, previousState, terminalId);
+    if (state === previousState) return;
+
+    // Idle is never a notification, escalation, or working-pulse destination,
+    // so no branch below consumes terminal metadata for it.
+    const terminal = state === "idle" ? undefined : this.getTerminalSnapshot(terminalId);
     const settings = projectStore.getEffectiveNotificationSettings();
     // Backend no longer emits worktreeId on agent events (#5139). Resolve it
     // from persisted renderer state so focus suppression, dedup keying, and
     // notification context still work correctly.
-    const worktreeId =
-      payload.worktreeId ?? this.resolveWorktreeIdForTerminal(terminals, terminalId);
+    const worktreeId = payload.worktreeId ?? terminal?.worktreeId;
 
     // Clear spawn grace tracking once the agent starts doing real work
     // (waiting→working means the user gave input, so future waiting sounds are legitimate)
@@ -354,11 +381,6 @@ class AgentNotificationService {
       const graceKey = terminalId ?? agentId;
       if (graceKey) this.agentSpawnTimestamps.delete(graceKey);
     }
-
-    // All-clear tracking runs regardless of notification settings
-    this.checkAllClear(state, previousState, terminals);
-
-    if (state === previousState) return;
 
     // Prefer terminalId so per-terminal dedup timers don't collide when two
     // runtime-detected terminals share the same agentId value (e.g. both
@@ -427,7 +449,7 @@ class AgentNotificationService {
       this.scheduleWaitingEscalation(
         terminalId,
         settings,
-        terminals,
+        terminal,
         worktreeId,
         agentId,
         coerceWaitingReason(payload.waitingReason)
@@ -436,7 +458,7 @@ class AgentNotificationService {
 
     // Schedule working pulse for watched/docked agents entering working state
     if (state === "working" && previousState !== "working" && terminalId) {
-      this.scheduleWorkingPulse(terminalId, settings, terminals);
+      this.scheduleWorkingPulse(terminalId, settings, terminal);
     }
 
     // Skip if all OS notification types are disabled (off by default).
@@ -482,14 +504,33 @@ class AgentNotificationService {
     return terminals.filter((t) => t.agentState && ACTIVE_AGENT_STATES.has(t.agentState)).length;
   }
 
-  private checkAllClear(state: string, previousState: string, terminals: TerminalSnapshot): void {
+  private checkAllClear(state: string, previousState: string, terminalId?: string): void {
     const wasActive = ACTIVE_AGENT_STATES.has(previousState);
     const isActive = ACTIVE_AGENT_STATES.has(state);
 
+    if (terminalId) {
+      if (isActive) this.activeTerminalIds.add(terminalId);
+      else this.activeTerminalIds.delete(terminalId);
+    }
+
+    let activeCount = terminalId
+      ? this.activeTerminalIds.size
+      : this.countActiveAgents(store.get("appState").terminals);
+
     // Track when agents start working
     if (!wasActive && isActive) {
+      // Preserve the persisted-snapshot contract on the first active transition
+      // of a session. Renderer state can already contain active siblings whose
+      // transitions preceded initialization (or were not observed here). The
+      // peak only has a two-agent floor, so later transitions can stay on the
+      // event-maintained set without rescanning the fleet.
+      if (!this.hasEverGoneWorking) {
+        activeCount = Math.max(
+          activeCount,
+          this.countActiveAgents(store.get("appState").terminals)
+        );
+      }
       this.hasEverGoneWorking = true;
-      const activeCount = this.countActiveAgents(terminals);
       this.peakConcurrentWorking = Math.max(this.peakConcurrentWorking, activeCount);
 
       // Cancel any pending all-clear — a new agent just started
@@ -502,8 +543,6 @@ class AgentNotificationService {
 
     // Only consider transitions OUT of active states
     if (!wasActive || isActive) return;
-
-    const activeCount = this.countActiveAgents(terminals);
 
     // All conditions must hold to schedule the all-clear
     if (!this.hasEverGoneWorking || this.peakConcurrentWorking < 2 || activeCount > 0) return;
@@ -653,7 +692,7 @@ class AgentNotificationService {
   private scheduleWaitingEscalation(
     terminalId: string,
     settings: NotificationSettings,
-    terminals: TerminalSnapshot,
+    terminal: TerminalSnapshotEntry | undefined,
     worktreeId?: string,
     agentId?: string,
     waitingReason?: WaitingReason
@@ -665,7 +704,6 @@ class AgentNotificationService {
     if (!settings.waitingEscalationEnabled || !settings.waitingEnabled) return;
 
     // Only escalate for docked terminals
-    const terminal = terminals.find((t) => t.id === terminalId);
     if (!terminal || terminal.location !== "dock") return;
 
     const timer = setTimeout(() => {
@@ -675,14 +713,13 @@ class AgentNotificationService {
       if (!currentSettings.waitingEscalationEnabled || !currentSettings.waitingEnabled) return;
 
       // Re-read terminal state — skip if moved out of dock or removed
-      const currentTerminals = store.get("appState").terminals;
-      const currentTerminal = currentTerminals.find((t) => t.id === terminalId);
+      const currentTerminal = this.getTerminalSnapshot(terminalId);
       if (!currentTerminal || currentTerminal.location !== "dock") return;
 
       // Count all dock terminals currently waiting (for grouped escalation)
-      const waitingDockTerminalIds = currentTerminals
-        .filter((t) => t.location === "dock" && this.waitingTerminalIds.has(t.id))
-        .map((t) => t.id);
+      const waitingDockTerminalIds = [...this.waitingTerminalIds].filter(
+        (id) => this.getTerminalSnapshot(id)?.location === "dock"
+      );
 
       this.playNotificationSound(currentSettings.soundEnabled, currentSettings.escalationSoundFile);
 
@@ -752,7 +789,7 @@ class AgentNotificationService {
   private scheduleWorkingPulse(
     terminalId: string,
     settings: NotificationSettings,
-    terminals: TerminalSnapshot
+    terminal: TerminalSnapshotEntry | undefined
   ): void {
     this.clearWorkingPulse(terminalId);
 
@@ -761,7 +798,6 @@ class AgentNotificationService {
     // Eligibility: watched OR (docked + escalation enabled)
     const isWatched = this.isWatched(terminalId);
     if (!isWatched) {
-      const terminal = terminals.find((t) => t.id === terminalId);
       if (!terminal || terminal.location !== "dock" || !settings.waitingEscalationEnabled) return;
     }
 
@@ -974,9 +1010,11 @@ class AgentNotificationService {
     this.watchedPanelsByOwner.clear();
     this.ownersByPanel.clear();
     this.lastOwnerByPanel.clear();
+    this.terminalIndexById.clear();
     this.notificationQueue = [];
     this.hasEverGoneWorking = false;
     this.peakConcurrentWorking = 0;
+    this.activeTerminalIds.clear();
     this.sessionMuteUntil = 0;
 
     soundService.cancel();

--- a/electron/services/AgentNotificationService.ts
+++ b/electron/services/AgentNotificationService.ts
@@ -325,24 +325,16 @@ class AgentNotificationService {
     return true;
   }
 
-  /**
-   * Look up the renderer-owned worktreeId for a terminal from persisted app state.
-   *
-   * Backend-emitted agent events (agent:state-changed, agent:completed, etc.) no
-   * longer carry worktreeId — it's renderer-owned layout state. Main-side
-   * consumers that need worktreeId for focus/dedup/routing should resolve it
-   * here from the IPC-synced appState. May briefly lag a drag-to-worktree
-   * gesture; that is acceptable because the fallback (undefined) simply means
-   * notifications aren't suppressed, not that they fire wrongly.
-   */
   private rebuildTerminalIndex(terminals: TerminalSnapshot): void {
     this.terminalIndexById.clear();
     terminals.forEach((terminal, index) => this.terminalIndexById.set(terminal.id, index));
   }
 
-  private getTerminalSnapshot(terminalId?: string): TerminalSnapshotEntry | undefined {
+  private getTerminalSnapshotFrom(
+    terminals: TerminalSnapshot,
+    terminalId?: string
+  ): TerminalSnapshotEntry | undefined {
     if (!terminalId) return undefined;
-    const terminals = store.get("appState").terminals;
     const index = this.terminalIndexById.get(terminalId);
     if (index !== undefined) {
       const terminal = terminals[index];
@@ -351,6 +343,26 @@ class AgentNotificationService {
 
     this.rebuildTerminalIndex(terminals);
     return terminals.find((terminal) => terminal.id === terminalId);
+  }
+
+  /**
+   * Look up a terminal's persisted entry — notably its renderer-owned
+   * worktreeId — from persisted app state.
+   *
+   * Backend-emitted agent events (agent:state-changed, agent:completed, etc.) no
+   * longer carry worktreeId — it's renderer-owned layout state. Main-side
+   * consumers that need worktreeId for focus/dedup/routing should resolve it
+   * here from the IPC-synced appState. May briefly lag a drag-to-worktree
+   * gesture; that is acceptable because the fallback (undefined) simply means
+   * notifications aren't suppressed, not that they fire wrongly.
+   *
+   * Each `store.get` deep-clones the whole appState, so callers resolving more
+   * than one terminal should read `terminals` once and use
+   * `getTerminalSnapshotFrom`.
+   */
+  private getTerminalSnapshot(terminalId?: string): TerminalSnapshotEntry | undefined {
+    if (!terminalId) return undefined;
+    return this.getTerminalSnapshotFrom(store.get("appState").terminals, terminalId);
   }
 
   private handleStateChanged(payload: {
@@ -712,13 +724,15 @@ class AgentNotificationService {
       if (currentSettings.enabled === false) return;
       if (!currentSettings.waitingEscalationEnabled || !currentSettings.waitingEnabled) return;
 
-      // Re-read terminal state — skip if moved out of dock or removed
-      const currentTerminal = this.getTerminalSnapshot(terminalId);
+      // Re-read terminal state — skip if moved out of dock or removed. One
+      // appState read serves every lookup below; each `store.get` deep-clones it.
+      const currentTerminals = store.get("appState").terminals;
+      const currentTerminal = this.getTerminalSnapshotFrom(currentTerminals, terminalId);
       if (!currentTerminal || currentTerminal.location !== "dock") return;
 
       // Count all dock terminals currently waiting (for grouped escalation)
       const waitingDockTerminalIds = [...this.waitingTerminalIds].filter(
-        (id) => this.getTerminalSnapshot(id)?.location === "dock"
+        (id) => this.getTerminalSnapshotFrom(currentTerminals, id)?.location === "dock"
       );
 
       this.playNotificationSound(currentSettings.soundEnabled, currentSettings.escalationSoundFile);


### PR DESCRIPTION
## Summary

`AgentNotificationService` was cloning the persisted terminal fleet and scanning it on every real state transition, including transitions into `idle` whose downstream routing consumes no terminal metadata. This change:

- skips that persisted snapshot for `idle` destinations;
- tracks active terminal IDs from lifecycle events instead of rescanning the fleet for all-clear decisions;
- samples persisted concurrency once at the start of an active session so restored/unobserved siblings still contribute to the all-clear peak;
- indexes terminal snapshots by ID while retaining a fresh store read for states whose routing consumes terminal metadata.

The branch is one focused production commit. No benchmark, fixture, budget, or gate changed.

## Trees and protocol

- Branch point / baseline: `6dd9528c29d253f0d375b337cc59d9b152bd8d0d`
- Final tree / candidate: `53f5a3007cc68c1ffc66b5c95f0f97847050b415`
- Commit: `53f5a3007c perf(notifications): index terminal routing state`
- Apparatus: `1d64b293f6cf94593ab291e280300bb41bcf1ba5998e9229d88ea5cf1a0a7b41` over 162 files
- Machine: `host-02d9f218-darwin-arm64` (`darwin`/`arm64`, Apple M1 Max, 10 CPUs, 32 GiB, Darwin 25.4.0)
- Toolchain: Node 24.20.0, Git 2.55.0, Electron 42.7.1
- Protocol for both benchmarks: `smoke`, 20 iterations, 1 warmup, six fresh interleaved arms in `champ1 → cand1 → cand2 → champ2 → champ3 → cand3` order, branch point versus final tree, `--max-cv 10`

The repository-pinned Node 22.13.0 failed before measurement in the shared dependency tree with `ERR_UNKNOWN_FILE_EXTENSION` while loading `electron/store.ts`. Every probe, baseline, selection, confirmation, and headline arm therefore used Node 24.20.0 consistently; the gate verified the version on every arm.

## PERF-320 `p50Ms` — `host-02d9f218-darwin-arm64`

Precommitted target: `p50Ms`, lower is better; threshold 22.7%; statistic median arm. The final headline arms were branch point `22.345 / 22.006 / 21.952 ms` and final tree `17.014 / 16.923 / 16.888 ms`.

| Metric | Role | Before | After | Absolute change | Percentage / result |
| --- | --- | ---: | ---: | ---: | --- |
| `p50Ms` | target | 22.006 ms | 16.923 ms | −5.083 ms | **−23.1%** |
| `routingDecisionCount` | guard | 384 | 384 | 0 | 0.0% |
| `notificationCount` | guard | 72 | 72 | 0 | 0.0% |
| `suppressedDecisionCount` | guard | 312 | 312 | 0 | 0.0% |
| `soundPlayCount` | guard | 72 | 72 | 0 | 0.0% |
| `expectedNotificationCount` | guard | 72 | 72 | 0 | 0.0% |
| `pendingTimerCount` | guard | 0 | 0 | 0 | ok |
| `missedNotificationMisses` | predicate + guard | 0 | 0 | 0 | ok |
| `spuriousNotificationMisses` | predicate + guard | 0 | 0 | 0 | ok |
| `notificationBodyMisses` | predicate + guard | 0 | 0 | 0 | ok |
| `clickRoutingMisses` | predicate + guard | 0 | 0 | 0 | ok |
| `payloadSchemaMisses` | predicate + guard | 0 | 0 | 0 | ok |
| `decisionShortfallCount` | predicate + guard | 0 | 0 | 0 | ok |

Every predicate was emitted 20/20 times in every arm with `min = max = 0`.

Headline verdict:

```text
Target: p50Ms on PERF-320 · lower is better
Champion drift D: 1.8% (worst of 3, champ1 v champ3) — same code on both sides, so this is the machine
Drift ceiling (--max-drift): 10.0%
Worst within-arm spread: 8.5% on champ2 · ceiling 10%

  pair 1: 22.345 → 17.014  23.9%  WON
  pair 2: 22.006 → 16.923  23.1%  WON
  pair 3: 21.952 → 16.888  23.1%  WON

  median arm: 22.006 → 16.923  improvement 23.1%
  precommitted threshold (--threshold): 22.7%

  guards (cost metrics — up is worse):
    OK      routingDecisionCount  384 → 384  +0.0% better  tolerance 5%
    OK      notificationCount  72 → 72  +0.0% better  tolerance 5%
    OK      suppressedDecisionCount  312 → 312  +0.0% better  tolerance 5%
    OK      soundPlayCount  72 → 72  +0.0% better  tolerance 5%
    OK      decisionShortfallCount  0 → 0 (champion is zero, so no percentage)
    OK      expectedNotificationCount  72 → 72  +0.0% better  tolerance 5%
    OK      missedNotificationMisses  0 → 0 (champion is zero, so no percentage)
    OK      spuriousNotificationMisses  0 → 0 (champion is zero, so no percentage)
    OK      notificationBodyMisses  0 → 0 (champion is zero, so no percentage)
    OK      clickRoutingMisses  0 → 0 (champion is zero, so no percentage)
    OK      payloadSchemaMisses  0 → 0 (champion is zero, so no percentage)
    OK      pendingTimerCount  0 → 0 (champion is zero, so no percentage)

  condition 1  PASS  candidate won every index-paired arm — 3/3
  condition 2  PASS  median-to-median improvement 23.1% >= precommitted threshold 22.7%
  condition 3  PASS  improvement 23.1% > champion drift D 1.8%
  condition 4  PASS  no guard outside its precommitted tolerance — 12 checked

VERDICT: CLAIM

CLAIM — all four conditions hold.
```

## PERF-321 `metricStats.largeFleetPerDecisionUs.mean` — `host-02d9f218-darwin-arm64`

Precommitted target: large-fleet synchronous routing time per decision, lower is better; threshold 12.0%; statistic median arm.

| Metric | Role | Before | After | Absolute change | Percentage / result |
| --- | --- | ---: | ---: | ---: | --- |
| `largeFleetPerDecisionUs` | target | 104.295 µs | 78.435 µs | −25.860 µs | **−24.8%** |
| `smallFleetTerminalCount` | guard | 8 | 8 | 0 | 0.0% |
| `largeFleetTerminalCount` | guard | 96 | 96 | 0 | 0.0% |
| `routingDecisionCount` | guard | 768 | 768 | 0 | 0.0% |
| `smallFleetPerDecisionUs` | guard | 15.168 µs | 12.198 µs | −2.970 µs | −19.6% |
| `fleetScalingOverheadRatio` | guard | 6.860 | 6.463 | −0.397 | −5.8% |
| `missedNotificationMisses` | predicate + guard | 0 | 0 | 0 | ok |
| `spuriousNotificationMisses` | predicate + guard | 0 | 0 | 0 | ok |
| `notificationBodyMisses` | predicate + guard | 0 | 0 | 0 | ok |
| `payloadSchemaMisses` | predicate + guard | 0 | 0 | 0 | ok |
| `decisionShortfallCount` | predicate + guard | 0 | 0 | 0 | ok |

Every predicate was emitted 20/20 times in every arm with `min = max = 0`.

Headline verdict:

```text
Target: metricStats.largeFleetPerDecisionUs.mean on PERF-321 · lower is better
Champion drift D: 0.7% (worst of 3, champ1 v champ2) — same code on both sides, so this is the machine
Drift ceiling (--max-drift): 10.0%
Worst within-arm spread: 6.8% on cand3 · ceiling 10%

  pair 1: 103.986 → 78.435  24.6%  WON
  pair 2: 104.668 → 77.863  25.6%  WON
  pair 3: 104.295 → 78.89  24.4%  WON

  median arm: 104.295 → 78.435  improvement 24.8%
  precommitted threshold (--threshold): 12.0%

  guards (cost metrics — up is worse):
    OK      smallFleetTerminalCount  8 → 8  +0.0% better  tolerance 5%
    OK      largeFleetTerminalCount  96 → 96  +0.0% better  tolerance 5%
    OK      routingDecisionCount  768 → 768  +0.0% better  tolerance 5%
    OK      smallFleetPerDecisionUs  15.168 → 12.198  -19.6% better  tolerance 10% (machine-dependent)
    OK      fleetScalingOverheadRatio  6.86 → 6.463  -5.8% better  tolerance 10% (machine-dependent)
    OK      missedNotificationMisses  0 → 0 (champion is zero, so no percentage)
    OK      spuriousNotificationMisses  0 → 0 (champion is zero, so no percentage)
    OK      notificationBodyMisses  0 → 0 (champion is zero, so no percentage)
    OK      payloadSchemaMisses  0 → 0 (champion is zero, so no percentage)
    OK      decisionShortfallCount  0 → 0 (champion is zero, so no percentage)

  condition 1  PASS  candidate won every index-paired arm — 3/3
  condition 2  PASS  median-to-median improvement 24.8% >= precommitted threshold 12.0%
  condition 3  PASS  improvement 24.8% > champion drift D 0.7%
  condition 4  PASS  no guard outside its precommitted tolerance — 10 checked

VERDICT: CLAIM

CLAIM — all four conditions hold.
```

## Hypothesis ledger

- H1 `d5275a3020b86c9afa414dbfadd8b44c1f4a0195` — read only `appState.terminals` through the dot-path getter. PERF-320 regressed 21.870 → 23.220 ms (+6.2%). Reverted: reducing the cloned object did not remove the terminal-array clone and scan.
- H2 `01abf2dda47dd5651d114fad9491c3a6dfc42b7a` — event-driven active IDs, same-state early return, fresh debounce recheck. Improved 21.870 → 19.123 ms (−12.6%), below the locked 22.7% threshold. Reverted.
- H3 `1a3d0b9ebfe4b1da642197b997a38e508760f470` — indexed positions plus single-terminal clone. Selection reached 2.901 ms, but two complete A/Bs had 39–106% candidate CV. No measurement; reverted.
- H4 `d8209a0d13ae19a36b8107731b147ff13e9d25ea` — fresh whole-array snapshot with indexed lookup and active IDs. Improved 21.870 → 19.802 ms (−9.5%), below threshold. Rejected.
- H5 `bf9fc3a0aa2da60b116b11c2e31b922908275c12` — lazy terminal resolution inside consuming branches. Selection reached 16.036 ms, but confirmation CV was 14.4% then 19.3%. No measurement; not kept.
- H6 `e52f39f470a4efc2f28628024eec07944418d0ae` — H5 without resolver-closure allocation. Selection reached 15.532 ms, but clean confirmations still had 52.6% then 17.7% CV. No measurement; not kept.
- H7 `d1e9515c0173a782a2c0680bf09fb13037a58739` — subscribe to persisted terminal changes and maintain the lookup map. Selection reached 1.891 ms, but the A/B candidate CV was 78.8%; the shortened scenario was unresolvable. No measurement; not kept.
- H8 `53f5a3007cc68c1ffc66b5c95f0f97847050b415` — skip persisted terminal work only for `idle`, retain fresh snapshots for metadata-consuming states, plus indexed lookup and event-driven active IDs. The first candidate SHA replaced all-clear's persisted peak observation with only the event-maintained set; PERF-322's Linux liveness predicate caught one fail-closed miss twice. The corrected final tree samples persisted concurrency only on the first active transition, after which standalone PERF-322 ran 3/3 with all predicates zero. Fresh headline A/Bs produced stable claims for both PERF-320 (−23.1%) and PERF-321 (−24.8%). Kept.

The loop also rejected PERF-325 (badge/title fan-out in `NotificationService.updateNotifications`), PERF-322 (settings/timer suppression gates), and PERF-323/PERF-324 (burst buffering and idle-sweep timers) because they do not share this synchronous routing mechanism. H1–H8 exhausted the credible persisted-lookup, scan, freshness, and allocation avenues inside the requested subject and the 8-hour run budget.

## OS coverage

| Machine / runner | PERF-320 | PERF-321 | Reason |
| --- | --- | --- | --- |
| Physical macOS arm64 `host-02d9f218-darwin-arm64` | CLAIM, −23.1% | CLAIM, −24.8% | Full local interleaved duration protocol |
| GitHub macOS hosted | not dispatched | not dispatched | wall-clock duration targets are not portable hosted-runner claims |
| GitHub Linux hosted | not dispatched | not dispatched | wall-clock duration targets are not portable hosted-runner claims |
| GitHub Windows hosted | not dispatched | not dispatched | wall-clock duration targets are not portable hosted-runner claims |
| Other physical machines | not measured | not measured | none reachable from this session |

The emitted count guards were unchanged, not optimization targets. `fleetScalingOverheadRatio` is classified as a machine-dependent derived ratio. There was therefore no portable count, size, or structural-ratio improvement eligible for `perf-ab`; `--os all` is satisfied by the explicit not-measured classification above. No hosted-runner duration is claimed.

## Validation

- `npm run check` (including typecheck) — pass on corrected final tree
- local full `npm test` — 54,504/54,513 tests pass on corrected final tree; the sole persistent local failure after three prove iterations is pooled `scenarioLiveness`, driven by pre-existing PERF-063 `batcherShortfallCount=2`
- scoped `AgentNotificationService` coverage — 3 files, 113 tests, pass
- focused corrected-tree validation — all-clear and notification scenario tests pass; standalone PERF-322 ran 3/3 with all predicates zero
- liveness classification — PERF-063 reproduces identically at branch point `6dd9528c29d253f0d375b337cc59d9b152bd8d0d` and current `origin/develop` `6cb3a684d7cf7ffc913ac6e1821d29b9b73eae68`; transient PERF-075/PERF-076 persistence-fixture startup failures both pass standalone with every predicate zero
- fresh PR CI run `33551555592` — build, combined Ubuntu check, all four Vitest shards (including shard 2/scenario liveness), and `ci-ok` pass against current `develop`
- diff audit — only `electron/services/AgentNotificationService.ts`; no change under `scripts/perf/`
- tests-green receipt — `53f5a3007cc68c1ffc66b5c95f0f97847050b415`, matching HEAD, origin, PR head, and the green CI run
- E2E — not run; the optimize contract permits only a human-named spec or bucket, and none was named

Governance finding: this checkout contains no `AREAS.md`, although the optimize contract references it for ownership auditing. Repository architecture documentation identifies `AgentNotificationService` as the canonical notification-routing service, matching this task's scope.
