### PR TITLE
perf(actions): fuse manifest projection allocations

### DIFF
--- a/src/services/ActionService.ts
+++ b/src/services/ActionService.ts
@@ -708,17 +708,19 @@ export class ActionService {
   list(ctx?: ActionContext, options?: { includeSchemas?: boolean }): ActionManifestEntry[] {
     const context = ctx ?? this.getActionContext();
     const includeSchemas = options?.includeSchemas !== false;
-    return Array.from(this.registry.values())
-      .filter((def) => def.danger !== "restricted")
-      .filter((def) => {
+    const entries: ActionManifestEntry[] = [];
+    for (const definition of this.registry.values()) {
+      if (definition.danger === "restricted") continue;
+      if (definition.isVisible) {
         try {
-          return def.isVisible?.(context) ?? true;
+          if (!(definition.isVisible(context) ?? true)) continue;
         } catch (err) {
-          logWarn("Action isVisible threw", { actionId: def.id, error: err });
-          return true;
+          logWarn("Action isVisible threw", { actionId: definition.id, error: err });
         }
-      })
-      .map((def) => this.toManifestEntry(def, context, includeSchemas));
+      }
+      entries.push(this.toManifestEntry(definition, context, includeSchemas));
+    }
+    return entries;
   }
 
   get(actionId: ActionId, ctx?: ActionContext): ActionManifestEntry | null {
@@ -815,7 +817,7 @@ export class ActionService {
     // spread only isolated the top level (issue #9569). structuredClone is safe
     // here: z.toJSONSchema finalizes through a JSON round-trip, so the cached
     // value has no cycles or non-cloneable shapes.
-    return {
+    const entry: ActionManifestEntry = {
       id: definition.id,
       name: definition.id,
       title: definition.title ?? "",
@@ -834,17 +836,18 @@ export class ActionService {
       disabledReason,
       requiresArgs,
       keywords: definition.keywords?.slice(),
-      ...(definition.mcpAnnotations ? { mcpAnnotations: { ...definition.mcpAnnotations } } : {}),
-      ...(definition.mcpVisibility ? { mcpVisibility: definition.mcpVisibility } : {}),
-      ...(definition.deprecated ? { deprecated: { ...definition.deprecated } } : {}),
-      ...(definition.pluginId ? { pluginId: definition.pluginId } : {}),
-      ...(definition.examples ? { examples: structuredClone(definition.examples) } : {}),
-      ...(definition.dangerRationale ? { dangerRationale: definition.dangerRationale } : {}),
-      ...(paletteHidden ? { paletteHidden } : {}),
-      ...(paletteRedirectTo ? { paletteRedirectTo } : {}),
-      ...(paletteDisabled ? { paletteDisabled } : {}),
-      ...(paletteDisabledReason ? { paletteDisabledReason } : {}),
     };
+    if (definition.mcpAnnotations) entry.mcpAnnotations = { ...definition.mcpAnnotations };
+    if (definition.mcpVisibility) entry.mcpVisibility = definition.mcpVisibility;
+    if (definition.deprecated) entry.deprecated = { ...definition.deprecated };
+    if (definition.pluginId) entry.pluginId = definition.pluginId;
+    if (definition.examples) entry.examples = structuredClone(definition.examples);
+    if (definition.dangerRationale) entry.dangerRationale = definition.dangerRationale;
+    if (paletteHidden) entry.paletteHidden = true;
+    if (paletteRedirectTo) entry.paletteRedirectTo = paletteRedirectTo;
+    if (paletteDisabled) entry.paletteDisabled = true;
+    if (paletteDisabledReason) entry.paletteDisabledReason = paletteDisabledReason;
+    return entry;
   }
 
   private getActionContext(): ActionContext {


### PR DESCRIPTION
## Summary

- Fuse the schema-free action manifest projection into one ordered registry loop instead of allocating `Array.from()` plus two filtered arrays.
- Build optional manifest fields with ordered assignments instead of nine conditional object spreads.
- Preserve registry order, restricted-action filtering, fail-open `isVisible` behavior and warning, defensive copies, property order, schema behavior, and all catalog counts.

This is a mechanism-only optimization. The benchmark fidelity is `entryPoint=internal-function`, `renderer=absent`, `electronTransport=none`, `pty=none`, `processTopology=single-process`, and `externalDependencies=hermetic`. It does **not** measure or claim user-perceived startup, palette, MCP, or interaction latency.

## Final local evidence

Machine: `host-02d9f218-darwin-arm64` (`studio-04`), Apple M1 Max, macOS 26.4.1 arm64, AC power, Node 22.23.2, npm 11.19.0, Git 2.55.0.

All values below are median arm means. Invalid rows retain raw before/after values for auditability, but their absolute and percentage changes are intentionally not claimed.

| Benchmark | Class and exact claim boundary | Branch-point before | Final-tree after | Absolute change | Percentage | Verdict |
| --- | --- | ---: | ---: | ---: | ---: | --- |
| PERF-200 `registerMs.mean` | mechanism duration; real built-in catalog construction/registration only | 8.677319 ms | 8.714213 ms | n/a | n/a | **NO MEASUREMENT** — champion arm 3 CV 16.5% > 10% |
| PERF-202 `avgSweepMs.mean` | mechanism duration; real schema-free `ActionService.list()` enablement projection only | 0.291092696 ms/sweep | 0.244908450 ms/sweep | **−0.046184246 ms/sweep** | **15.9% faster** | **CLAIM** |
| PERF-205 `msPerKAction.mean` | mechanism duration; schema-free 1×/2×/4× catalog projection slope only | 0.837160896 ms/K action | 0.665963527 ms/K action | **−0.171197369 ms/K action** | **20.4% faster** | **CLAIM** |

PERF-202 paired wins were 16.7%, 15.3%, and 14.2%; champion drift was 2.3%; worst whole-arm CV was 9.1%. Its median `p95SweepMs` guard improved from 0.378283492 to 0.289209879 ms (23.5%), with all structural guards unchanged. Two exact-tree 20-iteration sets failed the 10% CV gate, so a replacement precommit retained the target, predicate, 10.4% threshold, warmups, branch point, guards, and apparatus while raising only the repetition count to 60.

PERF-205 paired wins were 23.2%, 17.4%, and 20.4%; champion drift was 5.4%; worst whole-arm CV was 4.0%. Base/largest sweep guards improved 13.7% and 20.4%; all counts were unchanged.

PERF-200's raw row is descriptive only. The final exact-SHA 60-iteration set failed the mandatory CV gate, after earlier retries failed the same stability gate; no absolute or percentage delta is claimed.

## Locked protocol, predicates, floors, and guards

Every measured arm used `--enforce-integrity`. Each final set used three branch-point champion arms and three final-tree candidate arms in `champ1, cand1, cand2, champ2, champ3, cand3` order, smoke mode, two warmups, the locked median statistic, and a maximum 10% whole-arm CV. Measurements were local, quiet, and checked for competing perf/test/typecheck work before and after each arm. `perf calibrate` was used only for unchanged-tree noise; predicate-break durations and diagnostic profiles were not used as benchmark evidence.

| Benchmark | Iterations/arm | Locked threshold | Predicate | Workload floors and structural guards | Duration guard |
| --- | ---: | ---: | --- | --- | --- |
| PERF-200 | 60 | 6.1% | `builtInRegistrationMisses`: count 60, min/max 0 in every arm | registered 504, built-in 406; both ±5% | `factoryMs` ±10% |
| PERF-202 | 60 | 10.4% | `enablementMisses`: count 60, min/max 0 in every arm | manifest 508, enabled 493, disabled 15, hidden 60, palette-disabled 7, context flips 3; all ±5% | `p95SweepMs` ±10% |
| PERF-205 | 60 | 5.1% | `scalingMisses`: count 60, min/max 0 in every arm | base/largest 504/2016, projected/expected 3528/3528; all ±5% | base/largest sweep ±10% |

No guard regression was pre-authorized. Predicate-break proofs failed with 406 registration misses/iteration for PERF-200, 409 enablement misses/iteration for PERF-202, and 3528 scaling misses/iteration for PERF-205.

Apparatus digest: `78ed867d5ac93be9b1fa8aabf0c81b8b9223b0ea2e4881a7fd439baa74cb81db` across 185 harness files.

## Cross-OS verdict

| OS | Verdict |
| --- | --- |
| macOS | PERF-202 and PERF-205 measured locally on the named machine; PERF-200 is `NO MEASUREMENT` |
| Linux | Not measured: no portable count, size, or structural-ratio target improved; hosted duration claims are forbidden |
| Windows | Not measured: no portable count, size, or structural-ratio target improved; hosted duration claims are forbidden |
| hosted macOS | Not measured for the same target-class reason; the local macOS duration result is the only claim |

`perf-ab.yml` was not dispatched because every optimization target is classified as machine-dependent duration. The unchanged count metrics are guards, not portable improvements.

## Rejected hypotheses

- Skip a redundant direct-`ZodObject` required-argument parse: encouraging PERF-200 screens, but every confirmation failed the CV gate; reverted.
- Co-locate cached `requiresArgs` with registry entries: 1.5% movement, below the locked threshold; reverted.
- Also cache the risk band with the registry entry: 1.3% regression; reverted.
- Use only the fused loop or only imperative optional-field assignment: each moved PERF-202 about 8%, below its 10.4% floor; combined because both remove allocations in the same projector.
- Pass the definition directly to `deriveBand`: 0.7% movement, below PERF-205's 5.1% floor; reverted.
- Cache a complete static manifest prefix: rejected without implementation because action definitions are not frozen and there is no sound mutation/invalidation contract.
- Duplicate a schema-free projector: rejected because the maintenance and semantic-drift cost outweighed the exhausted low-risk evidence.

## Source and checks

- Branch point/champion: `cfd38b0b0215ab2b56e1b7a565407860102ef4fb`
- Final candidate: `b4778909a6a4730386884b0336562168dae55225`
- Focused diff: `src/services/ActionService.ts`, 22 insertions and 19 deletions
- Focused ActionService coverage: 143 tests passed after the final semantic correction
- `npm run typecheck`: passed on the exact final SHA
- `npm test`: passed — 2,491 files; 54,958 passing, 7 skipped, 1 todo
- `npm run check`: passed — typecheck, guards, IPC/codegen, manifests, API surface, lint ratchet, formatting
- Diff audit: passed — one owned source file; no `scripts/perf`, fixture, test, generated, or unrelated changes; exact nullish/falsy and throw fail-open visibility semantics preserved
- Hosted CI: passed — build/smoke, Ubuntu check, all four unit shards, and required `ci-ok`
- E2E: not run, per repository policy and the explicit request
