### PR TITLE
perf(pty): cap terminal submit settle polling to deadlines

### DIFF
--- a/electron/services/pty/WriteQueue.ts
+++ b/electron/services/pty/WriteQueue.ts
@@ -106,11 +106,18 @@ export class WriteQueue {
     const startWait = Date.now();
     while (true) {
       if (this.disposed || this.options.isExited()) return;
+      const now = Date.now();
       const settleFrom = Math.max(startWait, this.options.lastOutputTime());
-      const timeSinceOutput = Date.now() - settleFrom;
+      const timeSinceOutput = now - settleFrom;
       if (timeSinceOutput >= opts.debounceMs) return;
-      if (Date.now() - startWait > opts.maxWaitMs) return;
-      await new Promise((r) => setTimeout(r, opts.pollMs));
+      const timeSinceStart = now - startWait;
+      if (timeSinceStart >= opts.maxWaitMs) return;
+      const nextPollMs = Math.min(
+        opts.pollMs,
+        opts.debounceMs - timeSinceOutput,
+        opts.maxWaitMs - timeSinceStart
+      );
+      await new Promise((r) => setTimeout(r, nextPollMs));
     }
   }
 

--- a/electron/services/pty/__tests__/WriteQueue.test.ts
+++ b/electron/services/pty/__tests__/WriteQueue.test.ts
@@ -298,6 +298,41 @@ describe("WriteQueue.waitForOutputSettle", () => {
     }
     expect(resolved).toBe(true);
   });
+
+  it("caps the final poll at the remaining debounce and max-wait windows", async () => {
+    const debounceOptions = makeOptions();
+    const debounceQueue = new WriteQueue(debounceOptions.options);
+    let debounceResolved = false;
+    void debounceQueue
+      .waitForOutputSettle({ debounceMs: 100, maxWaitMs: 1000, pollMs: 60 })
+      .then(() => {
+        debounceResolved = true;
+      });
+
+    await vi.advanceTimersByTimeAsync(99);
+    expect(debounceResolved).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(debounceResolved).toBe(true);
+
+    const maxWaitOptions = makeOptions();
+    maxWaitOptions.lastOutputTime.value = Date.now();
+    const maxWaitQueue = new WriteQueue(maxWaitOptions.options);
+    let maxWaitResolved = false;
+    void maxWaitQueue
+      .waitForOutputSettle({ debounceMs: 500, maxWaitMs: 200, pollMs: 75 })
+      .then(() => {
+        maxWaitResolved = true;
+      });
+
+    for (let elapsed = 0; elapsed < 199; elapsed += 25) {
+      maxWaitOptions.lastOutputTime.value = Date.now();
+      await vi.advanceTimersByTimeAsync(Math.min(25, 199 - elapsed));
+    }
+    expect(maxWaitResolved).toBe(false);
+    maxWaitOptions.lastOutputTime.value = Date.now();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(maxWaitResolved).toBe(true);
+  });
 });
 
 // #11875. The slow-submit timer reports; it does not release the submit lane.


### PR DESCRIPTION
## Outcome

Cap each submit-settle poll to the remaining debounce or max-wait deadline. This removes poll-interval overshoot while preserving the existing quiet-window and maximum-wait semantics.

PERF-036 is a **mechanism** benchmark. These numbers measure the real `WriteQueue` serialization mechanism and exact body/Enter ordering with a fake recording PTY; they are not user-perceived latency.

## Report-grade benchmark result

| Machine | Benchmark / metric | Class | Before | After | Absolute | Change | Verdict |
| --- | --- | --- | ---: | ---: | ---: | ---: | --- |
| `host-02d9f218-darwin-arm64` (Apple M1 Max, macOS 26.4.1) | PERF-036 `metricStats.contendedMsPerSlowSubmit.mean` | mechanism, duration | 28.543 ms | 23.711 ms | -4.832 ms | -16.9% | CLAIM |

| Paired arm | Before | After | Improvement |
| --- | ---: | ---: | ---: |
| 1 | 28.504 ms | 23.699 ms | 16.9% |
| 2 | 28.562 ms | 23.814 ms | 16.6% |
| 3 | 28.543 ms | 23.711 ms | 16.9% |

