### PR TITLE
feat(diff): expose the wrap toggle everywhere, default it on for prose

### DIFF
--- a/src/components/FileViewer/FileViewerToolbar.tsx
+++ b/src/components/FileViewer/FileViewerToolbar.tsx
@@ -87,9 +87,9 @@ function useFittedPath(fullText: string | undefined): {
 }
 
 /**
- * One icon size for every control in this toolbar family, so the four panels
- * that use it (FilePane, DiffPane, and the file browser's two header rows)
- * cannot drift apart a pixel at a time.
+ * One icon size for every control in this toolbar family, so every surface that
+ * uses it (FilePane, DiffPane, the cross-worktree comparison dialog, and the
+ * file browser's two header rows) cannot drift apart a pixel at a time.
  *
  * 14px rather than 16: at 16 the glyphs read heavier than the text beside them
  * and Refresh in particular dominated a row it only shares. With the button's

--- a/src/components/FileViewer/__tests__/isProseFile.test.ts
+++ b/src/components/FileViewer/__tests__/isProseFile.test.ts
@@ -9,7 +9,16 @@ describe("isProseFilePath", () => {
   });
 
   it("classifies the non-markdown prose formats", () => {
-    for (const path of ["CHANGELOG.txt", "index.rst", "guide.adoc", "guide.asciidoc"]) {
+    // `.text` and `.rest` are the recognised aliases of the two formats above
+    // them; `.asciidoc` is AsciiDoc's own long spelling.
+    for (const path of [
+      "CHANGELOG.txt",
+      "notes.text",
+      "index.rst",
+      "manual.rest",
+      "guide.adoc",
+      "guide.asciidoc",
+    ]) {
       expect(isProseFilePath(path)).toBe(true);
     }
   });

--- a/src/components/FileViewer/__tests__/isProseFile.test.ts
+++ b/src/components/FileViewer/__tests__/isProseFile.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { isProseFilePath } from "../isProseFile";
+
+describe("isProseFilePath", () => {
+  it("classifies markdown through the shared markdown check", () => {
+    for (const path of ["README.md", "notes.markdown", "page.mdx", "old.mkd"]) {
+      expect(isProseFilePath(path)).toBe(true);
+    }
+  });
+
+  it("classifies the non-markdown prose formats", () => {
+    for (const path of ["CHANGELOG.txt", "index.rst", "guide.adoc", "guide.asciidoc"]) {
+      expect(isProseFilePath(path)).toBe(true);
+    }
+  });
+
+  it("leaves code and config unwrapped", () => {
+    // Wrapping these would hide the column structure that makes them readable,
+    // which is why prose is an allowlist rather than a code denylist.
+    for (const path of ["src/index.ts", "main.py", "styles.css", "package.json", "Cargo.toml"]) {
+      expect(isProseFilePath(path)).toBe(false);
+    }
+  });
+
+  it("ignores extension case", () => {
+    expect(isProseFilePath("README.MD")).toBe(true);
+    expect(isProseFilePath("NOTES.TXT")).toBe(true);
+  });
+
+  it("handles absolute, relative and Windows-style paths", () => {
+    expect(isProseFilePath("/Users/x/docs/spec.md")).toBe(true);
+    expect(isProseFilePath("./docs/spec.rst")).toBe(true);
+    expect(isProseFilePath("C:\\docs\\spec.txt")).toBe(true);
+  });
+
+  it("does not wrap files with no extension", () => {
+    // `split(".").pop()` returns the whole name for these, so the guard has to
+    // fall through the allowlist rather than matching on it.
+    expect(isProseFilePath("LICENSE")).toBe(false);
+    expect(isProseFilePath("Makefile")).toBe(false);
+    expect(isProseFilePath("/etc/hosts")).toBe(false);
+  });
+
+  it("does not treat a prose word in the path as a prose file", () => {
+    expect(isProseFilePath("txt/parser.ts")).toBe(false);
+    expect(isProseFilePath("docs.md/index.ts")).toBe(false);
+  });
+});

--- a/src/components/FileViewer/isProseFile.ts
+++ b/src/components/FileViewer/isProseFile.ts
@@ -10,7 +10,7 @@ import { isMarkdownFilePath } from "@/components/Markdown/isMarkdownFile";
  * unrecognised extension is far more likely to be code or config, and wrapping
  * those hides the column structure that makes them readable.
  */
-const PROSE_EXTENSIONS = new Set(["txt", "rst", "adoc", "asciidoc"]);
+const PROSE_EXTENSIONS = new Set(["txt", "text", "rst", "rest", "adoc", "asciidoc"]);
 
 /**
  * Whether a path names a prose document, which decides the default for diff

--- a/src/components/FileViewer/isProseFile.ts
+++ b/src/components/FileViewer/isProseFile.ts
@@ -1,0 +1,23 @@
+import { isMarkdownFilePath } from "@/components/Markdown/isMarkdownFile";
+
+/**
+ * Prose formats beyond Markdown. Plain text, reStructuredText and AsciiDoc are
+ * written the same way Markdown is — a paragraph is one physical line, wrapped
+ * by the renderer rather than the author — so their diffs are unreadable
+ * without soft wrap for exactly the same reason.
+ *
+ * Deliberately an allowlist, not a "not a known code extension" test: an
+ * unrecognised extension is far more likely to be code or config, and wrapping
+ * those hides the column structure that makes them readable.
+ */
+const PROSE_EXTENSIONS = new Set(["txt", "rst", "adoc", "asciidoc"]);
+
+/**
+ * Whether a path names a prose document, which decides the default for diff
+ * soft-wrap (#12170). Markdown is answered by the existing check rather than a
+ * second extension list, so the two can't drift.
+ */
+export function isProseFilePath(filePath: string): boolean {
+  if (isMarkdownFilePath(filePath)) return true;
+  return PROSE_EXTENSIONS.has(filePath.split(".").pop()?.toLowerCase() ?? "");
+}

