### PR TITLE
perf(file-browser): reduce hidden-pattern matching cost

### DIFF
--- a/src/panels/file-browser/fileBrowserTree.ts
+++ b/src/panels/file-browser/fileBrowserTree.ts
@@ -282,16 +282,26 @@ function matchesBasenameGlob(name: string, pattern: string): boolean {
   return p === pattern.length;
 }
 
+function createBasenameMatcher(patterns: readonly string[]): (name: string) => boolean {
+  const exact: string[] = [];
+  const globs: string[] = [];
+  for (const pattern of patterns) {
+    if (pattern.includes("*")) globs.push(pattern);
+    else exact.push(pattern);
+  }
+  return (name: string): boolean =>
+    exact.includes(name) || globs.some((pattern) => matchesBasenameGlob(name, pattern));
+}
+
 /**
  * Build the per-entry visibility predicate for one panel's current settings. A
  * `true` result means "show this entry".
  */
 export function createVisibilityFilter(visibility: FileVisibility): (name: string) => boolean {
   const { hideDotfiles, alwaysHiddenPatterns } = visibility;
+  const isJunk = createBasenameMatcher(alwaysHiddenPatterns);
   return (name: string): boolean => {
-    for (const pattern of alwaysHiddenPatterns) {
-      if (matchesBasenameGlob(name, pattern)) return false;
-    }
+    if (isJunk(name)) return false;
     if (hideDotfiles && name.startsWith(".")) return false;
     return true;
   };
@@ -332,8 +342,7 @@ export function countHiddenRows(
   let dotfiles = 0;
   let alwaysHidden = 0;
 
-  const isJunk = (name: string): boolean =>
-    alwaysHiddenPatterns.some((pattern) => matchesBasenameGlob(name, pattern));
+  const isJunk = createBasenameMatcher(alwaysHiddenPatterns);
 
   const walk = (dirPath: string, depth: number): void => {
     // The same depth bound `flattenTree` walks under, and for the same reason:


### PR DESCRIPTION
## What changed

File Browser visibility filters now partition always-hidden basename patterns once when the filter is created:

- literal basenames use a short native array lookup;
- only patterns containing `*` enter the bounded wildcard scanner;
- hidden-row counting uses the same matcher.

The matcher is rebuilt from the current visibility settings, so this introduces no persistent cache or invalidation surface. Wildcard semantics, dotfile precedence, row order, accessibility positions, and hidden-row accounting are unchanged.

## Benchmark contract

All three scenarios are **mechanism benchmarks** with **partial process topology**. They measure real File Browser listing/filter/flatten/prune work over repository fixtures. They do **not** include IPC transport, React rendering, frames, paint, or user-perceived latency.

| Scenario | Target | Protocol | Threshold | Predicates | Workload floor |
| --- | --- | --- | ---: | --- | --- |
| PERF-240 | `metricStats.flattenMs.mean` (duration) | smoke, 20 iterations, 1 warmup | 7% | `treeRowMisses`, `hiddenCountMisses`, `rowOrderMisses` | 61 directories, 769 nodes, 744 rows, 25 hidden junk rows |
| PERF-241 | `metricStats.largeFlattenMs.mean` (duration) | ci, 20 iterations, 1 warmup | 6% | `treeRowMisses`, `hiddenCountMisses`, `rowOrderMisses` | 6,489 nodes, 6,405 rows, 84 hidden junk rows; dotfile pass holds 6,279 rows / 126 hidden |
| PERF-243 | `metricStats.expandMs.mean` (duration) | smoke, 20 iterations, 1 warmup | 24% | `expandCollapseMisses` | 18 expansion steps, depth 6, 89 rows fully expanded, 1 listing after prune |

Every arm used `--enforce-integrity`. Precommit apparatus digest: `78ed867d5ac93be9b1fa8aabf0c81b8b9223b0ea2e4881a7fd439baa74cb81db` over 185 files.

## PERF-240 `metricStats.flattenMs.mean` — host-02d9f218-darwin-arm64

This final six-arm set is **not a measurement**: `champ1` had 42.0% within-arm CV against the fixed 10% ceiling. Raw medians and absolute deltas are shown for completeness; duration percentages are deliberately not claimed.

| Metric | Before | After | Absolute change | Percentage |
| --- | ---: | ---: | ---: | ---: |
| `flattenMs` target | 0.116110 ms | 0.101058 ms | −0.015052 ms | not claimable |
| `treeRowMisses` predicate | 0 | 0 | 0 | ok |
| `hiddenCountMisses` predicate | 0 | 0 | 0 | ok |
| `rowOrderMisses` predicate | 0 | 0 | 0 | ok |
| `listMs` guard (10%) | 11.953742 ms | 11.298656 ms | −0.655086 ms | not claimable |
| `hiddenCountMs` guard (10%) | 0.056717 ms | 0.041179 ms | −0.015538 ms | not claimable |
| `resortFlattenMs` guard (10%) | 0.191231 ms | 0.177704 ms | −0.013527 ms | not claimable |
| `directoryCount` guard (5%) | 61 | 61 | 0 | 0.0% |
| `nodeCount` guard (5%) | 769 | 769 | 0 | 0.0% |
| `rowCount` guard (5%) | 744 | 744 | 0 | 0.0% |
| `hiddenDotfileCount` guard (5%) | 0 | 0 | 0 | 0.0% |
| `hiddenJunkCount` guard (5%) | 25 | 25 | 0 | 0.0% |

Machine: `host-02d9f218-darwin-arm64` (macOS 26.4.1 / arm64 / Apple M1 Max) · smoke · 20 iterations · 1 warmup  
Trees: `cfd38b0b0215ab2b56e1b7a565407860102ef4fb` → `d59d63b2bd9974b3079e5bf4853b67a08975ab64` · git 2.55.0 · Electron 42.7.1 · Node 22.23.2  
Statistic: median arm · precommitted threshold 7% · measured drift unavailable because the CV evidence gate failed first.

```text
FAIL  within-arm spread under --max-cv — champ1 varied 42.0% across its own iterations, over the 10% allowed — that arm measured the machine, not the code

1 check(s) FAILED — these arms are not a result.
```

## PERF-241 `metricStats.largeFlattenMs.mean` — host-02d9f218-darwin-arm64

| Metric | Before | After | Absolute change | Percentage |
| --- | ---: | ---: | ---: | ---: |
| `largeFlattenMs` target | 0.799577 ms | 0.609464 ms | −0.190113 ms | **−23.8%** |
| `treeRowMisses` predicate | 0 | 0 | 0 | ok |
| `hiddenCountMisses` predicate | 0 | 0 | 0 | ok |
| `rowOrderMisses` predicate | 0 | 0 | 0 | ok |
| `smallListMs` guard (10%) | 11.761096 ms | 12.322125 ms | +0.561029 ms | +4.8% |
| `smallFlattenMs` guard (10%) | 0.119825 ms | 0.102821 ms | −0.017004 ms | −14.2% |
| `largeListMs` guard (10%) | 68.896858 ms | 69.284473 ms | +0.387615 ms | +0.6% |
| `largeHiddenCountMs` guard (10%) | 0.303960 ms | 0.172844 ms | −0.131117 ms | −43.1% |
| `largeResortFlattenMs` guard (10%) | 1.640535 ms | 1.533773 ms | −0.106763 ms | −6.5% |
| `dotfilesHiddenFlattenMs` guard (10%) | 0.737802 ms | 0.553835 ms | −0.183967 ms | −24.9% |
| `msPerKNode` guard (10%) | 10.778503 | 10.813176 | +0.034672 | +0.3% |
| `largeNodeCount` guard (5%) | 6,489 | 6,489 | 0 | 0.0% |
| `largeRowCount` guard (5%) | 6,405 | 6,405 | 0 | 0.0% |
| `largeHiddenJunkCount` guard (5%) | 84 | 84 | 0 | 0.0% |
| `dotfilesHiddenRowCount` guard (5%) | 6,279 | 6,279 | 0 | 0.0% |
| `dotfilesHiddenTallyCount` guard (5%) | 126 | 126 | 0 | 0.0% |

Machine: `host-02d9f218-darwin-arm64` (macOS 26.4.1 / arm64 / Apple M1 Max) · ci · 20 iterations · 1 warmup  
Trees: `cfd38b0b0215ab2b56e1b7a565407860102ef4fb` → `d59d63b2bd9974b3079e5bf4853b67a08975ab64` · git 2.55.0 · Electron 42.7.1 · Node 22.23.2  
Statistic: median arm · precommitted threshold 6% · measured drift D 9.1% · worst within-arm CV 4.2%.

```text
Target: metricStats.largeFlattenMs.mean on PERF-241 · lower is better
Champion drift D: 9.1% (worst of 3, champ2 v champ3) — same code on both sides, so this is the machine
Drift ceiling (--max-drift): 12.0% (default, 2x threshold)
Worst within-arm spread: 4.2% on cand1 · ceiling 10%

  pair 1: 0.8 → 0.684  14.5%  WON
  pair 2: 0.738 → 0.609  17.5%  WON
  pair 3: 0.805 → 0.568  29.5%  WON

  median arm: 0.8 → 0.609  improvement 23.8%
  precommitted threshold (--threshold): 6.0%

  guards (cost metrics — up is worse):
    NOISE   smallListMs  11.761 → 12.322  +4.8% worse  tolerance 10% (machine-dependent)
    OK      smallFlattenMs  0.12 → 0.103  -14.2% better  tolerance 10% (machine-dependent)
    NOISE   largeListMs  68.897 → 69.284  +0.6% worse  tolerance 10% (machine-dependent)
    OK      largeHiddenCountMs  0.304 → 0.173  -43.1% better  tolerance 10% (machine-dependent)
    NOISE   largeResortFlattenMs  1.641 → 1.534  -6.5% better  tolerance 10% (machine-dependent)
    OK      dotfilesHiddenFlattenMs  0.738 → 0.554  -24.9% better  tolerance 10% (machine-dependent)
    NOISE   msPerKNode  10.779 → 10.813  +0.3% worse  tolerance 10% (machine-dependent)
    OK      largeNodeCount  6489 → 6489  +0.0% better  tolerance 5%
    OK      largeRowCount  6405 → 6405  +0.0% better  tolerance 5%
    OK      largeHiddenJunkCount  84 → 84  +0.0% better  tolerance 5%
    OK      dotfilesHiddenRowCount  6279 → 6279  +0.0% better  tolerance 5%
    OK      dotfilesHiddenTallyCount  126 → 126  +0.0% better  tolerance 5%

  condition 1  PASS  candidate won every index-paired arm — 3/3
  condition 2  PASS  median-to-median improvement 23.8% >= precommitted threshold 6.0%
  condition 3  PASS  improvement 23.8% > champion drift D 9.1%
  condition 4  PASS  no guard outside its precommitted tolerance — 12 checked

VERDICT: CLAIM

CLAIM — all four conditions hold.
```

## PERF-243 `metricStats.expandMs.mean` — host-02d9f218-darwin-arm64

This final six-arm set is **not a measurement**: `champ1` had 37.6% within-arm CV against the fixed 10% ceiling. Raw medians and absolute deltas are shown for completeness; duration percentages are deliberately not claimed.

| Metric | Before | After | Absolute change | Percentage |
| --- | ---: | ---: | ---: | ---: |
| `expandMs` target | 4.591354 ms | 4.336833 ms | −0.254521 ms | not claimable |
| `expandCollapseMisses` predicate | 0 | 0 | 0 | ok |
| `collapseMs` guard (10%) | 0.021929 ms | 0.020104 ms | −0.001825 ms | not claimable |
| `pruneMs` guard (10%) | 0.005592 ms | 0.005285 ms | −0.000306 ms | not claimable |
| `p99ExpandStepMs` diagnostic guard (10%) | 0.641023 ms | 0.563526 ms | −0.077497 ms | not claimable |
| `expandStepCount` guard (5%) | 18 | 18 | 0 | 0.0% |
| `spineDepth` guard (5%) | 6 | 6 | 0 | 0.0% |
| `rowCountAtFullExpansion` guard (5%) | 89 | 89 | 0 | 0.0% |
| `listingCountAfterPrune` guard (5%) | 1 | 1 | 0 | 0.0% |

Machine: `host-02d9f218-darwin-arm64` (macOS 26.4.1 / arm64 / Apple M1 Max) · smoke · 20 iterations · 1 warmup  
Trees: `cfd38b0b0215ab2b56e1b7a565407860102ef4fb` → `d59d63b2bd9974b3079e5bf4853b67a08975ab64` · git 2.55.0 · Electron 42.7.1 · Node 22.23.2  
Statistic: median arm · precommitted threshold 24% · measured drift unavailable because the CV evidence gate failed first. `p99ExpandStepMs` is a diagnostic guard at this iteration count, not a user-latency result.

```text
FAIL  within-arm spread under --max-cv — champ1 varied 37.6% across its own iterations, over the 10% allowed — that arm measured the machine, not the code

1 check(s) FAILED — these arms are not a result.
```

## Hypotheses

- **H1 — literal `Set` plus wildcard scan:** rejected. PERF-240 regressed 0.117333 → 0.139042 ms (+18.50%); hashing four literals cost more than their early-reject scans.
- **H2 — literal array plus wildcard scan:** kept. The larger final headline set above proves a 23.8% PERF-241 reduction with all predicates and guards healthy.
- **H3 — direct conditional row assignments:** rejected. PERF-241 moved 0.587525 → 0.555071 ms (−5.52%), inside the locked 6% threshold.
- **H4 — indexed visible-row traversal:** rejected. PERF-241 regressed 0.587525 → 0.613606 ms (+4.44%).
- **PERF-243 shared H2 selection:** 4.063248 → 3.950527 ms (−2.77%), far inside its locked 24% threshold; no expansion-latency claim.

PERF-242 was considered but excluded before measurement because refresh-after-change is a different trigger/sweep subject. PERF-244–246 cover Review Hub/viewer mechanisms and were also out of cluster.

## Platform verdicts

| Machine / OS | PERF-240 | PERF-241 | PERF-243 |
| --- | --- | --- | --- |
| `host-02d9f218-darwin-arm64` / macOS | no measurement (CV) | **claim: −23.8%** | no measurement (CV) |
| GitHub Linux | not measured: duration target | not measured: duration target | not measured: duration target |
| GitHub Windows | not measured: duration target | not measured: duration target | not measured: duration target |
| GitHub macOS | not measured: hosted duration target; local Mac above is authoritative | not measured: hosted duration target; local Mac above is authoritative | not measured: hosted duration target; local Mac above is authoritative |

`perf-ab.yml` correctly refuses cross-machine duration claims, so no hosted duration run was dispatched. All deterministic count guards were unchanged; there was no portable count, size, or structural-ratio target improvement to verify across Linux, Windows, and macOS.

## Verification

- `npm run typecheck` — passed
- `npm test` — passed: 2,491 files; 54,958 passed; 7 skipped; 1 todo
- `npm run check` — passed
- diff audit — only `src/panels/file-browser/fileBrowserTree.ts`; no change under `scripts/perf/`; Area E ownership confirmed
- required GitHub CI — passed: build, Ubuntu check, four unit-test shards, `ci-ok`, and PR classification; 8 successful, 1 inapplicable ratio job skipped, 0 pending
- E2E — not run; no human named a spec

Exact trees: branch point `cfd38b0b0215ab2b56e1b7a565407860102ef4fb`; final `d59d63b2bd9974b3079e5bf4853b67a08975ab64`.
