### PR TITLE
fix(media): keep playback running when a project view is revealed

### DIFF
--- a/src/components/FileViewer/FileAudioPreview.tsx
+++ b/src/components/FileViewer/FileAudioPreview.tsx
@@ -37,7 +37,9 @@ interface FileAudioPreviewProps {
    * move `reloadKey` can hold off (#12165). Always taken back on unmount or a
    * source change: a fresh element starts paused and fires no `pause` of its
    * own, so an owner left holding the last `true` would suppress reloads for a
-   * player that no longer exists.
+   * player that no longer exists. That retraction goes to whichever handler is
+   * committed at the time, so the callback must belong to one stable owner
+   * rather than being swapped between independent recipients.
    */
   onPlayingChange?: (playing: boolean) => void;
 }
@@ -105,7 +107,14 @@ export function FileAudioPreview({
           onEnded={(event) =>
             onPlayingChange?.(!event.currentTarget.paused && !event.currentTarget.ended)
           }
-          onError={() => onError?.()}
+          // A decode failure stops playback without a `pause`. Every caller in
+          // tree unmounts the preview here, which would retract it anyway — but
+          // the leaf is shared, and one that merely logs must not be left
+          // holding a player that stopped.
+          onError={() => {
+            onPlayingChange?.(false);
+            onError?.();
+          }}
         />
       ) : fetching ? (
         // The whole file downloads before playback starts, so a long recording

--- a/src/components/FileViewer/FileAudioPreview.tsx
+++ b/src/components/FileViewer/FileAudioPreview.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useEffectEvent } from "react";
 import { Skeleton, SkeletonBone, SkeletonHint } from "@/components/ui/Skeleton";
 import { useMediaBlobUrl } from "./useMediaBlobUrl";
 import type { MediaPreviewError } from "./useMediaBlobUrl";
@@ -31,6 +32,14 @@ interface FileAudioPreviewProps {
   reloadKey?: string | number;
   /** Called when the audio can't be fetched or played; an error overrides the caller's generic copy. */
   onError?: (error?: AudioPreviewError) => void;
+  /**
+   * Reports whether this preview is mid-track, so an owner that would otherwise
+   * move `reloadKey` can hold off (#12165). Always taken back on unmount or a
+   * source change: a fresh element starts paused and fires no `pause` of its
+   * own, so an owner left holding the last `true` would suppress reloads for a
+   * player that no longer exists.
+   */
+  onPlayingChange?: (playing: boolean) => void;
 }
 
 /**
@@ -47,6 +56,7 @@ export function FileAudioPreview({
   label,
   reloadKey,
   onError,
+  onPlayingChange,
 }: FileAudioPreviewProps) {
   const { objectUrl, fetching } = useMediaBlobUrl({
     filePath,
@@ -56,6 +66,16 @@ export function FileAudioPreview({
     tooLargeError: AUDIO_TOO_LARGE_ERROR,
     onError,
   });
+
+  // Effect event so this keys on the source alone — callers pass inline
+  // closures, and re-running on every parent render would report a stop the
+  // element never made.
+  const reportPlaying = useEffectEvent((playing: boolean) => onPlayingChange?.(playing));
+  // Scoped to the same identity the fetch is: whatever moves the source
+  // replaces the element, and the replacement starts paused.
+  useEffect(() => {
+    return () => reportPlaying(false);
+  }, [filePath, rootPath, reloadKey]);
 
   return (
     // Chromium's native audio control drops its scrubber and volume slider
@@ -73,6 +93,18 @@ export function FileAudioPreview({
           preload="metadata"
           aria-label={label}
           className="w-full max-w-md min-w-[300px]"
+          // `paused` alone would call a buffering stall a stop; `ended` alone
+          // would call a finished track still playing (the spec leaves `paused`
+          // false at the end). Both, on all three events, or neither is right.
+          onPlay={(event) =>
+            onPlayingChange?.(!event.currentTarget.paused && !event.currentTarget.ended)
+          }
+          onPause={(event) =>
+            onPlayingChange?.(!event.currentTarget.paused && !event.currentTarget.ended)
+          }
+          onEnded={(event) =>
+            onPlayingChange?.(!event.currentTarget.paused && !event.currentTarget.ended)
+          }
           onError={() => onError?.()}
         />
       ) : fetching ? (

--- a/src/components/FileViewer/FileAudioPreview.tsx
+++ b/src/components/FileViewer/FileAudioPreview.tsx
@@ -40,6 +40,8 @@ interface FileAudioPreviewProps {
    * player that no longer exists. That retraction goes to whichever handler is
    * committed at the time, so the callback must belong to one stable owner
    * rather than being swapped between independent recipients.
+   * Each call is a snapshot rather than a transition — the same value may
+   * arrive twice (an error retracts, then the unmount retracts again).
    */
   onPlayingChange?: (playing: boolean) => void;
 }

--- a/src/components/FileViewer/FileVideoPreview.tsx
+++ b/src/components/FileViewer/FileVideoPreview.tsx
@@ -40,6 +40,8 @@ interface FileVideoPreviewProps {
    * reloads for a player that no longer exists. That retraction goes to
    * whichever handler is committed at the time, so the callback must belong to
    * one stable owner rather than being swapped between independent recipients.
+   * Each call is a snapshot rather than a transition — the same value may
+   * arrive twice (an error retracts, then the unmount retracts again).
    */
   onPlayingChange?: (playing: boolean) => void;
   /** Height cap for the preview surface — dialogs and panes want different ones. */

--- a/src/components/FileViewer/FileVideoPreview.tsx
+++ b/src/components/FileViewer/FileVideoPreview.tsx
@@ -37,7 +37,9 @@ interface FileVideoPreviewProps {
    * otherwise move `reloadKey` can hold off (#12165). Always taken back on
    * unmount or a source change: a fresh element starts paused and fires no
    * `pause` of its own, so an owner left holding the last `true` would suppress
-   * reloads for a player that no longer exists.
+   * reloads for a player that no longer exists. That retraction goes to
+   * whichever handler is committed at the time, so the callback must belong to
+   * one stable owner rather than being swapped between independent recipients.
    */
   onPlayingChange?: (playing: boolean) => void;
   /** Height cap for the preview surface — dialogs and panes want different ones. */
@@ -108,7 +110,14 @@ export function FileVideoPreview({
           onEnded={(event) =>
             onPlayingChange?.(!event.currentTarget.paused && !event.currentTarget.ended)
           }
-          onError={() => onError?.()}
+          // A decode failure stops playback without a `pause`. Every caller in
+          // tree unmounts the preview here, which would retract it anyway — but
+          // the leaf is shared, and one that merely logs must not be left
+          // holding a player that stopped.
+          onError={() => {
+            onPlayingChange?.(false);
+            onError?.();
+          }}
         />
       ) : fetching ? (
         // The whole file downloads before playback starts, so this wait is

--- a/src/components/FileViewer/FileVideoPreview.tsx
+++ b/src/components/FileViewer/FileVideoPreview.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useEffectEvent } from "react";
 import { Skeleton, SkeletonBone, SkeletonHint } from "@/components/ui/Skeleton";
 import { useMediaBlobUrl } from "./useMediaBlobUrl";
 import type { MediaPreviewError } from "./useMediaBlobUrl";
@@ -31,6 +32,14 @@ interface FileVideoPreviewProps {
   reloadKey?: string | number;
   /** Called when the video can't be fetched or played; an error overrides the caller's generic copy. */
   onError?: (error?: VideoPreviewError) => void;
+  /**
+   * Reports whether this preview is mid-playback, so an owner that would
+   * otherwise move `reloadKey` can hold off (#12165). Always taken back on
+   * unmount or a source change: a fresh element starts paused and fires no
+   * `pause` of its own, so an owner left holding the last `true` would suppress
+   * reloads for a player that no longer exists.
+   */
+  onPlayingChange?: (playing: boolean) => void;
   /** Height cap for the preview surface — dialogs and panes want different ones. */
   maxHeightClassName?: string;
 }
@@ -49,6 +58,7 @@ export function FileVideoPreview({
   label,
   reloadKey,
   onError,
+  onPlayingChange,
   maxHeightClassName = "max-h-[70vh]",
 }: FileVideoPreviewProps) {
   const { objectUrl, fetching } = useMediaBlobUrl({
@@ -59,6 +69,16 @@ export function FileVideoPreview({
     tooLargeError: VIDEO_TOO_LARGE_ERROR,
     onError,
   });
+
+  // Effect event so this keys on the source alone — callers pass inline
+  // closures, and re-running on every parent render would report a stop the
+  // element never made.
+  const reportPlaying = useEffectEvent((playing: boolean) => onPlayingChange?.(playing));
+  // Scoped to the same identity the fetch is: whatever moves the source
+  // replaces the element, and the replacement starts paused.
+  useEffect(() => {
+    return () => reportPlaying(false);
+  }, [filePath, rootPath, reloadKey]);
 
   return (
     <div className="flex items-center justify-center p-6 min-h-[300px]">
@@ -76,6 +96,18 @@ export function FileVideoPreview({
           preload="metadata"
           aria-label={label}
           className={`max-w-full ${maxHeightClassName} rounded`}
+          // `paused` alone would call a buffering stall a stop; `ended` alone
+          // would call a finished video still playing (the spec leaves `paused`
+          // false at the end). Both, on all three events, or neither is right.
+          onPlay={(event) =>
+            onPlayingChange?.(!event.currentTarget.paused && !event.currentTarget.ended)
+          }
+          onPause={(event) =>
+            onPlayingChange?.(!event.currentTarget.paused && !event.currentTarget.ended)
+          }
+          onEnded={(event) =>
+            onPlayingChange?.(!event.currentTarget.paused && !event.currentTarget.ended)
+          }
           onError={() => onError?.()}
         />
       ) : fetching ? (

--- a/src/components/FileViewer/__tests__/FileAudioPreview.test.tsx
+++ b/src/components/FileViewer/__tests__/FileAudioPreview.test.tsx
@@ -293,6 +293,31 @@ describe("FileAudioPreview", () => {
     expect(onPlayingChange).toHaveBeenCalledWith(false);
   });
 
+  it("reports a stop when the element errors mid-playback", async () => {
+    // A decode failure stops playback without a `pause`. Owners that unmount on
+    // error get the retraction from the cleanup anyway; one that only logs
+    // would otherwise be left holding a player that stopped.
+    respondWith(new Blob(["x"]));
+    const onPlayingChange = vi.fn();
+    const { container } = render(
+      <FileAudioPreview
+        filePath="/repo/track.mp3"
+        rootPath="/repo"
+        label="track.mp3"
+        onPlayingChange={onPlayingChange}
+      />
+    );
+    await waitFor(() => expect(container.querySelector("audio")).not.toBeNull());
+    const element = container.querySelector("audio")!;
+    setPlaybackState(element, { paused: false });
+    fireEvent.play(element);
+
+    onPlayingChange.mockClear();
+    fireEvent.error(element);
+
+    expect(onPlayingChange).toHaveBeenCalledWith(false);
+  });
+
   it("reports nothing when no owner is listening", async () => {
     // DiffPane renders this leaf without the prop; an unconditional call rather
     // than optional chaining would throw the moment anyone pressed play.

--- a/src/components/FileViewer/__tests__/FileAudioPreview.test.tsx
+++ b/src/components/FileViewer/__tests__/FileAudioPreview.test.tsx
@@ -15,6 +15,11 @@ import { FileAudioPreview } from "../FileAudioPreview";
 const fetchMock = vi.fn();
 const createObjectURL = vi.fn();
 const revokeObjectURL = vi.fn();
+// `vi.unstubAllGlobals()` does not restore a directly assigned method, and
+// `mockReset()` leaves this one handing back `undefined` — enough to poison a
+// later file sharing the fork.
+const realCreateObjectURL = URL.createObjectURL;
+const realRevokeObjectURL = URL.revokeObjectURL;
 
 function respondWith(blob: Blob, headers: Record<string, string> = {}) {
   fetchMock.mockResolvedValue({
@@ -51,6 +56,8 @@ afterEach(() => {
   fetchMock.mockReset();
   createObjectURL.mockReset();
   revokeObjectURL.mockReset();
+  URL.createObjectURL = realCreateObjectURL;
+  URL.revokeObjectURL = realRevokeObjectURL;
 });
 
 describe("FileAudioPreview", () => {
@@ -276,10 +283,34 @@ describe("FileAudioPreview", () => {
     expect(onPlayingChange).toHaveBeenLastCalledWith(false);
 
     // The spec leaves `paused` false at the end of a track, so `ended` is the
-    // only thing that says playback stopped here.
+    // only thing that says playback stopped here. Cleared first: `pause` above
+    // already left `false` as the last call, so asserting on that alone would
+    // stay green with the `onEnded` handler deleted outright.
+    onPlayingChange.mockClear();
     setPlaybackState(element, { paused: false, ended: true });
     fireEvent.ended(element);
-    expect(onPlayingChange).toHaveBeenLastCalledWith(false);
+    expect(onPlayingChange).toHaveBeenCalledTimes(1);
+    expect(onPlayingChange).toHaveBeenCalledWith(false);
+  });
+
+  it("reports nothing when no owner is listening", async () => {
+    // DiffPane renders this leaf without the prop; an unconditional call rather
+    // than optional chaining would throw the moment anyone pressed play.
+    respondWith(new Blob(["x"]));
+    const { container, unmount } = render(
+      <FileAudioPreview filePath="/repo/track.mp3" rootPath="/repo" label="track.mp3" />
+    );
+    await waitFor(() => expect(container.querySelector("audio")).not.toBeNull());
+    const element = container.querySelector("audio")!;
+
+    setPlaybackState(element, { paused: false });
+    expect(() => {
+      fireEvent.play(element);
+      fireEvent.pause(element);
+      fireEvent.ended(element);
+      fireEvent.error(element);
+      unmount();
+    }).not.toThrow();
   });
 
   it("takes a reported play back when the source is replaced", async () => {

--- a/src/components/FileViewer/__tests__/FileAudioPreview.test.tsx
+++ b/src/components/FileViewer/__tests__/FileAudioPreview.test.tsx
@@ -25,6 +25,18 @@ function respondWith(blob: Blob, headers: Record<string, string> = {}) {
   });
 }
 
+// jsdom neither decodes media nor tracks playback: `fireEvent.play` dispatches
+// the event but leaves `paused` true and `ended` false, so a handler reading
+// them off the element would see the opposite of what it was told. Set the
+// state the real element would be in before firing.
+function setPlaybackState(
+  element: HTMLMediaElement,
+  state: { paused: boolean; ended?: boolean }
+): void {
+  Object.defineProperty(element, "paused", { configurable: true, value: state.paused });
+  Object.defineProperty(element, "ended", { configurable: true, value: state.ended ?? false });
+}
+
 beforeEach(() => {
   vi.stubGlobal("fetch", fetchMock);
   let nextUrl = 0;
@@ -235,5 +247,93 @@ describe("FileAudioPreview", () => {
     await waitFor(() => expect(container.querySelector("audio")).not.toBeNull());
     fireEvent.error(container.querySelector("audio")!);
     expect(onError).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports playing state through play, pause and ended", async () => {
+    // The signal an owner gates its reload key on: without it, coming back to a
+    // project remounts the element and drops the listener's place (#12165).
+    respondWith(new Blob(["x"]));
+    const onPlayingChange = vi.fn();
+    const { container } = render(
+      <FileAudioPreview
+        filePath="/repo/track.mp3"
+        rootPath="/repo"
+        label="track.mp3"
+        onPlayingChange={onPlayingChange}
+      />
+    );
+    await waitFor(() => expect(container.querySelector("audio")).not.toBeNull());
+    const element = container.querySelector("audio")!;
+
+    setPlaybackState(element, { paused: false });
+    fireEvent.play(element);
+    expect(onPlayingChange).toHaveBeenLastCalledWith(true);
+
+    // Buffering drops readyState while `paused` stays false, which is why the
+    // component reads paused/ended and never readiness.
+    setPlaybackState(element, { paused: true });
+    fireEvent.pause(element);
+    expect(onPlayingChange).toHaveBeenLastCalledWith(false);
+
+    // The spec leaves `paused` false at the end of a track, so `ended` is the
+    // only thing that says playback stopped here.
+    setPlaybackState(element, { paused: false, ended: true });
+    fireEvent.ended(element);
+    expect(onPlayingChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it("takes a reported play back when the source is replaced", async () => {
+    // The replacement element mounts paused and fires no `pause` of its own, so
+    // an owner left holding the last `true` would suppress reloads forever.
+    respondWith(new Blob(["x"]));
+    const onPlayingChange = vi.fn();
+    const { container, rerender } = render(
+      <FileAudioPreview
+        filePath="/repo/track.mp3"
+        rootPath="/repo"
+        label="track.mp3"
+        reloadKey={1}
+        onPlayingChange={onPlayingChange}
+      />
+    );
+    await waitFor(() => expect(container.querySelector("audio")).not.toBeNull());
+    const element = container.querySelector("audio")!;
+    setPlaybackState(element, { paused: false });
+    fireEvent.play(element);
+    expect(onPlayingChange).toHaveBeenLastCalledWith(true);
+
+    rerender(
+      <FileAudioPreview
+        filePath="/repo/track.mp3"
+        rootPath="/repo"
+        label="track.mp3"
+        reloadKey={2}
+        onPlayingChange={onPlayingChange}
+      />
+    );
+
+    expect(onPlayingChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it("takes a reported play back when it unmounts", async () => {
+    respondWith(new Blob(["x"]));
+    const onPlayingChange = vi.fn();
+    const { container, unmount } = render(
+      <FileAudioPreview
+        filePath="/repo/track.mp3"
+        rootPath="/repo"
+        label="track.mp3"
+        onPlayingChange={onPlayingChange}
+      />
+    );
+    await waitFor(() => expect(container.querySelector("audio")).not.toBeNull());
+    const element = container.querySelector("audio")!;
+    setPlaybackState(element, { paused: false });
+    fireEvent.play(element);
+    expect(onPlayingChange).toHaveBeenLastCalledWith(true);
+
+    unmount();
+
+    expect(onPlayingChange).toHaveBeenLastCalledWith(false);
   });
 });

--- a/src/components/FileViewer/__tests__/FileVideoPreview.test.tsx
+++ b/src/components/FileViewer/__tests__/FileVideoPreview.test.tsx
@@ -25,6 +25,18 @@ function respondWith(blob: Blob, headers: Record<string, string> = {}) {
   });
 }
 
+// jsdom neither decodes media nor tracks playback: `fireEvent.play` dispatches
+// the event but leaves `paused` true and `ended` false, so a handler reading
+// them off the element would see the opposite of what it was told. Set the
+// state the real element would be in before firing.
+function setPlaybackState(
+  element: HTMLMediaElement,
+  state: { paused: boolean; ended?: boolean }
+): void {
+  Object.defineProperty(element, "paused", { configurable: true, value: state.paused });
+  Object.defineProperty(element, "ended", { configurable: true, value: state.ended ?? false });
+}
+
 beforeEach(() => {
   vi.stubGlobal("fetch", fetchMock);
   let nextUrl = 0;
@@ -219,5 +231,93 @@ describe("FileVideoPreview", () => {
     await waitFor(() => expect(container.querySelector("video")).not.toBeNull());
     fireEvent.error(container.querySelector("video")!);
     expect(onError).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports playing state through play, pause and ended", async () => {
+    // The signal an owner gates its reload key on: without it, coming back to a
+    // project remounts the element and drops the listener's place (#12165).
+    respondWith(new Blob(["x"]));
+    const onPlayingChange = vi.fn();
+    const { container } = render(
+      <FileVideoPreview
+        filePath="/repo/demo.mp4"
+        rootPath="/repo"
+        label="demo.mp4"
+        onPlayingChange={onPlayingChange}
+      />
+    );
+    await waitFor(() => expect(container.querySelector("video")).not.toBeNull());
+    const element = container.querySelector("video")!;
+
+    setPlaybackState(element, { paused: false });
+    fireEvent.play(element);
+    expect(onPlayingChange).toHaveBeenLastCalledWith(true);
+
+    // Buffering drops readyState while `paused` stays false, which is why the
+    // component reads paused/ended and never readiness.
+    setPlaybackState(element, { paused: true });
+    fireEvent.pause(element);
+    expect(onPlayingChange).toHaveBeenLastCalledWith(false);
+
+    // The spec leaves `paused` false at the end of a track, so `ended` is the
+    // only thing that says playback stopped here.
+    setPlaybackState(element, { paused: false, ended: true });
+    fireEvent.ended(element);
+    expect(onPlayingChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it("takes a reported play back when the source is replaced", async () => {
+    // The replacement element mounts paused and fires no `pause` of its own, so
+    // an owner left holding the last `true` would suppress reloads forever.
+    respondWith(new Blob(["x"]));
+    const onPlayingChange = vi.fn();
+    const { container, rerender } = render(
+      <FileVideoPreview
+        filePath="/repo/demo.mp4"
+        rootPath="/repo"
+        label="demo.mp4"
+        reloadKey={1}
+        onPlayingChange={onPlayingChange}
+      />
+    );
+    await waitFor(() => expect(container.querySelector("video")).not.toBeNull());
+    const element = container.querySelector("video")!;
+    setPlaybackState(element, { paused: false });
+    fireEvent.play(element);
+    expect(onPlayingChange).toHaveBeenLastCalledWith(true);
+
+    rerender(
+      <FileVideoPreview
+        filePath="/repo/demo.mp4"
+        rootPath="/repo"
+        label="demo.mp4"
+        reloadKey={2}
+        onPlayingChange={onPlayingChange}
+      />
+    );
+
+    expect(onPlayingChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it("takes a reported play back when it unmounts", async () => {
+    respondWith(new Blob(["x"]));
+    const onPlayingChange = vi.fn();
+    const { container, unmount } = render(
+      <FileVideoPreview
+        filePath="/repo/demo.mp4"
+        rootPath="/repo"
+        label="demo.mp4"
+        onPlayingChange={onPlayingChange}
+      />
+    );
+    await waitFor(() => expect(container.querySelector("video")).not.toBeNull());
+    const element = container.querySelector("video")!;
+    setPlaybackState(element, { paused: false });
+    fireEvent.play(element);
+    expect(onPlayingChange).toHaveBeenLastCalledWith(true);
+
+    unmount();
+
+    expect(onPlayingChange).toHaveBeenLastCalledWith(false);
   });
 });

--- a/src/components/FileViewer/__tests__/FileVideoPreview.test.tsx
+++ b/src/components/FileViewer/__tests__/FileVideoPreview.test.tsx
@@ -15,6 +15,11 @@ import { FileVideoPreview } from "../FileVideoPreview";
 const fetchMock = vi.fn();
 const createObjectURL = vi.fn();
 const revokeObjectURL = vi.fn();
+// `vi.unstubAllGlobals()` does not restore a directly assigned method, and
+// `mockReset()` leaves this one handing back `undefined` — enough to poison a
+// later file sharing the fork.
+const realCreateObjectURL = URL.createObjectURL;
+const realRevokeObjectURL = URL.revokeObjectURL;
 
 function respondWith(blob: Blob, headers: Record<string, string> = {}) {
   fetchMock.mockResolvedValue({
@@ -51,6 +56,8 @@ afterEach(() => {
   fetchMock.mockReset();
   createObjectURL.mockReset();
   revokeObjectURL.mockReset();
+  URL.createObjectURL = realCreateObjectURL;
+  URL.revokeObjectURL = realRevokeObjectURL;
 });
 
 describe("FileVideoPreview", () => {
@@ -260,10 +267,34 @@ describe("FileVideoPreview", () => {
     expect(onPlayingChange).toHaveBeenLastCalledWith(false);
 
     // The spec leaves `paused` false at the end of a track, so `ended` is the
-    // only thing that says playback stopped here.
+    // only thing that says playback stopped here. Cleared first: `pause` above
+    // already left `false` as the last call, so asserting on that alone would
+    // stay green with the `onEnded` handler deleted outright.
+    onPlayingChange.mockClear();
     setPlaybackState(element, { paused: false, ended: true });
     fireEvent.ended(element);
-    expect(onPlayingChange).toHaveBeenLastCalledWith(false);
+    expect(onPlayingChange).toHaveBeenCalledTimes(1);
+    expect(onPlayingChange).toHaveBeenCalledWith(false);
+  });
+
+  it("reports nothing when no owner is listening", async () => {
+    // DiffPane renders this leaf without the prop; an unconditional call rather
+    // than optional chaining would throw the moment anyone pressed play.
+    respondWith(new Blob(["x"]));
+    const { container, unmount } = render(
+      <FileVideoPreview filePath="/repo/demo.mp4" rootPath="/repo" label="demo.mp4" />
+    );
+    await waitFor(() => expect(container.querySelector("video")).not.toBeNull());
+    const element = container.querySelector("video")!;
+
+    setPlaybackState(element, { paused: false });
+    expect(() => {
+      fireEvent.play(element);
+      fireEvent.pause(element);
+      fireEvent.ended(element);
+      fireEvent.error(element);
+      unmount();
+    }).not.toThrow();
   });
 
   it("takes a reported play back when the source is replaced", async () => {

--- a/src/components/FileViewer/__tests__/FileVideoPreview.test.tsx
+++ b/src/components/FileViewer/__tests__/FileVideoPreview.test.tsx
@@ -277,6 +277,31 @@ describe("FileVideoPreview", () => {
     expect(onPlayingChange).toHaveBeenCalledWith(false);
   });
 
+  it("reports a stop when the element errors mid-playback", async () => {
+    // A decode failure stops playback without a `pause`. Owners that unmount on
+    // error get the retraction from the cleanup anyway; one that only logs
+    // would otherwise be left holding a player that stopped.
+    respondWith(new Blob(["x"]));
+    const onPlayingChange = vi.fn();
+    const { container } = render(
+      <FileVideoPreview
+        filePath="/repo/demo.mp4"
+        rootPath="/repo"
+        label="demo.mp4"
+        onPlayingChange={onPlayingChange}
+      />
+    );
+    await waitFor(() => expect(container.querySelector("video")).not.toBeNull());
+    const element = container.querySelector("video")!;
+    setPlaybackState(element, { paused: false });
+    fireEvent.play(element);
+
+    onPlayingChange.mockClear();
+    fireEvent.error(element);
+
+    expect(onPlayingChange).toHaveBeenCalledWith(false);
+  });
+
   it("reports nothing when no owner is listening", async () => {
     // DiffPane renders this leaf without the prop; an unconditional call rather
     // than optional chaining would throw the moment anyone pressed play.

--- a/src/panels/file-browser/FileBrowserPane.tsx
+++ b/src/panels/file-browser/FileBrowserPane.tsx
@@ -622,8 +622,8 @@ export function FileBrowserPane({
   // flag being right.
   const [mediaReloadNonce, setMediaReloadNonce] = useState(0);
   // Set only while a mounted player is mid-playback: the preview takes its own
-  // `true` back on unmount or a source change, so this can never name a player
-  // that has gone away.
+  // `true` back on unmount or a source change, so nothing can strand it set
+  // beyond the passive-effect pass that retires the player.
   const mediaPlayingRef = useRef(false);
   const handleMediaPlayingChange = useCallback((playing: boolean) => {
     mediaPlayingRef.current = playing;

--- a/src/panels/file-browser/FileBrowserPane.tsx
+++ b/src/panels/file-browser/FileBrowserPane.tsx
@@ -609,14 +609,34 @@ export function FileBrowserPane({
   // The foreground half of the refresh signal, counted apart from the ambient
   // change tick so Refresh also re-reads the open file, not just the tree. It
   // then travels to the viewer BOTH ways, and both are load-bearing: merged
-  // into `viewerRevision` below, and handed over on its own as the media
-  // previews' reload key (#11586). Dropping the direct handoff makes Refresh
-  // inert for media again; substituting the merged value there restarts
-  // playback on every ambient write. Keep both.
+  // into `viewerRevision` below, and handed over on its own to seed the media
+  // reload nonce (#11586). Dropping the direct handoff makes Refresh inert for
+  // media again; substituting the merged value there restarts playback on
+  // every ambient write. Keep both.
   const [surfaceRefreshNonce, setSurfaceRefreshNonce] = useState(0);
+  // The media half of that signal, split off rather than gated inside it
+  // (#12165). Returning to a project while a track is playing is a catch-up,
+  // not a request for fresh bytes, so this one holds still — but the nonce
+  // above keeps moving, so the text re-read, the PDF re-navigation and the
+  // reclassification that revives a failed preview never depend on a playback
+  // flag being right.
+  const [mediaReloadNonce, setMediaReloadNonce] = useState(0);
+  // Set only while a mounted player is mid-playback: the preview takes its own
+  // `true` back on unmount or a source change, so this can never name a player
+  // that has gone away.
+  const mediaPlayingRef = useRef(false);
+  const handleMediaPlayingChange = useCallback((playing: boolean) => {
+    mediaPlayingRef.current = playing;
+  }, []);
   const refreshAll = useCallback(
     (options?: { manual?: boolean }) => {
       setSurfaceRefreshNonce((nonce) => nonce + 1);
+      // A gesture outranks playback — someone pressing Refresh mid-track is
+      // asking for the rewritten bytes and accepts losing their place. A
+      // reveal is not a gesture, so it yields to a running player.
+      if (options?.manual || !mediaPlayingRef.current) {
+        setMediaReloadNonce((nonce) => nonce + 1);
+      }
       refresh(options);
     },
     [refresh]
@@ -1293,10 +1313,12 @@ export function FileBrowserPane({
               relativePath={isSelectedReadableFile ? (selectedPath ?? null) : null}
               revision={viewerRevision}
               // Handed over separately from `revision` rather than pulled back
-              // out of it: the media previews may only re-fetch on the explicit
-              // half of that pair, and a merged string can't say which half
-              // moved (#11586).
+              // out of it: the PDF frame and the media previews may only
+              // re-fetch on the explicit half of that pair, and a merged string
+              // can't say which half moved (#11586).
               surfaceRefreshNonce={surfaceRefreshNonce}
+              mediaReloadNonce={mediaReloadNonce}
+              onMediaPlayingChange={handleMediaPlayingChange}
               onRefresh={handleRefresh}
               isRefreshing={isRefreshing}
               onCollapseAll={handleCollapseAll}

--- a/src/panels/file-browser/FileBrowserPane.tsx
+++ b/src/panels/file-browser/FileBrowserPane.tsx
@@ -609,10 +609,10 @@ export function FileBrowserPane({
   // The foreground half of the refresh signal, counted apart from the ambient
   // change tick so Refresh also re-reads the open file, not just the tree. It
   // then travels to the viewer BOTH ways, and both are load-bearing: merged
-  // into `viewerRevision` below, and handed over on its own to seed the media
-  // reload nonce (#11586). Dropping the direct handoff makes Refresh inert for
-  // media again; substituting the merged value there restarts playback on
-  // every ambient write. Keep both.
+  // into `viewerRevision` below, and handed over on its own to drive the PDF
+  // frame (#11586). Dropping the direct handoff makes Refresh inert for PDFs
+  // again; substituting the merged value there re-navigates the frame on every
+  // ambient write. Keep both.
   const [surfaceRefreshNonce, setSurfaceRefreshNonce] = useState(0);
   // The media half of that signal, split off rather than gated inside it
   // (#12165). Returning to a project while a track is playing is a catch-up,
@@ -1313,9 +1313,9 @@ export function FileBrowserPane({
               relativePath={isSelectedReadableFile ? (selectedPath ?? null) : null}
               revision={viewerRevision}
               // Handed over separately from `revision` rather than pulled back
-              // out of it: the PDF frame and the media previews may only
-              // re-fetch on the explicit half of that pair, and a merged string
-              // can't say which half moved (#11586).
+              // out of it: the PDF frame may only re-navigate on the explicit
+              // half of that pair, and a merged string can't say which half
+              // moved (#11586).
               surfaceRefreshNonce={surfaceRefreshNonce}
               mediaReloadNonce={mediaReloadNonce}
               onMediaPlayingChange={handleMediaPlayingChange}

--- a/src/panels/file-browser/FileBrowserViewer.tsx
+++ b/src/panels/file-browser/FileBrowserViewer.tsx
@@ -80,10 +80,11 @@ export interface FileBrowserViewerProps {
   /**
    * Changes on a foreground refresh — pressing Refresh, or returning to this
    * project after it sat cached — never on an ambient worktree tick. The half
-   * of `revision` the media branches can safely honour. Typed `number` rather
-   * than `string | number` so handing it the merged `revision` (which also
-   * carries the change tick) is a compile error, not a silent regression to
-   * restarting playback on every background write.
+   * of `revision` the PDF frame can safely honour; media takes the narrower
+   * `mediaReloadNonce` below. Typed `number` rather than `string | number` so
+   * handing it the merged `revision` (which also carries the change tick) is a
+   * compile error, not a silent regression to re-navigating the frame on every
+   * background write.
    */
   surfaceRefreshNonce: number;
   /**

--- a/src/panels/file-browser/FileBrowserViewer.tsx
+++ b/src/panels/file-browser/FileBrowserViewer.tsx
@@ -86,6 +86,16 @@ export interface FileBrowserViewerProps {
    * restarting playback on every background write.
    */
   surfaceRefreshNonce: number;
+  /**
+   * The media half of `surfaceRefreshNonce`, held back when the player on
+   * screen is mid-playback (#12165). Split from it rather than gated inside it
+   * so a stale playback flag can at worst skip a media re-fetch — never stall
+   * the text re-read, the PDF re-navigation, or the reclassification that
+   * brings a failed preview back.
+   */
+  mediaReloadNonce: number;
+  /** Reports the media preview's play state up to the pane that owns the nonce above. */
+  onMediaPlayingChange: (playing: boolean) => void;
   /** Runs the pane's manual refresh — re-reads the tree and the open file. */
   onRefresh: () => void;
   /** Whether that refresh is still draining; spins the Refresh icon. */
@@ -202,6 +212,8 @@ export function FileBrowserViewer({
   relativePath,
   revision,
   surfaceRefreshNonce,
+  mediaReloadNonce,
+  onMediaPlayingChange,
   onRefresh,
   isRefreshing,
   onCollapseAll,
@@ -802,17 +814,18 @@ export function FileBrowserViewer({
       case "video":
         return (
           <div className="h-full w-full overflow-auto">
-            {/* Reloaded on `surfaceRefreshNonce`, never on `revision`: that
-                ticks on every worktree write, and re-fetching would reset
-                playback whenever an agent touches any file. Only a foreground
-                refresh outranks continuity — pressing Refresh (#11586), or
-                coming back to this project (#11588) — so only those pull the
-                rewritten bytes. */}
+            {/* Reloaded on `mediaReloadNonce`, never on `revision`: that ticks
+                on every worktree write, and re-fetching would reset playback
+                whenever an agent touches any file. Only a foreground refresh
+                outranks continuity — pressing Refresh (#11586), or coming back
+                to this project while nothing is playing (#11588, #12165) — so
+                only those pull the rewritten bytes. */}
             <FileVideoPreview
               filePath={filePath}
               rootPath={rootPath}
               label={fileName}
-              reloadKey={surfaceRefreshNonce}
+              reloadKey={mediaReloadNonce}
+              onPlayingChange={onMediaPlayingChange}
               onError={(error) =>
                 setState({
                   status: "error",
@@ -834,7 +847,8 @@ export function FileBrowserViewer({
               filePath={filePath}
               rootPath={rootPath}
               label={fileName}
-              reloadKey={surfaceRefreshNonce}
+              reloadKey={mediaReloadNonce}
+              onPlayingChange={onMediaPlayingChange}
               onError={(error) =>
                 setState({
                   status: "error",

--- a/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
@@ -2641,10 +2641,11 @@ describe("FileBrowserPane re-reads when the project view is revealed (#11588)", 
         await waitFor(() => expect(mediaFetchMock.mock.calls.length).toBe(fetchesBefore + 1));
       });
 
-      it(`does not carry ${kind.tag} playing state to a text file`, async () => {
-        // The guarantee the nonce split exists to protect: whatever the media
-        // half is doing, a reveal must never leave the open file stale. If the
-        // flag outlived the player, this read would never happen.
+      it(`re-reads a text file revealed after a played ${kind.tag}`, async () => {
+        // The player is gone by the time this reveal lands, so the flag must be
+        // too. It is retracted when the preview unmounts, not by anything the
+        // pane does — leave that out of the leaf and the open file goes stale
+        // for the rest of the session.
         const { rerender } = await renderPlaying(kind);
 
         mockPanel.browserSelectedPath = "src/app.ts";

--- a/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
@@ -2502,6 +2502,136 @@ describe("FileBrowserPane re-reads when the project view is revealed (#11588)", 
     expect(lifecycleListeners.size).toBe(0);
   });
 
+  // #12165: the media nonce is split from `surfaceRefreshNonce` so a reveal can
+  // hold it still without also stalling the text re-read, the PDF frame, or the
+  // reclassification that revives a failed preview.
+  describe("playing media (#12165)", () => {
+    const AUDIO_ROW = {
+      path: "media/track.mp3",
+      name: "track.mp3",
+      isDirectory: false,
+      depth: 1,
+      isExpanded: false,
+      isLoading: false,
+    };
+    const OTHER_AUDIO_ROW = { ...AUDIO_ROW, path: "media/other.mp3", name: "other.mp3" };
+
+    const mediaFetchMock = vi.fn();
+    const realCreateObjectURL = URL.createObjectURL;
+    const realRevokeObjectURL = URL.revokeObjectURL;
+
+    beforeEach(() => {
+      let objectUrlSequence = 0;
+      mediaFetchMock.mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        blob: () => Promise.resolve(new Blob(["x"])),
+      });
+      vi.stubGlobal("fetch", mediaFetchMock);
+      // Unique per call: a constant would let a stale response satisfy an
+      // assertion that a fresh one arrived.
+      URL.createObjectURL = vi.fn(() => `blob:app://daintree/pane-play-${objectUrlSequence++}`);
+      URL.revokeObjectURL = vi.fn();
+      treeState.rows = [...defaultRows, AUDIO_ROW, OTHER_AUDIO_ROW];
+      mockPanel.browserSelectedPath = AUDIO_ROW.path;
+      mockPanel.browserSidebarCollapsed = true;
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+      mediaFetchMock.mockReset();
+      // `vi.unstubAllGlobals` does not restore a directly assigned method.
+      URL.createObjectURL = realCreateObjectURL;
+      URL.revokeObjectURL = realRevokeObjectURL;
+    });
+
+    // jsdom neither decodes media nor tracks playback: `fireEvent.play` fires
+    // the event but leaves `paused` true, so the preview's own paused/ended
+    // read would see the opposite of what the test just said happened.
+    function setPlaybackState(
+      element: HTMLMediaElement,
+      state: { paused: boolean; ended?: boolean }
+    ): void {
+      Object.defineProperty(element, "paused", { configurable: true, value: state.paused });
+      Object.defineProperty(element, "ended", { configurable: true, value: state.ended ?? false });
+    }
+
+    async function renderPlaying() {
+      const view = renderPane();
+      await waitFor(() => expect(view.container.querySelector("audio")).not.toBeNull());
+      const audio = view.container.querySelector("audio")!;
+      setPlaybackState(audio, { paused: false });
+      fireEvent.play(audio);
+      return { ...view, audio };
+    }
+
+    it("leaves the player alone on reveal while still re-listing the tree", async () => {
+      // Both halves matter: a re-fetch mints a new object URL and drops the
+      // listener back to zero, while the tree has nothing to protect and must
+      // still catch up on what changed while the project sat cached.
+      const { audio, container } = await renderPlaying();
+      const fetchesBefore = mediaFetchMock.mock.calls.length;
+      const srcBefore = audio.getAttribute("src");
+
+      await emit("revealed");
+
+      expect(mediaFetchMock.mock.calls.length).toBe(fetchesBefore);
+      // The same element, still pointed at the same blob — a src comparison
+      // alone would go green on the empty gap while a replacement loads.
+      expect(container.querySelector("audio")).toBe(audio);
+      expect(audio.getAttribute("src")).toBe(srcBefore);
+      expect(treeState.refresh).toHaveBeenCalledTimes(1);
+    });
+
+    it("re-fetches on the next reveal once the track ends", async () => {
+      // The suppression is scoped to playback, not permanent — and the spec
+      // leaves `paused` false at the end, so `ended` is what says it stopped.
+      const { audio } = await renderPlaying();
+      const fetchesBefore = mediaFetchMock.mock.calls.length;
+
+      await emit("revealed");
+      expect(mediaFetchMock.mock.calls.length).toBe(fetchesBefore);
+
+      setPlaybackState(audio, { paused: false, ended: true });
+      fireEvent.ended(audio);
+      await emit("revealed");
+
+      await waitFor(() => expect(mediaFetchMock.mock.calls.length).toBe(fetchesBefore + 1));
+    });
+
+    it("still re-fetches the player when Refresh is pressed", async () => {
+      // A gesture outranks playback: someone pressing Refresh mid-track is
+      // asking for the rewritten bytes and accepts losing their place.
+      await renderPlaying();
+      const fetchesBefore = mediaFetchMock.mock.calls.length;
+
+      act(() => {
+        fireEvent.click(screen.getByTestId("file-browser-refresh"));
+      });
+
+      await waitFor(() => expect(mediaFetchMock.mock.calls.length).toBe(fetchesBefore + 1));
+    });
+
+    it("does not carry playing state to the next selected media file", async () => {
+      // The stale-flag failure this would otherwise invite: a track left
+      // playing, a different file selected, and every later reveal silently
+      // refusing to refresh a player that was never running.
+      const { rerender, container } = await renderPlaying();
+
+      mockPanel.browserSelectedPath = OTHER_AUDIO_ROW.path;
+      await act(async () => {
+        rerender(paneElement());
+      });
+      await waitFor(() => expect(container.querySelector("audio")).not.toBeNull());
+      const fetchesBefore = mediaFetchMock.mock.calls.length;
+
+      await emit("revealed");
+
+      await waitFor(() => expect(mediaFetchMock.mock.calls.length).toBe(fetchesBefore + 1));
+    });
+  });
+
   describe("dock parking", () => {
     it("defers the refresh while parked offscreen, then runs it once on activation", async () => {
       // A dock panel stays mounted in the offscreen parking container whether

--- a/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
@@ -2506,15 +2506,21 @@ describe("FileBrowserPane re-reads when the project view is revealed (#11588)", 
   // hold it still without also stalling the text re-read, the PDF frame, or the
   // reclassification that revives a failed preview.
   describe("playing media (#12165)", () => {
-    const AUDIO_ROW = {
-      path: "media/track.mp3",
-      name: "track.mp3",
+    // Both kinds, because FileBrowserViewer wires them in two separate branches:
+    // an audio-only suite would let the video one drift back to the surface
+    // nonce with everything still green.
+    const KINDS = [
+      { tag: "audio" as const, path: "media/track.mp3", next: "media/other.mp3" },
+      { tag: "video" as const, path: "media/demo.mp4", next: "media/other.mp4" },
+    ];
+    const row = (path: string) => ({
+      path,
+      name: path.split("/").pop()!,
       isDirectory: false,
       depth: 1,
       isExpanded: false,
       isLoading: false,
-    };
-    const OTHER_AUDIO_ROW = { ...AUDIO_ROW, path: "media/other.mp3", name: "other.mp3" };
+    });
 
     const mediaFetchMock = vi.fn();
     const realCreateObjectURL = URL.createObjectURL;
@@ -2533,8 +2539,10 @@ describe("FileBrowserPane re-reads when the project view is revealed (#11588)", 
       // assertion that a fresh one arrived.
       URL.createObjectURL = vi.fn(() => `blob:app://daintree/pane-play-${objectUrlSequence++}`);
       URL.revokeObjectURL = vi.fn();
-      treeState.rows = [...defaultRows, AUDIO_ROW, OTHER_AUDIO_ROW];
-      mockPanel.browserSelectedPath = AUDIO_ROW.path;
+      treeState.rows = [
+        ...defaultRows,
+        ...KINDS.flatMap((kind) => [row(kind.path), row(kind.next)]),
+      ];
       mockPanel.browserSidebarCollapsed = true;
     });
 
@@ -2557,79 +2565,99 @@ describe("FileBrowserPane re-reads when the project view is revealed (#11588)", 
       Object.defineProperty(element, "ended", { configurable: true, value: state.ended ?? false });
     }
 
-    async function renderPlaying() {
+    async function renderPlaying(kind: (typeof KINDS)[number]) {
+      mockPanel.browserSelectedPath = kind.path;
       const view = renderPane();
-      await waitFor(() => expect(view.container.querySelector("audio")).not.toBeNull());
-      const audio = view.container.querySelector("audio")!;
-      setPlaybackState(audio, { paused: false });
-      fireEvent.play(audio);
-      return { ...view, audio };
+      await waitFor(() => expect(view.container.querySelector(kind.tag)).not.toBeNull());
+      const player = view.container.querySelector<HTMLMediaElement>(kind.tag)!;
+      setPlaybackState(player, { paused: false });
+      fireEvent.play(player);
+      return { ...view, player };
     }
 
-    it("leaves the player alone on reveal while still re-listing the tree", async () => {
-      // Both halves matter: a re-fetch mints a new object URL and drops the
-      // listener back to zero, while the tree has nothing to protect and must
-      // still catch up on what changed while the project sat cached.
-      const { audio, container } = await renderPlaying();
-      const fetchesBefore = mediaFetchMock.mock.calls.length;
-      const srcBefore = audio.getAttribute("src");
+    for (const kind of KINDS) {
+      it(`leaves a playing ${kind.tag} alone on reveal while still re-listing the tree`, async () => {
+        // Both halves matter: a re-fetch mints a new object URL and drops the
+        // listener back to zero, while the tree has nothing to protect and must
+        // still catch up on what changed while the project sat cached.
+        const { player, container } = await renderPlaying(kind);
+        const fetchesBefore = mediaFetchMock.mock.calls.length;
+        const srcBefore = player.getAttribute("src");
 
-      await emit("revealed");
+        await emit("revealed");
 
-      expect(mediaFetchMock.mock.calls.length).toBe(fetchesBefore);
-      // The same element, still pointed at the same blob — a src comparison
-      // alone would go green on the empty gap while a replacement loads.
-      expect(container.querySelector("audio")).toBe(audio);
-      expect(audio.getAttribute("src")).toBe(srcBefore);
-      expect(treeState.refresh).toHaveBeenCalledTimes(1);
-    });
-
-    it("re-fetches on the next reveal once the track ends", async () => {
-      // The suppression is scoped to playback, not permanent — and the spec
-      // leaves `paused` false at the end, so `ended` is what says it stopped.
-      const { audio } = await renderPlaying();
-      const fetchesBefore = mediaFetchMock.mock.calls.length;
-
-      await emit("revealed");
-      expect(mediaFetchMock.mock.calls.length).toBe(fetchesBefore);
-
-      setPlaybackState(audio, { paused: false, ended: true });
-      fireEvent.ended(audio);
-      await emit("revealed");
-
-      await waitFor(() => expect(mediaFetchMock.mock.calls.length).toBe(fetchesBefore + 1));
-    });
-
-    it("still re-fetches the player when Refresh is pressed", async () => {
-      // A gesture outranks playback: someone pressing Refresh mid-track is
-      // asking for the rewritten bytes and accepts losing their place.
-      await renderPlaying();
-      const fetchesBefore = mediaFetchMock.mock.calls.length;
-
-      act(() => {
-        fireEvent.click(screen.getByTestId("file-browser-refresh"));
+        expect(mediaFetchMock.mock.calls.length).toBe(fetchesBefore);
+        // The same element, still pointed at the same blob — a src comparison
+        // alone would go green on the empty gap while a replacement loads.
+        expect(container.querySelector(kind.tag)).toBe(player);
+        expect(player.getAttribute("src")).toBe(srcBefore);
+        expect(treeState.refresh).toHaveBeenCalledTimes(1);
       });
 
-      await waitFor(() => expect(mediaFetchMock.mock.calls.length).toBe(fetchesBefore + 1));
-    });
+      it(`re-fetches the ${kind.tag} on the next reveal once it ends`, async () => {
+        // The suppression is scoped to playback, not permanent — and the spec
+        // leaves `paused` false at the end, so `ended` is what says it stopped.
+        const { player } = await renderPlaying(kind);
+        const fetchesBefore = mediaFetchMock.mock.calls.length;
 
-    it("does not carry playing state to the next selected media file", async () => {
-      // The stale-flag failure this would otherwise invite: a track left
-      // playing, a different file selected, and every later reveal silently
-      // refusing to refresh a player that was never running.
-      const { rerender, container } = await renderPlaying();
+        await emit("revealed");
+        expect(mediaFetchMock.mock.calls.length).toBe(fetchesBefore);
 
-      mockPanel.browserSelectedPath = OTHER_AUDIO_ROW.path;
-      await act(async () => {
-        rerender(paneElement());
+        setPlaybackState(player, { paused: false, ended: true });
+        fireEvent.ended(player);
+        await emit("revealed");
+
+        await waitFor(() => expect(mediaFetchMock.mock.calls.length).toBe(fetchesBefore + 1));
       });
-      await waitFor(() => expect(container.querySelector("audio")).not.toBeNull());
-      const fetchesBefore = mediaFetchMock.mock.calls.length;
 
-      await emit("revealed");
+      it(`still re-fetches the ${kind.tag} when Refresh is pressed`, async () => {
+        // A gesture outranks playback: someone pressing Refresh mid-track is
+        // asking for the rewritten bytes and accepts losing their place.
+        await renderPlaying(kind);
+        const fetchesBefore = mediaFetchMock.mock.calls.length;
 
-      await waitFor(() => expect(mediaFetchMock.mock.calls.length).toBe(fetchesBefore + 1));
-    });
+        act(() => {
+          fireEvent.click(screen.getByTestId("file-browser-refresh"));
+        });
+
+        await waitFor(() => expect(mediaFetchMock.mock.calls.length).toBe(fetchesBefore + 1));
+      });
+
+      it(`does not carry ${kind.tag} playing state to the next selected file`, async () => {
+        // The stale-flag failure this would otherwise invite: a track left
+        // playing, a different file selected, and every later reveal silently
+        // refusing to refresh a player that was never running.
+        const { rerender, container } = await renderPlaying(kind);
+
+        mockPanel.browserSelectedPath = kind.next;
+        await act(async () => {
+          rerender(paneElement());
+        });
+        await waitFor(() => expect(container.querySelector(kind.tag)).not.toBeNull());
+        const fetchesBefore = mediaFetchMock.mock.calls.length;
+
+        await emit("revealed");
+
+        await waitFor(() => expect(mediaFetchMock.mock.calls.length).toBe(fetchesBefore + 1));
+      });
+
+      it(`does not carry ${kind.tag} playing state to a text file`, async () => {
+        // The guarantee the nonce split exists to protect: whatever the media
+        // half is doing, a reveal must never leave the open file stale. If the
+        // flag outlived the player, this read would never happen.
+        const { rerender } = await renderPlaying(kind);
+
+        mockPanel.browserSelectedPath = "src/app.ts";
+        await act(async () => {
+          rerender(paneElement());
+        });
+        await waitFor(() => expect(readMock).toHaveBeenCalledTimes(1));
+
+        await emit("revealed");
+
+        await waitFor(() => expect(readMock).toHaveBeenCalledTimes(2));
+      });
+    }
   });
 
   describe("dock parking", () => {

--- a/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
@@ -194,6 +194,13 @@ interface ViewerOpts {
   onToggleSidebar?: () => void;
   revision?: string;
   surfaceRefreshNonce?: number;
+  /**
+   * Defaulted independently of `surfaceRefreshNonce`, never derived from it: the
+   * two are split precisely so a reveal can move one without the other (#12165),
+   * and a test that could not tell them apart would go green on the merge.
+   */
+  mediaReloadNonce?: number;
+  onMediaPlayingChange?: (playing: boolean) => void;
   onRefresh?: () => void;
   isRefreshing?: boolean;
   /**
@@ -246,6 +253,8 @@ function viewerJsx(filePath: string | null, opts: ViewerOpts = {}) {
         relativePath={filePath ? fileName : null}
         revision={opts.revision ?? "r1"}
         surfaceRefreshNonce={opts.surfaceRefreshNonce ?? 0}
+        mediaReloadNonce={opts.mediaReloadNonce ?? 0}
+        onMediaPlayingChange={opts.onMediaPlayingChange ?? vi.fn()}
         onRefresh={opts.onRefresh ?? vi.fn()}
         isRefreshing={opts.isRefreshing ?? false}
         sidebarCollapsed={opts.sidebarCollapsed ?? false}
@@ -529,6 +538,7 @@ describe("FileBrowserViewer video preview (#11382)", () => {
     const { container, rerender } = renderViewer("/repo/media/demo.webm", {
       revision: "r1",
       surfaceRefreshNonce: 0,
+      mediaReloadNonce: 0,
     });
     await waitFor(() => expect(container.querySelector("video")).not.toBeNull());
     const firstNode = container.querySelector("video");
@@ -536,7 +546,13 @@ describe("FileBrowserViewer video preview (#11382)", () => {
     expect(videoFetchMock).toHaveBeenCalledTimes(1);
 
     // A worktree write elsewhere: the player must be left completely alone.
-    rerender(viewerJsx("/repo/media/demo.webm", { revision: "r2", surfaceRefreshNonce: 0 }));
+    rerender(
+      viewerJsx("/repo/media/demo.webm", {
+        revision: "r2",
+        surfaceRefreshNonce: 0,
+        mediaReloadNonce: 0,
+      })
+    );
     await act(async () => {});
     expect(container.querySelector("video")).toBe(firstNode);
     expect(container.querySelector("video")?.getAttribute("src")).toBe(firstSrc);
@@ -544,7 +560,13 @@ describe("FileBrowserViewer video preview (#11382)", () => {
 
     // Refresh pressed: exactly one more request, aimed at a different URL —
     // proof the nonce reached it, without pinning the leaf's `v=` spelling.
-    rerender(viewerJsx("/repo/media/demo.webm", { revision: "r2", surfaceRefreshNonce: 1 }));
+    rerender(
+      viewerJsx("/repo/media/demo.webm", {
+        revision: "r2",
+        surfaceRefreshNonce: 1,
+        mediaReloadNonce: 1,
+      })
+    );
     await waitFor(() => expect(videoFetchMock).toHaveBeenCalledTimes(2));
     expect(String(videoFetchMock.mock.calls[1]?.[0])).not.toBe(
       String(videoFetchMock.mock.calls[0]?.[0])
@@ -628,13 +650,14 @@ describe("FileBrowserViewer audio preview (#11425)", () => {
 
     const { container, rerender } = renderViewer("/repo/media/track.mp3", {
       surfaceRefreshNonce: 0,
+      mediaReloadNonce: 0,
     });
     await waitFor(() => expect(container.querySelector("audio")).not.toBeNull());
     const firstNode = container.querySelector("audio");
     const firstSrc = firstNode?.getAttribute("src");
     expect(audioFetchMock).toHaveBeenCalledTimes(1);
 
-    rerender(viewerJsx("/repo/media/track.mp3", { surfaceRefreshNonce: 1 }));
+    rerender(viewerJsx("/repo/media/track.mp3", { surfaceRefreshNonce: 1, mediaReloadNonce: 1 }));
     await waitFor(() => expect(audioFetchMock).toHaveBeenCalledTimes(2));
 
     // A different URL, so the nonce genuinely reached the request rather than
@@ -654,6 +677,38 @@ describe("FileBrowserViewer audio preview (#11425)", () => {
     });
   });
 
+  it("rides the media nonce, not the surface one a paused-for-playback reveal still moves (#12165)", async () => {
+    // The whole point of the split: a reveal that finds a player running keeps
+    // the media nonce still while `revision` and `surfaceRefreshNonce` move on
+    // for the text re-read and the PDF frame. Wire media back to
+    // `surfaceRefreshNonce` and this goes red.
+    let objectUrlSequence = 0;
+    URL.createObjectURL = vi.fn(() => `blob:app://daintree/audio-split-${objectUrlSequence++}`);
+
+    const { container, rerender } = renderViewer("/repo/media/track.mp3", {
+      revision: "0:0",
+      surfaceRefreshNonce: 0,
+      mediaReloadNonce: 0,
+    });
+    await waitFor(() => expect(container.querySelector("audio")).not.toBeNull());
+    const firstNode = container.querySelector("audio");
+    const firstSrc = firstNode?.getAttribute("src");
+    expect(audioFetchMock).toHaveBeenCalledTimes(1);
+
+    rerender(
+      viewerJsx("/repo/media/track.mp3", {
+        revision: "0:1",
+        surfaceRefreshNonce: 1,
+        mediaReloadNonce: 0,
+      })
+    );
+    await act(async () => {});
+
+    expect(audioFetchMock).toHaveBeenCalledTimes(1);
+    expect(container.querySelector("audio")).toBe(firstNode);
+    expect(container.querySelector("audio")?.getAttribute("src")).toBe(firstSrc);
+  });
+
   it("recovers a failed track on refresh, which takes both halves of the signal", async () => {
     // A failed fetch unmounts the preview entirely (`status: "error"`), so
     // `reloadKey` alone can't bring it back — nothing is mounted to receive it.
@@ -667,12 +722,19 @@ describe("FileBrowserViewer audio preview (#11425)", () => {
     const { container, rerender } = renderViewer("/repo/media/track.mp3", {
       revision: "0:0",
       surfaceRefreshNonce: 0,
+      mediaReloadNonce: 0,
     });
     await screen.findByText("This audio file couldn't be played");
     expect(container.querySelector("audio")).toBeNull();
 
-    // Exactly what the pane emits for one Refresh press: both values move.
-    rerender(viewerJsx("/repo/media/track.mp3", { revision: "0:1", surfaceRefreshNonce: 1 }));
+    // Exactly what the pane emits for one Refresh press: all three values move.
+    rerender(
+      viewerJsx("/repo/media/track.mp3", {
+        revision: "0:1",
+        surfaceRefreshNonce: 1,
+        mediaReloadNonce: 1,
+      })
+    );
 
     await waitFor(() => expect(container.querySelector("audio")).not.toBeNull());
     expect(screen.queryByText("This audio file couldn't be played")).toBeNull();

--- a/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
@@ -716,6 +716,12 @@ describe("FileBrowserViewer audio preview (#11425)", () => {
 // either one back at `surfaceRefreshNonce` recreates the bug for that kind.
 describe("FileBrowserViewer media rides its own nonce (#12165)", () => {
   const mediaFetchMock = vi.fn();
+  // Restored one global at a time rather than through `vi.unstubAllGlobals()`:
+  // vitest.setup.ts installs ResizeObserver and rAF once at module load, so a
+  // blanket unstub here would strip them from every test that runs after this
+  // block. `unstubAllGlobals` would not restore the two URL methods anyway —
+  // they are assigned directly, not stubbed.
+  const realFetch = globalThis.fetch;
   const realCreateObjectURL = URL.createObjectURL;
   const realRevokeObjectURL = URL.revokeObjectURL;
   beforeEach(() => {
@@ -732,9 +738,8 @@ describe("FileBrowserViewer media rides its own nonce (#12165)", () => {
     URL.revokeObjectURL = vi.fn();
   });
   afterEach(() => {
-    vi.unstubAllGlobals();
     mediaFetchMock.mockReset();
-    // `vi.unstubAllGlobals` does not restore a directly assigned method.
+    vi.stubGlobal("fetch", realFetch);
     URL.createObjectURL = realCreateObjectURL;
     URL.revokeObjectURL = realRevokeObjectURL;
   });

--- a/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
@@ -677,38 +677,6 @@ describe("FileBrowserViewer audio preview (#11425)", () => {
     });
   });
 
-  it("rides the media nonce, not the surface one a paused-for-playback reveal still moves (#12165)", async () => {
-    // The whole point of the split: a reveal that finds a player running keeps
-    // the media nonce still while `revision` and `surfaceRefreshNonce` move on
-    // for the text re-read and the PDF frame. Wire media back to
-    // `surfaceRefreshNonce` and this goes red.
-    let objectUrlSequence = 0;
-    URL.createObjectURL = vi.fn(() => `blob:app://daintree/audio-split-${objectUrlSequence++}`);
-
-    const { container, rerender } = renderViewer("/repo/media/track.mp3", {
-      revision: "0:0",
-      surfaceRefreshNonce: 0,
-      mediaReloadNonce: 0,
-    });
-    await waitFor(() => expect(container.querySelector("audio")).not.toBeNull());
-    const firstNode = container.querySelector("audio");
-    const firstSrc = firstNode?.getAttribute("src");
-    expect(audioFetchMock).toHaveBeenCalledTimes(1);
-
-    rerender(
-      viewerJsx("/repo/media/track.mp3", {
-        revision: "0:1",
-        surfaceRefreshNonce: 1,
-        mediaReloadNonce: 0,
-      })
-    );
-    await act(async () => {});
-
-    expect(audioFetchMock).toHaveBeenCalledTimes(1);
-    expect(container.querySelector("audio")).toBe(firstNode);
-    expect(container.querySelector("audio")?.getAttribute("src")).toBe(firstSrc);
-  });
-
   it("recovers a failed track on refresh, which takes both halves of the signal", async () => {
     // A failed fetch unmounts the preview entirely (`status: "error"`), so
     // `reloadKey` alone can't bring it back — nothing is mounted to receive it.
@@ -740,6 +708,90 @@ describe("FileBrowserViewer audio preview (#11425)", () => {
     expect(screen.queryByText("This audio file couldn't be played")).toBeNull();
     expect(audioFetchMock).toHaveBeenCalledTimes(2);
   });
+});
+
+// #12165: a reveal that finds a player running holds the media nonce still
+// while `revision` and `surfaceRefreshNonce` move on for the text re-read and
+// the PDF frame. Both branches, because they are wired separately — pointing
+// either one back at `surfaceRefreshNonce` recreates the bug for that kind.
+describe("FileBrowserViewer media rides its own nonce (#12165)", () => {
+  const mediaFetchMock = vi.fn();
+  const realCreateObjectURL = URL.createObjectURL;
+  const realRevokeObjectURL = URL.revokeObjectURL;
+  beforeEach(() => {
+    let objectUrlSequence = 0;
+    mediaFetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      blob: () => Promise.resolve(new Blob(["x"])),
+    });
+    vi.stubGlobal("fetch", mediaFetchMock);
+    // Unique per call: a constant would let a silent remount read as continuity.
+    URL.createObjectURL = vi.fn(() => `blob:app://daintree/split-${objectUrlSequence++}`);
+    URL.revokeObjectURL = vi.fn();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    mediaFetchMock.mockReset();
+    // `vi.unstubAllGlobals` does not restore a directly assigned method.
+    URL.createObjectURL = realCreateObjectURL;
+    URL.revokeObjectURL = realRevokeObjectURL;
+  });
+
+  for (const kind of [
+    { tag: "video" as const, path: "/repo/media/demo.webm" },
+    { tag: "audio" as const, path: "/repo/media/track.mp3" },
+  ]) {
+    it(`keeps the ${kind.tag} mounted when only the surface nonce advances`, async () => {
+      const { container, rerender } = renderViewer(kind.path, {
+        revision: "0:0",
+        surfaceRefreshNonce: 0,
+        mediaReloadNonce: 0,
+      });
+      await waitFor(() => expect(container.querySelector(kind.tag)).not.toBeNull());
+      const firstNode = container.querySelector(kind.tag);
+      const firstSrc = firstNode?.getAttribute("src");
+      expect(mediaFetchMock).toHaveBeenCalledTimes(1);
+
+      rerender(
+        viewerJsx(kind.path, { revision: "0:1", surfaceRefreshNonce: 1, mediaReloadNonce: 0 })
+      );
+      await act(async () => {});
+
+      expect(mediaFetchMock).toHaveBeenCalledTimes(1);
+      expect(container.querySelector(kind.tag)).toBe(firstNode);
+      expect(container.querySelector(kind.tag)?.getAttribute("src")).toBe(firstSrc);
+    });
+
+    it(`re-fetches the ${kind.tag} when the media nonce alone advances`, async () => {
+      // The other direction, so "keeps it mounted" above can't be satisfied by a
+      // branch that simply ignores both nonces.
+      const { container, rerender } = renderViewer(kind.path, {
+        revision: "0:0",
+        surfaceRefreshNonce: 0,
+        mediaReloadNonce: 0,
+      });
+      await waitFor(() => expect(container.querySelector(kind.tag)).not.toBeNull());
+      const firstNode = container.querySelector(kind.tag);
+      const firstSrc = firstNode?.getAttribute("src");
+      expect(mediaFetchMock).toHaveBeenCalledTimes(1);
+
+      rerender(
+        viewerJsx(kind.path, { revision: "0:0", surfaceRefreshNonce: 0, mediaReloadNonce: 1 })
+      );
+
+      await waitFor(() => expect(mediaFetchMock).toHaveBeenCalledTimes(2));
+      // Both halves in one waitFor: the hook nulls its object URL while
+      // refetching, so a bare src comparison would pass on the empty gap.
+      await waitFor(() => {
+        const refreshed = container.querySelector(kind.tag);
+        expect(refreshed).not.toBeNull();
+        expect(refreshed?.getAttribute("src")).not.toBe(firstSrc);
+        expect(refreshed).not.toBe(firstNode);
+      });
+    });
+  }
 });
 
 describe("FileBrowserViewer PDF preview (#11427)", () => {

--- a/src/panels/file/FilePane.tsx
+++ b/src/panels/file/FilePane.tsx
@@ -500,6 +500,15 @@ export function FilePane({
   // every successful load, not just entry-file changes, so relative assets stay
   // fresh too. Never a `loadFile` dependency — that would re-trigger the load.
   const [reloadNonce, setReloadNonce] = useState(0);
+  // Whether the media preview on screen is mid-playback. A ref, not state: the
+  // only reader is `loadFile`, which runs as an event and would rather not be
+  // re-created (and re-run its effects) every time someone presses play. The
+  // preview takes its own `true` back on unmount or a source change, so a set
+  // flag always names the player currently on screen (#12165).
+  const mediaPlayingRef = useRef(false);
+  const handleMediaPlayingChange = useCallback((playing: boolean) => {
+    mediaPlayingRef.current = playing;
+  }, []);
   // Which surface a toolbar Refresh press is currently spinning for (or null).
   // The mode is captured at click so a mode switch mid-refresh doesn't settle
   // the spin against the wrong signal. Drives the shared SpinningIcon.
@@ -549,6 +558,12 @@ export function FilePane({
       // moves the reload key that a background tick deliberately leaves alone.
       const silent = intent !== "explicit";
       const forceSurfaceReload = intent !== "ambient";
+      // Reveal is the one intent that can arrive while someone is listening: it
+      // is not a request for fresh bytes, it is this pane catching up on a
+      // project it was away from. A track mid-play is worth more than a
+      // re-fetch, so it keeps its key and the next Refresh pulls the rewrite
+      // instead (#12165). Explicit gestures still outrank playback.
+      const keepMediaPlaying = intent === "revealed" && mediaPlayingRef.current;
       if (!filePath) {
         requestRef.current++;
         setContent(null);
@@ -586,8 +601,9 @@ export function FilePane({
         setSanitizedSvg(null);
         // Only a foreground load (open, toolbar Refresh, returning to this
         // project) re-requests the media — an ambient background pass must not
-        // remount the player and reset playback while someone is watching.
-        if (forceSurfaceReload) setReloadNonce((nonce) => nonce + 1);
+        // remount the player and reset playback while someone is watching, and
+        // neither may a reveal that finds the player already running.
+        if (forceSurfaceReload && !keepMediaPlaying) setReloadNonce((nonce) => nonce + 1);
         setLoadState("video");
         setErrorCode(null);
         setErrorMessage(null);
@@ -601,8 +617,9 @@ export function FilePane({
         setSanitizedSvg(null);
         // Only a foreground load (open, toolbar Refresh, returning to this
         // project) re-requests the media — an ambient background pass must not
-        // remount the player and reset playback while someone is listening.
-        if (forceSurfaceReload) setReloadNonce((nonce) => nonce + 1);
+        // remount the player and reset playback while someone is listening, and
+        // neither may a reveal that finds the player already running.
+        if (forceSurfaceReload && !keepMediaPlaying) setReloadNonce((nonce) => nonce + 1);
         setLoadState("audio");
         setErrorCode(null);
         setErrorMessage(null);
@@ -1287,6 +1304,7 @@ export function FilePane({
             rootPath={effectiveRootPath}
             label={fileName ?? filePath}
             reloadKey={reloadNonce}
+            onPlayingChange={handleMediaPlayingChange}
             onError={(error) => {
               // An allowlisted container can still hold a codec Chromium lacks;
               // name that instead of implying the file is missing.
@@ -1304,6 +1322,7 @@ export function FilePane({
             rootPath={effectiveRootPath}
             label={fileName ?? filePath}
             reloadKey={reloadNonce}
+            onPlayingChange={handleMediaPlayingChange}
             onError={(error) => {
               // An allowlisted extension can still hold a codec Chromium lacks;
               // name that instead of implying the file is missing.

--- a/src/panels/file/FilePane.tsx
+++ b/src/panels/file/FilePane.tsx
@@ -137,7 +137,9 @@ type LoadState =
 // otherwise use to reset playback. `revealed` is returning to this project:
 // silent like ambient, because nobody asked for a skeleton, but forcing the
 // reload key like explicit, because everything that happened while the view sat
-// cached is precisely what this pane cannot otherwise see.
+// cached is precisely what this pane cannot otherwise see — with one exception,
+// a player already running, whose position outranks bytes nobody asked for
+// (#12165).
 type FileLoadIntent = "explicit" | "ambient" | "revealed";
 
 // Which surface a toolbar action aims the current file at. `reveal` is always

--- a/src/panels/file/__tests__/FilePane.test.tsx
+++ b/src/panels/file/__tests__/FilePane.test.tsx
@@ -2878,7 +2878,10 @@ describe("FilePane re-reads when the project view is revealed (#11588)", () => {
         blob: () => Promise.resolve(new Blob(["x"])),
       });
       vi.stubGlobal("fetch", mediaFetchMock);
-      URL.createObjectURL = vi.fn(() => "blob:app://daintree/media-preview");
+      // Unique per call: a constant would let a remount pass as continuity, and
+      // hide a stale response arriving after a newer one.
+      let objectUrlSequence = 0;
+      URL.createObjectURL = vi.fn(() => `blob:app://daintree/media-${objectUrlSequence++}`);
       URL.revokeObjectURL = vi.fn();
     });
     afterEach(() => {
@@ -2931,10 +2934,15 @@ describe("FilePane re-reads when the project view is revealed (#11588)", () => {
       setPlaybackState(video, { paused: false });
       fireEvent.play(video);
       const fetchesBefore = mediaFetchMock.mock.calls.length;
+      const srcBefore = video.getAttribute("src");
 
       await emit("revealed");
 
       expect(mediaFetchMock.mock.calls.length).toBe(fetchesBefore);
+      // The same element on the same blob. Fetch count alone would stay green
+      // for a regression that remounted the player without re-requesting it.
+      expect(container.querySelector("video")).toBe(video);
+      expect(video.getAttribute("src")).toBe(srcBefore);
     });
 
     it("leaves playing audio alone on reveal, then re-fetches once it ends (#12165)", async () => {
@@ -2946,9 +2954,12 @@ describe("FilePane re-reads when the project view is revealed (#11588)", () => {
       setPlaybackState(audio, { paused: false });
       fireEvent.play(audio);
       const fetchesBefore = mediaFetchMock.mock.calls.length;
+      const srcBefore = audio.getAttribute("src");
 
       await emit("revealed");
       expect(mediaFetchMock.mock.calls.length).toBe(fetchesBefore);
+      expect(container.querySelector("audio")).toBe(audio);
+      expect(audio.getAttribute("src")).toBe(srcBefore);
 
       // The spec leaves `paused` false at the end of a track, so `ended` is the
       // only thing that says this one stopped.

--- a/src/panels/file/__tests__/FilePane.test.tsx
+++ b/src/panels/file/__tests__/FilePane.test.tsx
@@ -2910,6 +2910,99 @@ describe("FilePane re-reads when the project view is revealed (#11588)", () => {
       await waitFor(() => expect(mediaFetchMock.mock.calls.length).toBe(fetchesBefore + 1));
     });
 
+    // jsdom neither decodes media nor tracks playback: `fireEvent.play` fires
+    // the event but leaves `paused` true, so the preview's own paused/ended
+    // read would see the opposite of what the test just said happened.
+    function setPlaybackState(
+      element: HTMLMediaElement,
+      state: { paused: boolean; ended?: boolean }
+    ): void {
+      Object.defineProperty(element, "paused", { configurable: true, value: state.paused });
+      Object.defineProperty(element, "ended", { configurable: true, value: state.ended ?? false });
+    }
+
+    it("leaves a playing video alone on reveal (#12165)", async () => {
+      // Coming back to a project is this pane catching up, not a request for
+      // fresh bytes — and a re-fetch mints a new object URL, which remounts the
+      // player and drops the viewer back to zero.
+      const { container } = await renderPane({ filePath: "/repo/media/demo.mp4" });
+      await waitFor(() => expect(container.querySelector("video")).not.toBeNull());
+      const video = container.querySelector("video")!;
+      setPlaybackState(video, { paused: false });
+      fireEvent.play(video);
+      const fetchesBefore = mediaFetchMock.mock.calls.length;
+
+      await emit("revealed");
+
+      expect(mediaFetchMock.mock.calls.length).toBe(fetchesBefore);
+    });
+
+    it("leaves playing audio alone on reveal, then re-fetches once it ends (#12165)", async () => {
+      // Its own nonce condition, separate from video's — and the second half
+      // proves the suppression is scoped to playback rather than permanent.
+      const { container } = await renderPane({ filePath: "/repo/media/track.mp3" });
+      await waitFor(() => expect(container.querySelector("audio")).not.toBeNull());
+      const audio = container.querySelector("audio")!;
+      setPlaybackState(audio, { paused: false });
+      fireEvent.play(audio);
+      const fetchesBefore = mediaFetchMock.mock.calls.length;
+
+      await emit("revealed");
+      expect(mediaFetchMock.mock.calls.length).toBe(fetchesBefore);
+
+      // The spec leaves `paused` false at the end of a track, so `ended` is the
+      // only thing that says this one stopped.
+      setPlaybackState(audio, { paused: false, ended: true });
+      fireEvent.ended(audio);
+      await emit("revealed");
+
+      await waitFor(() => expect(mediaFetchMock.mock.calls.length).toBe(fetchesBefore + 1));
+    });
+
+    it("still re-fetches playing media when Refresh is pressed (#12165)", async () => {
+      // A gesture outranks playback: someone pressing Refresh mid-track is
+      // asking for the rewritten bytes and accepts losing their place.
+      const { container } = await renderPane({ filePath: "/repo/media/track.mp3" });
+      await waitFor(() => expect(container.querySelector("audio")).not.toBeNull());
+      const audio = container.querySelector("audio")!;
+      setPlaybackState(audio, { paused: false });
+      fireEvent.play(audio);
+      const fetchesBefore = mediaFetchMock.mock.calls.length;
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+      });
+
+      await waitFor(() => expect(mediaFetchMock.mock.calls.length).toBe(fetchesBefore + 1));
+    });
+
+    it("does not carry playing state to the next media file (#12165)", async () => {
+      // The stale-flag failure this would otherwise invite: a track left
+      // playing, then a different file opened, and every later reveal silently
+      // refusing to refresh a player that was never running.
+      const { container, rerender } = await renderPane({ filePath: "/repo/media/track.mp3" });
+      await waitFor(() => expect(container.querySelector("audio")).not.toBeNull());
+      const audio = container.querySelector("audio")!;
+      setPlaybackState(audio, { paused: false });
+      fireEvent.play(audio);
+
+      panelsById["file-1"] = {
+        id: "file-1",
+        kind: "file",
+        filePath: "/repo/media/other.mp3",
+        worktreeId: WORKTREE_ID,
+      };
+      await act(async () => {
+        rerender(paneElement());
+      });
+      await waitFor(() => expect(container.querySelector("audio")).not.toBeNull());
+      const fetchesBefore = mediaFetchMock.mock.calls.length;
+
+      await emit("revealed");
+
+      await waitFor(() => expect(mediaFetchMock.mock.calls.length).toBe(fetchesBefore + 1));
+    });
+
     it("re-navigates the PDF frame on reveal", async () => {
       const { container } = await renderPane({ filePath: "/repo/docs/spec.pdf" });
       await waitFor(() => expect(container.querySelector("iframe")).not.toBeNull());


### PR DESCRIPTION
## Summary

- Playing an audio or video file in the file panel or the file-browser preview, then switching to another project view and back, reset playback to zero.
- Returning to a project bumps a reload nonce that both surfaces hand their media previews as `reloadKey`. `useMediaBlobUrl` keys its fetch on that value, so it re-requested the file, minted a new object URL, and the `<audio>`/`<video>` element (keyed on the object URL) remounted, losing the listener's place.
- The reveal refresh itself is intentional, existing behavior from #11588: it's the only moment either pane can learn what changed while the project sat cached in the background. What it lacked was any notion that someone might currently be listening.

Resolves #12165

## Fix

1. `FileAudioPreview` and `FileVideoPreview` each gain an optional `onPlayingChange` callback prop, computed as not-paused and not-ended, updated on the `play`, `pause`, and `ended` events, and retracted on a media error. `paused` alone isn't enough because a buffering stall looks like a stop; `ended` alone isn't enough because a finished track still reports `paused` as false per spec. The report is retracted by an effect cleanup keyed on the same identity the fetch uses, so a freshly mounted element, which starts paused and never fires its own `pause` event, can never leave a stale "still playing" flag for its owner.
2. `FilePane` skips its media reload-nonce bump specifically when a revealed load finds the player currently running. Explicit user actions (opening a file, pressing the toolbar Refresh button) and the ambient background-change tick are untouched and still bump the nonce as before.
3. `FileBrowserPane` splits a new `mediaReloadNonce` out from the existing `surfaceRefreshNonce` rather than gating the shared nonce. The surface nonce needs to keep moving on every reveal regardless of playback, since it drives the text file re-read, the PDF frame, and the reclassification logic that revives a previously failed preview. Only the media-specific half of that state holds still while playing. A manual Refresh press bumps both nonces regardless of playback state, since pressing Refresh mid-track is a deliberate request for the freshest bytes.

Deliberately untouched: `useMediaBlobUrl` itself (only the `reloadKey` value passed into it changes, not its own logic), and `DiffPane`, which has no reveal path at all since its nonce only moves on an explicit Refresh press.

**Rejected alternative:** capturing and restoring `currentTime` across the remount instead of preventing the remount. This seeks before `loadedmetadata` fires (InvalidStateError), stutters on demuxer reinit, and the resumed `play()` can be blocked by autoplay policy. Not minting a new object URL in the first place sidesteps all three.

## Changes

- `FileAudioPreview.tsx` and `FileVideoPreview.tsx` gain the `onPlayingChange` prop.
- `FilePane.tsx` skips the reload-nonce bump on a revealed load when media is playing.
- `FileBrowserPane.tsx` and `FileBrowserViewer.tsx` split `mediaReloadNonce` from `surfaceRefreshNonce`.

## Testing

427 targeted tests pass. New coverage is parameterized over both audio and video, since they're wired through separate code branches, covering:

- Revealing the pane while media is playing leaves the same DOM node on the same blob URL in place.
- The next reveal after playback has ended does trigger a re-fetch.
- Pressing Refresh re-fetches even mid-playback.
- The playing state doesn't leak over to the next media file opened, or to a text file opened afterward.
- The viewer only re-fetches on a `mediaReloadNonce` change, ignoring a `surfaceRefreshNonce` or `revision` change alone.

Leaf-level unit tests pin down the play, pause, ended, and error event reporting, confirm the report is retracted on unmount and on source change, and confirm the behavior when the callback prop is simply omitted, which is the path `DiffPane` relies on.

Typecheck is clean. Prettier and eslint are clean on the changed files with no new warnings.

**Known limitation:** jsdom doesn't decode media, so no unit test can prove real playback continuity across a reveal. The suites prove the element, its blob, and the underlying request are all left untouched. A manual play-then-switch-project check in the running app is the real end-to-end confirmation.
