### PR TITLE
perf(switch): drop the frame-paced warm-switch handshake and add the project-switch rotation benchmark

### DIFF
--- a/e2e/full/resilience/project-switch-perf.spec.ts
+++ b/e2e/full/resilience/project-switch-perf.spec.ts
@@ -144,7 +144,8 @@ perfDescribe("Resilience: project-switch latency measurement", () => {
     cleanups = fixtures.map((f) => f.cleanup);
     const repos = fixtures.map((f) => f.dir);
 
-    ctx = await launchApp();
+    // Real GPU + WebGL, as a user runs it; see the rotation spec for why.
+    ctx = await launchApp({ enableWebgl: true });
     ctx.window = await openAndOnboardProject(ctx.app, ctx.window, repos[0]);
 
     for (let i = 1; i < repos.length; i++) {

--- a/e2e/full/resilience/project-switch-perf.spec.ts
+++ b/e2e/full/resilience/project-switch-perf.spec.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any -- window.electron is untyped in Playwright evaluate() */
 import { test, expect } from "@playwright/test";
-import { readFileSync, existsSync } from "node:fs";
+import { readFileSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { execSync } from "node:child_process";
 import path from "node:path";
 import { launchApp, closeApp, getActiveAppWindow, type AppContext } from "../../helpers/launch";
 import { createFixtureRepos } from "../../helpers/fixtures";
@@ -26,6 +27,9 @@ const TERMINAL_PROJECTS = Number(process.env.PERF_SWITCH_TERMINALS ?? 2);
 // Idle gap between measured switches so deferred post-switch work (LRU
 // eviction, persist flushes) from one sample can't bleed into the next.
 const SETTLE_MS = 400;
+// Optional JSON output for A/B comparison; nothing is written when unset.
+const OUTPUT_PATH = process.env.PERF_SWITCH_OUT;
+const LABEL = process.env.PERF_SWITCH_LABEL ?? "run";
 
 let ctx: AppContext;
 let cleanups: Array<() => void> = [];
@@ -41,13 +45,22 @@ interface ColdReveal {
   loadToPaintMs: number;
 }
 
+interface ColdInteractive {
+  interactiveMs: number;
+  loadMs: number;
+  visibleMs: number;
+  hydrateMs: number;
+}
+
 /** Pull projectview reveal telemetry from the app's own log, scoped by time. */
 function readRevealTelemetry(logPath: string, sinceMs: number) {
   const cold: ColdReveal[] = [];
   const warm: number[] = [];
-  if (!existsSync(logPath)) return { cold, warm };
+  const interactive: ColdInteractive[] = [];
+  if (!existsSync(logPath)) return { cold, warm, interactive };
   const log = readFileSync(logPath, "utf8");
-  const re = /\[([^\]]+)\]\s+\[INFO\]\s+projectview\.(coldstart|warm-swap)\s*(\{[\s\S]*?\})/g;
+  const re =
+    /\[([^\]]+)\]\s+\[INFO\]\s+projectview\.(coldstart\.interactive|coldstart|warm-swap)\s*(\{[\s\S]*?\})/g;
   let m: RegExpExecArray | null;
   while ((m = re.exec(log)) !== null) {
     const atMs = Date.parse(m[1]);
@@ -56,6 +69,16 @@ function readRevealTelemetry(logPath: string, sinceMs: number) {
     try {
       payload = JSON.parse(m[3]);
     } catch {
+      continue;
+    }
+    if (m[2] === "coldstart.interactive") {
+      if (typeof payload?.interactiveMs !== "number") continue;
+      interactive.push({
+        interactiveMs: payload.interactiveMs,
+        loadMs: typeof payload.loadMs === "number" ? payload.loadMs : NaN,
+        visibleMs: typeof payload.visibleMs === "number" ? payload.visibleMs : NaN,
+        hydrateMs: typeof payload.hydrateMs === "number" ? payload.hydrateMs : NaN,
+      });
       continue;
     }
     if (typeof payload?.visibleMs !== "number") continue;
@@ -68,7 +91,7 @@ function readRevealTelemetry(logPath: string, sinceMs: number) {
       warm.push(payload.visibleMs);
     }
   }
-  return { cold, warm };
+  return { cold, warm, interactive };
 }
 
 function countMatches(logPath: string, sinceMs: number, needle: RegExp): number {
@@ -94,6 +117,15 @@ function pct(arr: number[], p: number): number {
 function stats(label: string, arr: number[]): string {
   if (arr.length === 0) return `${label}: n=0`;
   return `${label}: n=${arr.length} p50=${pct(arr, 50)}ms p95=${pct(arr, 95)}ms max=${Math.max(...arr)}ms`;
+}
+
+function summary(arr: number[]) {
+  return {
+    n: arr.length,
+    p50: arr.length ? pct(arr, 50) : null,
+    p95: arr.length ? pct(arr, 95) : null,
+    max: arr.length ? Math.max(...arr) : null,
+  };
 }
 
 // Opt-in only — a measurement harness for local A/B runs, not a CI gate.
@@ -269,6 +301,12 @@ perfDescribe("Resilience: project-switch latency measurement", () => {
     );
     console.log(
       stats(
+        "cold interactive (interactiveMs)",
+        coldTele.interactive.map((c) => c.interactiveMs)
+      )
+    );
+    console.log(
+      stats(
         "warm round-trip (switch IPC settled)",
         warmRoundTrips.filter((v) => v >= 0)
       )
@@ -279,6 +317,45 @@ perfDescribe("Resilience: project-switch latency measurement", () => {
     );
     console.log(`reliability: renderer-gone=${rendererGone} paint-hard-timeouts=${hardTimeouts}`);
     console.log("─────────────────────────────────────────────────");
+
+    if (OUTPUT_PATH) {
+      let commit = "unknown";
+      try {
+        commit = execSync("git rev-parse HEAD", {
+          encoding: "utf8",
+          stdio: ["ignore", "pipe", "ignore"],
+        }).trim();
+      } catch {
+        // Not a git checkout; the label still identifies the run.
+      }
+      mkdirSync(path.dirname(OUTPUT_PATH), { recursive: true });
+      writeFileSync(
+        OUTPUT_PATH,
+        JSON.stringify(
+          {
+            label: LABEL,
+            commit,
+            createdAt: new Date().toISOString(),
+            cold: {
+              roundTrip: summary(coldRoundTrips.filter((v) => v >= 0)),
+              visible: summary(coldTele.cold.map((c) => c.visibleMs)),
+              loadToPaint: summary(
+                coldTele.cold.map((c) => c.loadToPaintMs).filter((v) => Number.isFinite(v))
+              ),
+              interactive: summary(coldTele.interactive.map((c) => c.interactiveMs)),
+            },
+            warm: {
+              roundTrip: summary(warmRoundTrips.filter((v) => v >= 0)),
+              visible: summary(warmTele.warm),
+            },
+            reliability: { rendererGone, hardTimeouts },
+          },
+          null,
+          2
+        )
+      );
+      console.log(`written: ${OUTPUT_PATH}`);
+    }
 
     // Reliability invariants only — latency itself is reported, not gated.
     expect(rendererGone, "no renderer crashes during measurement").toBe(0);

--- a/e2e/full/resilience/project-switch-rotation-perf.spec.ts
+++ b/e2e/full/resilience/project-switch-rotation-perf.spec.ts
@@ -1,0 +1,1196 @@
+/* eslint-disable @typescript-eslint/no-explicit-any -- window.electron is untyped in Playwright evaluate() */
+import { test, expect, type Page } from "@playwright/test";
+import { execFileSync, execSync } from "node:child_process";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { launchApp, closeApp, getActiveAppWindow, type AppContext } from "../../helpers/launch";
+import { openAndOnboardProject } from "../../helpers/project";
+import { addAndSwitchToProject } from "../../helpers/workflows";
+import {
+  createSwitchFixture,
+  seedProjectWorkload,
+  type SeededWorkload,
+  type SwitchFixture,
+} from "../../helpers/switchFixture";
+import { getDescendantPids } from "../../helpers/stress";
+import { SEL } from "../../helpers/selectors";
+import {
+  aggregate,
+  DEFAULT_DEPTH_WEIGHTS,
+  findMark,
+  generateStackDistanceTrace,
+  groupMarksBySwitch,
+  parseNdjson,
+  pct,
+  summarizeSample,
+  SWITCH_MARK,
+  TIMING_KEYS,
+  type CacheClass,
+  type EntryPoint,
+  type MarkRecord,
+  type MemorySample,
+  type MemoryViewSample,
+  type RotationRapidBurst,
+  type RotationResult,
+  type RotationSample,
+  type SampleTimings,
+  type SwitchTraceStep,
+} from "../../helpers/switchRotation";
+
+// Real-UI project-switch rotation benchmark. Every isolated sample drives the
+// shortcut, palette or toolbar the user would, waits for the target view to
+// attach, types a nonce into the target's focused shell pane and reads the
+// moment xterm painted it — so "done" means input-ready, not "IPC resolved".
+// Depth (MRU stack distance) and cache cap are controlled so warm and cold
+// switches are predicted before they happen and the app is held to the
+// prediction. Latency, lag and memory are reported and written, never gated;
+// the assertions are apparatus invariants only.
+//   RUN_PERF_SWITCH_ROTATION=1 npx playwright test --project=full-resilience \
+//     e2e/full/resilience/project-switch-rotation-perf.spec.ts
+const CAP = Number(process.env.PERF_SWITCH_CAP ?? 3);
+const LABEL = process.env.PERF_SWITCH_LABEL ?? `cap${CAP}`;
+const OUTPUT_PATH =
+  process.env.PERF_SWITCH_ROTATION_OUT ??
+  path.join(process.cwd(), ".tmp", "perf-results", "project-switch-rotation", `${LABEL}.json`);
+const SAMPLES_PER_DEPTH = Number(process.env.PERF_SWITCH_SAMPLES_PER_DEPTH ?? 20);
+const SEED = Number(process.env.PERF_SWITCH_SEED ?? 1);
+const EXTRA_STRATA = Number(process.env.PERF_SWITCH_EXTRA_STRATA ?? 5);
+const RAPID_BURSTS = Number(process.env.PERF_SWITCH_RAPID_BURSTS ?? 3);
+const INCLUDE_MARKS = process.env.PERF_SWITCH_INCLUDE_MARKS === "1";
+const PROJECT_COUNT = 5;
+const WORKTREES_PER_PROJECT = 3;
+const AGENTS_PER_PROJECT = 3;
+const FILES_PER_REPO = 180;
+const STREAM_LINES_PER_SEC = 20;
+const MAX_DEPTH = 4;
+const WEIGHTS = DEFAULT_DEPTH_WEIGHTS;
+const ENTRY_POINTS: EntryPoint[] = ["mru", "palette-keyboard", "palette-mouse", "toolbar"];
+
+const IS_MAC = process.platform === "darwin";
+const MRU_COMBO = IS_MAC ? "Meta+Alt+Equal" : "Control+Alt+Equal";
+const PALETTE_COMBO = IS_MAC ? "Meta+Alt+p" : "Control+Alt+p";
+// The toolbar dropdown carries the testid; the ⌘P modal is a plain dialog.
+const PALETTE_ANY =
+  '[data-testid="project-switcher-palette"], [role="dialog"][aria-label="Project switcher"]';
+const PALETTE_INPUT = '[role="combobox"][aria-label="Search workspaces"]';
+const SETTLE_CEILING_MS = 8_000;
+const POST_SETTLE_MS = 300;
+const RAPID_GAP_MS = 150;
+const PURGE_IDLE_MS = 25_000;
+const MEMORY_EVERY = 5;
+
+const RENDERER_GONE_RE =
+  /render-process-gone|Renderer process gone|Renderer crashed|Crash loop detected/;
+const HARD_TIMEOUT_RE = /projectview\.(paintgate|warmpaintgate)\.hardtimeout/;
+
+interface ProjectInfo {
+  id: string;
+  name: string;
+  path: string;
+}
+
+interface ProjectState {
+  info: ProjectInfo;
+  fixtureName: string;
+  workload: SeededWorkload;
+}
+
+let ctx: AppContext;
+let fixture: SwitchFixture | null = null;
+const states = new Map<string, ProjectState>();
+
+const perfDescribe = process.env.RUN_PERF_SWITCH_ROTATION
+  ? test.describe.serial
+  : test.describe.skip;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+function readMarks(): MarkRecord[] {
+  if (!fixture || !existsSync(fixture.metricsPath)) return [];
+  return parseNdjson(readFileSync(fixture.metricsPath, "utf8"));
+}
+
+function countLogMatches(logPath: string, sinceMs: number, needle: RegExp): number {
+  if (!existsSync(logPath)) return 0;
+  let count = 0;
+  for (const line of readFileSync(logPath, "utf8").split(/\r?\n/)) {
+    const ts = line.match(/^\[([^\]]+)\]/);
+    if (!ts) continue;
+    const atMs = Date.parse(ts[1]!);
+    if (Number.isFinite(atMs) && atMs >= sinceMs && needle.test(line)) count++;
+  }
+  return count;
+}
+
+function gitHead(): string {
+  try {
+    return execSync("git rev-parse HEAD", {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return "unknown";
+  }
+}
+
+// ── Main-process view access ─────────────────────────────
+
+async function getAttachedProjectId(): Promise<string | null> {
+  return ctx.app.evaluate(async ({ BrowserWindow }) => {
+    const win = BrowserWindow.getAllWindows()[0];
+    if (!win || win.isDestroyed()) return null;
+    const views = (win.contentView?.children ?? []) as Electron.WebContentsView[];
+    for (let i = views.length - 1; i >= 0; i--) {
+      const wc = views[i]?.webContents;
+      if (!wc || wc.isDestroyed()) continue;
+      const id = await wc
+        .executeJavaScript("window.__DAINTREE_INITIAL_PROJECT__?.id ?? null", true)
+        .catch(() => null);
+      if (typeof id === "string" && id.length > 0) return id;
+    }
+    return null;
+  });
+}
+
+interface ViewEval<T> {
+  found: boolean;
+  value: T | null;
+  error?: string;
+}
+
+/** Run a script inside the (possibly hidden, cached) view for a project. */
+async function evaluateInProjectView<T>(projectId: string, script: string): Promise<ViewEval<T>> {
+  return ctx.app.evaluate(
+    async ({ BrowserWindow }, { projectId, script }) => {
+      const g = globalThis as Record<string, unknown>;
+      const pvm = (g.__daintreeGetPvm as (() => any) | undefined)?.();
+      const candidates: Electron.WebContents[] = [];
+      for (const entry of pvm?.getAllViews?.() ?? []) {
+        const wc = entry?.view?.webContents as Electron.WebContents | undefined;
+        if (wc && !wc.isDestroyed()) candidates.push(wc);
+      }
+      if (candidates.length === 0) {
+        const win = BrowserWindow.getAllWindows()[0];
+        for (const view of (win?.contentView?.children ?? []) as Electron.WebContentsView[]) {
+          const wc = view?.webContents;
+          if (wc && !wc.isDestroyed()) candidates.push(wc);
+        }
+      }
+      for (const wc of candidates) {
+        const id = await wc
+          .executeJavaScript("window.__DAINTREE_INITIAL_PROJECT__?.id ?? null", true)
+          .catch(() => null);
+        if (id !== projectId) continue;
+        try {
+          const value = await Promise.race([
+            wc.executeJavaScript(script, true),
+            new Promise((_, reject) =>
+              setTimeout(() => reject(new Error("view eval timeout")), 10_000)
+            ),
+          ]);
+          return { found: true, value: value as any };
+        } catch (error) {
+          return { found: true, value: null, error: String(error) };
+        }
+      }
+      return { found: false, value: null };
+    },
+    { projectId, script }
+  );
+}
+
+// ── Nonce probe (runs inside the target view) ────────────
+
+function probeInstallScript(panelId: string, nonce: string): string {
+  return `(() => {
+    const w = window;
+    const getTerm = w.__daintreeGetTerminalForE2E;
+    const term = typeof getTerm === "function" ? getTerm(${JSON.stringify(panelId)}) : null;
+    if (!term) return { armed: false, reason: "no-terminal" };
+    if (w.__switchProbe && typeof w.__switchProbe.dispose === "function") w.__switchProbe.dispose();
+    const nonce = ${JSON.stringify(nonce)};
+    const panelId = ${JSON.stringify(panelId)};
+    const state = { nonce, panelId, hits: 0, done: false, paintedAt: null, frameAt: null, dispose: null, renders: 0, lastScan: null };
+    const scan = () => {
+      // The echo lands on the cursor row, which on a tall, fresh pane is row 0,
+      // so scan the whole viewport rather than the buffer tail.
+      const buf = term.buffer.active;
+      const start = buf.baseY;
+      const end = Math.min(buf.length, start + term.rows);
+      let hits = 0;
+      for (let i = Math.max(0, start); i < end; i++) {
+        const line = buf.getLine(i);
+        if (line && line.translateToString(true).includes(nonce)) hits++;
+      }
+      return hits;
+    };
+    const sub = term.onRender(() => {
+      state.renders += 1;
+      if (state.done) return;
+      const hits = scan();
+      state.lastScan = hits;
+      if (hits === 0) return;
+      state.hits = hits;
+      state.done = true;
+      state.paintedAt = performance.now();
+      if (typeof w.__daintreeMarkPerf === "function") {
+        w.__daintreeMarkPerf("project_switch.nonce_painted", { nonce, panelId });
+      }
+      requestAnimationFrame(() => {
+        state.frameAt = performance.now();
+        if (typeof w.__daintreeMarkPerf === "function") {
+          w.__daintreeMarkPerf("project_switch.nonce_frame", { nonce, panelId });
+        }
+      });
+    });
+    state.dispose = () => sub.dispose();
+    w.__switchProbe = state;
+    return { armed: true };
+  })()`;
+}
+
+const PROBE_READ_SCRIPT =
+  "window.__switchProbe ? { done: window.__switchProbe.done, hits: window.__switchProbe.hits, nonce: window.__switchProbe.nonce, markHook: typeof window.__daintreeMarkPerf, renders: window.__switchProbe.renders, lastScan: window.__switchProbe.lastScan } : null";
+
+/** Count buffer lines containing each nonce across the given panels, whole scrollback. */
+function nonceCountScript(panelIds: string[], nonces: string[]): string {
+  return `(() => {
+    const getTerm = window.__daintreeGetTerminalForE2E;
+    const panelIds = ${JSON.stringify(panelIds)};
+    const nonces = ${JSON.stringify(nonces)};
+    const hits = [];
+    let checkedPanels = 0;
+    for (const panelId of panelIds) {
+      const term = typeof getTerm === "function" ? getTerm(panelId) : null;
+      if (!term) continue;
+      checkedPanels++;
+      const counts = new Map();
+      const buf = term.buffer.active;
+      for (let i = 0; i < buf.length; i++) {
+        const line = buf.getLine(i);
+        if (!line) continue;
+        const text = line.translateToString(true);
+        for (const nonce of nonces) {
+          if (text.includes(nonce)) counts.set(nonce, (counts.get(nonce) ?? 0) + 1);
+        }
+      }
+      for (const [nonce, count] of counts) hits.push({ panelId, nonce, count });
+    }
+    return { checkedPanels, hits };
+  })()`;
+}
+
+interface NonceCount {
+  checkedPanels: number;
+  hits: Array<{ panelId: string; nonce: string; count: number }>;
+}
+
+// ── Memory ───────────────────────────────────────────────
+
+async function takeMemorySample(phase: string, sampleIndex: number | null): Promise<MemorySample> {
+  const attribution = await ctx.app
+    .evaluate(async () => {
+      const fn = (globalThis as Record<string, unknown>).__daintreeGetMemoryAttribution;
+      return typeof fn === "function" ? await (fn as () => Promise<any>)() : null;
+    })
+    .catch(() => null);
+  const metrics: Array<{ pid: number; type: string; name: string | null; workingSetKb: number }> =
+    await ctx.app.evaluate(({ app }) =>
+      app.getAppMetrics().map((m) => ({
+        pid: m.pid,
+        type: m.type,
+        name: (m as any).name ?? (m as any).serviceName ?? null,
+        workingSetKb: m.memory.workingSetSize,
+      }))
+    );
+  let browserKb = 0;
+  let gpuKb = 0;
+  let rendererTotalKb = 0;
+  const utilityByNameKb: Record<string, number> = {};
+  const metricPids = new Set<number>();
+  for (const m of metrics) {
+    metricPids.add(m.pid);
+    if (m.type === "Browser") browserKb += m.workingSetKb;
+    else if (m.type === "GPU") gpuKb += m.workingSetKb;
+    else if (m.type === "Tab") rendererTotalKb += m.workingSetKb;
+    else if (m.type === "Utility") {
+      const name = m.name ?? "unknown";
+      utilityByNameKb[name] = (utilityByNameKb[name] ?? 0) + m.workingSetKb;
+    }
+  }
+  // Shells and fake agents are children of the pty-host, not Chromium
+  // processes, so app.getAppMetrics() never sees them.
+  let ptyDescendantsKb = 0;
+  const rootPid = ctx.app.process().pid;
+  if (rootPid && process.platform !== "win32") {
+    const foreign = getDescendantPids(rootPid).filter((pid) => !metricPids.has(pid));
+    if (foreign.length > 0) {
+      try {
+        const out = execFileSync("ps", ["-o", "pid=,rss=", "-p", foreign.join(",")], {
+          encoding: "utf8",
+        });
+        for (const line of out.split("\n")) {
+          const m = line.match(/^\s*(\d+)\s+(\d+)/);
+          if (m) ptyDescendantsKb += Number(m[2]);
+        }
+      } catch {
+        // A shell can exit between the pid walk and ps.
+      }
+    }
+  }
+  const views: MemoryViewSample[] = [];
+  for (const win of attribution?.windows ?? []) {
+    for (const view of win?.views ?? []) {
+      views.push({
+        projectId: view?.projectId ?? null,
+        state: view?.state ?? null,
+        webContentsId: view?.webContentsId ?? null,
+        pid: view?.pid ?? null,
+        workingSetKb: Number(view?.workingSetKb ?? 0),
+        guestPids: Array.isArray(view?.guestPids) ? view.guestPids : [],
+      });
+    }
+  }
+  const utilityKb = Object.values(utilityByNameKb).reduce((a, b) => a + b, 0);
+  return {
+    at: new Date().toISOString(),
+    phase,
+    sampleIndex,
+    totalKb: browserKb + gpuKb + rendererTotalKb + utilityKb + ptyDescendantsKb,
+    browserKb,
+    gpuKb,
+    rendererTotalKb,
+    unattributedRendererKb: Number(attribution?.processes?.unattributedRendererKb ?? NaN),
+    utilityByNameKb,
+    ptyDescendantsKb,
+    views,
+  };
+}
+
+// ── Entry-point drivers ──────────────────────────────────
+
+async function dispatchOn(page: Page, actionId: string, args?: unknown): Promise<any> {
+  return page
+    .evaluate(
+      async ([id, payload]) => {
+        const fn = (window as any).__daintreeDispatchAction;
+        return typeof fn === "function" ? fn(id, payload, { source: "test" }) : null;
+      },
+      [actionId, args] as const
+    )
+    .catch(() => null);
+}
+
+function newMainReceived(before: number, targetProjectId: string | null): MarkRecord | null {
+  const records = readMarks();
+  const fresh = records
+    .slice(before)
+    .filter(
+      (r) =>
+        r.mark === SWITCH_MARK.MAIN_RECEIVED &&
+        (targetProjectId === null || r.meta?.targetProjectId === targetProjectId)
+    );
+  return fresh[fresh.length - 1] ?? null;
+}
+
+async function waitForSwitchStart(
+  before: number,
+  targetProjectId: string,
+  timeoutMs: number
+): Promise<MarkRecord | null> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const hit = newMainReceived(before, targetProjectId);
+    if (hit) return hit;
+    await sleep(50);
+  }
+  return null;
+}
+
+async function openPalette(page: Page, viaToolbar: boolean): Promise<{ fallback: boolean }> {
+  const palette = page.locator(PALETTE_ANY);
+  if (viaToolbar) {
+    await page.locator(SEL.toolbar.projectSwitcherTrigger).first().click({ force: true });
+  } else {
+    await page.keyboard.press(PALETTE_COMBO);
+  }
+  try {
+    await expect(palette).toBeVisible({ timeout: 1_500 });
+    return { fallback: false };
+  } catch {
+    // The chord can be swallowed by xterm's key handler; fall through.
+  }
+  // The action is a toggle, so only dispatch it when the palette is really
+  // absent — dispatching over a palette that opened late would close it.
+  if ((await palette.count()) === 0) {
+    await dispatchOn(page, "project.switcherPalette");
+    try {
+      await expect(palette).toBeVisible({ timeout: 3_000 });
+      return { fallback: true };
+    } catch {
+      // Last resort below.
+    }
+  }
+  await page.locator(SEL.toolbar.projectSwitcherTrigger).first().click({ force: true });
+  try {
+    await expect(palette).toBeVisible({ timeout: 5_000 });
+  } catch (error) {
+    const diag = await page
+      .evaluate(() => {
+        const trigger = document.querySelector('[data-testid="project-switcher-trigger"]');
+        return {
+          project: (window as any).__DAINTREE_INITIAL_PROJECT__?.id ?? null,
+          visibility: document.visibilityState,
+          hasFocus: document.hasFocus(),
+          activeElement: document.activeElement?.tagName ?? null,
+          activeClass: document.activeElement?.className?.toString().slice(0, 80) ?? null,
+          triggerPresent: Boolean(trigger),
+          triggerDisabled: trigger?.hasAttribute("disabled") ?? null,
+          triggerAria: trigger?.getAttribute("aria-expanded") ?? null,
+          dialogs: document.querySelectorAll('[role="dialog"]').length,
+          cached: (window as any).electron?.app?.isViewCached?.() ?? null,
+        };
+      })
+      .catch((e) => ({ evaluateError: String(e) }));
+    const dispatchResult = await page
+      .evaluate(async () => {
+        const fn = (window as any).__daintreeDispatchAction;
+        try {
+          return {
+            ok: true,
+            value: await fn?.("project.switcherPalette", undefined, { source: "test" }),
+          };
+        } catch (e) {
+          return { ok: false, error: String(e) };
+        }
+      })
+      .catch((e) => ({ evaluateError: String(e) }));
+    const views = await ctx.app.evaluate(({ BrowserWindow }) => {
+      const win = BrowserWindow.getAllWindows()[0];
+      const g = globalThis as any;
+      const pvm = g.__daintreeGetPvm?.();
+      return {
+        children: (win?.contentView?.children ?? []).map((v: any) => v.webContents?.id ?? null),
+        views: (pvm?.getAllViews?.() ?? []).map((v: any) => ({
+          projectId: String(v.projectId).slice(0, 8),
+          state: v.state,
+          wc: v.view?.webContents?.id ?? null,
+          destroyed: v.view?.webContents?.isDestroyed?.() ?? null,
+        })),
+        active: String(pvm?.getActiveProjectId?.() ?? "").slice(0, 8),
+      };
+    });
+    console.log("[rotation] palette diagnostics", JSON.stringify({ diag, dispatchResult, views }));
+    throw error;
+  }
+  return { fallback: true };
+}
+
+async function filterPaletteTo(page: Page, targetName: string): Promise<void> {
+  const palette = page.locator(PALETTE_ANY);
+  const input = page.locator(PALETTE_INPUT);
+  await expect(input).toBeVisible({ timeout: 5_000 });
+  await input.fill(targetName);
+  await expect
+    .poll(
+      async () => {
+        const first = palette.locator('[role="option"]').first();
+        const text = (await first.textContent().catch(() => "")) ?? "";
+        const selected = await first.getAttribute("aria-selected").catch(() => null);
+        return text.includes(targetName) && selected === "true";
+      },
+      { timeout: 5_000, intervals: [50, 100, 250] }
+    )
+    .toBe(true);
+}
+
+interface DriveResult {
+  pressedAt: number;
+  fallback: boolean;
+}
+
+/** Drive one switch through the real UI on `page`; returns when the input was sent. */
+async function driveSwitch(
+  page: Page,
+  entryPoint: EntryPoint,
+  targetProjectId: string,
+  targetName: string,
+  recordsBefore: number
+): Promise<DriveResult> {
+  if (entryPoint === "mru") {
+    const pressedAt = Date.now();
+    await page.keyboard.press(MRU_COMBO);
+    if (await waitForSwitchStart(recordsBefore, targetProjectId, 1_500)) {
+      return { pressedAt, fallback: false };
+    }
+    // xterm's key handler can swallow the chord on some layouts; the action
+    // path is the same function the hook calls.
+    const fallbackAt = Date.now();
+    await dispatchOn(page, "project.mruCycleOlder");
+    return { pressedAt: fallbackAt, fallback: true };
+  }
+
+  const { fallback } = await openPalette(page, entryPoint === "toolbar");
+  await filterPaletteTo(page, targetName);
+  const pressedAt = Date.now();
+  if (entryPoint === "palette-keyboard") {
+    await page.keyboard.press("Enter");
+  } else {
+    const option = page.locator(PALETTE_ANY).locator('[role="option"]').first();
+    await option.click({ force: true, noWaitAfter: true });
+  }
+  if (await waitForSwitchStart(recordsBefore, targetProjectId, 3_000)) {
+    return { pressedAt, fallback };
+  }
+  await page.keyboard.press("Escape").catch(() => undefined);
+  const fallbackAt = Date.now();
+  await dispatchOn(page, "project.switch", { projectId: targetProjectId });
+  return { pressedAt: fallbackAt, fallback: true };
+}
+
+async function waitForAttached(targetProjectId: string, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if ((await getAttachedProjectId()) === targetProjectId) return true;
+    await sleep(10);
+  }
+  return false;
+}
+
+async function pageForProject(projectId: string): Promise<Page> {
+  for (let attempt = 0; attempt < 5; attempt++) {
+    const page = await getActiveAppWindow(ctx.app, 60_000, { requireProject: true });
+    const id = await page
+      .evaluate(() => (window as any).__DAINTREE_INITIAL_PROJECT__?.id ?? null)
+      .catch(() => null);
+    if (id === projectId) return page;
+    await sleep(100);
+  }
+  throw new Error(`active page never resolved to project ${projectId}`);
+}
+
+async function isProbeFocused(page: Page, probePanelId: string): Promise<boolean> {
+  return page
+    .evaluate((id) => {
+      const el = document.activeElement;
+      return Boolean(
+        el &&
+        el.classList.contains("xterm-helper-textarea") &&
+        el.closest(`[data-panel-id="${id}"]`) !== null
+      );
+    }, probePanelId)
+    .catch(() => false);
+}
+
+let warnedMissingMarkHook = false;
+
+async function waitForProbeDone(page: Page, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const probe = (await page.evaluate(PROBE_READ_SCRIPT).catch(() => null)) as {
+      done: boolean;
+      markHook?: string;
+    } | null;
+    if (probe && probe.markHook !== "function" && !warnedMissingMarkHook) {
+      warnedMissingMarkHook = true;
+      console.log(`[rotation] probe has no __daintreeMarkPerf (typeof=${probe.markHook})`);
+    }
+    if (probe?.done) return true;
+    await sleep(25);
+  }
+  const diag = await page
+    .evaluate(() => {
+      const w = window as any;
+      const probe = w.__switchProbe;
+      const term = probe ? w.__daintreeGetTerminalForE2E?.(probe.panelId) : null;
+      const buf = term?.buffer?.active;
+      const tail: string[] = [];
+      if (buf) {
+        for (let i = Math.max(0, buf.length - 4); i < buf.length; i++) {
+          tail.push(buf.getLine(i)?.translateToString(true) ?? "");
+        }
+      }
+      return {
+        probe: probe
+          ? { done: probe.done, renders: probe.renders, lastScan: probe.lastScan }
+          : null,
+        bufLength: buf?.length ?? null,
+        baseY: buf?.baseY ?? null,
+        cursorY: buf?.cursorY ?? null,
+        rows: term?.rows ?? null,
+        tail,
+        activeElement: document.activeElement?.className?.toString().slice(0, 60) ?? null,
+      };
+    })
+    .catch((e) => ({ evaluateError: String(e) }));
+  console.log(`[rotation] probe not done: ${JSON.stringify(diag)}`);
+  return false;
+}
+
+interface SettleResult {
+  settled: boolean;
+  backstop: boolean;
+}
+
+/**
+ * A sample is settled once main logged `settled` and the incoming view has run
+ * its last reveal obligation: the 3 s repaint backstop for a warm view, or
+ * first-interactive for a cold one (a cold view never receives the reveal
+ * repaint event, so waiting on its backstop would only run out the ceiling).
+ */
+async function waitForSettle(switchId: string, cacheHit: boolean | null): Promise<SettleResult> {
+  const deadline = Date.now() + SETTLE_CEILING_MS;
+  let result: SettleResult = { settled: false, backstop: false };
+  while (Date.now() < deadline) {
+    const group = groupMarksBySwitch(readMarks()).bySwitch.get(switchId);
+    if (group) {
+      const backstop =
+        cacheHit === false
+          ? Boolean(findMark(group.marks, SWITCH_MARK.FIRST_INTERACTIVE))
+          : group.marks.some(
+              (r) => r.mark === SWITCH_MARK.REVEAL_REPAINT_DONE && r.meta?.pass === "backstop-3000"
+            );
+      result = { settled: Boolean(findMark(group.marks, SWITCH_MARK.SETTLED)), backstop };
+      if (result.settled && result.backstop) break;
+    }
+    await sleep(250);
+  }
+  await sleep(POST_SETTLE_MS);
+  return result;
+}
+
+function nanTimings(): SampleTimings {
+  return Object.fromEntries(TIMING_KEYS.map((k) => [k, NaN])) as SampleTimings;
+}
+
+function fmt(v: number | undefined): string {
+  return v === undefined || !Number.isFinite(v) ? "-" : `${Math.round(v)}`;
+}
+
+function mb(kb: number | undefined | null): string {
+  return kb === undefined || kb === null || !Number.isFinite(kb)
+    ? "-"
+    : `${(kb / 1024).toFixed(0)}MB`;
+}
+
+perfDescribe("Resilience: project-switch rotation (real UI, nonce-to-paint)", () => {
+  test.beforeAll(async () => {
+    if (![3, 4, 5].includes(CAP)) throw new Error(`PERF_SWITCH_CAP must be 3, 4 or 5 (got ${CAP})`);
+    fixture = createSwitchFixture({
+      projects: PROJECT_COUNT,
+      worktreesPerProject: WORKTREES_PER_PROJECT,
+      filesPerRepo: FILES_PER_REPO,
+      streamLinesPerSec: STREAM_LINES_PER_SEC,
+    });
+    ctx = await launchApp({ env: fixture.launchEnv });
+  });
+
+  test.afterAll(async () => {
+    if (ctx?.app) await closeApp(ctx.app);
+    fixture?.cleanup();
+  });
+
+  test("rotates through every LRU depth with a typed nonce and reports latency and memory", async () => {
+    test.setTimeout(1_800_000);
+    const fx = fixture!;
+    const logPath = path.join(ctx.userDataDir, "logs", "daintree.log");
+    const runStartedAt = Date.now();
+
+    // ── Setup: onboard, cap the cache, add and seed every project ──
+    ctx.window = await openAndOnboardProject(ctx.app, ctx.window, fx.projects[0]!.dir);
+    await ctx.app.evaluate((_electron, limit) => {
+      const g = globalThis as Record<string, unknown>;
+      const pvm = (g.__daintreeGetPvm as (() => any) | undefined)?.();
+      pvm?.setLowMemoryFreeThresholdMb?.(null);
+      pvm?.setCachedViewLimit?.(limit);
+    }, CAP);
+
+    const resolveProject = async (dir: string): Promise<ProjectInfo> => {
+      const all: ProjectInfo[] = await ctx.window.evaluate(() =>
+        (window as any).electron.project.getAll()
+      );
+      // The app stores the canonical path; on macOS the fixture's tmpdir is
+      // reached through the /var -> /private/var symlink, so compare real paths.
+      const canon = (p: string) => {
+        try {
+          return realpathSync(p);
+        } catch {
+          return path.resolve(p);
+        }
+      };
+      const want = canon(dir);
+      const hit = all.find((p) => canon(p.path) === want);
+      if (!hit) throw new Error(`project for ${dir} not registered`);
+      return hit;
+    };
+
+    for (let i = 0; i < fx.projects.length; i++) {
+      const project = fx.projects[i]!;
+      if (i > 0) {
+        ctx.window = await addAndSwitchToProject(ctx.app, ctx.window, project.dir, project.name);
+      }
+      const info = await resolveProject(project.dir);
+      const workload = await seedProjectWorkload(ctx.app, ctx.window, project);
+      states.set(info.id, { info, fixtureName: project.name, workload });
+      console.log(
+        `[rotation] seeded ${project.name}: probe=${workload.probePanelId} agents=${workload.agentPanelIds.join(",")}`
+      );
+    }
+    await sleep(3_000);
+
+    const projectIds = fx.projects.map((p) => {
+      const state = [...states.values()].find((s) => s.fixtureName === p.name)!;
+      return state.info.id;
+    });
+
+    // Unmeasured warm-all rotation, visiting in reverse so the MRU stack ends
+    // up in fixture order: head = project 0.
+    for (const id of [...projectIds].reverse()) {
+      if ((await getAttachedProjectId()) === id) continue;
+      const page = await getActiveAppWindow(ctx.app, 60_000, { requireProject: true });
+      await dispatchOn(page, "project.switch", { projectId: id });
+      expect(await waitForAttached(id, 60_000), `warm-all switch to ${id}`).toBe(true);
+      await sleep(1_000);
+    }
+    await sleep(2_000);
+
+    const extraSteps: Array<{ depth: number; entryPoint: EntryPoint }> = [];
+    for (let i = 0; i < EXTRA_STRATA; i++) {
+      extraSteps.push({ depth: 1 + (i % 2), entryPoint: "palette-mouse" });
+      extraSteps.push({ depth: 1 + ((i + 1) % 2), entryPoint: "toolbar" });
+    }
+    const trace = generateStackDistanceTrace({
+      projectIds,
+      samplesPerDepth: SAMPLES_PER_DEPTH,
+      cap: CAP,
+      maxDepth: MAX_DEPTH,
+      seed: SEED,
+      extraSteps,
+    });
+
+    const samples: RotationSample[] = [];
+    const memorySamples: MemorySample[] = [];
+    const nonces: string[] = [];
+    let attachedMismatches = 0;
+    let settleTimeouts = 0;
+    const measureStartedAt = Date.now();
+
+    // ── Isolated phase ──
+    const runIsolated = async (step: SwitchTraceStep): Promise<void> => {
+      const target = states.get(step.targetProjectId)!;
+      const nonce = `sw${step.index}x${Math.random().toString(36).slice(2, 8)}`;
+      nonces.push(nonce);
+      const probeScript = probeInstallScript(target.workload.probePanelId, nonce);
+
+      let probeArmedAfterSwitch = false;
+      const preArm = await evaluateInProjectView<{ armed: boolean }>(
+        step.targetProjectId,
+        probeScript
+      );
+      if (!preArm.found || !preArm.value?.armed) probeArmedAfterSwitch = true;
+
+      const recordsBefore = readMarks().length;
+      const currentPage = await pageForProject(step.fromProjectId);
+      console.log(
+        `[rotation] step #${step.index} d${step.depth} ${step.entryPoint} ${states.get(step.fromProjectId)?.fixtureName} -> ${target.fixtureName} (${step.expectedCache})`
+      );
+      const drive = await driveSwitch(
+        currentPage,
+        step.entryPoint,
+        step.targetProjectId,
+        target.fixtureName,
+        recordsBefore
+      );
+
+      const attached = await waitForAttached(step.targetProjectId, 20_000);
+      if (!attached) attachedMismatches++;
+      const targetPage = await pageForProject(step.targetProjectId);
+
+      if (probeArmedAfterSwitch) {
+        await expect
+          .poll(
+            async () => {
+              const r = await targetPage.evaluate(probeScript).catch(() => null);
+              return Boolean((r as any)?.armed);
+            },
+            { timeout: 15_000, intervals: [50, 100, 250] }
+          )
+          .toBe(true);
+      }
+
+      let focusRescued = false;
+      let focusReadyAt = NaN;
+      const focusDeadline = Date.now() + 5_000;
+      while (Date.now() < focusDeadline) {
+        if (await isProbeFocused(targetPage, target.workload.probePanelId)) {
+          focusReadyAt = Date.now();
+          break;
+        }
+        await sleep(20);
+      }
+      if (!Number.isFinite(focusReadyAt)) {
+        focusRescued = true;
+        await targetPage
+          .locator(`[data-panel-id="${target.workload.probePanelId}"] ${SEL.terminal.xtermRows}`)
+          .first()
+          .click({ force: true });
+        await expect
+          .poll(() => isProbeFocused(targetPage, target.workload.probePanelId), {
+            timeout: 5_000,
+            intervals: [50, 100],
+          })
+          .toBe(true);
+      }
+
+      await targetPage.keyboard.type(nonce);
+      await waitForProbeDone(targetPage, 6_000);
+      const counted = (await targetPage
+        .evaluate(nonceCountScript([target.workload.probePanelId], [nonce]))
+        .catch(() => null)) as NonceCount | null;
+      const nonceHits = counted ? counted.hits.reduce((sum, h) => sum + h.count, 0) : null;
+      await targetPage.keyboard.press("Control+U");
+
+      const mainReceived =
+        newMainReceived(recordsBefore, step.targetProjectId) ??
+        (await waitForSwitchStart(recordsBefore, step.targetProjectId, 5_000));
+      const switchId = (mainReceived?.meta?.switchId as string | undefined) ?? null;
+      let settle: SettleResult = { settled: false, backstop: false };
+      if (switchId) {
+        const mainReceivedRecord = newMainReceived(recordsBefore, step.targetProjectId);
+        const cacheState = mainReceivedRecord?.meta?.cacheState;
+        settle = await waitForSettle(
+          switchId,
+          cacheState === "warm" ? true : cacheState === "cold" ? false : null
+        );
+      } else await sleep(POST_SETTLE_MS);
+      if (!settle.settled || !settle.backstop) settleTimeouts++;
+
+      const grouped = groupMarksBySwitch(readMarks());
+      const group = switchId ? grouped.bySwitch.get(switchId) : undefined;
+      const summary = group
+        ? summarizeSample(
+            group,
+            grouped.byNonce.get(nonce) ?? [],
+            Number.isFinite(focusReadyAt) ? focusReadyAt - drive.pressedAt : NaN
+          )
+        : null;
+
+      const sample: RotationSample = {
+        index: step.index,
+        phase: "isolated",
+        switchId,
+        entryPoint: step.entryPoint,
+        entryPointFallback: drive.fallback,
+        depth: step.depth,
+        fromProjectId: step.fromProjectId,
+        targetProjectId: step.targetProjectId,
+        expectedCache: step.expectedCache,
+        actualCache: summary?.actualCache ?? null,
+        gateOutcome: summary?.gateOutcome ?? null,
+        releaseChannel: summary?.releaseChannel ?? null,
+        prefetchHit: summary?.prefetchHit ?? null,
+        probeArmedAfterSwitch,
+        focusRescued,
+        nonce,
+        nonceHits,
+        anchorMark: summary?.anchorMark ?? null,
+        orderingViolations: summary?.orderingViolations ?? [],
+        settleTimedOut: !settle.settled || !settle.backstop,
+        timings: summary?.timings ?? nanTimings(),
+        lag: summary?.lag ?? {
+          mainLoopLagMs: NaN,
+          eventLoopLagOverlapMs: NaN,
+          rendererLoafCount: 0,
+          rendererLoafTotalMs: NaN,
+        },
+      };
+      if ((step.index + 1) % MEMORY_EVERY === 0) {
+        sample.memory = await takeMemorySample("isolated", step.index);
+        memorySamples.push(sample.memory);
+      }
+      samples.push(sample);
+      console.log(
+        `[rotation] #${step.index} d${step.depth} ${step.entryPoint}${drive.fallback ? "(fallback)" : ""} ${step.expectedCache}/${sample.actualCache ?? "?"} nonce=${fmt(sample.timings.intentToNoncePaintedMs)}ms revealed=${fmt(sample.timings.intentToRevealedMs)}ms settled=${fmt(sample.timings.intentToSettledMs)}ms hits=${nonceHits ?? "?"}${focusRescued ? " focusRescued" : ""}${probeArmedAfterSwitch ? " armedAfter" : ""}`
+      );
+    };
+
+    for (const step of trace) await runIsolated(step);
+
+    const hot = await takeMemorySample("hot", null);
+    memorySamples.push(hot);
+
+    // ── Rapid phase: bursts of queued switches, no nonce ──
+    const mruStack = (() => {
+      const stack = [...projectIds];
+      for (const step of trace) {
+        stack.splice(stack.indexOf(step.targetProjectId), 1);
+        stack.unshift(step.targetProjectId);
+      }
+      return stack;
+    })();
+    const bursts: RotationRapidBurst[] = [];
+    const rapidPlan: Array<{ entryPoint: EntryPoint; depth: number }> = [
+      { entryPoint: "mru", depth: 1 },
+      { entryPoint: "mru", depth: 1 },
+      { entryPoint: "mru", depth: 1 },
+      { entryPoint: "palette-keyboard", depth: 2 },
+      { entryPoint: "palette-keyboard", depth: 3 },
+      { entryPoint: "mru", depth: 1 },
+    ];
+    for (let burst = 0; burst < RAPID_BURSTS; burst++) {
+      const recordsBefore = readMarks().length;
+      let finalTarget = mruStack[0]!;
+      for (const step of rapidPlan) {
+        const target = mruStack[step.depth]!;
+        const targetState = states.get(target)!;
+        const page = await getActiveAppWindow(ctx.app, 10_000, { requireProject: true });
+        const before = readMarks().length;
+        if (step.entryPoint === "mru") {
+          await page.keyboard.press(MRU_COMBO);
+          await sleep(RAPID_GAP_MS);
+          if (!newMainReceived(before, null)) await dispatchOn(page, "project.mruCycleOlder");
+        } else {
+          try {
+            await openPalette(page, false);
+            await filterPaletteTo(page, targetState.fixtureName);
+            await page.keyboard.press("Enter");
+          } catch {
+            await page.keyboard.press("Escape").catch(() => undefined);
+            await dispatchOn(page, "project.switch", { projectId: target });
+          }
+          await sleep(RAPID_GAP_MS);
+        }
+        mruStack.splice(step.depth, 1);
+        mruStack.unshift(target);
+        finalTarget = target;
+      }
+      const attachedMatchedTarget = await waitForAttached(finalTarget, 60_000);
+      // Every switch the burst produced, in arrival order; settle on the last.
+      let mainReceiveds = readMarks()
+        .slice(recordsBefore)
+        .filter((r) => r.mark === SWITCH_MARK.MAIN_RECEIVED);
+      const last = mainReceiveds[mainReceiveds.length - 1];
+      if (last?.meta?.switchId) await waitForSettle(String(last.meta.switchId), null);
+      const grouped = groupMarksBySwitch(readMarks());
+      mainReceiveds = readMarks()
+        .slice(recordsBefore)
+        .filter((r) => r.mark === SWITCH_MARK.MAIN_RECEIVED);
+      const switchIds = mainReceiveds
+        .map((r) => String(r.meta?.switchId ?? ""))
+        .filter((id) => id.length > 0);
+      const queueDelaysMs: number[] = [];
+      const settleMs: number[] = [];
+      const gateOutcomes: Record<string, number> = {};
+      for (const id of switchIds) {
+        const group = grouped.bySwitch.get(id);
+        if (!group) continue;
+        const received = findMark(group.marks, SWITCH_MARK.MAIN_RECEIVED);
+        const chain = findMark(group.marks, SWITCH_MARK.CHAIN_ENTERED);
+        const settled = findMark(group.marks, SWITCH_MARK.SETTLED);
+        const gate = findMark(group.marks, SWITCH_MARK.GATE_RESOLVED);
+        if (received && chain) queueDelaysMs.push(chain.elapsedMs - received.elapsedMs);
+        if (received && settled) settleMs.push(settled.elapsedMs - received.elapsedMs);
+        const outcome = String(gate?.meta?.gateOutcome ?? "missing");
+        gateOutcomes[outcome] = (gateOutcomes[outcome] ?? 0) + 1;
+      }
+      bursts.push({
+        burst,
+        switchIds,
+        queueDelaysMs,
+        settleMs,
+        gateOutcomes,
+        attachedMatchedTarget,
+      });
+      console.log(
+        `[rotation] rapid burst ${burst}: switches=${switchIds.length} maxQueue=${fmt(Math.max(...queueDelaysMs, 0))}ms maxSettle=${fmt(Math.max(...settleMs, 0))}ms gates=${JSON.stringify(gateOutcomes)} landed=${attachedMatchedTarget}`
+      );
+      await sleep(2_000);
+    }
+
+    // ── Post-purge checkpoint and cross-PTY exclusivity ──
+    await sleep(PURGE_IDLE_MS);
+    const postPurge = await takeMemorySample("postPurge", null);
+    memorySamples.push(postPurge);
+
+    let crossPtyLeaks = 0;
+    let uncheckedEvictedViews = 0;
+    for (const state of states.values()) {
+      const panelIds = [state.workload.probePanelId, ...state.workload.agentPanelIds];
+      const result = await evaluateInProjectView<NonceCount>(
+        state.info.id,
+        nonceCountScript(panelIds, nonces)
+      );
+      if (!result.found || !result.value) {
+        uncheckedEvictedViews++;
+        continue;
+      }
+      // Every nonce was Ctrl+U'd out of its own probe line, so any surviving
+      // occurrence anywhere is a byte that reached the wrong PTY.
+      for (const hit of result.value.hits) {
+        crossPtyLeaks += hit.count;
+        console.log(
+          `[rotation] LEAK: nonce ${hit.nonce} found ${hit.count}x in ${state.fixtureName} panel ${hit.panelId}`
+        );
+      }
+    }
+
+    // ── Aggregate, print, write ──
+    const isolated = samples.filter((s) => s.phase === "isolated");
+    const agg = aggregate(
+      isolated.map((s) => ({
+        depth: s.depth,
+        actualCache: s.actualCache,
+        expectedCache: s.expectedCache,
+        entryPoint: s.entryPoint,
+        timings: s.timings,
+      })),
+      WEIGHTS
+    );
+    const rendererGone = countLogMatches(logPath, runStartedAt, RENDERER_GONE_RE);
+    const hardTimeoutLogs = countLogMatches(logPath, runStartedAt, HARD_TIMEOUT_RE);
+    const hardTimeouts =
+      hardTimeoutLogs +
+      samples.filter((s) => s.gateOutcome === "hard-timeout").length +
+      bursts.reduce((sum, b) => sum + (b.gateOutcomes["hard-timeout"] ?? 0), 0);
+    const cacheMisclassified = isolated.filter((s) => s.actualCache !== s.expectedCache).length;
+    const nonceLost = isolated.filter((s) => (s.nonceHits ?? 0) === 0).length;
+    const nonceDuplicated = isolated.filter((s) => (s.nonceHits ?? 0) > 1).length;
+    const samplesInvalid = isolated.filter(
+      (s) => !s.switchId || !Number.isFinite(s.timings.intentToNoncePaintedMs)
+    ).length;
+    const allQueue = bursts.flatMap((b) => b.queueDelaysMs);
+    const allSettle = bursts.flatMap((b) => b.settleMs);
+    const rapidGates: Record<string, number> = {};
+    for (const b of bursts) {
+      for (const [k, v] of Object.entries(b.gateOutcomes)) rapidGates[k] = (rapidGates[k] ?? 0) + v;
+    }
+
+    const result: RotationResult = {
+      label: LABEL,
+      platform: process.platform,
+      arch: process.arch,
+      createdAt: new Date().toISOString(),
+      commit: gitHead(),
+      config: {
+        cap: CAP,
+        projects: PROJECT_COUNT,
+        worktreesPerProject: WORKTREES_PER_PROJECT,
+        agentsPerProject: AGENTS_PER_PROJECT,
+        filesPerRepo: FILES_PER_REPO,
+        samplesPerDepth: SAMPLES_PER_DEPTH,
+        seed: SEED,
+        weights: WEIGHTS,
+        entryPoints: ENTRY_POINTS,
+        rapidBursts: RAPID_BURSTS,
+      },
+      apparatus: {
+        rendererGone,
+        hardTimeouts,
+        cacheMisclassified,
+        nonceLost,
+        nonceDuplicated,
+        crossPtyLeaks,
+        uncheckedEvictedViews,
+        samplesInvalid,
+        settleTimeouts,
+      },
+      samples,
+      byDepth: agg.byDepth,
+      byCache: agg.byCache,
+      byEntryPoint: agg.byEntryPoint,
+      weighted: agg.weighted,
+      rapid: {
+        bursts,
+        maxQueueDelayMs: allQueue.length ? Math.max(...allQueue) : NaN,
+        maxSettleMs: allSettle.length ? Math.max(...allSettle) : NaN,
+        gateOutcomes: rapidGates,
+      },
+      memory: { checkpoints: { hot, postPurge }, samples: memorySamples },
+    };
+    if (INCLUDE_MARKS) {
+      result.markRecords = readMarks().filter(
+        (r) => r.mark.startsWith("project_switch.") || r.mark === SWITCH_MARK.EVENT_LOOP_LAG
+      );
+    }
+    mkdirSync(path.dirname(OUTPUT_PATH), { recursive: true });
+    if (fixture && existsSync(fixture.metricsPath)) {
+      copyFileSync(fixture.metricsPath, OUTPUT_PATH.replace(/\.json$/, ".marks.ndjson"));
+    }
+    writeFileSync(
+      OUTPUT_PATH,
+      JSON.stringify(
+        result,
+        (_k, v) => (typeof v === "number" && !Number.isFinite(v) ? null : v),
+        2
+      )
+    );
+
+    const row = (
+      label: string,
+      n: number,
+      t: Partial<Record<string, { p50: number; p95: number }>>
+    ) =>
+      `${label.padEnd(18)} n=${String(n).padStart(3)}  nonce p50/p95=${fmt(t.intentToNoncePaintedMs?.p50)}/${fmt(t.intentToNoncePaintedMs?.p95)}ms  revealed p50/p95=${fmt(t.intentToRevealedMs?.p50)}/${fmt(t.intentToRevealedMs?.p95)}ms  settled p50/p95=${fmt(t.intentToSettledMs?.p50)}/${fmt(t.intentToSettledMs?.p95)}ms`;
+    console.log(`──────── project-switch rotation (${LABEL}, cap=${CAP}) ────────`);
+    for (const [depth, bucket] of Object.entries(agg.byDepth)) {
+      console.log(row(`depth ${depth}`, bucket.n, bucket.timings));
+    }
+    for (const cache of ["warm", "cold"] as CacheClass[]) {
+      console.log(row(cache, agg.byCache[cache].n, agg.byCache[cache].timings));
+    }
+    for (const [entry, bucket] of Object.entries(agg.byEntryPoint)) {
+      console.log(row(entry, bucket.n, bucket.timings));
+    }
+    console.log(row("weighted", isolated.length, agg.weighted.timings));
+    console.log(
+      `rapid: bursts=${bursts.length} maxQueueDelay=${fmt(result.rapid.maxQueueDelayMs)}ms maxSettle=${fmt(result.rapid.maxSettleMs)}ms gates=${JSON.stringify(rapidGates)}`
+    );
+    console.log(
+      `memory hot: total=${mb(hot.totalKb)} renderers=${mb(hot.rendererTotalKb)} gpu=${mb(hot.gpuKb)} pty=${mb(hot.ptyDescendantsKb)} views=${hot.views.length} | postPurge: total=${mb(postPurge.totalKb)} renderers=${mb(postPurge.rendererTotalKb)} gpu=${mb(postPurge.gpuKb)} views=${postPurge.views.length}`
+    );
+    console.log(
+      `apparatus: rendererGone=${rendererGone} hardTimeouts=${hardTimeouts} cacheMisclassified=${cacheMisclassified} nonceLost=${nonceLost} nonceDuplicated=${nonceDuplicated} crossPtyLeaks=${crossPtyLeaks} uncheckedEvicted=${uncheckedEvictedViews} invalid=${samplesInvalid} settleTimeouts=${settleTimeouts} fallbacks=${samples.filter((s) => s.entryPointFallback).length} focusRescued=${samples.filter((s) => s.focusRescued).length}`
+    );
+    console.log(`written: ${OUTPUT_PATH} (${Date.now() - measureStartedAt}ms measured)`);
+    console.log("─────────────────────────────────────────────────");
+
+    // Apparatus invariants only — latency, lag and memory are never asserted.
+    expect(attachedMismatches, "attached view is the target after every sample").toBe(0);
+    expect(rendererGone, "no renderer crashes during measurement").toBe(0);
+    // Hard timeouts are a product finding this harness exists to expose; they
+    // are reported in `apparatus` and never gate the run.
+    expect(
+      isolated.flatMap((s) => s.orderingViolations.map((v) => `#${s.index}: ${v}`)),
+      "switch marks arrive in causal order"
+    ).toEqual([]);
+    expect(cacheMisclassified, "cache state matched the MRU model for every sample").toBe(0);
+    expect(nonceLost, "every nonce painted in the probe pane").toBe(0);
+    expect(nonceDuplicated, "no nonce painted more than once").toBe(0);
+    expect(crossPtyLeaks, "no nonce reached another PTY").toBe(0);
+    for (let depth = 1; depth <= MAX_DEPTH; depth++) {
+      const valid = isolated.filter(
+        (s) => s.depth === depth && Number.isFinite(s.timings.intentToNoncePaintedMs)
+      ).length;
+      expect(valid, `depth ${depth} produced the requested samples`).toBeGreaterThanOrEqual(
+        SAMPLES_PER_DEPTH
+      );
+    }
+    // Every sample's stats feed the aggregate; a NaN-only bucket means the
+    // marks the report depends on never arrived.
+    expect(
+      pct(
+        isolated.map((s) => s.timings.intentToNoncePaintedMs),
+        50
+      )
+    ).not.toBeNaN();
+  });
+});

--- a/e2e/full/resilience/project-switch-rotation-perf.spec.ts
+++ b/e2e/full/resilience/project-switch-rotation-perf.spec.ts
@@ -691,7 +691,10 @@ perfDescribe("Resilience: project-switch rotation (real UI, nonce-to-paint)", ()
       filesPerRepo: FILES_PER_REPO,
       streamLinesPerSec: STREAM_LINES_PER_SEC,
     });
-    ctx = await launchApp({ env: fixture.launchEnv });
+    // Real GPU + WebGL terminals: the default E2E launch disables both, which
+    // renders a 6K window in software at a few frames per second and makes
+    // every frame-paced interval here an artefact rather than a measurement.
+    ctx = await launchApp({ env: fixture.launchEnv, enableWebgl: true });
   });
 
   test.afterAll(async () => {
@@ -839,6 +842,18 @@ perfDescribe("Resilience: project-switch rotation (real UI, nonce-to-paint)", ()
       }
       if (!Number.isFinite(focusReadyAt)) {
         focusRescued = true;
+        const focusDiag = await targetPage
+          .evaluate(() => {
+            const el = document.activeElement;
+            return {
+              hasFocus: document.hasFocus(),
+              tag: el?.tagName ?? null,
+              cls: el?.className?.toString().slice(0, 60) ?? null,
+              panel: el?.closest("[data-panel-id]")?.getAttribute("data-panel-id") ?? null,
+            };
+          })
+          .catch((e) => ({ error: String(e) }));
+        console.log(`[rotation] focus rescue #${step.index}: ${JSON.stringify(focusDiag)}`);
         await targetPage
           .locator(`[data-panel-id="${target.workload.probePanelId}"] ${SEL.terminal.xtermRows}`)
           .first()

--- a/e2e/helpers/__tests__/switchRotation.test.ts
+++ b/e2e/helpers/__tests__/switchRotation.test.ts
@@ -1,0 +1,384 @@
+import { describe, expect, it } from "vitest";
+import {
+  aggregate,
+  generateStackDistanceTrace,
+  groupMarksBySwitch,
+  JOIN_TAIL_MS,
+  mulberry32,
+  parseNdjson,
+  pct,
+  summarizeSample,
+  SWITCH_MARK,
+  weightedQuantile,
+  type AggregateInput,
+  type MarkRecord,
+  type SampleTimings,
+  type SwitchMarkGroup,
+} from "../switchRotation";
+
+const PROJECTS = ["alpha", "bravo", "charlie", "delta", "echo"];
+
+describe("generateStackDistanceTrace", () => {
+  it("emits exactly samplesPerDepth samples per depth and is deterministic per seed", () => {
+    const a = generateStackDistanceTrace({
+      projectIds: PROJECTS,
+      samplesPerDepth: 5,
+      cap: 3,
+      seed: 7,
+    });
+    const b = generateStackDistanceTrace({
+      projectIds: PROJECTS,
+      samplesPerDepth: 5,
+      cap: 3,
+      seed: 7,
+    });
+    const c = generateStackDistanceTrace({
+      projectIds: PROJECTS,
+      samplesPerDepth: 5,
+      cap: 3,
+      seed: 8,
+    });
+    expect(a).toEqual(b);
+    expect(a.map((s) => s.depth)).not.toEqual(c.map((s) => s.depth));
+    for (let depth = 1; depth <= 4; depth++) {
+      expect(a.filter((s) => s.depth === depth)).toHaveLength(5);
+    }
+    expect(a.map((s) => s.index)).toEqual(a.map((_, i) => i));
+  });
+
+  it("models the MRU stack so every step's target is the project at that stack distance", () => {
+    const trace = generateStackDistanceTrace({
+      projectIds: PROJECTS,
+      samplesPerDepth: 6,
+      cap: 3,
+      seed: 3,
+    });
+    const stack = [...PROJECTS];
+    for (const step of trace) {
+      expect(step.fromProjectId).toBe(stack[0]);
+      expect(step.targetProjectId).toBe(stack[step.depth]);
+      expect(step.targetProjectId).not.toBe(step.fromProjectId);
+      stack.splice(step.depth, 1);
+      stack.unshift(step.targetProjectId);
+    }
+  });
+
+  it("classifies depth against the cache cap", () => {
+    const cap3 = generateStackDistanceTrace({ projectIds: PROJECTS, samplesPerDepth: 2, cap: 3 });
+    for (const step of cap3) {
+      expect(step.expectedCache).toBe(step.depth <= 2 ? "warm" : "cold");
+    }
+    const cap5 = generateStackDistanceTrace({ projectIds: PROJECTS, samplesPerDepth: 2, cap: 5 });
+    expect(cap5.every((step) => step.expectedCache === "warm")).toBe(true);
+  });
+
+  it("appends extra strata after the shuffled base and keeps the stack continuous", () => {
+    const trace = generateStackDistanceTrace({
+      projectIds: PROJECTS,
+      samplesPerDepth: 1,
+      cap: 3,
+      extraSteps: [
+        { depth: 1, entryPoint: "palette-mouse" },
+        { depth: 2, entryPoint: "toolbar" },
+      ],
+    });
+    expect(trace).toHaveLength(6);
+    expect(
+      trace.slice(0, 4).every((s) => s.entryPoint === "mru" || s.entryPoint === "palette-keyboard")
+    ).toBe(true);
+    expect(trace[4]!.entryPoint).toBe("palette-mouse");
+    expect(trace[5]!.entryPoint).toBe("toolbar");
+    expect(trace[5]!.fromProjectId).toBe(trace[4]!.targetProjectId);
+  });
+
+  it("refuses a project set too small for the requested depth", () => {
+    expect(() =>
+      generateStackDistanceTrace({ projectIds: PROJECTS.slice(0, 3), samplesPerDepth: 1, cap: 3 })
+    ).toThrow(/at least 5 projects/);
+  });
+
+  it("mulberry32 is stable in [0, 1)", () => {
+    const rand = mulberry32(42);
+    const values = Array.from({ length: 1000 }, () => rand());
+    expect(values.every((v) => v >= 0 && v < 1)).toBe(true);
+    expect(mulberry32(42)()).toBe(values[0]);
+  });
+});
+
+describe("percentiles", () => {
+  it("pct uses nearest rank and ignores non-finite values", () => {
+    expect(pct([5, 1, 3, NaN, 2, 4], 50)).toBe(3);
+    expect(pct([5, 1, 3, 2, 4], 95)).toBe(5);
+    expect(pct([10], 95)).toBe(10);
+    expect(pct([], 50)).toBeNaN();
+  });
+
+  it("weightedQuantile weights samples rather than counting them", () => {
+    // Two heavy 100s outweigh eight light 10s: the median is 100.
+    const values = [10, 10, 10, 10, 10, 10, 10, 10, 100, 100];
+    const weights = [1, 1, 1, 1, 1, 1, 1, 1, 10, 10];
+    expect(weightedQuantile(values, weights, 0.5)).toBe(100);
+    expect(
+      weightedQuantile(
+        values,
+        values.map(() => 1),
+        0.5
+      )
+    ).toBe(10);
+    expect(weightedQuantile([3, NaN, 1], [1, 1, 0], 0.5)).toBe(3);
+    expect(weightedQuantile([], [], 0.5)).toBeNaN();
+    expect(() => weightedQuantile([1], [], 0.5)).toThrow();
+  });
+});
+
+function mark(name: string, elapsedMs: number, meta: Record<string, unknown> = {}): MarkRecord {
+  return { mark: name, timestamp: 1_700_000_000_000 + elapsedMs, elapsedMs, meta };
+}
+
+const SWITCH = "sw-1";
+const WC = 42;
+
+function fullSwitch(): MarkRecord[] {
+  const s = { switchId: SWITCH };
+  return [
+    mark(SWITCH_MARK.KEYDOWN, 1000, { ...s, webContentsId: 7 }),
+    mark(SWITCH_MARK.INTENT, 1002, { ...s, webContentsId: 7 }),
+    mark(SWITCH_MARK.BUSY_PAINTED, 1010, { ...s, webContentsId: 7 }),
+    mark(SWITCH_MARK.IPC_SENT, 1020, { ...s, webContentsId: 7 }),
+    mark(SWITCH_MARK.MAIN_RECEIVED, 1025, {
+      ...s,
+      cacheState: "cold",
+      entryPoint: "mru",
+      targetProjectId: "bravo",
+      mainLoopLagMs: 3,
+    }),
+    mark(SWITCH_MARK.CHAIN_ENTERED, 1030, s),
+    mark(SWITCH_MARK.VIEW_ATTACHED, 1100, { ...s, isNew: true, webContentsId: WC }),
+    mark(SWITCH_MARK.GATE_RESOLVED, 1400, { ...s, gateOutcome: "signal", releaseChannel: "paint" }),
+    mark(SWITCH_MARK.REVEALED, 1410, s),
+    mark(SWITCH_MARK.REVEAL_REPAINT_DONE, 1430, { ...s, pass: "initial" }),
+    mark(SWITCH_MARK.REVEAL_REPAINT_DONE, 2410, { ...s, pass: "backstop-1000" }),
+    mark(SWITCH_MARK.SETTLED, 1600, { ...s, totalMs: 575 }),
+    mark(SWITCH_MARK.FOCUSED_PANE_WOKEN, 1450, { ...s, webContentsId: WC }),
+    mark(SWITCH_MARK.PTY_PORT_READY, 1460, { ...s, webContentsId: WC }),
+  ];
+}
+
+describe("groupMarksBySwitch", () => {
+  it("joins unlabelled renderer marks by webContentsId inside the switch window", () => {
+    const records = [
+      ...fullSwitch(),
+      mark(SWITCH_MARK.HYDRATE_START, 1150, { webContentsId: WC }),
+      mark(SWITCH_MARK.HYDRATE_COMPLETE, 1350, { webContentsId: WC }),
+      // Same view but after the join tail: belongs to nothing.
+      mark(SWITCH_MARK.RENDERER_LOAF, 1600 + JOIN_TAIL_MS + 1, {
+        webContentsId: WC,
+        durationMs: 80,
+      }),
+      // Another view inside the window: not this switch's incoming renderer.
+      mark(SWITCH_MARK.HYDRATE_COMPLETE, 1300, { webContentsId: 99 }),
+      // Before main_received: a previous switch's leftovers.
+      mark(SWITCH_MARK.HYDRATE_COMPLETE, 900, { webContentsId: WC }),
+      mark(SWITCH_MARK.EVENT_LOOP_LAG, 1200, { lagMs: 120 }),
+      mark(SWITCH_MARK.EVENT_LOOP_LAG, 5000 + JOIN_TAIL_MS, { lagMs: 500 }),
+      mark(SWITCH_MARK.APP_HYDRATE_PREFETCH, 1120, { hit: true, projectId: "bravo" }),
+      mark(SWITCH_MARK.NONCE_PAINTED, 1500, { nonce: "n1", panelId: "p1" }),
+      mark(SWITCH_MARK.NONCE_FRAME, 1516, { nonce: "n1" }),
+    ];
+    const { bySwitch, byNonce } = groupMarksBySwitch(records);
+    const group = bySwitch.get(SWITCH)!;
+    expect(group).toBeDefined();
+    expect(group.targetWebContentsId).toBe(WC);
+    expect(group.joined.map((r) => [r.mark, r.elapsedMs])).toEqual([
+      [SWITCH_MARK.HYDRATE_START, 1150],
+      [SWITCH_MARK.HYDRATE_COMPLETE, 1350],
+    ]);
+    expect(group.lagSamples.map((r) => r.elapsedMs)).toEqual([1200]);
+    expect(group.prefetch?.elapsedMs).toBe(1120);
+    expect(byNonce.get("n1")?.map((r) => r.mark)).toEqual([
+      SWITCH_MARK.NONCE_PAINTED,
+      SWITCH_MARK.NONCE_FRAME,
+    ]);
+    // Nonce marks never leak into the switch group.
+    expect(group.marks.some((r) => r.mark === SWITCH_MARK.NONCE_PAINTED)).toBe(false);
+  });
+
+  it("parses NDJSON tolerantly, skipping partial trailing lines", () => {
+    const text = [
+      JSON.stringify(mark("a", 1)),
+      "",
+      JSON.stringify({ mark: "no-elapsed" }),
+      '{"mark":"truncated","elapsedMs":',
+    ].join("\n");
+    expect(parseNdjson(text).map((r) => r.mark)).toEqual(["a"]);
+  });
+});
+
+describe("summarizeSample", () => {
+  function groupFor(records: MarkRecord[]): SwitchMarkGroup {
+    return groupMarksBySwitch(records).bySwitch.get(SWITCH)!;
+  }
+
+  it("measures every timing from intent and reads the switch metadata", () => {
+    const records = [
+      ...fullSwitch(),
+      mark(SWITCH_MARK.HYDRATE_COMPLETE, 1350, { webContentsId: WC }),
+      mark(SWITCH_MARK.RENDERER_FIRST_INTERACTIVE, 1380, { webContentsId: WC }),
+      mark(SWITCH_MARK.EVENT_LOOP_LAG, 1200, { lagMs: 120 }),
+      mark(SWITCH_MARK.EVENT_LOOP_LAG, 1550, { lagMs: 30 }),
+      // After settled: outside the lag overlap window even though inside the join tail.
+      mark(SWITCH_MARK.EVENT_LOOP_LAG, 1700, { lagMs: 999 }),
+      mark(SWITCH_MARK.RENDERER_LOAF, 1420, { webContentsId: WC, durationMs: 70 }),
+      mark(SWITCH_MARK.APP_HYDRATE_PREFETCH, 1120, { hit: false, projectId: "bravo" }),
+    ];
+    const { bySwitch, byNonce } = groupMarksBySwitch([
+      ...records,
+      mark(SWITCH_MARK.NONCE_PAINTED, 1500, { nonce: "n1", panelId: "p1" }),
+    ]);
+    const summary = summarizeSample(bySwitch.get(SWITCH)!, byNonce.get("n1"), 480);
+
+    expect(summary.anchorMark).toBe(SWITCH_MARK.INTENT);
+    expect(summary.timings.keydownToIntentMs).toBe(2);
+    expect(summary.timings.intentToBusyPaintedMs).toBe(8);
+    expect(summary.timings.intentToIpcSentMs).toBe(18);
+    expect(summary.timings.intentToMainReceivedMs).toBe(23);
+    expect(summary.timings.intentToChainEnteredMs).toBe(28);
+    expect(summary.timings.intentToViewAttachedMs).toBe(98);
+    expect(summary.timings.intentToGateResolvedMs).toBe(398);
+    expect(summary.timings.intentToRevealedMs).toBe(408);
+    expect(summary.timings.intentToFocusReadyMs).toBe(480);
+    expect(summary.timings.intentToNoncePaintedMs).toBe(498);
+    expect(summary.timings.intentToFocusedPaneWokenMs).toBe(448);
+    expect(summary.timings.intentToPtyPortReadyMs).toBe(458);
+    expect(summary.timings.intentToHydrateCompleteMs).toBe(348);
+    expect(summary.timings.intentToFirstInteractiveMs).toBe(378);
+    expect(summary.timings.intentToSettledMs).toBe(598);
+    expect(summary.timings.revealToRepaintDoneMs).toBe(20);
+    expect(summary.timings.intentToAllPanesWokenMs).toBeNaN();
+
+    expect(summary.lag).toEqual({
+      mainLoopLagMs: 3,
+      eventLoopLagOverlapMs: 150,
+      rendererLoafCount: 1,
+      rendererLoafTotalMs: 70,
+    });
+    expect(summary.actualCache).toBe("cold");
+    expect(summary.gateOutcome).toBe("signal");
+    expect(summary.releaseChannel).toBe("paint");
+    expect(summary.prefetchHit).toBe(false);
+    expect(summary.entryPointReported).toBe("mru");
+    expect(summary.orderingViolations).toEqual([]);
+  });
+
+  it("prefers the main first_interactive mark and the main_loop_probe when present", () => {
+    const records = [
+      ...fullSwitch(),
+      mark(SWITCH_MARK.FIRST_INTERACTIVE, 1390, { switchId: SWITCH }),
+      mark(SWITCH_MARK.MAIN_LOOP_PROBE, 1026, { switchId: SWITCH, lagMs: 11 }),
+      mark(SWITCH_MARK.RENDERER_FIRST_INTERACTIVE, 1380, { webContentsId: WC }),
+    ];
+    const summary = summarizeSample(groupFor(records));
+    expect(summary.timings.intentToFirstInteractiveMs).toBe(388);
+    expect(summary.lag.mainLoopLagMs).toBe(11);
+  });
+
+  it("anchors on main_received when the switch had no renderer intent", () => {
+    const records = fullSwitch().filter(
+      (r) => r.mark !== SWITCH_MARK.KEYDOWN && r.mark !== SWITCH_MARK.INTENT
+    );
+    const summary = summarizeSample(groupFor(records));
+    expect(summary.anchorMark).toBe(SWITCH_MARK.MAIN_RECEIVED);
+    expect(summary.timings.intentToMainReceivedMs).toBe(0);
+    expect(summary.timings.intentToRevealedMs).toBe(385);
+    expect(summary.timings.keydownToIntentMs).toBeNaN();
+  });
+
+  it("reports ordering violations instead of silently producing negative timings", () => {
+    const records = fullSwitch().map((r) =>
+      r.mark === SWITCH_MARK.REVEALED ? { ...r, elapsedMs: 1399 } : r
+    );
+    const { bySwitch, byNonce } = groupMarksBySwitch([
+      ...records,
+      mark(SWITCH_MARK.NONCE_PAINTED, 1399, { nonce: "n1" }),
+    ]);
+    const summary = summarizeSample(bySwitch.get(SWITCH)!, byNonce.get("n1"));
+    expect(summary.orderingViolations).toEqual([
+      "gate_resolved ≤ revealed (1400 vs 1399)",
+      "revealed < nonce_painted (1399 vs 1399)",
+    ]);
+  });
+});
+
+describe("aggregate", () => {
+  function sample(
+    depth: number,
+    nonceMs: number,
+    entryPoint = depth === 1 ? "mru" : "palette-keyboard",
+    actualCache: AggregateInput["actualCache"] = depth <= 2 ? "warm" : "cold"
+  ): AggregateInput {
+    const timings = Object.fromEntries(
+      [
+        "keydownToIntentMs",
+        "intentToBusyPaintedMs",
+        "intentToIpcSentMs",
+        "intentToMainReceivedMs",
+        "intentToChainEnteredMs",
+        "intentToViewAttachedMs",
+        "intentToGateResolvedMs",
+        "intentToRevealedMs",
+        "intentToFocusReadyMs",
+        "intentToNoncePaintedMs",
+        "intentToFocusedPaneWokenMs",
+        "intentToAllPanesWokenMs",
+        "intentToPtyPortReadyMs",
+        "intentToHydrateCompleteMs",
+        "intentToFirstInteractiveMs",
+        "intentToSettledMs",
+        "revealToRepaintDoneMs",
+      ].map((key) => [key, NaN])
+    ) as SampleTimings;
+    timings.intentToNoncePaintedMs = nonceMs;
+    timings.intentToRevealedMs = nonceMs / 2;
+    return { depth, actualCache, expectedCache: actualCache ?? "warm", entryPoint, timings };
+  }
+
+  it("buckets by depth, cache and entry point and weights depths as configured", () => {
+    const samples = [
+      sample(1, 100),
+      sample(1, 110),
+      sample(1, 120),
+      sample(2, 200),
+      sample(2, 220),
+      sample(3, 800),
+      sample(4, 1000, "toolbar"),
+    ];
+    const result = aggregate(samples, { 1: 0.55, 2: 0.25, 3: 0.12, 4: 0.08 });
+    expect(result.byDepth[1]!.n).toBe(3);
+    expect(result.byDepth[1]!.timings.intentToNoncePaintedMs!.p50).toBe(110);
+    expect(result.byDepth[1]!.timings.intentToNoncePaintedMs!.max).toBe(120);
+    expect(result.byDepth[1]!.timings.intentToAllPanesWokenMs).toBeUndefined();
+    expect(result.byCache.warm.n).toBe(5);
+    expect(result.byCache.cold.n).toBe(2);
+    expect(result.byCache.cold.timings.intentToRevealedMs!.p95).toBe(500);
+    expect(Object.keys(result.byEntryPoint).sort()).toEqual(["mru", "palette-keyboard", "toolbar"]);
+    expect(result.byEntryPoint["toolbar"]!.n).toBe(1);
+    // 55% of the weight sits at depth 1 (0.183 per sample), so the weighted
+    // median is reached at the last depth-1 value...
+    expect(result.weighted.timings.intentToNoncePaintedMs!.p50).toBe(120);
+    // ...while the p95 reaches into the cold tail (cumulative 0.92 at depth 3 < 0.95).
+    expect(result.weighted.timings.intentToNoncePaintedMs!.p95).toBe(1000);
+    expect(result.weighted.effectiveWeights).toEqual({ 1: 0.55, 2: 0.25, 3: 0.12, 4: 0.08 });
+  });
+
+  it("renormalises weights across the depths actually present", () => {
+    const result = aggregate([sample(1, 100), sample(2, 200)], { 1: 0.5, 2: 0.5, 3: 1 });
+    expect(result.weighted.effectiveWeights).toEqual({ 1: 0.5, 2: 0.5 });
+    expect(result.byDepth[3]).toBeUndefined();
+  });
+
+  it("falls back to the expected cache class when the app reported none", () => {
+    const result = aggregate([sample(3, 500, "palette-keyboard", null)]);
+    expect(result.byCache.warm.n).toBe(1);
+    expect(result.byCache.cold.n).toBe(0);
+  });
+});

--- a/e2e/helpers/__tests__/switchRotation.test.ts
+++ b/e2e/helpers/__tests__/switchRotation.test.ts
@@ -294,6 +294,23 @@ describe("summarizeSample", () => {
   });
 
   it("reports ordering violations instead of silently producing negative timings", () => {
+    // Violations larger than the 2 ms cross-process clock-skew allowance; a
+    // sub-skew inversion is rebasing error, not a causality break.
+    const records = fullSwitch().map((r) =>
+      r.mark === SWITCH_MARK.REVEALED ? { ...r, elapsedMs: 1390 } : r
+    );
+    const { bySwitch, byNonce } = groupMarksBySwitch([
+      ...records,
+      mark(SWITCH_MARK.NONCE_PAINTED, 1385, { nonce: "n1" }),
+    ]);
+    const summary = summarizeSample(bySwitch.get(SWITCH)!, byNonce.get("n1"));
+    expect(summary.orderingViolations).toEqual([
+      "gate_resolved ≤ revealed (1400 vs 1390)",
+      "revealed < nonce_painted (1390 vs 1385)",
+    ]);
+  });
+
+  it("tolerates inversions inside the clock-skew allowance", () => {
     const records = fullSwitch().map((r) =>
       r.mark === SWITCH_MARK.REVEALED ? { ...r, elapsedMs: 1399 } : r
     );
@@ -302,10 +319,7 @@ describe("summarizeSample", () => {
       mark(SWITCH_MARK.NONCE_PAINTED, 1399, { nonce: "n1" }),
     ]);
     const summary = summarizeSample(bySwitch.get(SWITCH)!, byNonce.get("n1"));
-    expect(summary.orderingViolations).toEqual([
-      "gate_resolved ≤ revealed (1400 vs 1399)",
-      "revealed < nonce_painted (1399 vs 1399)",
-    ]);
+    expect(summary.orderingViolations).toEqual([]);
   });
 });
 

--- a/e2e/helpers/fakeAgent.ts
+++ b/e2e/helpers/fakeAgent.ts
@@ -19,13 +19,25 @@ import type { Page } from "@playwright/test";
 export const FAKE_AGENT_STOP = "__DAINTREE_FAKE_CLAUDE_STOP__";
 export const FAKE_AGENT_IDLE = "__DAINTREE_FAKE_CLAUDE_IDLE__";
 export const FAKE_AGENT_READY = "FAKE_CLAUDE_READY";
+export const FAKE_AGENT_STREAM_ON = "__DAINTREE_FAKE_CLAUDE_STREAM_ON__";
+export const FAKE_AGENT_STREAM_OFF = "__DAINTREE_FAKE_CLAUDE_STREAM_OFF__";
+
+export interface FakeAgentOptions {
+  /**
+   * Coloured output lines per second the agent emits while streaming. The
+   * stream is off until `FAKE_AGENT_STREAM_ON` is written to stdin, so the
+   * default (0) leaves every existing spec's byte tape untouched.
+   */
+  streamLinesPerSec?: number;
+}
 
 /**
  * Write the fake CLI into `<repoDir>/.e2e bin` and return that directory.
  * The space in the directory name is deliberate — it keeps launches exercising
  * the quoted-absolute-path form that real resolved CLI paths can take.
  */
-export function installFakeAgent(repoDir: string): string {
+export function installFakeAgent(repoDir: string, options: FakeAgentOptions = {}): string {
+  const streamLinesPerSec = Math.max(0, Math.floor(options.streamLinesPerSec ?? 0));
   const binDir = path.join(repoDir, ".e2e bin");
   mkdirSync(binDir, { recursive: true });
 
@@ -42,6 +54,9 @@ export function installFakeAgent(repoDir: string): string {
       "}",
       `const stopToken = ${JSON.stringify(FAKE_AGENT_STOP)};`,
       `const idleToken = ${JSON.stringify(FAKE_AGENT_IDLE)};`,
+      `const streamOnToken = ${JSON.stringify(FAKE_AGENT_STREAM_ON)};`,
+      `const streamOffToken = ${JSON.stringify(FAKE_AGENT_STREAM_OFF)};`,
+      `const streamLinesPerSec = ${streamLinesPerSec};`,
       // OSC 9;4 taskbar-progress: state 1 = working, state 0 = idle hint.
       "const OSC_WORKING = '\\u001b]9;4;1;0\\u0007';",
       "const OSC_IDLE = '\\u001b]9;4;0;0\\u0007';",
@@ -69,7 +84,24 @@ export function installFakeAgent(repoDir: string): string {
       "  if (workingTimer) { clearInterval(workingTimer); workingTimer = null; }",
       "  process.stdout.write(OSC_IDLE);",
       "};",
+      // Background chatter for switch benchmarks: a real agent keeps painting
+      // while the user is elsewhere, so a cached view is never idle.
+      "let streamTimer = null;",
+      "let streamSeq = 0;",
+      "const STREAM_COLOURS = [31, 32, 33, 34, 35, 36];",
+      "const startStream = () => {",
+      "  if (streamTimer || streamLinesPerSec <= 0) return;",
+      "  streamTimer = setInterval(() => {",
+      "    streamSeq += 1;",
+      "    const colour = STREAM_COLOURS[streamSeq % STREAM_COLOURS.length];",
+      "    process.stdout.write('\\u001b[' + colour + 'm[fake-claude ' + String(streamSeq).padStart(6, '0') + '] analysing chunk ' + (streamSeq * 17 % 997) + ' \\u2026' + '\\u001b[0m\\r\\n');",
+      "  }, Math.max(1, Math.round(1000 / streamLinesPerSec)));",
+      "};",
+      "const stopStream = () => {",
+      "  if (streamTimer) { clearInterval(streamTimer); streamTimer = null; }",
+      "};",
       "const shutdown = () => {",
+      "  stopStream();",
       "  stopWorking();",
       "  console.log('FAKE_CLAUDE_EXIT');",
       "  clearInterval(keepAlive);",
@@ -86,6 +118,8 @@ export function installFakeAgent(repoDir: string): string {
       "  if (!trusted) return;",
       "  if (input.includes(stopToken)) { shutdown(); return; }",
       "  if (input.includes(idleToken)) { stopWorking(); return; }",
+      "  if (input.includes(streamOnToken)) { startStream(); return; }",
+      "  if (input.includes(streamOffToken)) { stopStream(); return; }",
       "});",
       "process.on('SIGINT', shutdown);",
       "process.on('SIGTERM', shutdown);",

--- a/e2e/helpers/switchFixture.ts
+++ b/e2e/helpers/switchFixture.ts
@@ -136,6 +136,9 @@ export function createSwitchFixture(options: SwitchFixtureOptions = {}): SwitchF
       ...fakeAgentEnv(fakeBinDir),
       ZDOTDIR: zdotdir,
       DAINTREE_PERF_CAPTURE: "1",
+      // Keep the warm cache honest: without this a busy host can report ~1.5 GB
+      // "available" and the tier-2 pressure pass evicts every cached view mid-run.
+      DAINTREE_E2E_SYSTEM_AVAILABLE_MEMORY_MB: "40000",
       DAINTREE_PERF_METRICS_FILE: metricsPath,
     },
     cleanup: () => {

--- a/e2e/helpers/switchFixture.ts
+++ b/e2e/helpers/switchFixture.ts
@@ -1,0 +1,316 @@
+/* eslint-disable @typescript-eslint/no-explicit-any -- window.electron is untyped in Playwright evaluate() */
+/**
+ * Multi-project workload for the project-switch rotation benchmark.
+ *
+ * Five small repos, each with three worktrees, a shared fake `claude` that
+ * keeps streaming while the user is elsewhere, and a per-project seeding pass
+ * that leaves one focused shell pane (the nonce probe) plus three agent panes
+ * behind — so every switch carries the PTY wake, agent-state and paint work
+ * a real workspace does.
+ */
+import { execSync } from "child_process";
+import { mkdirSync, mkdtempSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+import { expect, type ElectronApplication, type Page } from "@playwright/test";
+import { createFixtureRepo, removePathSync } from "./fixtures";
+import {
+  FAKE_AGENT_IDLE,
+  FAKE_AGENT_STREAM_ON,
+  fakeAgentEnv,
+  installFakeAgent,
+  ptyWrite,
+} from "./fakeAgent";
+import { getGridPanelIds, openTerminal } from "./panels";
+import { SEL } from "./selectors";
+import { waitForTerminalReady, waitForTerminalText } from "./terminal";
+import { T_LONG } from "./timeouts";
+
+export const SWITCH_FIXTURE_NAMES = ["alpha", "bravo", "charlie", "delta", "echo"] as const;
+const BRANCHES = ["feat/one", "feat/two", "feat/three"] as const;
+
+export interface SwitchFixtureProject {
+  name: string;
+  dir: string;
+  branches: string[];
+}
+
+export interface SwitchFixture {
+  projects: SwitchFixtureProject[];
+  fakeBinDir: string;
+  zdotdir: string;
+  launchEnv: Record<string, string>;
+  metricsPath: string;
+  cleanup: () => void;
+}
+
+export interface SwitchFixtureOptions {
+  projects?: number;
+  worktreesPerProject?: number;
+  filesPerRepo?: number;
+  streamLinesPerSec?: number;
+}
+
+function git(cmd: string, cwd: string): void {
+  execSync(`git ${cmd}`, { cwd, stdio: "ignore" });
+}
+
+function writeSourceTree(dir: string, fileCount: number, salt: string): void {
+  // ~12 directories × ~15 files: enough for the file browser, git status and
+  // the sidebar watcher to have real work without dwarfing the switch itself.
+  const dirs = Math.max(1, Math.min(12, Math.ceil(fileCount / 15)));
+  let written = 0;
+  for (let d = 0; d < dirs && written < fileCount; d++) {
+    const sub = path.join(dir, "src", `module-${String(d).padStart(2, "0")}`);
+    mkdirSync(sub, { recursive: true });
+    for (let f = 0; f < 15 && written < fileCount; f++, written++) {
+      const name = `unit-${String(f).padStart(2, "0")}.ts`;
+      writeFileSync(
+        path.join(sub, name),
+        `// ${salt} ${d}/${f}\nexport const value${d}_${f} = ${d * 100 + f};\nexport function fn${d}_${f}(x: number): number {\n  return x + ${f};\n}\n`
+      );
+    }
+  }
+}
+
+/**
+ * Build the repos, worktrees, fake CLI and launch env. Everything lives under
+ * the OS temp dir and `cleanup` removes it, including the `<dir>-worktrees`
+ * siblings that `createFixtureRepo` already knows how to tear down.
+ */
+export function createSwitchFixture(options: SwitchFixtureOptions = {}): SwitchFixture {
+  const {
+    projects: projectCount = 5,
+    worktreesPerProject = 3,
+    filesPerRepo = 180,
+    streamLinesPerSec = 20,
+  } = options;
+  if (projectCount > SWITCH_FIXTURE_NAMES.length) {
+    throw new Error(`at most ${SWITCH_FIXTURE_NAMES.length} switch fixture projects are named`);
+  }
+  if (worktreesPerProject > BRANCHES.length) {
+    throw new Error(`at most ${BRANCHES.length} worktrees per project are named`);
+  }
+
+  const cleanups: Array<() => void> = [];
+  const projects: SwitchFixtureProject[] = [];
+  for (let i = 0; i < projectCount; i++) {
+    const name = `switchperf-${SWITCH_FIXTURE_NAMES[i]}`;
+    const repo = createFixtureRepo({ name, withMultipleFiles: true });
+    cleanups.push(repo.cleanup);
+    writeSourceTree(repo.dir, filesPerRepo, name);
+    git("add -A", repo.dir);
+    git('commit -m "seed source tree"', repo.dir);
+
+    const branches: string[] = [];
+    const worktreeRoot = path.join(path.dirname(repo.dir), `${path.basename(repo.dir)}-worktrees`);
+    mkdirSync(worktreeRoot, { recursive: true });
+    for (let w = 0; w < worktreesPerProject; w++) {
+      const branch = BRANCHES[w]!;
+      git(`branch ${branch}`, repo.dir);
+      const worktreeDir = path.join(worktreeRoot, branch.replace("/", "-"));
+      git(`worktree add ${JSON.stringify(worktreeDir)} ${branch}`, repo.dir);
+      writeFileSync(path.join(worktreeDir, "NOTES.md"), `# ${branch}\n\n- ${name}\n`);
+      git("add -A", worktreeDir);
+      git(`commit -m "notes for ${branch}"`, worktreeDir);
+      branches.push(branch);
+    }
+    projects.push({ name: path.basename(repo.dir), dir: repo.dir, branches });
+  }
+
+  const sharedDir = mkdtempSync(path.join(tmpdir(), "daintree-e2e-switchperf-cli-"));
+  cleanups.push(() => removePathSync(sharedDir));
+  const fakeBinDir = installFakeAgent(sharedDir, { streamLinesPerSec });
+  // An empty ZDOTDIR keeps the user's zsh rc files from putting a real
+  // `claude` ahead of the fake one on PATH (see worktree-agent-ready-perf).
+  const zdotdir = path.join(sharedDir, ".e2e-zdotdir");
+  mkdirSync(zdotdir, { recursive: true });
+  const metricsPath = path.join(sharedDir, "perf-marks.ndjson");
+
+  return {
+    projects,
+    fakeBinDir,
+    zdotdir,
+    metricsPath,
+    launchEnv: {
+      ...fakeAgentEnv(fakeBinDir),
+      ZDOTDIR: zdotdir,
+      DAINTREE_PERF_CAPTURE: "1",
+      DAINTREE_PERF_METRICS_FILE: metricsPath,
+    },
+    cleanup: () => {
+      for (const fn of cleanups.reverse()) {
+        try {
+          fn();
+        } catch {
+          // Best effort; a locked worktree dir must not fail the run.
+        }
+      }
+    },
+  };
+}
+
+export interface SeededWorkload {
+  probePanelId: string;
+  agentPanelIds: string[];
+  worktreeIds: string[];
+}
+
+interface WorktreeRow {
+  id: string;
+  path: string;
+  branch?: string;
+}
+
+async function listWorktrees(page: Page): Promise<WorktreeRow[]> {
+  const rows = await page
+    .evaluate(() => (window as any).electron?.worktree?.getAll?.())
+    .catch(() => null);
+  return Array.isArray(rows) ? (rows as WorktreeRow[]) : [];
+}
+
+async function dispatch(page: Page, actionId: string, args: unknown): Promise<any> {
+  return page.evaluate(
+    async ([id, payload]) => {
+      const fn = (window as any).__daintreeDispatchAction;
+      if (typeof fn !== "function") return { ok: false, error: { message: "no dispatch bridge" } };
+      return fn(id, payload, { source: "test" });
+    },
+    [actionId, args] as const
+  );
+}
+
+async function selectWorktree(page: Page, worktreeId: string, branch: string): Promise<void> {
+  const result = await dispatch(page, "worktree.select", { worktreeId });
+  if (result && result.ok === false) {
+    throw new Error(`worktree.select failed: ${result.error?.message ?? "unknown"}`);
+  }
+  // The sidebar card carries data-active once the store has flipped; the grid
+  // remounts for the new worktree right after, so give it a beat.
+  await expect(
+    page.locator(`${SEL.worktree.card(branch)}[data-active="true"]`).first()
+  ).toBeAttached({ timeout: T_LONG });
+  await page.waitForTimeout(300);
+}
+
+async function newestGridPanel(page: Page, before: Set<string>): Promise<string> {
+  await expect
+    .poll(async () => (await getGridPanelIds(page)).filter((id) => !before.has(id)).length, {
+      timeout: T_LONG,
+      intervals: [100, 250],
+    })
+    .toBeGreaterThan(0);
+  const fresh = (await getGridPanelIds(page)).filter((id) => !before.has(id));
+  return fresh[fresh.length - 1]!;
+}
+
+async function launchAgent(page: Page, worktreeId: string): Promise<string> {
+  const before = new Set(await getGridPanelIds(page));
+  const result = await dispatch(page, "agent.launch", {
+    agentId: "claude",
+    worktreeId,
+    location: "grid",
+    focusPolicy: "preserve",
+  });
+  if (!result?.ok) {
+    throw new Error(`agent.launch failed: ${result?.error?.message ?? JSON.stringify(result)}`);
+  }
+  const reported: string | null = result.result?.terminalId ?? null;
+  // Prefer the DOM diff — it proves the panel mounted — and only trust the
+  // reported id when the grid already held it (e.g. a re-used panel).
+  const fresh = (await getGridPanelIds(page)).filter((id) => !before.has(id));
+  const panelId = fresh.includes(reported ?? "")
+    ? reported!
+    : fresh.length > 0
+      ? fresh[fresh.length - 1]!
+      : reported
+        ? reported
+        : await newestGridPanel(page, before);
+
+  const panel = page.locator(`[data-panel-id="${panelId}"]`);
+  await waitForTerminalText(panel, "Enter to confirm", T_LONG);
+  await ptyWrite(page, panelId, "\r");
+  await waitForTerminalText(panel, "FAKE_CLAUDE_READY", T_LONG);
+  await expect
+    .poll(() => panel.getAttribute("data-agent-state"), { timeout: 60_000, intervals: [250, 500] })
+    .toBe("working");
+  return panelId;
+}
+
+/**
+ * Seed one project the way a working session leaves it: a focused shell
+ * pane in worktree 1 (the nonce probe), two agents there — one streaming, one
+ * quietly working — and one waiting agent in worktree 2. Ends back on
+ * worktree 1 with the probe pane focused.
+ */
+export async function seedProjectWorkload(
+  _app: ElectronApplication,
+  page: Page,
+  project: SwitchFixtureProject
+): Promise<SeededWorkload> {
+  const wanted = project.branches.slice(0, 2);
+  let worktrees: WorktreeRow[] = [];
+  await expect
+    .poll(
+      async () => {
+        worktrees = await listWorktrees(page);
+        return wanted.every((branch) =>
+          worktrees.some(
+            (row) => row.branch === branch || row.path.endsWith(branch.replace("/", "-"))
+          )
+        );
+      },
+      { timeout: 60_000, intervals: [250, 500] }
+    )
+    .toBe(true);
+  const worktreeIds = wanted.map(
+    (branch) =>
+      worktrees.find((row) => row.branch === branch || row.path.endsWith(branch.replace("/", "-")))!
+        .id
+  );
+
+  await selectWorktree(page, worktreeIds[0]!, wanted[0]!);
+
+  const beforeProbe = new Set(await getGridPanelIds(page));
+  await openTerminal(page);
+  const probePanelId = await newestGridPanel(page, beforeProbe);
+  await waitForTerminalReady(page, page.locator(`[data-panel-id="${probePanelId}"]`), T_LONG);
+
+  const agentPanelIds: string[] = [];
+  agentPanelIds.push(await launchAgent(page, worktreeIds[0]!));
+  agentPanelIds.push(await launchAgent(page, worktreeIds[0]!));
+
+  await selectWorktree(page, worktreeIds[1]!, wanted[1]!);
+  agentPanelIds.push(await launchAgent(page, worktreeIds[1]!));
+  // Cooked-mode stdin: the fake CLI only sees a line once it is terminated.
+  await ptyWrite(page, agentPanelIds[2]!, `${FAKE_AGENT_IDLE}\r`);
+  await expect
+    .poll(
+      () => page.locator(`[data-panel-id="${agentPanelIds[2]}"]`).getAttribute("data-agent-state"),
+      { timeout: 60_000, intervals: [250, 500] }
+    )
+    .toBe("waiting");
+
+  await selectWorktree(page, worktreeIds[0]!, wanted[0]!);
+  await ptyWrite(page, agentPanelIds[0]!, `${FAKE_AGENT_STREAM_ON}\r`);
+
+  const probe = page.locator(`[data-panel-id="${probePanelId}"]`);
+  await expect(probe).toBeVisible({ timeout: T_LONG });
+  await probe.locator(SEL.terminal.xtermRows).first().click({ force: true });
+  await expect
+    .poll(
+      () =>
+        page.evaluate(
+          (id) =>
+            Boolean(
+              document.activeElement?.closest(`[data-panel-id="${id}"]`) &&
+              document.activeElement?.classList.contains("xterm-helper-textarea")
+            ),
+          probePanelId
+        ),
+      { timeout: T_LONG, intervals: [100, 250] }
+    )
+    .toBe(true);
+
+  return { probePanelId, agentPanelIds, worktreeIds };
+}

--- a/e2e/helpers/switchRotation.ts
+++ b/e2e/helpers/switchRotation.ts
@@ -1,0 +1,778 @@
+/**
+ * Pure analysis for the project-switch rotation benchmark
+ * (`e2e/full/resilience/project-switch-rotation-perf.spec.ts`).
+ *
+ * Nothing here touches Playwright or Electron: the spec feeds it the NDJSON
+ * perf-mark file and gets back per-sample timings and aggregates, so the
+ * joining rules that decide what a number means are unit-tested rather than
+ * buried in a 30-minute E2E run.
+ */
+
+export type CacheClass = "warm" | "cold";
+export type EntryPoint = "mru" | "palette-keyboard" | "palette-mouse" | "toolbar";
+
+export interface MarkRecord {
+  mark: string;
+  timestamp: number;
+  elapsedMs: number;
+  meta?: Record<string, unknown> | null;
+}
+
+export interface SwitchTraceStep {
+  index: number;
+  depth: number;
+  fromProjectId: string;
+  targetProjectId: string;
+  expectedCache: CacheClass;
+  entryPoint: EntryPoint;
+}
+
+export interface StackDistanceTraceOptions {
+  projectIds: readonly string[];
+  samplesPerDepth: number;
+  /** Cached-view limit the app runs with; depth `cap - 1` is the deepest warm target. */
+  cap: number;
+  maxDepth?: number;
+  seed?: number;
+  /** Entry point for a base sample at a given depth. Depth 1 is the MRU toggle by default. */
+  entryPointForDepth?: (depth: number) => EntryPoint;
+  /** Extra strata appended after the shuffled base samples, continuing the same MRU stack. */
+  extraSteps?: ReadonlyArray<{ depth: number; entryPoint: EntryPoint }>;
+}
+
+/** Deterministic 32-bit PRNG so a trace can be replayed from its seed. */
+export function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export function expectedCacheForDepth(depth: number, cap: number): CacheClass {
+  return depth <= cap - 1 ? "warm" : "cold";
+}
+
+/**
+ * Simulate an MRU stack (head = current project) and emit switches at the
+ * requested stack distances. Choosing depth `d` moves `stack[d]` to the head,
+ * which is exactly what the LRU view cache does, so `expectedCache` is a
+ * prediction the spec can hold the app to.
+ */
+export function generateStackDistanceTrace(options: StackDistanceTraceOptions): SwitchTraceStep[] {
+  const {
+    projectIds,
+    samplesPerDepth,
+    cap,
+    maxDepth = 4,
+    seed = 1,
+    entryPointForDepth = (depth) => (depth === 1 ? "mru" : "palette-keyboard"),
+    extraSteps = [],
+  } = options;
+  if (projectIds.length < maxDepth + 1) {
+    throw new Error(
+      `need at least ${maxDepth + 1} projects for depth ${maxDepth}, got ${projectIds.length}`
+    );
+  }
+  if (!Number.isInteger(samplesPerDepth) || samplesPerDepth < 0) {
+    throw new Error(`samplesPerDepth must be a non-negative integer, got ${samplesPerDepth}`);
+  }
+
+  const plan: Array<{ depth: number; entryPoint: EntryPoint }> = [];
+  for (let depth = 1; depth <= maxDepth; depth++) {
+    for (let i = 0; i < samplesPerDepth; i++) {
+      plan.push({ depth, entryPoint: entryPointForDepth(depth) });
+    }
+  }
+  const rand = mulberry32(seed);
+  for (let i = plan.length - 1; i > 0; i--) {
+    const j = Math.floor(rand() * (i + 1));
+    const tmp = plan[i]!;
+    plan[i] = plan[j]!;
+    plan[j] = tmp;
+  }
+  for (const step of extraSteps) {
+    if (step.depth < 1 || step.depth > projectIds.length - 1) {
+      throw new Error(`extra step depth ${step.depth} is outside 1..${projectIds.length - 1}`);
+    }
+    plan.push({ depth: step.depth, entryPoint: step.entryPoint });
+  }
+
+  const stack = [...projectIds];
+  return plan.map((step, index) => {
+    const fromProjectId = stack[0]!;
+    const [targetProjectId] = stack.splice(step.depth, 1) as [string];
+    stack.unshift(targetProjectId);
+    return {
+      index,
+      depth: step.depth,
+      fromProjectId,
+      targetProjectId,
+      expectedCache: expectedCacheForDepth(step.depth, cap),
+      entryPoint: step.entryPoint,
+    };
+  });
+}
+
+/** Nearest-rank percentile; `p` in 0..100. Returns NaN for an empty input. */
+export function pct(values: readonly number[], p: number): number {
+  const finite = values.filter((v) => Number.isFinite(v));
+  if (finite.length === 0) return NaN;
+  const sorted = [...finite].sort((a, b) => a - b);
+  const rank = Math.ceil((p / 100) * sorted.length);
+  return sorted[Math.min(sorted.length - 1, Math.max(0, rank - 1))]!;
+}
+
+export function mean(values: readonly number[]): number {
+  const finite = values.filter((v) => Number.isFinite(v));
+  if (finite.length === 0) return NaN;
+  return finite.reduce((sum, v) => sum + v, 0) / finite.length;
+}
+
+/**
+ * Quantile of a weighted sample: the smallest value at which the cumulative
+ * normalised weight reaches `q` (0..1). Non-finite values and non-positive
+ * weights are dropped together.
+ */
+export function weightedQuantile(
+  values: readonly number[],
+  weights: readonly number[],
+  q: number
+): number {
+  if (values.length !== weights.length) {
+    throw new Error(`values (${values.length}) and weights (${weights.length}) differ in length`);
+  }
+  const pairs: Array<[number, number]> = [];
+  for (let i = 0; i < values.length; i++) {
+    const v = values[i]!;
+    const w = weights[i]!;
+    if (Number.isFinite(v) && Number.isFinite(w) && w > 0) pairs.push([v, w]);
+  }
+  if (pairs.length === 0) return NaN;
+  pairs.sort((a, b) => a[0] - b[0]);
+  const total = pairs.reduce((sum, [, w]) => sum + w, 0);
+  const threshold = Math.min(1, Math.max(0, q)) * total;
+  let cumulative = 0;
+  for (const [v, w] of pairs) {
+    cumulative += w;
+    if (cumulative >= threshold - 1e-12) return v;
+  }
+  return pairs[pairs.length - 1]![0];
+}
+
+export function parseNdjson(text: string): MarkRecord[] {
+  const records: MarkRecord[] = [];
+  for (const line of text.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      // A partial trailing line while the app is still writing is expected.
+      continue;
+    }
+    if (!parsed || typeof parsed !== "object") continue;
+    const record = parsed as Partial<MarkRecord>;
+    if (typeof record.mark !== "string" || typeof record.elapsedMs !== "number") continue;
+    records.push({
+      mark: record.mark,
+      timestamp: typeof record.timestamp === "number" ? record.timestamp : NaN,
+      elapsedMs: record.elapsedMs,
+      meta: record.meta && typeof record.meta === "object" ? record.meta : null,
+    });
+  }
+  return records;
+}
+
+export const SWITCH_MARK = {
+  KEYDOWN: "project_switch.keydown",
+  INTENT: "project_switch.intent",
+  BUSY_PAINTED: "project_switch.busy_painted",
+  PERSIST_IDLE: "project_switch.persist_idle",
+  SNAPSHOT_BUILT: "project_switch.snapshot_built",
+  IPC_SENT: "project_switch.ipc_sent",
+  MAIN_RECEIVED: "project_switch.main_received",
+  MAIN_LOOP_PROBE: "project_switch.main_loop_probe",
+  PENDING_PERSIST_DONE: "project_switch.pending_persist_done",
+  CHAIN_ENTERED: "project_switch.chain_entered",
+  VIEW_ATTACHED: "project_switch.view_attached",
+  LOAD_FINISHED: "project_switch.load_finished",
+  GATE_RESOLVED: "project_switch.gate_resolved",
+  REVEALED: "project_switch.revealed",
+  SWAP_DONE: "project_switch.swap_done",
+  PTY_PORT_SENT: "project_switch.pty_port_sent",
+  WORKTREES_LOADED: "project_switch.worktrees_loaded",
+  SETTLED: "project_switch.settled",
+  FIRST_INTERACTIVE: "project_switch.first_interactive",
+  ON_SWITCH_RECEIVED: "project_switch.on_switch_received",
+  WARM_ACTIVATED_RECEIVED: "project_switch.warm_activated_received",
+  FOCUSED_PANE_WOKEN: "project_switch.focused_pane_woken",
+  ALL_PANES_WOKEN: "project_switch.all_panes_woken",
+  WARM_PAINT_SIGNALLED: "project_switch.warm_paint_signalled",
+  REVEALED_RECEIVED: "project_switch.revealed_received",
+  REVEAL_REPAINT_DONE: "project_switch.reveal_repaint_done",
+  PTY_PORT_READY: "project_switch.pty_port_ready",
+  NONCE_PAINTED: "project_switch.nonce_painted",
+  NONCE_FRAME: "project_switch.nonce_frame",
+  HYDRATE_START: "hydrate_start",
+  HYDRATE_COMPLETE: "hydrate_complete",
+  RENDERER_FIRST_INTERACTIVE: "renderer_first_interactive",
+  APP_HYDRATE_PREFETCH: "app_hydrate_prefetch",
+  EVENT_LOOP_LAG: "event_loop_lag",
+  RENDERER_LOAF: "renderer_long_animation_frame",
+} as const;
+
+/** Renderer marks that carry no switchId and are joined to a switch by view + time window. */
+const JOINABLE_RENDERER_MARKS: ReadonlySet<string> = new Set([
+  SWITCH_MARK.HYDRATE_START,
+  SWITCH_MARK.HYDRATE_COMPLETE,
+  SWITCH_MARK.RENDERER_FIRST_INTERACTIVE,
+  SWITCH_MARK.RENDERER_LOAF,
+]);
+
+/** Tail after `settled` in which incoming-renderer marks still belong to the switch. */
+export const JOIN_TAIL_MS = 5_000;
+
+export interface SwitchMarkGroup {
+  switchId: string;
+  /** Marks that named this switchId in their meta. */
+  marks: MarkRecord[];
+  /** Renderer marks joined by webContentsId + time window. */
+  joined: MarkRecord[];
+  /** Main-process `event_loop_lag` samples inside the switch window. */
+  lagSamples: MarkRecord[];
+  /** `app_hydrate_prefetch` inside the window for the target project, when one was emitted. */
+  prefetch: MarkRecord | null;
+  windowStartMs: number;
+  windowEndMs: number;
+  targetWebContentsId: number | null;
+}
+
+export interface GroupedMarks {
+  bySwitch: Map<string, SwitchMarkGroup>;
+  byNonce: Map<string, MarkRecord[]>;
+}
+
+function metaString(record: MarkRecord, key: string): string | null {
+  const value = record.meta?.[key];
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function metaNumber(record: MarkRecord, key: string): number | null {
+  const value = record.meta?.[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+export function findMark(marks: readonly MarkRecord[], mark: string): MarkRecord | undefined {
+  return marks.find((record) => record.mark === mark);
+}
+
+export function groupMarksBySwitch(records: readonly MarkRecord[]): GroupedMarks {
+  const bySwitch = new Map<string, SwitchMarkGroup>();
+  const byNonce = new Map<string, MarkRecord[]>();
+
+  for (const record of records) {
+    const nonce = metaString(record, "nonce");
+    if (
+      nonce &&
+      (record.mark === SWITCH_MARK.NONCE_PAINTED || record.mark === SWITCH_MARK.NONCE_FRAME)
+    ) {
+      const list = byNonce.get(nonce) ?? [];
+      list.push(record);
+      byNonce.set(nonce, list);
+      continue;
+    }
+    const switchId = metaString(record, "switchId");
+    if (!switchId) continue;
+    let group = bySwitch.get(switchId);
+    if (!group) {
+      group = {
+        switchId,
+        marks: [],
+        joined: [],
+        lagSamples: [],
+        prefetch: null,
+        windowStartMs: NaN,
+        windowEndMs: NaN,
+        targetWebContentsId: null,
+      };
+      bySwitch.set(switchId, group);
+    }
+    group.marks.push(record);
+  }
+
+  for (const group of bySwitch.values()) {
+    group.marks.sort((a, b) => a.elapsedMs - b.elapsedMs);
+    const mainReceived = findMark(group.marks, SWITCH_MARK.MAIN_RECEIVED);
+    const settled = findMark(group.marks, SWITCH_MARK.SETTLED);
+    const viewAttached = findMark(group.marks, SWITCH_MARK.VIEW_ATTACHED);
+    const first = group.marks[0]!;
+    const last = group.marks[group.marks.length - 1]!;
+    group.windowStartMs = (mainReceived ?? first).elapsedMs;
+    group.windowEndMs = (settled ?? last).elapsedMs + JOIN_TAIL_MS;
+    group.targetWebContentsId = viewAttached ? metaNumber(viewAttached, "webContentsId") : null;
+  }
+
+  const groups = [...bySwitch.values()];
+  for (const record of records) {
+    if (metaString(record, "switchId")) continue;
+    if (record.mark === SWITCH_MARK.EVENT_LOOP_LAG) {
+      for (const group of groups) {
+        if (record.elapsedMs >= group.windowStartMs && record.elapsedMs <= group.windowEndMs) {
+          group.lagSamples.push(record);
+        }
+      }
+      continue;
+    }
+    if (record.mark === SWITCH_MARK.APP_HYDRATE_PREFETCH) {
+      const projectId = metaString(record, "projectId");
+      for (const group of groups) {
+        if (record.elapsedMs < group.windowStartMs || record.elapsedMs > group.windowEndMs) {
+          continue;
+        }
+        const mainReceived = findMark(group.marks, SWITCH_MARK.MAIN_RECEIVED);
+        const target = mainReceived ? metaString(mainReceived, "targetProjectId") : null;
+        if (projectId && target && projectId !== target) continue;
+        // The earliest prefetch mark inside the window is the one this switch's hydrate consumed.
+        if (!group.prefetch || record.elapsedMs < group.prefetch.elapsedMs) group.prefetch = record;
+      }
+      continue;
+    }
+    if (!JOINABLE_RENDERER_MARKS.has(record.mark)) continue;
+    const webContentsId = metaNumber(record, "webContentsId");
+    if (webContentsId === null) continue;
+    for (const group of groups) {
+      if (group.targetWebContentsId !== webContentsId) continue;
+      if (record.elapsedMs < group.windowStartMs || record.elapsedMs > group.windowEndMs) continue;
+      group.joined.push(record);
+    }
+  }
+  for (const group of groups) group.joined.sort((a, b) => a.elapsedMs - b.elapsedMs);
+
+  return { bySwitch, byNonce };
+}
+
+export const TIMING_KEYS = [
+  "keydownToIntentMs",
+  "intentToBusyPaintedMs",
+  "intentToIpcSentMs",
+  "intentToMainReceivedMs",
+  "intentToChainEnteredMs",
+  "intentToViewAttachedMs",
+  "intentToGateResolvedMs",
+  "intentToRevealedMs",
+  "intentToFocusReadyMs",
+  "intentToNoncePaintedMs",
+  "intentToWarmActivatedReceivedMs",
+  "intentToFocusedPaneWokenMs",
+  "intentToAllPanesWokenMs",
+  "intentToWarmPaintSignalledMs",
+  "intentToPtyPortReadyMs",
+  "intentToHydrateCompleteMs",
+  "intentToFirstInteractiveMs",
+  "intentToSettledMs",
+  "revealToRepaintDoneMs",
+] as const;
+
+export type TimingKey = (typeof TIMING_KEYS)[number];
+export type SampleTimings = Record<TimingKey, number>;
+
+export interface SampleLag {
+  mainLoopLagMs: number;
+  eventLoopLagOverlapMs: number;
+  rendererLoafCount: number;
+  rendererLoafTotalMs: number;
+}
+
+export interface SampleSummary {
+  timings: SampleTimings;
+  lag: SampleLag;
+  actualCache: CacheClass | null;
+  gateOutcome: string | null;
+  releaseChannel: string | null;
+  prefetchHit: boolean | null;
+  entryPointReported: string | null;
+  /** `main_received` elapsedMs — the anchor when the outgoing renderer emitted no intent. */
+  anchorMs: number;
+  anchorMark: string;
+  /** Ordering-invariant violations, empty when every present mark is in order. */
+  orderingViolations: string[];
+}
+
+const NAN_TIMINGS: SampleTimings = Object.fromEntries(
+  TIMING_KEYS.map((key) => [key, NaN])
+) as SampleTimings;
+
+/**
+ * Turn one switch's marks into the timings the report carries. Every timing is
+ * measured from `intent` (the outgoing renderer deciding to switch); when the
+ * switch was driven without a keyboard/palette intent the anchor falls back to
+ * `main_received` and the summary says so.
+ */
+export function summarizeSample(
+  group: SwitchMarkGroup,
+  nonceMarks: readonly MarkRecord[] = [],
+  focusReadyMs: number = NaN
+): SampleSummary {
+  const all = [...group.marks, ...group.joined];
+  const at = (mark: string, source: readonly MarkRecord[] = all): number => {
+    const record = findMark(source, mark);
+    return record ? record.elapsedMs : NaN;
+  };
+
+  const keydown = at(SWITCH_MARK.KEYDOWN);
+  const intentRaw = at(SWITCH_MARK.INTENT);
+  const mainReceived = at(SWITCH_MARK.MAIN_RECEIVED);
+  const anchorMark = Number.isFinite(intentRaw)
+    ? SWITCH_MARK.INTENT
+    : Number.isFinite(keydown)
+      ? SWITCH_MARK.KEYDOWN
+      : SWITCH_MARK.MAIN_RECEIVED;
+  const intent = Number.isFinite(intentRaw)
+    ? intentRaw
+    : Number.isFinite(keydown)
+      ? keydown
+      : mainReceived;
+
+  const revealed = at(SWITCH_MARK.REVEALED);
+  const noncePainted = at(SWITCH_MARK.NONCE_PAINTED, nonceMarks);
+  const hydrateComplete = at(SWITCH_MARK.HYDRATE_COMPLETE, group.joined);
+  const firstInteractiveMain = at(SWITCH_MARK.FIRST_INTERACTIVE, group.marks);
+  const firstInteractive = Number.isFinite(firstInteractiveMain)
+    ? firstInteractiveMain
+    : at(SWITCH_MARK.RENDERER_FIRST_INTERACTIVE, group.joined);
+  const repaintDone = group.marks.find(
+    (record) =>
+      record.mark === SWITCH_MARK.REVEAL_REPAINT_DONE && metaString(record, "pass") === "initial"
+  );
+
+  const timings: SampleTimings = {
+    ...NAN_TIMINGS,
+    keydownToIntentMs: intentRaw - keydown,
+    intentToBusyPaintedMs: at(SWITCH_MARK.BUSY_PAINTED) - intent,
+    intentToIpcSentMs: at(SWITCH_MARK.IPC_SENT) - intent,
+    intentToMainReceivedMs: mainReceived - intent,
+    intentToChainEnteredMs: at(SWITCH_MARK.CHAIN_ENTERED) - intent,
+    intentToViewAttachedMs: at(SWITCH_MARK.VIEW_ATTACHED) - intent,
+    intentToGateResolvedMs: at(SWITCH_MARK.GATE_RESOLVED) - intent,
+    intentToRevealedMs: revealed - intent,
+    intentToFocusReadyMs: focusReadyMs,
+    intentToNoncePaintedMs: noncePainted - intent,
+    intentToWarmActivatedReceivedMs: at(SWITCH_MARK.WARM_ACTIVATED_RECEIVED) - intent,
+    intentToFocusedPaneWokenMs: at(SWITCH_MARK.FOCUSED_PANE_WOKEN) - intent,
+    intentToAllPanesWokenMs: at(SWITCH_MARK.ALL_PANES_WOKEN) - intent,
+    intentToWarmPaintSignalledMs: at(SWITCH_MARK.WARM_PAINT_SIGNALLED) - intent,
+    intentToPtyPortReadyMs: at(SWITCH_MARK.PTY_PORT_READY) - intent,
+    intentToHydrateCompleteMs: hydrateComplete - intent,
+    intentToFirstInteractiveMs: firstInteractive - intent,
+    intentToSettledMs: at(SWITCH_MARK.SETTLED) - intent,
+    revealToRepaintDoneMs: repaintDone ? repaintDone.elapsedMs - revealed : NaN,
+  };
+
+  const mainReceivedRecord = findMark(group.marks, SWITCH_MARK.MAIN_RECEIVED);
+  const probe = findMark(group.marks, SWITCH_MARK.MAIN_LOOP_PROBE);
+  const mainLoopLagMs =
+    (probe ? metaNumber(probe, "lagMs") : null) ??
+    (mainReceivedRecord ? metaNumber(mainReceivedRecord, "mainLoopLagMs") : null) ??
+    NaN;
+  const settledMs = at(SWITCH_MARK.SETTLED);
+  const lagWindowEnd = Number.isFinite(settledMs) ? settledMs : group.windowEndMs;
+  const eventLoopLagOverlapMs = group.lagSamples
+    .filter((record) => record.elapsedMs <= lagWindowEnd)
+    .reduce((sum, record) => sum + (metaNumber(record, "lagMs") ?? 0), 0);
+  const loafs = group.joined.filter(
+    (record) => record.mark === SWITCH_MARK.RENDERER_LOAF && record.elapsedMs <= lagWindowEnd
+  );
+  const rendererLoafTotalMs = loafs.reduce(
+    (sum, record) =>
+      sum + (metaNumber(record, "durationMs") ?? metaNumber(record, "duration") ?? 0),
+    0
+  );
+
+  const gate = findMark(group.marks, SWITCH_MARK.GATE_RESOLVED);
+  const cacheState = mainReceivedRecord ? metaString(mainReceivedRecord, "cacheState") : null;
+  const prefetchHitRaw = group.prefetch?.meta?.hit;
+
+  const orderingViolations: string[] = [];
+  const check = (label: string, earlier: number, later: number, strict: boolean): void => {
+    if (!Number.isFinite(earlier) || !Number.isFinite(later)) return;
+    if (strict ? later <= earlier : later < earlier) {
+      orderingViolations.push(`${label} (${earlier} vs ${later})`);
+    }
+  };
+  check("keydown ≤ intent", keydown, intentRaw, false);
+  check("intent < main_received", intentRaw, mainReceived, true);
+  check("main_received ≤ chain_entered", mainReceived, at(SWITCH_MARK.CHAIN_ENTERED), false);
+  check(
+    "chain_entered < view_attached",
+    at(SWITCH_MARK.CHAIN_ENTERED),
+    at(SWITCH_MARK.VIEW_ATTACHED),
+    true
+  );
+  check(
+    "view_attached ≤ gate_resolved",
+    at(SWITCH_MARK.VIEW_ATTACHED),
+    at(SWITCH_MARK.GATE_RESOLVED),
+    false
+  );
+  check("gate_resolved ≤ revealed", at(SWITCH_MARK.GATE_RESOLVED), revealed, false);
+  check("revealed ≤ settled", revealed, settledMs, false);
+  check("revealed < nonce_painted", revealed, noncePainted, true);
+
+  return {
+    timings,
+    lag: {
+      mainLoopLagMs,
+      eventLoopLagOverlapMs,
+      rendererLoafCount: loafs.length,
+      rendererLoafTotalMs,
+    },
+    actualCache: cacheState === "warm" || cacheState === "cold" ? cacheState : null,
+    gateOutcome: gate ? metaString(gate, "gateOutcome") : null,
+    releaseChannel: gate ? metaString(gate, "releaseChannel") : null,
+    prefetchHit: typeof prefetchHitRaw === "boolean" ? prefetchHitRaw : null,
+    entryPointReported: mainReceivedRecord ? metaString(mainReceivedRecord, "entryPoint") : null,
+    anchorMs: intent,
+    anchorMark,
+    orderingViolations,
+  };
+}
+
+export interface MetricStats {
+  n: number;
+  p50: number;
+  p95: number;
+  max: number;
+  mean: number;
+}
+
+export type StatsByTiming = Partial<Record<TimingKey, MetricStats>>;
+
+export interface AggregateBucket {
+  n: number;
+  timings: StatsByTiming;
+}
+
+export interface WeightedAggregate {
+  weights: Record<number, number>;
+  /** Weight actually applied per depth after dropping depths with no valid samples. */
+  effectiveWeights: Record<number, number>;
+  timings: Partial<Record<TimingKey, { p50: number; p95: number }>>;
+}
+
+export interface AggregateInput {
+  depth: number;
+  actualCache: CacheClass | null;
+  expectedCache: CacheClass;
+  entryPoint: string;
+  timings: SampleTimings;
+}
+
+export interface Aggregate {
+  byDepth: Record<number, AggregateBucket>;
+  byCache: Record<CacheClass, AggregateBucket>;
+  byEntryPoint: Record<string, AggregateBucket>;
+  weighted: WeightedAggregate;
+}
+
+export const DEFAULT_DEPTH_WEIGHTS: Record<number, number> = { 1: 0.55, 2: 0.25, 3: 0.12, 4: 0.08 };
+
+function statsFor(values: readonly number[]): MetricStats | null {
+  const finite = values.filter((v) => Number.isFinite(v));
+  if (finite.length === 0) return null;
+  return {
+    n: finite.length,
+    p50: pct(finite, 50),
+    p95: pct(finite, 95),
+    max: Math.max(...finite),
+    mean: mean(finite),
+  };
+}
+
+function bucketFor(samples: readonly AggregateInput[]): AggregateBucket {
+  const timings: StatsByTiming = {};
+  for (const key of TIMING_KEYS) {
+    const stats = statsFor(samples.map((sample) => sample.timings[key]));
+    if (stats) timings[key] = stats;
+  }
+  return { n: samples.length, timings };
+}
+
+/**
+ * Per-depth, per-cache-class and per-entry-point stats, plus a weighted
+ * quantile that answers "what does a typical switch cost" given how often each
+ * stack distance is used. Each depth's weight is split evenly across its valid
+ * samples, so an over-sampled depth does not out-vote the weights.
+ */
+export function aggregate(
+  samples: readonly AggregateInput[],
+  weights: Record<number, number> = DEFAULT_DEPTH_WEIGHTS
+): Aggregate {
+  const byDepth: Record<number, AggregateBucket> = {};
+  const byEntryPoint: Record<string, AggregateBucket> = {};
+  const depthGroups = new Map<number, AggregateInput[]>();
+  const cacheGroups: Record<CacheClass, AggregateInput[]> = { warm: [], cold: [] };
+  const entryGroups = new Map<string, AggregateInput[]>();
+  for (const sample of samples) {
+    depthGroups.set(sample.depth, [...(depthGroups.get(sample.depth) ?? []), sample]);
+    const cache = sample.actualCache ?? sample.expectedCache;
+    cacheGroups[cache].push(sample);
+    entryGroups.set(sample.entryPoint, [...(entryGroups.get(sample.entryPoint) ?? []), sample]);
+  }
+  for (const [depth, group] of [...depthGroups.entries()].sort((a, b) => a[0] - b[0])) {
+    byDepth[depth] = bucketFor(group);
+  }
+  const byCache: Record<CacheClass, AggregateBucket> = {
+    warm: bucketFor(cacheGroups.warm),
+    cold: bucketFor(cacheGroups.cold),
+  };
+  for (const [entryPoint, group] of [...entryGroups.entries()].sort((a, b) =>
+    a[0].localeCompare(b[0])
+  )) {
+    byEntryPoint[entryPoint] = bucketFor(group);
+  }
+
+  const weightedDepths = [...depthGroups.keys()].filter((depth) => (weights[depth] ?? 0) > 0);
+  const totalWeight = weightedDepths.reduce((sum, depth) => sum + (weights[depth] ?? 0), 0);
+  const effectiveWeights: Record<number, number> = {};
+  for (const depth of weightedDepths) {
+    effectiveWeights[depth] = totalWeight > 0 ? (weights[depth] ?? 0) / totalWeight : 0;
+  }
+  const weighted: WeightedAggregate = { weights, effectiveWeights, timings: {} };
+  for (const key of TIMING_KEYS) {
+    const values: number[] = [];
+    const sampleWeights: number[] = [];
+    for (const depth of weightedDepths) {
+      const valid = (depthGroups.get(depth) ?? []).filter((sample) =>
+        Number.isFinite(sample.timings[key])
+      );
+      if (valid.length === 0) continue;
+      for (const sample of valid) {
+        values.push(sample.timings[key]);
+        sampleWeights.push(effectiveWeights[depth]! / valid.length);
+      }
+    }
+    if (values.length === 0) continue;
+    weighted.timings[key] = {
+      p50: weightedQuantile(values, sampleWeights, 0.5),
+      p95: weightedQuantile(values, sampleWeights, 0.95),
+    };
+  }
+
+  return { byDepth, byCache, byEntryPoint, weighted };
+}
+
+// ── Result file shape (shared with scripts/perf/project-switch-rotation-compare.ts) ──
+
+export interface RotationConfig {
+  cap: number;
+  projects: number;
+  worktreesPerProject: number;
+  agentsPerProject: number;
+  filesPerRepo: number;
+  samplesPerDepth: number;
+  seed: number;
+  weights: Record<number, number>;
+  entryPoints: string[];
+  rapidBursts: number;
+}
+
+export interface RotationApparatus {
+  rendererGone: number;
+  hardTimeouts: number;
+  cacheMisclassified: number;
+  nonceLost: number;
+  nonceDuplicated: number;
+  crossPtyLeaks: number;
+  uncheckedEvictedViews: number;
+  samplesInvalid: number;
+  settleTimeouts: number;
+}
+
+export interface MemoryViewSample {
+  projectId: string | null;
+  state: string | null;
+  webContentsId: number | null;
+  pid: number | null;
+  workingSetKb: number;
+  guestPids: number[];
+}
+
+export interface MemorySample {
+  at: string;
+  phase: string;
+  sampleIndex: number | null;
+  totalKb: number;
+  browserKb: number;
+  gpuKb: number;
+  rendererTotalKb: number;
+  unattributedRendererKb: number;
+  utilityByNameKb: Record<string, number>;
+  ptyDescendantsKb: number;
+  views: MemoryViewSample[];
+}
+
+export interface RotationSample {
+  index: number;
+  phase: "isolated" | "rapid";
+  switchId: string | null;
+  entryPoint: string;
+  entryPointFallback: boolean;
+  depth: number;
+  fromProjectId: string;
+  targetProjectId: string;
+  expectedCache: CacheClass;
+  actualCache: CacheClass | null;
+  gateOutcome: string | null;
+  releaseChannel: string | null;
+  prefetchHit: boolean | null;
+  probeArmedAfterSwitch: boolean;
+  focusRescued: boolean;
+  nonce: string | null;
+  nonceHits: number | null;
+  anchorMark: string | null;
+  orderingViolations: string[];
+  settleTimedOut: boolean;
+  timings: SampleTimings;
+  lag: SampleLag;
+  memory?: MemorySample;
+}
+
+export interface RotationRapidBurst {
+  burst: number;
+  switchIds: string[];
+  queueDelaysMs: number[];
+  settleMs: number[];
+  gateOutcomes: Record<string, number>;
+  attachedMatchedTarget: boolean;
+}
+
+export interface RotationResult {
+  label: string;
+  platform: string;
+  arch: string;
+  createdAt: string;
+  commit: string;
+  config: RotationConfig;
+  apparatus: RotationApparatus;
+  samples: RotationSample[];
+  byDepth: Aggregate["byDepth"];
+  byCache: Aggregate["byCache"];
+  byEntryPoint: Aggregate["byEntryPoint"];
+  weighted: WeightedAggregate;
+  rapid: {
+    bursts: RotationRapidBurst[];
+    maxQueueDelayMs: number;
+    maxSettleMs: number;
+    gateOutcomes: Record<string, number>;
+  };
+  memory: {
+    checkpoints: { hot: MemorySample | null; postPurge: MemorySample | null };
+    samples: MemorySample[];
+  };
+  markRecords?: MarkRecord[];
+}

--- a/e2e/helpers/switchRotation.ts
+++ b/e2e/helpers/switchRotation.ts
@@ -498,9 +498,13 @@ export function summarizeSample(
   const prefetchHitRaw = group.prefetch?.meta?.hit;
 
   const orderingViolations: string[] = [];
+  // Renderer marks are rebased onto main's clock; the two clocks disagree by a
+  // few hundred microseconds, which a switch that completes in single-digit
+  // milliseconds would otherwise report as a causality violation.
+  const CLOCK_SKEW_MS = 2;
   const check = (label: string, earlier: number, later: number, strict: boolean): void => {
     if (!Number.isFinite(earlier) || !Number.isFinite(later)) return;
-    if (strict ? later <= earlier : later < earlier) {
+    if (strict ? later + CLOCK_SKEW_MS <= earlier : later + CLOCK_SKEW_MS < earlier) {
       orderingViolations.push(`${label} (${earlier} vs ${later})`);
     }
   };

--- a/electron/__tests__/menu.test.ts
+++ b/electron/__tests__/menu.test.ts
@@ -1003,7 +1003,10 @@ describe("handleDirectoryOpen window targeting", () => {
     const targetWindow = { id: 7, isDestroyed: () => false } as unknown as Electron.BrowserWindow;
     await handleDirectoryOpen(PROJECT.path, targetWindow);
 
-    expect(targetManager.switchTo).toHaveBeenCalledWith(PROJECT.id, PROJECT.path);
+    expect(targetManager.switchTo).toHaveBeenCalledWith(PROJECT.id, PROJECT.path, {
+      switchId: expect.any(String),
+      entryPoint: "menu",
+    });
     expect(newestManager.switchTo).not.toHaveBeenCalled();
   });
 });

--- a/electron/ipc/handlers/__tests__/perf.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/perf.handlers.test.ts
@@ -102,6 +102,62 @@ describe("registerPerfHandlers", () => {
     expect((record.meta as Record<string, unknown>).webContentsId).toBe(7);
   });
 
+  it("stamps each record with the sender view's project id via the per-window manager", () => {
+    const deps = {
+      projectViewManager: { getProjectIdForWebContents: () => "proj-static" },
+      windowRegistry: {
+        getByWebContentsId: (id: number) =>
+          id === 22
+            ? {
+                services: {
+                  projectViewManager: {
+                    getProjectIdForWebContents: (wcId: number) =>
+                      wcId === 22 ? "proj-window-b" : null,
+                  },
+                },
+              }
+            : undefined,
+      },
+    } as unknown as HandlerDependencies;
+
+    registerPerfHandlers(deps);
+    const handler = getHandler();
+
+    handler(makeEvent(22), {
+      marks: [
+        {
+          mark: "project_switch.pty_port_ready",
+          timestamp: "2026-01-01T00:00:00.000Z",
+          elapsedMs: 100,
+          meta: { switchId: "abc" },
+        },
+      ],
+      rendererTimeOrigin: 1_000_100,
+      rendererT0: 5,
+    });
+
+    const record = appendedPayloads[0] as Record<string, unknown>;
+    expect((record.meta as Record<string, unknown>).projectId).toBe("proj-window-b");
+    expect((record.meta as Record<string, unknown>).switchId).toBe("abc");
+  });
+
+  it("omits projectId when no manager knows the sender", () => {
+    const deps = {
+      projectViewManager: { getProjectIdForWebContents: () => null },
+    } as unknown as HandlerDependencies;
+    registerPerfHandlers(deps);
+    const handler = getHandler();
+
+    handler(makeEvent(5), {
+      marks: [{ mark: "hydrate_start", timestamp: "2026-01-01T00:00:00.000Z", elapsedMs: 1 }],
+      rendererTimeOrigin: 1_000_100,
+      rendererT0: 5,
+    });
+
+    const record = appendedPayloads[0] as Record<string, unknown>;
+    expect(record.meta as Record<string, unknown>).not.toHaveProperty("projectId");
+  });
+
   it("omits webContents id when the sender is destroyed", () => {
     registerPerfHandlers();
     const handler = getHandler();

--- a/electron/ipc/handlers/__tests__/project.switch.test.ts
+++ b/electron/ipc/handlers/__tests__/project.switch.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { _resetTerminalInventoryPrefetchForTests } from "../../../services/terminalInventoryPrefetch.js";
 import os from "os";
 
 vi.mock("electron", () => ({
@@ -1723,6 +1724,8 @@ describe("project:switch PTY port ordering (#10075)", () => {
     const pvm = {
       switchTo: vi.fn().mockResolvedValue({ view: mockView, isNew: opts.isNew }),
       getProjectIdForWebContents: vi.fn(),
+      // A warm target has a live entry before the swap; a cold one has none.
+      getAllViews: vi.fn(() => (opts.isNew ? [] : [{ projectId: "proj-new", view: mockView }])),
     };
 
     mockGetWindowForWebContents.mockReturnValue({ id: 7, isDestroyed: () => false });
@@ -1735,7 +1738,15 @@ describe("project:switch PTY port ordering (#10075)", () => {
     });
     projectStoreMock.setCurrentProject.mockResolvedValue(undefined);
 
-    const ptyClient = { onProjectSwitch: vi.fn() };
+    const ptyClient = {
+      onProjectSwitch: vi.fn(),
+      getTerminalsForProjectAsync: vi.fn(async () => ["t1"]),
+      getTerminalAsync: vi.fn(async (id: string) => ({
+        id,
+        projectId: "proj-new",
+        kind: "terminal",
+      })),
+    };
     const worktreeService = {
       loadProject: vi.fn(opts.loadProject),
       attachDirectPort: vi.fn(),
@@ -2079,5 +2090,82 @@ describe("project:switch outgoing project is the sender's, not the global (#1110
       expect(worktreeService.loadProject).toHaveBeenCalledWith("/projects/p2", WINDOW_B)
     );
     expect(worktreeService.loadProject).not.toHaveBeenCalledWith("/projects/p1", WINDOW_B);
+  });
+});
+
+describe("project:switch terminal inventory prefetch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _resetTerminalInventoryPrefetchForTests();
+  });
+
+  function setupWith(isNew: boolean) {
+    const sendMock = vi.fn();
+    const mockView = {
+      webContents: { id: 300, isDestroyed: () => false, send: sendMock },
+    };
+    const pvm = {
+      switchTo: vi.fn().mockResolvedValue({ view: mockView, isNew }),
+      getProjectIdForWebContents: vi.fn(),
+      getAllViews: vi.fn(() => (isNew ? [] : [{ projectId: "proj-new", view: mockView }])),
+    };
+    mockGetWindowForWebContents.mockReturnValue({ id: 7, isDestroyed: () => false });
+    projectStoreMock.getCurrentProjectId.mockReturnValue("proj-old");
+    projectStoreMock.getProjectById.mockReturnValue({
+      id: "proj-new",
+      name: "New Project",
+      path: "/projects/new",
+    });
+    projectStoreMock.setCurrentProject.mockResolvedValue(undefined);
+    const ptyClient = {
+      onProjectSwitch: vi.fn(),
+      getTerminalsForProjectAsync: vi.fn(async () => ["t1"]),
+      getTerminalAsync: vi.fn(async (id: string) => ({
+        id,
+        projectId: "proj-new",
+        kind: "terminal",
+      })),
+    };
+    const worktreeService = {
+      loadProject: vi.fn(async () => undefined),
+      attachDirectPort: vi.fn(),
+      getHostForProject: vi.fn(() => null),
+      resumeProject: vi.fn(),
+      pauseProject: vi.fn(),
+    };
+    const windowRegistry = makeWindowRegistry([makeWindowContext(7, 300)]);
+    (
+      windowRegistry as unknown as { registerAppViewWebContents: unknown }
+    ).registerAppViewWebContents = vi.fn();
+    const deps = {
+      mainWindow: { id: 7 } as unknown,
+      projectViewManager: pvm,
+      worktreeService: worktreeService as never,
+      ptyClient: ptyClient as never,
+      windowRegistry,
+    } as unknown as HandlerDependencies;
+    registerProjectCrudHandlers(deps);
+    const handleMap = new Map<string, (...args: unknown[]) => unknown>();
+    for (const call of (ipcMain.handle as ReturnType<typeof vi.fn>).mock.calls) {
+      handleMap.set(call[0] as string, call[1] as (...args: unknown[]) => unknown);
+    }
+    const invoke = () =>
+      handleMap.get(CHANNELS.PROJECT_SWITCH)!({ sender: { id: 300 } }, "proj-new");
+    return { invoke, ptyClient, pvm };
+  }
+
+  it("starts the pty-host inventory fetch for a cold target before the swap", async () => {
+    const { invoke, ptyClient, pvm } = setupWith(true);
+    await invoke();
+    expect(ptyClient.getTerminalsForProjectAsync).toHaveBeenCalledWith("proj-new");
+    expect(ptyClient.getTerminalsForProjectAsync.mock.invocationCallOrder[0]).toBeLessThan(
+      pvm.switchTo.mock.invocationCallOrder[0]!
+    );
+  });
+
+  it("does not fetch the inventory for a target that already has a live view", async () => {
+    const { invoke, ptyClient } = setupWith(false);
+    await invoke();
+    expect(ptyClient.getTerminalsForProjectAsync).not.toHaveBeenCalled();
   });
 });

--- a/electron/ipc/handlers/__tests__/project.switch.test.ts
+++ b/electron/ipc/handlers/__tests__/project.switch.test.ts
@@ -611,7 +611,11 @@ describe("project:switch multi-window PVM routing", () => {
     await handler!(fakeEvent, "proj-new");
 
     // Window 2's PVM should have been called
-    expect(pvm2.switchTo).toHaveBeenCalledWith("proj-new", "/projects/new");
+    expect(pvm2.switchTo).toHaveBeenCalledWith(
+      "proj-new",
+      "/projects/new",
+      expect.objectContaining({ switchId: expect.any(String), entryPoint: "api" })
+    );
     // Window 1's PVM should NOT have been called
     expect(pvm1.switchTo).not.toHaveBeenCalled();
   });
@@ -653,7 +657,11 @@ describe("project:switch multi-window PVM routing", () => {
     const fakeEvent = { sender: { id: 99 } };
     await handler!(fakeEvent, "proj-new");
 
-    expect(pvmFallback.switchTo).toHaveBeenCalledWith("proj-new", "/projects/new");
+    expect(pvmFallback.switchTo).toHaveBeenCalledWith(
+      "proj-new",
+      "/projects/new",
+      expect.objectContaining({ switchId: expect.any(String), entryPoint: "api" })
+    );
   });
 
   it("resolves correct PVM for handleProjectGetCurrent", async () => {
@@ -747,7 +755,11 @@ describe("project:switch multi-window PVM routing", () => {
     const fakeEvent = { sender: { id: 20 } };
     await handler!(fakeEvent, "proj-reopen");
 
-    expect(pvm2.switchTo).toHaveBeenCalledWith("proj-reopen", "/projects/reopen");
+    expect(pvm2.switchTo).toHaveBeenCalledWith(
+      "proj-reopen",
+      "/projects/reopen",
+      expect.objectContaining({ switchId: expect.any(String), entryPoint: "api" })
+    );
     expect(pvm1.switchTo).not.toHaveBeenCalled();
   });
 });

--- a/electron/ipc/handlers/app/state.ts
+++ b/electron/ipc/handlers/app/state.ts
@@ -1022,6 +1022,15 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
         webContentsId: ctx.webContentsId,
       });
       signalFirstInteractive(ctx.webContentsId);
+      // Close the cold-start timeline for a view this window's manager
+      // cold-started (input-ready log + trace mark); no-op for warm views.
+      // Same per-window resolution as APP_VIEW_PAINTED below.
+      const senderWindow = getWindowForWebContents(ctx.event.sender);
+      const pvm =
+        (senderWindow &&
+          deps?.windowRegistry?.getByWindowId(senderWindow.id)?.services?.projectViewManager) ??
+        deps?.projectViewManager;
+      pvm?.recordFirstInteractive?.(ctx.webContentsId);
     })
   );
 

--- a/electron/ipc/handlers/perf.ts
+++ b/electron/ipc/handlers/perf.ts
@@ -16,6 +16,17 @@ export function registerPerfHandlers(deps?: HandlerDependencies): () => void {
 
     const { marks, rendererTimeOrigin, rendererT0 } = payload;
     const webContentsId = event.sender.isDestroyed() ? undefined : event.sender.id;
+    // Per-window manager first (IPC handlers register once with the first
+    // window's deps), so a second window's views resolve to their own project.
+    const projectViewManager =
+      webContentsId !== undefined
+        ? (deps?.windowRegistry?.getByWebContentsId(webContentsId)?.services.projectViewManager ??
+          deps?.projectViewManager)
+        : undefined;
+    const projectId =
+      webContentsId !== undefined
+        ? (projectViewManager?.getProjectIdForWebContents?.(webContentsId) ?? undefined)
+        : undefined;
     // A preload reports exactly one eval:end mark per flush; guard so a
     // malformed payload with duplicates forwards the cost only once (#9770).
     let preloadRecorded = false;
@@ -34,6 +45,7 @@ export function registerPerfHandlers(deps?: HandlerDependencies): () => void {
           source: "renderer",
           originalElapsedMs: record.elapsedMs,
           webContentsId,
+          ...(projectId !== undefined ? { projectId } : {}),
         },
       });
 
@@ -51,9 +63,6 @@ export function registerPerfHandlers(deps?: HandlerDependencies): () => void {
       ) {
         const durationMs = (record.meta as { durationMs?: unknown } | undefined)?.durationMs;
         if (typeof durationMs === "number" && Number.isFinite(durationMs)) {
-          const projectViewManager =
-            deps?.windowRegistry?.getByWebContentsId(webContentsId)?.services.projectViewManager ??
-            deps?.projectViewManager;
           projectViewManager?.recordPreloadDuration(webContentsId, durationMs);
           preloadRecorded = true;
         }

--- a/electron/ipc/handlers/projectCrud/switch.ts
+++ b/electron/ipc/handlers/projectCrud/switch.ts
@@ -19,6 +19,8 @@ import { scheduleOpenWindowsSave } from "../../../window/openWindowsTracker.js";
 import { notificationService } from "../../../services/NotificationService.js";
 import { formatErrorMessage } from "../../../../shared/utils/errorMessage.js";
 import { logInfo } from "../../../utils/logger.js";
+import { isPerformanceCaptureEnabled, markPerformance } from "../../../utils/performance.js";
+import { PERF_MARKS } from "../../../../shared/perf/marks.js";
 import {
   sanitizeTerminals,
   sanitizeTerminalSizes,
@@ -34,7 +36,10 @@ import {
 } from "../../../../shared/utils/layoutMerge.js";
 import type { HandlerDependencies, IpcContext } from "../../types.js";
 import type { Project } from "../../../types/index.js";
-import type { ProjectSwitchOutgoingState } from "../../../../shared/types/ipc/project.js";
+import type {
+  ProjectSwitchOutgoingState,
+  ProjectSwitchTrace,
+} from "../../../../shared/types/ipc/project.js";
 import type { TabGroup } from "../../../../shared/types/panel.js";
 import type { ProjectFocusOnActivateIntent } from "../../../../shared/types/ipc/project.js";
 
@@ -47,7 +52,7 @@ export function registerProjectSwitchHandlers(deps: HandlerDependencies): () => 
     ctx: IpcContext,
     projectId: string,
     outgoingState?: ProjectSwitchOutgoingState,
-    options?: { focusIntent?: ProjectFocusOnActivateIntent }
+    options?: { focusIntent?: ProjectFocusOnActivateIntent; trace?: ProjectSwitchTrace }
   ) => {
     if (typeof projectId !== "string" || !projectId) {
       throw new Error("Invalid project ID");
@@ -59,6 +64,8 @@ export function registerProjectSwitchHandlers(deps: HandlerDependencies): () => 
     }
 
     const operation = captureSwitchOperation(deps, ctx, projectId, "project:switch");
+    const trace = resolveSwitchTrace(options?.trace);
+    markMainReceived(trace, operation);
 
     // After the capture but before anything acts on it. The capture is a pure
     // synchronous snapshot and has to stay one: read after an await, the
@@ -86,10 +93,12 @@ export function registerProjectSwitchHandlers(deps: HandlerDependencies): () => 
       // Rapid switch-back: a cold-start hydrate of the target must not read
       // its state file while a previous switch's persist is still writing it.
       await awaitPendingOutgoingPersist(projectId);
+      markPerformance(PERF_MARKS.PROJECT_SWITCH_PENDING_PERSIST_DONE, { switchId: trace.switchId });
       try {
         await activateProjectView(deps, operation, pvm, project, {
           logPrefix: "[ProjectSwitch]",
           resumeWorkspace: true,
+          trace,
         });
         await persistOutgoing;
       } finally {
@@ -129,7 +138,8 @@ export function registerProjectSwitchHandlers(deps: HandlerDependencies): () => 
   const handleProjectReopen = async (
     ctx: IpcContext,
     projectId: string,
-    outgoingState?: ProjectSwitchOutgoingState
+    outgoingState?: ProjectSwitchOutgoingState,
+    options?: { trace?: ProjectSwitchTrace }
   ) => {
     if (typeof projectId !== "string" || !projectId) {
       throw new Error("Invalid project ID");
@@ -149,6 +159,8 @@ export function registerProjectSwitchHandlers(deps: HandlerDependencies): () => 
     }
 
     const operation = captureSwitchOperation(deps, ctx, projectId, "project:reopen");
+    const trace = resolveSwitchTrace(options?.trace);
+    markMainReceived(trace, operation);
 
     await assertProjectRepositoryIntact(project);
 
@@ -166,11 +178,13 @@ export function registerProjectSwitchHandlers(deps: HandlerDependencies): () => 
 
     if (pvm) {
       await awaitPendingOutgoingPersist(projectId);
+      markPerformance(PERF_MARKS.PROJECT_SWITCH_PENDING_PERSIST_DONE, { switchId: trace.switchId });
       try {
         await activateProjectView(deps, operation, pvm, project, {
           logPrefix: "[ProjectReopen]",
           markActive: true,
           resumeWorkspace: true,
+          trace,
         });
         await persistOutgoing;
       } finally {
@@ -194,6 +208,58 @@ export function registerProjectSwitchHandlers(deps: HandlerDependencies): () => 
   handlers.push(typedHandleWithContext(CHANNELS.PROJECT_REOPEN, handleProjectReopen));
 
   return () => handlers.forEach((cleanup) => cleanup());
+}
+
+function resolveSwitchTrace(trace: ProjectSwitchTrace | undefined): ProjectSwitchTrace {
+  if (trace && typeof trace.switchId === "string" && trace.switchId) {
+    return { switchId: trace.switchId, entryPoint: trace.entryPoint ?? "api" };
+  }
+  return { switchId: randomUUID(), entryPoint: "api" };
+}
+
+/**
+ * First main-side mark of a switch trace. Reads the target's cache state and
+ * LRU position at arrival — before anything acts on the switch — and arms a
+ * `setImmediate` whose delay measures how backed up the main loop is right
+ * now (the event-loop lag monitor samples at 1 s and would miss it). Only
+ * evaluated under capture, so the inventory walk never runs in production.
+ */
+function markMainReceived(trace: ProjectSwitchTrace, operation: SwitchOperation): void {
+  if (!isPerformanceCaptureEnabled()) return;
+  const {
+    incomingProjectId: targetProjectId,
+    outgoingProjectId,
+    projectViewManager,
+    windowId,
+  } = operation;
+  let cacheState: "warm" | "cold" = "cold";
+  let lruDepth = -1;
+  try {
+    const live = projectViewManager
+      ?.getAllViews()
+      .some((v) => v.projectId === targetProjectId && !v.view.webContents.isDestroyed());
+    if (live) cacheState = "warm";
+    if (windowId !== undefined) {
+      lruDepth = getProjectHistory(windowId).snapshot().entries.indexOf(targetProjectId);
+    }
+  } catch {
+    // Diagnostics only — never let an inventory read fail the switch.
+  }
+  markPerformance(PERF_MARKS.PROJECT_SWITCH_MAIN_RECEIVED, {
+    switchId: trace.switchId,
+    entryPoint: trace.entryPoint,
+    outgoingProjectId,
+    targetProjectId,
+    cacheState,
+    lruDepth,
+  });
+  const armedAt = performance.now();
+  setImmediate(() => {
+    markPerformance(PERF_MARKS.PROJECT_SWITCH_MAIN_LOOP_PROBE, {
+      switchId: trace.switchId,
+      lagMs: Math.round((performance.now() - armedAt) * 100) / 100,
+    });
+  });
 }
 
 // Monotonic per-window switch epoch. A swap-failure restore (below) is
@@ -455,6 +521,7 @@ type ActivateOptions = {
   logPrefix: string;
   markActive?: boolean;
   resumeWorkspace?: boolean;
+  trace: ProjectSwitchTrace;
 };
 
 async function activateProjectView(
@@ -466,6 +533,10 @@ async function activateProjectView(
 ): Promise<void> {
   const activateStart = performance.now();
   const { incomingProjectId: projectId, outgoingProjectId, senderWindow, windowId } = operation;
+  const { trace } = options;
+  const mark = (name: string, meta?: Record<string, unknown>): void => {
+    markPerformance(name, { switchId: trace.switchId, projectId, ...meta });
+  };
 
   let switchEpoch = 0;
   if (windowId !== undefined) {
@@ -497,7 +568,7 @@ async function activateProjectView(
   // Multi-view path: swap WebContentsViews instead of resetting stores
   let swapResult: { view: Electron.WebContentsView; isNew: boolean };
   try {
-    swapResult = await pvm.switchTo(projectId, project.path);
+    swapResult = await pvm.switchTo(projectId, project.path, trace);
   } catch (error) {
     // The swap failed and rolled back to the previous view, but the early
     // loadProject may have already pointed windowToProject at the failed
@@ -545,6 +616,7 @@ async function activateProjectView(
   }
   const { view, isNew } = swapResult;
   const swapMs = Math.round(performance.now() - activateStart);
+  mark(PERF_MARKS.PROJECT_SWITCH_SWAP_DONE, { isNew, swapMs });
 
   // Fold the completed switch into this window's workspace history. Recorded
   // here — after the view swap has actually committed — because this is the path
@@ -625,7 +697,9 @@ async function activateProjectView(
     const switchedProject = projectStore.getProjectById(projectId) ?? project;
     view.webContents.send(CHANNELS.PROJECT_ON_SWITCH, {
       project: switchedProject,
-      switchId: randomUUID(),
+      switchId: trace.switchId,
+      entryPoint: trace.entryPoint,
+      cacheHit: !isNew,
     });
   }
 
@@ -657,6 +731,7 @@ async function activateProjectView(
         const ctx = deps.windowRegistry.getByWindowId(win.id);
         if (ctx) {
           distributePortsToView(win, ctx, view.webContents, deps.ptyClient ?? null);
+          mark(PERF_MARKS.PROJECT_SWITCH_PTY_PORT_SENT, { isNew: false });
         }
       }
     } catch (err) {
@@ -680,6 +755,7 @@ async function activateProjectView(
       let worktreeLoadError: string | null = null;
       try {
         await loadWorktrees;
+        mark(PERF_MARKS.PROJECT_SWITCH_WORKTREES_LOADED);
 
         // Always attach a direct MessagePort.  For new views this is the
         // first port; for cached views it re-establishes the relay after a
@@ -714,10 +790,12 @@ async function activateProjectView(
   // Switch-settle telemetry: `swapMs` is the view swap (reveal path), the
   // remainder to `totalMs` is the post-swap tail — now dominated by however
   // much of the concurrent worktree load outlived the swap.
+  const totalMs = Math.round(performance.now() - activateStart);
   logInfo("projectswitch.settled", {
     projectId,
     isNew,
     swapMs,
-    totalMs: Math.round(performance.now() - activateStart),
+    totalMs,
   });
+  mark(PERF_MARKS.PROJECT_SWITCH_SETTLED, { swapMs, totalMs, isNew });
 }

--- a/electron/ipc/handlers/projectCrud/switch.ts
+++ b/electron/ipc/handlers/projectCrud/switch.ts
@@ -13,6 +13,10 @@ import { AppError } from "../../../utils/errorTypes.js";
 import { scratchStore } from "../../../services/ScratchStore.js";
 import { ProjectSwitchService } from "../../../services/ProjectSwitchService.js";
 import { getProjectHistory } from "../../../services/ProjectHistoryService.js";
+import {
+  buildTerminalInventory,
+  prefetchTerminalInventory,
+} from "../../../services/terminalInventoryPrefetch.js";
 import { broadcastProjectSwitchUpdates } from "../../projectSwitchBroadcast.js";
 import { refreshProjectMenuState } from "../../../projectMenuState.js";
 import { scheduleOpenWindowsSave } from "../../../window/openWindowsTracker.js";
@@ -208,6 +212,19 @@ export function registerProjectSwitchHandlers(deps: HandlerDependencies): () => 
   handlers.push(typedHandleWithContext(CHANNELS.PROJECT_REOPEN, handleProjectReopen));
 
   return () => handlers.forEach((cleanup) => cleanup());
+}
+
+function hasLiveView(
+  pvm: ReturnType<typeof resolveProjectViewManager>,
+  projectId: string
+): boolean {
+  try {
+    return Boolean(
+      pvm?.getAllViews().some((v) => v.projectId === projectId && !v.view.webContents.isDestroyed())
+    );
+  } catch {
+    return false;
+  }
 }
 
 function resolveSwitchTrace(trace: ProjectSwitchTrace | undefined): ProjectSwitchTrace {
@@ -568,6 +585,13 @@ async function activateProjectView(
   // Multi-view path: swap WebContentsViews instead of resetting stores
   let swapResult: { view: Electron.WebContentsView; isNew: boolean };
   try {
+    // A target with no live view is about to hydrate from scratch and will ask
+    // for its backend terminal inventory ~240 ms from now, once React is up.
+    // Start that pty-host fetch here so the answer is waiting when it does.
+    if (deps.ptyClient && !hasLiveView(pvm, projectId)) {
+      const ptyClient = deps.ptyClient;
+      void prefetchTerminalInventory(projectId, (id) => buildTerminalInventory(ptyClient, id));
+    }
     swapResult = await pvm.switchTo(projectId, project.path, trace);
   } catch (error) {
     // The swap failed and rolled back to the previous view, but the early

--- a/electron/ipc/handlers/terminal/snapshots.ts
+++ b/electron/ipc/handlers/terminal/snapshots.ts
@@ -8,6 +8,12 @@ import type { HandlerDependencies, IpcContext } from "../../types.js";
 import { TerminalReplayHistoryPayloadSchema } from "../../../schemas/index.js";
 import { logDebug, logInfo, logWarn } from "../../../utils/logger.js";
 import { getAgentAvailabilityStore } from "../../../services/AgentAvailabilityStore.js";
+import {
+  buildTerminalInventory,
+  consumeTerminalInventoryPrefetch,
+} from "../../../services/terminalInventoryPrefetch.js";
+import { markPerformance } from "../../../utils/performance.js";
+import { PERF_MARKS } from "../../../../shared/perf/marks.js";
 import { getProjectIdFromSenderUrl } from "../../senderIdentity.js";
 import { defineIpcNamespace, op, opValidated } from "../../define.js";
 import { formatErrorMessage } from "../../../../shared/utils/errorMessage.js";
@@ -168,65 +174,21 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
         throw new Error("Invalid project ID: must be a non-empty string");
       }
 
-      const terminalIds = await ptyClient.getTerminalsForProjectAsync(projectId);
-
-      const infos = await Promise.all(terminalIds.map((id) => ptyClient.getTerminalAsync(id)));
-
-      const terminals: import("../../../../shared/types/ipc.js").BackendTerminalInfo[] = [];
-      for (const terminal of infos) {
-        // Dev preview and help PTYs should not be rehydrated as generic terminal
-        // panels during project switching/hydration.
-        if (
-          terminal &&
-          terminal.kind !== "dev-preview" &&
-          !getAgentAvailabilityStore().isHelpTerminal(terminal.id)
-        ) {
-          terminals.push({
-            id: terminal.id,
-            projectId: terminal.projectId,
-            kind: terminal.kind,
-
-            launchAgentId: terminal.launchAgentId,
-            title: terminal.title,
-            titleMode: terminal.titleMode,
-            cwd: terminal.cwd,
-            // Restore builds each pane's xterm on this grid instead of 80×24,
-            // so a reconnected pane never parses its live PTY at the wrong
-            // width (#11718).
-            ptyCols: terminal.ptyCols,
-            ptyRows: terminal.ptyRows,
-            agentState: terminal.agentState,
-            waitingReason: terminal.waitingReason,
-            lastStateChange: terminal.lastStateChange,
-            spawnedAt: terminal.spawnedAt,
-            isTrashed: terminal.isTrashed,
-            trashExpiresAt: terminal.trashExpiresAt,
-            activityTier: terminal.activityTier,
-            hasPty: terminal.hasPty,
-            agentSessionId: terminal.agentSessionId,
-            agentLaunchFlags: terminal.agentLaunchFlags,
-            agentModelId: terminal.agentModelId,
-            agentPresetId: terminal.agentPresetId,
-            agentPresetColor: terminal.agentPresetColor,
-            originalAgentPresetId: terminal.originalAgentPresetId,
-            everDetectedAgent: terminal.everDetectedAgent,
-            detectedAgentId: terminal.detectedAgentId,
-            detectedProcessId: terminal.detectedProcessId,
-          });
+      // A cold switch starts this fetch the moment it reaches main; serving
+      // the in-flight result here keeps the pty-host round trip off the
+      // hydration critical path. A rejected prefetch falls back to a live one.
+      const prefetched = consumeTerminalInventoryPrefetch(projectId);
+      if (prefetched) {
+        try {
+          const terminals = await prefetched;
+          markPerformance(PERF_MARKS.TERMINAL_INVENTORY_PREFETCH, { projectId, hit: true });
+          return terminals;
+        } catch {
+          // fall through to a live fetch
         }
       }
-
-      logInfo(
-        `terminal:getForProject(${projectId.slice(0, 8)}): found ${terminals.length} terminals`,
-        {
-          terminals: terminals.map((t) => ({
-            id: t.id.slice(0, 12),
-            kind: t.kind,
-            projectId: t.projectId?.slice(0, 8),
-          })),
-        }
-      );
-      return terminals;
+      markPerformance(PERF_MARKS.TERMINAL_INVENTORY_PREFETCH, { projectId, hit: false });
+      return await buildTerminalInventory(ptyClient, projectId);
     } catch (error) {
       const errorMessage = formatErrorMessage(error, "Failed to get terminals for project");
       throw new Error(`Failed to get terminals for project: ${errorMessage}`);

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -53,6 +53,7 @@ import {
 } from "./window/windowRef.js";
 import { WindowRegistry } from "./window/WindowRegistry.js";
 import { ProjectViewManager } from "./window/ProjectViewManager.js";
+import { buildMemoryAttribution } from "./utils/memoryAttribution.js";
 import { helpSessionService } from "./services/HelpSessionService.js";
 import { effectiveCachedProjectViews } from "./utils/cachedProjectViews.js";
 import { setupBrowserWindow } from "./window/createWindow.js";
@@ -471,6 +472,20 @@ if (!gotTheLock) {
         const wCtx = windowRegistry.getByWindowId(win.id);
         if (wCtx) {
           distributePortsToView(win, wCtx, wc, getPtyClient());
+          // A cold-started view gets its first PTY port here, not from the
+          // switch handler — mark it under the switch's trace while the entry
+          // still carries its cold-start timeline (cleared at first-interactive,
+          // so a later crash reload does not re-report under a stale id).
+          const readyEntry = pvm
+            .getAllViews()
+            .find((v) => !v.view.webContents.isDestroyed() && v.view.webContents.id === wc.id);
+          if (readyEntry?.switchTrace && readyEntry.coldStartAt !== undefined) {
+            markPerformance(PERF_MARKS.PROJECT_SWITCH_PTY_PORT_SENT, {
+              switchId: readyEntry.switchTrace.switchId,
+              projectId: readyEntry.projectId,
+              isNew: true,
+            });
+          }
         }
         // Refresh workspace direct port (preload context is reset on reload)
         getWorkspaceClientRef()?.attachDirectPort(win.id, wc);
@@ -563,6 +578,10 @@ if (!gotTheLock) {
       (globalThis as Record<string, unknown>).__daintreeGetPvm = getProjectViewManager;
       (globalThis as Record<string, unknown>).__daintreeWriteHeapSnapshot = (filePath: string) =>
         nodeV8.writeHeapSnapshot(filePath);
+      // Fresh process-tree sweep joined to every window's view inventory, so
+      // the switch benchmark can attribute renderer memory per cached view.
+      (globalThis as Record<string, unknown>).__daintreeGetMemoryAttribution = () =>
+        buildMemoryAttribution(windowRegistry);
     }
 
     // E2E hook: crash a window's workspace host to exercise the

--- a/electron/menu.ts
+++ b/electron/menu.ts
@@ -924,7 +924,10 @@ export async function handleDirectoryOpen(
       // project row to be the current project of (#11936).
       const departingWorkspaceId = pvm.getActiveProjectId();
 
-      const { view, isNew } = await pvm.switchTo(project.id, project.path);
+      const { view, isNew } = await pvm.switchTo(project.id, project.path, {
+        switchId: randomUUID(),
+        entryPoint: "menu",
+      });
       // Capture the outgoing project id before the pointer flips so we can
       // broadcast its bumped `lastOpened` to every cached view (#8561).
       const previousProjectId = projectStore.getCurrentProjectId();

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -1686,8 +1686,9 @@ function buildElectronApi(): ElectronAPI {
 
       onConfigReloaded: (callback: () => void) => _typedOn(CHANNELS.APP_CONFIG_RELOADED, callback),
 
-      onViewRevealed: (callback: () => void) => _typedOn(CHANNELS.APP_VIEW_REVEALED, callback),
-      onViewWarmActivated: (callback: () => void) =>
+      onViewRevealed: (callback: (payload?: { switchId?: string }) => void) =>
+        _typedOn(CHANNELS.APP_VIEW_REVEALED, callback),
+      onViewWarmActivated: (callback: (payload?: { switchId?: string }) => void) =>
         _typedOn(CHANNELS.APP_VIEW_WARM_ACTIVATED, callback),
       onViewCached: (callback: () => void) => _typedOn(CHANNELS.APP_VIEW_CACHED, callback),
       isViewCached: () => _viewCached,
@@ -1814,6 +1815,7 @@ function buildElectronApi(): ElectronAPI {
         outgoingState?: import("../shared/types/ipc/project.js").ProjectSwitchOutgoingState,
         options?: {
           focusIntent?: import("../shared/types/ipc/project.js").ProjectFocusOnActivateIntent;
+          trace?: import("../shared/types/ipc/project.js").ProjectSwitchTrace;
         }
       ) => _unwrappingInvoke(CHANNELS.PROJECT_SWITCH, projectId, outgoingState, options),
 
@@ -1874,8 +1876,9 @@ function buildElectronApi(): ElectronAPI {
 
       reopen: (
         projectId: string,
-        outgoingState?: import("../shared/types/ipc/project.js").ProjectSwitchOutgoingState
-      ) => _unwrappingInvoke(CHANNELS.PROJECT_REOPEN, projectId, outgoingState),
+        outgoingState?: import("../shared/types/ipc/project.js").ProjectSwitchOutgoingState,
+        options?: { trace?: import("../shared/types/ipc/project.js").ProjectSwitchTrace }
+      ) => _unwrappingInvoke(CHANNELS.PROJECT_REOPEN, projectId, outgoingState, options),
 
       getStats: (projectId: string) => _unwrappingInvoke(CHANNELS.PROJECT_GET_STATS, projectId),
 
@@ -3625,6 +3628,10 @@ contextBridge.exposeInMainWorld("__DAINTREE_SURFACE_HOST__", {
 // same runtime flag as the rest of the perf pipeline; `process.env` is polyfilled
 // in the sandboxed preload, and the flag is intentionally NOT esbuild-stripped.
 if (process.env.DAINTREE_PERF_CAPTURE === "1") {
+  // Let the renderer know a capture run is live: the launch-time env var never
+  // reaches the sandboxed renderer, so without this bridge the renderer-side
+  // flush (`isRendererPerfCaptureEnabled`) stays off for the whole session.
+  contextBridge.exposeInMainWorld("__DAINTREE_PERF_CAPTURE__", true);
   const preloadEvalEndMs = perfNowMs();
   const timestamp = new Date().toISOString();
   ipcRenderer.send(CHANNELS.PERF_FLUSH_RENDERER_MARKS, {

--- a/electron/services/__tests__/terminalInventoryPrefetch.test.ts
+++ b/electron/services/__tests__/terminalInventoryPrefetch.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../AgentAvailabilityStore.js", () => ({
+  getAgentAvailabilityStore: () => ({ isHelpTerminal: (id: string) => id === "help-1" }),
+}));
+vi.mock("../../utils/logger.js", () => ({ logInfo: vi.fn() }));
+
+import {
+  _resetTerminalInventoryPrefetchForTests,
+  buildTerminalInventory,
+  consumeTerminalInventoryPrefetch,
+  invalidateTerminalInventoryPrefetch,
+  prefetchTerminalInventory,
+} from "../terminalInventoryPrefetch.js";
+
+function terminal(id: string, kind = "terminal") {
+  return { id, projectId: "p1", kind, title: id, hasPty: true } as never;
+}
+
+describe("buildTerminalInventory", () => {
+  it("lists the project's terminals and drops dev-preview and help PTYs", async () => {
+    const ptyClient = {
+      getTerminalsForProjectAsync: vi.fn(async () => ["t1", "dp", "help-1", "gone"]),
+      getTerminalAsync: vi.fn(async (id: string) =>
+        id === "gone" ? null : terminal(id, id === "dp" ? "dev-preview" : "terminal")
+      ),
+    };
+    const inventory = await buildTerminalInventory(ptyClient, "p1");
+    expect(inventory.map((t) => t.id)).toEqual(["t1"]);
+    expect(ptyClient.getTerminalAsync).toHaveBeenCalledTimes(4);
+  });
+});
+
+describe("prefetchTerminalInventory", () => {
+  beforeEach(() => {
+    _resetTerminalInventoryPrefetchForTests();
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("shares one in-flight fetch and hands it out exactly once", async () => {
+    const build = vi.fn(async () => [terminal("t1")]);
+    const first = prefetchTerminalInventory("p1", build);
+    const second = prefetchTerminalInventory("p1", build);
+    expect(second).toBe(first);
+    expect(build).toHaveBeenCalledTimes(1);
+
+    expect(consumeTerminalInventoryPrefetch("p1")).toBe(first);
+    expect(consumeTerminalInventoryPrefetch("p1")).toBeNull();
+    await expect(first).resolves.toHaveLength(1);
+  });
+
+  it("does not serve an inventory older than its TTL", () => {
+    prefetchTerminalInventory("p1", async () => []);
+    vi.advanceTimersByTime(6_000);
+    expect(consumeTerminalInventoryPrefetch("p1")).toBeNull();
+  });
+
+  it("drops a rejected prefetch so the handler fetches live", async () => {
+    const failed = prefetchTerminalInventory("p1", async () => {
+      throw new Error("pty-host down");
+    });
+    await expect(failed).rejects.toThrow("pty-host down");
+    await Promise.resolve();
+    expect(consumeTerminalInventoryPrefetch("p1")).toBeNull();
+  });
+
+  it("invalidates per project and globally", () => {
+    prefetchTerminalInventory("p1", async () => []);
+    prefetchTerminalInventory("p2", async () => []);
+    invalidateTerminalInventoryPrefetch("p1");
+    expect(consumeTerminalInventoryPrefetch("p1")).toBeNull();
+    expect(consumeTerminalInventoryPrefetch("p2")).not.toBeNull();
+    prefetchTerminalInventory("p3", async () => []);
+    invalidateTerminalInventoryPrefetch();
+    expect(consumeTerminalInventoryPrefetch("p3")).toBeNull();
+  });
+});

--- a/electron/services/terminalInventoryPrefetch.ts
+++ b/electron/services/terminalInventoryPrefetch.ts
@@ -1,0 +1,132 @@
+import type { BackendTerminalInfo } from "../../shared/types/ipc.js";
+import type { PtyClient } from "./PtyClient.js";
+import { getAgentAvailabilityStore } from "./AgentAvailabilityStore.js";
+import { logInfo } from "../utils/logger.js";
+
+/**
+ * Cold-switch prefetch of a project's backend terminal inventory.
+ *
+ * A cold view asks `terminal:get-for-project` only once React has booted,
+ * ~240 ms after the switch reached main, and then waits ~100 ms for the
+ * pty-host to answer (one id list plus one `get-terminal` per id) before it
+ * can restore a single pane. Main knows the target the instant the switch
+ * arrives, so it starts that fetch right away and the handler consumes the
+ * in-flight result instead of paying the round trip on the critical path.
+ *
+ * Consume-once with a short TTL: the inventory is a snapshot and a terminal
+ * can exit between prefetch and hydrate, so a stale answer must never outlive
+ * the switch it was taken for. A rejected prefetch is dropped so the handler
+ * falls back to a live fetch.
+ */
+const PREFETCH_TTL_MS = 5_000;
+
+interface Entry {
+  promise: Promise<BackendTerminalInfo[]>;
+  expiresAt: number;
+}
+
+const inflight = new Map<string, Entry>();
+
+type InventoryPtyClient = Pick<PtyClient, "getTerminalsForProjectAsync" | "getTerminalAsync">;
+
+/** The inventory `terminal:get-for-project` returns, minus panes hydration must never rebuild. */
+export async function buildTerminalInventory(
+  ptyClient: InventoryPtyClient,
+  projectId: string
+): Promise<BackendTerminalInfo[]> {
+  const terminalIds = await ptyClient.getTerminalsForProjectAsync(projectId);
+  const infos = await Promise.all(terminalIds.map((id) => ptyClient.getTerminalAsync(id)));
+
+  const terminals: BackendTerminalInfo[] = [];
+  for (const terminal of infos) {
+    // Dev preview and help PTYs should not be rehydrated as generic terminal
+    // panels during project switching/hydration.
+    if (
+      terminal &&
+      terminal.kind !== "dev-preview" &&
+      !getAgentAvailabilityStore().isHelpTerminal(terminal.id)
+    ) {
+      terminals.push({
+        id: terminal.id,
+        projectId: terminal.projectId,
+        kind: terminal.kind,
+        launchAgentId: terminal.launchAgentId,
+        title: terminal.title,
+        titleMode: terminal.titleMode,
+        cwd: terminal.cwd,
+        // Restore builds each pane's xterm on this grid instead of 80×24,
+        // so a reconnected pane never parses its live PTY at the wrong
+        // width (#11718).
+        ptyCols: terminal.ptyCols,
+        ptyRows: terminal.ptyRows,
+        agentState: terminal.agentState,
+        waitingReason: terminal.waitingReason,
+        lastStateChange: terminal.lastStateChange,
+        spawnedAt: terminal.spawnedAt,
+        isTrashed: terminal.isTrashed,
+        trashExpiresAt: terminal.trashExpiresAt,
+        activityTier: terminal.activityTier,
+        hasPty: terminal.hasPty,
+        agentSessionId: terminal.agentSessionId,
+        agentLaunchFlags: terminal.agentLaunchFlags,
+        agentModelId: terminal.agentModelId,
+        agentPresetId: terminal.agentPresetId,
+        agentPresetColor: terminal.agentPresetColor,
+        originalAgentPresetId: terminal.originalAgentPresetId,
+        everDetectedAgent: terminal.everDetectedAgent,
+        detectedAgentId: terminal.detectedAgentId,
+        detectedProcessId: terminal.detectedProcessId,
+      });
+    }
+  }
+
+  logInfo(`terminal:getForProject(${projectId.slice(0, 8)}): found ${terminals.length} terminals`, {
+    terminals: terminals.map((t) => ({
+      id: t.id.slice(0, 12),
+      kind: t.kind,
+      projectId: t.projectId?.slice(0, 8),
+    })),
+  });
+  return terminals;
+}
+
+export function prefetchTerminalInventory(
+  projectId: string,
+  build: (projectId: string) => Promise<BackendTerminalInfo[]>
+): Promise<BackendTerminalInfo[]> {
+  const existing = inflight.get(projectId);
+  if (existing && existing.expiresAt > Date.now()) return existing.promise;
+
+  const entry: Entry = {
+    promise: build(projectId),
+    expiresAt: Date.now() + PREFETCH_TTL_MS,
+  };
+  entry.promise.catch(() => {
+    if (inflight.get(projectId) === entry) inflight.delete(projectId);
+  });
+  inflight.set(projectId, entry);
+  return entry.promise;
+}
+
+/** Take the pending inventory for `projectId`, if one is fresh. Consume-once. */
+export function consumeTerminalInventoryPrefetch(
+  projectId: string
+): Promise<BackendTerminalInfo[]> | null {
+  const entry = inflight.get(projectId);
+  if (!entry) return null;
+  inflight.delete(projectId);
+  if (entry.expiresAt <= Date.now()) return null;
+  return entry.promise;
+}
+
+export function invalidateTerminalInventoryPrefetch(projectId?: string): void {
+  if (projectId === undefined) {
+    inflight.clear();
+    return;
+  }
+  inflight.delete(projectId);
+}
+
+export function _resetTerminalInventoryPrefetchForTests(): void {
+  inflight.clear();
+}

--- a/electron/utils/memoryAttribution.ts
+++ b/electron/utils/memoryAttribution.ts
@@ -1,0 +1,101 @@
+import { refreshAppMetricsSnapshot } from "./appMetricsSnapshot.js";
+import type { WindowRegistry } from "../window/WindowRegistry.js";
+
+export interface MemoryAttributionView {
+  projectId: string;
+  state: "loading" | "active" | "cached";
+  webContentsId: number;
+  pid: number | null;
+  workingSetKb: number | null;
+  guestPids: number[];
+}
+
+export interface MemoryAttribution {
+  sampledAt: number;
+  windows: Array<{
+    windowId: number;
+    activeProjectId: string | null;
+    views: MemoryAttributionView[];
+  }>;
+  processes: {
+    browserKb: number;
+    gpuKb: number;
+    utilityByNameKb: Record<string, number>;
+    rendererTotalKb: number;
+    /** Renderer footprint no project view (or its guests) claims — surface views, DevTools, orphans. */
+    unattributedRendererKb: number;
+  };
+}
+
+/**
+ * One fresh `app.getAppMetrics()` sweep joined to every window's project-view
+ * inventory by OS pid. Diagnostics for the switch benchmark: says which
+ * renderer belongs to which cached view, and how much of the process tree is
+ * nobody's. Always a fresh sweep — a before/after delta across a switch is
+ * meaningless against the 5 s shared snapshot.
+ */
+export function buildMemoryAttribution(windowRegistry: WindowRegistry): MemoryAttribution {
+  const metrics = refreshAppMetricsSnapshot();
+  const sampledAt = Date.now();
+  const kbByPid = new Map<number, number>();
+  let browserKb = 0;
+  let gpuKb = 0;
+  let rendererTotalKb = 0;
+  const utilityByNameKb: Record<string, number> = {};
+  for (const proc of metrics) {
+    const kb = proc.memory.workingSetSize;
+    kbByPid.set(proc.pid, kb);
+    switch (proc.type) {
+      case "Browser":
+        browserKb += kb;
+        break;
+      case "GPU":
+        gpuKb += kb;
+        break;
+      case "Tab":
+        rendererTotalKb += kb;
+        break;
+      default: {
+        const name = proc.serviceName || proc.name || proc.type;
+        utilityByNameKb[name] = (utilityByNameKb[name] ?? 0) + kb;
+      }
+    }
+  }
+
+  const attributedPids = new Set<number>();
+  const windows = windowRegistry.all().map((ctx) => {
+    const pvm = ctx.services.projectViewManager;
+    const views: MemoryAttributionView[] = (pvm?.getViewInventory() ?? []).map((view) => {
+      if (view.pid !== null) attributedPids.add(view.pid);
+      for (const pid of view.guestPids) attributedPids.add(pid);
+      return {
+        projectId: view.projectId,
+        state: view.state,
+        webContentsId: view.webContentsId,
+        pid: view.pid,
+        workingSetKb: view.pid !== null ? (kbByPid.get(view.pid) ?? null) : null,
+        guestPids: view.guestPids,
+      };
+    });
+    return {
+      windowId: ctx.windowId,
+      activeProjectId: pvm?.getActiveProjectId() ?? null,
+      views,
+    };
+  });
+
+  let attributedKb = 0;
+  for (const pid of attributedPids) attributedKb += kbByPid.get(pid) ?? 0;
+
+  return {
+    sampledAt,
+    windows,
+    processes: {
+      browserKb,
+      gpuKb,
+      utilityByNameKb,
+      rendererTotalKb,
+      unattributedRendererKb: Math.max(0, rendererTotalKb - attributedKb),
+    },
+  };
+}

--- a/electron/utils/systemMemory.ts
+++ b/electron/utils/systemMemory.ts
@@ -1,5 +1,5 @@
 import os from "node:os";
-import { getIsE2EFaultMode } from "../setup/runtimeFlags.js";
+import { getIsE2EFaultMode, getIsE2EMode } from "../setup/runtimeFlags.js";
 
 const CRITICAL_FRACTION = 0.1;
 const WARNING_FRACTION = 0.2;
@@ -96,7 +96,10 @@ export function readSystemMemorySnapshot(): SystemMemorySnapshot | null {
   const totalMb = os.totalmem() / 1024 / 1024;
   if (!Number.isFinite(totalMb) || totalMb <= 0) return null;
 
-  if (getIsE2EFaultMode()) {
+  // Pinned in E2E too, not only fault mode: a perf harness that keeps five
+  // renderers resident must not have its warm cache evicted because macOS
+  // reports a low free figure on a loaded machine.
+  if (getIsE2EFaultMode() || getIsE2EMode()) {
     const availableMb = Number(process.env.DAINTREE_E2E_SYSTEM_AVAILABLE_MEMORY_MB);
     if (Number.isFinite(availableMb) && availableMb > 0) {
       return { totalMb, freeMb: availableMb, purgeableMb: 0, availableMb };

--- a/electron/window/ProjectViewEvictionController.ts
+++ b/electron/window/ProjectViewEvictionController.ts
@@ -442,6 +442,9 @@ export function sampleCachedViewMemory(host: ProjectViewManager): void {
   const activeProjectId = host.activeProjectId;
 
   const memoryByPid = new Map<number, number>();
+  // The GPU process is shared by every view, so it is reported once per tick
+  // beside each sample rather than attributed to any one of them.
+  let gpuKb = 0;
   try {
     // Shared TTL snapshot — telemetry tolerates staleness; per-window
     // samplers near the 30s aligned sweeps reuse them instead of stacking
@@ -451,6 +454,7 @@ export function sampleCachedViewMemory(host: ProjectViewManager): void {
       if (kb > 0) {
         memoryByPid.set(proc.pid, kb);
       }
+      if (proc.type === "GPU") gpuKb += kb;
     }
   } catch {
     // app.getAppMetrics() throwing is non-fatal — skip this tick.
@@ -477,8 +481,10 @@ export function sampleCachedViewMemory(host: ProjectViewManager): void {
       const guestMemoryKb = sumGuestMemoryKb(wc, memoryByPid);
       const ctx: Record<string, unknown> = {
         projectId,
+        state: entry.state,
         memoryKb,
         pid,
+        gpuKb,
       };
       if (guestMemoryKb > 0) ctx.guestMemoryKb = guestMemoryKb;
       logInfo("projectview.cached-memory", ctx);

--- a/electron/window/ProjectViewLifecycleController.ts
+++ b/electron/window/ProjectViewLifecycleController.ts
@@ -349,23 +349,36 @@ function forEachGuest(
   }
 }
 
-/** Sum the footprint of `hostWc`'s <webview> guests from a pid index. */
-export function sumGuestMemoryKb(
-  hostWc: Electron.WebContents,
-  memoryByPid: ReadonlyMap<number, number>
-): number {
-  let totalKb = 0;
+/**
+ * OS pids of `hostWc`'s live <webview> guests. Guests are separate renderer
+ * processes the host pid lookup never sees, so memory attribution has to
+ * enumerate them explicitly.
+ */
+export function collectGuestPids(hostWc: Electron.WebContents): number[] {
+  const pids: number[] = [];
   forEachGuest(hostWc, (guest) => {
     try {
       const getPid = (guest as { getOSProcessId?: () => number }).getOSProcessId;
       if (typeof getPid !== "function") return;
       const pid = getPid.call(guest);
       if (typeof pid !== "number" || pid <= 0) return;
-      totalKb += memoryByPid.get(pid) ?? 0;
+      pids.push(pid);
     } catch {
       // Guest telemetry is best-effort; keep the host sample intact.
     }
   });
+  return pids;
+}
+
+/** Sum the footprint of `hostWc`'s <webview> guests from a pid index. */
+export function sumGuestMemoryKb(
+  hostWc: Electron.WebContents,
+  memoryByPid: ReadonlyMap<number, number>
+): number {
+  let totalKb = 0;
+  for (const pid of collectGuestPids(hostWc)) {
+    totalKb += memoryByPid.get(pid) ?? 0;
+  }
   return totalKb;
 }
 

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -14,9 +14,10 @@
  */
 
 import { BrowserWindow, type WebContentsView } from "electron";
+import { performance } from "node:perf_hooks";
 import { registerProjectView } from "./webContentsRegistry.js";
 import { isValidScratchStateId } from "../services/projectStorePaths.js";
-import { logWarn } from "../utils/logger.js";
+import { logInfo, logWarn } from "../utils/logger.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 import { CHANNELS } from "../ipc/channels.js";
 import { freezeWebContents, unfreezeWebContents } from "../utils/webContentsLifecycle.js";
@@ -30,7 +31,13 @@ import * as EvictionController from "./ProjectViewEvictionController.js";
 import { hasActiveAgent, initAgentStateCache } from "./ProjectViewAgentStateCache.js";
 import type { PaintGate, PaintGateOutcome, ViewEntry } from "./ProjectViewManagerTypes.js";
 import type { MemoryPressurePolicy } from "../utils/cachedProjectViews.js";
-import type { ProjectFocusOnActivateIntent } from "../../shared/types/ipc/project.js";
+import type {
+  ProjectFocusOnActivateIntent,
+  ProjectSwitchTrace,
+} from "../../shared/types/ipc/project.js";
+import { PERF_MARKS } from "../../shared/perf/marks.js";
+import { markPerformance } from "../utils/performance.js";
+import { collectGuestPids } from "./ProjectViewLifecycleController.js";
 
 // Trailing-edge debounce on freeze entry: the lag-pressure path can flip
 // efficiency on/off without going through the 30 s downgrade hysteresis, so
@@ -118,6 +125,10 @@ export interface ViewInventoryEntry {
   lastUsed: number;
   /** Epoch ms of the project's most recent eviction, if it was ever evicted. */
   evictedAt?: number;
+  /** Renderer OS pid, or null if the view was destroyed mid-read or the pid is unknown. */
+  pid: number | null;
+  /** OS pids of the view's live <webview> guests (browser / dev-preview panels). */
+  guestPids: number[];
 }
 
 export interface ProjectViewManagerOptions {
@@ -493,9 +504,10 @@ export class ProjectViewManager {
    */
   async switchTo(
     projectId: string,
-    projectPath: string
+    projectPath: string,
+    trace?: ProjectSwitchTrace
   ): Promise<{ view: WebContentsView; isNew: boolean }> {
-    const task = this.switchChain.then(() => performSwitch(this, projectId, projectPath));
+    const task = this.switchChain.then(() => performSwitch(this, projectId, projectPath, trace));
     this.switchChain = task.then(
       () => undefined,
       () => undefined
@@ -705,6 +717,42 @@ export class ProjectViewManager {
     entry.preloadEvalDurationMs = durationMs;
   }
 
+  /**
+   * The view's renderer reported `app:first-interactive`. For a view whose
+   * cold start this manager drove, that closes the cold-start timeline:
+   * emit the input-ready log (and the trace mark, when the switch carried one)
+   * and clear the timing fields so a later reload can't re-report them.
+   * No-op for warm views, the startup view, and unknown ids.
+   */
+  recordFirstInteractive(webContentsId: number): void {
+    const projectId = this.webContentsToProject.get(webContentsId);
+    if (projectId === undefined) return;
+    const entry = this.views.get(projectId);
+    if (!entry || entry.coldStartAt === undefined) return;
+    const now = performance.now();
+    const { coldStartAt, loadFinishedAt, visibleAt, switchTrace } = entry;
+    delete entry.coldStartAt;
+    delete entry.loadFinishedAt;
+    delete entry.visibleAt;
+    const interactiveMs = Math.round(now - coldStartAt);
+    logInfo("projectview.coldstart.interactive", {
+      projectId,
+      interactiveMs,
+      loadMs: loadFinishedAt !== undefined ? Math.round(loadFinishedAt - coldStartAt) : null,
+      visibleMs: visibleAt !== undefined ? Math.round(visibleAt - coldStartAt) : null,
+      // React boot after the document settled: the part of the cold start the
+      // load and paint gates cannot see.
+      hydrateMs: loadFinishedAt !== undefined ? Math.round(now - loadFinishedAt) : null,
+    });
+    if (switchTrace) {
+      markPerformance(PERF_MARKS.PROJECT_SWITCH_FIRST_INTERACTIVE, {
+        switchId: switchTrace.switchId,
+        projectId,
+        interactiveMs,
+      });
+    }
+  }
+
   getAllViews(): ViewEntry[] {
     return Array.from(this.views.values());
   }
@@ -728,6 +776,21 @@ export class ProjectViewManager {
       } catch {
         // View torn down mid-read — leave webContentsId as -1.
       }
+      let pid: number | null = null;
+      let guestPids: number[] = [];
+      try {
+        if (webContentsId !== -1) {
+          const wc = entry.view.webContents;
+          const getPid = (wc as { getOSProcessId?: () => number }).getOSProcessId;
+          if (typeof getPid === "function") {
+            const raw = getPid.call(wc);
+            if (typeof raw === "number" && raw > 0) pid = raw;
+          }
+          guestPids = collectGuestPids(wc);
+        }
+      } catch {
+        // View torn down mid-read — report no pid rather than a stale one.
+      }
       const evictedAt = this.evictionTimestamps.get(entry.projectId);
       out.push({
         projectId: entry.projectId,
@@ -735,6 +798,8 @@ export class ProjectViewManager {
         webContentsId,
         state: entry.state,
         lastUsed: entry.lastUsed,
+        pid,
+        guestPids,
         ...(evictedAt !== undefined ? { evictedAt } : {}),
       });
     }

--- a/electron/window/ProjectViewManagerTypes.ts
+++ b/electron/window/ProjectViewManagerTypes.ts
@@ -6,6 +6,7 @@
  */
 
 import type { WebContentsView } from "electron";
+import type { ProjectSwitchTrace } from "../../shared/types/ipc/project.js";
 
 export type ViewState = "loading" | "active" | "cached";
 
@@ -83,4 +84,19 @@ export interface ViewEntry {
    * signals carry the preload cost that was paid when the view cold-started.
    */
   preloadEvalDurationMs?: number;
+  /**
+   * Perf trace of the switch that most recently activated this view, so the
+   * post-swap marks main emits from outside `performSwitch` (PTY port on
+   * did-finish-load, first-interactive) can join the same `switchId`.
+   */
+  switchTrace?: ProjectSwitchTrace;
+  /**
+   * Cold-start timeline (`performance.now()` values), set by the cold path in
+   * `performSwitch` and cleared by the view's first `app:first-interactive` —
+   * which is what turns them into the `projectview.coldstart.interactive` log.
+   * Absent on warm reactivations and once the view has been interactive.
+   */
+  coldStartAt?: number;
+  loadFinishedAt?: number;
+  visibleAt?: number;
 }

--- a/electron/window/ProjectViewSwitchController.ts
+++ b/electron/window/ProjectViewSwitchController.ts
@@ -6,7 +6,10 @@
  */
 
 import type { WebContentsView } from "electron";
+import { randomUUID } from "node:crypto";
 import { performance } from "node:perf_hooks";
+import { PERF_MARKS } from "../../shared/perf/marks.js";
+import { markPerformance } from "../utils/performance.js";
 import {
   registerWebContents,
   registerAppView,
@@ -36,7 +39,10 @@ import { setupViewHandlers } from "./ProjectViewHandlers.js";
 import { evictStaleViews } from "./ProjectViewEvictionController.js";
 import type { ProjectViewManager } from "./ProjectViewManager.js";
 import type { ViewEntry } from "./ProjectViewManagerTypes.js";
-import type { ProjectFocusOnActivateIntent } from "../../shared/types/ipc/project.js";
+import type {
+  ProjectFocusOnActivateIntent,
+  ProjectSwitchTrace,
+} from "../../shared/types/ipc/project.js";
 
 /**
  * Largest delay `setTimeout` stores as-is (INT32_MAX ms, ~24.9 days). Anything
@@ -65,8 +71,16 @@ function deliverFocusIntent(view: WebContentsView, intent: ProjectFocusOnActivat
 export async function performSwitch(
   host: ProjectViewManager,
   projectId: string,
-  projectPath: string
+  projectPath: string,
+  trace?: ProjectSwitchTrace
 ): Promise<{ view: WebContentsView; isNew: boolean }> {
+  // Callers without a renderer-minted trace (menu, tests) still get a
+  // switchId so this switch's marks and the incoming view's stay joinable.
+  const switchTrace: ProjectSwitchTrace = trace ?? { switchId: randomUUID(), entryPoint: "api" };
+  const mark = (name: string, meta?: Record<string, unknown>): void => {
+    markPerformance(name, { switchId: switchTrace.switchId, projectId, ...meta });
+  };
+  mark(PERF_MARKS.PROJECT_SWITCH_CHAIN_ENTERED);
   // A switch queued behind switchChain can land after dispose() (window
   // close mid-queue). Creating a view on a disposed manager would leak it:
   // no timer sweeps, no eviction, no dispose pass will ever reach it.
@@ -125,6 +139,11 @@ export async function performSwitch(
       // notifyViewPainted is one-shot per V8 context, so the warm path needs its
       // own re-fireable channel.
       activateView(host, cached, /* insertBehind */ true);
+      cached.switchTrace = switchTrace;
+      mark(PERF_MARKS.PROJECT_SWITCH_VIEW_ATTACHED, {
+        isNew: false,
+        webContentsId: cached.view.webContents.id,
+      });
       const warmSoftMs = host.warmPaintGateTimeoutMs;
       const warmHardMs = Math.max(host.warmPaintGateHardTimeoutMs, warmSoftMs);
       const warmGate = host.waitForPaint(
@@ -152,9 +171,16 @@ export async function performSwitch(
       // the visibility/resume listeners remain as fallbacks. Sent after the
       // gate is armed so the wake's completion signal can't slip past it.
       if (!cached.view.webContents.isDestroyed()) {
-        cached.view.webContents.send(CHANNELS.APP_VIEW_WARM_ACTIVATED);
+        cached.view.webContents.send(CHANNELS.APP_VIEW_WARM_ACTIVATED, {
+          switchId: switchTrace.switchId,
+        });
       }
       const gateResult = await warmGate;
+      mark(PERF_MARKS.PROJECT_SWITCH_GATE_RESOLVED, {
+        gateOutcome: gateResult,
+        releaseChannel: "warm-painted",
+        waitedMs: Math.round(performance.now() - warmStart),
+      });
       if (gateResult === "hard-timeout") {
         logWarn("projectview.warmpaintgate.hardtimeout", {
           projectId,
@@ -171,17 +197,26 @@ export async function performSwitch(
         } else if (unboundOutgoingView) {
           detachUnboundOutgoingView(host, unboundOutgoingView);
         }
+        mark(PERF_MARKS.PROJECT_SWITCH_REVEALED, { isNew: false });
       }
     } else {
       // No outgoing view to bridge through (e.g. first-run with no welcome
       // view) — nothing to flash past, so reveal the cached view immediately.
       activateView(host, cached);
+      cached.switchTrace = switchTrace;
+      mark(PERF_MARKS.PROJECT_SWITCH_VIEW_ATTACHED, {
+        isNew: false,
+        webContentsId: cached.view.webContents.id,
+      });
       // Same deterministic wake trigger as the bridged path: the reattach
       // emits no visibility/resume event, so the terminals' refit/repaint
       // fan-out needs an explicit signal here too.
       if (!cached.view.webContents.isDestroyed()) {
-        cached.view.webContents.send(CHANNELS.APP_VIEW_WARM_ACTIVATED);
+        cached.view.webContents.send(CHANNELS.APP_VIEW_WARM_ACTIVATED, {
+          switchId: switchTrace.switchId,
+        });
       }
+      mark(PERF_MARKS.PROJECT_SWITCH_REVEALED, { isNew: false });
     }
 
     const visibleMs = Math.round(performance.now() - warmStart);
@@ -214,7 +249,9 @@ export async function performSwitch(
       // longer the revealed foreground, so repainting it would be wasted work.
       if (host.activeProjectId === projectId) {
         cached.view.webContents.invalidate();
-        cached.view.webContents.send(CHANNELS.APP_VIEW_REVEALED);
+        cached.view.webContents.send(CHANNELS.APP_VIEW_REVEALED, {
+          switchId: switchTrace.switchId,
+        });
       }
     }
     const cachedIntent = consumePendingFocusIntent(host, projectId);
@@ -249,6 +286,8 @@ export async function performSwitch(
     state: "loading",
     crashTimestamps: [],
     cleanupHandlers: () => {},
+    switchTrace,
+    coldStartAt,
   };
   host.views.set(projectId, entry);
   host.webContentsToProject.set(view.webContents.id, projectId);
@@ -274,6 +313,10 @@ export async function performSwitch(
   } else {
     host.win.contentView.addChildView(view);
   }
+  mark(PERF_MARKS.PROJECT_SWITCH_VIEW_ATTACHED, {
+    isNew: true,
+    webContentsId: view.webContents.id,
+  });
   updateViewBounds(host, view);
   host.activeProjectId = projectId;
   entry.state = "active";
@@ -369,6 +412,7 @@ export async function performSwitch(
       ? Math.max(paintHardMs, loadSoftMs)
       : Math.min(loadHardMs + paintHardMs, MAX_TIMEOUT_MS);
 
+  const gateArmedAt = performance.now();
   const paintGatePromise = host.waitForPaint(
     view.webContents.id,
     outgoingView,
@@ -403,6 +447,10 @@ export async function performSwitch(
       hardMs: loadHardMs,
     });
     loadFinishedAt = performance.now();
+    entry.loadFinishedAt = loadFinishedAt;
+    mark(PERF_MARKS.PROJECT_SWITCH_LOAD_FINISHED, {
+      loadMs: Math.round(loadFinishedAt - coldStartAt),
+    });
 
     // The skeleton gate's tight paint bound starts HERE, not at arm time — see
     // the sizing note above. `false` on the common fast path, where the
@@ -436,6 +484,12 @@ export async function performSwitch(
     // signal.
     const gateResult = await paintGatePromise;
     visibleAt = performance.now();
+    entry.visibleAt = visibleAt;
+    mark(PERF_MARKS.PROJECT_SWITCH_GATE_RESOLVED, {
+      gateOutcome: gateResult,
+      releaseChannel: coldReleaseChannel,
+      waitedMs: Math.round(visibleAt - gateArmedAt),
+    });
     if (gateResult === "hard-timeout") {
       // The bound that actually expired: once a skeleton gate has been retimed
       // the provisional `hardMs` is dead, and reporting it would overstate the
@@ -486,6 +540,7 @@ export async function performSwitch(
     } else if (unboundOutgoingView && host.activeProjectId === projectId) {
       detachUnboundOutgoingView(host, unboundOutgoingView);
     }
+    mark(PERF_MARKS.PROJECT_SWITCH_REVEALED, { isNew: true });
 
     logInfo("projectview.coldstart", {
       projectId,

--- a/electron/window/__tests__/ProjectViewManager.eviction.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.eviction.test.ts
@@ -363,6 +363,10 @@ describe("ProjectViewManager — eviction safety", () => {
       expect(inventory.find((v) => v.projectId === "proj-b")!.state).toBe("cached");
       // Never-evicted views carry no eviction timestamp.
       expect(invC.evictedAt).toBeUndefined();
+      // Memory-attribution fields are always present: the pid is the live
+      // renderer's OS pid, and guests are an empty list rather than undefined.
+      expect(invC.pid).toBe(liveC.view.webContents.getOSProcessId());
+      expect(invC.guestPids).toEqual([]);
       // The live WebContentsView must never leak through the projection.
       expect(invC).not.toHaveProperty("view");
     });

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -40,7 +40,7 @@ Alongside the class, each family carries a **fidelity record** — entry point, 
 
 Three families are `diagnostic` on evidence, and the test pins each so a silent upgrade back to `mechanism` fails:
 
-- **PERF-074..077** run real `ProjectViewManager` control flow against inert Electron and Chromium stand-ins. The structural counts (creates, reactivations, evictions) are trustworthy. The **durations are not a switch latency** — no navigation, GPU work, paint or real renderer failure happens inside the bracket. `npm run perf project-switch` is where switch latency lives.
+- **PERF-074..077** run real `ProjectViewManager` control flow against inert Electron and Chromium stand-ins. The structural counts (creates, reactivations, evictions) are trustworthy. The **durations are not a switch latency** — no navigation, GPU work, paint or real renderer failure happens inside the bracket. `npm run perf project-switch` (round trip and reveal telemetry) and `npm run perf project-switch-rotation` (real UI to a typed nonce painted in the target's focused pane) are where switch latency lives.
 - **PERF-196** is a declared parser floor. Production chunks payloads this size at 32 KiB with UI yields through `TerminalRestoreController`, which is not in the bracket, so real restore is slower by construction.
 - **PERF-035** drives the real detection FSM under a substituted virtual clock. Its CPU-per-MB is a real reading; its flip latencies are simulated time.
 
@@ -570,6 +570,34 @@ npm run perf memory-growth-compare -- .tmp/perf-results/memory-growth/before.jso
 ```
 
 Controls: `MEM_GROWTH_PROJECTS` (default `2`), `MEM_GROWTH_TERMINALS` (default `2` per project), `MEM_GROWTH_WARMUPS` (default `3`), `MEM_GROWTH_CYCLES` (default `10`), `MEM_GROWTH_SEED_OUTPUT_LINES` (default `5500` per terminal), `MEM_GROWTH_OUTPUT_LINES` (default `750` per terminal per cycle), `MEM_GROWTH_SETTLE_MS` (default `4000`), `MEM_GROWTH_EPHEMERAL` (`0` disables transient-terminal churn for diagnosis), `MEM_GROWTH_LABEL`, `MEM_GROWTH_OUTPUT`, and `MEM_GROWTH_TIMEOUT_MS`.
+
+## Project switch rotation (`perf project-switch-rotation`)
+
+`npm run perf project-switch-rotation` builds the E2E bundle, launches one Daintree with five seeded projects (three worktrees, one focused shell pane and three fake agents each — one streaming, one working, one waiting) and rotates through them with the real UI: the MRU shortcut for stack distance 1, the palette by keyboard for deeper targets, plus palette-by-mouse and toolbar strata. For every isolated sample it arms an `onRender` probe on the target's shell pane, drives the switch, waits for the target view to attach and its pane to hold focus, types a nonce, and reads the moment xterm painted it. The headline is **intent → nonce painted**: the outgoing renderer decided to switch, and the user's next keystroke is visibly on screen in the right pane. Everything between — busy paint, IPC, main receive, chain entry, view attach, gate resolve, reveal, pane wake, PTY port, hydrate, settle — is carried per sample from the `project_switch.*` NDJSON marks, joined by `switchId` and by `webContentsId` for the incoming renderer.
+
+Fidelity: real keyboard and pointer entry points, real WebContentsViews, real PTYs and xterm, production process topology; the agents are the fake `claude` from `e2e/helpers/fakeAgent.ts`. Cache state is predicted from an MRU-stack model before each switch and the app is held to it, so warm and cold numbers cannot mix. The apparatus asserts: the attached view is the target, marks arrive in causal order, the nonce painted exactly once in the probe pane and nowhere else that is still cached, no paint-gate hard timeouts, no renderer crashes, and the requested samples per depth. Latency, lag and memory are reported and written, never asserted.
+
+The two arms are cache caps. Cap 3 (the default) makes depths 3 and 4 cold; cap 5 keeps every target warm. Run both, then price a cached view with `--marginal`.
+
+```bash
+PERF_SWITCH_CAP=3 npm run perf project-switch-rotation
+PERF_SWITCH_CAP=5 npm run perf project-switch-rotation
+npm run perf project-switch-rotation-compare -- .tmp/perf-results/project-switch-rotation/before.json .tmp/perf-results/project-switch-rotation/after.json
+npm run perf project-switch-rotation-compare -- --marginal .tmp/perf-results/project-switch-rotation/cap5.json .tmp/perf-results/project-switch-rotation/cap3.json
+```
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `PERF_SWITCH_CAP` | `3` | Cached-view limit (3, 4 or 5); one fresh app per run |
+| `PERF_SWITCH_LABEL` | `cap<N>` | Result label |
+| `PERF_SWITCH_ROTATION_OUT` | `.tmp/perf-results/project-switch-rotation/<label>.json` | Output path |
+| `PERF_SWITCH_SAMPLES_PER_DEPTH` | `20` | Isolated samples at each stack distance 1..4 |
+| `PERF_SWITCH_SEED` | `1` | Shuffle seed for the depth sequence |
+| `PERF_SWITCH_EXTRA_STRATA` | `5` | Extra palette-mouse and toolbar samples each |
+| `PERF_SWITCH_RAPID_BURSTS` | `3` | Bursts of six queued switches at 150 ms gaps |
+| `PERF_SWITCH_INCLUDE_MARKS` | `0` | Embed the raw `project_switch.*` marks in the JSON |
+
+The compare refuses (exit 2) when the two runs' configs differ in anything but label or seed; `--marginal` refuses unless they differ only in cap, and prints the footprint per extra cached view alongside the per-depth latency it buys. Weighted quantiles use depth weights 1:0.55, 2:0.25, 3:0.12, 4:0.08. A bare run is a reading, not a result: a claim that switching got faster goes through `.agents/skills/optimize`, which re-measures the champion arm in the same session.
 
 ## GPU/compositor traces (`--trace`)
 

--- a/scripts/perf/__tests__/scenarioLiveness.test.ts
+++ b/scripts/perf/__tests__/scenarioLiveness.test.ts
@@ -213,11 +213,20 @@ interface DriverResult {
  * The child must NOT look like a Vitest process: every fixture disables its
  * module hooks when `VITEST` is set, so an inherited flag would silently turn
  * each scenario into a run against the real electron module graph.
+ *
+ * `DAINTREE_USER_DATA` goes too. `vitest.setup.ts` points it at one directory
+ * per worker pid, and every fixture that needs a user-data root takes an
+ * inherited value in preference to minting its own — so the whole pool would
+ * share a single `daintree.db`. Two children opening that database at the same
+ * time both read an empty `__drizzle_migrations` and both apply the same
+ * migration, and the loser dies on `duplicate column name` before its scenario
+ * runs. Unset, each child mints its own temp root.
  */
 function childEnv(): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = {};
   for (const [key, value] of Object.entries(process.env)) {
     if (key.startsWith("VITEST")) continue;
+    if (key === "DAINTREE_USER_DATA") continue;
     env[key] = value;
   }
   return env;

--- a/scripts/perf/journeys/manifest.ts
+++ b/scripts/perf/journeys/manifest.ts
@@ -97,9 +97,9 @@ export const JOURNEYS: readonly JourneyDefinition[] = [
     usableEndBoundary:
       "the target view is the visible top child, the old project intercepts nothing, the right terminal is attached at sane geometry, and input reaches the target PTY and no other",
     coverage: "partial",
-    commands: ["project-switch"],
+    commands: ["project-switch", "project-switch-rotation"],
     coverageNote:
-      "The spec measures a real switch round trip and the app's own reveal telemetry, which is genuinely user-facing. It does not send an input probe to the target PTY, so 'visible' is proven and 'input-ready' is not — and #11900 showed a terminal can hold the right text at a geometry that makes its history unusable.",
+      "project-switch-rotation drives the real MRU shortcut, palette and toolbar, then types a nonce into the target's focused shell pane and reads the frame xterm painted it, across LRU depths and cache caps — so both 'visible' and 'input-ready' are proven end to end. Still partial: cross-PTY exclusivity is only checked for views still cached at run end (evicted views cannot be scanned), and geometry is only bounded by the pane accepting the nonce, not proven sane — #11900 showed a terminal can hold the right text at a geometry that makes its history unusable.",
     linkedScenarios: [
       "PERF-010",
       "PERF-011",
@@ -124,6 +124,8 @@ export const JOURNEYS: readonly JourneyDefinition[] = [
       "src/services/terminal/**",
       "src/store/**",
       "src/components/Terminal/**",
+      "src/hooks/useProjectMruSwitcher.ts",
+      "src/lib/projectHistoryNav.ts",
     ],
   },
   {

--- a/scripts/perf/project-switch-rotation-compare.ts
+++ b/scripts/perf/project-switch-rotation-compare.ts
@@ -1,0 +1,312 @@
+import { readFileSync } from "node:fs";
+import type { MemorySample, RotationResult, TimingKey } from "../../e2e/helpers/switchRotation";
+
+/**
+ * Compare two project-switch rotation results, or (with --marginal) price one
+ * extra cached view by comparing a higher cap against a lower one.
+ */
+
+const USAGE = [
+  "usage:",
+  "  npm run perf project-switch-rotation-compare -- <before.json> <after.json>",
+  "  npm run perf project-switch-rotation-compare -- --marginal <capHigher.json> <capLower.json>",
+].join("\n");
+
+const args = process.argv.slice(2);
+const marginal = args.includes("--marginal");
+const files = args.filter((a) => a !== "--marginal");
+if (files.length !== 2) {
+  console.error(USAGE);
+  process.exit(1);
+}
+const [leftPath, rightPath] = files as [string, string];
+
+const load = (file: string): RotationResult => JSON.parse(readFileSync(file, "utf8"));
+const left = load(leftPath);
+const right = load(rightPath);
+
+// Seed only changes sample order; label lives outside config.
+const IGNORED_CONFIG_KEYS = new Set(["seed"]);
+const configMismatches = (): string[] => {
+  const keys = new Set([...Object.keys(left.config), ...Object.keys(right.config)]);
+  return [...keys].filter(
+    (key) =>
+      !IGNORED_CONFIG_KEYS.has(key) &&
+      JSON.stringify((left.config as unknown as Record<string, unknown>)[key]) !==
+        JSON.stringify((right.config as unknown as Record<string, unknown>)[key])
+  );
+};
+
+const mismatches = configMismatches();
+if (marginal) {
+  if (mismatches.length !== 1 || mismatches[0] !== "cap") {
+    console.error(
+      `--marginal needs two runs that differ only in cap; these differ in: ${mismatches.join(", ") || "nothing"}`
+    );
+    process.exit(2);
+  }
+  if (left.config.cap <= right.config.cap) {
+    console.error(
+      `--marginal expects <capHigher.json> first (got cap ${left.config.cap} then ${right.config.cap})`
+    );
+    process.exit(2);
+  }
+} else if (mismatches.length > 0) {
+  console.error(`Cannot compare runs with different settings: ${mismatches.join(", ")}`);
+  process.exit(2);
+}
+
+type Unit = "ms" | "mb" | "count";
+
+interface Row {
+  label: string;
+  before: number | null | undefined;
+  after: number | null | undefined;
+  unit: Unit;
+  /** Lower is better (latency, memory) unless flagged. */
+  higherIsBetter?: boolean;
+}
+
+const fmt = (value: number | null | undefined, unit: Unit): string => {
+  if (value === null || value === undefined || !Number.isFinite(value)) return "-";
+  if (unit === "mb") return `${(value / 1024).toFixed(1)} MB`;
+  if (unit === "count") return value.toFixed(0);
+  return `${value.toFixed(0)} ms`;
+};
+
+const delta = (row: Row): string => {
+  const { before, after } = row;
+  if (
+    before === null ||
+    before === undefined ||
+    after === null ||
+    after === undefined ||
+    !Number.isFinite(before) ||
+    !Number.isFinite(after) ||
+    before === 0
+  ) {
+    return "n/a";
+  }
+  const percent = ((after - before) / Math.abs(before)) * 100;
+  const improvement = row.higherIsBetter ? percent : -percent;
+  return `${improvement >= 0 ? "+" : ""}${improvement.toFixed(1)}%`;
+};
+
+const printTable = (title: string, rows: Row[], leftLabel: string, rightLabel: string): void => {
+  console.log(`\n### ${title}\n`);
+  console.log(`| Metric | ${leftLabel} | ${rightLabel} | Improvement |`);
+  console.log("|---|---:|---:|---:|");
+  for (const row of rows) {
+    console.log(
+      `| ${row.label} | ${fmt(row.before, row.unit)} | ${fmt(row.after, row.unit)} | ${delta(row)} |`
+    );
+  }
+};
+
+const stat = (
+  bucket: { timings: Partial<Record<TimingKey, { p50: number; p95: number }>> } | undefined,
+  key: TimingKey,
+  which: "p50" | "p95"
+): number | undefined => bucket?.timings[key]?.[which] ?? undefined;
+
+const latencyRows = (
+  a: RotationResult,
+  b: RotationResult,
+  pick: (
+    r: RotationResult
+  ) => Record<string, { timings: Partial<Record<TimingKey, { p50: number; p95: number }>> }>,
+  prefix: string
+): Row[] => {
+  const keys = [...new Set([...Object.keys(pick(a)), ...Object.keys(pick(b))])].sort();
+  const rows: Row[] = [];
+  for (const key of keys) {
+    for (const metric of ["intentToNoncePaintedMs", "intentToRevealedMs"] as const) {
+      const short = metric === "intentToNoncePaintedMs" ? "nonce painted" : "revealed";
+      for (const which of ["p50", "p95"] as const) {
+        rows.push({
+          label: `${prefix} ${key} ${short} ${which}`,
+          before: stat(pick(a)[key], metric, which),
+          after: stat(pick(b)[key], metric, which),
+          unit: "ms",
+        });
+      }
+    }
+  }
+  return rows;
+};
+
+const viewRss = (sample: MemorySample | null, projectId: string | null): number | undefined => {
+  if (!sample) return undefined;
+  const hit = sample.views.find((v) => v.projectId === projectId);
+  return hit?.workingSetKb;
+};
+
+const memoryRows = (a: RotationResult, b: RotationResult): Row[] => {
+  const rows: Row[] = [];
+  for (const checkpoint of ["hot", "postPurge"] as const) {
+    const sa = a.memory.checkpoints[checkpoint];
+    const sb = b.memory.checkpoints[checkpoint];
+    rows.push(
+      {
+        label: `${checkpoint} total footprint`,
+        before: sa?.totalKb,
+        after: sb?.totalKb,
+        unit: "mb",
+      },
+      {
+        label: `${checkpoint} renderers`,
+        before: sa?.rendererTotalKb,
+        after: sb?.rendererTotalKb,
+        unit: "mb",
+      },
+      { label: `${checkpoint} GPU`, before: sa?.gpuKb, after: sb?.gpuKb, unit: "mb" },
+      {
+        label: `${checkpoint} PTY descendants`,
+        before: sa?.ptyDescendantsKb,
+        after: sb?.ptyDescendantsKb,
+        unit: "mb",
+      },
+      {
+        label: `${checkpoint} cached views`,
+        before: sa?.views.length,
+        after: sb?.views.length,
+        unit: "count",
+      }
+    );
+    // Project ids are per-run temp dirs, so per-view rows pair by position in the fixture.
+    const projectIds = [...new Set(sa?.views.map((v) => v.projectId) ?? [])];
+    const otherIds = [...new Set(sb?.views.map((v) => v.projectId) ?? [])];
+    const n = Math.max(projectIds.length, otherIds.length);
+    for (let i = 0; i < n; i++) {
+      rows.push({
+        label: `${checkpoint} view ${i} renderer RSS`,
+        before: viewRss(sa, projectIds[i] ?? null),
+        after: viewRss(sb, otherIds[i] ?? null),
+        unit: "mb",
+      });
+    }
+  }
+  return rows;
+};
+
+const apparatusLine = (r: RotationResult): string =>
+  Object.entries(r.apparatus)
+    .map(([k, v]) => `${k}=${v}`)
+    .join(" ");
+
+if (!marginal) {
+  console.log(
+    `\n## Project switch rotation: ${left.label} vs ${right.label} (cap ${left.config.cap})`
+  );
+  console.log(`\n${left.label}: ${apparatusLine(left)}\n${right.label}: ${apparatusLine(right)}`);
+  printTable(
+    "Per depth",
+    latencyRows(left, right, (r) => r.byDepth as never, "depth"),
+    left.label,
+    right.label
+  );
+  printTable(
+    "Per cache class",
+    latencyRows(left, right, (r) => r.byCache as never, ""),
+    left.label,
+    right.label
+  );
+  printTable(
+    "Weighted and rapid",
+    [
+      {
+        label: "weighted nonce painted p50",
+        before: stat(left.weighted, "intentToNoncePaintedMs", "p50"),
+        after: stat(right.weighted, "intentToNoncePaintedMs", "p50"),
+        unit: "ms",
+      },
+      {
+        label: "weighted nonce painted p95",
+        before: stat(left.weighted, "intentToNoncePaintedMs", "p95"),
+        after: stat(right.weighted, "intentToNoncePaintedMs", "p95"),
+        unit: "ms",
+      },
+      {
+        label: "weighted revealed p50",
+        before: stat(left.weighted, "intentToRevealedMs", "p50"),
+        after: stat(right.weighted, "intentToRevealedMs", "p50"),
+        unit: "ms",
+      },
+      {
+        label: "weighted revealed p95",
+        before: stat(left.weighted, "intentToRevealedMs", "p95"),
+        after: stat(right.weighted, "intentToRevealedMs", "p95"),
+        unit: "ms",
+      },
+      {
+        label: "rapid max settle",
+        before: left.rapid.maxSettleMs,
+        after: right.rapid.maxSettleMs,
+        unit: "ms",
+      },
+      {
+        label: "rapid max queue delay",
+        before: left.rapid.maxQueueDelayMs,
+        after: right.rapid.maxQueueDelayMs,
+        unit: "ms",
+      },
+    ],
+    left.label,
+    right.label
+  );
+  printTable("Memory", memoryRows(left, right), left.label, right.label);
+  console.log("");
+  process.exit(0);
+}
+
+const capDelta = left.config.cap - right.config.cap;
+console.log(
+  `\n## Marginal cost of a cached view: cap ${left.config.cap} (${left.label}) vs cap ${right.config.cap} (${right.label})`
+);
+console.log(`\n${left.label}: ${apparatusLine(left)}\n${right.label}: ${apparatusLine(right)}`);
+console.log(`\n### Footprint per extra cached view (÷${capDelta})\n`);
+console.log("| Checkpoint | Higher cap | Lower cap | Per view |");
+console.log("|---|---:|---:|---:|");
+for (const checkpoint of ["hot", "postPurge"] as const) {
+  const hi = left.memory.checkpoints[checkpoint];
+  const lo = right.memory.checkpoints[checkpoint];
+  const rowsFor: Array<[string, number | undefined, number | undefined]> = [
+    [`${checkpoint} total`, hi?.totalKb, lo?.totalKb],
+    [`${checkpoint} renderers`, hi?.rendererTotalKb, lo?.rendererTotalKb],
+    [`${checkpoint} GPU`, hi?.gpuKb, lo?.gpuKb],
+  ];
+  for (const [label, a, b] of rowsFor) {
+    const per =
+      a !== undefined && b !== undefined && Number.isFinite(a) && Number.isFinite(b)
+        ? (a - b) / capDelta
+        : undefined;
+    console.log(`| ${label} | ${fmt(a, "mb")} | ${fmt(b, "mb")} | ${fmt(per, "mb")} |`);
+  }
+}
+printTable(
+  "Latency per depth (higher cap vs lower cap; positive = higher cap faster)",
+  latencyRows(right, left, (r) => r.byDepth as never, "depth"),
+  right.label,
+  left.label
+);
+printTable(
+  "Weighted",
+  [
+    {
+      label: "weighted nonce painted p50",
+      before: stat(right.weighted, "intentToNoncePaintedMs", "p50"),
+      after: stat(left.weighted, "intentToNoncePaintedMs", "p50"),
+      unit: "ms",
+    },
+    {
+      label: "weighted nonce painted p95",
+      before: stat(right.weighted, "intentToNoncePaintedMs", "p95"),
+      after: stat(left.weighted, "intentToNoncePaintedMs", "p95"),
+      unit: "ms",
+    },
+  ],
+  right.label,
+  left.label
+);
+console.log("");
+process.exit(0);

--- a/scripts/perf/registry.ts
+++ b/scripts/perf/registry.ts
@@ -265,6 +265,20 @@ export const REGISTRY: Record<string, Command> = {
     gate: "RUN_PERF_SWITCH",
     build: "build:e2e",
   }),
+  "project-switch-rotation": playwrightBench({
+    summary:
+      "Real-UI switch rotation: intent → focused pane paints a typed nonce, per LRU depth and cache cap, plus memory",
+    kind: "journey",
+    project: "full-resilience",
+    spec: "e2e/full/resilience/project-switch-rotation-perf.spec.ts",
+    gate: "RUN_PERF_SWITCH_ROTATION",
+    build: "build:e2e",
+  }),
+  "project-switch-rotation-compare": {
+    summary: "Compare two switch-rotation results, or price one cached view with --marginal",
+    kind: "diagnostic",
+    runner: tsxScript("project-switch-rotation-compare.ts"),
+  },
   "agent-launch": playwrightBench({
     summary: "agent.launch dispatch to panel, xterm and first agent output",
     kind: "journey",

--- a/shared/perf/marks.ts
+++ b/shared/perf/marks.ts
@@ -138,6 +138,12 @@ export const PERF_MARKS = {
   TERMINAL_DATA_PARSED: "terminal_data_parsed",
   TERMINAL_DATA_RENDERED: "terminal_data_rendered",
   /**
+   * Whether a cold switch's `terminal:get-for-project` was served from the
+   * inventory main prefetched when the switch arrived, or paid the pty-host
+   * round trip on the hydration critical path.
+   */
+  TERMINAL_INVENTORY_PREFETCH: "terminal_inventory_prefetch",
+  /**
    * Sampled keystroke→echo delta: time from a MessagePort terminal write to
    * the next port data chunk for the same terminal id (~1/32 writes; pairs
    * older than 250ms are discarded so unrelated output isn't counted as

--- a/shared/perf/marks.ts
+++ b/shared/perf/marks.ts
@@ -84,6 +84,45 @@ export const PERF_MARKS = {
    */
   WORKTREE_SWITCH_PAINTED: "worktree_switch_painted",
 
+  /**
+   * End-to-end project-switch trace on the real ProjectViewManager path. Every
+   * mark carries `switchId` in meta so one switch can be stitched across the
+   * outgoing renderer, main, and the incoming renderer. Ordered as they fire.
+   */
+  // Outgoing renderer
+  PROJECT_SWITCH_KEYDOWN: "project_switch.keydown",
+  PROJECT_SWITCH_INTENT: "project_switch.intent",
+  PROJECT_SWITCH_BUSY_PAINTED: "project_switch.busy_painted",
+  PROJECT_SWITCH_PERSIST_IDLE: "project_switch.persist_idle",
+  PROJECT_SWITCH_SNAPSHOT_BUILT: "project_switch.snapshot_built",
+  PROJECT_SWITCH_IPC_SENT: "project_switch.ipc_sent",
+  // Main
+  PROJECT_SWITCH_MAIN_RECEIVED: "project_switch.main_received",
+  PROJECT_SWITCH_MAIN_LOOP_PROBE: "project_switch.main_loop_probe",
+  PROJECT_SWITCH_PENDING_PERSIST_DONE: "project_switch.pending_persist_done",
+  PROJECT_SWITCH_CHAIN_ENTERED: "project_switch.chain_entered",
+  PROJECT_SWITCH_VIEW_ATTACHED: "project_switch.view_attached",
+  PROJECT_SWITCH_LOAD_FINISHED: "project_switch.load_finished",
+  PROJECT_SWITCH_GATE_RESOLVED: "project_switch.gate_resolved",
+  PROJECT_SWITCH_REVEALED: "project_switch.revealed",
+  PROJECT_SWITCH_SWAP_DONE: "project_switch.swap_done",
+  PROJECT_SWITCH_PTY_PORT_SENT: "project_switch.pty_port_sent",
+  PROJECT_SWITCH_WORKTREES_LOADED: "project_switch.worktrees_loaded",
+  PROJECT_SWITCH_SETTLED: "project_switch.settled",
+  PROJECT_SWITCH_FIRST_INTERACTIVE: "project_switch.first_interactive",
+  // Incoming renderer
+  PROJECT_SWITCH_ON_SWITCH_RECEIVED: "project_switch.on_switch_received",
+  PROJECT_SWITCH_WARM_ACTIVATED_RECEIVED: "project_switch.warm_activated_received",
+  PROJECT_SWITCH_FOCUSED_PANE_WOKEN: "project_switch.focused_pane_woken",
+  PROJECT_SWITCH_ALL_PANES_WOKEN: "project_switch.all_panes_woken",
+  PROJECT_SWITCH_WARM_PAINT_SIGNALLED: "project_switch.warm_paint_signalled",
+  PROJECT_SWITCH_REVEALED_RECEIVED: "project_switch.revealed_received",
+  PROJECT_SWITCH_REVEAL_REPAINT_DONE: "project_switch.reveal_repaint_done",
+  PROJECT_SWITCH_PTY_PORT_READY: "project_switch.pty_port_ready",
+  // Spec-driven: emitted by the E2E harness through `__daintreeMarkPerf`.
+  PROJECT_SWITCH_NONCE_PAINTED: "project_switch.nonce_painted",
+  PROJECT_SWITCH_NONCE_FRAME: "project_switch.nonce_frame",
+
   PROJECT_STATE_WRITE: "project_state_write",
   PROJECT_STATE_READ: "project_state_read",
   PROJECT_STATE_QUARANTINE: "project_state_quarantine",

--- a/shared/perf/marks.ts
+++ b/shared/perf/marks.ts
@@ -119,6 +119,8 @@ export const PERF_MARKS = {
   PROJECT_SWITCH_REVEALED_RECEIVED: "project_switch.revealed_received",
   PROJECT_SWITCH_REVEAL_REPAINT_DONE: "project_switch.reveal_repaint_done",
   PROJECT_SWITCH_PTY_PORT_READY: "project_switch.pty_port_ready",
+  /** Whether a warm reveal moved DOM focus back onto a terminal, or why not. */
+  PROJECT_SWITCH_FOCUS_RESTORE: "project_switch.focus_restore",
   // Spec-driven: emitted by the E2E harness through `__daintreeMarkPerf`.
   PROJECT_SWITCH_NONCE_PAINTED: "project_switch.nonce_painted",
   PROJECT_SWITCH_NONCE_FRAME: "project_switch.nonce_frame",

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -516,7 +516,7 @@ export interface ElectronAPI extends GeneratedElectronAPI {
      * re-runs its terminal redraw then, since the wake fan-out driven by
      * visibilitychange/resume ran while the view was still occluded.
      */
-    onViewRevealed(callback: () => void): () => void;
+    onViewRevealed(callback: (payload?: { switchId?: string }) => void): () => void;
     /**
      * Subscribe to the warm-activation wake signal. Main fires this the moment
      * it re-attaches a cached view behind the anti-flash bridge (or reveals it
@@ -527,7 +527,7 @@ export interface ElectronAPI extends GeneratedElectronAPI {
      * lifecycle event (the Efficiency-profile freeze path), and every other
      * warm swap stalled until the warm paint gate's hard timeout.
      */
-    onViewWarmActivated(callback: () => void): () => void;
+    onViewWarmActivated(callback: (payload?: { switchId?: string }) => void): () => void;
     onViewCached(callback: () => void): () => void;
     /**
      * Whether main currently has this view cached. The three signals above are
@@ -600,7 +600,10 @@ export interface ElectronAPI extends GeneratedElectronAPI {
     switch(
       projectId: string,
       outgoingState?: ProjectSwitchOutgoingState,
-      options?: { focusIntent?: import("./project.js").ProjectFocusOnActivateIntent }
+      options?: {
+        focusIntent?: import("./project.js").ProjectFocusOnActivateIntent;
+        trace?: import("./project.js").ProjectSwitchTrace;
+      }
     ): Promise<Project>;
     /**
      * Hover-prefetch trigger for the project switcher palette. Fire-and-forget:
@@ -610,14 +613,7 @@ export interface ElectronAPI extends GeneratedElectronAPI {
      */
     prefetchHydrate(projectId: string): Promise<void>;
     openDialog(): Promise<string | null>;
-    onSwitch(
-      callback: (payload: {
-        project: Project;
-        switchId: string;
-        worktreeLoadError?: string;
-        hydrateResult?: import("./app.js").HydrateResult;
-      }) => void
-    ): () => void;
+    onSwitch(callback: (payload: import("./project.js").ProjectSwitchPayload) => void): () => void;
     onWorktreeLoadStatus(
       callback: (payload: { projectId: string; worktreeLoadError: string | null }) => void
     ): () => void;
@@ -659,7 +655,11 @@ export interface ElectronAPI extends GeneratedElectronAPI {
      * Reopen a background project, making it the active project.
      * Terminals that were running in the background will be reconnected.
      */
-    reopen(projectId: string, outgoingState?: ProjectSwitchOutgoingState): Promise<Project>;
+    reopen(
+      projectId: string,
+      outgoingState?: ProjectSwitchOutgoingState,
+      options?: { trace?: import("./project.js").ProjectSwitchTrace }
+    ): Promise<Project>;
     getStats(projectId: string): Promise<ProjectStats>;
     getBulkStats(projectIds: string[]): Promise<BulkProjectStats>;
     getNotificationOverrides(

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -79,6 +79,7 @@ import type {
   ProjectSwitchOutgoingState,
   ProjectWorktreeLoadStatusPayload,
   ProjectFocusOnActivateIntent,
+  ProjectSwitchTrace,
 } from "./project.js";
 import type { FleetSnapshot } from "./fleet.js";
 import type {
@@ -612,7 +613,7 @@ export interface IpcInvokeMap extends GeneratedIpcInvokeMap {
     args: [
       projectId: string,
       outgoingState?: ProjectSwitchOutgoingState,
-      options?: { focusIntent?: ProjectFocusOnActivateIntent },
+      options?: { focusIntent?: ProjectFocusOnActivateIntent; trace?: ProjectSwitchTrace },
     ];
     result: Project;
   };
@@ -641,7 +642,11 @@ export interface IpcInvokeMap extends GeneratedIpcInvokeMap {
     result: ProjectCloseResult;
   };
   "project:reopen": {
-    args: [projectId: string, outgoingState?: ProjectSwitchOutgoingState];
+    args: [
+      projectId: string,
+      outgoingState?: ProjectSwitchOutgoingState,
+      options?: { trace?: ProjectSwitchTrace },
+    ];
     result: Project;
   };
   "project:get-stats": {
@@ -1863,12 +1868,14 @@ export interface IpcEventMap {
   // renderer re-runs its terminal redraw here — the wake fan-out driven by
   // visibilitychange/resume ran while the view was still occluded, where
   // Chromium culls the paint, so it can fail to stick until the user clicks.
-  "app:view-revealed": void;
+  // Carries the switch trace id so the incoming renderer's perf marks join the
+  // same `project_switch.*` trace main is emitting; absent on the rollback send.
+  "app:view-revealed": { switchId?: string } | undefined;
   // Fired by ProjectViewManager the moment it re-attaches a cached view (warm
   // switch). A detached setVisible(false) view receives no visibilitychange or
   // resume event on reattach, so this is the renderer's deterministic trigger
   // to run the wake fan-out whose completion releases the warm paint gate.
-  "app:view-warm-activated": void;
+  "app:view-warm-activated": { switchId?: string } | undefined;
   "app:view-cached": void;
 
   // Privacy events

--- a/shared/types/ipc/project.ts
+++ b/shared/types/ipc/project.ts
@@ -91,12 +91,31 @@ export interface ProjectSwitchOutgoingState {
 export type ProjectFocusOnActivateIntent =
   { intent: "focus-next-waiting" } | { intent: "focus-panel"; panelId: string };
 
+/** Which surface started a project switch — the first field of its perf trace. */
+export type ProjectSwitchEntryPoint =
+  "mru-shortcut" | "palette-keyboard" | "palette-mouse" | "toolbar" | "menu" | "api";
+
+/**
+ * Correlation handle threaded from the initiating renderer through main to the
+ * incoming view, so every `project_switch.*` perf mark of one switch shares an
+ * id. Minted where the gesture lands; main mints one itself when a caller has
+ * none (menu, MCP, tests).
+ */
+export interface ProjectSwitchTrace {
+  switchId: string;
+  entryPoint: ProjectSwitchEntryPoint;
+}
+
 /** Payload for project:on-switch event with cancellation token */
 export interface ProjectSwitchPayload {
   /** The project being switched to */
   project: Project;
   /** Unique identifier for this switch operation */
   switchId: string;
+  /** Where the switch started; absent on the legacy non-PVM path. */
+  entryPoint?: ProjectSwitchEntryPoint;
+  /** True when the view was reactivated from the LRU cache rather than cold-started. */
+  cacheHit?: boolean;
   /** If the workspace host failed to load worktrees (e.g. non-git directory) */
   worktreeLoadError?: string;
   /** Pre-built hydration data to skip the redundant APP_HYDRATE IPC round-trip */

--- a/src/clients/projectClient.ts
+++ b/src/clients/projectClient.ts
@@ -15,7 +15,13 @@ import type {
 import type { NotificationSettings } from "@shared/types/ipc/api";
 import type { RelocationPreview, RelocationRequest } from "@shared/types/projectRelocation";
 import type { AgentPreset } from "@shared/config/agentRegistry";
-import type { ProjectSwitchOutgoingState } from "@shared/types/ipc/project";
+import type {
+  ProjectSwitchOutgoingState,
+  ProjectSwitchPayload,
+  ProjectSwitchTrace,
+} from "@shared/types/ipc/project";
+import { PERF_MARKS } from "@shared/perf/marks";
+import { markSwitch, setActiveSwitchTrace } from "@/utils/switchTrace";
 import type { IdArrayFieldEdit } from "@shared/utils/layoutMerge";
 import type {
   GitInitOptions,
@@ -70,8 +76,17 @@ export function invalidateProjectSettingsCache(projectId?: string): void {
 function ensureSubscribed(): void {
   if (subscribed) return;
   subscribed = true;
-  window.electron.project.onSwitch(() => {
+  window.electron.project.onSwitch((payload) => {
     invalidateCurrentCache();
+    // This view is now the incoming side of `switchId`: adopt the trace so its
+    // own marks (port ready, repaint passes) join main's. Guarded because test
+    // doubles fire the listener bare.
+    if (!payload?.switchId) return;
+    setActiveSwitchTrace({ switchId: payload.switchId, entryPoint: payload.entryPoint });
+    markSwitch(PERF_MARKS.PROJECT_SWITCH_ON_SWITCH_RECEIVED, {
+      cacheHit: payload.cacheHit,
+      targetProjectId: payload.project?.id,
+    });
   });
 }
 
@@ -130,7 +145,10 @@ export const projectClient = {
   switch: (
     projectId: string,
     outgoingState?: ProjectSwitchOutgoingState,
-    options?: { focusIntent?: import("@shared/types/ipc/project").ProjectFocusOnActivateIntent }
+    options?: {
+      focusIntent?: import("@shared/types/ipc/project").ProjectFocusOnActivateIntent;
+      trace?: ProjectSwitchTrace;
+    }
   ): Promise<Project> => {
     invalidateCurrentCache();
     return window.electron.project.switch(projectId, outgoingState, options);
@@ -166,14 +184,7 @@ export const projectClient = {
     return window.electron.projectRelocation.apply(request);
   },
 
-  onSwitch: (
-    callback: (payload: {
-      project: Project;
-      switchId: string;
-      worktreeLoadError?: string;
-      hydrateResult?: import("@shared/types/ipc/app").HydrateResult;
-    }) => void
-  ): (() => void) => {
+  onSwitch: (callback: (payload: ProjectSwitchPayload) => void): (() => void) => {
     return window.electron.project.onSwitch(callback);
   },
 
@@ -238,9 +249,13 @@ export const projectClient = {
     return window.electron.project.sleepProject(projectId);
   },
 
-  reopen: (projectId: string, outgoingState?: ProjectSwitchOutgoingState): Promise<Project> => {
+  reopen: (
+    projectId: string,
+    outgoingState?: ProjectSwitchOutgoingState,
+    options?: { trace?: ProjectSwitchTrace }
+  ): Promise<Project> => {
     invalidateCurrentCache();
-    return window.electron.project.reopen(projectId, outgoingState);
+    return window.electron.project.reopen(projectId, outgoingState, options);
   },
 
   getStats: (projectId: string): Promise<ProjectStats> => {

--- a/src/clients/terminalClient.ts
+++ b/src/clients/terminalClient.ts
@@ -23,6 +23,7 @@ import { normalizeTerminalGridDimension } from "@shared/types/terminal";
 import { PERF_MARKS } from "@shared/perf/marks";
 import { logDebug, logWarn } from "@/utils/logger";
 import { isRendererPerfCaptureEnabled, markRendererPerformance } from "@/utils/performance";
+import { markSwitch } from "@/utils/switchTrace";
 import { safeFireAndForget } from "@/utils/safeFireAndForget";
 
 let messagePort: MessagePort | null = null;
@@ -235,6 +236,7 @@ function activatePort(port: MessagePort): void {
   pendingPortAckBytes.clear();
   messagePort = port;
   installPortDataHandler(port);
+  markSwitch(PERF_MARKS.PROJECT_SWITCH_PTY_PORT_READY);
   port.addEventListener("close", () => {
     if (messagePort === port) {
       messagePort = null;

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -2135,6 +2135,9 @@ export function Toolbar({
                       fleetLiveness={projectSwitcher.fleetLiveness}
                       onClose={handlePillDropdownClose}
                       onDropdownCloseAutoFocus={suppressPillTooltipForFocusRestore}
+                      consumeCloseAutoFocusSuppression={
+                        projectSwitcher.consumeCloseAutoFocusSuppression
+                      }
                       onAddProject={projectSwitcher.addProject}
                       onCloneRepo={projectSwitcher.cloneRepo}
                       onStopProject={handleStopProject}

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -159,6 +159,8 @@ export interface ProjectSwitcherPaletteProps {
    * reopening on the refocused trigger after a project switch. Dropdown-only.
    */
   onDropdownCloseAutoFocus?: () => void;
+  /** Dropdown only: whether this close must not return focus to the trigger. */
+  consumeCloseAutoFocusSuppression?: () => boolean;
   children?: React.ReactNode;
   removeConfirmProject?: SearchableProject | null;
   onRemoveConfirmClose?: () => void;
@@ -2511,6 +2513,7 @@ function DropdownContent({
   children,
   mode,
   onDropdownCloseAutoFocus,
+  consumeCloseAutoFocusSuppression,
   paletteInputRef: inputRef,
   onQueryChange,
   ...innerProps
@@ -2548,6 +2551,7 @@ function DropdownContent({
         inputRef={inputRef}
         onClearQuery={handleClearQuery}
         onCloseAutoFocus={onDropdownCloseAutoFocus}
+        consumeCloseAutoFocusSuppression={consumeCloseAutoFocusSuppression}
         // Keeps the trigger's focus ring on a pointer dismissal, which is what
         // this palette has always done. The shell's default (suppress) is the
         // better behaviour and worth adopting — but as its own change, not

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -80,6 +80,7 @@ import type {
   ProjectSwitcherProjectRow,
   ProjectSwitcherRow,
   ProjectSwitcherScratchRow,
+  ProjectSwitchSelectSource,
   SearchableProject,
   SearchableScratch,
 } from "@/hooks/useProjectSwitcherPalette";
@@ -122,7 +123,7 @@ export interface ProjectSwitcherPaletteProps {
   onSelectPrevious: () => void;
   onSelectNext: () => void;
   /** Commits any row. Project-only callbacks below stay typed to projects. */
-  onSelect: (row: ProjectSwitcherRow) => void;
+  onSelect: (row: ProjectSwitcherRow, source?: ProjectSwitchSelectSource) => void;
   onClose: () => void;
   mode?: ProjectSwitcherMode;
   onAddProject?: () => void;
@@ -232,7 +233,7 @@ interface ProjectListItemProps {
    * to it — source-level, because vitest cannot see the freeze.
    */
   nowMs: number;
-  onSelect: (row: ProjectSwitcherProjectRow) => void;
+  onSelect: (row: ProjectSwitcherProjectRow, source?: ProjectSwitchSelectSource) => void;
   onStopProject?: (projectId: string) => void;
   onCloseProject?: (projectId: string) => void;
   onSleepProject?: (projectId: string) => void;
@@ -640,7 +641,7 @@ function ProjectListItem({
       // The current project is selectable too: picking where you already are is
       // a "never mind", and the handler closes the palette rather than sitting
       // there doing nothing.
-      onClick={() => onSelect(project)}
+      onClick={() => onSelect(project, "pointer")}
       onPointerEnter={onHoverProject ? (e) => onHoverProject(project.id, e.pointerType) : undefined}
       onPointerLeave={onHoverProjectEnd ? (e) => onHoverProjectEnd(e.pointerType) : undefined}
     >
@@ -1152,7 +1153,7 @@ interface ProjectListContentProps {
   browseBands?: ProjectSwitcherBrowseBand[];
   selectedIndex: number;
   query: string;
-  onSelect: (row: ProjectSwitcherRow) => void;
+  onSelect: (row: ProjectSwitcherRow, source?: ProjectSwitchSelectSource) => void;
   listRef: React.RefObject<HTMLDivElement | null>;
   /** Whether this surface offers "Add project…" — decides what the empty state can name. */
   canAddProject: boolean;
@@ -2102,7 +2103,7 @@ interface ProjectPaletteInnerProps {
   selectedIndex: number;
   mode?: ProjectSwitcherMode;
   onQueryChange: (query: string) => void;
-  onSelect: (row: ProjectSwitcherRow) => void;
+  onSelect: (row: ProjectSwitcherRow, source?: ProjectSwitchSelectSource) => void;
   onSelectNewWindow?: (project: SearchableProject) => void;
   onClose: () => void;
   onSelectPrevious: () => void;
@@ -2216,7 +2217,7 @@ function ProjectPaletteInner({
             ) {
               onSelectNewWindow(selected);
             } else {
-              onSelect(selected);
+              onSelect(selected, "keyboard");
             }
           }
           break;

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.keyboard.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.keyboard.test.tsx
@@ -341,7 +341,7 @@ describe("ProjectSwitcherPalette keyboard navigation", () => {
     const input = screen.getByTestId("palette-input");
     fireEvent.keyDown(input, { key: "Enter", altKey: true });
     expect(defaultProps.onSelect).toHaveBeenCalledTimes(1);
-    expect(defaultProps.onSelect).toHaveBeenCalledWith(defaultProps.results[0]);
+    expect(defaultProps.onSelect).toHaveBeenCalledWith(defaultProps.results[0], "keyboard");
     expect(onSelectNewWindow).not.toHaveBeenCalled();
   });
 
@@ -515,7 +515,7 @@ describe("ProjectSwitcherPalette keyboard on a scratch row", () => {
     render(<ProjectSwitcherPalette {...scratchProps} />);
     fireEvent.keyDown(screen.getByTestId("palette-input"), { key: "Enter" });
 
-    expect(scratchProps.onSelect).toHaveBeenCalledWith(scratchRow);
+    expect(scratchProps.onSelect).toHaveBeenCalledWith(scratchRow, "keyboard");
   });
 
   it("falls back to a plain switch on Meta+Enter instead of swallowing it", () => {
@@ -526,7 +526,7 @@ describe("ProjectSwitcherPalette keyboard on a scratch row", () => {
     fireEvent.keyDown(screen.getByTestId("palette-input"), { key: "Enter", metaKey: true });
 
     expect(onSelectNewWindow).not.toHaveBeenCalled();
-    expect(scratchProps.onSelect).toHaveBeenCalledWith(scratchRow);
+    expect(scratchProps.onSelect).toHaveBeenCalledWith(scratchRow, "keyboard");
   });
 
   it("leaves Meta+Backspace inert rather than removing by scratch id", () => {

--- a/src/contexts/WorktreeStoreContext.tsx
+++ b/src/contexts/WorktreeStoreContext.tsx
@@ -1000,6 +1000,32 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
       if (wakeRafId !== null) cancelAnimationFrame(wakeRafId);
     });
 
+    // Warm reactivation runs the fan-out NOW rather than through scheduleWake's
+    // double-rAF settle. Main has just re-attached this view beneath the
+    // outgoing one and is holding that bridge until the fan-out reports back;
+    // an undrawn view's frames are throttled to ~2 Hz, so each deferred frame
+    // cost ~500 ms and the gate (1.5 s hard) expired on every switch that had
+    // panes to wake. The wake's repairs are synchronous and the post-reveal
+    // repaint (#10362) redoes the paint at full rate once the view is on top.
+    // A pending frame-deferred wake is folded in, and one frame of
+    // `wakePending` absorbs the same-turn `resume`/`visibilitychange` echoes.
+    function runWakeNow() {
+      if (wakeRafId !== null) {
+        cancelAnimationFrame(wakeRafId);
+        wakeRafId = null;
+      }
+      wakePending = true;
+      void wakeActiveWorktreeTerminals();
+      if (typeof requestAnimationFrame !== "function") {
+        wakePending = false;
+        return;
+      }
+      wakeRafId = requestAnimationFrame(() => {
+        wakeRafId = null;
+        wakePending = false;
+      });
+    }
+
     function handleVisibilityChange() {
       if (document.visibilityState !== "visible") return;
       scheduleWake();
@@ -1084,19 +1110,17 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
     // WebContentsView, and `resume` needs an actual freeze), so on most warm
     // switches the wake fan-out — whose completion releases main's warm paint
     // gate via notifyWarmViewPainted — had no trigger and the gate always ran
-    // to its hard timeout. Routed through scheduleWake so it coalesces with any
-    // visibility/resume-triggered wake and inherits the same double-rAF settle.
-    // Deliberately NO entry-time visibility guard: this is the one trigger main
-    // asserts is valid, and dropping it here would re-open the hard-timeout
-    // stall; scheduleWake re-checks visibility at execution and APP_VIEW_CACHED
-    // cancels a pending wake if the view is switched away mid-schedule.
+    // to its hard timeout. Runs the fan-out synchronously (see runWakeNow) and
+    // deliberately has NO visibility guard: main asserts the activation and is
+    // holding the bridge on the reply, so skipping the wake would only trade a
+    // fan-out for a 1.5 s stall.
     const offViewWarmActivated = window.electron?.app?.onViewWarmActivated?.((payload) => {
       // First signal the incoming view gets on a warm switch: adopt the trace
       // so the wake fan-out marks below join it (`project:on-switch` fills in
       // the entry point later).
       if (payload?.switchId) setActiveSwitchTrace({ switchId: payload.switchId });
       markSwitch(PERF_MARKS.PROJECT_SWITCH_WARM_ACTIVATED_RECEIVED);
-      scheduleWake();
+      runWakeNow();
     });
     if (offViewWarmActivated) cleanups.push(offViewWarmActivated);
 

--- a/src/contexts/WorktreeStoreContext.tsx
+++ b/src/contexts/WorktreeStoreContext.tsx
@@ -21,6 +21,7 @@ import { usePRCircuitBreakerStore } from "@/store/prCircuitBreakerStore";
 import {
   repaintActiveWorktreeTerminals,
   wakeActiveWorktreeTerminals,
+  restoreTerminalFocusOnReveal,
 } from "@/store/wakeActiveWorktreeTerminals";
 import { worktreeClient } from "@/clients/worktreeClient";
 import { PERF_MARKS } from "@shared/perf/marks";
@@ -1129,6 +1130,9 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
         ...(payload?.switchId ? { switchId: payload.switchId } : {}),
       });
       if (document.visibilityState !== "visible") return;
+      // Main has just focused this webContents; put DOM focus back on the
+      // working terminal if the round trip left it on a button or the body.
+      restoreTerminalFocusOnReveal();
       scheduleRepaint("initial");
       // Cancel any backstops still pending from a prior switch so rapid
       // back-and-forth switching can't stack passes, then arm this switch's.

--- a/src/contexts/WorktreeStoreContext.tsx
+++ b/src/contexts/WorktreeStoreContext.tsx
@@ -23,6 +23,9 @@ import {
   wakeActiveWorktreeTerminals,
 } from "@/store/wakeActiveWorktreeTerminals";
 import { worktreeClient } from "@/clients/worktreeClient";
+import { PERF_MARKS } from "@shared/perf/marks";
+import { flushPendingPerfMarks } from "@/utils/performance";
+import { markSwitch, setActiveSwitchTrace } from "@/utils/switchTrace";
 import { notify } from "@/lib/notify";
 import { actionService } from "@/services/ActionService";
 
@@ -1028,7 +1031,9 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
     // vice versa); the repaint skips the byte-pull the wake already did.
     let repaintPending = false;
     let repaintRafId: number | null = null;
-    function scheduleRepaint() {
+    // `pass` only labels the perf mark — it says which reveal-repaint pass
+    // (initial or a timed backstop) actually landed, and changes nothing else.
+    function scheduleRepaint(pass: "initial" | "backstop-1000" | "backstop-3000") {
       if (repaintPending) return;
       repaintPending = true;
       repaintRafId = requestAnimationFrame(() => {
@@ -1036,7 +1041,10 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
           repaintRafId = null;
           repaintPending = false;
           if (document.visibilityState === "visible") {
-            void repaintActiveWorktreeTerminals();
+            void repaintActiveWorktreeTerminals().then(() => {
+              markSwitch(PERF_MARKS.PROJECT_SWITCH_REVEAL_REPAINT_DONE, { pass });
+              flushPendingPerfMarks();
+            });
           }
         });
       });
@@ -1082,14 +1090,22 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
     // asserts is valid, and dropping it here would re-open the hard-timeout
     // stall; scheduleWake re-checks visibility at execution and APP_VIEW_CACHED
     // cancels a pending wake if the view is switched away mid-schedule.
-    const offViewWarmActivated = window.electron?.app?.onViewWarmActivated?.(() => {
+    const offViewWarmActivated = window.electron?.app?.onViewWarmActivated?.((payload) => {
+      // First signal the incoming view gets on a warm switch: adopt the trace
+      // so the wake fan-out marks below join it (`project:on-switch` fills in
+      // the entry point later).
+      if (payload?.switchId) setActiveSwitchTrace({ switchId: payload.switchId });
+      markSwitch(PERF_MARKS.PROJECT_SWITCH_WARM_ACTIVATED_RECEIVED);
       scheduleWake();
     });
     if (offViewWarmActivated) cleanups.push(offViewWarmActivated);
 
-    const offViewRevealed = window.electron?.app?.onViewRevealed?.(() => {
+    const offViewRevealed = window.electron?.app?.onViewRevealed?.((payload) => {
+      markSwitch(PERF_MARKS.PROJECT_SWITCH_REVEALED_RECEIVED, {
+        ...(payload?.switchId ? { switchId: payload.switchId } : {}),
+      });
       if (document.visibilityState !== "visible") return;
-      scheduleRepaint();
+      scheduleRepaint("initial");
       // Cancel any backstops still pending from a prior switch so rapid
       // back-and-forth switching can't stack passes, then arm this switch's.
       clearRevealBackstops();
@@ -1098,7 +1114,9 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
           setTimeout(() => {
             // Re-checked here AND inside scheduleRepaint's rAF: if the user
             // switched away again the view is hidden and this no-ops.
-            if (document.visibilityState === "visible") scheduleRepaint();
+            if (document.visibilityState === "visible") {
+              scheduleRepaint(delay === 1000 ? "backstop-1000" : "backstop-3000");
+            }
           }, delay)
         );
       }
@@ -1106,6 +1124,9 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
     if (offViewRevealed) cleanups.push(offViewRevealed);
 
     const offViewCached = window.electron?.app?.onViewCached?.(() => {
+      // Last chance to drain this view's outgoing-side marks before it is
+      // parked (and possibly frozen) in the LRU cache.
+      flushPendingPerfMarks();
       clearRevealBackstops();
       if (wakeRafId !== null) {
         cancelAnimationFrame(wakeRafId);

--- a/src/contexts/__tests__/WorktreeStoreContext.prDetected.test.tsx
+++ b/src/contexts/__tests__/WorktreeStoreContext.prDetected.test.tsx
@@ -17,6 +17,7 @@ import type { WorktreeSnapshot, WorktreeEventVersion } from "@shared/types";
 import type { Project } from "@shared/types/project";
 
 vi.mock("@/store/wakeActiveWorktreeTerminals", () => ({
+  restoreTerminalFocusOnReveal: () => false,
   wakeActiveWorktreeTerminals: vi.fn(() => Promise.resolve()),
 }));
 

--- a/src/contexts/__tests__/WorktreeStoreContext.scheduleWake.test.tsx
+++ b/src/contexts/__tests__/WorktreeStoreContext.scheduleWake.test.tsx
@@ -10,6 +10,7 @@ import type { Project } from "@shared/types/project";
 const wakeMock = vi.fn<() => Promise<void>>(() => Promise.resolve());
 const repaintMock = vi.fn<() => Promise<void>>(() => Promise.resolve());
 vi.mock("@/store/wakeActiveWorktreeTerminals", () => ({
+  restoreTerminalFocusOnReveal: () => false,
   wakeActiveWorktreeTerminals: () => wakeMock(),
   repaintActiveWorktreeTerminals: () => repaintMock(),
 }));

--- a/src/contexts/__tests__/WorktreeStoreContext.scheduleWake.test.tsx
+++ b/src/contexts/__tests__/WorktreeStoreContext.scheduleWake.test.tsx
@@ -405,7 +405,7 @@ describe("WorktreeStoreProvider — wake fan-out scheduling (#10362)", () => {
     expect(repaintMock).toHaveBeenCalledTimes(1);
   });
 
-  it("runs the wake fan-out on the warm-activation signal through the double-rAF gate", async () => {
+  it("runs the wake fan-out synchronously on the warm-activation signal", async () => {
     await renderProvider();
     // Drain the mount-scheduled missed-event wake first.
     act(() => flushFrame());
@@ -415,11 +415,13 @@ describe("WorktreeStoreProvider — wake fan-out scheduling (#10362)", () => {
 
     // A detached setVisible(false) view receives no visibilitychange/resume on
     // reattach, so main's explicit warm-activation send is the only trigger
-    // this path can rely on — it must drive the same deferred wake fan-out.
+    // this path can rely on. It must NOT wait for animation frames: the view is
+    // undrawn behind the bridge and its frames are throttled, and main holds
+    // the bridge until the fan-out reports back.
     act(() => viewWarmActivatedCb?.());
-    act(() => flushFrame());
-    expect(wakeMock).not.toHaveBeenCalled();
+    expect(wakeMock).toHaveBeenCalledTimes(1);
 
+    act(() => flushFrame());
     act(() => flushFrame());
     expect(wakeMock).toHaveBeenCalledTimes(1);
   });
@@ -445,25 +447,22 @@ describe("WorktreeStoreProvider — wake fan-out scheduling (#10362)", () => {
     expect(wakeMock).toHaveBeenCalledTimes(1);
   });
 
-  it("skips a warm-activation wake when the view is hidden by execution time", async () => {
+  it("runs the warm-activation wake even while the document reports hidden", async () => {
     await renderProvider();
     act(() => flushFrame());
     act(() => flushFrame());
     wakeMock.mockClear();
     expect(viewWarmActivatedCb).not.toBeNull();
 
-    // The trigger itself has no entry-time visibility guard (main asserts the
-    // activation), but scheduleWake's execution-time re-check still applies:
-    // a view hidden again before the second frame must not run the fan-out.
+    // Main asserts the activation and is holding the anti-flash bridge on the
+    // reply, so a visibility guard here would only trade a fan-out for a stall.
     setVisibilityState("hidden");
     act(() => viewWarmActivatedCb?.());
-    act(() => flushFrame());
-    act(() => flushFrame());
 
-    expect(wakeMock).not.toHaveBeenCalled();
+    expect(wakeMock).toHaveBeenCalledTimes(1);
   });
 
-  it("cancels a pending warm-activation wake when the view is cached mid-schedule", async () => {
+  it("folds a pending frame-deferred wake into the warm-activation wake and runs nothing more once cached", async () => {
     await renderProvider();
     act(() => flushFrame());
     act(() => flushFrame());
@@ -471,15 +470,17 @@ describe("WorktreeStoreProvider — wake fan-out scheduling (#10362)", () => {
     expect(viewWarmActivatedCb).not.toBeNull();
     expect(viewCachedCb).not.toBeNull();
 
-    // Rapid A→B→A→B: the warm activation schedules a wake, but the view is
-    // cached again (superseding switch) before the second frame — the pending
-    // rAF must be cancelled so the fan-out can't run against an occluded view.
+    // A lifecycle event queued a frame-deferred wake; the warm activation runs
+    // the fan-out immediately and absorbs that pending frame. Rapid A→B→A→B
+    // then caches the view again before any frame fires: nothing further runs.
+    act(() => document.dispatchEvent(new Event("visibilitychange")));
     act(() => viewWarmActivatedCb?.());
-    act(() => flushFrame());
+    expect(wakeMock).toHaveBeenCalledTimes(1);
+
     act(() => viewCachedCb?.());
     act(() => flushFrame());
-
-    expect(wakeMock).not.toHaveBeenCalled();
+    act(() => flushFrame());
+    expect(wakeMock).toHaveBeenCalledTimes(1);
   });
 
   it("ignores visibilitychange dispatched while hidden", async () => {

--- a/src/hooks/__tests__/useProjectSwitcherPalette.test.tsx
+++ b/src/hooks/__tests__/useProjectSwitcherPalette.test.tsx
@@ -3271,6 +3271,47 @@ describe("useProjectSwitcherPalette", () => {
       expect(target).toBe(highlighted.id);
     });
 
+    it("suppresses the dropdown's close-autofocus only for the close that commits a switch", async () => {
+      const result = await openIn("dropdown");
+      await waitFor(() => {
+        expect(result.current.results).toHaveLength(3);
+      });
+      // Nothing armed by merely opening, and asking disarms nothing.
+      expect(result.current.consumeCloseAutoFocusSuppression()).toBe(false);
+
+      const target = asProject(result.current.results.find((project) => !project.isActive));
+      act(() => {
+        void result.current.selectProject(target);
+      });
+      await waitFor(() => {
+        expect(result.current.isOpen).toBe(false);
+      });
+      // Armed exactly once: the shell asks on close and the answer is spent.
+      expect(result.current.consumeCloseAutoFocusSuppression()).toBe(true);
+      expect(result.current.consumeCloseAutoFocusSuppression()).toBe(false);
+    });
+
+    it("does not suppress the modal's close-autofocus or a plain dismissal", async () => {
+      const modal = await openIn("modal");
+      await waitFor(() => {
+        expect(modal.current.results).toHaveLength(3);
+      });
+      const target = asProject(modal.current.results.find((project) => !project.isActive));
+      act(() => {
+        void modal.current.selectProject(target);
+      });
+      await waitFor(() => {
+        expect(modal.current.isOpen).toBe(false);
+      });
+      expect(modal.current.consumeCloseAutoFocusSuppression()).toBe(false);
+
+      const dropdown = await openIn("dropdown");
+      act(() => {
+        dropdown.current.close();
+      });
+      expect(dropdown.current.consumeCloseAutoFocusSuppression()).toBe(false);
+    });
+
     it("treats picking the current project as a dismissal, not a dead end", async () => {
       const result = await openIn("modal");
       await waitFor(() => {

--- a/src/hooks/useProjectMruSwitcher.ts
+++ b/src/hooks/useProjectMruSwitcher.ts
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import { beginSwitchTrace } from "@/utils/switchTrace";
 
 import { switchToLastWorkspace } from "@/lib/projectHistoryNav";
 
@@ -41,6 +42,7 @@ export function useProjectMruSwitcher(): UseProjectMruSwitcherReturn {
 
       consumeEvent(event);
       if (event.repeat) return;
+      beginSwitchTrace("mru-shortcut");
       void switchToLastWorkspace();
     };
 

--- a/src/hooks/useProjectSwitcherPalette.ts
+++ b/src/hooks/useProjectSwitcherPalette.ts
@@ -343,6 +343,13 @@ export interface UseProjectSwitcherPaletteReturn {
   onHoverProject: (projectId: string, pointerType: string) => void;
   /** Cancel any pending hover prefetch for `projectId`. */
   onHoverProjectEnd: (pointerType: string) => void;
+  /**
+   * Asked by the anchored dropdown once per close. Answers true — and disarms —
+   * only for the close that committed a switch, so that close does not bounce
+   * focus back to the toolbar pill: the view is about to be parked, and a
+   * warm return would otherwise send keystrokes to a button.
+   */
+  consumeCloseAutoFocusSuppression: () => boolean;
   confirmSelection: () => void;
   addProject: () => Promise<void>;
   cloneRepo: () => void;
@@ -865,6 +872,7 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
   const [isDeletingScratch, setIsDeletingScratch] = useState(false);
   const isDeletingScratchRef = useRef(false);
   const prefetchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const suppressCloseAutoFocusRef = useRef(false);
   const prefetchInFlightRef = useRef<Set<string>>(new Set());
   const prefetchLastAtRef = useRef<Map<string, number>>(new Map());
 
@@ -1701,6 +1709,9 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
         return;
       }
 
+      // The dropdown's close must not return focus to the pill: this view is
+      // being parked and comes back with focus wherever this close leaves it.
+      if (mode === "dropdown") suppressCloseAutoFocusRef.current = true;
       // Perf-trace entry point: the anchored dropdown is the toolbar surface;
       // the modal palette splits on how the row was committed.
       beginSwitchTrace(
@@ -1725,6 +1736,7 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
         close();
         return;
       }
+      if (mode === "dropdown") suppressCloseAutoFocusRef.current = true;
       close();
       try {
         await switchScratchAction(scratch.id);
@@ -1737,12 +1749,20 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
         });
       }
     },
-    [close, switchScratchAction]
+    [close, mode, switchScratchAction]
   );
 
   // The one commit path for a row of `results`. Both branches are fire-and-
   // forget by design — each closes the palette first and reports its own
   // failure, so there is nothing here for a caller to await.
+  // Read-and-disarm in one step so a close the shell suppressed for its own
+  // reasons still spends the flag instead of leaving it for the next Escape.
+  const consumeCloseAutoFocusSuppression = useCallback(() => {
+    const suppress = suppressCloseAutoFocusRef.current;
+    suppressCloseAutoFocusRef.current = false;
+    return suppress;
+  }, []);
+
   const selectRow = useCallback(
     (row: ProjectSwitcherRow, source?: ProjectSwitchSelectSource) => {
       if (row.kind === "scratch") {
@@ -2446,6 +2466,7 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
     selectRow,
     onHoverProject,
     onHoverProjectEnd,
+    consumeCloseAutoFocusSuppression,
     confirmSelection,
     addProject,
     cloneRepo,

--- a/src/hooks/useProjectSwitcherPalette.ts
+++ b/src/hooks/useProjectSwitcherPalette.ts
@@ -6,6 +6,7 @@ import {
 } from "@/lib/projectSwitcherSearch";
 import { buildDisplayPaths } from "@/lib/projectDisplayPath";
 import { useProjectStore } from "@/store/projectStore";
+import { beginSwitchTrace } from "@/utils/switchTrace";
 import { useProjectStatsStore } from "@/store/projectStatsStore";
 import { useProjectSettingsStore } from "@/store/projectSettingsStore";
 import { useScratchStore } from "@/store/scratchStore";
@@ -26,6 +27,8 @@ import { projectClient, scratchClient } from "@/clients";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 export type ProjectSwitcherMode = "modal" | "dropdown";
+/** How a palette row was committed — only the perf-trace entry point reads it. */
+export type ProjectSwitchSelectSource = "keyboard" | "pointer";
 
 /**
  * The agent-activity fields a switcher row's status line is derived from —
@@ -324,13 +327,13 @@ export interface UseProjectSwitcherPaletteReturn {
   setQuery: (query: string) => void;
   selectPrevious: () => void;
   selectNext: () => void;
-  selectProject: (project: SearchableProject) => void;
+  selectProject: (project: SearchableProject, source?: ProjectSwitchSelectSource) => void;
   /**
    * Commits a row of {@link results}, dispatching on its kind. The palette's
    * primary select handler — a surface that renders `results` must use this
    * rather than `selectProject`, which cannot accept a scratch row.
    */
-  selectRow: (row: ProjectSwitcherRow) => void;
+  selectRow: (row: ProjectSwitcherRow, source?: ProjectSwitchSelectSource) => void;
   /**
    * Schedule a 150ms trailing-edge hover prefetch that primes the
    * main-process hydrate cache for `projectId`. Mouse-only — touch and pen
@@ -1672,7 +1675,7 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
   const selectNext = useCallback(() => step(1), [step]);
 
   const selectProject = useCallback(
-    async (project: SearchableProject) => {
+    async (project: SearchableProject, source?: ProjectSwitchSelectSource) => {
       // Picking the project already on screen is a "never mind", not a dead
       // end: there is nothing to switch to, but leaving the palette open with
       // no feedback reads as a swallowed keypress. Mirrors `selectScratch`.
@@ -1698,13 +1701,22 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
         return;
       }
 
+      // Perf-trace entry point: the anchored dropdown is the toolbar surface;
+      // the modal palette splits on how the row was committed.
+      beginSwitchTrace(
+        mode === "dropdown"
+          ? "toolbar"
+          : source === "keyboard"
+            ? "palette-keyboard"
+            : "palette-mouse"
+      );
       if (project.isBackground) {
         void reopenProject(project.id);
       } else {
         void switchProject(project.id);
       }
     },
-    [close, switchProject, reopenProject, openRelocation]
+    [close, mode, switchProject, reopenProject, openRelocation]
   );
 
   const selectScratch = useCallback(
@@ -1732,12 +1744,12 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
   // forget by design — each closes the palette first and reports its own
   // failure, so there is nothing here for a caller to await.
   const selectRow = useCallback(
-    (row: ProjectSwitcherRow) => {
+    (row: ProjectSwitcherRow, source?: ProjectSwitchSelectSource) => {
       if (row.kind === "scratch") {
         void selectScratch(row);
         return;
       }
-      void selectProject(row);
+      void selectProject(row, source);
     },
     [selectProject, selectScratch]
   );
@@ -1805,7 +1817,7 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
 
   const confirmSelection = useCallback(() => {
     if (results.length === 0) return;
-    selectRow(results[selectedIndex]!);
+    selectRow(results[selectedIndex]!, "keyboard");
   }, [results, selectedIndex, selectRow]);
 
   const addProject = useCallback(async () => {

--- a/src/services/actions/definitions/projectActions.ts
+++ b/src/services/actions/definitions/projectActions.ts
@@ -1,4 +1,5 @@
 import type { ActionCallbacks, ActionRegistry } from "../actionTypes";
+import { beginSwitchTrace } from "@/utils/switchTrace";
 import type { ActionContext } from "@shared/types/actions";
 import type { AgentVisibleProjectSettingsKey, ProjectSettings } from "@shared/types";
 import { pickAgentVisibleProjectSettings } from "@shared/types";
@@ -390,7 +391,10 @@ export function registerProjectActions(actions: ActionRegistry, callbacks: Actio
     kind: "command",
     danger: "safe",
     scope: "renderer",
-    run: () => switchToLastWorkspace(),
+    run: () => {
+      beginSwitchTrace("mru-shortcut");
+      return switchToLastWorkspace();
+    },
   }));
 
   actions.set("project.add", () => ({

--- a/src/store/__tests__/projectStore.switching.test.ts
+++ b/src/store/__tests__/projectStore.switching.test.ts
@@ -169,7 +169,9 @@ describe("buildOutgoingState draft propagation (#4985)", () => {
     expect(projectClientMock.switch).toHaveBeenCalledWith(
       projectB.id,
       expect.objectContaining({ draftInputs: {} }),
-      undefined
+      expect.objectContaining({
+        trace: expect.objectContaining({ switchId: expect.any(String), entryPoint: "api" }),
+      })
     );
   });
 
@@ -187,7 +189,10 @@ describe("buildOutgoingState draft propagation (#4985)", () => {
 
     expect(projectClientMock.reopen).toHaveBeenCalledWith(
       projectB.id,
-      expect.objectContaining({ draftInputs: {} })
+      expect.objectContaining({ draftInputs: {} }),
+      expect.objectContaining({
+        trace: expect.objectContaining({ switchId: expect.any(String), entryPoint: "api" }),
+      })
     );
   });
 
@@ -205,7 +210,9 @@ describe("buildOutgoingState draft propagation (#4985)", () => {
     expect(projectClientMock.switch).toHaveBeenCalledWith(
       projectB.id,
       expect.objectContaining({ draftInputs: { "terminal-1": "hello world" } }),
-      undefined
+      expect.objectContaining({
+        trace: expect.objectContaining({ switchId: expect.any(String), entryPoint: "api" }),
+      })
     );
   });
 
@@ -228,7 +235,9 @@ describe("buildOutgoingState draft propagation (#4985)", () => {
     expect(projectClientMock.switch).toHaveBeenCalledWith(
       projectB.id,
       expect.objectContaining({ draftDelta: { changedIds: ["terminal-1"], removedIds: [] } }),
-      undefined
+      expect.objectContaining({
+        trace: expect.objectContaining({ switchId: expect.any(String), entryPoint: "api" }),
+      })
     );
   });
 
@@ -241,7 +250,13 @@ describe("buildOutgoingState draft propagation (#4985)", () => {
     await useProjectStore.getState().switchProject(projectB.id);
     await Promise.resolve();
 
-    expect(projectClientMock.switch).toHaveBeenCalledWith(projectB.id, undefined, undefined);
+    expect(projectClientMock.switch).toHaveBeenCalledWith(
+      projectB.id,
+      undefined,
+      expect.objectContaining({
+        trace: expect.objectContaining({ switchId: expect.any(String), entryPoint: "api" }),
+      })
+    );
   });
 });
 
@@ -270,7 +285,9 @@ describe("instant switch feedback: deferred snapshot + IPC", () => {
     expect(projectClientMock.switch).toHaveBeenCalledWith(
       projectB.id,
       expect.any(Object),
-      undefined
+      expect.objectContaining({
+        trace: expect.objectContaining({ switchId: expect.any(String), entryPoint: "api" }),
+      })
     );
   });
 
@@ -291,7 +308,9 @@ describe("instant switch feedback: deferred snapshot + IPC", () => {
     expect(projectClientMock.switch).toHaveBeenCalledWith(
       projectC.id,
       expect.any(Object),
-      undefined
+      expect.objectContaining({
+        trace: expect.objectContaining({ switchId: expect.any(String), entryPoint: "api" }),
+      })
     );
   });
 

--- a/src/store/__tests__/restoreTerminalFocusOnReveal.test.ts
+++ b/src/store/__tests__/restoreTerminalFocusOnReveal.test.ts
@@ -97,6 +97,19 @@ describe("restoreTerminalFocusOnReveal", () => {
     expect(focusMock).not.toHaveBeenCalled();
   });
 
+  it("moves focus out of the switcher palette that committed the switch", () => {
+    setGrid("term-a");
+    mountActive(
+      '<div data-testid="project-switcher-palette"><input data-active-target role="combobox" aria-label="Search workspaces" /></div>'
+    );
+    expect(restoreTerminalFocusOnReveal()).toBe(true);
+    mountActive(
+      '<div role="dialog" aria-label="Project switcher"><input data-active-target role="combobox" /></div>'
+    );
+    expect(restoreTerminalFocusOnReveal()).toBe(true);
+    expect(focusMock).toHaveBeenCalledTimes(2);
+  });
+
   it("leaves focus inside an open dialog alone", () => {
     setGrid("term-a");
     mountActive('<div role="dialog"><button data-active-target>ok</button></div>');

--- a/src/store/__tests__/restoreTerminalFocusOnReveal.test.ts
+++ b/src/store/__tests__/restoreTerminalFocusOnReveal.test.ts
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { PanelInstance } from "@shared/types/panel";
+
+const focusMock = vi.fn();
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: {
+    fullWakeForVisibilityRestore: vi.fn(),
+    repaintForReveal: vi.fn(),
+    revealTerminal: vi.fn(),
+    isFocused: vi.fn(() => false),
+    setFocused: vi.fn(),
+    focus: focusMock,
+  },
+}));
+vi.mock("@/utils/logger", () => ({ logWarn: vi.fn() }));
+vi.mock("@/utils/warmReactivationGate", () => ({ notifyWarmReactivationComplete: vi.fn() }));
+
+let mockActiveWorktreeId: string | null = null;
+let mockPanelIds: string[] = [];
+let mockPanelsById: Record<string, PanelInstance> = {};
+let mockFocusedId: string | null = null;
+
+vi.mock("@/store/worktreeStore", () => ({
+  useWorktreeSelectionStore: { getState: () => ({ activeWorktreeId: mockActiveWorktreeId }) },
+}));
+vi.mock("@/store/panelStore", () => ({
+  usePanelStore: {
+    getState: () => ({
+      panelIds: mockPanelIds,
+      panelsById: mockPanelsById,
+      focusedId: mockFocusedId,
+    }),
+  },
+}));
+vi.mock("@/store/helpPanelStore", () => ({
+  useHelpPanelStore: { getState: () => ({ terminalId: null }) },
+  selectSlotTerminalIds: () => [],
+}));
+
+const { restoreTerminalFocusOnReveal } = await import("@/store/wakeActiveWorktreeTerminals");
+
+function panel(id: string, overrides: Partial<PanelInstance> = {}): PanelInstance {
+  return { id, title: id, kind: "terminal", location: "grid", ...overrides } as PanelInstance;
+}
+
+function setGrid(focused: string | null, ids = ["term-a", "term-b"]) {
+  mockActiveWorktreeId = "wt-1";
+  mockPanelIds = ids;
+  mockPanelsById = Object.fromEntries(ids.map((id) => [id, panel(id, { worktreeId: "wt-1" })]));
+  mockFocusedId = focused;
+}
+
+function mountActive(html: string): HTMLElement {
+  document.body.innerHTML = html;
+  const el = document.querySelector<HTMLElement>("[data-active-target]")!;
+  el.focus();
+  expect(document.activeElement).toBe(el);
+  return el;
+}
+
+describe("restoreTerminalFocusOnReveal", () => {
+  beforeEach(() => {
+    focusMock.mockReset();
+  });
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("moves focus from the switcher pill button to the focused terminal", () => {
+    setGrid("term-a");
+    mountActive('<button data-active-target class="toolbar-project-pill">pill</button>');
+    expect(restoreTerminalFocusOnReveal()).toBe(true);
+    expect(focusMock).toHaveBeenCalledWith("term-a");
+  });
+
+  it("moves focus from the body to the focused terminal", () => {
+    setGrid("term-a");
+    document.body.innerHTML = "<div>nothing focused</div>";
+    expect(document.activeElement).toBe(document.body);
+    expect(restoreTerminalFocusOnReveal()).toBe(true);
+    expect(focusMock).toHaveBeenCalledWith("term-a");
+  });
+
+  it("leaves a text field, a combobox and editable content alone", () => {
+    setGrid("term-a");
+    mountActive('<input data-active-target value="typing" />');
+    expect(restoreTerminalFocusOnReveal()).toBe(false);
+    mountActive('<div data-active-target role="combobox" tabindex="0">search</div>');
+    expect(restoreTerminalFocusOnReveal()).toBe(false);
+    mountActive('<div data-active-target contenteditable="true" tabindex="0">note</div>');
+    expect(restoreTerminalFocusOnReveal()).toBe(false);
+    expect(focusMock).not.toHaveBeenCalled();
+  });
+
+  it("leaves focus inside an open dialog alone", () => {
+    setGrid("term-a");
+    mountActive('<div role="dialog"><button data-active-target>ok</button></div>');
+    expect(restoreTerminalFocusOnReveal()).toBe(false);
+    expect(focusMock).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when the focused pane already holds focus", () => {
+    setGrid("term-a");
+    mountActive(
+      '<div data-panel-id="term-a"><textarea data-active-target class="xterm-helper-textarea"></textarea></div>'
+    );
+    expect(restoreTerminalFocusOnReveal()).toBe(false);
+    expect(focusMock).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when the focused panel is not in the active worktree's grid", () => {
+    setGrid("term-a");
+    mockPanelsById["term-a"] = panel("term-a", { worktreeId: "wt-other" });
+    mountActive("<button data-active-target>pill</button>");
+    expect(restoreTerminalFocusOnReveal()).toBe(false);
+    expect(focusMock).not.toHaveBeenCalled();
+  });
+
+  it("does nothing without a focused panel", () => {
+    setGrid(null);
+    mountActive("<button data-active-target>pill</button>");
+    expect(restoreTerminalFocusOnReveal()).toBe(false);
+  });
+});

--- a/src/store/__tests__/restoreTerminalFocusOnReveal.test.ts
+++ b/src/store/__tests__/restoreTerminalFocusOnReveal.test.ts
@@ -78,6 +78,15 @@ describe("restoreTerminalFocusOnReveal", () => {
     expect(focusMock).toHaveBeenCalledWith("term-a");
   });
 
+  it("moves focus off the switcher pill even though it wears role=combobox", () => {
+    setGrid("term-a");
+    mountActive(
+      '<button data-active-target role="combobox" aria-label="Open project switcher for x" data-testid="project-switcher-trigger">pill</button>'
+    );
+    expect(restoreTerminalFocusOnReveal()).toBe(true);
+    expect(focusMock).toHaveBeenCalledWith("term-a");
+  });
+
   it("moves focus from the body to the focused terminal", () => {
     setGrid("term-a");
     document.body.innerHTML = "<div>nothing focused</div>";

--- a/src/store/__tests__/restoreTerminalFocusOnReveal.test.ts
+++ b/src/store/__tests__/restoreTerminalFocusOnReveal.test.ts
@@ -21,6 +21,7 @@ let mockActiveWorktreeId: string | null = null;
 let mockPanelIds: string[] = [];
 let mockPanelsById: Record<string, PanelInstance> = {};
 let mockFocusedId: string | null = null;
+let mockPreviousFocusedId: string | null = null;
 
 vi.mock("@/store/worktreeStore", () => ({
   useWorktreeSelectionStore: { getState: () => ({ activeWorktreeId: mockActiveWorktreeId }) },
@@ -31,6 +32,7 @@ vi.mock("@/store/panelStore", () => ({
       panelIds: mockPanelIds,
       panelsById: mockPanelsById,
       focusedId: mockFocusedId,
+      previousFocusedId: mockPreviousFocusedId,
     }),
   },
 }));
@@ -50,6 +52,7 @@ function setGrid(focused: string | null, ids = ["term-a", "term-b"]) {
   mockPanelIds = ids;
   mockPanelsById = Object.fromEntries(ids.map((id) => [id, panel(id, { worktreeId: "wt-1" })]));
   mockFocusedId = focused;
+  mockPreviousFocusedId = null;
 }
 
 function mountActive(html: string): HTMLElement {
@@ -101,6 +104,21 @@ describe("restoreTerminalFocusOnReveal", () => {
     expect(focusMock).not.toHaveBeenCalled();
   });
 
+  it("falls back to the previously focused pane when the store's focus was cleared", () => {
+    setGrid(null);
+    mockPreviousFocusedId = "term-b";
+    mountActive('<button data-active-target class="toolbar-project-pill">pill</button>');
+    expect(restoreTerminalFocusOnReveal()).toBe(true);
+    expect(focusMock).toHaveBeenCalledWith("term-b");
+  });
+
+  it("falls back to the first grid terminal when nothing was ever focused", () => {
+    setGrid(null);
+    mountActive("<button data-active-target>pill</button>");
+    expect(restoreTerminalFocusOnReveal()).toBe(true);
+    expect(focusMock).toHaveBeenCalledWith("term-a");
+  });
+
   it("is a no-op when the focused pane already holds focus", () => {
     setGrid("term-a");
     mountActive(
@@ -110,17 +128,18 @@ describe("restoreTerminalFocusOnReveal", () => {
     expect(focusMock).not.toHaveBeenCalled();
   });
 
-  it("does nothing when the focused panel is not in the active worktree's grid", () => {
+  it("falls back to a grid pane when the focused panel lives in another worktree", () => {
     setGrid("term-a");
     mockPanelsById["term-a"] = panel("term-a", { worktreeId: "wt-other" });
     mountActive("<button data-active-target>pill</button>");
-    expect(restoreTerminalFocusOnReveal()).toBe(false);
-    expect(focusMock).not.toHaveBeenCalled();
+    expect(restoreTerminalFocusOnReveal()).toBe(true);
+    expect(focusMock).toHaveBeenCalledWith("term-b");
   });
 
-  it("does nothing without a focused panel", () => {
-    setGrid(null);
+  it("does nothing when the active worktree has no grid terminal at all", () => {
+    setGrid(null, []);
     mountActive("<button data-active-target>pill</button>");
     expect(restoreTerminalFocusOnReveal()).toBe(false);
+    expect(focusMock).not.toHaveBeenCalled();
   });
 });

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -38,7 +38,13 @@ import {
   getWorktreeSelectionSnapshot,
   getWorktreeIdSet,
 } from "./storeAccessors";
-import type { ProjectSwitchOutgoingState } from "@shared/types/ipc/project";
+import type {
+  ProjectSwitchEntryPoint,
+  ProjectSwitchOutgoingState,
+} from "@shared/types/ipc/project";
+import { PERF_MARKS } from "@shared/perf/marks";
+import { flushPendingPerfMarks } from "@/utils/performance";
+import { beginSwitchTrace, consumeSwitchTrace, markSwitch } from "@/utils/switchTrace";
 import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
 import { isEphemeralPanel } from "./slices/panelRegistry/panelCount";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
@@ -246,7 +252,11 @@ interface ProjectState {
   createProjectFolder: (parentPath: string, folderName: string, emoji?: string) => Promise<void>;
   switchProject: (
     projectId: string,
-    options?: { focusIntent?: import("@shared/types/ipc/project").ProjectFocusOnActivateIntent }
+    options?: {
+      focusIntent?: import("@shared/types/ipc/project").ProjectFocusOnActivateIntent;
+      /** Perf-trace entry point when no gesture site minted a trace first. */
+      entryPoint?: ProjectSwitchEntryPoint;
+    }
   ) => Promise<void>;
   setWorktreeLoadError: (error: string | null) => void;
   clearSwitching: () => void;
@@ -272,7 +282,10 @@ interface ProjectState {
    * this one is showing.
    */
   dropToNoProject: () => void;
-  reopenProject: (projectId: string) => Promise<void>;
+  reopenProject: (
+    projectId: string,
+    options?: { entryPoint?: ProjectSwitchEntryPoint }
+  ) => Promise<void>;
   checkMissingProjects: () => Promise<void>;
   locateProject: (projectId: string) => Promise<void>;
   openGitInitDialog: (
@@ -809,6 +822,11 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
   switchProject: async (projectId, options) => {
     if (get().currentProject?.id === projectId) return;
     const requestId = ++projectTransitionRequestId;
+    // Adopt the trace the gesture site minted (keydown/click instant), else
+    // start one here so every switch is traceable, API-driven ones included.
+    const trace = consumeSwitchTrace() ?? beginSwitchTrace(options?.entryPoint ?? "api");
+    const traceMeta: Record<string, unknown> = { ...trace };
+    markSwitch(PERF_MARKS.PROJECT_SWITCH_INTENT, { ...traceMeta, targetProjectId: projectId });
 
     // Drop fleet arming selections synchronously — the outgoing view's armed
     // set is project-scoped and must not leak if the view is later restored
@@ -834,6 +852,7 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
     });
 
     await yieldToPaint();
+    markSwitch(PERF_MARKS.PROJECT_SWITCH_BUSY_PAINTED, traceMeta);
     // A newer transition started while we yielded — let it own the switch so a
     // stale snapshot/IPC can't clobber it.
     if (requestId !== projectTransitionRequestId) return;
@@ -846,6 +865,7 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
     if (currentProjectId) {
       panelPersistence.flush();
       await panelPersistence.whenIdle().catch(() => {});
+      markSwitch(PERF_MARKS.PROJECT_SWITCH_PERSIST_IDLE, traceMeta);
       if (requestId !== projectTransitionRequestId) return;
     }
 
@@ -853,11 +873,21 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
     // view is not detached until the main process handles the IPC, so the panel
     // store still reflects the outgoing project here.
     const outgoingState = currentProjectId ? buildOutgoingState(currentProjectId) : undefined;
+    markSwitch(PERF_MARKS.PROJECT_SWITCH_SNAPSHOT_BUILT, {
+      ...traceMeta,
+      terminalCount: outgoingState?.terminals?.length ?? 0,
+      tabGroupCount: outgoingState?.tabGroups?.length ?? 0,
+    });
 
     // Fire-and-forget: the main process swaps WebContentsViews, so this
     // renderer gets detached. Don't write the response into stores — the
     // new view handles its own state independently.
-    projectClient.switch(projectId, outgoingState, options).catch((error) => {
+    markSwitch(PERF_MARKS.PROJECT_SWITCH_IPC_SENT, traceMeta);
+    // Drain now: this view is about to be detached and its steady-state flush
+    // may never tick again before it is cached or evicted.
+    flushPendingPerfMarks();
+    const { entryPoint: _entryPoint, ...switchOptions } = options ?? {};
+    projectClient.switch(projectId, outgoingState, { ...switchOptions, trace }).catch((error) => {
       if (requestId !== projectTransitionRequestId) {
         return;
       }
@@ -1133,9 +1163,12 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
     }
   },
 
-  reopenProject: async (projectId) => {
+  reopenProject: async (projectId, options) => {
     const requestId = ++projectTransitionRequestId;
     const currentProjectId = get().currentProject?.id;
+    const trace = consumeSwitchTrace() ?? beginSwitchTrace(options?.entryPoint ?? "api");
+    const traceMeta: Record<string, unknown> = { ...trace };
+    markSwitch(PERF_MARKS.PROJECT_SWITCH_INTENT, { ...traceMeta, targetProjectId: projectId });
 
     // Flip the busy/switch flags first, then yield so the click stays responsive
     // before the heavy outgoing-state snapshot + IPC (see switchProject for the why).
@@ -1148,6 +1181,7 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
     });
 
     await yieldToPaint();
+    markSwitch(PERF_MARKS.PROJECT_SWITCH_BUSY_PAINTED, traceMeta);
     if (requestId !== projectTransitionRequestId) return;
 
     // Settle pending/in-flight layout autosave so the outgoing delta is
@@ -1155,11 +1189,19 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
     if (currentProjectId) {
       panelPersistence.flush();
       await panelPersistence.whenIdle().catch(() => {});
+      markSwitch(PERF_MARKS.PROJECT_SWITCH_PERSIST_IDLE, traceMeta);
       if (requestId !== projectTransitionRequestId) return;
     }
 
     const outgoingState = currentProjectId ? buildOutgoingState(currentProjectId) : undefined;
-    projectClient.reopen(projectId, outgoingState).catch((error) => {
+    markSwitch(PERF_MARKS.PROJECT_SWITCH_SNAPSHOT_BUILT, {
+      ...traceMeta,
+      terminalCount: outgoingState?.terminals?.length ?? 0,
+      tabGroupCount: outgoingState?.tabGroups?.length ?? 0,
+    });
+    markSwitch(PERF_MARKS.PROJECT_SWITCH_IPC_SENT, traceMeta);
+    flushPendingPerfMarks();
+    projectClient.reopen(projectId, outgoingState, { trace }).catch((error) => {
       if (requestId !== projectTransitionRequestId) {
         return;
       }

--- a/src/store/wakeActiveWorktreeTerminals.ts
+++ b/src/store/wakeActiveWorktreeTerminals.ts
@@ -193,7 +193,15 @@ async function wakeActiveWorktreeTerminalsInner(): Promise<void> {
  */
 export function restoreTerminalFocusOnReveal(): boolean {
   const outcome = restoreTerminalFocusOnRevealInner();
-  markSwitch(PERF_MARKS.PROJECT_SWITCH_FOCUS_RESTORE, { outcome });
+  const active = typeof document === "undefined" ? null : document.activeElement;
+  markSwitch(PERF_MARKS.PROJECT_SWITCH_FOCUS_RESTORE, {
+    outcome,
+    activeTag: active?.tagName ?? null,
+    activeRole: active?.getAttribute("role") ?? null,
+    activeLabel: active?.getAttribute("aria-label") ?? null,
+    activeTestId: active?.getAttribute("data-testid") ?? null,
+    activeClass: active instanceof HTMLElement ? active.className.toString().slice(0, 60) : null,
+  });
   return outcome === "moved";
 }
 

--- a/src/store/wakeActiveWorktreeTerminals.ts
+++ b/src/store/wakeActiveWorktreeTerminals.ts
@@ -224,6 +224,13 @@ function restoreTerminalFocusOnRevealInner(): FocusRestoreOutcome {
   const active = document.activeElement;
   if (active instanceof HTMLElement) {
     if (active.closest("[data-panel-id]")) return "already-in-pane";
+    // The switcher that committed the switch is still mid-close when the view
+    // was parked (its exit never got a frame), so its search box can hold
+    // focus here; that close is suppressed from bouncing to the pill, and the
+    // terminal is where the user expects to type.
+    const insideClosingSwitcher = Boolean(
+      active.closest('[data-testid="project-switcher-palette"], [aria-label="Project switcher"]')
+    );
     const tag = active.tagName;
     const takesInput =
       tag === "INPUT" ||
@@ -232,11 +239,13 @@ function restoreTerminalFocusOnRevealInner(): FocusRestoreOutcome {
       active.isContentEditable ||
       active.getAttribute("role") === "combobox" ||
       active.getAttribute("role") === "textbox";
-    if (takesInput) return "input-has-focus";
-    if (active.closest('[role="dialog"], [role="alertdialog"], [role="menu"]')) {
-      return "overlay-open";
+    if (!insideClosingSwitcher) {
+      if (takesInput) return "input-has-focus";
+      if (active.closest('[role="dialog"], [role="alertdialog"], [role="menu"]')) {
+        return "overlay-open";
+      }
+      if (tag !== "BUTTON" && tag !== "BODY") return "non-button-focused";
     }
-    if (tag !== "BUTTON" && tag !== "BODY") return "non-button-focused";
   }
   terminalInstanceService.focus(targetId);
   return "moved";

--- a/src/store/wakeActiveWorktreeTerminals.ts
+++ b/src/store/wakeActiveWorktreeTerminals.ts
@@ -6,6 +6,8 @@ import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { logWarn } from "@/utils/logger";
 import { getErrorMessage } from "@/utils/errorContext";
 import { notifyWarmReactivationComplete } from "@/utils/warmReactivationGate";
+import { PERF_MARKS } from "@shared/perf/marks";
+import { markSwitch } from "@/utils/switchTrace";
 
 const WAKE_CONCURRENCY = 2;
 
@@ -136,10 +138,14 @@ async function wakeActiveWorktreeTerminalsInner(): Promise<void> {
   // Slot the focused panel first. It still runs inside the same worker pool, so
   // a hang on the focused panel doesn't block the other visible panels.
   prioritizeFocusedFirst(targets);
+  const focusedTarget = targets[0];
 
   const wakeOne = async (id: string): Promise<void> => {
     try {
       await terminalInstanceService.fullWakeForVisibilityRestore(id);
+      if (id === focusedTarget) {
+        markSwitch(PERF_MARKS.PROJECT_SWITCH_FOCUSED_PANE_WOKEN, { paneId: id });
+      }
     } catch (error) {
       // One broken terminal must not abort the fan-out — the next visible
       // terminal still needs its missed range pulled from the headless mirror.
@@ -169,6 +175,7 @@ async function wakeActiveWorktreeTerminalsInner(): Promise<void> {
     workers.push(worker());
   }
   await Promise.all(workers);
+  markSwitch(PERF_MARKS.PROJECT_SWITCH_ALL_PANES_WOKEN, { paneCount: targets.length });
 }
 
 // At most this many terminals repaint on any one frame so a large grid never

--- a/src/store/wakeActiveWorktreeTerminals.ts
+++ b/src/store/wakeActiveWorktreeTerminals.ts
@@ -240,19 +240,22 @@ function restoreTerminalFocusOnRevealInner(): FocusRestoreOutcome {
       active.closest('[data-testid="project-switcher-palette"], [aria-label="Project switcher"]')
     );
     const tag = active.tagName;
-    const takesInput =
-      tag === "INPUT" ||
-      tag === "TEXTAREA" ||
-      tag === "SELECT" ||
-      active.isContentEditable ||
-      active.getAttribute("role") === "combobox" ||
-      active.getAttribute("role") === "textbox";
     if (!insideClosingSwitcher) {
-      if (takesInput) return "input-has-focus";
       if (active.closest('[role="dialog"], [role="alertdialog"], [role="menu"]')) {
         return "overlay-open";
       }
-      if (tag !== "BUTTON" && tag !== "BODY") return "non-button-focused";
+      // A button never takes typed text, whatever ARIA role it wears — the
+      // toolbar switcher pill is a button with role="combobox".
+      if (tag !== "BUTTON" && tag !== "BODY") {
+        const takesInput =
+          tag === "INPUT" ||
+          tag === "TEXTAREA" ||
+          tag === "SELECT" ||
+          active.isContentEditable ||
+          active.getAttribute("role") === "combobox" ||
+          active.getAttribute("role") === "textbox";
+        return takesInput ? "input-has-focus" : "non-button-focused";
+      }
     }
   }
   terminalInstanceService.focus(targetId);

--- a/src/store/wakeActiveWorktreeTerminals.ts
+++ b/src/store/wakeActiveWorktreeTerminals.ts
@@ -192,16 +192,38 @@ async function wakeActiveWorktreeTerminalsInner(): Promise<void> {
  * active worktree's grid. Returns whether focus was moved.
  */
 export function restoreTerminalFocusOnReveal(): boolean {
-  if (typeof document === "undefined") return false;
-  const { focusedId, panelsById } = usePanelStore.getState();
-  if (!focusedId) return false;
-  const panel = panelsById[focusedId];
-  if (!panel || (panel.kind ?? "terminal") !== "terminal") return false;
-  if (!collectActiveWorktreeTerminalTargets().includes(focusedId)) return false;
+  const outcome = restoreTerminalFocusOnRevealInner();
+  markSwitch(PERF_MARKS.PROJECT_SWITCH_FOCUS_RESTORE, { outcome });
+  return outcome === "moved";
+}
+
+type FocusRestoreOutcome =
+  | "moved"
+  | "no-document"
+  | "already-in-pane"
+  | "input-has-focus"
+  | "overlay-open"
+  | "non-button-focused"
+  | "no-terminal";
+
+function restoreTerminalFocusOnRevealInner(): FocusRestoreOutcome {
+  if (typeof document === "undefined") return "no-document";
+  const targets = collectActiveWorktreeTerminalTargets();
+  const { focusedId, previousFocusedId, panelsById } = usePanelStore.getState();
+  const isGridTerminal = (id: string | null): id is string =>
+    Boolean(id) && (panelsById[id!]?.kind ?? "terminal") === "terminal" && targets.includes(id!);
+  // The store's focused pane, else the pane focus last left (a click on the
+  // toolbar clears the store's focus), else the first pane in the grid.
+  const targetId = isGridTerminal(focusedId)
+    ? focusedId
+    : isGridTerminal(previousFocusedId)
+      ? previousFocusedId
+      : (targets.find((id) => isGridTerminal(id)) ?? null);
+  if (!targetId) return "no-terminal";
 
   const active = document.activeElement;
   if (active instanceof HTMLElement) {
-    if (active.closest(`[data-panel-id="${focusedId}"]`)) return false;
+    if (active.closest("[data-panel-id]")) return "already-in-pane";
     const tag = active.tagName;
     const takesInput =
       tag === "INPUT" ||
@@ -210,12 +232,14 @@ export function restoreTerminalFocusOnReveal(): boolean {
       active.isContentEditable ||
       active.getAttribute("role") === "combobox" ||
       active.getAttribute("role") === "textbox";
-    if (takesInput) return false;
-    if (active.closest('[role="dialog"], [role="alertdialog"], [role="menu"]')) return false;
-    if (tag !== "BUTTON" && tag !== "BODY") return false;
+    if (takesInput) return "input-has-focus";
+    if (active.closest('[role="dialog"], [role="alertdialog"], [role="menu"]')) {
+      return "overlay-open";
+    }
+    if (tag !== "BUTTON" && tag !== "BODY") return "non-button-focused";
   }
-  terminalInstanceService.focus(focusedId);
-  return true;
+  terminalInstanceService.focus(targetId);
+  return "moved";
 }
 
 // At most this many terminals repaint on any one frame so a large grid never

--- a/src/store/wakeActiveWorktreeTerminals.ts
+++ b/src/store/wakeActiveWorktreeTerminals.ts
@@ -178,6 +178,46 @@ async function wakeActiveWorktreeTerminalsInner(): Promise<void> {
   markSwitch(PERF_MARKS.PROJECT_SWITCH_ALL_PANES_WOKEN, { paneCount: targets.length });
 }
 
+/**
+ * Put keyboard focus back on the working terminal when a warm view is revealed
+ * and nothing that takes typed input holds focus.
+ *
+ * Switching away through the toolbar switcher leaves the outgoing document's
+ * focus on the switcher pill (Radix returns focus to the trigger on close), and
+ * a document can be left on `body` by an unmounted overlay. Neither survives a
+ * round trip usefully: the user comes back, types, and the keystrokes land on
+ * a button. Focus is only moved off a button or the body — never off an input,
+ * a textarea, a combobox, editable content or anything inside an open dialog —
+ * and only onto the panel store's focused terminal when that pane is in the
+ * active worktree's grid. Returns whether focus was moved.
+ */
+export function restoreTerminalFocusOnReveal(): boolean {
+  if (typeof document === "undefined") return false;
+  const { focusedId, panelsById } = usePanelStore.getState();
+  if (!focusedId) return false;
+  const panel = panelsById[focusedId];
+  if (!panel || (panel.kind ?? "terminal") !== "terminal") return false;
+  if (!collectActiveWorktreeTerminalTargets().includes(focusedId)) return false;
+
+  const active = document.activeElement;
+  if (active instanceof HTMLElement) {
+    if (active.closest(`[data-panel-id="${focusedId}"]`)) return false;
+    const tag = active.tagName;
+    const takesInput =
+      tag === "INPUT" ||
+      tag === "TEXTAREA" ||
+      tag === "SELECT" ||
+      active.isContentEditable ||
+      active.getAttribute("role") === "combobox" ||
+      active.getAttribute("role") === "textbox";
+    if (takesInput) return false;
+    if (active.closest('[role="dialog"], [role="alertdialog"], [role="menu"]')) return false;
+    if (tag !== "BUTTON" && tag !== "BODY") return false;
+  }
+  terminalInstanceService.focus(focusedId);
+  return true;
+}
+
 // At most this many terminals repaint on any one frame so a large grid never
 // produces a single long task on the reveal frame.
 const REVEAL_CONCURRENCY = 2;

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -56,6 +56,10 @@ declare global {
     };
     __DAINTREE_E2E_MODE__?: boolean;
     __DAINTREE_E2E_SKIP_FIRST_RUN_DIALOGS__?: boolean;
+    /** Preload bridge for the launch-time `DAINTREE_PERF_CAPTURE=1` flag, which cannot reach the sandboxed renderer via env. */
+    __DAINTREE_PERF_CAPTURE__?: boolean;
+    /** E2E-only: append a renderer perf mark (routes through `markRendererPerformance`). */
+    __daintreeMarkPerf?: (mark: string, meta?: Record<string, unknown>) => void;
     /** Persisted color scheme id seeded by preload for first-paint theming (#9169). */
     __DAINTREE_INITIAL_THEME__?: { colorSchemeId: string };
     /** Destination project id seeded by preload, replacing the `?projectId=` query string (#9162). */

--- a/src/utils/__tests__/env.test.ts
+++ b/src/utils/__tests__/env.test.ts
@@ -6,6 +6,7 @@ import { getDaintreeEnv, isDaintreeEnvEnabled } from "../env";
 type WindowWithBridge = Window &
   typeof globalThis & {
     __DAINTREE_E2E_SKIP_FIRST_RUN_DIALOGS__?: boolean;
+    __DAINTREE_PERF_CAPTURE__?: boolean;
   };
 
 describe("getDaintreeEnv / isDaintreeEnvEnabled", () => {
@@ -13,6 +14,7 @@ describe("getDaintreeEnv / isDaintreeEnvEnabled", () => {
 
   beforeEach(() => {
     delete (window as WindowWithBridge).__DAINTREE_E2E_SKIP_FIRST_RUN_DIALOGS__;
+    delete (window as WindowWithBridge).__DAINTREE_PERF_CAPTURE__;
     vi.stubEnv("DAINTREE_E2E_SKIP_FIRST_RUN_DIALOGS", "");
     vi.stubEnv("DAINTREE_VERBOSE", "");
     vi.stubEnv("DAINTREE_PERF_CAPTURE", "");
@@ -20,6 +22,7 @@ describe("getDaintreeEnv / isDaintreeEnvEnabled", () => {
 
   afterEach(() => {
     delete (window as WindowWithBridge).__DAINTREE_E2E_SKIP_FIRST_RUN_DIALOGS__;
+    delete (window as WindowWithBridge).__DAINTREE_PERF_CAPTURE__;
     vi.unstubAllEnvs();
     Object.assign(import.meta.env, originalViteEnv);
   });
@@ -39,6 +42,22 @@ describe("getDaintreeEnv / isDaintreeEnvEnabled", () => {
   it("falls back to import.meta.env when the bridge is absent", () => {
     vi.stubEnv("DAINTREE_E2E_SKIP_FIRST_RUN_DIALOGS", "1");
     expect(isDaintreeEnvEnabled("DAINTREE_E2E_SKIP_FIRST_RUN_DIALOGS")).toBe(true);
+  });
+
+  it("returns true for DAINTREE_PERF_CAPTURE when the runtime window bridge is set", () => {
+    (window as WindowWithBridge).__DAINTREE_PERF_CAPTURE__ = true;
+    expect(isDaintreeEnvEnabled("DAINTREE_PERF_CAPTURE")).toBe(true);
+    expect(getDaintreeEnv("DAINTREE_PERF_CAPTURE")).toBe("1");
+  });
+
+  it("DAINTREE_PERF_CAPTURE bridge takes precedence over import.meta.env", () => {
+    (window as WindowWithBridge).__DAINTREE_PERF_CAPTURE__ = true;
+    vi.stubEnv("DAINTREE_PERF_CAPTURE", "0");
+    expect(isDaintreeEnvEnabled("DAINTREE_PERF_CAPTURE")).toBe(true);
+  });
+
+  it("DAINTREE_PERF_CAPTURE stays off when the bridge is absent and env is unset", () => {
+    expect(isDaintreeEnvEnabled("DAINTREE_PERF_CAPTURE")).toBe(false);
   });
 
   it("returns false when neither the bridge nor import.meta.env is set to '1'", () => {

--- a/src/utils/__tests__/performance.test.ts
+++ b/src/utils/__tests__/performance.test.ts
@@ -126,6 +126,34 @@ describe("markRendererPerformance", () => {
     expect(buffer[buffer.length - 1]!.mark).toBe("mark-2104");
   });
 
+  it("exposes __daintreeMarkPerf only under the E2E flag, routing through the mark buffer", async () => {
+    vi.resetModules();
+    const w = window as Window & { __DAINTREE_E2E_MODE__?: boolean };
+    delete w.__daintreeMarkPerf;
+    delete w.__DAINTREE_E2E_MODE__;
+    await import("../performance");
+    expect(w.__daintreeMarkPerf).toBeUndefined();
+
+    vi.resetModules();
+    w.__DAINTREE_E2E_MODE__ = true;
+    try {
+      await import("../performance");
+      expect(typeof w.__daintreeMarkPerf).toBe("function");
+      window.__DAINTREE_PERF_MARKS__ = [];
+      w.__daintreeMarkPerf!("project_switch.nonce_painted", { switchId: "s1" });
+      expect(window.__DAINTREE_PERF_MARKS__).toEqual([
+        expect.objectContaining({
+          mark: "project_switch.nonce_painted",
+          meta: { switchId: "s1" },
+        }),
+      ]);
+    } finally {
+      delete w.__DAINTREE_E2E_MODE__;
+      delete w.__daintreeMarkPerf;
+      vi.resetModules();
+    }
+  });
+
   it("steady-state flush drains buffered marks on the interval during capture runs", () => {
     vi.useFakeTimers();
     try {

--- a/src/utils/__tests__/switchTrace.test.ts
+++ b/src/utils/__tests__/switchTrace.test.ts
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  beginSwitchTrace,
+  consumeSwitchTrace,
+  getActiveSwitchTrace,
+  markSwitch,
+  resetSwitchTraceForTesting,
+  setActiveSwitchTrace,
+} from "../switchTrace";
+
+describe("switchTrace", () => {
+  beforeEach(() => {
+    resetSwitchTraceForTesting();
+    window.__DAINTREE_PERF_MARKS__ = [];
+  });
+
+  afterEach(() => {
+    delete window.__DAINTREE_PERF_MARKS__;
+    vi.useRealTimers();
+  });
+
+  it("beginSwitchTrace mints a unique id, records the entry point, and marks keydown", () => {
+    const a = beginSwitchTrace("mru-shortcut");
+    const b = beginSwitchTrace("palette-mouse");
+    expect(a.switchId).not.toBe(b.switchId);
+    expect(a.entryPoint).toBe("mru-shortcut");
+    const marks = window.__DAINTREE_PERF_MARKS__!;
+    expect(marks.map((m) => m.mark)).toEqual(["project_switch.keydown", "project_switch.keydown"]);
+    expect(marks[0]!.meta).toEqual({ switchId: a.switchId, entryPoint: "mru-shortcut" });
+  });
+
+  it("consumeSwitchTrace returns the fresh pending trace once", () => {
+    const trace = beginSwitchTrace("toolbar");
+    expect(consumeSwitchTrace()).toEqual(trace);
+    expect(consumeSwitchTrace()).toBeNull();
+  });
+
+  it("consumeSwitchTrace drops a pending trace older than 5s", () => {
+    vi.useFakeTimers();
+    beginSwitchTrace("palette-keyboard");
+    vi.advanceTimersByTime(5_001);
+    expect(consumeSwitchTrace()).toBeNull();
+  });
+
+  it("a later gesture replaces the pending trace", () => {
+    beginSwitchTrace("toolbar");
+    const second = beginSwitchTrace("menu");
+    expect(consumeSwitchTrace()).toEqual(second);
+  });
+
+  it("markSwitch stamps the active trace over the pending one, with explicit meta winning", () => {
+    beginSwitchTrace("toolbar");
+    markSwitch("project_switch.intent", { extra: 1 });
+    setActiveSwitchTrace({ switchId: "active-id", entryPoint: "api" });
+    markSwitch("project_switch.on_switch_received");
+    markSwitch("project_switch.pty_port_ready", { switchId: "override" });
+
+    const marks = window.__DAINTREE_PERF_MARKS__!;
+    const intent = marks.find((m) => m.mark === "project_switch.intent")!;
+    expect(intent.meta).toEqual(
+      expect.objectContaining({ entryPoint: "toolbar", extra: 1, switchId: expect.any(String) })
+    );
+    expect(marks.find((m) => m.mark === "project_switch.on_switch_received")!.meta).toEqual({
+      switchId: "active-id",
+      entryPoint: "api",
+    });
+    expect(marks.find((m) => m.mark === "project_switch.pty_port_ready")!.meta).toEqual({
+      switchId: "override",
+      entryPoint: "api",
+    });
+    expect(getActiveSwitchTrace()).toEqual({ switchId: "active-id", entryPoint: "api" });
+  });
+
+  it("markSwitch without any trace still records the mark", () => {
+    markSwitch("project_switch.intent");
+    expect(window.__DAINTREE_PERF_MARKS__![0]!.meta).toEqual({});
+  });
+});

--- a/src/utils/__tests__/warmReactivationGate.test.ts
+++ b/src/utils/__tests__/warmReactivationGate.test.ts
@@ -27,24 +27,17 @@ describe("notifyWarmReactivationComplete", () => {
     if (cb) cb(0);
   }
 
-  it("fires the IPC only after two animation frames, not one", () => {
+  it("fires the IPC synchronously without waiting for an animation frame", () => {
+    // The view is undrawn behind the anti-flash bridge, where frames arrive at
+    // ~2 Hz, so a frame-deferred signal would run the gate into its hard timeout.
     notifyWarmReactivationComplete();
-    expect(notifyWarmViewPainted).not.toHaveBeenCalled();
-
-    flushFrame();
-    expect(notifyWarmViewPainted).not.toHaveBeenCalled();
-
-    flushFrame();
     expect(notifyWarmViewPainted).toHaveBeenCalledTimes(1);
+    expect(rafQueue).toHaveLength(0);
   });
 
   it("swallows a rejected IPC promise without throwing", () => {
     notifyWarmViewPainted.mockReturnValue(Promise.reject(new Error("bridge down")));
-    notifyWarmReactivationComplete();
-    expect(() => {
-      flushFrame();
-      flushFrame();
-    }).not.toThrow();
+    expect(() => notifyWarmReactivationComplete()).not.toThrow();
   });
 
   it("fires synchronously when requestAnimationFrame is unavailable", () => {

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -26,6 +26,9 @@ function getRuntimeBridgeValue(key: DaintreeEnvKey): string | undefined {
   if (key === "DAINTREE_E2E_SKIP_FIRST_RUN_DIALOGS") {
     return window.__DAINTREE_E2E_SKIP_FIRST_RUN_DIALOGS__ === true ? "1" : undefined;
   }
+  if (key === "DAINTREE_PERF_CAPTURE") {
+    return window.__DAINTREE_PERF_CAPTURE__ === true ? "1" : undefined;
+  }
   return undefined;
 }
 

--- a/src/utils/performance.ts
+++ b/src/utils/performance.ts
@@ -132,6 +132,20 @@ export function startSteadyStatePerfFlush(intervalMs = 15000): () => void {
   };
 }
 
+// E2E-only mark injector so a Playwright spec can drop its own marks (e.g. the
+// nonce-painted probes of the switch benchmark) into the same NDJSON stream as
+// the app's. Gated on the preload-injected E2E flag exactly like the terminal
+// introspection bridges in TerminalInstanceService, so it never attaches in a
+// production session.
+if (typeof window !== "undefined" && window.__DAINTREE_E2E_MODE__ === true) {
+  window.__daintreeMarkPerf = (mark: string, meta?: Record<string, unknown>): void => {
+    markRendererPerformance(mark, meta);
+    // A probe mark is read by the harness right away; the steady-state flush
+    // would hold it for up to 15 s.
+    flushPendingPerfMarks();
+  };
+}
+
 export function startRendererSpan(
   mark: PerfMarkName | string,
   meta?: Record<string, unknown>

--- a/src/utils/switchTrace.ts
+++ b/src/utils/switchTrace.ts
@@ -1,0 +1,84 @@
+import { PERF_MARKS } from "@shared/perf/marks";
+import type { ProjectSwitchEntryPoint, ProjectSwitchTrace } from "@shared/types/ipc/project";
+import { markRendererPerformance } from "./performance";
+
+/**
+ * Renderer half of the project-switch perf trace.
+ *
+ * A switch starts as a gesture in the OUTGOING view (keydown, palette pick,
+ * toolbar click) and ends in the INCOMING view, which is a different V8
+ * context. The gesture site mints the trace and parks it as "pending"; the
+ * store consumes it when `switchProject` runs so the `switchId` rides the IPC
+ * to main. The incoming view learns its trace from main's targeted sends and
+ * keeps it as "active" so its own marks join the same trace.
+ */
+
+/**
+ * A pending trace older than this is a gesture that never became a switch
+ * (the palette closed on the current project, the MRU toggle had nowhere to
+ * go) — it must not attach to an unrelated switch minutes later.
+ */
+const PENDING_TRACE_TTL_MS = 5_000;
+
+/** The trace this view is inside; `entryPoint` arrives with `project:on-switch`. */
+export type ActiveSwitchTrace = { switchId: string; entryPoint?: ProjectSwitchEntryPoint };
+
+let pending: { trace: ProjectSwitchTrace; startedAt: number } | null = null;
+let active: ActiveSwitchTrace | null = null;
+
+function now(): number {
+  return typeof performance !== "undefined" ? performance.now() : Date.now();
+}
+
+// Counter fallback only for exotic test contexts without WebCrypto; a real
+// renderer always has `crypto.randomUUID`.
+let fallbackCounter = 0;
+
+function newSwitchId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  fallbackCounter += 1;
+  return `switch-${Date.now().toString(36)}-${fallbackCounter}`;
+}
+
+/** Mint a trace at the gesture site and mark its keydown/click instant. */
+export function beginSwitchTrace(entryPoint: ProjectSwitchEntryPoint): ProjectSwitchTrace {
+  const trace: ProjectSwitchTrace = { switchId: newSwitchId(), entryPoint };
+  pending = { trace, startedAt: now() };
+  markRendererPerformance(PERF_MARKS.PROJECT_SWITCH_KEYDOWN, { ...trace });
+  return trace;
+}
+
+/** Take the pending trace if it is still fresh; clears it either way. */
+export function consumeSwitchTrace(): ProjectSwitchTrace | null {
+  const current = pending;
+  pending = null;
+  if (!current) return null;
+  if (now() - current.startedAt > PENDING_TRACE_TTL_MS) return null;
+  return current.trace;
+}
+
+export function setActiveSwitchTrace(trace: ActiveSwitchTrace | null): void {
+  active = trace;
+}
+
+export function getActiveSwitchTrace(): ActiveSwitchTrace | null {
+  return active;
+}
+
+/**
+ * Emit a renderer mark stamped with the trace this view is in: the active
+ * (incoming-side) trace wins, else the pending (outgoing-side) one. Explicit
+ * `meta` overrides so a caller can pass the trace it already holds.
+ */
+export function markSwitch(mark: string, meta?: Record<string, unknown>): void {
+  const trace = active ?? pending?.trace ?? null;
+  markRendererPerformance(mark, { ...(trace ?? {}), ...(meta ?? {}) });
+}
+
+/** Test-only reset. */
+export function resetSwitchTraceForTesting(): void {
+  pending = null;
+  active = null;
+}

--- a/src/utils/warmReactivationGate.ts
+++ b/src/utils/warmReactivationGate.ts
@@ -1,3 +1,7 @@
+import { PERF_MARKS } from "@shared/perf/marks";
+import { flushPendingPerfMarks } from "@/utils/performance";
+import { markSwitch } from "./switchTrace";
+
 /**
  * Renderer half of the warm-reactivation paint gate (#9679).
  *
@@ -19,6 +23,8 @@
  */
 export function notifyWarmReactivationComplete(): void {
   const fire = (): void => {
+    markSwitch(PERF_MARKS.PROJECT_SWITCH_WARM_PAINT_SIGNALLED);
+    flushPendingPerfMarks();
     try {
       window.electron?.app?.notifyWarmViewPainted?.().catch(() => {
         // Main may have already released the gate via its timeout fallback —

--- a/src/utils/warmReactivationGate.ts
+++ b/src/utils/warmReactivationGate.ts
@@ -5,41 +5,33 @@ import { markSwitch } from "./switchTrace";
 /**
  * Renderer half of the warm-reactivation paint gate (#9679).
  *
- * When `ProjectViewManager` reactivates a warm cached `WebContentsView`, it
- * covers the incoming view with an opaque background color before `addChildView`
- * so Chromium's compositor can't flash the stale pre-freeze WebGL surface. The
- * cover is held until this renderer signals that its wake fan-out has finished
- * and a clean post-atlas-repair frame has painted.
+ * When `ProjectViewManager` reactivates a warm cached `WebContentsView` it
+ * re-attaches the view BENEATH the still-visible outgoing view and holds that
+ * bridge until this renderer reports that its wake fan-out has finished.
  *
  * Fired unconditionally after every {@link wakeActiveWorktreeTerminals} pass:
  * main only holds a gate when it actually armed one for this view's warm switch,
  * so a signal with no pending gate is a harmless no-op. Unlike the one-shot
  * `notifyViewPainted` (cold start), this is re-fireable across reactivations.
  *
- * The double `requestAnimationFrame` mirrors `removeStartupSkeleton`: the first
- * rAF lands after the wake's synchronous `terminal.refresh()` work commits, the
- * second guarantees the compositor has produced one frame reflecting the
- * repaired atlas before main drops the cover.
+ * Deliberately NOT deferred to an animation frame. While the view sits behind
+ * the bridge nothing it renders is drawn, and Chromium throttles an undrawn
+ * view's frames to roughly two per second — so a double-rAF settle here cost
+ * ~1 s per switch and, with the same wait in front of the wake, every warm
+ * switch with terminal panes ran into the gate's 1.5 s hard timeout. The wake's
+ * repair work is synchronous (`terminal.refresh` etc.), and the post-reveal
+ * repaint pass (#10362) re-runs the paint at full frame rate once the view is
+ * on top, so the gate can release as soon as the synchronous repair is done.
  */
 export function notifyWarmReactivationComplete(): void {
-  const fire = (): void => {
-    markSwitch(PERF_MARKS.PROJECT_SWITCH_WARM_PAINT_SIGNALLED);
-    flushPendingPerfMarks();
-    try {
-      window.electron?.app?.notifyWarmViewPainted?.().catch(() => {
-        // Main may have already released the gate via its timeout fallback —
-        // safe to ignore.
-      });
-    } catch {
-      // Preload bridge may be unavailable in exotic test contexts — safe to ignore.
-    }
-  };
-
-  if (typeof requestAnimationFrame !== "function") {
-    fire();
-    return;
+  markSwitch(PERF_MARKS.PROJECT_SWITCH_WARM_PAINT_SIGNALLED);
+  flushPendingPerfMarks();
+  try {
+    window.electron?.app?.notifyWarmViewPainted?.().catch(() => {
+      // Main may have already released the gate via its timeout fallback —
+      // safe to ignore.
+    });
+  } catch {
+    // Preload bridge may be unavailable in exotic test contexts — safe to ignore.
   }
-  requestAnimationFrame(() => {
-    requestAnimationFrame(fire);
-  });
 }


### PR DESCRIPTION
This PR makes switching between open projects faster, and adds a benchmark that measures it the way a user actually experiences it.

## The warm switch stall

A cached project view is re-attached underneath the visible view (the anti-flash bridge from #9679) and held there until its wake fan-out reports back. That view is never drawn, so Chromium throttles its frames to around two per second. The wake handshake waited on four animation frames, so on any view with terminal panes to wake it ran into the gate's 1.5 s hard timeout. The main process log only ever showed the timeout, and a CPU profile showed an idle main thread, which is why this hid for so long.

The wake now runs synchronously on `APP_VIEW_WARM_ACTIVATED` and signals `APP_VIEW_WARM_PAINTED` as soon as the synchronous repair is done. The post-reveal repaint from #10362 still does the frame-paced work once the view is on top.

Two smaller fixes ride along:

- A cold target's backend terminal inventory is prefetched from the pty-host the moment the switch reaches main, concurrently with the view swap, so `terminal:get-for-project` is served from the in-flight result instead of paying the round trip on the hydration critical path.
- After a warm return, focus goes back to the working terminal. Leaving a project through the toolbar switcher left focus on the pill button, so the next warm return sent keystrokes to a button until you clicked the terminal. The commit close no longer bounces focus to its trigger, and the reveal side restores focus onto the focused pane (falling back to the previous or first grid pane) whenever a button or the body holds it.

## The benchmark

`npm run perf project-switch-rotation` opens five projects, each with three real worktrees and fake agents (one streaming), then drives real switches through the MRU shortcut, the palette and the toolbar in a recency-weighted trace. The headline is keypress to a typed nonce painted in the target's focused terminal, confirmed by xterm's render event, broken down by LRU depth, cache class and entry point, with memory checkpoints per view. Every switch carries a `switchId` through `project_switch.*` perf marks so the intervals are attributable. `PERF_SWITCH_CAP=3` emulates a 16 GB machine (depth 3 and 4 are cold); `PERF_SWITCH_CAP=5` keeps everything warm.

Both switch benchmarks now launch with `enableWebgl: true`. The default local E2E launch disables the GPU and WebGL, which rendered the 6K window in software at a few frames per second and inflated every frame-paced number. Under that harness the warm switch above read as 1.5 s; on the GPU it reads as the 77 ms below.

## Results

Both arms measured on this machine (M4 Max, 64 GB) with the same harness, interleaved: the branch point's product code (`dc7c554fc1`) against `6f87aebfa4`. The commit on top of that only fixes an analysis-lib test. Cap 3 is three pairs; the rest is one pair.

| Benchmark | Metric | Before | After | Change | Arms |
| --- | --- | ---: | ---: | ---: | --- |
| rotation cap 3 | weighted intent→nonce painted p50 | 175 | 144 | -17.6% | 3×3 arms |
| rotation cap 3 | weighted intent→nonce painted p95 | 606 | 597 | -1.4% | 3×3 arms |
| rotation cap 3 | weighted intent→revealed p50 | 78 | 27 | -65.4% | 3×3 arms |
| rotation cap 3 | warm intent→revealed p50 | 78 | 26 | -66.3% | 3×3 arms |
| rotation cap 3 | warm intent→nonce painted p50 | 174 | 141 | -18.8% | 3×3 arms |
| rotation cap 3 | warm intent→nonce painted p95 | 195 | 164 | -15.9% | 3×3 arms |
| rotation cap 3 | cold intent→revealed p50 | 171 | 168 | -2.0% | 3×3 arms |
| rotation cap 3 | cold intent→first interactive p50 | 517 | 510 | -1.3% | 3×3 arms |
| rotation cap 3 | cold intent→nonce painted p50 | 586 | 589 | 0.5% | 3×3 arms |
| rotation cap 3 | depth 1 intent→nonce painted p50 | 173 | 139 | -19.7% | 3×3 arms |
| rotation cap 3 | depth 2 intent→nonce painted p50 | 174 | 143 | -17.4% | 3×3 arms |
| rotation cap 3 | depth 3 intent→nonce painted p50 | 591 | 591 | -0.0% | 3×3 arms |
| rotation cap 3 | depth 4 intent→nonce painted p50 | 586 | 587 | 0.2% | 3×3 arms |
| rotation cap 3 | rapid burst max settle | 158 | 162 | 2.8% | 3×3 arms |
| rotation cap 3 | paint-gate hard timeouts (count) | 0 | 0 | n/a | 3×3 arms |
| rotation cap 3 | focus rescues (count) | 0 | 0 | n/a | 3×3 arms |
| rotation cap 3 | post-purge total footprint MB | 3411 | 3417 | 0.2% | 3×3 arms |
| rotation cap 3 | post-purge renderers MB | 1241 | 1244 | 0.3% | 3×3 arms |
| rotation cap 3 | post-purge GPU MB | 189 | 192 | 2.0% | 3×3 arms |
| rotation cap 3 | predicates (7) | ok | ok |  |  |
| rotation cap 5 | weighted intent→nonce painted p50 | 191 | 165 | -13.6% | 1×1 arms |
| rotation cap 5 | weighted intent→nonce painted p95 | 5188 | 196 | -96.2% | 1×1 arms |
| rotation cap 5 | weighted intent→revealed p50 | 77 | 23 | -69.9% | 1×1 arms |
| rotation cap 5 | warm intent→revealed p50 | 89 | 39 | -56.1% | 1×1 arms |
| rotation cap 5 | warm intent→nonce painted p50 | 202 | 172 | -15.1% | 1×1 arms |
| rotation cap 5 | warm intent→nonce painted p95 | 253 | 198 | -21.6% | 1×1 arms |
| rotation cap 5 | cold intent→revealed p50 | - | - | n/a | 1×1 arms |
| rotation cap 5 | cold intent→first interactive p50 | - | - | n/a | 1×1 arms |
| rotation cap 5 | cold intent→nonce painted p50 | - | - | n/a | 1×1 arms |
| rotation cap 5 | depth 1 intent→nonce painted p50 | 186 | 155 | -16.7% | 1×1 arms |
| rotation cap 5 | depth 2 intent→nonce painted p50 | 209 | 175 | -16.0% | 1×1 arms |
| rotation cap 5 | depth 3 intent→nonce painted p50 | 206 | 179 | -13.3% | 1×1 arms |
| rotation cap 5 | depth 4 intent→nonce painted p50 | 207 | 174 | -16.2% | 1×1 arms |
| rotation cap 5 | rapid burst max settle | 87 | 52 | -40.0% | 1×1 arms |
| rotation cap 5 | paint-gate hard timeouts (count) | 0 | 0 | n/a | 1×1 arms |
| rotation cap 5 | focus rescues (count) | 4 | 0 | -100.0% | 1×1 arms |
| rotation cap 5 | post-purge total footprint MB | 4750 | 4793 | 0.9% | 1×1 arms |
| rotation cap 5 | post-purge renderers MB | 2435 | 2473 | 1.6% | 1×1 arms |
| rotation cap 5 | post-purge GPU MB | 217 | 222 | 2.6% | 1×1 arms |
| rotation cap 5 | predicates (7) | ok | ok |  |  |
| project-switch (pre-existing) | cold reveal visibleMs p50 | 147 | 147 | 0.0% | 1×1 |
| project-switch (pre-existing) | cold round-trip p50 | 193 | 192 | -0.5% | 1×1 |
| project-switch (pre-existing) | cold interactiveMs p50 | 328 | 332 | 1.2% | 1×1 |
| project-switch (pre-existing) | warm reveal visibleMs p50 | 64 | 8 | -87.5% | 1×1 |
| project-switch (pre-existing) | warm round-trip p50 | 68 | 54 | -20.6% | 1×1 |
| project-switch (pre-existing) | paint-gate hard timeouts (count) | 0 | 0 | n/a | 1×1 |
| PERF-011 (pre-existing) | Project Switch A->B (Medium) p50 ms | 1 | 1 | -2.9% | 10 runs, predicates ok / ok |
| PERF-012 (pre-existing) | Rapid Project Switch Loop A<->B<->C p50 ms | 4 | 4 | -13.1% | 6 runs, predicates ok / ok |
| PERF-070 (pre-existing) | Project Switch Phases - Small p50 ms | 0 | 0 | 1.7% | 10 runs, predicates ok / ok |
| PERF-071 (pre-existing) | Project Switch Phases - Medium p50 ms | 0 | 0 | -3.6% | 10 runs, predicates ok / ok |
| PERF-074 (pre-existing) | Project View Warm Switch Rotation p50 ms | 14 | 16 | 11.1% | 4 runs, predicates ok / ok |
| PERF-075 (pre-existing) | Project View Cold Switch with LRU Eviction p50 ms | 47 | 46 | -2.5% | 4 runs, predicates ok / ok |
| PERF-076 (pre-existing) | Project View Eviction Under Memory Pressure p50 ms | 21 | 21 | 3.9% | 4 runs, predicates ok / ok |
| PERF-077 (pre-existing) | Project View Rapid Queued Switches p50 ms | 6 | 8 | 27.1% | 4 runs, predicates ok / ok |

_cap 3 target per arm (measurement order): before1=174 after1=143 after2=154 before2=178 after4=144 before4=175_
_pairs (before→after): 174→143 win, 178→154 win, 175→144 win; champion drift D = 4 ms (2.1%); medians 175 → 144 (-17.6%)_

The in-process rows (PERF-011 to PERF-077) drive merge, restore and view-manager mechanics against stubbed Electron; their durations are harness time rather than switch latency, and the 4-run PERF-074 and PERF-077 movements are noise. They are here because they share the subject and their predicates stayed healthy. The rotation numbers include the harness typing the nonce, which is a constant on both arms. One cap 3 pair was discarded and re-measured because a single cold sample lost its nonce to a prompt redraw race in the probe.

## Tried and reverted

Releasing every cached view's WebGL contexts while hidden saved no measurable memory (the ~400 MB per renderer is not in the addon or the atlas) and added the re-attach drain to every warm reveal, so it is out.

## Verification

- `npm run typecheck`, the full `npm test` and `npm run check` pass.
- E2E: only the two switch specs were run, locally, as the measurement. No cross-OS legs.