- Precommitted threshold: 6.0%; champion drift: 0.2%; worst within-arm spread: 1.4%.
- Exact trees: branch point/champion `cfd38b0b0215ab2b56e1b7a565407860102ef4fb`; candidate `36609ebd42b1fd204215f1f926b5480533691866`.
- Protocol: smoke, 20 iterations per arm, 1 warmup, median arm statistic, three alternating A/B pairs, every arm with `--enforce-integrity`; Node 22.13.0, Electron 42.7.1, git 2.55.0.
- Apparatus: unchanged, digest `78ed867d5ac93be9b1fa8aabf0c81b8b9223b0ea2e4881a7fd439baa74cb81db` across 185 files.
- Fidelity: public API entry point; renderer absent; no Electron transport; fake recording PTY; single process; hermetic dependencies.
- Claim boundary: real `WriteQueue` serialization and exact body/Enter byte ordering are authoritative. Smoke/CI cover the defect class with a 20 ms held-open window; only nightly crosses the shipped 3000 ms slow-submit threshold. The composer is not rendered.

## Predicates, workload floors, and guards

All ten predicates were healthy on all six headline arms (`count = 20/20`, `min = 0`, `max = 0`): `deliveryMisses`, `interleaveMisses`, `orderMisses`, `enterCountMisses`, `bodyIntegrityMisses`, `strayWriteMisses`, `concurrentSubmitMisses`, `settleShortfallMisses`, `drainTimeoutMisses`, and `heldLaneStatusMisses`.

The workload floors held on every arm: `submitsCompleted >= 48` (observed 48) and `slowSubmits >= 6` (observed 6). Predicate sensitivity was proved with a temporary queue bypass: `interleaveMisses = 48` and `concurrentSubmitMisses = 46` on each of three integrity-enforced iterations; that throwaway change was then reset.

| Guard | Before | After | Change | Tolerance / result |
| --- | ---: | ---: | ---: | --- |
| `fastDrainMs` | 55.063 ms | 28.225 ms | -48.7% | 10% / pass |
| `contendedDrainMs` | 171.261 ms | 142.268 ms | -16.9% | 10% / pass |
| `fastMsPerSubmit` | 2.294 ms | 1.176 ms | -48.7% | 10% / pass |
| `submitsCompleted` | 48 | 48 | 0 | 5% / pass |
| `slowSubmits` | 6 | 6 | 0 | 5% / pass |
| `failedSubmits` | 0 | 0 | 0 | pass |
| `drainTimeouts` | 0 | 0 | 0 | pass |
| `bytesWritten` | 1192 | 1192 | 0 | 5% / pass |
| `heldSubmitMs` | 0 | 0 | 0 | pass |
| `heldStatusEvents` | 0 | 0 | 0 | pass |

## Rejected hypotheses

- Shortening the quiet debounce or held-open maximum wait would improve the number by deleting safety semantics, so it was rejected without implementation.
- Replacing array `shift()` or reducing status-timer bookkeeping cannot credibly clear the 6% threshold. After this change, the 23.775 ms confirmed candidate median is only 3.37% above PERF-036's 23 ms semantic timer floor.

## Cross-OS result

Linux, Windows, and macOS hosted `perf-ab` legs were intentionally **not measured**. The target is a non-portable duration (`crossMachineComparable: false`), and no machine-independent count, size, or structural-ratio metric improved: bytes remained 1192 and all workload/status counts remained fixed. No hosted-runner duration is claimed.

## Verification

- Focused `WriteQueue` suite: 24 tests passed.
- `npm run typecheck`: passed.
- `npm test`: 54,967 tests across 2,491 files passed.
- `npm run check`: passed.
- Scoped diff/ownership audit and `git diff --check`: passed; only `electron/services/pty/WriteQueue.ts` and its colocated test changed; no `scripts/perf/**` changes.
- E2E: not run, per the optimization contract.

All performance evidence used the precommitted Node 22.13.0 protocol. Full repository checks used supported Node 22.23.2 after the locally npm-packaged 22.13.0 executable crashed while spawning unrelated scenario-liveness children; the exact affected driver and suite passed on Node 22.23.2 before the full green run.
