### PR TITLE
docs(plugins): add an agent brief for project-local plugins

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -58,6 +58,7 @@ From there, follow the architecture doc nearest the surface you're changing. Eac
 | --- | --- |
 | [plugins/README.md](./plugins/README.md) | Sub-index for the plugin system — start here for everything plugin-author-facing. |
 | [plugins/project-local.md](./plugins/project-local.md) | Plugins a project ships in its own repository — on-disk layout, the committed `dist/` contract, the trust gate, hot reload, contribution scoping. |
+| [plugins/agent-brief.md](./plugins/agent-brief.md) | The brief to hand an AI agent that is writing a project plugin — the rules that decide whether it loads, and a skeleton that needs no build tooling. |
 
 The plugin sub-index links onward to getting-started, manifest reference, contribution points, host API, agent extensions, distribution, the dev loop, trust model, architecture, and the [1.0 freeze plan](./plugins/freeze-plan.md) (the roadmap to a stable, freezeable plugin API).
 

--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -1,10 +1,17 @@
 # Daintree Plugins
 
+**Start here.** Two kinds of plugin live in this folder, and building the wrong one is the most common way to waste an afternoon:
+
+- **A plugin for one project**, committed to that project's repository at `<projectRoot>/.daintree/plugins/` and loaded only while it is open — a dashboard over your own build, a panel for your team. Read the [agent brief](./agent-brief.md), then [project-local.md](./project-local.md). The brief is self-contained and is the file to hand an AI agent.
+- **A plugin for you**, installed to `~/.daintree/plugins/` and present in every project. Read [getting-started.md](./getting-started.md).
+
+The two have different manifests, different load contracts, and a different set of things they may contribute. Everything else in this folder is reference for both — read it on demand rather than front to back.
+
 > **Status: pre-release, in active development.** The runtime (`PluginService`: load/activate/unload, manifest validation, panel/toolbar/menu/keybinding/context-menu registration, host settings, MCP supervision, worktree observation) is implemented, and the `daintree-plugin` CLI ships `new`, `validate`, `package`, `install`, `uninstall`, and `dev` (hot-reload). All five packages exist in-repo under `packages/` (`daintree-plugin`, `create-daintree-plugin`, `@daintreehq/plugin-sdk`, `@daintreehq/plugin-vite`, `@daintreehq/plugin-testing`) and are workspace-linked, so the `@daintreehq/*` imports resolve and build from within this repo. None are published to public npm yet, so `npx daintree-plugin …` / `npm install @daintreehq/plugin-sdk` returns E404 outside the workspace. Per-contribution-point status lives in [Contribution points](./contribution-points.md); APIs may still change before 1.0.
 
 Plugins extend Daintree with new panels, actions, keybindings, MCP servers, agents, and — planned — skills. You can write a plugin for your own workflow and sideload it, share a plugin with your team by distributing a single file or URL, or publish one for others to install.
 
-A plugin can also belong to a **project** rather than to you: committed to a repository at `<projectRoot>/.daintree/plugins/`, gated by one trust decision, and loaded only while that project is open. See [Project-local plugins](./project-local.md).
+A plugin can also belong to a **project** rather than to you: committed to a repository at `<projectRoot>/.daintree/plugins/`, gated by one trust decision, and loaded only while that project is open. See [Project-local plugins](./project-local.md), or hand [the agent brief](./agent-brief.md) to the agent that is going to write it.
 
 This section documents the plugin system for plugin authors. If you're looking for information on Daintree's internals, see [`../development.md`](../development.md).
 
@@ -27,6 +34,8 @@ Plugins are **sandboxed by convention, not by runtime enforcement.** They run wi
 
 | Doc | What it covers |
 | --- | --- |
+| [Agent brief](./agent-brief.md) | The one file to hand an AI agent writing a plugin into a project's own repo — load rules, a zero-build skeleton, reading order |
+| [Project-local plugins](./project-local.md) | Plugins a project ships in its own repo — layout, the committed `dist/` contract, trust, hot reload |
 | [Getting started](./getting-started.md) | Scaffold and run your first plugin in 5 minutes |
 | [Manifest reference](./manifest.md) | Full `plugin.json` schema |
 | [Contribution points](./contribution-points.md) | Every contribution type with examples and current status |
@@ -35,7 +44,6 @@ Plugins are **sandboxed by convention, not by runtime enforcement.** They run wi
 | [Forge providers](./forge-provider.md) | The `forgeProviders` contribution type for code-hosting integrations |
 | [Distribution](./distribution.md) | Packaging, sharing, installing from file or URL |
 | [Development loop](./dev-loop.md) | The `daintree-plugin` CLI, hot reload, debugging |
-| [Project-local plugins](./project-local.md) | Plugins a project ships in its own repo — layout, the committed `dist/` contract, trust, hot reload |
 | [Trust model](./trust-model.md) | Capability disclosure, confirm-dialog policy, the security contract |
 | [Architecture](./architecture.md) | How the plugin system works under the hood |
 | [1.0 freeze plan](./freeze-plan.md) | Planning: the path to a frozen/stable 1.0 plugin API — root decisions, freeze roadmap, and rationale of record |

