### PR TITLE
perf(workspace-host): shorten topology pickup debounce

### DIFF
--- a/electron/workspace-host/TopologyWatcher.ts
+++ b/electron/workspace-host/TopologyWatcher.ts
@@ -25,7 +25,7 @@ const TOPOLOGY_RECONCILE_TIMEOUT_MS = 60_000;
 // several metadata files within a few milliseconds, so a short window still
 // coalesces one operation into one reconcile while keeping pickup latency low
 // (a reconcile is one `git worktree list` — cheap enough to run promptly).
-const TOPOLOGY_EVENT_DEBOUNCE_MS = 50;
+const TOPOLOGY_EVENT_DEBOUNCE_MS = 25;
 
 // Rate-limit window after a completed reconcile. Events that land inside it
 // set the dirty flag and drain via `armCooldownDrain()` at expiry — the


### PR DESCRIPTION
## Summary

Shorten the real worktree-topology watcher's trailing event debounce from 50 ms to 25 ms.

The serialized reconcile queue, 500 ms cooldown + dirty drain, 60 s reconcile watchdog, first-worktree sentinel, pending app-operation suppression, dark/recovery signalling, and 90 s safety reconcile are unchanged. The final diff is one line in one production file.

## Claim boundary

PERF-135 through PERF-138 are **mechanism** benchmarks with partial `processTopology` fidelity. They exercise real filesystem watchers, real git topology, and the real workspace-host/store application path through `worktree-update` emission. Renderer MessagePort transit, virtualization, React commit, paint, and user-perceived visibility are outside the bracket. Nothing below is a sidebar-visible or user-perceived latency claim.

Every arm used `--enforce-integrity`. All reportable comparisons are quiet local A/B measurements on one physical machine. `perf calibrate` was not used because it cannot forward the mandatory integrity flag; unchanged-tree noise came from full benchmark arms. `perf diagnose` was not needed, and no profiled duration is benchmark evidence.

## Final-tree evidence

Machine: `host-02d9f218-darwin-arm64` (`studio-04`, Apple M1 Max, macOS 26.4.1 / build 25E253)  
Trees: `2a957ded2c1e7c4fb953934a9022d92aac02b43c` -> `49cc097926c89b037123d9014bbf60efce1d7330`  
Toolchain: Node v22.23.2, git 2.55.0, Electron 42.7.1  
Apparatus: `78ed867d5ac93be9…`, 185 files

### PERF-135 `p50Ms` — steady external topology pickup

| Metric | Before | After | Absolute change | Percentage / verdict |
| --- | ---: | ---: | ---: | ---: |
| `p50Ms` (median arm) | 60.443 ms | 35.377 ms | -25.066 ms | **-41.5%** |
| `timeoutMisses` | 0 | 0 | 0 | healthy in every arm |
| `spawnObserverMisses` | 0 | 0 | 0 | healthy in every arm |
| `worktreeListSpawns` mean (guard ±5%) | 2.05 | 2.05 | 0 | 0.0% |

Protocol: smoke, 20 iterations, 1 warmup per arm; median statistic; precommitted threshold 5%; fixed workload floor one external linked-worktree add.

```text
Target: p50Ms on PERF-135 · lower is better
Champion drift D: 0.2% (worst of 3, champ2 v champ3)
Worst within-arm spread: 2.7% on cand2 · ceiling 10%

  pair 1: 60.443 -> 34.959  42.2%  WON
  pair 2: 60.518 -> 35.590  41.2%  WON
  pair 3: 60.410 -> 35.377  41.4%  WON

  median arm: 60.443 -> 35.377  improvement 41.5%
  precommitted threshold: 5.0%

  guard worktreeListSpawns: 2.05 -> 2.05, OK
  condition 1 PASS: candidate won 3/3 pairs
  condition 2 PASS: 41.5% >= 5.0%
  condition 3 PASS: 41.5% > drift D 0.2%
  condition 4 PASS: no guard outside tolerance

VERDICT: CLAIM
```

### PERF-136 `p50Ms` — cold sentinel handoff

| Metric | Before | After | Absolute change | Percentage / verdict |
| --- | ---: | ---: | ---: | --- |
| `p50Ms` | — | — | — | **not claimable under locked protocol** |
| `timeoutMisses` | 0 | 0 | 0 | healthy in every complete arm |

Protocol: smoke, 20 iterations, 1 warmup per arm; median statistic; precommitted threshold 5.821%; fixed workload floor the first linked worktree in a repository with no prior `.git/worktrees` directory.

Two complete fresh six-arm headlines were integrity-healthy but refused as non-results by the fixed 10% within-arm spread gate (worst 74.4% on the first set and 87.7% on the second). Rare cold-start outliers occurred on both trees. No arm was reused, the ceiling was not relaxed, and no before/after percentage is claimed.

### PERF-137 `metricStats.worktreeListSpawns.max` — ten-add bulk coalescing

