### PR TITLE
perf(worktree): skip absent remote divergence probe

### DIFF
--- a/.github/workflows/perf-ab.yml
+++ b/.github/workflows/perf-ab.yml
@@ -222,7 +222,8 @@ jobs:
               --iterations "$ITERATIONS" \
               --warmups "$WARMUPS" \
               --label "$2" \
-              --json ".tmp/opt/ab/$2.json"
+              --json ".tmp/opt/ab/$2.json" \
+              --enforce-integrity
           }
           arm "$BASE_SHA" champ1
           arm "$CAND_SHA" cand1

--- a/electron/utils/__tests__/baseCompareRef.test.ts
+++ b/electron/utils/__tests__/baseCompareRef.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import {
   gatherBaseCompareRefInputs,
+  gatherBaseCompareRefInputsWithRemoteStatus,
   readRemotes,
   readRemotesCarrying,
   readSymbolicRef,
@@ -87,6 +88,20 @@ describe("readRemotesCarrying", () => {
 });
 
 describe("gatherBaseCompareRefInputs", () => {
+  it("distinguishes a repository with no remotes from a failed remote read", async () => {
+    const successful = fakeGit({ remote: "" });
+    const failed = fakeGit({});
+
+    expect(
+      (await gatherBaseCompareRefInputsWithRemoteStatus(successful.git, "develop"))
+        .remotesReadSucceeded
+    ).toBe(true);
+    expect(
+      (await gatherBaseCompareRefInputsWithRemoteStatus(failed.git, "develop"))
+        .remotesReadSucceeded
+    ).toBe(false);
+  });
+
   it("skips the for-each-ref spawn when the base branch tracks something", async () => {
     const { git, raw } = fakeGit({
       remote: "origin\n",

--- a/electron/utils/__tests__/baseCompareRef.test.ts
+++ b/electron/utils/__tests__/baseCompareRef.test.ts
@@ -97,8 +97,7 @@ describe("gatherBaseCompareRefInputs", () => {
         .remotesReadSucceeded
     ).toBe(true);
     expect(
-      (await gatherBaseCompareRefInputsWithRemoteStatus(failed.git, "develop"))
-        .remotesReadSucceeded
+      (await gatherBaseCompareRefInputsWithRemoteStatus(failed.git, "develop")).remotesReadSucceeded
     ).toBe(false);
   });
 

--- a/electron/utils/baseCompareRef.ts
+++ b/electron/utils/baseCompareRef.ts
@@ -34,16 +34,25 @@ export interface BaseCompareRefGit {
 }
 
 /** `git remote` — names only, no URLs, no network. */
-export async function readRemotes(git: BaseCompareRefGit): Promise<string[]> {
+async function readRemotesWithStatus(
+  git: BaseCompareRefGit
+): Promise<{ availableRemotes: string[]; succeeded: boolean }> {
   try {
     const out = await git.raw(["remote"]);
-    return out
-      .split("\n")
-      .map((line) => line.trim())
-      .filter((line) => line.length > 0);
+    return {
+      availableRemotes: out
+        .split("\n")
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0),
+      succeeded: true,
+    };
   } catch {
-    return [];
+    return { availableRemotes: [], succeeded: false };
   }
+}
+
+export async function readRemotes(git: BaseCompareRefGit): Promise<string[]> {
+  return (await readRemotesWithStatus(git)).availableRemotes;
 }
 
 /**
@@ -116,12 +125,29 @@ export async function gatherBaseCompareRefInputs(
   git: BaseCompareRefGit,
   baseBranch: string
 ): Promise<ResolveBaseCompareRefInputs> {
-  const availableRemotes = await readRemotes(git);
+  return (await gatherBaseCompareRefInputsWithRemoteStatus(git, baseBranch)).inputs;
+}
+
+/**
+ * The same resolver inputs plus whether an empty remote list is authoritative.
+ * Most callers intentionally fail soft and need only the inputs. Poll-loop
+ * callers may use the status to avoid an impossible remote probe without
+ * confusing a transient `git remote` failure with a repository that has no
+ * remotes.
+ */
+export async function gatherBaseCompareRefInputsWithRemoteStatus(
+  git: BaseCompareRefGit,
+  baseBranch: string
+): Promise<{ inputs: ResolveBaseCompareRefInputs; remotesReadSucceeded: boolean }> {
+  const { availableRemotes, succeeded: remotesReadSucceeded } = await readRemotesWithStatus(git);
   const trackedRef = await readSymbolicRef(git, `${baseBranch}@{upstream}`);
   const remotesWithBaseRef = trackedRef
     ? []
     : await readRemotesCarrying(git, baseBranch, availableRemotes);
-  return { baseBranch, trackedRef, remotesWithBaseRef, availableRemotes };
+  return {
+    inputs: { baseBranch, trackedRef, remotesWithBaseRef, availableRemotes },
+    remotesReadSucceeded,
+  };
 }
 
 /** A base ref that was confirmed to exist, named both ways. */

--- a/electron/workspace-host/BaseDivergence.ts
+++ b/electron/workspace-host/BaseDivergence.ts
@@ -3,7 +3,10 @@ import { createHardenedGit, createWslHardenedGit } from "../utils/hardenedGit.js
 import type { WslGitInvocation } from "../utils/hardenedGit.js";
 import { getGitDir } from "../utils/gitUtils.js";
 import { resolveBaseCompareRef } from "../../shared/utils/baseRemoteSelection.js";
-import { gatherBaseCompareRefInputs, readSymbolicRef } from "../utils/baseCompareRef.js";
+import {
+  gatherBaseCompareRefInputsWithRemoteStatus,
+  readSymbolicRef,
+} from "../utils/baseCompareRef.js";
 import type { StatPrecheck } from "./StatPrecheck.js";
 
 /**
@@ -51,6 +54,8 @@ interface RemoteResolution {
   upstreamRef: string | null;
   /** `git remote` output, cached so the stat stamp can cover each candidate ref. */
   availableRemotes: readonly string[];
+  /** Whether an empty `availableRemotes` came from a successful `git remote`. */
+  remotesReadSucceeded: boolean;
 }
 
 export interface BaseDivergenceHost {
@@ -152,16 +157,22 @@ export class BaseDivergence {
       let resolvedRef = remoteRef;
       let resolvedRemote = remoteName;
       let result: string;
-      try {
-        result = await git.raw(["rev-list", "--count", "--left-right", `${remoteRef}...HEAD`]);
-      } catch {
+      if (resolution?.remotesReadSucceeded && resolution.availableRemotes.length === 0) {
+        result = await git.raw(["rev-list", "--count", "--left-right", `${localRef}...HEAD`]);
+        resolvedRef = localRef;
+        resolvedRemote = null;
+      } else {
         try {
-          result = await git.raw(["rev-list", "--count", "--left-right", `${localRef}...HEAD`]);
-          resolvedRef = localRef;
-          resolvedRemote = null;
+          result = await git.raw(["rev-list", "--count", "--left-right", `${remoteRef}...HEAD`]);
         } catch {
-          this.lastKey = null;
-          return null;
+          try {
+            result = await git.raw(["rev-list", "--count", "--left-right", `${localRef}...HEAD`]);
+            resolvedRef = localRef;
+            resolvedRemote = null;
+          } catch {
+            this.lastKey = null;
+            return null;
+          }
         }
       }
       const trimmed = result.trim();
@@ -248,13 +259,20 @@ export class BaseDivergence {
     const git = await this.createGit();
     // Shared with the rebase/merge handlers (#12092) so the ref an operation
     // acts on is the ref the behind count was measured against.
-    const inputs = await gatherBaseCompareRefInputs(git, baseBranch);
+    const { inputs, remotesReadSucceeded } =
+      await gatherBaseCompareRefInputsWithRemoteStatus(git, baseBranch);
     const { availableRemotes } = inputs;
     const upstreamRef = hasUpstream ? await readSymbolicRef(git, "@{u}") : null;
 
     const { compareRef, remote } = resolveBaseCompareRef(inputs);
 
-    this.resolution = { compareRef, remote, upstreamRef, availableRemotes };
+    this.resolution = {
+      compareRef,
+      remote,
+      upstreamRef,
+      availableRemotes,
+      remotesReadSucceeded,
+    };
     this.resolutionAt = Date.now();
     // Re-derive the stamp: the first resolution discovers the remote names the
     // stamp's candidate-ref stats are built from, so the stamp computed before

--- a/electron/workspace-host/BaseDivergence.ts
+++ b/electron/workspace-host/BaseDivergence.ts
@@ -259,8 +259,10 @@ export class BaseDivergence {
     const git = await this.createGit();
     // Shared with the rebase/merge handlers (#12092) so the ref an operation
     // acts on is the ref the behind count was measured against.
-    const { inputs, remotesReadSucceeded } =
-      await gatherBaseCompareRefInputsWithRemoteStatus(git, baseBranch);
+    const { inputs, remotesReadSucceeded } = await gatherBaseCompareRefInputsWithRemoteStatus(
+      git,
+      baseBranch
+    );
     const { availableRemotes } = inputs;
     const upstreamRef = hasUpstream ? await readSymbolicRef(git, "@{u}") : null;
 

--- a/electron/workspace-host/__tests__/BaseDivergence.test.ts
+++ b/electron/workspace-host/__tests__/BaseDivergence.test.ts
@@ -187,6 +187,16 @@ describe("BaseDivergence", () => {
     expect(result?.baseRemote).toBeNull();
   });
 
+  it("uses the local base ref directly when the repository has no remotes", async () => {
+    installRepo({ remotes: [], revList: { "main...HEAD": "1\t2\n" } });
+    const divergence = new BaseDivergence(makeHost(), makeStatPrecheck());
+
+    const result = await divergence.compute(false);
+
+    expect(result?.baseCompareRef).toBe("main");
+    expect(revListRanges()).toEqual(["main...HEAD"]);
+  });
+
   it("returns null when both the remote and local rev-list fail", async () => {
     installRepo({});
     const divergence = new BaseDivergence(makeHost(), makeStatPrecheck());


### PR DESCRIPTION
## Summary

- Avoid the impossible `origin/<base>...HEAD` divergence probe when a successful `git remote` read proves that a worktree has no remotes.
- Preserve the historical origin-first fallback when remote discovery itself fails, so a transient Git error cannot change base-ref behavior.
- Require `--enforce-integrity` on every arm of the cross-platform `perf-ab` workflow.

This removes one of four Git subprocesses from the PERF-131 watcher-to-store-emission mechanism. The three remaining subprocesses supply distinct sidebar state: status, HEAD-keyed commit metadata, and local-base divergence.

## Claim boundary and protocol

PERF-130, PERF-131, PERF-133, and PERF-134 are **mechanism** benchmarks with `processTopology: partial` fidelity. They use real watchers, real Git topology, and the real store apply path, ending at store emission. Store emission is not a rendered card: virtualization, React commit, paint, and user-perceived latency are outside the measured bracket. Accordingly, the retained claim is only the portable Git-spawn count; duration readings below are descriptive guard readings, not user-perceived latency claims.

- Branch point: `cfd38b0b0215ab2b56e1b7a565407860102ef4fb`
- Candidate: `fb156deff18699222373d55d69c848440b032549`
- Local apparatus digest: `78ed867d5ac93be9…` over 185 files
- Local machine: Apple M1 Max, Darwin arm64; Node 22.23.2, Git 2.55.0, Electron 42.7.1
- Protocol: smoke, 5 iterations, 1 warmup, precommitted 1% count threshold, clean reserved same-session base/candidate pairs, `--enforce-integrity` on every arm
- Every local pair gate passed; every declared predicate was emitted on 5/5 iterations and remained zero.

## Local before/after

| Scenario | Git spawns before | After | Absolute | Percent | Descriptive p50 before | After | p50 delta | Verdict |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| PERF-130 | 1 | 1 | 0 | 0% | 53.346 ms | 53.325 ms | −0.021 ms (−0.0%) | No claim; healthy one-spawn floor |
| PERF-131 | 4 | 3 | −1 | −25% | 180.811 ms | 169.194 ms | −11.617 ms (−6.4%) | **Claim on count only** |
| PERF-133 | 2 | 2 | 0 | 0% | 47.590 ms | 45.740 ms | −1.850 ms (−3.9%) | No claim; guards within tolerance |
| PERF-134 | 12 | 12 | 0 | 0% | 118.068 ms | 117.331 ms | −0.737 ms (−0.6%) | No claim; one status observation per worktree |

PERF-133 guards: mean `firstEmitMs`/`settleMs` 48.287 → 46.105 ms (−4.5%, 10% guard); `emitCount` 4 → 4 (5% guard). PERF-134 guards: mean `p95LatencyMs`/`maxLatencyMs` 119.139 → 117.733 ms (−1.2%, 10% guard); `meanLatencyMs` 109.154 → 107.288 ms (−1.7%, 10% guard). All miss/observer predicates remained zero.

## Cross-OS count verification

Exact-tree workflow: [run 33607483833](https://github.com/daintreehq/daintree/actions/runs/33607483833). Every arm log contains `--enforce-integrity`; all three gates exited zero.

| Machine | Champion arms | Candidate arms | Median before | After | Absolute | Percent | Verdict |
| --- | --- | --- | ---: | ---: | ---: | ---: | --- |
| Local macOS / Apple M1 Max | one 5-iteration arm | one 5-iteration arm | 4 | 3 | −1 | −25% | Claim |
| GitHub Linux | 4 / 4 / 4 | 3 / 3 / 3 | 4 | 3 | −1 | −25% | Claim |
| GitHub Windows | 4 / 4 / 4 | 3 / 3 / 3 | 4 | 3 | −1 | −25% | Claim |
| GitHub macOS | 4 / 4 / 4 | 3 / 3 / 3 | 4 | 3 | −1 | −25% | Claim |

Hosted-runner durations are not measured or claimed. PERF-130, PERF-133, and PERF-134 were not dispatched because their final local deterministic targets did not improve, leaving no portable improvement to verify.

## Predicates, workloads, and guards

No scenario declares a formal workload floor; the fixed fixture scales were preserved.

| Scenario | Fixed workload | Integrity predicates | Other guards |
| --- | --- | --- | --- |
| PERF-130 | 1 focused watched-worktree edit | `spawnObserverMisses`, `timeoutMisses` | Both miss counts at 5% |
| PERF-131 | 1 external add/commit through the metadata watcher | `spawnObserverMisses`, `timeoutMisses` | Both miss counts at 5% |
| PERF-133 | 50 rapid edits | `spawnObserverMisses`, `timeoutMisses` | `firstEmitMs`/`settleMs` 10%; `emitCount` and miss counts 5% |
| PERF-134 | 12 simultaneously watched worktrees | `emitMisses`, `spawnObserverMisses`, `timeoutMisses` | `p95LatencyMs`/`maxLatencyMs`/`meanLatencyMs` 10%; miss counts 5% |

Predicate-break proofs confirmed that a dead watcher can make the spawn count look better: PERF-130 and PERF-133 reached zero only with timeout misses, PERF-131 reached zero only with timeout misses, and PERF-134 reached zero with 12 emission misses. Integrity enforcement rejected every such arm.

## Rejected hypotheses and floors

- PERF-130 debounce 25 → 10 ms selected at −35.7% p50, but a required candidate arm produced a timeout miss; reverted as unhealthy.
- PERF-130 debounce 25 → 20 ms selected at −11.2% p50, but seven confirmation attempts could not produce a quiet, predicate-healthy six-arm session; reverted with no duration measurement.
- PERF-130 count cannot responsibly fall below one: the zero-spawn proof is the dead-watcher shape.
- PERF-133's two status passes come from separate native watcher flushes. Suppressing the second is unsafe because the stat precheck intentionally excludes worktree paths; delaying the first enough to coalesce both would harm watcher latency and PERF-130.
- PERF-134 is already at one independent status observation for each of 12 real worktrees.
- The initial PERF-131 implementation treated a failed remote-table read like an authoritative empty table. Focused tests exposed this; the retained implementation carries read success separately and preserves the origin-first fallback on failure.
- `perf calibrate` was not used because the repository command does not accept/forward `--enforce-integrity`; no duration claim was made. `perf diagnose` was not used, and no profiled duration is benchmark evidence.

## Checks

- Focused BaseDivergence/base-compare suites: 39/39 passed
- Full exact-final Vitest suite: 2,491 files; 54,960 passed, 7 skipped, 1 todo; zero failures
- `npm run check`: passed, including all typechecks, structural validators, lint ratchet, and Prettier
- Diff audit and `git diff --check`: clean; no generated artifacts, secrets, unrelated changes, or `scripts/perf/**` edits
- E2E: not run because no human named a spec