--- a/docs/plugins/agent-brief.md
+++ b/docs/plugins/agent-brief.md
@@ -35,6 +35,19 @@ The whole design exists so that an agent working in a fresh worktree can write a
 
 Skip [distribution.md](./distribution.md). A project plugin is distributed by being committed; there is no `.dntr` archive in this workflow.
 
+### If you have the Daintree repo checked out
+
+Prose can drift; these cannot. Read them in preference to any doc that disagrees.
+
+| File | Why it is ground truth |
+| --- | --- |
+| `electron/schemas/plugin.ts` | The zod schema that actually accepts or rejects your manifest, including the `scope` cross-checks and every refused project contribution, each with the error string you will see |
+| `plugins/fixtures/project-local/` | A known-good project plugin at the real path discovery scans, kept working by the load tests — the skeleton below, on disk |
+| `plugins/sample/rich-daintree/` | A fuller plugin exercising most contribution points |
+| `packages/plugin-sdk/` | The real `PluginHostApi` types behind the `host` object |
+
+Run the agent in **your own project**, not in the Daintree checkout, and give it the checkout as a read path. The plugin has to be written into your project, and a Claude Code session started inside the Daintree clone picks up that repo's root `CLAUDE.md` — a contributor guide about gitflow and `npm run check` that has nothing to do with authoring a plugin.
+
 ## The rules that decide whether it loads
 
 Ten things an agent gets wrong on the first attempt. Every one of them is silent — the plugin appears in the manager and does nothing.

--- a/docs/plugins/agent-brief.md
+++ b/docs/plugins/agent-brief.md
@@ -222,5 +222,5 @@ Edits to `plugin.json` or `dist/` reload the plugin live, per plugin directory, 
 
 - [project-local.md](./project-local.md) — the full contract this brief compresses
 - [README.md](./README.md) — the plugin documentation index
-- `plugins/fixtures/project-local/` — the skeleton above, as a test fixture
+- `plugins/fixtures/project-local/` — a discovery/schema/watcher fixture at the real path, not the skeleton above: it registers no action and its view returns a plain object rather than React
 - `plugins/sample/rich-daintree/` — a fuller plugin exercising most contribution points

