### PR TITLE
perf(migrations): batch per-version store rewrites

### DIFF
--- a/electron/services/StoreMigrations.ts
+++ b/electron/services/StoreMigrations.ts
@@ -76,6 +76,66 @@ const PostMigrationSanitySchema = z
   })
   .passthrough();
 
+type StoreRecord = Record<string, unknown>;
+
+function cloneStoreValue<T>(value: T): T {
+  return typeof value === "object" && value !== null ? structuredClone(value) : value;
+}
+
+function readStorePath(snapshot: StoreRecord, key: string): unknown {
+  let node: unknown = snapshot;
+  for (const part of key.split(".")) {
+    if (node === null || typeof node !== "object" || !Object.hasOwn(node, part)) {
+      return undefined;
+    }
+    node = (node as StoreRecord)[part];
+  }
+  return node;
+}
+
+function writeStorePath(snapshot: StoreRecord, key: string, value: unknown): void {
+  const parts = key.split(".");
+  let node = snapshot;
+  for (const part of parts.slice(0, -1)) {
+    const current = node[part];
+    if (current === null || typeof current !== "object" || Array.isArray(current)) {
+      node[part] = {};
+    }
+    node = node[part] as StoreRecord;
+  }
+  node[parts.at(-1)!] = cloneStoreValue(value);
+}
+
+function deleteStorePath(snapshot: StoreRecord, key: string): void {
+  const parts = key.split(".");
+  let node = snapshot;
+  for (const part of parts.slice(0, -1)) {
+    const current = node[part];
+    if (current === null || typeof current !== "object" || Array.isArray(current)) return;
+    node = current as StoreRecord;
+  }
+  delete node[parts.at(-1)!];
+}
+
+function bufferedMigrationStore(snapshot: StoreRecord): Store<StoreSchema> {
+  const facade = {
+    get(key: string, defaultValue?: unknown): unknown {
+      const value = readStorePath(snapshot, key);
+      return value === undefined ? defaultValue : cloneStoreValue(value);
+    },
+    set(key: string, value: unknown): void {
+      if (value === undefined) {
+        throw new TypeError(`Use delete() to clear migration key "${key}"`);
+      }
+      writeStorePath(snapshot, key, value);
+    },
+    delete(key: string): void {
+      deleteStorePath(snapshot, key);
+    },
+  };
+  return facade as unknown as Store<StoreSchema>;
+}
+
 export class MigrationRunner {
   constructor(
     private store: Store<StoreSchema>,
@@ -250,8 +310,23 @@ export class MigrationRunner {
       for (const migration of pending.sort((a, b) => a.version - b.version)) {
         activeMigrationVersion = migration.version;
         console.log(`[Migrations] Applying v${migration.version}: ${migration.description}`);
-        await migration.up(this.store);
-        this.store.set("_schemaVersion", migration.version);
+        // electron-store rewrites the entire JSON document on every set/delete.
+        // Buffer one migration's main-store mutations in memory, then persist
+        // its data and resume checkpoint together in one atomic write. The
+        // per-migration boundary remains crash-safe: a terminated process
+        // resumes from the last fully committed version, while sidecar-writing
+        // migrations remain idempotent as required by the migration contract.
+        // Lightweight test doubles and the in-memory recovery store keep the
+        // direct path because they have no whole-file rewrite to remove.
+        if (this.store.path !== "" && "store" in this.store) {
+          const snapshot = this.store.store as unknown as StoreRecord;
+          await migration.up(bufferedMigrationStore(snapshot));
+          snapshot._schemaVersion = migration.version;
+          this.store.store = snapshot as unknown as StoreSchema;
+        } else {
+          await migration.up(this.store);
+          this.store.set("_schemaVersion", migration.version);
+        }
         console.log(`[Migrations] Applied v${migration.version} successfully`);
       }
 

--- a/electron/services/StoreMigrations.ts
+++ b/electron/services/StoreMigrations.ts
@@ -93,8 +93,18 @@ function readStorePath(snapshot: StoreRecord, key: string): unknown {
   return node;
 }
 
+// conf's `set()` and dot-prop's `setProperty()` both refuse these segments, so
+// the buffered facade must refuse them too or it becomes a prototype-pollution
+// hole that the direct path does not have.
+function hasReservedSegment(parts: string[]): boolean {
+  return parts.some(
+    (part) => part === "__proto__" || part === "prototype" || part === "constructor"
+  );
+}
+
 function writeStorePath(snapshot: StoreRecord, key: string, value: unknown): void {
   const parts = key.split(".");
+  if (hasReservedSegment(parts)) return;
   let node = snapshot;
   for (const part of parts.slice(0, -1)) {
     const current = node[part];
@@ -108,6 +118,7 @@ function writeStorePath(snapshot: StoreRecord, key: string, value: unknown): voi
 
 function deleteStorePath(snapshot: StoreRecord, key: string): void {
   const parts = key.split(".");
+  if (hasReservedSegment(parts)) return;
   let node = snapshot;
   for (const part of parts.slice(0, -1)) {
     const current = node[part];
@@ -122,6 +133,9 @@ function bufferedMigrationStore(snapshot: StoreRecord): Store<StoreSchema> {
     get(key: string, defaultValue?: unknown): unknown {
       const value = readStorePath(snapshot, key);
       return value === undefined ? defaultValue : cloneStoreValue(value);
+    },
+    has(key: string): boolean {
+      return readStorePath(snapshot, key) !== undefined;
     },
     set(key: string, value: unknown): void {
       if (value === undefined) {

--- a/electron/services/__tests__/StoreMigrations.test.ts
+++ b/electron/services/__tests__/StoreMigrations.test.ts
@@ -109,6 +109,20 @@ function createMockStore(storePath: string, initialData: MockStoreData = {}): Mo
   };
 }
 
+/** A mock store carrying a `store` accessor, so the runner takes the buffered-facade branch. */
+function createBufferedMockStore(storePath: string, initialData: MockStoreData = {}): MockStore {
+  const store = createMockStore(storePath, initialData);
+  Object.defineProperty(store, "store", {
+    configurable: true,
+    get: () => structuredClone(store.data),
+    set: (value: MockStoreData) => {
+      store.clear();
+      Object.assign(store.data, structuredClone(value));
+    },
+  });
+  return store;
+}
+
 describe("MigrationRunner", () => {
   let tempDir: string;
   let storePath: string;
@@ -226,6 +240,54 @@ describe("MigrationRunner", () => {
       nested: { retained: true },
     });
     expect(store.data.second).toBeUndefined();
+  });
+
+  it("serves has/get/delete on dot-path keys through the buffered facade", async () => {
+    const store = createBufferedMockStore(storePath, {
+      _schemaVersion: 0,
+      userConfig: { githubToken: "ghp_legacy", locale: "en" },
+    });
+    const seen: boolean[] = [];
+
+    await new MigrationRunner(store as never).runMigrations([
+      {
+        version: 1,
+        description: "drop the legacy token",
+        up: (migrationStore) => {
+          seen.push(migrationStore.has("userConfig.githubToken" as never));
+          seen.push(migrationStore.has("userConfig.missing" as never));
+          expect(migrationStore.get("userConfig.githubToken" as never)).toBe("ghp_legacy");
+          migrationStore.delete("userConfig.githubToken" as never);
+          seen.push(migrationStore.has("userConfig.githubToken" as never));
+        },
+      },
+    ]);
+
+    expect(seen).toEqual([true, false, false]);
+    expect(store.data).toMatchObject({ _schemaVersion: 1, userConfig: { locale: "en" } });
+    expect((store.data.userConfig as Record<string, unknown>).githubToken).toBeUndefined();
+  });
+
+  it("refuses reserved path segments in buffered writes and deletes", async () => {
+    const store = createBufferedMockStore(storePath, { _schemaVersion: 0 });
+
+    await new MigrationRunner(store as never).runMigrations([
+      {
+        version: 1,
+        description: "attempt prototype pollution",
+        up: (migrationStore) => {
+          migrationStore.set("__proto__.polluted" as never, true as never);
+          migrationStore.set("a.constructor.polluted" as never, true as never);
+          migrationStore.set("prototype" as never, true as never);
+          migrationStore.delete("__proto__" as never);
+        },
+      },
+    ]);
+
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    expect(Object.prototype.hasOwnProperty.call(store.data, "prototype")).toBe(false);
+    expect(store.data.a).toBeUndefined();
+    expect(store.data._schemaVersion).toBe(1);
   });
 
   it("skips migrations and preserves version when store schema is newer than supported", async () => {

--- a/electron/services/__tests__/StoreMigrations.test.ts
+++ b/electron/services/__tests__/StoreMigrations.test.ts
@@ -181,6 +181,53 @@ describe("MigrationRunner", () => {
     expect(store.data._schemaVersion).toBe(3);
   });
 
+  it("commits each migration and its resume checkpoint in one store write", async () => {
+    const store = createMockStore(storePath, {
+      _schemaVersion: 0,
+      nested: { retained: true },
+    });
+    let storeWrites = 0;
+    Object.defineProperty(store, "store", {
+      configurable: true,
+      get: () => structuredClone(store.data),
+      set: (value: MockStoreData) => {
+        storeWrites += 1;
+        store.clear();
+        Object.assign(store.data, structuredClone(value));
+      },
+    });
+    const runner = new MigrationRunner(store as never);
+
+    await runner.runMigrations([
+      {
+        version: 1,
+        description: "write two keys",
+        up: (migrationStore) => {
+          migrationStore.set("first" as never, "one" as never);
+          migrationStore.set("second" as never, "two" as never);
+          const nested = migrationStore.get("nested" as never) as { retained: boolean };
+          nested.retained = false;
+        },
+      },
+      {
+        version: 2,
+        description: "read prior checkpoint",
+        up: (migrationStore) => {
+          expect(migrationStore.get("first" as never)).toBe("one");
+          migrationStore.delete("second" as never);
+        },
+      },
+    ]);
+
+    expect(storeWrites).toBe(2);
+    expect(store.data).toMatchObject({
+      _schemaVersion: 2,
+      first: "one",
+      nested: { retained: true },
+    });
+    expect(store.data.second).toBeUndefined();
+  });
+
   it("skips migrations and preserves version when store schema is newer than supported", async () => {
     const store = createMockStore(storePath, { _schemaVersion: 5 });
     const runner = new MigrationRunner(store as never);


### PR DESCRIPTION
## Summary

- Buffer each electron-store migration's key-level mutations in an isolated snapshot.
- Persist that snapshot together with `_schemaVersion` once per migration boundary, retaining durable per-version crash resume.
- Add regression coverage for one write per version, nested-value isolation, and visibility of the preceding committed migration.

## Results

Both benchmarks are **mechanism** benchmarks. These numbers measure migration-chain execution only; they do not measure or claim user-perceived startup, project-open, or UI latency.

Machine: `host-02d9f218-darwin-arm64` (Apple M1 Max, macOS 26.4.1 / Darwin 25.4.0, Node v24.20.0, npm 11.19.0, git 2.55.0, Electron 42.7.1, AC power).

| Benchmark | Class / fidelity | Target | Before | After | Absolute | Change | Verdict |
| --- | --- | --- | ---: | ---: | ---: | ---: | --- |
| PERF-056 | mechanism; hermetic single-process real better-sqlite3/Drizzle migration chain | `metricStats.migrateMs.mean` | 11.356 ms | 11.505 ms | +0.149 ms | 1.3% worse | **NO CLAIM** |
| PERF-080 | mechanism; partial process topology, real MigrationRunner/electron-store/SQLite with Electron stubbed | `p50Ms` | 1210.923 ms | 561.192 ms | -649.731 ms | **53.7% better** | **CLAIM** |

PERF-056 final pairs were -3.1%, -1.3%, and +0.6% (one of three won); champion drift was 0.7%, worst within-arm CV was 9.5%, and the precommitted threshold was 6.2%. All predicates and guards passed. The sound NO CLAIM is final and was not extended after seeing the result.

PERF-080 final pairs improved 53.9%, 53.7%, and 53.9% (three of three won); champion drift was 0.8%, worst within-arm CV was 1.9%, and the precommitted threshold was 5.3%. All predicates and guards passed.

## Protocol and integrity

- Branch point / champion: `cfd38b0b0215ab2b56e1b7a565407860102ef4fb`
- Measured candidate: `705c93b61ac73fba81e12bf616238ba5c8ecb773`
- PR head: `aa8b3f6c140f8e432933bc7a301b8bd1ad9b68dd`
- The PR head differs only by Prettier formatting in the adjacent unit test; production code and the benchmark apparatus are byte-identical. A fresh exact-head rerun was queued under the same reservation protocol, but the shared Mac did not become quiet before the precommitted eight-hour run ceiling. No contaminated result was accepted, and this limitation is explicit rather than representing the measured candidate as the PR head.
- Apparatus hash: `78ed867d5ac93be9…` over 185 files, unchanged across all arms
- Arm order for each benchmark: champion 1 → candidate 1 → candidate 2 → champion 2 → champion 3 → candidate 3
- PERF-056: `smoke`, 20 measured iterations, 1 warmup per arm, `--enforce-integrity`
- PERF-080: `ci`, 20 measured iterations, 2 warmups per arm, `--enforce-integrity`
- The final 12 arms ran under one quiet local reservation. Every arm had distinct provenance/timestamps and the expected source SHA.

PERF-056 workload floor and predicates:

- 13 migrations over 4,000 seeded rows.
- `migrationCountMisses`, `schemaColumnMisses`, `rowMisses`, and `dataMigrationMisses`: 20/20 emissions at zero in every arm.
- Guards: `migrationCount`, `seedRowCount`, `dbFileKB` within 5%; `msPerKRow` within 10%. Final deterministic values were unchanged: 13 migrations, 4,000 rows, 920 KiB database.

PERF-080 workload floor and predicates:

- Real v0→v27 heavy on-disk corpus.
- `migrationMisses`, `terminalLocationMisses`, `recipeMigrationMisses`, `notificationMisses`, `windowStateMisses`, `agentPinMisses`, `phantomPinMisses`, `agentPresetMisses`, `notesArchiveMisses`, `auditRingMisses`, `scalarMigrationMisses`, `backupMisses`, and `schemaVersionMisses`: 20/20 emissions at zero in every arm.
- Guards: `terminalCount`, `recipeCount`, `agentCount`, `bytes`, `backupBytes`, `chainLogLines`, and `fixtureBytes` within 5%; `schemaVersion` within 10%.
- Final deterministic values were exactly unchanged: 10,000 terminals, 500 recipes, 100 agents, 1,599,182 bytes, 1,834,412 backup bytes, schema v27, 68 chain log lines, 1,374,793 fixture bytes.

## Cross-OS verdict

| OS leg | Result |
| --- | --- |
| Local macOS arm64 | Measured as above |
| Hosted Linux | Not measured: both precommitted targets are machine-dependent durations |
| Hosted Windows | Not measured: both precommitted targets are machine-dependent durations |
| Hosted macOS | Not measured: hosted-runner durations are not claimable |

No portable count, size, or structural-ratio target improved; all deterministic guards were exactly unchanged. Therefore there was no eligible portable improvement to dispatch with `perf-ab`. No hosted-runner duration is claimed.

## Rejected hypotheses and invalid runs

- Combining two full-table UPDATEs in historical Drizzle migration 0009 screened at 18.9% faster on PERF-056, but was reverted because applied generated migrations are immutable; changing it would create divergent migration histories and violate recovery/audit guarantees.
- Removing the historical add/drop-column pair was rejected for the same immutability reason.
- Lowering SQLite synchronous durability was rejected because it would trade crash safety for a one-time mechanism win.
- Batching all electron-store versions into one final write was rejected because crashes could replay already-completed side-effecting migrations and lose per-version recovery progress.
- Skipping version-only commits was rejected for the same crash-resume reason.
- Two early PERF-080 confirmation runs were discarded because unrelated shared-host activity pushed at least one arm over the 10% CV ceiling. Neither was used as evidence. A later clean confirmation passed before the independent final headline close.

## Checks

- `npm run typecheck`
- `npm test`
- `npm run check`
- Focused StoreMigrations suite: 111 tests passed
- `git diff --check`
- GitHub CI run `33624283203`: build/smoke, Ubuntu typecheck/lint/format, all four unit-test shards, and `ci-ok` passed on PR head `aa8b3f6c140f8e432933bc7a301b8bd1ad9b68dd`

The serial local checks above and the focused suite ran on measured candidate `705c93b61ac73fba81e12bf616238ba5c8ecb773`; GitHub reran the complete required CI surface on the formatting-only PR head. No E2E was run, as required. The diff is limited to `electron/services/StoreMigrations.ts` and its adjacent unit test. Those directly scoped paths are not explicitly enumerated in the optimize Area D ownership table (`electron/services/migrations/` is listed), so that partition omission is recorded here.
