### PR TITLE
perf(theme): cache repeated OKLab conversions

### DIFF
--- a/shared/theme/contrast.ts
+++ b/shared/theme/contrast.ts
@@ -226,7 +226,14 @@ interface Oklab {
   b: number;
 }
 
+const OKLAB_CACHE_LIMIT = 2048;
+const oklabCache = new Map<string, Oklab>();
+
 function hexToOklab(hex: string): Oklab {
+  const key = hex.trim().toLowerCase();
+  const cached = oklabCache.get(key);
+  if (cached) return cached;
+
   const [r8, g8, b8] = hexToRgb(hex);
   const r = hexToLinear(r8);
   const g = hexToLinear(g8);
@@ -240,11 +247,14 @@ function hexToOklab(hex: string): Oklab {
   const m_ = Math.cbrt(m);
   const s_ = Math.cbrt(s);
 
-  return {
+  const value = {
     L: 0.2104542553 * l_ + 0.793617785 * m_ - 0.0040720468 * s_,
     a: 1.9779984951 * l_ - 2.428592205 * m_ + 0.4505937099 * s_,
     b: 0.0259040371 * l_ + 0.7827717662 * m_ - 0.808675766 * s_,
   };
+  if (oklabCache.size >= OKLAB_CACHE_LIMIT) oklabCache.clear();
+  oklabCache.set(key, value);
+  return value;
 }
 
 /**


### PR DESCRIPTION
## Summary

- cache normalized hex-to-OKLab conversions reused by theme audits
- cap the private cache at 2,048 entries and clear it as a unit at the limit
- preserve every audit warning, corpus cardinality, and correctness predicate

## Performance

Machine: `host-02d9f218-darwin-arm64` (Apple M1 Max, macOS 26.4.1 / arm64)

Protocol: smoke mode, 20 iterations, 2 warmups per arm, median of three fresh interleaved arms per tree. Node 22.13.0, npm 10.9.2, git 2.55.0, Electron 42.7.1. Apparatus digest `1d64b293f6cf94593ab291e280300bb41bcf1ba5998e9229d88ea5cf1a0a7b41`.

Trees: branch point `6dd9528c29d253f0d375b337cc59d9b152bd8d0d` -> final `327a50b166cf6aa80e1c7b05ffdb55acd8147e3e`.

### PERF-301 theme audit

| Metric | Before | After | Absolute change | Relative change |
| --- | ---: | ---: | ---: | ---: |
| `msPerTheme.mean` | 0.234529 | 0.202137 | -0.032392 ms/theme | -13.8% |
| `auditMisses` | 0 | 0 | 0 | ok |
| audited themes | 15 | 15 | 0 | unchanged |
| shipped warnings | 0 | 0 | 0 | unchanged |
| planted warnings | 68 | 68 | 0 | unchanged |
| light-matrix warnings | 0 | 0 | 0 | unchanged |
| accent-override warnings | 5 | 5 | 0 | unchanged |

Candidate won 3/3 paired arms; champion drift D 2.1%; worst within-arm CV 5.9%; precommitted threshold 7.2%. `auditMisses` was healthy in 120/120 measured iterations. The branch-point headline gate returned `CLAIM`.

### PERF-302 colour-maths corpus

| Metric | Before | After | Absolute change | Relative change |
| --- | ---: | ---: | ---: | ---: |
| `usPerKConversions.mean` | 421.831108 | 345.071788 | -76.759320 us/K | -18.2% |
| `mathMisses` | 0 | 0 | 0 | ok |
| hex tokens | 1,064 | 1,064 | 0 | unchanged |
| conversions | 6,384 | 6,384 | 0 | unchanged |

Candidate won 3/3 paired arms; champion drift D 0.5%; worst within-arm CV 3.1%; precommitted threshold 5.0%. `mathMisses` was healthy in 120/120 measured iterations. The branch-point headline gate returned `CLAIM`.

## Hypotheses

- `8f09e9c0fca16b10545ecb8e73dc02be94d7fdad`: bounded `hexToRgb` memoization improved PERF-301 by 6.2%, below the locked 7.2% threshold; reverted.
- `327a50b166cf6aa80e1c7b05ffdb55acd8147e3e`: bounded private `hexToOklab` memoization improved PERF-301 by 13.8% and PERF-302 by 18.2%; kept.
- `5b46a40e3ad50645480c466ab519d77bec920821`: private `hexToOklch` memoization with fresh exported result objects passed its focused semantics test, but was stopped unmeasured when sustained renderer/display/video CPU load kept the duration gate closed. No arm was started and no number was read; reverted to the champion to preserve the final proof reserve.
- Noisy H2 interleaves were quarantined in full. No refused arm was reused in a claim.

Both requested targets are duration metrics. `--os all` therefore has no legitimate hosted Linux/Windows/macOS percentage leg; hosted-runner durations were explicitly not measured or claimed. No deterministic count, size, or structural-ratio target exists in this cluster to dispatch through `perf-ab.yml`.

## Verification

- focused colour-math tests: 105 passed
- typecheck: passed
- full Vitest suite: 2,473 files and 54,505 tests passed (7 skipped, 1 todo)
- `npm run check`: passed
- diff audit: only `shared/theme/contrast.ts`; no `scripts/perf/` changes
- E2E: not run; this workflow only runs a human-named E2E spec

The full suite used Node 22.23.2, which satisfies the repository engine and current dependency requirements. Node 22.13.0 reproducibly SIGSEGVs in the unrelated PERF-053 native SQLite driver; the same driver passes on Node 22.23.2.