--- a/src/components/Worktree/CrossWorktreeDiff.tsx
+++ b/src/components/Worktree/CrossWorktreeDiff.tsx
@@ -401,7 +401,7 @@ export function CrossWorktreeDiff({ isOpen, onClose, initialWorktreeId }: CrossW
                       disabled={selectedFileIndex <= 0}
                       aria-label="Previous file"
                       title="Previous file ([)"
-                      className="toolbar-icon-button p-1.5 rounded-md text-text-secondary disabled:opacity-40 disabled:cursor-not-allowed disabled:pointer-events-none"
+                      className="toolbar-icon-button p-1.5 rounded-lg text-text-secondary disabled:opacity-40 disabled:cursor-not-allowed disabled:pointer-events-none"
                     >
                       <ChevronLeft className="w-3.5 h-3.5" />
                     </button>
@@ -417,7 +417,7 @@ export function CrossWorktreeDiff({ isOpen, onClose, initialWorktreeId }: CrossW
                       disabled={selectedFileIndex >= files.length - 1}
                       aria-label="Next file"
                       title="Next file (])"
-                      className="toolbar-icon-button p-1.5 rounded-md text-text-secondary disabled:opacity-40 disabled:cursor-not-allowed disabled:pointer-events-none"
+                      className="toolbar-icon-button p-1.5 rounded-lg text-text-secondary disabled:opacity-40 disabled:cursor-not-allowed disabled:pointer-events-none"
                     >
                       <ChevronRight className="w-3.5 h-3.5" />
                     </button>

--- a/src/components/Worktree/CrossWorktreeDiff.tsx
+++ b/src/components/Worktree/CrossWorktreeDiff.tsx
@@ -401,7 +401,7 @@ export function CrossWorktreeDiff({ isOpen, onClose, initialWorktreeId }: CrossW
                       disabled={selectedFileIndex <= 0}
                       aria-label="Previous file"
                       title="Previous file ([)"
-                      className="p-1 rounded transition-colors text-text-muted hover:text-text-primary hover:bg-surface-panel-elevated disabled:opacity-40 disabled:cursor-not-allowed disabled:pointer-events-none"
+                      className="toolbar-icon-button p-1.5 rounded-md text-text-secondary disabled:opacity-40 disabled:cursor-not-allowed disabled:pointer-events-none"
                     >
                       <ChevronLeft className="w-3.5 h-3.5" />
                     </button>
@@ -417,7 +417,7 @@ export function CrossWorktreeDiff({ isOpen, onClose, initialWorktreeId }: CrossW
                       disabled={selectedFileIndex >= files.length - 1}
                       aria-label="Next file"
                       title="Next file (])"
-                      className="p-1 rounded transition-colors text-text-muted hover:text-text-primary hover:bg-surface-panel-elevated disabled:opacity-40 disabled:cursor-not-allowed disabled:pointer-events-none"
+                      className="toolbar-icon-button p-1.5 rounded-md text-text-secondary disabled:opacity-40 disabled:cursor-not-allowed disabled:pointer-events-none"
                     >
                       <ChevronRight className="w-3.5 h-3.5" />
                     </button>

--- a/src/components/Worktree/CrossWorktreeDiff.tsx
+++ b/src/components/Worktree/CrossWorktreeDiff.tsx
@@ -1,5 +1,12 @@
 import { useEffect, useRef, useState, useCallback, useMemo } from "react";
-import { GitCompare, FileIcon, AlertCircle, ChevronLeft, ChevronRight } from "lucide-react";
+import {
+  GitCompare,
+  FileIcon,
+  AlertCircle,
+  ChevronLeft,
+  ChevronRight,
+  WrapText,
+} from "lucide-react";
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import { Skeleton, SkeletonBone, SkeletonText } from "@/components/ui/Skeleton";
 import { cn } from "@/lib/utils";
@@ -13,6 +20,8 @@ import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { useTruncationDetection } from "@/hooks/useTruncationDetection";
 import { TruncatedTooltip } from "@/components/ui/TruncatedTooltip";
 import { usePreferencesStore } from "@/store/preferencesStore";
+import { FileViewerToolbar, TOOLBAR_ICON_CLASS } from "@/components/FileViewer/FileViewerToolbar";
+import { isProseFilePath } from "@/components/FileViewer/isProseFile";
 
 interface CrossWorktreeDiffProps {
   isOpen: boolean;
@@ -184,6 +193,8 @@ export function CrossWorktreeDiff({ isOpen, onClose, initialWorktreeId }: CrossW
   }, [leftId, rightId, fetchComparison]);
 
   const ignoreWhitespace = usePreferencesStore((s) => s.diffIgnoreWhitespace);
+  const diffWrapLines = usePreferencesStore((s) => s.diffWrapLines);
+  const setDiffWrapLines = usePreferencesStore((s) => s.setDiffWrapLines);
 
   const fetchFileDiff = useCallback(
     async (file: CrossWorktreeFile) => {
@@ -222,6 +233,11 @@ export function CrossWorktreeDiff({ isOpen, onClose, initialWorktreeId }: CrossW
   // File stepping through the comparison set, mirroring the diff modals:
   // `[` / `]` keys plus a footer stepper in the diff panel.
   const files = result?.files ?? null;
+  // `null` means auto — prose wraps, code doesn't. Derived from the file on
+  // screen during render so the diff is already wrapped on first paint (#12170).
+  const effectiveWrapLines =
+    diffWrapLines ?? (selectedFile !== null && isProseFilePath(selectedFile.path));
+
   const selectedFileIndex = useMemo(() => {
     if (!files || !selectedFile) return -1;
     return files.findIndex((f) => f.path === selectedFile.path && f.status === selectedFile.status);
@@ -366,35 +382,56 @@ export function CrossWorktreeDiff({ isOpen, onClose, initialWorktreeId }: CrossW
 
         {/* Diff panel */}
         <div className="flex-1 flex flex-col overflow-hidden bg-surface-canvas">
-          {selectedFile && files && files.length > 1 && (
-            <div className="flex items-center justify-end gap-1 px-2 py-1 border-b border-border-subtle shrink-0">
-              <button
-                type="button"
-                onClick={() => navigateFile(-1)}
-                disabled={selectedFileIndex <= 0}
-                aria-label="Previous file"
-                title="Previous file ([)"
-                className="p-1 rounded transition-colors text-text-muted hover:text-text-primary hover:bg-surface-panel-elevated disabled:opacity-40 disabled:cursor-not-allowed disabled:pointer-events-none"
-              >
-                <ChevronLeft className="w-3.5 h-3.5" />
-              </button>
-              <span
-                data-testid="cross-worktree-file-position"
-                className="text-xs text-text-muted tabular-nums"
-              >
-                {selectedFileIndex + 1} of {files.length}
-              </span>
-              <button
-                type="button"
-                onClick={() => navigateFile(1)}
-                disabled={selectedFileIndex >= files.length - 1}
-                aria-label="Next file"
-                title="Next file (])"
-                className="p-1 rounded transition-colors text-text-muted hover:text-text-primary hover:bg-surface-panel-elevated disabled:opacity-40 disabled:cursor-not-allowed disabled:pointer-events-none"
-              >
-                <ChevronRight className="w-3.5 h-3.5" />
-              </button>
-            </div>
+          {/* One row for every selected file, not just multi-file comparisons:
+              wrap applies to a single-file diff exactly as much, and gating the
+              whole row on the file count is what left this surface with no
+              reachable toggle at all (#12170). Only stepping is count-gated. */}
+          {selectedFile && files && (
+            <FileViewerToolbar.Root label="Comparison controls">
+              <FileViewerToolbar.Actions>
+                {files.length > 1 && (
+                  <div
+                    role="group"
+                    aria-label="File navigation"
+                    className="flex items-center gap-1"
+                  >
+                    <button
+                      type="button"
+                      onClick={() => navigateFile(-1)}
+                      disabled={selectedFileIndex <= 0}
+                      aria-label="Previous file"
+                      title="Previous file ([)"
+                      className="p-1 rounded transition-colors text-text-muted hover:text-text-primary hover:bg-surface-panel-elevated disabled:opacity-40 disabled:cursor-not-allowed disabled:pointer-events-none"
+                    >
+                      <ChevronLeft className="w-3.5 h-3.5" />
+                    </button>
+                    <span
+                      data-testid="cross-worktree-file-position"
+                      className="text-xs text-text-muted tabular-nums"
+                    >
+                      {selectedFileIndex + 1} of {files.length}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() => navigateFile(1)}
+                      disabled={selectedFileIndex >= files.length - 1}
+                      aria-label="Next file"
+                      title="Next file (])"
+                      className="p-1 rounded transition-colors text-text-muted hover:text-text-primary hover:bg-surface-panel-elevated disabled:opacity-40 disabled:cursor-not-allowed disabled:pointer-events-none"
+                    >
+                      <ChevronRight className="w-3.5 h-3.5" />
+                    </button>
+                  </div>
+                )}
+                <FileViewerToolbar.IconButton
+                  label="Wrap long lines"
+                  pressed={effectiveWrapLines}
+                  onClick={() => setDiffWrapLines(!effectiveWrapLines)}
+                >
+                  <WrapText className={TOOLBAR_ICON_CLASS} />
+                </FileViewerToolbar.IconButton>
+              </FileViewerToolbar.Actions>
+            </FileViewerToolbar.Root>
           )}
           <div className="flex-1 overflow-auto diff-scroll-root">
             {!selectedFile && (
@@ -435,6 +472,7 @@ export function CrossWorktreeDiff({ isOpen, onClose, initialWorktreeId }: CrossW
                 diff={fileDiff}
                 viewType="split"
                 rootPath={rightWorktree?.path}
+                wrapLines={effectiveWrapLines}
                 onRetry={() => void fetchFileDiff(selectedFile)}
               />
             )}

--- a/src/components/Worktree/__tests__/CrossWorktreeDiff.wrap.test.tsx
+++ b/src/components/Worktree/__tests__/CrossWorktreeDiff.wrap.test.tsx
@@ -1,0 +1,171 @@
+// @vitest-environment jsdom
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { ReactNode } from "react";
+import { CrossWorktreeDiff } from "../CrossWorktreeDiff";
+import { TooltipProvider } from "@/components/ui/tooltip";
+
+// Cross-worktree compare passed no `wrapLines` at all before #12170, so it
+// always scrolled horizontally with no reachable way out. These cover the
+// toggle and the prose default; stepping stays in its own suite.
+
+const worktrees = new Map([
+  [
+    "wt-left",
+    { id: "wt-left", name: "left", path: "/wt/left", branch: "main", isMainWorktree: true },
+  ],
+  [
+    "wt-right",
+    { id: "wt-right", name: "right", path: "/wt/right", branch: "feature", isMainWorktree: false },
+  ],
+]);
+
+vi.mock("@/hooks/useWorktreeStore", () => ({
+  useWorktreeStore: (sel: (s: { worktrees: Map<string, unknown> }) => unknown) =>
+    sel({ worktrees }),
+}));
+
+// Mocked rather than real so a test can seed an explicit override without
+// leaking a persisted value into the next one.
+const preferences = {
+  diffIgnoreWhitespace: false,
+  diffWrapLines: null as boolean | null,
+  setDiffWrapLines: vi.fn(),
+};
+vi.mock("@/store/preferencesStore", () => ({
+  usePreferencesStore: (selector: (state: unknown) => unknown) => selector(preferences),
+}));
+
+vi.mock("@/components/ui/AppDialog", () => {
+  interface MockProps {
+    isOpen: boolean;
+    children: ReactNode;
+  }
+  interface SectionProps {
+    children?: ReactNode;
+    className?: string;
+  }
+  const AppDialog = ({ isOpen, children }: MockProps) =>
+    isOpen ? <div data-testid="app-dialog">{children}</div> : null;
+  AppDialog.Header = ({ children }: SectionProps) => <div>{children}</div>;
+  AppDialog.Title = ({ children }: SectionProps) => <h2>{children}</h2>;
+  AppDialog.CloseButton = () => <button type="button">close</button>;
+  return { AppDialog };
+});
+
+vi.mock("../DiffViewer", () => ({
+  DiffViewer: ({ wrapLines }: { wrapLines?: boolean }) => (
+    <div data-testid="diff-viewer" data-wrap-lines={String(wrapLines)} />
+  ),
+}));
+
+vi.mock("../WorktreeSelector", () => ({
+  WorktreeSelector: ({ label, onChange }: { label: string; onChange: (id: string) => void }) => (
+    <button
+      type="button"
+      onClick={() => onChange(label.startsWith("Left") ? "wt-left" : "wt-right")}
+    >
+      {label}
+    </button>
+  ),
+}));
+
+const mockCompareWorktrees = vi.fn();
+
+beforeEach(() => {
+  mockCompareWorktrees.mockReset();
+  preferences.diffWrapLines = null;
+  preferences.setDiffWrapLines.mockReset();
+  Object.defineProperty(window, "electron", {
+    value: { git: { compareWorktrees: mockCompareWorktrees } },
+    configurable: true,
+  });
+});
+
+async function setupComparison(files: { path: string; status: string }[]) {
+  mockCompareWorktrees.mockImplementation((_path, _b1, _b2, filePath?: string) =>
+    Promise.resolve(
+      filePath === undefined
+        ? {
+            branch1: "main",
+            branch2: "feature",
+            files: files.map((f) => ({ ...f, insertions: 1, deletions: 1 })),
+          }
+        : `diff --git a/${filePath} b/${filePath}\n--- a/${filePath}\n+++ b/${filePath}\n@@ -1 +1 @@\n-old\n+new`
+    )
+  );
+
+  render(
+    <TooltipProvider>
+      <CrossWorktreeDiff isOpen onClose={vi.fn()} initialWorktreeId={null} />
+    </TooltipProvider>
+  );
+  fireEvent.click(screen.getByText("Left (base)"));
+  fireEvent.click(screen.getByText("Right (compare)"));
+
+  const name = files[0]!.path.split("/").pop()!;
+  await waitFor(() => {
+    expect(screen.getByText(name)).toBeTruthy();
+  });
+  fireEvent.click(screen.getByText(name));
+  await waitFor(() => {
+    expect(screen.getByTestId("diff-viewer")).toBeTruthy();
+  });
+}
+
+function wrapButton(): HTMLElement {
+  return screen.getByRole("button", { name: "Wrap long lines" });
+}
+
+function viewerWrap(): string | null {
+  return screen.getByTestId("diff-viewer").getAttribute("data-wrap-lines");
+}
+
+describe("CrossWorktreeDiff wrap toggle (#12170)", () => {
+  it("offers the toggle for a single-file comparison, where stepping is absent", async () => {
+    // The whole row used to be gated on `files.length > 1`, which is exactly how
+    // this surface ended up with no reachable toggle.
+    await setupComparison([{ path: "docs/spec.md", status: "M" }]);
+
+    expect(wrapButton()).toBeTruthy();
+    expect(screen.queryByTestId("cross-worktree-file-position")).toBeNull();
+    expect(screen.queryByLabelText("Next file")).toBeNull();
+  });
+
+  it("keeps the stepper alongside the toggle for a multi-file comparison", async () => {
+    await setupComparison([
+      { path: "docs/spec.md", status: "M" },
+      { path: "src/a.ts", status: "M" },
+    ]);
+
+    expect(wrapButton()).toBeTruthy();
+    expect(screen.getByTestId("cross-worktree-file-position").textContent).toBe("1 of 2");
+  });
+
+  it("wraps a prose diff and not a code diff under the auto default", async () => {
+    await setupComparison([{ path: "docs/spec.md", status: "M" }]);
+    expect(viewerWrap()).toBe("true");
+    expect(wrapButton().getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("leaves a code diff unwrapped", async () => {
+    await setupComparison([{ path: "src/a.ts", status: "M" }]);
+    expect(viewerWrap()).toBe("false");
+    expect(wrapButton().getAttribute("aria-pressed")).toBe("false");
+  });
+
+  it("writes the opposite of the effective value, not of the stored one", async () => {
+    await setupComparison([{ path: "docs/spec.md", status: "M" }]);
+
+    fireEvent.click(wrapButton());
+
+    expect(preferences.setDiffWrapLines).toHaveBeenCalledWith(false);
+  });
+
+  it("honours an explicit override over the file type", async () => {
+    preferences.diffWrapLines = false;
+    await setupComparison([{ path: "docs/spec.md", status: "M" }]);
+
+    expect(viewerWrap()).toBe("false");
+  });
+});

--- a/src/components/Worktree/__tests__/CrossWorktreeDiff.wrap.test.tsx
+++ b/src/components/Worktree/__tests__/CrossWorktreeDiff.wrap.test.tsx
@@ -168,4 +168,44 @@ describe("CrossWorktreeDiff wrap toggle (#12170)", () => {
 
     expect(viewerWrap()).toBe("false");
   });
+
+  it("honours an explicit `true` on a code file", async () => {
+    preferences.diffWrapLines = true;
+    await setupComparison([{ path: "src/a.ts", status: "M" }]);
+
+    expect(viewerWrap()).toBe("true");
+    expect(wrapButton().getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("recomputes auto wrapping when stepping from prose to code", async () => {
+    // Auto is derived per file, so stepping has to re-resolve it — a value
+    // captured once when the dialog opened would keep the code diff wrapped.
+    await setupComparison([
+      { path: "docs/spec.md", status: "M" },
+      { path: "src/a.ts", status: "M" },
+    ]);
+    expect(viewerWrap()).toBe("true");
+
+    fireEvent.click(screen.getByLabelText("Next file"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("cross-worktree-file-position").textContent).toBe("2 of 2");
+    });
+    expect(viewerWrap()).toBe("false");
+    expect(wrapButton().getAttribute("aria-pressed")).toBe("false");
+  });
+
+  it("keeps the roving tab stop on the wrap button after it is clicked", async () => {
+    // The toolbar applies roving tabindex over every descendant button. Moving
+    // the stop off the focused control would set `tabindex="-1"` on it, and
+    // AppDialog's trap excludes negative tabindex when computing its boundary.
+    await setupComparison([{ path: "docs/spec.md", status: "M" }]);
+    const button = wrapButton();
+    button.focus();
+
+    fireEvent.click(button);
+
+    expect(document.activeElement).toBe(button);
+    expect(button.tabIndex).toBe(0);
+  });
 });

--- a/src/components/Worktree/__tests__/CrossWorktreeDiff.wrap.test.tsx
+++ b/src/components/Worktree/__tests__/CrossWorktreeDiff.wrap.test.tsx
@@ -195,17 +195,23 @@ describe("CrossWorktreeDiff wrap toggle (#12170)", () => {
     expect(wrapButton().getAttribute("aria-pressed")).toBe("false");
   });
 
-  it("keeps the roving tab stop on the wrap button after it is clicked", async () => {
-    // The toolbar applies roving tabindex over every descendant button. Moving
-    // the stop off the focused control would set `tabindex="-1"` on it, and
-    // AppDialog's trap excludes negative tabindex when computing its boundary.
-    await setupComparison([{ path: "docs/spec.md", status: "M" }]);
+  it("hands the roving tab stop to the wrap button when it takes focus", async () => {
+    // Two files on purpose: with one, Wrap is the toolbar's only control and
+    // already owns the stop, so the assertion would hold no matter what the
+    // hook did. Behind the stepper it starts at `tabindex="-1"`, and leaving it
+    // there while focused is what lets Tab out of AppDialog, whose trap skips
+    // negative tabindex when computing its first/last boundary.
+    await setupComparison([
+      { path: "docs/spec.md", status: "M" },
+      { path: "src/a.ts", status: "M" },
+    ]);
     const button = wrapButton();
-    button.focus();
+    expect(button.tabIndex).toBe(-1);
 
-    fireEvent.click(button);
+    button.focus();
 
     expect(document.activeElement).toBe(button);
     expect(button.tabIndex).toBe(0);
+    expect(screen.getByLabelText("Next file").tabIndex).toBe(-1);
   });
 });

--- a/src/hooks/__tests__/useToolbarRoving.test.tsx
+++ b/src/hooks/__tests__/useToolbarRoving.test.tsx
@@ -131,6 +131,23 @@ describe("useToolbarRoving", () => {
     expect(tabIndexes().filter((t) => t === 0)).toHaveLength(1);
   });
 
+  it("moves the tab stop to a clicked control even with no re-render", () => {
+    // The repair cannot wait for a commit: a descendant can re-render alone, so
+    // clicking a control the row marks `tabindex="-1"` would otherwise leave
+    // focus on an untabbable element — the exact state that lets Tab escape a
+    // focus trap, which excludes negative tabindex when computing its boundary.
+    render(<Toolbar labels={["a", "b", "c"]} />);
+    const c = screen.getByText("c");
+    expect(c.tabIndex).toBe(-1);
+
+    fireEvent.focus(c, { target: c });
+    c.focus();
+
+    expect(c.tabIndex).toBe(0);
+    expect(screen.getByText("a").tabIndex).toBe(-1);
+    expect(tabIndexes().filter((t) => t === 0)).toHaveLength(1);
+  });
+
   it("leaves the tab stop on the control that holds focus after a click", () => {
     // Clicking focuses without going through the arrow handler, so the
     // remembered index is stale by the time the re-render's effect runs. Handing

--- a/src/hooks/__tests__/useToolbarRoving.test.tsx
+++ b/src/hooks/__tests__/useToolbarRoving.test.tsx
@@ -130,4 +130,36 @@ describe("useToolbarRoving", () => {
     fireEvent.click(screen.getByText("toggle"));
     expect(tabIndexes().filter((t) => t === 0)).toHaveLength(1);
   });
+
+  it("leaves the tab stop on the control that holds focus after a click", () => {
+    // Clicking focuses without going through the arrow handler, so the
+    // remembered index is stale by the time the re-render's effect runs. Handing
+    // the stop to some other control would set `tabindex="-1"` on the focused
+    // one — and `TABBABLE_SELECTOR` excludes negative tabindex, so AppDialog's
+    // trap would stop recognising it as the row's last element and let Tab walk
+    // out of the modal.
+    render(<Growing />);
+    const toggle = screen.getByText("toggle");
+    toggle.focus();
+
+    fireEvent.click(toggle);
+
+    expect(document.activeElement).toBe(toggle);
+    expect(toggle.tabIndex).toBe(0);
+    expect(tabIndexes().filter((t) => t === 0)).toHaveLength(1);
+  });
+
+  it("keeps the stop with the focused control when one appears ahead of it", () => {
+    // A control inserted before the focused one shifts every index after it, so
+    // a remembered index now names the wrong button. Keyed by label, so React
+    // reconciles "c" to the same node and it keeps focus across the re-render.
+    const { rerender } = render(<Toolbar labels={["a", "b", "c"]} />);
+    screen.getByText("c").focus();
+
+    rerender(<Toolbar labels={["a", "new", "b", "c"]} />);
+
+    expect(document.activeElement).toBe(screen.getByText("c"));
+    expect(screen.getByText("c").tabIndex).toBe(0);
+    expect(tabIndexes().filter((t) => t === 0)).toHaveLength(1);
+  });
 });

--- a/src/hooks/useToolbarRoving.ts
+++ b/src/hooks/useToolbarRoving.ts
@@ -59,10 +59,20 @@ export function useToolbarRoving(
     const items = controls();
     if (items.length === 0) return;
 
-    // Clamp rather than reset: a control disappearing from the middle of the
-    // row should leave the tab stop near where it was, not throw it back to the
+    // Focus wins over the remembered index whenever it is already inside the
+    // row. A pointer click moves focus without telling us, and a control
+    // appearing ahead of the focused one shifts every index after it — so
+    // trusting the index alone would hand the tab stop to a different control
+    // and set `tabindex="-1"` on the one that actually holds focus. That is not
+    // merely untidy: `TABBABLE_SELECTOR` excludes negative tabindex, so a focus
+    // trap computing its boundary (AppDialog) stops recognising the focused
+    // element as first or last and lets Tab walk straight out of the modal.
+    //
+    // Clamp for the rest: a control disappearing from the middle of the row
+    // should leave the tab stop near where it was, not throw it back to the
     // start of the toolbar.
-    const active = Math.min(activeIndexRef.current, items.length - 1);
+    const focused = items.findIndex((item) => item === document.activeElement);
+    const active = focused === -1 ? Math.min(activeIndexRef.current, items.length - 1) : focused;
     activeIndexRef.current = active;
     items.forEach((item, index) => {
       item.tabIndex = index === active ? 0 : -1;

--- a/src/hooks/useToolbarRoving.ts
+++ b/src/hooks/useToolbarRoving.ts
@@ -49,6 +49,14 @@ export function useToolbarRoving(
     );
   }, [ref]);
 
+  // Give the row's single tab stop to `active` and take it from everyone else.
+  const applyStop = useCallback((items: HTMLElement[], active: number): void => {
+    activeIndexRef.current = active;
+    items.forEach((item, index) => {
+      item.tabIndex = index === active ? 0 : -1;
+    });
+  }, []);
+
   // Re-applied after every render, because the control set is conditional: the
   // root anchor becomes a button when the tree is scoped, Up one level appears
   // with it, and the viewer's actions come and go with the selection. An effect
@@ -60,24 +68,41 @@ export function useToolbarRoving(
     if (items.length === 0) return;
 
     // Focus wins over the remembered index whenever it is already inside the
-    // row. A pointer click moves focus without telling us, and a control
-    // appearing ahead of the focused one shifts every index after it — so
-    // trusting the index alone would hand the tab stop to a different control
-    // and set `tabindex="-1"` on the one that actually holds focus. That is not
-    // merely untidy: `TABBABLE_SELECTOR` excludes negative tabindex, so a focus
-    // trap computing its boundary (AppDialog) stops recognising the focused
-    // element as first or last and lets Tab walk straight out of the modal.
+    // row: a control appearing ahead of the focused one shifts every index
+    // after it, so trusting the index alone would hand the tab stop to a
+    // different control and mark the focused one `tabindex="-1"`.
     //
     // Clamp for the rest: a control disappearing from the middle of the row
     // should leave the tab stop near where it was, not throw it back to the
     // start of the toolbar.
     const focused = items.findIndex((item) => item === document.activeElement);
-    const active = focused === -1 ? Math.min(activeIndexRef.current, items.length - 1) : focused;
-    activeIndexRef.current = active;
-    items.forEach((item, index) => {
-      item.tabIndex = index === active ? 0 : -1;
-    });
+    applyStop(items, focused === -1 ? Math.min(activeIndexRef.current, items.length - 1) : focused);
   });
+
+  // Repairing on commit alone is not enough, because focus moves on its own
+  // schedule. A pointer click focuses whichever control was hit — routinely one
+  // the row currently marks `tabindex="-1"` — and nothing guarantees the
+  // toolbar's owner re-renders afterwards, since a descendant can re-render
+  // alone. Leaving focus on an untabbable control is what lets Tab escape a
+  // focus trap: `TABBABLE_SELECTOR` excludes negative tabindex, so AppDialog
+  // stops recognising the focused element as the row's first or last and never
+  // wraps. `focusin` rather than `focus` because only the former bubbles, so one
+  // listener on the container covers every control the row will ever hold.
+  useEffect(() => {
+    if (!enabled) return;
+    const root = ref.current;
+    if (!root) return;
+
+    const handleFocusIn = (event: FocusEvent): void => {
+      const items = controls();
+      const index = items.findIndex((item) => item === event.target);
+      if (index === -1) return;
+      applyStop(items, index);
+    };
+
+    root.addEventListener("focusin", handleFocusIn);
+    return () => root.removeEventListener("focusin", handleFocusIn);
+  }, [applyStop, controls, enabled, ref]);
 
   return useCallback(
     (event: React.KeyboardEvent<HTMLElement>) => {
@@ -118,12 +143,9 @@ export function useToolbarRoving(
       // its default behaviour, which for a toolbar includes Tab leaving it.
       event.preventDefault();
       event.stopPropagation();
-      activeIndexRef.current = next;
-      items.forEach((item, index) => {
-        item.tabIndex = index === next ? 0 : -1;
-      });
+      applyStop(items, next);
       items[next]?.focus();
     },
-    [controls, enabled]
+    [applyStop, controls, enabled]
   );
 }

--- a/src/panels/diff/DiffPane.tsx
+++ b/src/panels/diff/DiffPane.tsx
@@ -30,6 +30,7 @@ import {
   isVideoFilePath,
 } from "@/components/FileViewer/filePreviewKinds";
 import { ImageDiffViewer, isImageDiffCandidate } from "@/components/FileViewer/ImageDiffViewer";
+import { isProseFilePath } from "@/components/FileViewer/isProseFile";
 import { DiffViewer, FULL_FILE_MAX_LINES } from "@/components/Worktree/DiffViewer";
 import type { FullFileUnavailableReason } from "@/components/Worktree/DiffViewer";
 import { FILE_READ_ERROR_MESSAGES } from "@/components/FileViewer/fileReadErrors";
@@ -187,6 +188,11 @@ export function DiffPane({
   const setDiffShowFileList = usePreferencesStore((s) => s.setDiffShowFileList);
 
   const filePath = panel?.filePath;
+  // `null` means auto — prose wraps, code doesn't. Resolved here rather than in
+  // `DiffViewer` so the viewer keeps a plain boolean contract, and computed
+  // during render rather than held in state so the very first paint is already
+  // wrapped for a `.md` diff (#12170).
+  const effectiveWrapLines = diffWrapLines ?? (filePath !== undefined && isProseFilePath(filePath));
   // `filePath` is worktree-relative (unlike FilePanelData's), but both file
   // actions want an absolute path. Null means there is nothing to aim them at:
   // a relative path with no resolved worktree can't be made absolute, and
@@ -581,8 +587,8 @@ export function DiffPane({
           {!isImageMode && !isMediaMode && !isPdfMode && (
             <FileViewerToolbar.IconButton
               label="Wrap long lines"
-              pressed={diffWrapLines}
-              onClick={() => setDiffWrapLines(!diffWrapLines)}
+              pressed={effectiveWrapLines}
+              onClick={() => setDiffWrapLines(!effectiveWrapLines)}
             >
               <WrapText className={TOOLBAR_ICON_CLASS} />
             </FileViewerToolbar.IconButton>
@@ -841,7 +847,7 @@ export function DiffPane({
                 source={wantsFullFile ? source : undefined}
                 fullFile={wantsFullFile}
                 onFullFileVerdict={handleFullFileVerdict}
-                wrapLines={diffWrapLines}
+                wrapLines={effectiveWrapLines}
                 onRetry={retry}
               />
             )}

--- a/src/panels/diff/__tests__/DiffPane.test.tsx
+++ b/src/panels/diff/__tests__/DiffPane.test.tsx
@@ -29,7 +29,11 @@ vi.mock("@/components/ui/tooltip", () => ({
 }));
 
 vi.mock("@/components/Worktree/DiffViewer", () => ({
-  DiffViewer: () => <div data-testid="diff-viewer-mock" />,
+  // Surfaces `wrapLines` so the auto/override resolution is observable from the
+  // prop the viewer actually receives, not just from the toolbar's pressed state.
+  DiffViewer: (props: { wrapLines?: boolean }) => (
+    <div data-testid="diff-viewer-mock" data-wrap-lines={String(props.wrapLines)} />
+  ),
   FULL_FILE_MAX_LINES: 5000,
 }));
 
@@ -90,7 +94,8 @@ vi.mock("@/hooks/useWorktreeStore", () => ({
 const preferences = {
   diffViewType: "unified" as const,
   setDiffViewType: vi.fn(),
-  diffWrapLines: false,
+  // `null` is auto — prose wraps, everything else doesn't (#12170).
+  diffWrapLines: null as boolean | null,
   setDiffWrapLines: vi.fn(),
   diffShowFileList: true,
   setDiffShowFileList: vi.fn(),
@@ -171,6 +176,8 @@ beforeEach(() => {
   isImageDiffCandidateMock.mockReset();
   isImageDiffCandidateMock.mockReturnValue(false);
   preferences.diffShowFileList = true;
+  preferences.diffWrapLines = null;
+  preferences.setDiffWrapLines.mockReset();
   worktrees.clear();
   worktrees.set(WORKTREE_ID, { path: WORKTREE_PATH, branch: "feature/x" });
 });
@@ -906,5 +913,77 @@ describe("DiffPane — PDF current-version mode (#11427)", () => {
 
     expect(pdfFrame(container)).toBeNull();
     expect(screen.getByTestId("empty-state-mock")).toBeTruthy();
+  });
+});
+
+describe("DiffPane wrap toggle (#12170)", () => {
+  function wrapButton(): HTMLElement {
+    return screen.getByRole("button", { name: "Wrap long lines" });
+  }
+
+  function viewerWrap(): string | null {
+    return screen.getByTestId("diff-viewer-mock").getAttribute("data-wrap-lines");
+  }
+
+  it("wraps a prose diff on first render with nothing stored", () => {
+    seedPanel({
+      filePath: "docs/spec.md",
+      fileStatus: "modified",
+      changeSet: [entry("docs/spec.md")],
+    });
+    renderPane();
+
+    expect(viewerWrap()).toBe("true");
+    expect(wrapButton().getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("leaves a code diff unwrapped under the same auto default", () => {
+    seedPanel({ filePath: "src/a.ts", fileStatus: "modified", changeSet: [entry("src/a.ts")] });
+    renderPane();
+
+    expect(viewerWrap()).toBe("false");
+    expect(wrapButton().getAttribute("aria-pressed")).toBe("false");
+  });
+
+  it("stores an explicit off when toggled from an auto-wrapped prose diff", () => {
+    // The bug this guards: toggling against the raw stored value would write
+    // `true` here (`!null` is `true`), leaving the button visibly pressed and
+    // the diff wrapped after a click that asked for the opposite.
+    seedPanel({
+      filePath: "docs/spec.md",
+      fileStatus: "modified",
+      changeSet: [entry("docs/spec.md")],
+    });
+    renderPane();
+
+    fireEvent.click(wrapButton());
+
+    expect(preferences.setDiffWrapLines).toHaveBeenCalledWith(false);
+  });
+
+  it("stores an explicit on when toggled from an auto-unwrapped code diff", () => {
+    seedPanel({ filePath: "src/a.ts", fileStatus: "modified", changeSet: [entry("src/a.ts")] });
+    renderPane();
+
+    fireEvent.click(wrapButton());
+
+    expect(preferences.setDiffWrapLines).toHaveBeenCalledWith(true);
+  });
+
+  it("lets an explicit override beat the file type in both directions", () => {
+    preferences.diffWrapLines = false;
+    seedPanel({
+      filePath: "docs/spec.md",
+      fileStatus: "modified",
+      changeSet: [entry("docs/spec.md")],
+    });
+    const { unmount } = renderPane();
+    expect(viewerWrap()).toBe("false");
+    unmount();
+
+    preferences.diffWrapLines = true;
+    seedPanel({ filePath: "src/a.ts", fileStatus: "modified", changeSet: [entry("src/a.ts")] });
+    renderPane();
+    expect(viewerWrap()).toBe("true");
   });
 });

--- a/src/panels/diff/__tests__/DiffPane.test.tsx
+++ b/src/panels/diff/__tests__/DiffPane.test.tsx
@@ -96,7 +96,11 @@ const preferences = {
   setDiffViewType: vi.fn(),
   // `null` is auto — prose wraps, everything else doesn't (#12170).
   diffWrapLines: null as boolean | null,
-  setDiffWrapLines: vi.fn(),
+  // Writes through, so a test can follow a full toggle cycle instead of only
+  // the argument the click dispatched.
+  setDiffWrapLines: vi.fn((value: boolean) => {
+    preferences.diffWrapLines = value;
+  }),
   diffShowFileList: true,
   setDiffShowFileList: vi.fn(),
   diffFullFile: false,
@@ -140,8 +144,8 @@ function seedPanel(overrides: Record<string, unknown>): void {
   panelsById[PANEL_ID] = { id: PANEL_ID, kind: "diff", diffSource: "working-tree", ...overrides };
 }
 
-function renderPane(isFocused = true) {
-  return render(
+function paneElement(isFocused = true) {
+  return (
     <DiffPane
       id={PANEL_ID}
       title="pane"
@@ -152,6 +156,10 @@ function renderPane(isFocused = true) {
       onClose={() => {}}
     />
   );
+}
+
+function renderPane(isFocused = true) {
+  return render(paneElement(isFocused));
 }
 
 /** The stepping shortcuts ride bubbling from inside the pane, not the document. */
@@ -177,7 +185,7 @@ beforeEach(() => {
   isImageDiffCandidateMock.mockReturnValue(false);
   preferences.diffShowFileList = true;
   preferences.diffWrapLines = null;
-  preferences.setDiffWrapLines.mockReset();
+  preferences.setDiffWrapLines.mockClear();
   worktrees.clear();
   worktrees.set(WORKTREE_ID, { path: WORKTREE_PATH, branch: "feature/x" });
 });
@@ -968,6 +976,31 @@ describe("DiffPane wrap toggle (#12170)", () => {
     fireEvent.click(wrapButton());
 
     expect(preferences.setDiffWrapLines).toHaveBeenCalledWith(true);
+  });
+
+  it("cycles auto-on to explicit-off to explicit-on, updating button and viewer", () => {
+    // Dispatching the right argument is not enough: a regression that wrote the
+    // preference but left the control and the viewer showing the old value
+    // would pass every assertion that stops at the setter.
+    seedPanel({
+      filePath: "docs/spec.md",
+      fileStatus: "modified",
+      changeSet: [entry("docs/spec.md")],
+    });
+    const { rerender } = renderPane();
+    expect(viewerWrap()).toBe("true");
+
+    fireEvent.click(wrapButton());
+    rerender(paneElement());
+    expect(preferences.diffWrapLines).toBe(false);
+    expect(viewerWrap()).toBe("false");
+    expect(wrapButton().getAttribute("aria-pressed")).toBe("false");
+
+    fireEvent.click(wrapButton());
+    rerender(paneElement());
+    expect(preferences.diffWrapLines).toBe(true);
+    expect(viewerWrap()).toBe("true");
+    expect(wrapButton().getAttribute("aria-pressed")).toBe("true");
   });
 
   it("lets an explicit override beat the file type in both directions", () => {

--- a/src/panels/file/FilePane.tsx
+++ b/src/panels/file/FilePane.tsx
@@ -21,6 +21,7 @@ import { FolderOpen, FolderTree } from "@/components/icons";
 import type { TabInfo } from "@/components/Panel/TabButton";
 import { MarkdownViewer, type MarkdownViewerHandle } from "@/components/Markdown/MarkdownViewer";
 import { isMarkdownFilePath } from "@/components/Markdown/isMarkdownFile";
+import { isProseFilePath } from "@/components/FileViewer/isProseFile";
 import { MarkdownTextSizeControl } from "@/components/Markdown/MarkdownTextSizeControl";
 import { HtmlViewer } from "@/components/Html/HtmlViewer";
 import { isHtmlFilePath } from "@/components/Html/isHtmlFile";
@@ -277,11 +278,17 @@ export function FilePane({
   // across every surface that shows a diff.
   const diffViewType = usePreferencesStore((state) => state.diffViewType);
   const diffWrapLines = usePreferencesStore((state) => state.diffWrapLines);
+  const setDiffWrapLines = usePreferencesStore((state) => state.setDiffWrapLines);
 
   const heightHold = useHeightHold();
 
   const filePath = panel?.filePath;
   const isMarkdown = filePath !== undefined && isMarkdownFilePath(filePath);
+  // `null` means auto — prose wraps, code doesn't. Resolved during render so a
+  // `.md` diff is already wrapped on first paint, and separate from
+  // `markdownWrapLines`, which owns Source view only (#12170).
+  const effectiveDiffWrapLines =
+    diffWrapLines ?? (filePath !== undefined && isProseFilePath(filePath));
   const isHtml = filePath !== undefined && isHtmlFilePath(filePath);
   // Markdown and HTML get a Rendered mode; every other file is source-only.
   const isRenderable = isMarkdown || isHtml;
@@ -1064,6 +1071,19 @@ export function FilePane({
               <WrapText className={TOOLBAR_ICON_CLASS} />
             </FileViewerToolbar.IconButton>
           )}
+          {/* Diff mode's own wrap, on the shared `diffWrapLines` the diff panel
+              writes — not the markdown one above it, which only ever applied to
+              Source view. Ungated by file type: the diff below renders as text
+              for every file, images and binaries included. */}
+          {viewMode === "diff" && (
+            <FileViewerToolbar.IconButton
+              label="Wrap long lines"
+              pressed={effectiveDiffWrapLines}
+              onClick={() => setDiffWrapLines(!effectiveDiffWrapLines)}
+            >
+              <WrapText className={TOOLBAR_ICON_CLASS} />
+            </FileViewerToolbar.IconButton>
+          )}
           {/* Refresh follows what's on screen — re-reading the file wouldn't
               refetch a diff, and vice versa. */}
           <FileViewerToolbar.IconButton label="Refresh" onClick={handleToolbarRefresh}>
@@ -1197,7 +1217,7 @@ export function FilePane({
                 // so open-in-editor has to join against the same root the
                 // relative paths were derived from.
                 rootPath={diffWorktreePath}
-                wrapLines={diffWrapLines}
+                wrapLines={effectiveDiffWrapLines}
                 onRetry={retryDiff}
               />
             )}

--- a/src/panels/file/__tests__/FilePane.test.tsx
+++ b/src/panels/file/__tests__/FilePane.test.tsx
@@ -82,17 +82,20 @@ vi.mock("@/lib/viewCacheState", () => ({
 vi.mock("@/store/projectStore", () => ({
   useProjectStore: (selector: (state: unknown) => unknown) => selector({ currentProject: null }),
 }));
-const { setMarkdownFontSizeMock, setDiffWrapLinesMock } = vi.hoisted(() => ({
-  setMarkdownFontSizeMock: vi.fn(),
-  setDiffWrapLinesMock: vi.fn(),
-}));
+const { setMarkdownFontSizeMock, setDiffWrapLinesMock, setMarkdownWrapLinesMock } = vi.hoisted(
+  () => ({
+    setMarkdownFontSizeMock: vi.fn(),
+    setDiffWrapLinesMock: vi.fn(),
+    setMarkdownWrapLinesMock: vi.fn(),
+  })
+);
 // Mutable so a test can seed an explicit wrap override; `null` is auto (#12170).
 const preferences = { diffWrapLines: null as boolean | null };
 vi.mock("@/store/preferencesStore", () => ({
   usePreferencesStore: (selector: (state: unknown) => unknown) =>
     selector({
       markdownWrapLines: false,
-      setMarkdownWrapLines: vi.fn(),
+      setMarkdownWrapLines: setMarkdownWrapLinesMock,
       markdownFontSize: "lg",
       setMarkdownFontSize: setMarkdownFontSizeMock,
       diffViewType: "unified",
@@ -289,6 +292,7 @@ afterEach(() => {
   setFileViewModeMock.mockReset();
   setFilePanelPathMock.mockReset();
   setDiffWrapLinesMock.mockReset();
+  setMarkdownWrapLinesMock.mockReset();
   preferences.diffWrapLines = null;
   markdownViewerProps.current = null;
   lifecycleListeners.clear();
@@ -1905,8 +1909,38 @@ describe("FilePane diff mode (#11274)", () => {
       await renderPane({ filePath: "/repo/docs/spec.md", fileViewMode: "source" });
 
       fireEvent.click(wrapButton());
+      expect(setMarkdownWrapLinesMock).toHaveBeenCalledWith(true);
       expect(setDiffWrapLinesMock).not.toHaveBeenCalled();
       expect(screen.getAllByRole("button", { name: "Wrap long lines" }).length).toBe(1);
+    });
+
+    it("offers the toggle for an image diff, which renders as text like any other", async () => {
+      // The button is deliberately ungated by file type here, unlike the diff
+      // panel's: this pane's diff branch precedes every load-state branch, so a
+      // PNG shows a text diff rather than a preview. Gating it the way DiffPane
+      // does would silently strip the control from those diffs.
+      seedWorktree([{ path: "/repo/assets/logo.png", status: "modified" }]);
+      useDiffContentMock.mockReturnValue({
+        content: "Binary files differ",
+        stale: false,
+        retry: vi.fn(),
+      });
+      await renderPane({ filePath: "/repo/assets/logo.png", fileViewMode: "diff" });
+      expect(await screen.findByTestId("diff-viewer-mock")).toBeTruthy();
+
+      expect(wrapButton().getAttribute("aria-pressed")).toBe("false");
+      expect(viewerWrap()).toBe("false");
+
+      fireEvent.click(wrapButton());
+      expect(setDiffWrapLinesMock).toHaveBeenCalledWith(true);
+    });
+
+    it("honours an explicit `true` on a code file", async () => {
+      preferences.diffWrapLines = true;
+      await renderDiff("/repo/src/index.ts");
+
+      expect(viewerWrap()).toBe("true");
+      expect(wrapButton().getAttribute("aria-pressed")).toBe("true");
     });
   });
 

--- a/src/panels/file/__tests__/FilePane.test.tsx
+++ b/src/panels/file/__tests__/FilePane.test.tsx
@@ -82,9 +82,12 @@ vi.mock("@/lib/viewCacheState", () => ({
 vi.mock("@/store/projectStore", () => ({
   useProjectStore: (selector: (state: unknown) => unknown) => selector({ currentProject: null }),
 }));
-const { setMarkdownFontSizeMock } = vi.hoisted(() => ({
+const { setMarkdownFontSizeMock, setDiffWrapLinesMock } = vi.hoisted(() => ({
   setMarkdownFontSizeMock: vi.fn(),
+  setDiffWrapLinesMock: vi.fn(),
 }));
+// Mutable so a test can seed an explicit wrap override; `null` is auto (#12170).
+const preferences = { diffWrapLines: null as boolean | null };
 vi.mock("@/store/preferencesStore", () => ({
   usePreferencesStore: (selector: (state: unknown) => unknown) =>
     selector({
@@ -93,7 +96,8 @@ vi.mock("@/store/preferencesStore", () => ({
       markdownFontSize: "lg",
       setMarkdownFontSize: setMarkdownFontSizeMock,
       diffViewType: "unified",
-      diffWrapLines: false,
+      diffWrapLines: preferences.diffWrapLines,
+      setDiffWrapLines: setDiffWrapLinesMock,
       diffIgnoreWhitespace: false,
     }),
 }));
@@ -213,8 +217,13 @@ const { useDiffContentMock } = vi.hoisted(() => ({
 vi.mock("@/panels/diff/useDiffContent", () => ({ useDiffContent: useDiffContentMock }));
 // FilePane lazy-loads the viewer, so assertions on it must await the chunk.
 vi.mock("@/components/Worktree/DiffViewer", () => ({
-  DiffViewer: (props: { diff: string; rootPath?: string }) => (
-    <div data-testid="diff-viewer-mock" data-diff={props.diff} data-root={props.rootPath ?? ""} />
+  DiffViewer: (props: { diff: string; rootPath?: string; wrapLines?: boolean }) => (
+    <div
+      data-testid="diff-viewer-mock"
+      data-diff={props.diff}
+      data-root={props.rootPath ?? ""}
+      data-wrap-lines={String(props.wrapLines)}
+    />
   ),
 }));
 vi.mock("@/components/Html/HtmlViewer", () => ({
@@ -279,6 +288,8 @@ afterEach(() => {
   for (const key of Object.keys(panelsById)) delete panelsById[key];
   setFileViewModeMock.mockReset();
   setFilePanelPathMock.mockReset();
+  setDiffWrapLinesMock.mockReset();
+  preferences.diffWrapLines = null;
   markdownViewerProps.current = null;
   lifecycleListeners.clear();
   dockState.activeDockTerminalId = null;
@@ -1834,6 +1845,68 @@ describe("FilePane diff mode (#11274)", () => {
 
       expect(await screen.findByTestId("diff-viewer-mock")).toBeTruthy();
       expect(container.querySelector("img")).toBeNull();
+    });
+  });
+
+  // Diff mode had no wrap control at all before #12170: the only wrap button in
+  // this toolbar was gated to `isMarkdown && viewMode === "source"`, so a
+  // markdown file's diff — the case that needs wrapping most — had no reachable
+  // toggle.
+  describe("diff-mode wrap toggle (#12170)", () => {
+    function wrapButton(): HTMLElement {
+      return screen.getByRole("button", { name: "Wrap long lines" });
+    }
+
+    function viewerWrap(): string | null {
+      return screen.getByTestId("diff-viewer-mock").getAttribute("data-wrap-lines");
+    }
+
+    async function renderDiff(filePath: string) {
+      seedWorktree([{ path: filePath, status: "modified" }]);
+      useDiffContentMock.mockReturnValue({ content: "@@ -1 +1 @@", stale: false, retry: vi.fn() });
+      await renderPane({ filePath, fileViewMode: "diff" });
+      expect(await screen.findByTestId("diff-viewer-mock")).toBeTruthy();
+    }
+
+    it("wraps a markdown diff on first render with nothing stored", async () => {
+      await renderDiff("/repo/docs/spec.md");
+
+      expect(viewerWrap()).toBe("true");
+      expect(wrapButton().getAttribute("aria-pressed")).toBe("true");
+    });
+
+    it("offers the toggle for a non-markdown file too, unwrapped by default", async () => {
+      await renderDiff("/repo/src/index.ts");
+
+      expect(wrapButton()).toBeTruthy();
+      expect(viewerWrap()).toBe("false");
+      expect(wrapButton().getAttribute("aria-pressed")).toBe("false");
+    });
+
+    it("writes the opposite of the effective value, not of the stored one", async () => {
+      await renderDiff("/repo/docs/spec.md");
+
+      fireEvent.click(wrapButton());
+
+      expect(setDiffWrapLinesMock).toHaveBeenCalledWith(false);
+    });
+
+    it("honours an explicit override over the file type", async () => {
+      preferences.diffWrapLines = false;
+      await renderDiff("/repo/docs/spec.md");
+
+      expect(viewerWrap()).toBe("false");
+    });
+
+    it("stays out of the other view modes, which keep their own controls", async () => {
+      // Source view's wrap button is the markdown one, on a different
+      // preference; diff's must not appear beside it or double up on the slot.
+      seedWorktree([{ path: "/repo/docs/spec.md", status: "modified" }]);
+      await renderPane({ filePath: "/repo/docs/spec.md", fileViewMode: "source" });
+
+      fireEvent.click(wrapButton());
+      expect(setDiffWrapLinesMock).not.toHaveBeenCalled();
+      expect(screen.getAllByRole("button", { name: "Wrap long lines" }).length).toBe(1);
     });
   });
 

--- a/src/store/__tests__/preferencesStore.crossViewMerge.test.ts
+++ b/src/store/__tests__/preferencesStore.crossViewMerge.test.ts
@@ -99,6 +99,49 @@ describe("preferencesStore cross-view write merge (#11351)", () => {
     expect(written.state.showProjectPulse).toBe(false);
   });
 
+  it("a sibling's explicit wrap `false` survives a write from a view still on auto", async () => {
+    // `diffWrapLines` is the one tri-state scalar here (#12170). `null` is a
+    // real value, not an absent one, so the merge has to tell "this view never
+    // touched it" from "this view set it to false" — a falsy-coercing or
+    // null-skipping comparison would resurrect auto and re-wrap every prose
+    // diff the sibling had deliberately unwrapped.
+    const backing = installLocalStorage({});
+    const { usePreferencesStore: store } = await import("../preferencesStore");
+    expect(store.getState().diffWrapLines).toBeNull();
+
+    backing.set(
+      STORAGE_KEY,
+      JSON.stringify({
+        version: store.persist.getOptions().version,
+        state: { diffWrapLines: false },
+      })
+    );
+
+    // This view changes something unrelated while its own baseline is auto.
+    store.getState().setDockDensity("compact");
+
+    const written = readBlob(backing);
+    expect(written.state.diffWrapLines).toBe(false);
+    expect(written.state.dockDensity).toBe("compact");
+  });
+
+  it("this view's explicit wrap choice beats a sibling's on-disk value", async () => {
+    const backing = installLocalStorage({});
+    const { usePreferencesStore: store } = await import("../preferencesStore");
+
+    backing.set(
+      STORAGE_KEY,
+      JSON.stringify({
+        version: store.persist.getOptions().version,
+        state: { diffWrapLines: true },
+      })
+    );
+
+    store.getState().setDiffWrapLines(false);
+
+    expect(readBlob(backing).state.diffWrapLines).toBe(false);
+  });
+
   it("independent map and scalar changes from two views both survive", async () => {
     const backing = installLocalStorage({});
     const { usePreferencesStore: store } = await import("../preferencesStore");

--- a/src/store/__tests__/preferencesStore.test.ts
+++ b/src/store/__tests__/preferencesStore.test.ts
@@ -726,7 +726,7 @@ describe("preferencesStore migration", () => {
       // Pin the bump too: `migrate` only runs for a blob below the configured
       // version, so leaving it at 17 would skip the branch above entirely and
       // hydration's sanitizer would quietly supply the same default.
-      expect(store.persist.getOptions().version).toBe(18);
+      expect(store.persist.getOptions().version).toBe(19);
     });
 
     it("leaves an already-valid rung alone when migrating", async () => {
@@ -1173,6 +1173,69 @@ describe("preferencesStore migration", () => {
       setStoredState({ hasSeenActionPalettePrefixHint: "yes" }, 15);
       const store = await loadStore();
       expect(store.getState().hasSeenActionPalettePrefixHint).toBe(false);
+    });
+  });
+
+  describe("diffWrapLines auto mode (#12170)", () => {
+    it("defaults to auto rather than off", async () => {
+      const store = await loadStore();
+      expect(store.getState().diffWrapLines).toBeNull();
+    });
+
+    it("migrates a pre-v19 explicit `true` through untouched", async () => {
+      // `true` could only ever have come from a deliberate toggle, since `false`
+      // was the old default — so it is the one legacy value worth preserving.
+      const store = await loadStore();
+      const migrated = store.persist.getOptions().migrate?.({ diffWrapLines: true }, 18);
+
+      expect(migrated).toMatchObject({ diffWrapLines: true });
+    });
+
+    it("migrates a pre-v19 `false` to auto", async () => {
+      // Ambiguous on disk: the store persists the whole default snapshot with no
+      // per-field provenance, so "never touched it" and "on, then off again" are
+      // the same bytes. Auto reads that in favour of shipping the prose default.
+      const store = await loadStore();
+      const migrated = store.persist.getOptions().migrate?.({ diffWrapLines: false }, 18);
+
+      expect(migrated).toMatchObject({ diffWrapLines: null });
+    });
+
+    it("migrates an absent or corrupt pre-v19 value to auto", async () => {
+      const store = await loadStore();
+      for (const legacy of [{}, { diffWrapLines: "yes" }, { diffWrapLines: 1 }]) {
+        expect(store.persist.getOptions().migrate?.(legacy, 18)).toMatchObject({
+          diffWrapLines: null,
+        });
+      }
+    });
+
+    it("keeps an explicit `false` set at the current version", async () => {
+      // The migration only reinterprets pre-v19 blobs. A `false` written since
+      // is a real override and must survive a reload, or turning wrap off on a
+      // markdown diff would not stick.
+      setStoredState({ diffWrapLines: false }, 19);
+      const store = await loadStore();
+      expect(store.getState().diffWrapLines).toBe(false);
+    });
+
+    it("sanitises a corrupt current-version value to auto, not to off", async () => {
+      setStoredState({ diffWrapLines: "yes" }, 19);
+      const store = await loadStore();
+      expect(store.getState().diffWrapLines).toBeNull();
+    });
+
+    it("persists both explicit states to localStorage", async () => {
+      const store = await loadStore();
+      store.getState().setDiffWrapLines(true);
+      await vi.waitFor(() => {
+        expect(JSON.parse(storageMock.getItem(STORAGE_KEY)!).state.diffWrapLines).toBe(true);
+      });
+
+      store.getState().setDiffWrapLines(false);
+      await vi.waitFor(() => {
+        expect(JSON.parse(storageMock.getItem(STORAGE_KEY)!).state.diffWrapLines).toBe(false);
+      });
     });
   });
 });

--- a/src/store/preferencesStore.ts
+++ b/src/store/preferencesStore.ts
@@ -23,6 +23,16 @@ export type DiffViewType = "split" | "unified";
 export type DiffFontSize = "s" | "m" | "l";
 
 /**
+ * Diff soft-wrap: `null` means "derive it from the file", a boolean is an
+ * explicit user override. Modelled as a nullable boolean rather than an
+ * `"auto" | "on" | "off"` enum because every consumer resolves it to a plain
+ * boolean anyway — `?? isProseFilePath(path)` is the whole translation, where
+ * an enum would need mapping at each of the three call sites for no added
+ * behaviour.
+ */
+export type DiffWrapPreference = boolean | null;
+
+/**
  * Reading scale for rendered markdown, in reading order. The stepper walks this
  * and the persistence guard checks against it, and the type below is DERIVED
  * from it so the ladder is the single place a rung is declared — a rung added
@@ -123,7 +133,14 @@ interface PreferencesState {
   setReduceAnimations: (value: boolean) => void;
   diffViewType: DiffViewType;
   setDiffViewType: (value: DiffViewType) => void;
-  diffWrapLines: boolean;
+  /**
+   * Soft-wrap long lines in diffs. `null` is auto: prose extensions wrap,
+   * everything else doesn't (see `isProseFilePath`). A boolean is an explicit
+   * override the user set from a toolbar toggle, and it applies to every file
+   * until they flip it back — global and sticky, like every desktop diff tool
+   * (#12170). Hosts resolve it per file; `DiffViewer` only ever sees a boolean.
+   */
+  diffWrapLines: DiffWrapPreference;
   setDiffWrapLines: (value: boolean) => void;
   diffIgnoreWhitespace: boolean;
   setDiffIgnoreWhitespace: (value: boolean) => void;
@@ -251,6 +268,10 @@ function isDiffFontSize(value: unknown): value is DiffFontSize {
   return value === "s" || value === "m" || value === "l";
 }
 
+function isDiffWrapPreference(value: unknown): value is DiffWrapPreference {
+  return value === null || typeof value === "boolean";
+}
+
 function isMarkdownFontSize(value: unknown): value is MarkdownFontSize {
   // `some` rather than `includes`: the latter narrows its argument to the
   // tuple's own type, so it would need an assertion here to accept `unknown`.
@@ -283,7 +304,7 @@ function sanitizePersistedPreferences(
 
   if (!isDockDensity(sanitized.dockDensity)) sanitized.dockDensity = "normal";
   if (!isDiffViewType(sanitized.diffViewType)) sanitized.diffViewType = "split";
-  if (typeof sanitized.diffWrapLines !== "boolean") sanitized.diffWrapLines = false;
+  if (!isDiffWrapPreference(sanitized.diffWrapLines)) sanitized.diffWrapLines = null;
   if (typeof sanitized.diffIgnoreWhitespace !== "boolean") sanitized.diffIgnoreWhitespace = false;
   if (typeof sanitized.diffShowFileList !== "boolean") sanitized.diffShowFileList = true;
   if (typeof sanitized.diffFullFile !== "boolean") sanitized.diffFullFile = false;
@@ -369,7 +390,7 @@ const PREFERENCES_PERSISTED_DEFAULTS: PreferencesPersistedState = {
   assignWorktreeToSelf: false,
   reduceAnimations: false,
   diffViewType: "split",
-  diffWrapLines: false,
+  diffWrapLines: null,
   diffIgnoreWhitespace: false,
   diffShowFileList: true,
   diffFullFile: false,
@@ -497,7 +518,7 @@ function toPreferencesPersisted(
     assignWorktreeToSelf: coerceBool(raw.assignWorktreeToSelf, d.assignWorktreeToSelf),
     reduceAnimations: coerceBool(raw.reduceAnimations, d.reduceAnimations),
     diffViewType: isDiffViewType(raw.diffViewType) ? raw.diffViewType : d.diffViewType,
-    diffWrapLines: coerceBool(raw.diffWrapLines, d.diffWrapLines),
+    diffWrapLines: isDiffWrapPreference(raw.diffWrapLines) ? raw.diffWrapLines : d.diffWrapLines,
     diffIgnoreWhitespace: coerceBool(raw.diffIgnoreWhitespace, d.diffIgnoreWhitespace),
     diffShowFileList: coerceBool(raw.diffShowFileList, d.diffShowFileList),
     diffFullFile: coerceBool(raw.diffFullFile, d.diffFullFile),
@@ -694,7 +715,7 @@ export const usePreferencesStore = create<PreferencesState>()(
       setReduceAnimations: (value) => set({ reduceAnimations: value }),
       diffViewType: "split",
       setDiffViewType: (value) => set({ diffViewType: value }),
-      diffWrapLines: false,
+      diffWrapLines: null,
       setDiffWrapLines: (value) => set({ diffWrapLines: value }),
       diffIgnoreWhitespace: false,
       setDiffIgnoreWhitespace: (value) => set({ diffIgnoreWhitespace: value }),
@@ -797,7 +818,7 @@ export const usePreferencesStore = create<PreferencesState>()(
       storage: createSafeJSONStorage<PreferencesPersistedState>({
         mergeOnWrite: mergePreferencesPersistedWrite,
       }),
-      version: 18,
+      version: 19,
       // Explicit persisted subset — matches the pre-existing default (setters are
       // dropped by JSON serialization); named so the write merge (#11351) has a
       // typed persisted shape to reconcile.
@@ -969,6 +990,18 @@ export const usePreferencesStore = create<PreferencesState>()(
             persisted.markdownFontSize = DEFAULT_MARKDOWN_FONT_SIZE;
           }
         }
+        if (version < 19 && isRecord(persisted)) {
+          // Wrap gained an auto mode, so the old boolean has to be reinterpreted
+          // (#12170). Only `true` survives: it could only ever have come from a
+          // deliberate toggle, since `false` was the default. A stored `false`
+          // is genuinely ambiguous — the store persists the whole default
+          // snapshot and keeps no per-field provenance, so "never touched it"
+          // and "turned it on, then off again" are the same bytes on disk. This
+          // maps both to auto, which reads the ambiguity in favour of shipping
+          // the new prose default to existing installs rather than leaving it
+          // to new ones.
+          persisted.diffWrapLines = persisted.diffWrapLines === true ? true : null;
+        }
         return persisted as PreferencesState;
       },
     }
@@ -979,5 +1012,5 @@ registerPersistedStore({
   storeId: "preferencesStore",
   store: usePreferencesStore,
   persistedStateType:
-    "{ showProjectPulse: boolean; showDeveloperTools: boolean; showGridAgentHighlights: boolean; showDockAgentHighlights: boolean; showAgentTaskTitles: boolean; dockDensity: DockDensity; assignWorktreeToSelf: boolean; reduceAnimations: boolean; diffViewType: DiffViewType; diffWrapLines: boolean; diffIgnoreWhitespace: boolean; diffShowFileList: boolean; diffFullFile: boolean; diffFontSize: DiffFontSize; markdownWrapLines: boolean; markdownFontSize: MarkdownFontSize; lastSelectedWorktreeRecipeIdByProject: Record<string, string | null | undefined>; skipPushConfirmByWorktreePath: Record<string, boolean>; deletedWorktreeCleanupSeconds: DeletedWorktreeCleanupSeconds; projectSwitcherOtherSortMode: OtherProjectsSortMode; projectSwitcherCollapsedBands: Record<string, boolean>; fileBrowserAlwaysHiddenPatterns: string[]; hasSeenActionPalettePrefixHint: boolean; keyboardLayoutConfirmationsByBinding: Record<string, number> }",
+    "{ showProjectPulse: boolean; showDeveloperTools: boolean; showGridAgentHighlights: boolean; showDockAgentHighlights: boolean; showAgentTaskTitles: boolean; dockDensity: DockDensity; assignWorktreeToSelf: boolean; reduceAnimations: boolean; diffViewType: DiffViewType; diffWrapLines: boolean | null; diffIgnoreWhitespace: boolean; diffShowFileList: boolean; diffFullFile: boolean; diffFontSize: DiffFontSize; markdownWrapLines: boolean; markdownFontSize: MarkdownFontSize; lastSelectedWorktreeRecipeIdByProject: Record<string, string | null | undefined>; skipPushConfirmByWorktreePath: Record<string, boolean>; deletedWorktreeCleanupSeconds: DeletedWorktreeCleanupSeconds; projectSwitcherOtherSortMode: OtherProjectsSortMode; projectSwitcherCollapsedBands: Record<string, boolean>; fileBrowserAlwaysHiddenPatterns: string[]; hasSeenActionPalettePrefixHint: boolean; keyboardLayoutConfirmationsByBinding: Record<string, number> }",
 });


### PR DESCRIPTION
## Summary

- `diffWrapLines` was a persisted global boolean defaulting to `false`, and only the diff panel exposed a toggle for it. The file panel's diff mode and cross-worktree compare had no toggle at all, so a Markdown diff, the thing this diff viewer is used for most, opened as a wall of horizontal scroll with no way out.
- The setting is now `boolean | null`, where `null` means automatic: prose extensions wrap by default, code doesn't, and all three diff surfaces expose the toggle.
- Along the way, putting a roving toolbar inside a modal dialog for the first time surfaced a latent focus bug in a shared hook used by five other toolbar consumers. That's fixed too.

Resolves #12170

## Changes

**Preferences store** (`src/store/preferencesStore.ts`): new `DiffWrapPreference` type (`boolean | null`) with a type guard `isDiffWrapPreference`. Sanitizer, persisted defaults, `toPreferencesPersisted`, and the store initializer all move to `null`. A version 19 migration keeps a legacy stored `true` as an explicit override, and maps everything else, including a stored `false`, to the new automatic default. The store persists a whole default snapshot with no per-field history, so there's no way to tell "never touched it" apart from "turned it on then off" from the stored bytes alone. The migration resolves that ambiguity in favor of rolling the prose default out to existing installs.

**Prose detection**: new `src/components/FileViewer/isProseFile.ts` exporting `isProseFilePath`, which reuses the existing `isMarkdownFilePath` check and adds `txt`, `text`, `rst`, `rest`, `adoc`, and `asciidoc`. It's an allowlist of known prose extensions rather than a denylist of code extensions, because an unrecognized extension is far more likely to be code, and wrapping code hides column alignment.

**All three diff surfaces** now compute `effectiveWrap = diffWrapLines ?? isProseFilePath(path)` directly during render, not memoized, since React Compiler auto-memoizes and the value needs to be correct on first paint. Each passes a plain boolean down to `DiffViewer`, whose prop contract doesn't change. The wrap toggle button now always writes the opposite of `effectiveWrap`, so toggling wrap off on an automatically-wrapped Markdown diff writes an explicit `false` instead of flipping a stale stored value.

**`FilePane`** (`src/panels/file/FilePane.tsx`) gets a wrap toggle in diff mode it never had, ungated by file type: the diff-mode branch runs before any of the loading, error, or binary-file branches, so image and binary diffs get a text diff view with the toggle too.

**`CrossWorktreeDiff`** (`src/components/Worktree/CrossWorktreeDiff.tsx`) previously passed no `wrapLines` prop at all. It now renders a real `FileViewerToolbar` with the wrap toggle; only the multi-file stepper stays gated behind comparing more than one file.

## Fix: roving toolbar tab stop

Adding a roving-focus toolbar inside `AppDialog` for the first time exposed a bug in the shared `useToolbarRoving` hook, used by five toolbar consumers. It tracked only a numeric index for the tab stop and reapplied that index after each commit, so a pointer click, or a new control appearing ahead of the focused one, could silently move the roving tab stop away from the actually-focused element and mark that button `tabindex="-1"`. The tabbable-element selector excludes negative tabindex, and the dialog's own focus trap only wraps at the boundary when the active element is exactly the first or last tabbable one, so this combination let Tab walk a user straight out of the modal.

The fix makes the roving tab stop follow actual DOM focus, synced on `focusin` as well as on commit; repairing only on render wasn't enough, since a child control can re-render on its own without the parent re-rendering.

As part of the same fix, the cross-worktree stepper now matches the shared toolbar button contract it sits alongside: `text-text-secondary` instead of `text-text-muted` (which has no guaranteed contrast floor in dark themes), a 26px hit target, the shared focus ring, and a matching corner radius.

## Testing

696 tests across 16 files pass locally, including a full run of every suite touching `FileViewerToolbar`, `FileBrowserPane`, and `FileBrowserViewer` to confirm the shared hook fix doesn't break any of its five consumers. Prettier, eslint (zero errors), and typecheck are all clean, and `lint:ratchet` passes with eight fewer warnings than before.
