### PR TITLE
perf(worktree-store): avoid redundant state merge

### DIFF
--- a/src/store/createWorktreeStore.ts
+++ b/src/store/createWorktreeStore.ts
@@ -665,24 +665,33 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
       const workingTreeChangedAtChanged =
         workingTreeChangedAtById !== prevState.workingTreeChangedAtById;
 
+      // Replace with the complete state so Zustand does not merge into a second object.
       if (existing && snapshotsEqual(existing, merged)) {
-        set({
-          version,
-          ...(statusCheckedAtChanged ? { statusCheckedAt } : {}),
-          ...(workingTreeChangedAtChanged ? { workingTreeChangedAtById } : {}),
-          ...(tombstonesChanged ? { tombstones } : {}),
-        });
+        set(
+          {
+            ...prevState,
+            version,
+            ...(statusCheckedAtChanged ? { statusCheckedAt } : {}),
+            ...(workingTreeChangedAtChanged ? { workingTreeChangedAtById } : {}),
+            ...(tombstonesChanged ? { tombstones } : {}),
+          },
+          true
+        );
         return true;
       }
       const next = new Map(prev);
       next.set(state.id, merged);
-      set({
-        worktrees: next,
-        version,
-        ...(statusCheckedAtChanged ? { statusCheckedAt } : {}),
-        ...(workingTreeChangedAtChanged ? { workingTreeChangedAtById } : {}),
-        ...(tombstonesChanged ? { tombstones } : {}),
-      });
+      set(
+        {
+          ...prevState,
+          worktrees: next,
+          version,
+          ...(statusCheckedAtChanged ? { statusCheckedAt } : {}),
+          ...(workingTreeChangedAtChanged ? { workingTreeChangedAtById } : {}),
+          ...(tombstonesChanged ? { tombstones } : {}),
+        },
+        true
+      );
       return true;
     },
 


### PR DESCRIPTION
## Summary

- pass the complete post-update worktree-store state to Zustand with replace semantics
- avoid Zustand allocating and merging a second full state object for every host update
- preserve Map identity, notification count, freshness storage, sequencing, tombstones, and all existing store behavior

## Claim boundary

PERF-140 and PERF-141 are **mechanism** benchmarks with **partial process topology**. They exercise the real `createWorktreeStore.applyUpdate` path and stop at store emission. They do not measure React commit, virtualization, paint, rendered-card latency, or user-perceived latency.

Benchmark machine: `studio-04` / `host-02d9f218-darwin-arm64`, Apple M1 Max (10 cores), 32 GB, macOS 26.4.1 / Darwin 25.4.0, AC power. Benchmark toolchain: Node 24.20.0, npm 11.19.0, git 2.55.0, Electron 42.7.1.

Every reported arm used `smoke`, 20 iterations, 3 warmups, median statistic, `--enforce-integrity`, and the unchanged apparatus digest `78ed867d5ac93be9b1fa8aabf0c81b8b9223b0ea2e4881a7fd439baa74cb81db` over 185 files. Interleave: `champ1 → cand1 → cand2 → champ2 → champ3 → cand3`.

Baseline SHA: `cfd38b0b0215ab2b56e1b7a565407860102ef4fb`

Candidate SHA: `b1932e10c9b9a0b82d22dfae4c68b82eaf5411ac`

## PERF-140 — Store Apply Fan-Out

Fixed workload invariant: 50-row and 200-row stores, 400 real `applyUpdate` calls at each scale. The scenario declares no separate `workloadFloors` field. Predicate: `applyMisses`; every arm emitted it 20/20 with min=max=0. Precommitted threshold: 5.5%.

| Metric | Class | Before | After | Absolute | Change |
| --- | --- | ---: | ---: | ---: | ---: |
| `perApplyUsN200.mean` (target) | duration | 18.118 µs | 9.837 µs | −8.281 µs | −45.7% |
| `applyMsN50` (guard, 10%) | duration | 4.260 ms | 1.045 ms | −3.215 ms | −75.5% |
| `applyMsN200` (guard, 10%) | duration | 7.247 ms | 3.935 ms | −3.312 ms | −45.7% |
| `notifiesPerApply` (guard, 5%) | ratio | 1 | 1 | 0 | 0% |
| `mapChangesPerApply` (guard, 5%) | ratio | 1 | 1 | 0 | 0% |
| `applyMisses` (predicate) | count | 0 | 0 | 0 | healthy |