--- a/docs/plugins/agent-brief.md
+++ b/docs/plugins/agent-brief.md
@@ -1,0 +1,165 @@
+# Agent brief: building a project plugin
+
+The one file to hand an AI agent that is about to write a plugin into a project's own `.daintree/plugins/`. It carries the rules that decide whether the plugin loads at all, a working skeleton that needs no build tooling, and a reading order for everything else in this folder.
+
+Everything here is about **project plugins** — committed to a repository, loaded only while that project is open. For a plugin that belongs to you and follows you across every project, start at [Getting started](./getting-started.md) instead.
+
+## Point your agent here
+
+Paste this, with the two placeholders filled in:
+
+> Write a Daintree project plugin for this repository. It goes at `<projectRoot>/.daintree/plugins/<publisher>.<name>/`, is committed like any other source, and loads only while this project is open in Daintree.
+>
+> Read `docs/plugins/agent-brief.md` from the Daintree repository first — it has the load rules and a zero-build skeleton. If you can't reach that file, ask me to paste it. Then read `docs/plugins/project-local.md` for the full contract, and `docs/plugins/contribution-points.md` for the contribution you're adding.
+>
+> What it should do: **&lt;describe the panel, command, or surface&gt;**
+
+If the agent has no access to the Daintree repository — the normal case, since it is working in _your_ project — paste this file into the conversation. It is written to be self-contained: an agent that reads only this file can produce a plugin that loads.
+
+## What you are building
+
+A directory in your repository holding a `plugin.json` and a committed `dist/`. Daintree scans `<projectRoot>/.daintree/plugins/` when the project opens, asks you once whether to run the project's plugins, and from then on loads them silently — through branch switches, pulls, rebases, and every rebuild an agent commits.
+
+The whole design exists so that an agent working in a fresh worktree can write a plugin, commit it, and have it load on the next open with no install step and no build step. That is why `dist/` is committed and why the host never compiles anything.
+
+## Read in this order
+
+| When you need to know | Read |
+| --- | --- |
+| The full contract — layout, trust, binding, hot reload, what a project plugin may and may not contribute | [project-local.md](./project-local.md) |
+| Every field `plugin.json` accepts | [manifest.md](./manifest.md) |
+| The shape of the contribution you're adding — panels, views, commands, toolbar buttons, context menus, keybindings, settings | [contribution-points.md](./contribution-points.md) |
+| What `host` can do inside `activate()` | [host-api.md](./host-api.md) |
+| What the capability tokens actually mean, and what they don't | [trust-model.md](./trust-model.md) |
+| The watcher loop and the `daintree-plugin` CLI | [dev-loop.md](./dev-loop.md) |
+
+Skip [distribution.md](./distribution.md). A project plugin is distributed by being committed; there is no `.dntr` archive in this workflow.
+
+## The rules that decide whether it loads
+
+Ten things an agent gets wrong on the first attempt. Every one of them is silent — the plugin appears in the manager and does nothing.
+
+1. **`"scope": "project"` is required.** A manifest without it, found under `.daintree/plugins/`, is rejected as `project_scope_required`. The same manifest _with_ it, installed into `~/.daintree/plugins/`, is rejected the other way.
+2. **`dist/` must be committed.** Most repositories ignore `dist/` at the root, and that pattern covers this directory too. The plugin's own `.gitignore` needs both `!dist/` and `!dist/**` — the first so git descends into the directory, the second so the files inside survive a parent rule matching contents.
+3. **Rebuild and commit `dist/` in the same commit as the source change.** A branch with stale `dist/` is stale for everyone who checks it out. A branch with no `dist/` still shows the panels and commands, because the manifest parses — they just do nothing.
+4. **The host never reads `src/`, never runs `package.json`, never compiles.** `plugin.json` and `dist/` are the entire load contract.
+5. **Commands are registered from `activate()` with `host.registerAction`.** The filesystem-convention handler (`src/<commandId>.js`) that installed plugins may use does not exist here — it would run repository source in the main process, outside the worker every other plugin gets its crash isolation from.
+6. **Eight contribution types are refused under `scope: "project"`**: `menuItems`, `agents`, `skills`, `recipes`, `fileDecorationProviders`, `processTools`, `mcpServers`, `forgeProviders`. Each is rejected at manifest validation with an error naming the structural reason. See the table in [project-local.md](./project-local.md#what-a-project-plugin-may-contribute).
+7. **The directory name should equal the manifest `name`.** The host identifies the plugin by the manifest and does not compare the two, but every tool and every doc assumes they match.
+8. **Only `plugin.json` and `dist/` are watched.** Editing `src/` reloads nothing. Keep a build watcher running, or hand-write `dist/` (see below).
+9. **A new plugin id in an already-trusted project is staged, not run.** It is announced once and listed in the plugin manager with a one-click **Activate**. This is the expected state for a plugin an agent just created — it is not a failure.
+10. **`engines.daintree` must match the running app.** A range that doesn't is rejected at load with a user-visible warning.
+
+## The zero-build skeleton
+
+The `daintree-plugin` CLI is not on npm yet, so `npx daintree-plugin new --project` returns E404 outside this repository. That is fine: because the host loads `dist/` verbatim as browser ESM, a plugin can be hand-written with no build step, no `npm install`, and no toolchain. Bare `react` resolves through the host's import map, and `createElement` avoids needing a JSX transform.
+
+Four files. Replace `acme.dashboard` throughout with your own `<publisher>.<name>`.
+
+```
+<projectRoot>/.daintree/plugins/acme.dashboard/
+├── plugin.json
+├── .gitignore
+└── dist/
+    ├── index.js
+    └── panel.js
+```
+
+**`plugin.json`**
+
+```json
+{
+  "name": "acme.dashboard",
+  "version": "0.1.0",
+  "scope": "project",
+  "displayName": "Dashboard",
+  "description": "A panel for this project.",
+  "main": "dist/index.js",
+  "engines": { "daintree": ">=0.34.0" },
+  "capabilities": [],
+  "contributes": {
+    "panels": [{ "id": "main", "name": "Dashboard", "iconId": "gauge" }],
+    "views": [{ "id": "main", "componentPath": "dist/panel.js", "location": "panel" }]
+  }
+}
+```
+
+**`.gitignore`** — both negations, always:
+
+```gitignore
+node_modules/
+
+# dist/ is the load contract. The repository root very likely ignores dist/,
+# and a deeper .gitignore wins, so these two lines are what keep it tracked.
+# `!dist/` makes git descend into the directory; `!dist/**` re-includes the
+# files a parent rule matching contents would still exclude.
+!dist/
+!dist/**
+```
+
+**`dist/index.js`** — the worker entry. Runs once on load; the returned disposer runs on unload.
+
+```js
+export async function activate(host) {
+  host.registerAction(
+    {
+      id: "say-hello",
+      title: "Say Hello",
+      description: "Show a greeting toast.",
+      category: "Dashboard",
+      kind: "command",
+      danger: "safe",
+    },
+    async () => {
+      await host.showToast({ message: "Hello from the project plugin", type: "success" });
+    }
+  );
+
+  return () => {};
+}
+```
+
+**`dist/panel.js`** — the view. Default-exports a React component; receives `PanelViewProps`.
+
+```js
+import { createElement, useEffect, useState } from "react";
+
+export default function Panel({ panelId, pluginId }) {
+  const [worktree, setWorktree] = useState(null);
+  useEffect(() => window.electron.plugin.on(pluginId, "worktree", setWorktree), [pluginId]);
+  return createElement("div", { "data-panel-id": panelId }, worktree?.name ?? "No worktree");
+}
+```
+
+`plugins/fixtures/project-local/` in the Daintree repository is this same skeleton, kept working by the load tests.
+
+Two constraints the zero-build path buys you at a price: the React hooks in `@daintreehq/plugin-sdk/react` (`usePluginEvent`, `usePluginPanelEvent`, `useHostChannel`) resolve only in a bundle built with `@daintreehq/plugin-vite`, so a raw module subscribes through `window.electron.plugin.on(...)` directly as above; and you write ESM by hand rather than TypeScript with JSX. Both stop mattering the moment you add a real build — see [dev-loop.md](./dev-loop.md).
+
+## Owning the project's main surface
+
+If the point is for the project to present as a purpose-built application rather than as Daintree with one extra panel, `contributes.surfaces` lets a project plugin replace the host's own empty canvas — the region the stock launcher draws when no panels are open.
+
+```jsonc
+"surfaces": { "emptyCanvas": { "viewId": "main" } }
+```
+
+One slot exists today, it is project-scope only, and the frame keeps a control that swaps back to the stock launcher in both directions. See [Surfaces](./project-local.md#surfaces).
+
+## Verify it loaded
+
+1. Open the project in Daintree. First time, a dialog names the plugins and asks once — **Always enable** persists the decision for this project, in Daintree's own store, never in the repository.
+2. Open the plugin manager. The plugin appears under the project section, badged `Project`, with its source path and manifest id.
+3. If it says **Staged**, click **Activate plugin** — a manifest id the project has never had does not run until you do.
+4. If it says **Unreadable**, the detail pane carries the validation error verbatim. That is the diagnostic; read it rather than guessing.
+5. Run the command from the palette, or open the panel.
+
+Then check the trap that produces the most convincing false success: `git check-ignore -v .daintree/plugins/acme.dashboard/dist/index.js`. It works on the machine that built it whether or not `dist/` is tracked.
+
+Edits to `plugin.json` or `dist/` reload the plugin live, per plugin directory, about 200 ms after writes stop. Settings and `host.storage` survive a reload; module-scope state in the worker and React state in the views do not. No restart is ever required — anything that genuinely needed one is not offered to project plugins.
+
+## See also
+
+- [project-local.md](./project-local.md) — the full contract this brief compresses
+- [README.md](./README.md) — the plugin documentation index
+- `plugins/fixtures/project-local/` — the skeleton above, as a test fixture
+- `plugins/sample/rich-daintree/` — a fuller plugin exercising most contribution points

--- a/docs/plugins/agent-brief.md
+++ b/docs/plugins/agent-brief.md
@@ -18,7 +18,7 @@ If the agent has no access to the Daintree repository — the normal case, since
 
 ## What you are building
 
-A directory in your repository holding a `plugin.json` and a committed `dist/`. Daintree scans `<projectRoot>/.daintree/plugins/` when the project opens, asks you once whether to run the project's plugins, and from then on loads them silently — through branch switches, pulls, rebases, and every rebuild an agent commits.
+A directory in your repository holding a `plugin.json` and a committed `dist/`. Daintree scans `<projectRoot>/.daintree/plugins/` when the project opens and asks once whether to run the project's plugins. Answer **Always enable** and the decision persists: from then on the ids it already knows reload silently through branch switches, pulls, rebases, and every rebuild an agent commits. (**Enable for this session** is memory-only and asks again next launch; **Keep disabled** is remembered and runs nothing; dismissing records nothing and may prompt again.)
 
 The whole design exists so that an agent working in a fresh worktree can write a plugin, commit it, and have it load on the next open with no install step and no build step. That is why `dist/` is committed and why the host never compiles anything.
 
@@ -42,7 +42,7 @@ Prose can drift; these cannot. Read them in preference to any doc that disagrees
 | File | Why it is ground truth |
 | --- | --- |
 | `electron/schemas/plugin.ts` | The zod schema that actually accepts or rejects your manifest, including the `scope` cross-checks and every refused project contribution, each with the error string you will see |
-| `plugins/fixtures/project-local/` | A known-good project plugin at the real path discovery scans, kept working by the load tests — the skeleton below, on disk |
+| `plugins/fixtures/project-local/` | A minimal project plugin at the real path discovery scans. It is a discovery/schema/watcher fixture, not this skeleton: it registers no action and its view returns a plain object rather than rendering React, so do not copy it as a UI starting point |
 | `plugins/sample/rich-daintree/` | A fuller plugin exercising most contribution points |
 | `packages/plugin-sdk/` | The real `PluginHostApi` types behind the `host` object |
 
@@ -50,22 +50,36 @@ Run the agent in **your own project**, not in the Daintree checkout, and give it
 
 ## The rules that decide whether it loads
 
-Ten things an agent gets wrong on the first attempt. Every one of them is silent — the plugin appears in the manager and does nothing.
+Twelve things an agent gets wrong on the first attempt, grouped by how the failure shows up. The middle group is the dangerous one: the plugin loads, looks healthy in the manager, and does nothing.
+
+**Refused at validation — the manager shows `Unreadable` with the first schema issue, prefixed by its field path.**
 
 1. **`"scope": "project"` is required.** A manifest without it, found under `.daintree/plugins/`, is rejected as `project_scope_required`. The same manifest _with_ it, installed into `~/.daintree/plugins/`, is rejected the other way.
-2. **`dist/` must be committed.** Most repositories ignore `dist/` at the root, and that pattern covers this directory too. The plugin's own `.gitignore` needs both `!dist/` and `!dist/**` — the first so git descends into the directory, the second so the files inside survive a parent rule matching contents.
-3. **Rebuild and commit `dist/` in the same commit as the source change.** A branch with stale `dist/` is stale for everyone who checks it out. A branch with no `dist/` still shows the panels and commands, because the manifest parses — they just do nothing.
-4. **The host never reads `src/`, never runs `package.json`, never compiles.** `plugin.json` and `dist/` are the entire load contract.
-5. **Commands are registered from `activate()` with `host.registerAction`.** The filesystem-convention handler (`src/<commandId>.js`) that installed plugins may use does not exist here — it would run repository source in the main process, outside the worker every other plugin gets its crash isolation from.
-6. **Eight contribution types are refused under `scope: "project"`**: `menuItems`, `agents`, `skills`, `recipes`, `fileDecorationProviders`, `processTools`, `mcpServers`, `forgeProviders`. Each is rejected at manifest validation with an error naming the structural reason. See the table in [project-local.md](./project-local.md#what-a-project-plugin-may-contribute).
-7. **The directory name should equal the manifest `name`.** The host identifies the plugin by the manifest and does not compare the two, but every tool and every doc assumes they match.
-8. **Only `plugin.json` and `dist/` are watched.** Editing `src/` reloads nothing. Keep a build watcher running, or hand-write `dist/` (see below).
-9. **A new plugin id in an already-trusted project is staged, not run.** It is announced once and listed in the plugin manager with a one-click **Activate**. This is the expected state for a plugin an agent just created — it is not a failure.
-10. **`engines.daintree` must match the running app.** A range that doesn't is rejected at load with a user-visible warning.
+2. **Every panel needs `color` as well as `iconId`.** Both are required, and a missing `color` is the single most common reason a hand-written manifest is refused. Any CSS colour works; `var(--theme-category-orange)` is the convention for plugin panels.
+3. **A view's `id` must equal a panel's `id`.** The loader attaches a view to a panel kind by matching ids, and a view matching no panel is rejected outright rather than ignored. `surfaces.*.viewId` must likewise name a declared view, and that view's panel must not be `hasPty: true`.
+4. **`engines.daintree` must be an open-ended lower bound — never a caret.** `^0.11.0` means `>=0.11.0 <0.12.0` under semver's 0.x rule, so a caret is refused on every release after the one you wrote it against. Write `>=0.11.0`.
+5. **Eight contribution types are refused under `scope: "project"`**: `menuItems`, `agents`, `skills`, `recipes`, `fileDecorationProviders`, `processTools`, `mcpServers`, `forgeProviders`. Each error names the structural reason. See the table in [project-local.md](./project-local.md#what-a-project-plugin-may-contribute).
+
+**Loads, and stays inert.**
+
+6. **Activation is lazy.** `activationEvents` defaults to `[]`, so `activate()` does not run at project open — it runs the first time a contribution is _used_. Anything registered imperatively therefore does not exist yet. This is why a command must **also** be declared in `contributes.commands`: the manifest entry is what puts it in the palette and what triggers activation, and the `host.registerAction` call in `activate()` is what gives it a handler with host access. Declare both, with the same id. Use `"activationEvents": ["onStartupFinished"]` only for genuine background work.
+7. **The filesystem-convention handler does not exist here.** An installed plugin may drop a handler at `src/<commandId>.js` for the host to import; a project plugin may not, because that would run repository source in the main process, outside the worker every other plugin gets its crash isolation from. Register from `activate()` instead.
+8. **Nothing reaches a view on its own.** `window.electron.plugin.on(pluginId, channel, …)` only receives what the worker sends with `host.postToPanel` or `host.broadcastToRenderer`. There is no ambient `"worktree"` channel. Pushes are not buffered either, so a push during `activate()` is gone before the view mounts — have the view pull on mount, then push updates.
+9. **`host.registerAction` and `host.registerHandler` return promises.** Await them inside `activate`, or activation can resolve before the registration lands.
+
+**Works for you, broken for everyone who clones.**
+
+10. **`dist/` must be committed, and rebuilt in the same commit as the source change.** This is invisible on the machine that built it. A branch with stale `dist/` is stale for everyone; a branch missing it entirely still shows the panels and commands, because the manifest parses — using them then produces an activation, missing-handler, or view-import error.
+11. **The plugin's `.gitignore` needs both `!dist/` and `!dist/**`** — the first so git descends into the directory, the second so the files inside survive a parent rule matching contents. Neither helps if an ancestor rule ignores `.daintree/` or the plugin directory itself: git never reaches a nested `.gitignore` inside an excluded directory, so that rule has to be relaxed at the level that sets it.
+12. **Only the registered project root is scanned — never a worktree.** Worktrees are views of the project, not separate scan roots. An agent that writes the plugin inside its own worktree will not see it load until that commit reaches the root checkout Daintree has open. Expect to merge before you can test.
+
+Two more things that are not failures, and get misread as one. A new manifest id in an already-trusted project is **staged**: parsed, announced once, and listed with a one-click **Activate** — it does not run until you click, and that is by design. And the directory name is not compared to the manifest `name`; matching them is convention that every tool assumes, not a load rule.
 
 ## The zero-build skeleton
 
-The `daintree-plugin` CLI is not on npm yet, so `npx daintree-plugin new --project` returns E404 outside this repository. That is fine: because the host loads `dist/` verbatim as browser ESM, a plugin can be hand-written with no build step, no `npm install`, and no toolchain. Bare `react` resolves through the host's import map, and `createElement` avoids needing a JSX transform.
+The `daintree-plugin` CLI is not on npm yet, so `npx daintree-plugin new --project` returns E404 outside this repository. That is survivable, because neither half of a plugin has to be compiled: the **view** is imported by the renderer as browser ESM, where a bare `react` specifier resolves through the host's import map, and the **worker entry** is imported by Node in a utility process. Hand-write both and you need no toolchain at all.
+
+Treat this as a load probe — the smallest thing that provably activates and renders. Grow it once it works.
 
 Four files. Replace `acme.dashboard` throughout with your own `<publisher>.<name>`.
 
@@ -74,11 +88,11 @@ Four files. Replace `acme.dashboard` throughout with your own `<publisher>.<name
 ├── plugin.json
 ├── .gitignore
 └── dist/
-    ├── index.js
+    ├── index.mjs
     └── panel.js
 ```
 
-**`plugin.json`**
+**`plugin.json`** — the command is declared here _and_ registered in `activate()`; see rule 6.
 
 ```json
 {
@@ -87,17 +101,34 @@ Four files. Replace `acme.dashboard` throughout with your own `<publisher>.<name
   "scope": "project",
   "displayName": "Dashboard",
   "description": "A panel for this project.",
-  "main": "dist/index.js",
-  "engines": { "daintree": ">=0.34.0" },
+  "main": "dist/index.mjs",
+  "engines": { "daintree": ">=0.11.0" },
   "capabilities": [],
   "contributes": {
-    "panels": [{ "id": "main", "name": "Dashboard", "iconId": "gauge" }],
+    "commands": [
+      {
+        "id": "say-hello",
+        "title": "Say Hello",
+        "description": "Show a greeting toast.",
+        "category": "Dashboard",
+        "kind": "command",
+        "danger": "safe"
+      }
+    ],
+    "panels": [
+      {
+        "id": "main",
+        "name": "Dashboard",
+        "iconId": "gauge",
+        "color": "var(--theme-category-orange)"
+      }
+    ],
     "views": [{ "id": "main", "componentPath": "dist/panel.js", "location": "panel" }]
   }
 }
 ```
 
-**`.gitignore`** — both negations, always:
+**`.gitignore`** — both negations, and check no ancestor ignores `.daintree/`:
 
 ```gitignore
 node_modules/
@@ -110,11 +141,11 @@ node_modules/
 !dist/**
 ```
 
-**`dist/index.js`** — the worker entry. Runs once on load; the returned disposer runs on unload.
+**`dist/index.mjs`** — the worker entry, run by Node. The `.mjs` extension is not cosmetic: with no `package.json` of its own the file inherits the module type of the nearest enclosing one, and in a repository that is CommonJS (or declares no `type` at all) `export` fails to parse. `.mjs` is ESM regardless of what your project declares.
 
 ```js
 export async function activate(host) {
-  host.registerAction(
+  await host.registerAction(
     {
       id: "say-hello",
       title: "Say Hello",
@@ -128,25 +159,37 @@ export async function activate(host) {
     }
   );
 
+  // The view pulls through this on mount. Nothing reaches a panel unless the
+  // worker sends it, and a push made here would land before any view exists.
+  await host.registerHandler("worktree", async () => await host.getActiveWorktree());
+
   return () => {};
 }
 ```
 
-**`dist/panel.js`** — the view. Default-exports a React component; receives `PanelViewProps`.
+**`dist/panel.js`** — the view, imported by the renderer. Default-exports a React component and receives `PanelViewProps`.
 
 ```js
 import { createElement, useEffect, useState } from "react";
 
 export default function Panel({ panelId, pluginId }) {
   const [worktree, setWorktree] = useState(null);
-  useEffect(() => window.electron.plugin.on(pluginId, "worktree", setWorktree), [pluginId]);
+  useEffect(() => {
+    let live = true;
+    void window.electron.plugin.invoke(pluginId, "worktree").then((wt) => {
+      if (live) setWorktree(wt);
+    });
+    return () => {
+      live = false;
+    };
+  }, [pluginId]);
   return createElement("div", { "data-panel-id": panelId }, worktree?.name ?? "No worktree");
 }
 ```
 
-`plugins/fixtures/project-local/` in the Daintree repository is this same skeleton, kept working by the load tests.
+Use the `pluginId` prop rather than hardcoding your manifest name — for a project plugin the runtime id is an instance key, not the manifest id.
 
-Two constraints the zero-build path buys you at a price: the React hooks in `@daintreehq/plugin-sdk/react` (`usePluginEvent`, `usePluginPanelEvent`, `useHostChannel`) resolve only in a bundle built with `@daintreehq/plugin-vite`, so a raw module subscribes through `window.electron.plugin.on(...)` directly as above; and you write ESM by hand rather than TypeScript with JSX. Both stop mattering the moment you add a real build — see [dev-loop.md](./dev-loop.md).
+What the no-build path costs: the React hooks in `@daintreehq/plugin-sdk/react` resolve only in a bundle built with `@daintreehq/plugin-vite`, so a raw view uses the `window.electron.plugin` bridge directly as above; and the view can import `react` plus its own relative modules, but not arbitrary bare npm specifiers, TypeScript, JSX, or CSS. If you need those, build inside a Daintree checkout where the workspace packages resolve — outside one there is no published toolchain yet. [dev-loop.md](./dev-loop.md) covers the watcher.
 
 ## Owning the project's main surface
 
@@ -156,17 +199,22 @@ If the point is for the project to present as a purpose-built application rather
 "surfaces": { "emptyCanvas": { "viewId": "main" } }
 ```
 
-One slot exists today, it is project-scope only, and the frame keeps a control that swaps back to the stock launcher in both directions. See [Surfaces](./project-local.md#surfaces).
+`viewId` must name a declared `contributes.views` entry — a dangling id is a validation error — and that view's panel must not be `hasPty: true`. One slot exists today, it is project-scope only, and the frame keeps a control that swaps back to the stock launcher in both directions. See [Surfaces](./project-local.md#surfaces).
 
 ## Verify it loaded
 
 1. Open the project in Daintree. First time, a dialog names the plugins and asks once — **Always enable** persists the decision for this project, in Daintree's own store, never in the repository.
 2. Open the plugin manager. The plugin appears under the project section, badged `Project`, with its source path and manifest id.
 3. If it says **Staged**, click **Activate plugin** — a manifest id the project has never had does not run until you do.
-4. If it says **Unreadable**, the detail pane carries the validation error verbatim. That is the diagnostic; read it rather than guessing.
-5. Run the command from the palette, or open the panel.
+4. If it says **Unreadable**, the detail pane carries the first schema issue prefixed by its field path — or, for a manifest that never parsed, the JSON/read error. That is the diagnostic; read it rather than guessing.
+5. Run **Dashboard: Say Hello** from the palette, or open the panel. Either one activates the plugin — the manifest's `contributes.commands` entry is what makes the command reachable before `activate()` has ever run.
 
-Then check the trap that produces the most convincing false success: `git check-ignore -v .daintree/plugins/acme.dashboard/dist/index.js`. It works on the machine that built it whether or not `dist/` is tracked.
+Then check the trap that produces the most convincing false success — it works on the machine that built it whether or not `dist/` is tracked. Prove both halves, because neither implies the other:
+
+```bash
+git check-ignore -v --no-index .daintree/plugins/acme.dashboard/dist/index.mjs   # expect: no match
+git ls-files --error-unmatch .daintree/plugins/acme.dashboard/dist/index.mjs     # expect: the path
+```
 
 Edits to `plugin.json` or `dist/` reload the plugin live, per plugin directory, about 200 ms after writes stop. Settings and `host.storage` survive a reload; module-scope state in the worker and React state in the views do not. No restart is ever required — anything that genuinely needed one is not offered to project plugins.
 

--- a/docs/plugins/contribution-points.md
+++ b/docs/plugins/contribution-points.md
@@ -626,7 +626,14 @@ Available to `"scope": "project"` plugins alone. An installed plugin is bound to
 {
   "scope": "project",
   "contributes": {
-    "panels": [{ "id": "overview", "name": "Overview", "iconId": "gauge" }],
+    "panels": [
+      {
+        "id": "overview",
+        "name": "Overview",
+        "iconId": "gauge",
+        "color": "var(--theme-category-orange)"
+      }
+    ],
     "views": [{ "id": "overview", "componentPath": "dist/panel.js", "location": "panel" }],
     "surfaces": {
       "emptyCanvas": { "viewId": "overview" }

--- a/docs/plugins/getting-started.md
+++ b/docs/plugins/getting-started.md
@@ -2,6 +2,8 @@
 
 Scaffold your first plugin, package it, and install it in Daintree.
 
+> **This is the path for a plugin that belongs to you** — installed to `~/.daintree/plugins/` and present in every project. If you are writing a plugin that belongs to a **project**, committed to its repository at `<projectRoot>/.daintree/plugins/`, stop here and read the [agent brief](./agent-brief.md) instead. The two differ in ways that matter on the first line of the manifest, and the command-handler convention below is one project plugins reject.
+
 ## Prerequisites
 
 - Node.js 22 or newer

--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -163,11 +163,13 @@ Plugins with only static contributions (a theme pack, a standalone MCP server co
 
 ### `engines.daintree`
 
-Semver range expressing which Daintree versions the plugin supports. Examples track the latest pre-1.0 minor; the scaffolder (`npx daintree-plugin new`) generates `"^0.11.0"`:
+Semver range expressing which Daintree versions the plugin supports. The scaffolder (`npx daintree-plugin new`) generates `">=0.11.0"` — an open-ended lower bound, deliberately not a caret:
 
-- `"^0.11.0"` — compatible with 0.11 (scaffolder default)
+- `">=0.11.0"` — 0.11 and every later release (scaffolder default)
 - `">=0.11.0 <0.13.0"` — explicit range
 - `"0.11.x"` — any 0.11 release
+
+**Never use a caret on a 0.x range.** `"^0.11.0"` resolves to `>=0.11.0 <0.12.0` under semver's 0.x rule, so it stops matching at the very next minor and the plugin is rejected on every release after the one you wrote it against.
 
 If the running Daintree version doesn't satisfy the range, the plugin is rejected at load with a user-visible warning toast. If `engines.daintree` is omitted entirely, Daintree warns in the console but loads the plugin anyway.
 

--- a/docs/plugins/project-local.md
+++ b/docs/plugins/project-local.md
@@ -158,7 +158,7 @@ One slot exists today.
 
 ```jsonc
 "contributes": {
-  "panels": [{ "id": "overview", "name": "Overview", "iconId": "gauge" }],
+  "panels": [{ "id": "overview", "name": "Overview", "iconId": "gauge", "color": "var(--theme-category-orange)" }],
   "views":  [{ "id": "overview", "componentPath": "dist/panel.js", "location": "panel" }],
   "surfaces": {
     "emptyCanvas": { "viewId": "overview" }

--- a/docs/plugins/project-local.md
+++ b/docs/plugins/project-local.md
@@ -237,6 +237,7 @@ A project plugin's panel kind is qualified at runtime as `project:{projectId}/{m
 
 ## See also
 
+- [Agent brief](./agent-brief.md) — the compressed version to hand an agent, with a zero-build skeleton
 - [Manifest reference](./manifest.md) — `scope`, `contributes.surfaces`
 - [Contribution points](./contribution-points.md) — per-point project-scope status
 - [Trust model](./trust-model.md) — the capability contract and the non-guarantees


### PR DESCRIPTION
## Summary

Daintree supports plugins committed inside a project's own repo at `.daintree/plugins/`, but someone building one has nowhere to start. The published docs at daintree.org only cover user-installed plugins (six pages, zero mentions of `scope: "project"`), and this repo's `docs/plugins/` folder is 380KB written installed-first. An agent pointed at it reads `getting-started.md` first, which teaches the `src/<commandId>.ts` handler convention that project plugins reject, and confidently builds an installed plugin in the wrong directory.

This adds `docs/plugins/agent-brief.md`: one self-contained file you hand to an AI agent. It survives being pasted into a chat, fetched as a single raw URL, or read from a local checkout. The plugin README now routes on the only question that decides everything downstream, which of the two plugin kinds you are building, before the internals banner.

## Changes

- `docs/plugins/agent-brief.md`, new. The failure modes grouped by how they surface, a four-file skeleton that needs no build tooling, and pointers to the schema and fixtures as ground truth.
- `docs/plugins/README.md` leads with the project-plugin route instead of the installed one.
- `docs/plugins/getting-started.md` says on the file itself that it is the installed path. README routing cannot protect a search hit or a deep link.
- `docs/plugins/manifest.md` documented the scaffolder as generating `"^0.11.0"`. It generates `">=0.11.0"`, and `templates.ts` carries an explicit comment that a 0.x caret is rejected on every release past the one it was written against. The doc was teaching the trap.
- `docs/plugins/project-local.md` and `docs/plugins/contribution-points.md`: both `surfaces` examples omit the required `contributes.panels[].color`, so following the next doc did not repair the same bug.

## Review

A Codex review caught that the skeleton I first wrote does not load. Three blockers, all confirmed against source:

- `contributes.panels[].color` is required (`electron/schemas/plugin.ts:77`), so the manifest was refused as `Unreadable` before activation.
- Only the view is browser-imported. The worker entry is imported by Node in a utility process, so with no `package.json` of its own it inherits the enclosing repo's module type, and `export` fails to parse anywhere that is CommonJS. That is the default when no `type` is declared. Renamed to `dist/index.mjs`, which keeps the four-file skeleton.
- Activation is lazy. `activationEvents` defaults to `[]`, and the skeleton declared no `contributes.commands`, so the imperatively registered command did not exist until the panel had already been opened.

Also corrected: a `"worktree"` channel nothing published, a view with no matching panel being described as silently ignored when it is rejected, the trust dialog reading as one prompt then silence when only "Always enable" persists, and `git check-ignore` presented as proof a file is tracked.

## Testing

Extracted the manifest from the committed markdown and parsed it with `getPluginManifestSchema`. It passes under the `"project"` origin and is refused under `"user"`. Prettier clean. Docs only, so no suite run.

## Follow-ups

Two things worth issues rather than scope creep here:

- `ProjectPluginController` documents idle auto-close and free-memory paths that mark a project closed without unloading its plugins, so they can outlive it until the next project switch. That contradicts "loaded only while that project is open".
- Nothing stops these snippets rotting again. Schema-parsing every `scope: "project"` manifest in the docs would have caught the `color` bug at commit time.

The daintree.org docs still have no project-local page at all, which also means the `daintree-docs` MCP cannot answer these questions and the in-app assistant will describe installed plugins to anyone who asks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DEugCeJUGWcBH69RKyeStA