### PR TITLE
perf(workspace-host): reduce request response payloads

### DIFF
--- a/electron/workspace-host/CopytreeWorkerClient.ts
+++ b/electron/workspace-host/CopytreeWorkerClient.ts
@@ -380,10 +380,14 @@ export class CopytreeWorkerClient {
       memory: null,
       eligibility: { trim: false, dispose: false, restart: false },
       state: this.workerFailed ? "fallback-pinned" : this.worker ? "running" : "not-spawned",
-      detail: {
-        lastCompletedAt: this.lastCompletedAt,
-        workerGeneration: this.workerGeneration,
-      },
+      ...(this.workerGeneration === 0 && this.lastCompletedAt === null
+        ? {}
+        : {
+            detail: {
+              ...(this.lastCompletedAt === null ? {} : { lastCompletedAt: this.lastCompletedAt }),
+              workerGeneration: this.workerGeneration,
+            },
+          }),
     };
   }
 }

--- a/electron/workspace-host/PRIntegrationService.ts
+++ b/electron/workspace-host/PRIntegrationService.ts
@@ -205,10 +205,9 @@ export class PRIntegrationService {
       isRunning: status.isPolling,
       candidateCount: status.candidateCount,
       resolvedPRCount: status.resolvedCount,
-      lastCheckTime: undefined,
       // Use the dedicated breaker flag, NOT `!isEnabled`: a rate-limit pause
       // also disables polling but must not show the "detection paused" badge.
-      circuitBreakerTripped: status.detectionStateTripped,
+      ...(status.detectionStateTripped ? { circuitBreakerTripped: true } : {}),
     };
   }
 

--- a/electron/workspace-host/__tests__/CopytreeWorkerClient.test.ts
+++ b/electron/workspace-host/__tests__/CopytreeWorkerClient.test.ts
@@ -437,6 +437,7 @@ describe("CopytreeWorkerClient", () => {
       queueDepth: 0,
       eligibility: { trim: false, dispose: false, restart: false },
     });
+    expect(before.detail).toBeUndefined();
 
     const promise = client.generate("/root", {}, undefined, "op-1");
     expect(client.getGovernanceSnapshot()).toMatchObject({ alive: true, state: "running" });
@@ -446,6 +447,10 @@ describe("CopytreeWorkerClient", () => {
       result: { content: "", fileCount: 0 },
     });
     await promise;
+    expect(client.getGovernanceSnapshot().detail).toMatchObject({
+      lastCompletedAt: expect.any(Number),
+      workerGeneration: 1,
+    });
 
     worker.emit("exit", 1);
     expect(client.getGovernanceSnapshot()).toMatchObject({

--- a/electron/workspace-host/__tests__/PRIntegrationService.test.ts
+++ b/electron/workspace-host/__tests__/PRIntegrationService.test.ts
@@ -201,8 +201,6 @@ describe("PRIntegrationService", () => {
         isRunning: true,
         candidateCount: 7,
         resolvedPRCount: 3,
-        lastCheckTime: undefined,
-        circuitBreakerTripped: false,
       });
     });
 