```text
Target: metricStats.perApplyUsN200.mean on PERF-140 · lower is better
Champion drift D: 0.4% (worst of 3, champ1 v champ3) — same code on both sides, so this is the machine
Drift ceiling (--max-drift): 11.0% (default, 2x threshold)
Worst within-arm spread: 5.5% on cand3 · ceiling 10%

  pair 1: 18.135 → 9.806  45.9%  WON
  pair 2: 18.118 → 9.991  44.9%  WON
  pair 3: 18.067 → 9.837  45.6%  WON

  median arm: 18.118 → 9.837  improvement 45.7%
  precommitted threshold (--threshold): 5.5%

  guards (cost metrics — up is worse):
    OK      applyMsN50  4.26 → 1.045  -75.5% better  tolerance 10% (machine-dependent)
    OK      applyMsN200  7.247 → 3.935  -45.7% better  tolerance 10% (machine-dependent)
    OK      notifiesPerApply  1 → 1  +0.0% better  tolerance 5%
    OK      mapChangesPerApply  1 → 1  +0.0% better  tolerance 5%

  condition 1  PASS  candidate won every index-paired arm — 3/3
  condition 2  PASS  median-to-median improvement 45.7% >= precommitted threshold 5.5%
  condition 3  PASS  improvement 45.7% > champion drift D 0.4%
  condition 4  PASS  no guard outside its precommitted tolerance — 4 checked

VERDICT: CLAIM

CLAIM — all four conditions hold.
```

One earlier frozen-tree sequence was discarded wholesale because `cand3` CV was 36.4%, above the 10% ceiling. No arm from it appears in the table.

## PERF-141 — Store Freshness No-Churn

Fixed workload invariant: a 200-row store and 400 freshness-only real `applyUpdate` calls. The scenario declares no separate `workloadFloors` field. Predicate: `freshnessMisses`; every arm emitted it 20/20 with min=max=0. Precommitted threshold: 11.5%.

| Metric | Class | Before | After | Absolute | Change |
| --- | --- | ---: | ---: | ---: | ---: |
| `perApplyUs.mean` (target) | duration | 17.946 µs | 9.877 µs | −8.069 µs | −45.0% |
| `mapIdentityChanges` (guard, 5%) | count | 0 | 0 | 0 | healthy |
| `notifiesPerApply` (guard, 5%) | ratio | 1 | 1 | 0 | 0% |
| `freshnessMisses` (predicate) | count | 0 | 0 | 0 | healthy |

```text
Target: metricStats.perApplyUs.mean on PERF-141 · lower is better
Champion drift D: 3.9% (worst of 3, champ1 v champ3) — same code on both sides, so this is the machine
Drift ceiling (--max-drift): 23.0% (default, 2x threshold)
Worst within-arm spread: 7.9% on cand1 · ceiling 10%

  pair 1: 18.511 → 9.966  46.2%  WON
  pair 2: 17.946 → 9.754  45.6%  WON
  pair 3: 17.788 → 9.877  44.5%  WON

  median arm: 17.946 → 9.877  improvement 45.0%
  precommitted threshold (--threshold): 11.5%

  guards (cost metrics — up is worse):
    OK      mapIdentityChanges  0 → 0 (champion is zero, so no percentage)
    OK      notifiesPerApply  1 → 1  +0.0% better  tolerance 5%

  condition 1  PASS  candidate won every index-paired arm — 3/3
  condition 2  PASS  median-to-median improvement 45.0% >= precommitted threshold 11.5%
  condition 3  PASS  improvement 45.0% > champion drift D 3.9%
  condition 4  PASS  no guard outside its precommitted tolerance — 2 checked

VERDICT: CLAIM

CLAIM — all four conditions hold.
```

## Cross-OS disposition

Linux and Windows `perf-ab` legs were not dispatched. Both precommitted primary targets are machine-dependent durations, and the workflow hard-refuses hosted-runner duration claims. The deterministic predicate and guard values remained invariant, but they are safety properties rather than changed count/size/structural-ratio optimisation targets, so there is no eligible portable target improvement to claim. No hosted-runner duration is reported.

## Hypotheses

- Kept: complete state plus Zustand replace semantics, avoiding the redundant merge allocation.
- Rejected: reorder `worktreeChangesEqual` first (−1.12%, below threshold/noise).
- Rejected: incrementally assign the partial patch (+3.83% regression).
- Rejected: clone complete state once and directly assign changed side maps (+2.02% regression).
- Not attempted: mutating/reusing freshness side maps, because that would break the File Browser identity signal, cache soundness, and maintainability.
- Profiling was used only to identify allocation work; its durations are diagnostic and are not benchmark evidence.

## Checks

- `npm run typecheck` — PASS under repository-pinned Node 22
- full Vitest suite — PASS: 54,958 passed, 0 failed, 7 skipped, 1 todo
- `npm run check` — PASS under repository-pinned Node 22
- diff audit — one Area A production file; no `scripts/perf/` changes; `git diff --check` clean
- E2E — not run; no human named a spec