| Metric | Before | After | Absolute change | Percentage / verdict |
| --- | ---: | ---: | ---: | --- |
| `worktreeListSpawns.max` | 2 | 2 | 0 | 0.0%, no count improvement |
| `worktreeListSpawns.sum` | 10 | 10 | 0 | 0.0% |
| `gitSpawns.max` (guard ±5%) | 12 | 12 | 0 | 0.0% |
| `allSurfacedMs.max` (guard ±10%) | 374.273 ms | 351.435 ms | -22.838 ms | descriptive guard only; no duration claim |
| aggregate `p50Ms` (guard ±10%) | 368.456 ms | 345.178 ms | -23.278 ms | descriptive guard only; no duration claim |
| `timeoutMisses` | 0 | 0 | 0 | healthy |
| `removalMisses` | 0 | 0 | 0 | healthy |
| `spawnObserverMisses` | 0 | 0 | 0 | healthy |

Protocol: smoke, 5 iterations, 1 warmup per arm; deterministic count statistic; precommitted threshold 1%; fixed workload floor ten tight-loop external adds plus confirmed removal cleanup. The count target is the claim boundary. The five-sample duration guards are not presented as latency improvements.

### PERF-138 `p50Ms` — pickup scaling at 1/5/20/50 worktrees

| Metric | Before | After | Absolute change | Percentage / verdict |
| --- | ---: | ---: | ---: | --- |
| `p50Ms` | — | — | — | **not claimable under locked final protocol** |
| `latencyMsN1/N5/N20/N50` guards | — | — | — | no final comparison admitted |
| `surfaceMisses` | 0 | 0 | 0 | healthy in every complete arm |

Protocol: smoke, 20 iterations, 1 warmup per arm; median statistic; precommitted threshold 5%; fixed workload floor one external add at each of 1, 5, 20, and 50 existing worktrees; every per-size duration guarded at ±10%.

The first complete final-tree headline was integrity-healthy but refused because one candidate arm had 38.1% within-arm spread. A fresh repeat's first branch-point arm immediately reproduced the same upper-tail instability, making that immutable set unable to pass; the set was invalidated instead of spending five more four-minute arms on an impossible gate. An earlier clean selection confirmation is deliberately not substituted for Phase-6 evidence. No percentage is claimed.

## Predicates and safety proofs

| Benchmark | Declared predicates | Deliberate break proof |
| --- | --- | --- |
| PERF-135 | `timeoutMisses`, `spawnObserverMisses` | scheduling break produced `timeoutMisses=1` in 3/3 and integrity failure |
| PERF-136 | `timeoutMisses` | scheduling break produced `timeoutMisses=1` in 3/3 and integrity failure |
| PERF-137 | `timeoutMisses`, `removalMisses`, `spawnObserverMisses` | scheduling break produced `timeoutMisses=1`, `removalMisses=10` in 3/3 and integrity failure |
| PERF-138 | `surfaceMisses` | scheduling break produced `surfaceMisses=4` in 3/3 and integrity failure |

Throwaway proof commits were hard-reset before their baselines. Deadline values from those broken arms are predicate evidence only, never performance evidence.

## Hypothesis ledger

- **KEEP**: 50 ms -> 25 ms topology trailing debounce. PERF-135 final headline passed at -41.5% with list-spawn coalescing exactly flat.
- **REVERT**: schedule the cold sentinel reconcile before replacement watcher startup. The integrity-healthy PERF-136 screen moved in the wrong direction within the locked noise band.
- **REVERT**: overlap note-file setup with worktree-root `stat`. The integrity-healthy PERF-136 screen moved in the wrong direction within the locked noise band.
- **REJECTED before edit**: remove the sentinel's eager watcher restart. A failed discovery would leave the sentinel disarmed and defer watcher recovery to the 90 s safety pass.
- **REJECTED before edit**: suppress cooldown-dirty follow-up reconciles. Events arriving after the list snapshot can represent a concurrent external mutation; absorbing them recreates the documented stale-list race.
- **REJECTED before edit**: adapt debounce to raw watcher-event count. Parcel/FSEvents/inotify/Windows event batching differs, so a cardinality threshold has no portable semantic relationship to covered topology mutations.

## Cross-OS and checks

No GitHub `perf-ab` job was dispatched. PERF-135, PERF-136, and PERF-138 target machine-dependent durations, which must not be claimed from hosted runners. PERF-137 is the only portable count target and it was exactly flat locally, so there was no improved count/size/structural ratio to verify on Linux, Windows, or macOS.

- `npm run typecheck` — pass
- full `npm test` — pass: 2,491 files; 54,961 passed, 7 skipped, 1 todo; no failures
- `npm run check` — pass: TypeScript, channel/IPC, manifest/API, lint-ratchet, and Prettier checks
- independent diff audit — pass: one line, one file, one focused commit; no `scripts/perf/`, dependency, lockfile, config, or fixture changes
- ownership — `electron/workspace-host/` is assigned to Area D in the current optimize `AREAS.md`
- E2E — not run; no human named a spec