@@ -236,7 +234,7 @@ describe("PRIntegrationService", () => {
 
       const status = service.getStatus();
 
-      expect(status.circuitBreakerTripped).toBe(false);
+      expect(status.circuitBreakerTripped).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
## Summary

Reduce the structured-clone payload emitted by the workspace host without changing required protocol fields or lifecycle behavior:

- omit `lastCheckTime` when it has no value and emit `circuitBreakerTripped` only for the exceptional `true` state;
- omit copytree governance `detail` for a pristine, never-spawned worker, and omit `lastCompletedAt` until a completion exists;
- retain generation/completion detail after worker activity and add focused coverage for both optional-field paths.

This produces a deterministic PERF-044 response payload reduction. PERF-043 was also measured at the final SHA and has a sound **NO CLAIM** result; the patch does not improve host boot time.

## Claim boundary

Both scenarios are **mechanism** benchmarks with public-API fidelity over a real Node child-process channel and partial process topology.

- **PERF-043:** real workspace-host boot-to-ready, health check, and clean dispose. Its duration is a local mechanism reading only.
- **PERF-044:** real workspace host plus `parentPort` dispatcher for correlated requests. The portable claim is serialized response bytes over V8 structured clone.

Neither scenario includes Electron's transport, main-process lifecycle, renderer `MessagePort`, crash backoff/state replay, or the renderer journey. No number below is presented as user-perceived latency. Hosted-runner duration fields and the local PERF-044 mechanism duration are excluded from the claim.

## Final results

### PERF-043 — workspace-host boot p50

#### `studio-04` — macOS 26.4.1 / Apple M1 Max

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| boot p50 | 271.014 ms | 273.635 ms | +2.621 ms / 1.0% slower |
| `bootReadyMisses` | 0 | 0 | ok |
| `healthCheckMisses` | 0 | 0 | ok |
| `disposeExitMisses` | 0 | 0 | ok |
| `healthCheckMs` guard | 22.231 ms | 22.173 ms | -0.058 ms / -0.3% |
| `bootMessages` guard | 1 | 1 | 0 / 0.0% |
| `bootBytes` guard | 18 B | 18 B | 0 B / 0.0% |
| `disposeMs` guard | 508.190 ms | 508.754 ms | +0.564 ms / +0.1% |
| `residualHostCount` guard | 0 | 0 | ok |

Machine: `host-02d9f218-darwin-arm64` · smoke · 20 iterations · 1 warmup  
Trees: `2a957ded2c1e7c4fb953934a9022d92aac02b43c` → `0dc38797dc8fcf515894b60b8111b6560de10299` · git 2.55.0 · Electron 42.7.1  
Statistic: median · threshold 5% · champion drift D 0.9% · **NO CLAIM**

These are the median champion/candidate arms from the final six-arm interleave. Candidate arms were 271.649, 273.635, and 274.862 ms versus champion arms 271.014, 270.139, and 272.574 ms. The candidate won 0/3 index pairs; champion drift was 0.9%; worst within-arm CV was 2.8% (10% ceiling); the precommitted improvement threshold was 5%.

```text
Target: p50Ms on PERF-043 · lower is better
Champion drift D: 0.9% (worst of 3, champ2 v champ3) — same code on both sides, so this is the machine
Drift ceiling (--max-drift): 10.0% (default, 2x threshold)
Worst within-arm spread: 2.8% on champ2 · ceiling 10%

  pair 1: 271.014 → 271.649  -0.2%  LOST
  pair 2: 270.139 → 273.635  -1.3%  LOST
  pair 3: 272.574 → 274.862  -0.8%  LOST

  median arm: 271.014 → 273.635  improvement -1.0%
  precommitted threshold (--threshold): 5.0%

  guards (cost metrics — up is worse):
    NOISE   healthCheckMs  22.231 → 22.173  -0.3% better  tolerance 10% (machine-dependent)
    OK      bootMessages  1 → 1  +0.0% better  tolerance 5%
    OK      bootBytes  18 → 18  +0.0% better  tolerance 5%
    NOISE   disposeMs  508.19 → 508.754  +0.1% worse  tolerance 10% (machine-dependent)
    OK      residualHostCount  0 → 0 (champion is zero, so no percentage)

  condition 1  FAIL  candidate won every index-paired arm — 0/3
  condition 2  FAIL  median-to-median improvement -1.0% >= precommitted threshold 5.0%
  condition 3  FAIL  improvement -1.0% > champion drift D 0.9%
  condition 4  PASS  no guard outside its precommitted tolerance — 5 checked

VERDICT: NO CLAIM
```

| Cross-OS leg | Status | Reason |
| --- | --- | --- |
| Linux hosted runner | Not measured | `p50Ms` is a duration; hosted-runner durations are ineligible. |
| Windows hosted runner | Not measured | `p50Ms` is a duration; hosted-runner durations are ineligible. |
| macOS hosted runner | Not measured | `p50Ms` is a duration; the owned local macOS result is the only timing evidence. |

### PERF-044 — serialized response bytes per fixed request workload

#### `studio-04` — local macOS arm64

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| response bytes | 23,710 B | 21,930 B | -1,780 B / -7.5% |
| `responseMisses` | 0 | 0 | ok |
| `responseTypeMisses` | 0 | 0 | ok |
| `requestMessages` guard | 100 | 100 | 0 / 0.0% |
| `responseMessages` guard | 100 | 100 | 0 / 0.0% |
| `requestBytes` guard | 12,250 B | 12,250 B | 0 B / 0.0% |
| `unexpectedResponseMessages` guard | 0 | 0 | ok |
| `duplicateResponseMessages` guard | 0 | 0 | ok |
| `residualHostCount` guard | 0 | 0 | ok |

Machine: `host-02d9f218-darwin-arm64` · smoke · 5 iterations · 1 warmup  
Trees: `2a957ded2c1e7c4fb953934a9022d92aac02b43c` → `0dc38797dc8fcf515894b60b8111b6560de10299` · git 2.55.0 · Electron 42.7.1  
Statistic: deterministic size count · threshold 1% · **CLAIM**

#### GitHub Linux x64

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| response bytes | 23,710 B | 21,930 B | -1,780 B / -7.5% |
| correctness predicates | 0 | 0 | ok |
| request / response messages | 100 / 100 | 100 / 100 | unchanged |
| request bytes | 12,250 B | 12,250 B | unchanged |
| anomaly / duplicate / residual guards | 0 / 0 / 0 | 0 / 0 / 0 | ok |

Machine: `gh-linux-x64-ab-33659769348.1` · smoke · 5 iterations · 1 warmup  
Trees: branch point → final SHA · statistic deterministic size count · threshold 1% · drift D 0.0% · **CLAIM**

#### GitHub Windows x64

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| response bytes | 23,710 B | 21,930 B | -1,780 B / -7.5% |
| correctness predicates | 0 | 0 | ok |
| request / response messages | 100 / 100 | 100 / 100 | unchanged |
| request bytes | 12,250 B | 12,250 B | unchanged |
| anomaly / duplicate / residual guards | 0 / 0 / 0 | 0 / 0 / 0 | ok |

Machine: `gh-windows-x64-ab-33659769348.1` · smoke · 5 iterations · 1 warmup  
Trees: branch point → final SHA · statistic deterministic size count · threshold 1% · drift D 0.0% · **CLAIM**

#### GitHub macOS arm64

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| response bytes | 23,710 B | 21,930 B | -1,780 B / -7.5% |
| correctness predicates | 0 | 0 | ok |
| request / response messages | 100 / 100 | 100 / 100 | unchanged |
| request bytes | 12,250 B | 12,250 B | unchanged |
| anomaly / duplicate / residual guards | 0 / 0 / 0 | 0 / 0 / 0 | ok |

Machine: `gh-macos-arm64-ab-33659769348.1` · smoke · 5 iterations · 1 warmup  
Trees: branch point → final SHA · statistic deterministic size count · threshold 1% · drift D 0.0% · **CLAIM**

Every cross-OS leg reproduced the value on all three champion and all three candidate arms, won 3/3 index pairs, and had 0.0% champion drift. The threshold was 1%. Workflow: [Perf A/B run 33659769348](https://github.com/daintreehq/daintree/actions/runs/33659769348).

## Protocol, predicates, floors, and guards

Exact trees:

- branch-point champion: `2a957ded2c1e7c4fb953934a9022d92aac02b43c`
- final candidate: `0dc38797dc8fcf515894b60b8111b6560de10299`
- apparatus digest: `78ed867d5ac93be9b1fa8aabf0c81b8b9223b0ea2e4881a7fd439baa74cb81db` over 185 files
- Node v22.23.2, Electron 42.7.1, git 2.55.0 locally
- every local and workflow benchmark arm used `--enforce-integrity`

| Scenario | Protocol and floor | Predicates | Guards |
| --- | --- | --- | --- |
| PERF-043 | smoke; 20 measured iterations + 1 warmup per arm; six-arm `champ, cand, cand, champ, champ, cand`; one real boot, health check, and dispose per iteration | `bootReadyMisses=0`, `healthCheckMisses=0`, `disposeExitMisses=0` on all 120 final measured iterations | `healthCheckMs` 22.231→22.173 ms within 10%; `bootMessages` 1→1 within 5%; `bootBytes` 18→18 within 5%; `disposeMs` 508.190→508.754 ms within 10%; `residualHostCount` 0→0 within 5% |
| PERF-044 | smoke; 5 measured iterations + 1 warmup; exact 100-request floor: 20 cycles each of get-all-states, project-switch, get-pr-status, get-monitor, and governance snapshot | `responseMisses=0`, `responseTypeMisses=0` on every arm | `requestMessages` 100→100, `responseMessages` 100→100, `requestBytes` 12,250→12,250, `unexpectedResponseMessages` 0→0, `duplicateResponseMessages` 0→0, `residualHostCount` 0→0; each has 5% tolerance |

The PERF-044 workload and guard vector was identical on every Linux, Windows, hosted macOS, and local macOS arm. Only the response byte size moved.

## Hypotheses and engineering decisions

PERF-043 avenues were exhausted without retaining architecture or correctness costs:

- deferred eager exposed-GC resolution: 274.581→272.678 ms (-0.7%), below threshold; reverted;
- lazy copytree fallback import: rejected before measurement because cancellation during import could be lost;
- repaired early cancellation registration plus lazy fallback import: 274.581→274.082 ms (-0.2%), below threshold; reverted;
- deferring `WorkspaceService`/ready would move required usability work past the claimed boundary; deferring the small project-pulse graph would move cold cost to a user request; removing logging, perf marks, heap protection, or shutdown wiring would trade away safety/observability.

`perf diagnose` was used once only to explain the unchanged champion. Its profile covered the parent runner rather than the forked child and its durations are not benchmark evidence. `perf calibrate` was used only for unchanged-tree noise.

PERF-044 kept four focused optional-field omissions after individual clean confirmation:

- absent `lastCheckTime`: -320 B;
- ordinary false circuit-breaker state: -480 B;
- absent copytree completion timestamp: -360 B;
- pristine copytree detail map: -620 B.

The remaining response fields carry correlation, response discrimination, replay/epoch state, success/null semantics, or required worker lifecycle/memory state. Shortening public names or removing required defaults was rejected as a compatibility and maintainability trade.

## Validation

- `npm run typecheck` — pass
- `npm test` — pass: 2,491 files; 54,961 passed, 7 skipped, 1 todo
- `npm run check` — pass
- focused PR integration tests — pass: 24 tests
- focused copytree worker tests — pass: 25 tests
- delegated final diff audit — pass; focused four-file diff, no apparatus edits, artifacts, secrets, conflicts, or unrelated changes
- E2E — not run; no human named a spec

The first full-suite attempt encountered one unrelated `ProjectPluginWatcher` timing failure after 2,490/2,491 files passed. That file passed 23/23 in isolation, and the complete suite rerun passed as reported above.
