### PR TITLE
perf(pty): reduce agent analysis viewport work

### DIFF
--- a/electron/services/pty/__tests__/headlessViewport.snapshot.test.ts
+++ b/electron/services/pty/__tests__/headlessViewport.snapshot.test.ts
@@ -308,6 +308,47 @@ describe("ViewportSnapshotCache (PERF-035)", () => {
     expect(cache.read(term, 15)).not.toBe(six);
   });
 
+  // Production runs DEFAULT_SCROLLBACK on long-lived agent terminals, so the
+  // steady state is a FULL buffer: baseY stops advancing and read()'s baseY
+  // guard never fires again, leaving the onRender dirty range as the only thing
+  // that stops scrolled-up rows being served from their old viewport slot.
+  // xterm covers it today (CoreTerminal wires bufferService.onScroll to
+  // markRangeDirty over the whole scroll region) but that is an internal, and
+  // an xterm bump could drop it without a word.
+  it("re-reads rows shifted by scrolling once the scrollback buffer is full", async () => {
+    const pinned = new HeadlessTerminal({
+      cols: 40,
+      rows: 6,
+      scrollback: 3,
+      allowProposedApi: true,
+    });
+    pinned.loadAddon(new Unicode11Addon());
+    pinned.unicode.activeVersion = "11";
+    const pinnedCache = new ViewportSnapshotCache();
+    pinnedCache.attach(pinned);
+
+    try {
+      for (let i = 0; i < 20; i += 1) {
+        await write(pinned, `row ${i} content\r\n`);
+      }
+      const pinnedBaseY = pinned.buffer.active.baseY;
+      pinnedCache.read(pinned, 200);
+
+      await write(pinned, "row 20 content\r\n");
+      expect(pinned.buffer.active.baseY).toBe(pinnedBaseY);
+
+      expect(
+        measureVisibleContentDelta(
+          pinnedCache.read(pinned, 200)!,
+          readVisibleActivitySnapshot(pinned, 200)!
+        )
+      ).toEqual({ changed: false, changedChars: 0 });
+    } finally {
+      pinnedCache.detach();
+      pinned.dispose();
+    }
+  });
+
   it("preserves the legacy delta sequence while unchanged raw rows are reused", async () => {
     let previousLegacy = legacySnapshot(term);
     let previousCached = cache.read(term, 15)!;

--- a/electron/services/pty/analysis/AnalysisSession.ts
+++ b/electron/services/pty/analysis/AnalysisSession.ts
@@ -162,10 +162,9 @@ export class AnalysisSession {
     }
 
     this.headlessTerminal.write(data, () => {
-      // Invalidate before noteAgentOutputActivity reads the viewport: xterm
-      // fires per-write callbacks before the onWriteParsed event the cache
-      // subscribes to, and a stale hit here would diff a pre-parse snapshot.
-      this.viewportSnapshotCache.invalidate();
+      // xterm's onRender event fires before this callback and invalidates only
+      // the viewport rows the parser changed, so the activity read below is
+      // fresh without forcing every unchanged row through comparison again.
       this.noteProcessed(data.length);
       this.noteAgentOutputActivity();
       this.scheduleDigest();

--- a/electron/services/pty/analysis/headlessViewport.ts
+++ b/electron/services/pty/analysis/headlessViewport.ts
@@ -27,6 +27,7 @@ interface CachedRawRow {
   hasExtendedAttrs: boolean;
   units: VisibleContentUnit[];
   collapsible: boolean[];
+  hash: number;
 }
 
 type CursorBuffer = {
@@ -214,7 +215,8 @@ function cacheRawRow(
   raw: RawBufferLine,
   cols: number,
   units: VisibleContentUnit[],
-  collapsible: boolean[]
+  collapsible: boolean[],
+  hash: number
 ): CachedRawRow {
   const cellCount = Math.min(cols, raw.length);
   const combined: Record<number, string | undefined> = {};
@@ -241,7 +243,34 @@ function cacheRawRow(
     hasExtendedAttrs,
     units,
     collapsible,
+    hash,
   };
+}
+
+function hashUnits(units: readonly VisibleContentUnit[]): number {
+  let hash = FNV_SEED;
+  for (const key of units) {
+    if (typeof key === "number") {
+      if (key <= 0xffff) {
+        hash ^= key;
+        hash = Math.imul(hash, FNV_PRIME);
+      } else {
+        const astral = key - 0x10000;
+        hash ^= 0xd800 + (astral >> 10);
+        hash = Math.imul(hash, FNV_PRIME);
+        hash ^= 0xdc00 + (astral & 0x3ff);
+        hash = Math.imul(hash, FNV_PRIME);
+      }
+    } else {
+      for (let i = 0; i < key.length; i += 1) {
+        hash ^= key.charCodeAt(i);
+        hash = Math.imul(hash, FNV_PRIME);
+      }
+    }
+    hash ^= HASH_UNIT_SEPARATOR;
+    hash = Math.imul(hash, FNV_PRIME);
+  }
+  return hash >>> 0;
 }
 
 /**
@@ -268,7 +297,8 @@ function cacheRawRow(
  */
 function buildViewportUnitsSnapshot(
   terminal: HeadlessTerminal | undefined,
-  rawRowCache?: Array<CachedRawRow | undefined>
+  rawRowCache?: Array<CachedRawRow | undefined>,
+  dirtyRows?: { start: number; end: number }
 ): VisibleContentSnapshot | undefined {
   if (!terminal) return undefined;
 
@@ -299,9 +329,17 @@ function buildViewportUnitsSnapshot(
     const cached = raw === undefined ? undefined : rawRowCache?.[rowIndex];
     let rowUnits: VisibleContentUnit[];
     let rowCollapsible: boolean[];
-    if (raw !== undefined && cached !== undefined && rawRowMatches(cached, raw, cols)) {
+    let rowHash: number;
+    const rowMayHaveChanged =
+      dirtyRows === undefined || (rowIndex >= dirtyRows.start && rowIndex <= dirtyRows.end);
+    if (
+      raw !== undefined &&
+      cached !== undefined &&
+      (!rowMayHaveChanged || rawRowMatches(cached, raw, cols))
+    ) {
       rowUnits = cached.units;
       rowCollapsible = cached.collapsible;
+      rowHash = cached.hash;
     } else {
       rowUnits = [];
       rowCollapsible = [];
@@ -420,36 +458,30 @@ function buildViewportUnitsSnapshot(
         rowCollapsible.push(collapsible);
         rowLastKey = key;
       }
+      rowHash = hashUnits(rowUnits);
       if (rawRowCache) {
         rawRowCache[rowIndex] =
-          raw === undefined ? undefined : cacheRawRow(raw, cols, rowUnits, rowCollapsible);
+          raw === undefined ? undefined : cacheRawRow(raw, cols, rowUnits, rowCollapsible, rowHash);
       }
     }
 
-    for (let index = 0; index < rowUnits.length; index += 1) {
-      const key = rowUnits[index]!;
-      if (lastKey === key && rowCollapsible[index]) continue;
-      units.push(key);
-      if (typeof key === "number") {
-        if (key <= 0xffff) {
-          hash ^= key;
-          hash = Math.imul(hash, FNV_PRIME);
-        } else {
-          const astral = key - 0x10000;
-          hash ^= 0xd800 + (astral >> 10);
-          hash = Math.imul(hash, FNV_PRIME);
-          hash ^= 0xdc00 + (astral & 0x3ff);
-          hash = Math.imul(hash, FNV_PRIME);
-        }
-      } else {
-        for (let i = 0; i < key.length; i += 1) {
-          hash ^= key.charCodeAt(i);
-          hash = Math.imul(hash, FNV_PRIME);
-        }
-      }
-      hash ^= HASH_UNIT_SEPARATOR;
-      hash = Math.imul(hash, FNV_PRIME);
-      lastKey = key;
+    // The hash is only a rejection hint: measureVisibleContentDelta confirms
+    // equal hashes with exact unit comparison. Fold cached per-row hashes so
+    // an invalidation does not re-hash every styled string in clean rows.
+    hash ^= rowHash;
+    hash = Math.imul(hash, FNV_PRIME);
+    hash ^= rowUnits.length;
+    hash = Math.imul(hash, FNV_PRIME);
+
+    const skipFirst =
+      rowUnits.length > 0 && lastKey === rowUnits[0] && rowCollapsible[0] === true ? 1 : 0;
+    if (skipFirst === 0) {
+      units.push(...rowUnits);
+    } else {
+      for (let index = 1; index < rowUnits.length; index += 1) units.push(rowUnits[index]!);
+    }
+    if (rowUnits.length > skipFirst) {
+      lastKey = rowUnits[rowUnits.length - 1];
     }
   }
 
@@ -462,13 +494,12 @@ function buildViewportUnitsSnapshot(
 
 /**
  * Generation-keyed cache over readVisibleActivitySnapshot (PERF-035). The
- * viewport can only change when the parser applies data or the terminal
- * resizes/reflows, yet the polling cycle re-extracted and re-hashed the full
- * rows×cols grid every 50ms tick per agent. Attach() subscribes to
- * onWriteParsed/onResize so any parse or resize invalidates; producers whose
- * write callbacks read the snapshot in the same job must call invalidate()
- * in that callback too, because xterm fires per-write callbacks before the
- * onWriteParsed event.
+ * viewport can only change when xterm requests rows be rendered or the
+ * terminal resizes/reflows, yet the polling cycle re-extracted and re-hashed
+ * the full rows×cols grid every 50ms tick per agent. Attach() subscribes to
+ * onRender/onResize; onRender fires before a write callback and identifies the
+ * inclusive viewport-row range that changed, so callback consumers see fresh
+ * content without a second full invalidation at onWriteParsed.
  *
  * Invalidated snapshots still reuse normalized rows whose raw xterm cell
  * words, combined strings, and extended underline styles are byte-for-byte
@@ -482,11 +513,22 @@ export class ViewportSnapshotCache {
   private snapshotN = -1;
   private snapshot: VisibleContentSnapshot | undefined;
   private rawRows: Array<CachedRawRow | undefined> = [];
+  private rawRowsBaseY = -1;
+  private rawRowsCols = -1;
+  private rawRowsViewportRows = -1;
+  private dirtyStart = 0;
+  private dirtyEnd = Number.POSITIVE_INFINITY;
   private disposables: Array<{ dispose: () => void }> = [];
 
   attach(terminal: HeadlessTerminal): void {
     this.detach();
-    this.disposables.push(terminal.onWriteParsed(() => this.invalidate()));
+    this.disposables.push(
+      terminal.onRender(({ start, end }) => {
+        this.dirtyStart = Math.min(this.dirtyStart, start);
+        this.dirtyEnd = Math.max(this.dirtyEnd, end);
+        this.invalidateSnapshot();
+      })
+    );
     this.disposables.push(terminal.onResize(() => this.invalidate()));
   }
 
@@ -500,10 +542,19 @@ export class ViewportSnapshotCache {
     }
     this.disposables = [];
     this.rawRows = [];
+    this.rawRowsBaseY = -1;
+    this.rawRowsCols = -1;
+    this.rawRowsViewportRows = -1;
     this.invalidate();
   }
 
   invalidate(): void {
+    this.dirtyStart = 0;
+    this.dirtyEnd = Number.POSITIVE_INFINITY;
+    this.invalidateSnapshot();
+  }
+
+  private invalidateSnapshot(): void {
     this.generation += 1;
     this.snapshot = undefined;
   }
@@ -516,13 +567,33 @@ export class ViewportSnapshotCache {
     ) {
       return this.snapshot;
     }
+    const buffer = terminal?.buffer.active;
+    if (
+      terminal &&
+      buffer &&
+      (this.rawRowsBaseY !== buffer.baseY ||
+        this.rawRowsCols !== terminal.cols ||
+        this.rawRowsViewportRows !== terminal.rows)
+    ) {
+      this.rawRows = [];
+      this.dirtyStart = 0;
+      this.dirtyEnd = Number.POSITIVE_INFINITY;
+      this.rawRowsBaseY = buffer.baseY;
+      this.rawRowsCols = terminal.cols;
+      this.rawRowsViewportRows = terminal.rows;
+    }
+    const dirtyRows = Number.isFinite(this.dirtyEnd)
+      ? { start: this.dirtyStart, end: this.dirtyEnd }
+      : undefined;
     const snapshot =
-      buildViewportUnitsSnapshot(terminal, this.rawRows) ??
+      buildViewportUnitsSnapshot(terminal, this.rawRows, dirtyRows) ??
       createVisibleContentSnapshot(readVisibleActivityLines(terminal, n));
     if (snapshot !== undefined) {
       this.snapshot = snapshot;
       this.snapshotGeneration = this.generation;
       this.snapshotN = n;
+      this.dirtyStart = Number.POSITIVE_INFINITY;
+      this.dirtyEnd = Number.NEGATIVE_INFINITY;
     }
     return snapshot;
   }


### PR DESCRIPTION
## Summary

- use xterm's inclusive `onRender` row range to retain normalized viewport rows that did not change
- cache each normalized row's semantic hash so a one-row status rewrite does not re-hash every styled string in the viewport
- retain full rebuilds across scroll, resize, reflow, and explicit invalidation; exact unit comparison remains the collision-safe equality check

## PERF-035 result

Benchmark class: diagnostic. Fidelity: PURE internal-function harness with the renderer, Electron transport, and PTY absent; single-process and hermetic. It drives the real production analysis worker/session, headless xterm mirror, activity monitor, and FSM under a substituted virtual clock.

Claim boundary: `cpuMsPerMb30` is real local CPU time per MiB for that production analysis pipeline on the machine below. The wait/resume readings are simulated-time semantic guards. None of these numbers is user-perceived latency.

Machine: `studio-04`, Mac Studio Mac13,1, Apple M1 Max (10 cores, 8P+2E), 32 GB, Darwin 25.4.0 arm64, AC power with sleep disabled.

The table reports the median of three arm means from the final interleaved headline A/B.

| Metric | Class | Before | After | Absolute change | Change |
| --- | --- | ---: | ---: | ---: | ---: |
| `cpuMsPerMb30` (target) | duration, machine-dependent | 259.688 ms/MB | 212.432 ms/MB | -47.256 ms/MB | -18.2% |
| `cpuMsPerMb1` | duration guard | 232.296 ms/MB | 191.400 ms/MB | -40.896 ms/MB | -17.6% |
| `cpuMsPerMb10` | duration guard | 242.297 ms/MB | 202.374 ms/MB | -39.923 ms/MB | -16.5% |
| `cpuMsPerAgentSec30` | duration guard | 0.591 ms/agent-s | 0.483 ms/agent-s | -0.108 ms/agent-s | -18.2% |
| `fleetCpuMs30` | duration guard | 367.773 ms | 300.848 ms | -66.925 ms | -18.2% |
| `waitFlipLatencyMs` | simulated-time semantic guard | 7927.5 ms | 7927.5 ms | 0 ms | 0.0% |
| `resumeFlipLatencyMs` | simulated-time semantic guard | 1204.5 ms | 1204.5 ms | 0 ms | 0.0% |
| `analysisMisses` | correctness predicate | 0 | 0 | 0 | n/a |

All three target pairs won: 18.2%, 17.6%, and 17.9%. Median improvement was 18.2% against a precommitted 5% threshold and 1.1% measured champion drift. Worst within-arm CV was 7.4% (10% ceiling). All six guards passed.

## Protocol and integrity

- baseline SHA: `164758467b9a5e7a242a2e2c8691c8c28a25a43e`
- candidate SHA: `38543e5338c870c8db830e425b43d980a7d309a2`
- scenario/target: `PERF-035` / `metricStats.cpuMsPerMb30.mean`, lower is better
- mode: smoke; 20 measured iterations and 1 warmup per arm
- arm order: champion 1, candidate 1, candidate 2, champion 2, champion 3, candidate 3
- every probe, exploratory comparison, confirmation, and headline arm used `--enforce-integrity`
- final command shape: `npm run perf smoke -- --scenario PERF-035 --iterations 20 --warmups 1 --enforce-integrity --label <arm> --json <arm.json>`
- benchmark runtime: Node v24.20.0, Electron 42.7.1, Git 2.55.0 on every arm
- apparatus digest: `78ed867d5ac93be9b1fa8aabf0c81b8b9223b0ea2e4881a7fd439baa74cb81db` over 185 files, unchanged
- workload floors: exactly 1, 10, and 30 agents; each sweep requires `fedBytes === scriptedBytes`; every agent must emit both canonical state flips and the full state-change record floor
- predicate: `analysisMisses` was emitted and equal to zero in all 20 samples of all six final arms. A cheap predicate sabotage was not available: losing the canonical FSM sequence throws before aggregation, while editing the fixture-owned counters would self-grade the benchmark.

`perf calibrate` was not used because its internal runner does not forward `--enforce-integrity`. `perf diagnose` was used only to locate CPU ownership; its instrumented durations are not benchmark evidence.

## Cross-OS verdict

No `perf-ab` workflow was dispatched. The target and all quantitative guards in this admitted cluster are duration/machine-dependent; PERF-035 exposes no portable count, size, or structural-ratio target. Linux, Windows, and hosted macOS durations are therefore explicitly not measured, and this PR makes no hosted-runner duration claim. The local macOS machine above is the sole duration claim surface.

## Rejected hypotheses

- fuse changed-row hashing into unit construction: quiet integrity-gated pair improved 211.908 to 206.379 ms/MB (2.6%), below the precommitted 5% floor; reverted
- bypass xterm `getLine` for cached rows outside the render range: six-arm result regressed 212.743 to 213.832 ms/MB (0.5%), won only 1/3 pairs, with 2.5% champion drift; reverted with `NO CLAIM`
- remaining owned profile buckets (raw-row capture, viewport digest translation, delta comparison, semantic-buffer bookkeeping) are each below the signal floor; changing viewport scope, polling cadence, FSM semantics, or collision safety was rejected as an invalid trade

## Checks

- `npm run typecheck` — pass
- `npm test` under the repository's Node 22 line — pass: 2,491 files and 54,959 tests; 7 skipped, 1 todo
- `npm run check` under Node 22 — pass
- focused viewport/analysis runtime suite — pass: 29 tests
- no E2E run; no spec was named by a human

Two earlier full-suite attempts under Node 24 failed only PERF-063's minor-GC-observer liveness predicate. Its dedicated invariant suite passed, and the full suite passed on the repository's pinned Node 22 line. No product or benchmark code was changed in response.
