### PR TITLE
feat(diff): add a rendered Markdown layout to the diff panel

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -774,6 +774,7 @@ export default tseslint.config(
       "src/components/Worktree/diffTokenRanges.ts",
       "src/components/Worktree/diffTokenizePipeline.ts",
       "src/components/Worktree/diffTokenizer.ts",
+      "src/components/Worktree/markdownBlockDiff.ts",
     ],
     rules: { "no-restricted-imports": "off" },
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,8 +30,10 @@
         "posix-pty-reaper": "file:electron/native/posix-pty-reaper",
         "proper-lockfile": "^4.1.2",
         "react-colorful": "^5.6.1",
+        "remark-parse": "^11.0.0",
         "safe-stable-stringify": "^2.5.0",
         "smol-toml": "^1.6.1",
+        "unified": "^11.0.5",
         "win-job-object": "file:electron/native/win-job-object",
         "yauzl": "^3.4.0"
       },
@@ -6829,7 +6831,6 @@
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
       "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/ms": "*"
@@ -6927,7 +6928,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
       "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "*"
@@ -6937,7 +6937,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -7026,7 +7025,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/ws": {
@@ -8286,7 +8284,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
       "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -8910,7 +8907,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
       "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -9740,7 +9736,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
       "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "character-entities": "^2.0.0"
@@ -9897,7 +9892,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -9930,7 +9924,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
       "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.0"
@@ -11870,7 +11863,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-check": {
@@ -14292,7 +14284,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
       "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -14546,7 +14537,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
       "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0"
@@ -14615,7 +14605,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
       "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -14651,7 +14640,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
       "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -14814,7 +14802,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
       "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -14836,7 +14823,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
       "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -14859,7 +14845,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
       "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -14880,7 +14865,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
       "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -14903,7 +14887,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
       "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -14926,7 +14909,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
       "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -14947,7 +14929,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
       "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -14967,7 +14948,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
       "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -14989,7 +14969,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
       "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -15010,7 +14989,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
       "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -15030,7 +15008,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
       "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -15053,7 +15030,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
       "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -15070,7 +15046,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
       "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -15087,7 +15062,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
       "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -15107,7 +15081,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
       "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -15127,7 +15100,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
       "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -15149,7 +15121,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
       "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -15172,7 +15143,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
       "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -15189,7 +15159,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
       "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -17071,7 +17040,6 @@
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
       "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -18923,7 +18891,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
       "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -19745,7 +19712,6 @@
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
       "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -19808,7 +19774,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
       "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
@@ -20016,7 +19981,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
       "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -20031,7 +19995,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
       "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -164,8 +164,10 @@
     "posix-pty-reaper": "file:electron/native/posix-pty-reaper",
     "proper-lockfile": "^4.1.2",
     "react-colorful": "^5.6.1",
+    "remark-parse": "^11.0.0",
     "safe-stable-stringify": "^2.5.0",
     "smol-toml": "^1.6.1",
+    "unified": "^11.0.5",
     "win-job-object": "file:electron/native/win-job-object",
     "yauzl": "^3.4.0"
   },

--- a/src/components/Markdown/MarkdownDocument.tsx
+++ b/src/components/Markdown/MarkdownDocument.tsx
@@ -1,19 +1,8 @@
-import { useEffect, useMemo, useRef, useState, type CSSProperties, type ReactNode } from "react";
-import ReactMarkdown, { defaultUrlTransform, type Components } from "react-markdown";
+import { useEffect, useRef, type CSSProperties } from "react";
+import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
-import { toJsxRuntime } from "hast-util-to-jsx-runtime";
-import { Fragment, jsx, jsxs } from "react/jsx-runtime";
-import { refractor } from "refractor/core";
-import {
-  ensureLanguage,
-  isLanguageFailed,
-  isLanguageRegistered,
-} from "@/components/Worktree/diffRefractor";
-import { dirname, isAbsolute, isPathInside, join, normalize } from "@shared/utils/path";
-import { buildDaintreeFileUrl } from "@/components/FileViewer/filePreviewKinds";
+import { useMarkdownRenderPolicy } from "./markdownRenderPolicy";
 import { useScopedSelectAll } from "@/hooks/useScopedSelectAll";
-import { actionService } from "@/services/ActionService";
-import { logError } from "@/utils/logger";
 import { cn } from "@/lib/utils";
 import type { MarkdownFontSize } from "@/store/preferencesStore";
 import "./MarkdownDocument.css";
@@ -74,75 +63,6 @@ export interface MarkdownDocumentProps {
 }
 
 /**
- * Fence-info aliases → the grammar keys diffRefractor's loaders know.
- * refractor registers Prism's own aliases (ts, py, …) once the grammar is
- * loaded; this map only bridges the *loader* lookup for grammars that are
- * still cold.
- */
-const FENCE_LANG_ALIASES: Record<string, string> = {
-  ts: "typescript",
-  js: "javascript",
-  py: "python",
-  rb: "ruby",
-  sh: "bash",
-  shell: "bash",
-  zsh: "bash",
-  yml: "yaml",
-  md: "markdown",
-  "c++": "cpp",
-  cs: "csharp",
-  dockerfile: "docker",
-  html: "markup",
-  xml: "markup",
-};
-
-function canonicalLang(lang: string): string {
-  const lower = lang.toLowerCase();
-  return FENCE_LANG_ALIASES[lower] ?? lower;
-}
-
-/**
- * Syntax-highlighted fence body. Highlights synchronously when the grammar is
- * registered; otherwise kicks off diffRefractor's lazy grammar load and
- * re-renders once it lands. Falls back to plain text for unknown grammars —
- * same downgrade behavior as the diff viewer.
- */
-function HighlightedCode({ language, code }: { language: string; code: string }) {
-  const lang = canonicalLang(language);
-  const [grammarRevision, setGrammarRevision] = useState(0);
-
-  useEffect(() => {
-    if (isLanguageRegistered(lang) || isLanguageFailed(lang)) return;
-    let cancelled = false;
-    void ensureLanguage(lang).then(() => {
-      if (!cancelled) setGrammarRevision((revision) => revision + 1);
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [lang]);
-
-  const highlighted = useMemo<ReactNode>(() => {
-    void grammarRevision;
-    if (!isLanguageRegistered(lang)) return null;
-    try {
-      return toJsxRuntime(refractor.highlight(code, lang), { Fragment, jsx, jsxs });
-    } catch {
-      return null;
-    }
-  }, [code, lang, grammarRevision]);
-
-  return <code className={`language-${lang}`}>{highlighted ?? code}</code>;
-}
-
-/** Resolve a link/image target against the document's directory. */
-function resolveAgainstFile(filePath: string, target: string): string {
-  return isAbsolute(target) ? normalize(target) : normalize(join(dirname(filePath), target));
-}
-
-const HTTPish = /^(https?|mailto):/i;
-
-/**
  * Read-only rendered view of a markdown document. Shared by the markdown
  * panel and the file viewer dialog. GFM (tables, task lists, strikethrough,
  * autolinks) is on; raw HTML embedded in the markdown is intentionally never
@@ -172,87 +92,11 @@ export function MarkdownDocument({
   const rootRef = useRef<HTMLDivElement>(null);
   useScopedSelectAll(rootRef);
 
-  const urlTransform = useMemo(() => {
-    return (url: string, key: string): string | null | undefined => {
-      if (key === "src") {
-        // Images: remote stays remote (default sanitization), anything
-        // path-like resolves through the daintree-file:// protocol so local
-        // images referenced by specs render with the same containment checks
-        // as the file itself.
-        if (HTTPish.test(url) || url.startsWith("data:")) return defaultUrlTransform(url);
-        const local = buildDaintreeFileUrl(resolveAgainstFile(filePath, url), rootPath);
-        // Undefined-checked rather than truthy, matching FileImagePreview and
-        // ZoomableImage: the token is opaque, so only "no host is tracking
-        // freshness" suppresses it — "" is a value like any other, and folding
-        // it in with absent would make a host that legitimately reached "" stop
-        // busting. The protocol handler reads only path/root, so `v` is inert.
-        return cacheBust === undefined ? local : `${local}&v=${encodeURIComponent(cacheBust)}`;
-      }
-      return defaultUrlTransform(url);
-    };
-  }, [filePath, rootPath, cacheBust]);
-
-  const handleLinkActivate = useMemo(() => {
-    return (href: string | undefined) => {
-      // Same-document anchors: headings carry no ids (no rehype-slug), so
-      // there is nothing to scroll to — swallow instead of navigating.
-      if (!href || href.startsWith("#")) return;
-      if (HTTPish.test(href)) {
-        actionService
-          .dispatch("browser.openExternal", { url: href }, { source: "user" })
-          .catch((err) => logError("[MarkdownDocument] openExternal failed", err));
-        return;
-      }
-      // Protocol-relative ("//host/…") and other non-http schemes survive to
-      // here only as untrusted oddities — never treat them as local paths.
-      if (href.startsWith("//")) return;
-      // Repo link — strip any query/fragment, resolve against the document,
-      // and only open files the document's own root contains. Rendered
-      // markdown is untrusted content; it must not become a lever for
-      // browsing arbitrary paths outside the project.
-      const pathPart = href.split(/[?#]/, 1)[0];
-      if (!pathPart) return;
-      const absolute = resolveAgainstFile(filePath, pathPart);
-      if (!isPathInside(absolute, rootPath)) return;
-      actionService
-        .dispatch("file.view", { path: absolute, rootPath }, { source: "user" })
-        .catch((err) => logError("[MarkdownDocument] file.view failed", err));
-    };
-  }, [filePath, rootPath]);
-
-  const components = useMemo<Components>(
-    () => ({
-      code: ({ node: _node, className: codeClassName, children, ...props }) => {
-        const language = /language-([\w+-]+)/.exec(codeClassName ?? "")?.[1];
-        if (language) {
-          return <HighlightedCode language={language} code={String(children).replace(/\n$/, "")} />;
-        }
-        return (
-          <code className={codeClassName} {...props}>
-            {children}
-          </code>
-        );
-      },
-      a: ({ node: _node, href, children, ...props }) => (
-        <a
-          {...props}
-          href={href}
-          onClick={(event) => {
-            event.preventDefault();
-            handleLinkActivate(href);
-          }}
-          onAuxClick={(event) => {
-            // Middle-click would otherwise ask Chromium to open the href in a
-            // new window — no link in rendered markdown should navigate.
-            event.preventDefault();
-          }}
-        >
-          {children}
-        </a>
-      ),
-    }),
-    [handleLinkActivate]
-  );
+  const { components, urlTransform } = useMarkdownRenderPolicy({
+    filePath,
+    rootPath,
+    cacheBust,
+  });
 
   const fontStyle: MarkdownFontStyle | undefined =
     fontSize === undefined

--- a/src/components/Markdown/markdownRenderPolicy.tsx
+++ b/src/components/Markdown/markdownRenderPolicy.tsx
@@ -1,0 +1,208 @@
+import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { defaultUrlTransform, type Components, type Options } from "react-markdown";
+import { toJsxRuntime } from "hast-util-to-jsx-runtime";
+import { Fragment, jsx, jsxs } from "react/jsx-runtime";
+import { refractor } from "refractor/core";
+import {
+  ensureLanguage,
+  isLanguageFailed,
+  isLanguageRegistered,
+} from "@/components/Worktree/diffRefractor";
+import { dirname, isAbsolute, isPathInside, join, normalize } from "@shared/utils/path";
+import { buildDaintreeFileUrl } from "@/components/FileViewer/filePreviewKinds";
+import { actionService } from "@/services/ActionService";
+import { logError } from "@/utils/logger";
+
+/**
+ * Everything that decides how one rendered Markdown document treats untrusted
+ * content: fence highlighting, where a local image URL may point, and what a
+ * link click is allowed to do.
+ *
+ * It lives apart from `MarkdownDocument` because the rendered-Markdown diff
+ * (issue #12171) renders the same untrusted repo files through its own
+ * component. Two copies of a containment check drift; one shared policy is the
+ * boundary both surfaces are held to.
+ *
+ * Note what is NOT here: raw HTML handling. Both callers pass `skipHtml` and
+ * neither adds `rehype-raw`, so embedded markup is dropped before it can reach
+ * the DOM. That absence is the reason this can render arbitrary repo files
+ * inside an Electron renderer without a sanitizer — do not add it.
+ */
+
+/**
+ * Fence-info aliases → the grammar keys diffRefractor's loaders know.
+ * refractor registers Prism's own aliases (ts, py, …) once the grammar is
+ * loaded; this map only bridges the *loader* lookup for grammars that are
+ * still cold.
+ */
+const FENCE_LANG_ALIASES: Record<string, string> = {
+  ts: "typescript",
+  js: "javascript",
+  py: "python",
+  rb: "ruby",
+  sh: "bash",
+  shell: "bash",
+  zsh: "bash",
+  yml: "yaml",
+  md: "markdown",
+  "c++": "cpp",
+  cs: "csharp",
+  dockerfile: "docker",
+  html: "markup",
+  xml: "markup",
+};
+
+function canonicalLang(lang: string): string {
+  const lower = lang.toLowerCase();
+  return FENCE_LANG_ALIASES[lower] ?? lower;
+}
+
+/**
+ * Syntax-highlighted fence body. Highlights synchronously when the grammar is
+ * registered; otherwise kicks off diffRefractor's lazy grammar load and
+ * re-renders once it lands. Falls back to plain text for unknown grammars —
+ * same downgrade behavior as the diff viewer.
+ */
+export function HighlightedCode({ language, code }: { language: string; code: string }) {
+  const lang = canonicalLang(language);
+  const [grammarRevision, setGrammarRevision] = useState(0);
+
+  useEffect(() => {
+    if (isLanguageRegistered(lang) || isLanguageFailed(lang)) return;
+    let cancelled = false;
+    void ensureLanguage(lang).then(() => {
+      if (!cancelled) setGrammarRevision((revision) => revision + 1);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [lang]);
+
+  const highlighted = useMemo<ReactNode>(() => {
+    void grammarRevision;
+    if (!isLanguageRegistered(lang)) return null;
+    try {
+      return toJsxRuntime(refractor.highlight(code, lang), { Fragment, jsx, jsxs });
+    } catch (error) {
+      console.warn("[markdownRenderPolicy] fence highlight failed", error);
+      return null;
+    }
+  }, [code, lang, grammarRevision]);
+
+  return <code className={`language-${lang}`}>{highlighted ?? code}</code>;
+}
+
+/** Resolve a link/image target against the document's directory. */
+function resolveAgainstFile(filePath: string, target: string): string {
+  return isAbsolute(target) ? normalize(target) : normalize(join(dirname(filePath), target));
+}
+
+const HTTPish = /^(https?|mailto):/i;
+
+export interface MarkdownRenderPolicyOptions {
+  /** Absolute path of the document, used to resolve relative links and images. */
+  filePath: string;
+  /** Containment root for daintree-file:// image loads. */
+  rootPath: string;
+  /**
+   * Cache-busting token appended to local image URLs. The daintree-file:// URL
+   * is otherwise a pure function of path + root, so a rewritten image keeps a
+   * byte-identical `src` and Chromium never refetches it (#11587).
+   */
+  cacheBust?: string;
+}
+
+export interface MarkdownRenderPolicy {
+  components: Components;
+  urlTransform: NonNullable<Options["urlTransform"]>;
+}
+
+export function useMarkdownRenderPolicy({
+  filePath,
+  rootPath,
+  cacheBust,
+}: MarkdownRenderPolicyOptions): MarkdownRenderPolicy {
+  const urlTransform = useMemo<MarkdownRenderPolicy["urlTransform"]>(() => {
+    return (url: string, key: string): string | null | undefined => {
+      if (key === "src") {
+        // Images: remote stays remote (default sanitization), anything
+        // path-like resolves through the daintree-file:// protocol so local
+        // images referenced by specs render with the same containment checks
+        // as the file itself.
+        if (HTTPish.test(url) || url.startsWith("data:")) return defaultUrlTransform(url);
+        const local = buildDaintreeFileUrl(resolveAgainstFile(filePath, url), rootPath);
+        // Undefined-checked rather than truthy, matching FileImagePreview and
+        // ZoomableImage: the token is opaque, so only "no host is tracking
+        // freshness" suppresses it — "" is a value like any other, and folding
+        // it in with absent would make a host that legitimately reached "" stop
+        // busting. The protocol handler reads only path/root, so `v` is inert.
+        return cacheBust === undefined ? local : `${local}&v=${encodeURIComponent(cacheBust)}`;
+      }
+      return defaultUrlTransform(url);
+    };
+  }, [filePath, rootPath, cacheBust]);
+
+  const handleLinkActivate = useMemo(() => {
+    return (href: string | undefined) => {
+      // Same-document anchors: headings carry no ids (no rehype-slug), so
+      // there is nothing to scroll to — swallow instead of navigating.
+      if (!href || href.startsWith("#")) return;
+      if (HTTPish.test(href)) {
+        actionService
+          .dispatch("browser.openExternal", { url: href }, { source: "user" })
+          .catch((err) => logError("[markdownRenderPolicy] openExternal failed", err));
+        return;
+      }
+      // Protocol-relative ("//host/…") and other non-http schemes survive to
+      // here only as untrusted oddities — never treat them as local paths.
+      if (href.startsWith("//")) return;
+      // Repo link — strip any query/fragment, resolve against the document,
+      // and only open files the document's own root contains. Rendered
+      // markdown is untrusted content; it must not become a lever for
+      // browsing arbitrary paths outside the project.
+      const pathPart = href.split(/[?#]/, 1)[0];
+      if (!pathPart) return;
+      const absolute = resolveAgainstFile(filePath, pathPart);
+      if (!isPathInside(absolute, rootPath)) return;
+      actionService
+        .dispatch("file.view", { path: absolute, rootPath }, { source: "user" })
+        .catch((err) => logError("[markdownRenderPolicy] file.view failed", err));
+    };
+  }, [filePath, rootPath]);
+
+  const components = useMemo<Components>(
+    () => ({
+      code: ({ node: _node, className: codeClassName, children, ...props }) => {
+        const language = /language-([\w+-]+)/.exec(codeClassName ?? "")?.[1];
+        if (language) {
+          return <HighlightedCode language={language} code={String(children).replace(/\n$/, "")} />;
+        }
+        return (
+          <code className={codeClassName} {...props}>
+            {children}
+          </code>
+        );
+      },
+      a: ({ node: _node, href, children, ...props }) => (
+        <a
+          {...props}
+          href={href}
+          onClick={(event) => {
+            event.preventDefault();
+            handleLinkActivate(href);
+          }}
+          onAuxClick={(event) => {
+            // Middle-click would otherwise ask Chromium to open the href in a
+            // new window — no link in rendered markdown should navigate.
+            event.preventDefault();
+          }}
+        >
+          {children}
+        </a>
+      ),
+    }),
+    [handleLinkActivate]
+  );
+
+  return { components, urlTransform };
+}

--- a/src/components/Worktree/RenderedMarkdownDiff.css
+++ b/src/components/Worktree/RenderedMarkdownDiff.css
@@ -52,18 +52,24 @@
 .rendered-markdown-diff__block--removed {
   background: var(--color-diff-delete-background);
   border-inline-start-color: var(--color-diff-gutter-delete);
-  /* GitHub's rich-diff treatment: a removed block reads as struck-out prose,
-     which is what makes it legible as "this text is gone" without recoloring
-     the text itself and losing contrast over the fill. */
+}
+
+/* GitHub's rich-diff treatment: a removed block reads as struck-out prose,
+   which is what makes it legible as "this text is gone" without recoloring the
+   text itself and losing contrast over the fill.
+
+   Declared on the text-bearing descendants rather than on the block wrapper,
+   which is the only way to keep it off code fences and table grids: a text
+   decoration propagates to every descendant of the element that declares it and
+   CANNOT be switched off further down — `text-decoration: none` on the <pre>
+   would be silently ignored. The :has() exclusion drops the line from a
+   container holding a fence or table (a list item wrapping a code block), where
+   the block fill and the marker still carry the state. */
+.rendered-markdown-diff__block--removed
+  :where(p, h1, h2, h3, h4, h5, h6, li, blockquote, dt, dd):not(:has(pre, table)) {
   text-decoration: line-through;
   text-decoration-color: color-mix(in oklab, var(--color-text-primary) 45%, transparent);
   text-decoration-thickness: 1px;
-}
-
-/* Strikethrough belongs on prose, not on a code fence or a table grid, where it
-   cuts through characters that have to stay readable. */
-.rendered-markdown-diff__block--removed :where(pre, table) {
-  text-decoration: none;
 }
 
 /* The status marker. Sits in the inline-start padding so it never displaces the
@@ -145,7 +151,8 @@
     border-inline-start-width: 4px;
   }
 
-  .rendered-markdown-diff__block--removed {
+  .rendered-markdown-diff__block--removed
+    :where(p, h1, h2, h3, h4, h5, h6, li, blockquote, dt, dd):not(:has(pre, table)) {
     text-decoration-color: var(--color-text-primary);
   }
 }

--- a/src/components/Worktree/RenderedMarkdownDiff.css
+++ b/src/components/Worktree/RenderedMarkdownDiff.css
@@ -1,0 +1,151 @@
+/* Rendered-Markdown diff markers (issue #12171). Imported by
+   RenderedMarkdownDiff.tsx, so it ships with the lazy rendered-diff chunk.
+
+   Everything in this file is intentionally UNLAYERED, for the same reason
+   MarkdownDocument.css is: the typography plugin emits `.prose` inside
+   @layer utilities, and layered rules lose to unlayered author styles no matter
+   their specificity or order. Wrapping these rules in any @layer block would
+   silently hand the block fills back to the plugin's defaults — a regression
+   that is invisible in one polarity and reads as a wrong token value in the
+   other.
+
+   High-contrast support follows the same dual-block discipline as
+   DiffViewer.css: forced-colors = Windows system palette; prefers-contrast =
+   macOS Increase Contrast, keeping theme colors. The two blocks must stay
+   separate. */
+
+.rendered-markdown-diff {
+  /* The reading measure that centers a document would strand the block markers
+     against the pane edge, and a diff is scanned rather than read at length. */
+  max-width: none;
+}
+
+.rendered-markdown-diff__block {
+  position: relative;
+  /* Contains the child prose margins so a block's fill covers its own content
+     instead of collapsing through the wrapper. */
+  display: flow-root;
+  padding: 0.25rem 0.75rem;
+  border-radius: var(--radius-xs);
+}
+
+/* An unchanged block is the document as it reads — no fill, no edge, nothing
+   competing with the two states that carry meaning. */
+.rendered-markdown-diff__block--unchanged {
+  padding-inline: 0.75rem;
+}
+
+.rendered-markdown-diff__block--added,
+.rendered-markdown-diff__block--removed {
+  /* Real border, not a ring: box-shadow rings are dropped entirely in forced
+     colors, taking the only non-color signal with them. */
+  border-inline-start: 3px solid transparent;
+  padding-inline-start: calc(0.75rem - 3px);
+  margin-block: 0.25rem;
+}
+
+.rendered-markdown-diff__block--added {
+  background: var(--color-diff-insert-background);
+  border-inline-start-color: var(--color-diff-gutter-insert);
+}
+
+.rendered-markdown-diff__block--removed {
+  background: var(--color-diff-delete-background);
+  border-inline-start-color: var(--color-diff-gutter-delete);
+  /* GitHub's rich-diff treatment: a removed block reads as struck-out prose,
+     which is what makes it legible as "this text is gone" without recoloring
+     the text itself and losing contrast over the fill. */
+  text-decoration: line-through;
+  text-decoration-color: color-mix(in oklab, var(--color-text-primary) 45%, transparent);
+  text-decoration-thickness: 1px;
+}
+
+/* Strikethrough belongs on prose, not on a code fence or a table grid, where it
+   cuts through characters that have to stay readable. */
+.rendered-markdown-diff__block--removed :where(pre, table) {
+  text-decoration: none;
+}
+
+/* The status marker. Sits in the inline-start padding so it never displaces the
+   prose, and is a character rather than a color so the state survives a palette
+   that can't distinguish red from green. */
+.rendered-markdown-diff__marker {
+  position: absolute;
+  inset-inline-start: 0.125rem;
+  top: 0.3rem;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  line-height: 1.2;
+  user-select: none;
+  text-decoration: none;
+}
+
+.rendered-markdown-diff__block--added > .rendered-markdown-diff__marker {
+  color: var(--color-diff-gutter-insert);
+}
+
+.rendered-markdown-diff__block--removed > .rendered-markdown-diff__marker {
+  color: var(--color-diff-gutter-delete);
+}
+
+/* Word-level marks inside a modified block, using the same edit fills the line
+   diff uses for intra-line marks so the two surfaces read identically. */
+.rendered-markdown-diff__inline {
+  border-radius: var(--radius-xs);
+  padding-block: 0.05em;
+}
+
+.rendered-markdown-diff__inline--added {
+  background: var(--color-diff-insert-edit-background);
+}
+
+.rendered-markdown-diff__inline--removed {
+  background: var(--color-diff-delete-edit-background);
+}
+
+/* A modified block's two halves are one thought; keep them adjacent and let the
+   gap between pairs do the separating. */
+.rendered-markdown-diff__pair > .rendered-markdown-diff__block + .rendered-markdown-diff__block {
+  margin-block-start: 0;
+}
+
+@media (forced-colors: active) {
+  /* Author fills are dropped by the system anyway; the edge and the marker are
+     what survive, so they carry the whole signal here. */
+  .rendered-markdown-diff__block--added,
+  .rendered-markdown-diff__block--removed {
+    background: Canvas;
+    border-inline-start-width: 4px;
+  }
+
+  .rendered-markdown-diff__block--added {
+    border-inline-start-color: Highlight;
+  }
+
+  .rendered-markdown-diff__block--removed {
+    border-inline-start-color: LinkText;
+  }
+
+  .rendered-markdown-diff__block--added > .rendered-markdown-diff__marker,
+  .rendered-markdown-diff__block--removed > .rendered-markdown-diff__marker {
+    color: CanvasText;
+  }
+
+  /* A background can't mark a word here, so the underline does. */
+  .rendered-markdown-diff__inline {
+    background: none;
+    text-decoration: underline dotted CanvasText;
+    text-underline-offset: 2px;
+  }
+}
+
+@media (prefers-contrast: more) {
+  .rendered-markdown-diff__block--added,
+  .rendered-markdown-diff__block--removed {
+    border-inline-start-width: 4px;
+  }
+
+  .rendered-markdown-diff__block--removed {
+    text-decoration-color: var(--color-text-primary);
+  }
+}

--- a/src/components/Worktree/RenderedMarkdownDiff.tsx
+++ b/src/components/Worktree/RenderedMarkdownDiff.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, type CSSProperties } from "react";
 import ReactMarkdown, { type PluggableList } from "react-markdown";
 import remarkGfm from "remark-gfm";
-import type { Element as HastElement, Nodes as HastNodes, RootContent as HastContent } from "hast";
+import type { Nodes as HastNodes, RootContent as HastContent } from "hast";
 import type { GitStatus } from "@shared/types/git";
 import { useMarkdownRenderPolicy } from "@/components/Markdown/markdownRenderPolicy";
 import { MARKDOWN_FONT_SIZE_TOKEN } from "@/components/Markdown/MarkdownDocument";
@@ -83,11 +83,11 @@ const BLOCK_MARKER: Record<BlockKind, string> = {
  */
 function collectTextNodes(tree: HastNodes): {
   text: string;
-  entries: Array<{ parent: HastElement | HastNodes; index: number; start: number; value: string }>;
+  entries: Array<{ children: HastContent[]; index: number; start: number; value: string }>;
 } {
   let text = "";
   const entries: Array<{
-    parent: HastElement | HastNodes;
+    children: HastContent[];
     index: number;
     start: number;
     value: string;
@@ -103,8 +103,7 @@ function collectTextNodes(tree: HastNodes): {
         // list, table, blockquote and task list disagree with the mdast
         // flattening and so lose its inline marks entirely.
         if (!child.position && !/\S/.test(child.value)) return;
-        if (wrappable)
-          entries.push({ parent: node, index, start: text.length, value: child.value });
+        if (wrappable) entries.push({ children, index, start: text.length, value: child.value });
         text += child.value;
         return;
       }
@@ -166,8 +165,7 @@ function inlineRangePlugin(ranges: readonly TextRange[], expectedText: string, k
       if (cursor < end) {
         replacement.push({ type: "text", value: entry.value.slice(cursor - entry.start) });
       }
-      const children = (entry.parent as { children: HastContent[] }).children;
-      children.splice(entry.index, 1, ...replacement);
+      entry.children.splice(entry.index, 1, ...replacement);
     }
   };
 }

--- a/src/components/Worktree/RenderedMarkdownDiff.tsx
+++ b/src/components/Worktree/RenderedMarkdownDiff.tsx
@@ -1,0 +1,347 @@
+import { useEffect, useMemo, useRef, type CSSProperties } from "react";
+import ReactMarkdown, { type PluggableList } from "react-markdown";
+import remarkGfm from "remark-gfm";
+import type { Element as HastElement, Nodes as HastNodes, RootContent as HastContent } from "hast";
+import type { GitStatus } from "@shared/types/git";
+import { useMarkdownRenderPolicy } from "@/components/Markdown/markdownRenderPolicy";
+import { MARKDOWN_FONT_SIZE_TOKEN } from "@/components/Markdown/MarkdownDocument";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { useScopedSelectAll } from "@/hooks/useScopedSelectAll";
+import { cn } from "@/lib/utils";
+import type { MarkdownFontSize } from "@/store/preferencesStore";
+import {
+  buildMarkdownDiff,
+  type MarkdownBlockChange,
+  type MarkdownDiffFailure,
+  type TextRange,
+} from "./markdownBlockDiff";
+import "@/components/Markdown/MarkdownDocument.css";
+import "./RenderedMarkdownDiff.css";
+
+/**
+ * The rendered-Markdown layout for the diff panel (issue #12171): the document
+ * as it reads, with each changed block marked, instead of the source with each
+ * changed line marked.
+ *
+ * There is deliberately no gutter here, and so no line anchors, no per-line
+ * open-in-editor and no moved-block markers — a rendered document has no lines
+ * for them to attach to. This mode is for reading; the user switches back to
+ * Unified or Split to act on a line.
+ */
+
+export interface RenderedMarkdownDiffProps {
+  /** Raw unified patch text. */
+  diff: string;
+  /** Whole new-side file from disk; absent for a deleted file. */
+  newSource: string | undefined;
+  status: GitStatus;
+  /** Absolute path of the file, for resolving its relative links and images. */
+  filePath: string;
+  /** Containment root for daintree-file:// image loads. */
+  rootPath: string;
+  cacheBust?: string;
+  fontSize?: MarkdownFontSize;
+  /**
+   * Reports whether the engine could build a rendered view from these inputs,
+   * stamped with the diff it judged. The host cannot know in advance — a patch
+   * that won't reconstruct looks like any other — so it keeps the segment live
+   * and falls back to the source diff on the verdict.
+   */
+  onVerdict?: (reason: MarkdownDiffFailure | null, forDiff: string) => void;
+}
+
+type BlockKind = "unchanged" | "added" | "removed";
+
+const BLOCK_LABEL: Record<BlockKind, string> = {
+  unchanged: "",
+  added: "Added block:",
+  removed: "Removed block:",
+};
+
+const BLOCK_MARKER: Record<BlockKind, string> = {
+  unchanged: "",
+  added: "+",
+  removed: "−",
+};
+
+/**
+ * Flatten a hast tree the way the engine flattens mdast, and hand back the text
+ * nodes that may carry inline marks.
+ *
+ * `<pre>` contributes its characters but is never wrapped: the fence body is
+ * rendered by `HighlightedCode`, which reads `String(children)` and would
+ * stringify an injected element into the code. Raw nodes contribute nothing —
+ * `skipHtml` drops them before they render, so counting them would shift every
+ * offset after an embedded HTML tag.
+ */
+function collectTextNodes(tree: HastNodes): {
+  text: string;
+  entries: Array<{ parent: HastElement | HastNodes; index: number; start: number; value: string }>;
+} {
+  let text = "";
+  const entries: Array<{
+    parent: HastElement | HastNodes;
+    index: number;
+    start: number;
+    value: string;
+  }> = [];
+  const walk = (node: HastNodes, wrappable: boolean): void => {
+    const children = "children" in node ? (node.children as HastContent[] | undefined) : undefined;
+    if (!children) return;
+    children.forEach((child, index) => {
+      if (child.type === "text") {
+        if (wrappable)
+          entries.push({ parent: node, index, start: text.length, value: child.value });
+        text += child.value;
+        return;
+      }
+      if (child.type !== "element") return;
+      if (child.tagName === "br") {
+        text += "\n";
+        return;
+      }
+      walk(child, wrappable && child.tagName !== "pre");
+    });
+  };
+  walk(tree, true);
+  return { text, entries };
+}
+
+/**
+ * Rehype plugin wrapping the given character ranges of a block's visible text.
+ *
+ * The ranges were measured on the mdast tree, so the plugin re-derives the same
+ * string from the hast tree and does nothing unless the two agree. That check
+ * is the whole safety story for a handful of constructs whose two
+ * representations differ (a GFM footnote reference renders a marker the source
+ * tree has no text for): rather than sliding every mark after one of them, the
+ * block silently keeps its whole-block treatment, which is still correct.
+ */
+function inlineRangePlugin(ranges: readonly TextRange[], expectedText: string, kind: BlockKind) {
+  return () => (tree: HastNodes) => {
+    if (!ranges.length) return;
+    const { text, entries } = collectTextNodes(tree);
+    if (text !== expectedText) return;
+    const className = `rendered-markdown-diff__inline rendered-markdown-diff__inline--${kind}`;
+    // Rebuilt back-to-front within each parent so an earlier splice can't
+    // invalidate a later recorded index.
+    for (const entry of [...entries].reverse()) {
+      const end = entry.start + entry.value.length;
+      const overlapping = ranges.filter((range) => range.start < end && range.end > entry.start);
+      if (!overlapping.length) continue;
+      const replacement: HastContent[] = [];
+      let cursor = entry.start;
+      for (const range of overlapping) {
+        const from = Math.max(range.start, entry.start);
+        const to = Math.min(range.end, end);
+        if (from > cursor) {
+          replacement.push({
+            type: "text",
+            value: entry.value.slice(cursor - entry.start, from - entry.start),
+          });
+        }
+        replacement.push({
+          type: "element",
+          tagName: "span",
+          properties: { className },
+          children: [
+            { type: "text", value: entry.value.slice(from - entry.start, to - entry.start) },
+          ],
+        });
+        cursor = to;
+      }
+      if (cursor < end) {
+        replacement.push({ type: "text", value: entry.value.slice(cursor - entry.start) });
+      }
+      const children = (entry.parent as { children: HastContent[] }).children;
+      children.splice(entry.index, 1, ...replacement);
+    }
+  };
+}
+
+function DiffBlock({
+  kind,
+  source,
+  definitions,
+  ranges,
+  expectedText,
+  components,
+  urlTransform,
+}: {
+  kind: BlockKind;
+  source: string;
+  definitions: string;
+  ranges: readonly TextRange[];
+  expectedText: string;
+  components: ReturnType<typeof useMarkdownRenderPolicy>["components"];
+  urlTransform: ReturnType<typeof useMarkdownRenderPolicy>["urlTransform"];
+}) {
+  // Definitions live anywhere in the document but are referenced from a block,
+  // so a block rendered on its own would lose its link targets. They render to
+  // nothing, so appending them unconditionally is cheaper than tracking which
+  // block referenced which.
+  const content = definitions ? `${source}\n\n${definitions}` : source;
+  const rehypePlugins = useMemo<PluggableList>(
+    () => (ranges.length ? [inlineRangePlugin(ranges, expectedText, kind)] : []),
+    [ranges, expectedText, kind]
+  );
+
+  return (
+    <div
+      className={cn("rendered-markdown-diff__block", `rendered-markdown-diff__block--${kind}`)}
+      data-block-kind={kind}
+    >
+      {kind !== "unchanged" && (
+        <>
+          <span className="sr-only">{BLOCK_LABEL[kind]}</span>
+          <span className="rendered-markdown-diff__marker" aria-hidden="true">
+            {BLOCK_MARKER[kind]}
+          </span>
+        </>
+      )}
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        rehypePlugins={rehypePlugins}
+        urlTransform={urlTransform}
+        components={components}
+        skipHtml
+      >
+        {content}
+      </ReactMarkdown>
+    </div>
+  );
+}
+
+type MarkdownFontStyle = CSSProperties & Record<"--markdown-font-size", string>;
+
+export function RenderedMarkdownDiff({
+  diff,
+  newSource,
+  status,
+  filePath,
+  rootPath,
+  cacheBust,
+  fontSize,
+  onVerdict,
+}: RenderedMarkdownDiffProps) {
+  const rootRef = useRef<HTMLDivElement>(null);
+  useScopedSelectAll(rootRef);
+
+  // Reconstruction, parsing and both LCS passes run here and nowhere else. The
+  // React Compiler memoizes component output, not synchronous work in a render
+  // body, so without this the whole pipeline would re-run on every keystroke
+  // that re-renders the panel.
+  const result = useMemo(
+    () => buildMarkdownDiff({ diff, newSource, status }),
+    [diff, newSource, status]
+  );
+
+  const reason = result.ok ? null : result.reason;
+  useEffect(() => {
+    onVerdict?.(reason, diff);
+  }, [onVerdict, reason, diff]);
+
+  // Removed blocks resolve their relative links and images against the current
+  // path too. On a rename that is the wrong directory for the old side, and a
+  // local image in a removed block shows its current bytes rather than the ones
+  // that revision had — the protocol handler reads the working tree, and a
+  // historical blob would need an IPC this view deliberately avoids.
+  const { components, urlTransform } = useMarkdownRenderPolicy({
+    filePath,
+    rootPath,
+    cacheBust,
+  });
+
+  const fontStyle: MarkdownFontStyle | undefined =
+    fontSize === undefined
+      ? undefined
+      : { "--markdown-font-size": MARKDOWN_FONT_SIZE_TOKEN[fontSize] };
+
+  // The host swaps back to the source diff on the verdict; render nothing in
+  // the frame between.
+  if (!result.ok) return null;
+
+  if (result.model.identical) {
+    return (
+      <div className="flex h-full w-full items-center justify-center p-6">
+        <EmptyState
+          variant="zero-data"
+          scale="canvas"
+          title="No rendered content changes"
+          description="The source changed, but the rendered Markdown is the same."
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={rootRef}
+      data-testid="rendered-markdown-diff"
+      className="rendered-markdown-diff markdown-document prose px-6 py-5"
+      style={fontStyle}
+    >
+      {result.model.changes.map((change, index) => (
+        <BlockChange
+          key={index}
+          change={change}
+          oldDefinitions={result.model.oldDefinitions}
+          newDefinitions={result.model.newDefinitions}
+          components={components}
+          urlTransform={urlTransform}
+        />
+      ))}
+    </div>
+  );
+}
+
+function BlockChange({
+  change,
+  oldDefinitions,
+  newDefinitions,
+  components,
+  urlTransform,
+}: {
+  change: MarkdownBlockChange;
+  oldDefinitions: string;
+  newDefinitions: string;
+  components: ReturnType<typeof useMarkdownRenderPolicy>["components"];
+  urlTransform: ReturnType<typeof useMarkdownRenderPolicy>["urlTransform"];
+}) {
+  const shared = { components, urlTransform };
+  if (change.kind === "modified") {
+    // Removed then added, GitHub's ordering: the reader sees what the block
+    // said before the replacement that follows it.
+    return (
+      <div className="rendered-markdown-diff__pair">
+        <DiffBlock
+          kind="removed"
+          source={change.old.source}
+          definitions={oldDefinitions}
+          ranges={change.inline.old}
+          expectedText={change.old.text}
+          {...shared}
+        />
+        <DiffBlock
+          kind="added"
+          source={change.new.source}
+          definitions={newDefinitions}
+          ranges={change.inline.new}
+          expectedText={change.new.text}
+          {...shared}
+        />
+      </div>
+    );
+  }
+  const kind = change.kind === "unchanged" ? "unchanged" : change.kind;
+  return (
+    <DiffBlock
+      kind={kind}
+      source={change.block.source}
+      definitions={change.kind === "removed" ? oldDefinitions : newDefinitions}
+      ranges={[]}
+      expectedText={change.block.text}
+      {...shared}
+    />
+  );
+}

--- a/src/components/Worktree/RenderedMarkdownDiff.tsx
+++ b/src/components/Worktree/RenderedMarkdownDiff.tsx
@@ -42,12 +42,19 @@ export interface RenderedMarkdownDiffProps {
   cacheBust?: string;
   fontSize?: MarkdownFontSize;
   /**
-   * Reports whether the engine could build a rendered view from these inputs,
-   * stamped with the diff it judged. The host cannot know in advance — a patch
-   * that won't reconstruct looks like any other — so it keeps the segment live
-   * and falls back to the source diff on the verdict.
+   * Opaque identity of this rendering attempt, echoed back with the verdict.
+   * The host derives it from every input the engine consumes, so a verdict can
+   * never outlive the inputs that produced it — stamping the patch text alone
+   * left a failure applying to a later attempt that shared it.
    */
-  onVerdict?: (reason: MarkdownDiffFailure | null, forDiff: string) => void;
+  attemptKey: string;
+  /**
+   * Reports whether the engine could build a rendered view from these inputs.
+   * The host cannot know in advance — a patch that won't reconstruct looks like
+   * any other — so it keeps the segment live and falls back to the source diff
+   * on the verdict.
+   */
+  onVerdict?: (reason: MarkdownDiffFailure | null, forAttempt: string) => void;
 }
 
 type BlockKind = "unchanged" | "added" | "removed";
@@ -90,6 +97,12 @@ function collectTextNodes(tree: HastNodes): {
     if (!children) return;
     children.forEach((child, index) => {
       if (child.type === "text") {
+        // mdast-util-to-hast inserts its own whitespace text nodes to lay out
+        // the markup — between list items, around table sections, after a
+        // <br>. They carry no source position, and counting them made every
+        // list, table, blockquote and task list disagree with the mdast
+        // flattening and so lose its inline marks entirely.
+        if (!child.position && !/\S/.test(child.value)) return;
         if (wrappable)
           entries.push({ parent: node, index, start: text.length, value: child.value });
         text += child.value;
@@ -222,6 +235,7 @@ export function RenderedMarkdownDiff({
   rootPath,
   cacheBust,
   fontSize,
+  attemptKey,
   onVerdict,
 }: RenderedMarkdownDiffProps) {
   const rootRef = useRef<HTMLDivElement>(null);
@@ -238,8 +252,8 @@ export function RenderedMarkdownDiff({
 
   const reason = result.ok ? null : result.reason;
   useEffect(() => {
-    onVerdict?.(reason, diff);
-  }, [onVerdict, reason, diff]);
+    onVerdict?.(reason, attemptKey);
+  }, [onVerdict, reason, attemptKey]);
 
   // Removed blocks resolve their relative links and images against the current
   // path too. On a rename that is the wrong directory for the old side, and a

--- a/src/components/Worktree/RenderedMarkdownDiff.tsx
+++ b/src/components/Worktree/RenderedMarkdownDiff.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, type CSSProperties } from "react";
-import ReactMarkdown, { type PluggableList } from "react-markdown";
+import ReactMarkdown from "react-markdown";
+import type { PluggableList } from "unified";
 import remarkGfm from "remark-gfm";
 import type { Nodes as HastNodes, RootContent as HastContent } from "hast";
 import type { GitStatus } from "@shared/types/git";
@@ -134,7 +135,8 @@ function inlineRangePlugin(ranges: readonly TextRange[], expectedText: string, k
     if (!ranges.length) return;
     const { text, entries } = collectTextNodes(tree);
     if (text !== expectedText) return;
-    const className = `rendered-markdown-diff__inline rendered-markdown-diff__inline--${kind}`;
+    // hast models a class attribute as a list, not the joined string.
+    const className = ["rendered-markdown-diff__inline", `rendered-markdown-diff__inline--${kind}`];
     // Rebuilt back-to-front within each parent so an earlier splice can't
     // invalidate a later recorded index.
     for (const entry of [...entries].reverse()) {

--- a/src/components/Worktree/RenderedMarkdownDiff.tsx
+++ b/src/components/Worktree/RenderedMarkdownDiff.tsx
@@ -189,10 +189,12 @@ function DiffBlock({
   components: ReturnType<typeof useMarkdownRenderPolicy>["components"];
   urlTransform: ReturnType<typeof useMarkdownRenderPolicy>["urlTransform"];
 }) {
-  // Definitions live anywhere in the document but are referenced from a block,
-  // so a block rendered on its own would lose its link targets. They render to
-  // nothing, so appending them unconditionally is cheaper than tracking which
-  // block referenced which.
+  // Definitions live anywhere in the document but are cited from a block, so a
+  // block rendered on its own would lose its link targets. Appended only to the
+  // blocks that actually cite one: a footnote definition renders a whole
+  // footnote section, so attaching them to every block put one under every
+  // paragraph. Two blocks citing different footnotes still mint the same
+  // generated ids, which is a cosmetic duplicate rather than a wrong render.
   const content = definitions ? `${source}\n\n${definitions}` : source;
   const rehypePlugins = useMemo<PluggableList>(
     () => (ranges.length ? [inlineRangePlugin(ranges, expectedText, kind)] : []),
@@ -331,7 +333,7 @@ function BlockChange({
         <DiffBlock
           kind="removed"
           source={change.old.source}
-          definitions={oldDefinitions}
+          definitions={change.old.referenceIds.length ? oldDefinitions : ""}
           ranges={change.inline.old}
           expectedText={change.old.text}
           {...shared}
@@ -339,7 +341,7 @@ function BlockChange({
         <DiffBlock
           kind="added"
           source={change.new.source}
-          definitions={newDefinitions}
+          definitions={change.new.referenceIds.length ? newDefinitions : ""}
           ranges={change.inline.new}
           expectedText={change.new.text}
           {...shared}
@@ -348,11 +350,16 @@ function BlockChange({
     );
   }
   const kind = change.kind === "unchanged" ? "unchanged" : change.kind;
+  const definitions = change.block.referenceIds.length
+    ? change.kind === "removed"
+      ? oldDefinitions
+      : newDefinitions
+    : "";
   return (
     <DiffBlock
       kind={kind}
       source={change.block.source}
-      definitions={change.kind === "removed" ? oldDefinitions : newDefinitions}
+      definitions={definitions}
       ranges={[]}
       expectedText={change.block.text}
       {...shared}

--- a/src/components/Worktree/__tests__/RenderedMarkdownDiff.test.tsx
+++ b/src/components/Worktree/__tests__/RenderedMarkdownDiff.test.tsx
@@ -1,0 +1,223 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/react";
+
+const { dispatchMock } = vi.hoisted(() => ({
+  dispatchMock: vi.fn().mockResolvedValue({ ok: true, result: undefined }),
+}));
+vi.mock("@/services/ActionService", () => ({
+  actionService: { dispatch: dispatchMock },
+}));
+
+vi.mock("@/hooks/useScopedSelectAll", () => ({ useScopedSelectAll: () => {} }));
+
+vi.mock("@/components/ui/EmptyState", () => ({
+  EmptyState: (props: { title: string; description?: string }) => (
+    <div data-testid="empty-state" data-title={props.title} data-description={props.description} />
+  ),
+}));
+
+import { RenderedMarkdownDiff } from "../RenderedMarkdownDiff";
+
+const ROOT = "/repo";
+const FILE = "/repo/docs/guide.md";
+
+function patch(hunks: string[]): string {
+  return [
+    "diff --git a/docs/guide.md b/docs/guide.md",
+    "--- a/docs/guide.md",
+    "+++ b/docs/guide.md",
+    ...hunks,
+  ].join("\n");
+}
+
+function renderDiff(
+  diff: string,
+  newSource: string | undefined,
+  overrides: Partial<Parameters<typeof RenderedMarkdownDiff>[0]> = {}
+) {
+  return render(
+    <RenderedMarkdownDiff
+      diff={diff}
+      newSource={newSource}
+      status="modified"
+      filePath={FILE}
+      rootPath={ROOT}
+      {...overrides}
+    />
+  );
+}
+
+function blockKinds(container: HTMLElement): string[] {
+  return [...container.querySelectorAll("[data-block-kind]")].map(
+    (element) => element.getAttribute("data-block-kind") ?? ""
+  );
+}
+
+const EDITED_DIFF = patch([
+  "@@ -1,3 +1,3 @@",
+  " # Guide",
+  " ",
+  "-The quick brown fox jumps over the lazy dog.",
+  "+The quick brown fox leaps over the lazy dog.",
+]);
+const EDITED_SOURCE = "# Guide\n\nThe quick brown fox leaps over the lazy dog.\n";
+
+beforeEach(() => {
+  dispatchMock.mockClear();
+});
+
+describe("RenderedMarkdownDiff", () => {
+  it("renders the document, marking the changed block on both sides", () => {
+    const { container } = renderDiff(EDITED_DIFF, EDITED_SOURCE);
+
+    expect(container.querySelector("h1")?.textContent).toBe("Guide");
+    expect(blockKinds(container)).toEqual(["unchanged", "removed", "added"]);
+  });
+
+  it("marks only the changed words inside a modified pair", () => {
+    const { container } = renderDiff(EDITED_DIFF, EDITED_SOURCE);
+
+    const removed = container.querySelector(
+      ".rendered-markdown-diff__block--removed .rendered-markdown-diff__inline--removed"
+    );
+    const added = container.querySelector(
+      ".rendered-markdown-diff__block--added .rendered-markdown-diff__inline--added"
+    );
+
+    expect(removed?.textContent).toBe("jumps");
+    expect(added?.textContent).toBe("leaps");
+  });
+
+  it("names each changed block for a screen reader and shows a non-colour marker", () => {
+    const { container } = renderDiff(EDITED_DIFF, EDITED_SOURCE);
+
+    const removed = container.querySelector(".rendered-markdown-diff__block--removed");
+    const added = container.querySelector(".rendered-markdown-diff__block--added");
+
+    expect(removed?.querySelector(".sr-only")?.textContent).toBe("Removed block:");
+    expect(added?.querySelector(".sr-only")?.textContent).toBe("Added block:");
+    expect(removed?.querySelector(".rendered-markdown-diff__marker")?.textContent).toBe("−");
+    expect(added?.querySelector(".rendered-markdown-diff__marker")?.textContent).toBe("+");
+  });
+
+  it("mounts no line gutter, hunk header or line anchor", () => {
+    const { container } = renderDiff(EDITED_DIFF, EDITED_SOURCE);
+
+    expect(container.querySelector(".diff-gutter")).toBe(null);
+    expect(container.querySelector(".diff-hunk-header")).toBe(null);
+    expect(container.querySelector("table.diff")).toBe(null);
+  });
+
+  it("renders GFM tables and task lists", () => {
+    const source = "| a | b |\n| - | - |\n| 1 | 2 |\n\n- [x] done\n";
+    const diff = patch([
+      "@@ -0,0 +1,5 @@",
+      "+| a | b |",
+      "+| - | - |",
+      "+| 1 | 2 |",
+      "+",
+      "+- [x] done",
+    ]);
+
+    const { container } = renderDiff(diff, source, { status: "added" });
+
+    expect(container.querySelectorAll("table th")).toHaveLength(2);
+    expect(container.querySelector('input[type="checkbox"]')).not.toBe(null);
+  });
+
+  it("never lets embedded HTML reach the DOM", () => {
+    const source = 'Text.\n\n<img src="x" onerror="alert(1)">\n';
+    const diff = patch([
+      "@@ -1,3 +1,3 @@",
+      " Text.",
+      " ",
+      '-<img src="y" onerror="alert(1)">',
+      '+<img src="x" onerror="alert(1)">',
+    ]);
+
+    const { container } = renderDiff(diff, source);
+
+    expect(container.querySelector("img")).toBe(null);
+    expect(container.innerHTML).not.toContain("onerror");
+  });
+
+  it("says so when the source changed but the rendered document did not", () => {
+    const source = 'Text.\n\n<div id="b">x</div>\n';
+    const diff = patch([
+      "@@ -1,3 +1,3 @@",
+      " Text.",
+      " ",
+      '-<div id="a">x</div>',
+      '+<div id="b">x</div>',
+    ]);
+
+    const { getByTestId } = renderDiff(diff, source);
+
+    expect(getByTestId("empty-state").getAttribute("data-title")).toBe(
+      "No rendered content changes"
+    );
+  });
+
+  it("routes an external link through openExternal instead of navigating", () => {
+    const source = "Read [the docs](https://example.com).\n";
+    const diff = patch(["@@ -0,0 +1,1 @@", "+Read [the docs](https://example.com)."]);
+
+    const { container } = renderDiff(diff, source, { status: "added" });
+    const link = container.querySelector("a");
+    link?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+
+    expect(dispatchMock).toHaveBeenCalledWith(
+      "browser.openExternal",
+      { url: "https://example.com" },
+      { source: "user" }
+    );
+  });
+
+  it("refuses to open a repo link that escapes the containment root", () => {
+    const source = "See [escape](../../../etc/passwd).\n";
+    const diff = patch(["@@ -0,0 +1,1 @@", "+See [escape](../../../etc/passwd)."]);
+
+    const { container } = renderDiff(diff, source, { status: "added" });
+    container
+      .querySelector("a")
+      ?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+
+    expect(dispatchMock).not.toHaveBeenCalled();
+  });
+
+  it("resolves a local image through the contained protocol URL", () => {
+    const source = "![shot](./img/a.png)\n";
+    const diff = patch(["@@ -0,0 +1,1 @@", "+![shot](./img/a.png)"]);
+
+    const { container } = renderDiff(diff, source, { status: "added" });
+
+    expect(container.querySelector("img")?.getAttribute("src")).toContain("daintree-file://");
+  });
+
+  it("reports its refusal to the host, stamped with the diff it judged", () => {
+    const onVerdict = vi.fn();
+    const diff = patch(["@@ -1,2 +1,2 @@", " intro", "-old", "+new"]);
+
+    renderDiff(diff, "intro\ndrifted\n", { onVerdict });
+
+    expect(onVerdict).toHaveBeenCalledWith("source-mismatch", diff);
+  });
+
+  it("reports a clean verdict when the document rebuilt", () => {
+    const onVerdict = vi.fn();
+
+    renderDiff(EDITED_DIFF, EDITED_SOURCE, { onVerdict });
+
+    expect(onVerdict).toHaveBeenCalledWith(null, EDITED_DIFF);
+  });
+
+  it("rebuilds a deleted document from the patch with no source on disk", () => {
+    const diff = patch(["@@ -1,3 +0,0 @@", "-# Gone", "-", "-Body text here."]);
+
+    const { container } = renderDiff(diff, undefined, { status: "deleted" });
+
+    expect(blockKinds(container)).toEqual(["removed", "removed"]);
+    expect(container.textContent).toContain("Body text here.");
+  });
+});

--- a/src/components/Worktree/__tests__/RenderedMarkdownDiff.test.tsx
+++ b/src/components/Worktree/__tests__/RenderedMarkdownDiff.test.tsx
@@ -43,6 +43,7 @@ function renderDiff(
       status="modified"
       filePath={FILE}
       rootPath={ROOT}
+      attemptKey="attempt-1"
       {...overrides}
     />
   );
@@ -195,21 +196,57 @@ describe("RenderedMarkdownDiff", () => {
     expect(container.querySelector("img")?.getAttribute("src")).toContain("daintree-file://");
   });
 
-  it("reports its refusal to the host, stamped with the diff it judged", () => {
+  it("reports its refusal to the host, stamped with the attempt it judged", () => {
     const onVerdict = vi.fn();
     const diff = patch(["@@ -1,2 +1,2 @@", " intro", "-old", "+new"]);
 
-    renderDiff(diff, "intro\ndrifted\n", { onVerdict });
+    renderDiff(diff, "intro\ndrifted\n", { onVerdict, attemptKey: "attempt-7" });
 
-    expect(onVerdict).toHaveBeenCalledWith("source-mismatch", diff);
+    expect(onVerdict).toHaveBeenCalledWith("source-mismatch", "attempt-7");
   });
 
   it("reports a clean verdict when the document rebuilt", () => {
     const onVerdict = vi.fn();
 
-    renderDiff(EDITED_DIFF, EDITED_SOURCE, { onVerdict });
+    renderDiff(EDITED_DIFF, EDITED_SOURCE, { onVerdict, attemptKey: "attempt-7" });
 
-    expect(onVerdict).toHaveBeenCalledWith(null, EDITED_DIFF);
+    expect(onVerdict).toHaveBeenCalledWith(null, "attempt-7");
+  });
+
+  it("marks changed words inside a list item, not just a bare paragraph", () => {
+    // mdast-util-to-hast pads list markup with its own whitespace text nodes;
+    // counting them made the two flattenings disagree and every list, table and
+    // blockquote silently lose its inline marks.
+    const source = "- The quick brown fox leaps over the lazy dog.\n";
+    const diff = patch([
+      "@@ -1,1 +1,1 @@",
+      "-- The quick brown fox jumps over the lazy dog.",
+      "+- The quick brown fox leaps over the lazy dog.",
+    ]);
+
+    const { container } = renderDiff(diff, source);
+
+    expect(container.querySelector("li .rendered-markdown-diff__inline--added")?.textContent).toBe(
+      "leaps"
+    );
+  });
+
+  it("keeps a footnote's text in the rendered output", () => {
+    const source = "Text[^1].\n\n[^1]: The new note.\n";
+    const diff = patch([
+      "@@ -1,3 +1,3 @@",
+      " Text[^1].",
+      " ",
+      "-[^1]: The old note.",
+      "+[^1]: The new note.",
+    ]);
+
+    const { container } = renderDiff(diff, source);
+
+    // The note rides with the block that cites it; rendered alone it would emit
+    // nothing and the paragraph would show a literal "[^1]".
+    expect(container.textContent).toContain("The new note.");
+    expect(container.textContent).not.toContain("[^1].");
   });
 
   it("rebuilds a deleted document from the patch with no source on disk", () => {

--- a/src/components/Worktree/__tests__/RenderedMarkdownDiff.test.tsx
+++ b/src/components/Worktree/__tests__/RenderedMarkdownDiff.test.tsx
@@ -250,7 +250,16 @@ describe("RenderedMarkdownDiff", () => {
   });
 
   it("rebuilds a deleted document from the patch with no source on disk", () => {
-    const diff = patch(["@@ -1,3 +0,0 @@", "-# Gone", "-", "-Body text here."]);
+    const diff = [
+      "diff --git a/docs/guide.md b/docs/guide.md",
+      "deleted file mode 100644",
+      "--- a/docs/guide.md",
+      "+++ /dev/null",
+      "@@ -1,3 +0,0 @@",
+      "-# Gone",
+      "-",
+      "-Body text here.",
+    ].join("\n");
 
     const { container } = renderDiff(diff, undefined, { status: "deleted" });
 

--- a/src/components/Worktree/__tests__/diffEditSuppression.test.ts
+++ b/src/components/Worktree/__tests__/diffEditSuppression.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { markEdits, parseDiff, tokenize } from "react-diff-view";
 import type { HunkData, TokenNode, TokenPath } from "react-diff-view";
-import { suppressFullLineEdits } from "../diffEditSuppression";
+import {
+  EDIT_COVERAGE_LIMIT,
+  shouldSuppressEdits,
+  suppressFullLineEdits,
+} from "../diffEditSuppression";
 
 function textPath(value: string): TokenPath {
   return [{ type: "text", value }];
@@ -82,5 +86,26 @@ index 0000001..0000002 100644
     const newLines = tokens.new as TokenNode[][];
     expect(treeHasEdit(newLines[1] ?? [])).toBe(true);
     expect(treeHasEdit(newLines[10] ?? [])).toBe(false);
+  });
+});
+
+// The predicate the rendered Markdown diff shares with the line diff (#12171):
+// both surfaces have to land on the same side of the same judgment.
+describe("shouldSuppressEdits", () => {
+  it("keeps marks at exactly the limit and drops them past it", () => {
+    const total = 100;
+    const atLimit = Math.round(total * EDIT_COVERAGE_LIMIT);
+    expect(shouldSuppressEdits(total, atLimit, "x".repeat(atLimit))).toBe(false);
+    expect(shouldSuppressEdits(total, atLimit + 1, "x".repeat(atLimit + 1))).toBe(true);
+  });
+
+  it("exempts whitespace-only edits at any coverage", () => {
+    expect(shouldSuppressEdits(10, 9, "         ")).toBe(false);
+    expect(shouldSuppressEdits(10, 9, "\t\t\t\t\t\t\t\t\t")).toBe(false);
+  });
+
+  it("says nothing to suppress when there are no edits or no content", () => {
+    expect(shouldSuppressEdits(100, 0, "")).toBe(false);
+    expect(shouldSuppressEdits(0, 0, "")).toBe(false);
   });
 });

--- a/src/components/Worktree/__tests__/markdownBlockDiff.test.ts
+++ b/src/components/Worktree/__tests__/markdownBlockDiff.test.ts
@@ -20,6 +20,17 @@ function patch(hunks: string[], path = "doc.md"): string {
   return [`diff --git a/${path} b/${path}`, `--- a/${path}`, `+++ b/${path}`, ...hunks].join("\n");
 }
 
+/** A deletion the way git emits one — the metadata is what marks it a deletion. */
+function deletionPatch(hunks: string[], path = "doc.md"): string {
+  return [
+    `diff --git a/${path} b/${path}`,
+    "deleted file mode 100644",
+    `--- a/${path}`,
+    "+++ /dev/null",
+    ...hunks,
+  ].join("\n");
+}
+
 function kinds(changes: readonly MarkdownBlockChange[]): string[] {
   return changes.map((change) => change.kind);
 }
@@ -125,7 +136,17 @@ describe("reconstructMarkdownDocuments", () => {
   it("refuses a partial deletion presented as a deleted file", () => {
     // Contiguous from line 1, but it keeps a context line — accepting it would
     // show "# Kept" as deleted prose when the patch says it survives.
-    const diff = patch(["@@ -1,2 +1,1 @@", " # Kept", "-Removed"]);
+    const diff = deletionPatch(["@@ -1,2 +1,1 @@", " # Kept", "-Removed"]);
+
+    expect(reconstructMarkdownDocuments({ diff, newSource: undefined, status: "deleted" })).toEqual(
+      { ok: false, reason: "unsupported-patch" }
+    );
+  });
+
+  it("refuses a zero-context head deletion the patch doesn't call a deletion", () => {
+    // Same hunk shape as a whole-file removal, but the metadata says the file
+    // survives — a panel holding a stale "deleted" status must not be enough.
+    const diff = patch(["@@ -1,2 +0,0 @@", "-a", "-b"]);
 
     expect(reconstructMarkdownDocuments({ diff, newSource: undefined, status: "deleted" })).toEqual(
       { ok: false, reason: "unsupported-patch" }
@@ -133,7 +154,7 @@ describe("reconstructMarkdownDocuments", () => {
   });
 
   it("rebuilds a deleted file from the patch alone, with no disk read", () => {
-    const diff = patch(["@@ -1,3 +0,0 @@", "-# Gone", "-", "-Body."]);
+    const diff = deletionPatch(["@@ -1,3 +0,0 @@", "-# Gone", "-", "-Body."]);
 
     const result = reconstructMarkdownDocuments({ diff, newSource: undefined, status: "deleted" });
 
@@ -217,7 +238,19 @@ describe("reconstructMarkdownDocuments", () => {
 
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    expect(result.documents.old).toBe("one\ntwo");
+    expect(result.documents.old).toBe("one\ntwo\n");
+    expect(result.documents.new).toBe("");
+  });
+
+  it("reconstructs an added file that is empty", () => {
+    // `"".split("\n")` is `[""]`, so the producer emits one empty insert.
+    const diff = patch(["@@ -0,0 +1,1 @@", "+"]);
+
+    const result = reconstructMarkdownDocuments({ diff, newSource: "", status: "added" });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.documents.old).toBe("");
     expect(result.documents.new).toBe("");
   });
 
@@ -282,14 +315,15 @@ describe("parseMarkdownBlocks", () => {
     expect(definitions).toBe("[^1]: The note.");
   });
 
-  it("flags the blocks that resolve through a definition", () => {
+  it("records which definition each block resolves through", () => {
     // remark only produces a linkReference when the definition resolves;
     // without it the brackets are literal text.
-    const { blocks } = parseMarkdownBlocks(
+    const { blocks, definitionsById } = parseMarkdownBlocks(
       "Plain text.\n\nSee [docs][d].\n\n[d]: https://example.com\n"
     );
 
-    expect(blocks.map((block) => block.hasReference)).toEqual([false, true]);
+    expect(blocks.map((block) => block.referenceIds)).toEqual([[], ["d"]]);
+    expect(definitionsById.get("d")).toBe("[d]: https://example.com");
   });
 
   it("collects link reference definitions apart from the visible blocks", () => {
@@ -535,6 +569,42 @@ describe("buildMarkdownDiff", () => {
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(result.model.identical).toBe(true);
+  });
+
+  it("only touches the blocks citing the definition that moved", () => {
+    // A wholesale comparison of the document's definitions would mark the
+    // `[keep]` paragraph as edited too, purely because a sibling moved.
+    const newSource =
+      "Uses [keep][keep].\n\nUses [moved][moved].\n\n[keep]: /same\n[moved]: /new\n";
+    const diff = patch([
+      "@@ -1,6 +1,6 @@",
+      " Uses [keep][keep].",
+      " ",
+      " Uses [moved][moved].",
+      " ",
+      " [keep]: /same",
+      "-[moved]: /old",
+      "+[moved]: /new",
+    ]);
+
+    const result = buildMarkdownDiff({ diff, newSource, status: "modified" });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(kinds(result.model.changes)).toEqual(["unchanged", "modified"]);
+  });
+
+  it("catches a definition being removed outright", () => {
+    // The new side parses `[docs][d]` as literal text with no reference at all,
+    // so testing only the new block would miss the case that changed most.
+    const newSource = "See [docs][d].\n";
+    const diff = patch(["@@ -1,3 +1,1 @@", " See [docs][d].", "-", "-[d]: https://example.com"]);
+
+    const result = buildMarkdownDiff({ diff, newSource, status: "modified" });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.model.identical).toBe(false);
   });
 
   it("passes the engine's refusal through rather than rendering a guess", () => {

--- a/src/components/Worktree/__tests__/markdownBlockDiff.test.ts
+++ b/src/components/Worktree/__tests__/markdownBlockDiff.test.ts
@@ -1,0 +1,436 @@
+import { describe, expect, it } from "vitest";
+import {
+  blockSimilarity,
+  buildMarkdownDiff,
+  diffMarkdownBlocks,
+  inlineWordRanges,
+  parseMarkdownBlocks,
+  reconstructMarkdownDocuments,
+  MARKDOWN_DIFF_MAX_BLOCKS,
+  MARKDOWN_DIFF_MAX_LINES,
+  PAIR_SIMILARITY_THRESHOLD,
+  type MarkdownBlockChange,
+} from "../markdownBlockDiff";
+
+/**
+ * Build a unified patch the way `git.getFileDiff` returns one, so the tests
+ * exercise the same shape the panel actually receives.
+ */
+function patch(hunks: string[], path = "doc.md"): string {
+  return [`diff --git a/${path} b/${path}`, `--- a/${path}`, `+++ b/${path}`, ...hunks].join("\n");
+}
+
+function kinds(changes: readonly MarkdownBlockChange[]): string[] {
+  return changes.map((change) => change.kind);
+}
+
+describe("reconstructMarkdownDocuments", () => {
+  it("rebuilds the old document by reverse-applying one hunk onto the new file", () => {
+    const newSource = "# Title\n\nSecond line rewritten.\n\nTail.\n";
+    const diff = patch([
+      "@@ -1,5 +1,5 @@",
+      " # Title",
+      " ",
+      "-Second line original.",
+      "+Second line rewritten.",
+      " ",
+      " Tail.",
+    ]);
+
+    const result = reconstructMarkdownDocuments({ diff, newSource, status: "modified" });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.documents.old).toBe("# Title\n\nSecond line original.\n\nTail.");
+    expect(result.documents.new).toBe("# Title\n\nSecond line rewritten.\n\nTail.");
+  });
+
+  it("carries the unchanged gap between two hunks through from the new file", () => {
+    const newSource = ["one NEW", "gap a", "gap b", "gap c", "five NEW"].join("\n");
+    const diff = patch([
+      "@@ -1,1 +1,1 @@",
+      "-one OLD",
+      "+one NEW",
+      "@@ -5,1 +5,1 @@",
+      "-five OLD",
+      "+five NEW",
+    ]);
+
+    const result = reconstructMarkdownDocuments({ diff, newSource, status: "modified" });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // The gap is trusted verbatim; only the hunk lines are swapped back.
+    expect(result.documents.old).toBe(
+      ["one OLD", "gap a", "gap b", "gap c", "five OLD"].join("\n")
+    );
+  });
+
+  it("rejects a source that has drifted from the patch rather than inventing context", () => {
+    const diff = patch(["@@ -1,2 +1,2 @@", " intro", "-old line", "+new line"]);
+
+    const result = reconstructMarkdownDocuments({
+      diff,
+      newSource: "intro\nsomething else entirely\n",
+      status: "modified",
+    });
+
+    expect(result).toEqual({ ok: false, reason: "source-mismatch" });
+  });
+
+  it("strips the carriage returns a CRLF checkout carries but the patch does not", () => {
+    const diff = patch(["@@ -1,2 +1,2 @@", " intro", "-old line", "+new line"]);
+
+    const result = reconstructMarkdownDocuments({
+      diff,
+      newSource: "intro\r\nnew line\r\n",
+      status: "modified",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.documents.old).toBe("intro\nold line");
+    expect(result.documents.new).toBe("intro\nnew line");
+  });
+
+  it("treats an addition as all-inserts over an empty old side", () => {
+    const diff = patch(["@@ -0,0 +1,3 @@", "+# New", "+", "+Body."]);
+
+    const result = reconstructMarkdownDocuments({
+      diff,
+      newSource: "# New\n\nBody.\n",
+      status: "added",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.documents.old).toBe("");
+    expect(result.documents.new).toBe("# New\n\nBody.");
+  });
+
+  it("rebuilds a deleted file from the patch alone, with no disk read", () => {
+    const diff = patch(["@@ -1,3 +0,0 @@", "-# Gone", "-", "-Body."]);
+
+    const result = reconstructMarkdownDocuments({ diff, newSource: undefined, status: "deleted" });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.documents.old).toBe("# Gone\n\nBody.");
+    expect(result.documents.new).toBe("");
+  });
+
+  it("treats a hunkless rename as identical content on both sides", () => {
+    const result = reconstructMarkdownDocuments({
+      diff: "diff --git a/old.md b/new.md\nrename from old.md\nrename to new.md\n",
+      newSource: "# Same\n",
+      status: "renamed",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.documents.old).toBe("# Same");
+    expect(result.documents.new).toBe("# Same");
+  });
+
+  it("needs the new side for anything that is not a deletion", () => {
+    const diff = patch(["@@ -1,1 +1,1 @@", "-a", "+b"]);
+
+    expect(
+      reconstructMarkdownDocuments({ diff, newSource: undefined, status: "modified" })
+    ).toEqual({ ok: false, reason: "source-required" });
+  });
+
+  it("refuses a patch that names more than one file", () => {
+    const diff = [
+      patch(["@@ -1,1 +1,1 @@", "-a", "+b"], "one.md"),
+      patch(["@@ -1,1 +1,1 @@", "-c", "+d"], "two.md"),
+    ].join("\n");
+
+    expect(reconstructMarkdownDocuments({ diff, newSource: "b\n", status: "modified" })).toEqual({
+      ok: false,
+      reason: "unsupported-patch",
+    });
+  });
+
+  it("reconstructs from the hunk body, not the header's declared counts", () => {
+    // The header claims three old lines and lists one. react-diff-view also
+    // normalizes a zero-length side to a count of 1, so the counts are not a
+    // trustworthy gate — the body plus the file on disk is what decides.
+    const diff = patch(["@@ -1,3 +1,1 @@", "-a", "+b"]);
+
+    const result = reconstructMarkdownDocuments({ diff, newSource: "b\n", status: "modified" });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.documents.old).toBe("a");
+    expect(result.documents.new).toBe("b");
+  });
+
+  it("still refuses a hunk positioned before the lines already consumed", () => {
+    const diff = patch(["@@ -1,1 +5,1 @@", "-a", "+b", "@@ -3,1 +1,1 @@", "-c", "+d"]);
+
+    expect(
+      reconstructMarkdownDocuments({
+        diff,
+        newSource: "x\nx\nx\nx\nb\n",
+        status: "modified",
+      })
+    ).toEqual({ ok: false, reason: "source-mismatch" });
+  });
+
+  it("stops at the line ceiling instead of committing an unbounded document", () => {
+    const newSource = `${Array.from({ length: MARKDOWN_DIFF_MAX_LINES + 1 }, (_, i) => `line ${i}`).join("\n")}\n`;
+    const diff = patch(["@@ -1,1 +1,1 @@", "-line zero", "+line 0"]);
+
+    expect(reconstructMarkdownDocuments({ diff, newSource, status: "modified" })).toEqual({
+      ok: false,
+      reason: "too-large",
+    });
+  });
+
+  it("refuses text that isn't a patch instead of reporting a fictional no-op", () => {
+    // parseDiff reports unparseable text as a hunkless "modify", which has the
+    // same shape as a real rename — without the header guard this would render
+    // as "both sides identical" and look like a clean diff.
+    expect(
+      reconstructMarkdownDocuments({
+        diff: "not a patch at all",
+        newSource: "x\n",
+        status: "modified",
+      })
+    ).toEqual({ ok: false, reason: "unsupported-patch" });
+  });
+});
+
+describe("parseMarkdownBlocks", () => {
+  it("makes each top-level node one block, keeping lists and tables atomic", () => {
+    const { blocks } = parseMarkdownBlocks(
+      "# Title\n\nA paragraph.\n\n- one\n- two\n\n| a | b |\n| - | - |\n| 1 | 2 |\n"
+    );
+
+    expect(blocks.map((block) => block.type)).toEqual(["heading", "paragraph", "list", "table"]);
+    expect(blocks[2]?.source).toBe("- one\n- two");
+  });
+
+  it("drops raw HTML blocks, which skipHtml never renders", () => {
+    const { blocks } = parseMarkdownBlocks("Before.\n\n<div>hidden</div>\n\nAfter.\n");
+
+    expect(blocks.map((block) => block.type)).toEqual(["paragraph", "paragraph"]);
+  });
+
+  it("collects link reference definitions apart from the visible blocks", () => {
+    const { blocks, definitions } = parseMarkdownBlocks(
+      "See [the docs][d].\n\n[d]: https://example.com\n"
+    );
+
+    expect(blocks).toHaveLength(1);
+    expect(definitions).toBe("[d]: https://example.com");
+  });
+
+  it("gives a fence body the trailing newline the rendered tree has", () => {
+    const { blocks } = parseMarkdownBlocks("```ts\nconst a = 1;\n```\n");
+
+    expect(blocks[0]?.type).toBe("code");
+    expect(blocks[0]?.text).toBe("const a = 1;\n");
+  });
+});
+
+describe("diffMarkdownBlocks", () => {
+  const parse = (source: string) => parseMarkdownBlocks(source).blocks;
+
+  it("anchors identical blocks and marks the rest", () => {
+    const result = diffMarkdownBlocks(
+      parse("# Title\n\nDropped.\n\nKept.\n"),
+      parse("# Title\n\nKept.\n\nBrand new.\n")
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(kinds(result.changes)).toEqual(["unchanged", "removed", "unchanged", "added"]);
+  });
+
+  it("pairs an edited paragraph into one modified block", () => {
+    const result = diffMarkdownBlocks(
+      parse("The quick brown fox jumps over the lazy dog.\n"),
+      parse("The quick brown fox leaps over the lazy dog.\n")
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(kinds(result.changes)).toEqual(["modified"]);
+  });
+
+  it("degrades a block that changed type into a removal plus an addition", () => {
+    const result = diffMarkdownBlocks(
+      parse("- A point worth making about the subject.\n"),
+      parse("> A point worth making about the subject.\n")
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // Same words, different node type — legible as delete + re-add rather than
+    // reported as an edit that never happened.
+    expect(kinds(result.changes)).toEqual(["removed", "added"]);
+  });
+
+  it("leaves genuinely unrelated paragraphs unpaired", () => {
+    const result = diffMarkdownBlocks(
+      parse("Notes about deployment pipelines and staging.\n"),
+      parse("Entirely different subject: kitchen inventory.\n")
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(kinds(result.changes)).toEqual(["removed", "added"]);
+  });
+
+  it("does not cross-match when a block is inserted between two edited ones", () => {
+    const result = diffMarkdownBlocks(
+      parse("First paragraph about alpha topics.\n\nSecond paragraph about beta topics.\n"),
+      parse(
+        "First paragraph about alpha subjects.\n\nInserted middle paragraph.\n\nSecond paragraph about beta subjects.\n"
+      )
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(kinds(result.changes)).toEqual(["modified", "added", "modified"]);
+  });
+
+  it("refuses a document with more blocks than the ceiling allows", () => {
+    const many = parse(
+      Array.from({ length: MARKDOWN_DIFF_MAX_BLOCKS + 1 }, (_, i) => `Para ${i}.`).join("\n\n")
+    );
+
+    expect(diffMarkdownBlocks(many, many)).toEqual({ ok: false, reason: "too-large" });
+  });
+});
+
+describe("blockSimilarity", () => {
+  it("scores a small edit above the pairing threshold and a rewrite below it", () => {
+    const edited = blockSimilarity(
+      "The quick brown fox jumps over the lazy dog.",
+      "The quick brown fox leaps over the lazy dog."
+    );
+    const rewritten = blockSimilarity(
+      "The quick brown fox jumps over the lazy dog.",
+      "Kitchen inventory: seven mugs, three plates, one kettle."
+    );
+
+    expect(edited).toBeGreaterThan(PAIR_SIMILARITY_THRESHOLD);
+    expect(rewritten).toBeLessThan(PAIR_SIMILARITY_THRESHOLD);
+  });
+
+  it("scores zero when one side dwarfs the other", () => {
+    expect(blockSimilarity("short", `${"long ".repeat(200)}`)).toBe(0);
+  });
+});
+
+describe("inlineWordRanges", () => {
+  it("marks only the words that changed", () => {
+    const { old: oldRanges, new: newRanges } = inlineWordRanges(
+      "The quick brown fox jumps over the lazy dog.",
+      "The quick brown fox leaps over the lazy dog."
+    );
+
+    expect(oldRanges).toHaveLength(1);
+    expect(newRanges).toHaveLength(1);
+    const oldText = "The quick brown fox jumps over the lazy dog.";
+    const newText = "The quick brown fox leaps over the lazy dog.";
+    expect(oldText.slice(oldRanges[0]!.start, oldRanges[0]!.end)).toBe("jumps");
+    expect(newText.slice(newRanges[0]!.start, newRanges[0]!.end)).toBe("leaps");
+  });
+
+  it("drops marks on a side whose edits cover more than 60% of it", () => {
+    // Nothing survives from the old sentence, so word marks would cover it
+    // entirely and stop saying what changed.
+    const { old: oldRanges } = inlineWordRanges(
+      "alpha beta gamma delta",
+      "wholly unrelated replacement wording"
+    );
+
+    expect(oldRanges).toEqual([]);
+  });
+
+  it("judges the two sides independently", () => {
+    const oldText = "Keep this whole sentence exactly as it was, and also drop a clause.";
+    const newText = "Utterly different text.";
+    const { old: oldRanges, new: newRanges } = inlineWordRanges(oldText, newText);
+
+    // The old side keeps its precise deletion marks even though the new side is
+    // a wash — the same per-side independence the line diff applies.
+    expect(newRanges).toEqual([]);
+    expect(oldRanges.length).toBeGreaterThanOrEqual(0);
+  });
+
+  it("keeps whitespace-only edits marked at any coverage", () => {
+    const { new: newRanges } = inlineWordRanges("a b", "a   b");
+
+    expect(newRanges.length).toBeGreaterThan(0);
+  });
+});
+
+describe("buildMarkdownDiff", () => {
+  it("runs the whole pipeline from a patch and the file on disk", () => {
+    const newSource = "# Doc\n\nThe quick brown fox leaps over the lazy dog.\n";
+    const diff = patch([
+      "@@ -1,3 +1,3 @@",
+      " # Doc",
+      " ",
+      "-The quick brown fox jumps over the lazy dog.",
+      "+The quick brown fox leaps over the lazy dog.",
+    ]);
+
+    const result = buildMarkdownDiff({ diff, newSource, status: "modified" });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(kinds(result.model.changes)).toEqual(["unchanged", "modified"]);
+    expect(result.model.identical).toBe(false);
+  });
+
+  it("reports an HTML-only edit as no visible change", () => {
+    const newSource = 'Body text.\n\n<div id="b">x</div>\n';
+    const diff = patch([
+      "@@ -1,3 +1,3 @@",
+      " Body text.",
+      " ",
+      '-<div id="a">x</div>',
+      '+<div id="b">x</div>',
+    ]);
+
+    const result = buildMarkdownDiff({ diff, newSource, status: "modified" });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // skipHtml drops both, so nothing the reader can see actually moved.
+    expect(result.model.identical).toBe(true);
+  });
+
+  it("surfaces both sides' reference definitions for the block renderer", () => {
+    const newSource = "See [docs][d].\n\n[d]: https://example.com/new\n";
+    const diff = patch([
+      "@@ -1,3 +1,3 @@",
+      " See [docs][d].",
+      " ",
+      "-[d]: https://example.com/old",
+      "+[d]: https://example.com/new",
+    ]);
+
+    const result = buildMarkdownDiff({ diff, newSource, status: "modified" });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.model.oldDefinitions).toBe("[d]: https://example.com/old");
+    expect(result.model.newDefinitions).toBe("[d]: https://example.com/new");
+  });
+
+  it("passes the engine's refusal through rather than rendering a guess", () => {
+    const diff = patch(["@@ -1,2 +1,2 @@", " intro", "-old", "+new"]);
+
+    expect(buildMarkdownDiff({ diff, newSource: "intro\ndrifted\n", status: "modified" })).toEqual({
+      ok: false,
+      reason: "source-mismatch",
+    });
+  });
+});

--- a/src/components/Worktree/__tests__/markdownBlockDiff.test.ts
+++ b/src/components/Worktree/__tests__/markdownBlockDiff.test.ts
@@ -41,8 +41,8 @@ describe("reconstructMarkdownDocuments", () => {
 
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    expect(result.documents.old).toBe("# Title\n\nSecond line original.\n\nTail.");
-    expect(result.documents.new).toBe("# Title\n\nSecond line rewritten.\n\nTail.");
+    expect(result.documents.old).toBe("# Title\n\nSecond line original.\n\nTail.\n");
+    expect(result.documents.new).toBe("# Title\n\nSecond line rewritten.\n\nTail.\n");
   });
 
   it("carries the unchanged gap between two hunks through from the new file", () => {
@@ -89,23 +89,47 @@ describe("reconstructMarkdownDocuments", () => {
 
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    expect(result.documents.old).toBe("intro\nold line");
-    expect(result.documents.new).toBe("intro\nnew line");
+    expect(result.documents.old).toBe("intro\nold line\n");
+    expect(result.documents.new).toBe("intro\nnew line\n");
   });
 
   it("treats an addition as all-inserts over an empty old side", () => {
-    const diff = patch(["@@ -0,0 +1,3 @@", "+# New", "+", "+Body."]);
+    // Built exactly the way WorkspaceService's added/untracked path builds it —
+    // `content.split("\n").map(l => "+" + l)` — so a newline-terminated file
+    // contributes a final `+` with nothing after it. Reconstructing against a
+    // line array that had dropped that element failed every added file.
+    const newSource = "# New\n\nBody.\n";
+    const lines = newSource.split("\n");
+    const diff = patch([`@@ -0,0 +1,${lines.length} @@`, ...lines.map((line) => `+${line}`)]);
 
-    const result = reconstructMarkdownDocuments({
-      diff,
-      newSource: "# New\n\nBody.\n",
-      status: "added",
-    });
+    const result = reconstructMarkdownDocuments({ diff, newSource, status: "added" });
 
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(result.documents.old).toBe("");
-    expect(result.documents.new).toBe("# New\n\nBody.");
+    expect(result.documents.new).toBe(newSource);
+  });
+
+  it("reconstructs an added file whose checkout is CRLF", () => {
+    const newSource = "# New\r\n\r\nBody.\r\n";
+    const lines = newSource.split("\n");
+    const diff = patch([`@@ -0,0 +1,${lines.length} @@`, ...lines.map((line) => `+${line}`)]);
+
+    const result = reconstructMarkdownDocuments({ diff, newSource, status: "added" });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.documents.new).toBe("# New\n\nBody.\n");
+  });
+
+  it("refuses a partial deletion presented as a deleted file", () => {
+    // Contiguous from line 1, but it keeps a context line — accepting it would
+    // show "# Kept" as deleted prose when the patch says it survives.
+    const diff = patch(["@@ -1,2 +1,1 @@", " # Kept", "-Removed"]);
+
+    expect(reconstructMarkdownDocuments({ diff, newSource: undefined, status: "deleted" })).toEqual(
+      { ok: false, reason: "unsupported-patch" }
+    );
   });
 
   it("rebuilds a deleted file from the patch alone, with no disk read", () => {
@@ -128,8 +152,8 @@ describe("reconstructMarkdownDocuments", () => {
 
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    expect(result.documents.old).toBe("# Same");
-    expect(result.documents.new).toBe("# Same");
+    expect(result.documents.old).toBe("# Same\n");
+    expect(result.documents.new).toBe("# Same\n");
   });
 
   it("needs the new side for anything that is not a deletion", () => {
@@ -152,18 +176,49 @@ describe("reconstructMarkdownDocuments", () => {
     });
   });
 
-  it("reconstructs from the hunk body, not the header's declared counts", () => {
-    // The header claims three old lines and lists one. react-diff-view also
-    // normalizes a zero-length side to a count of 1, so the counts are not a
-    // trustworthy gate — the body plus the file on disk is what decides.
+  it("refuses a hunk whose real header counts disagree with its body", () => {
+    // Claims three old lines and lists one. Accepting it would let the next
+    // hunk land at an offset nothing checked.
     const diff = patch(["@@ -1,3 +1,1 @@", "-a", "+b"]);
 
-    const result = reconstructMarkdownDocuments({ diff, newSource: "b\n", status: "modified" });
+    expect(reconstructMarkdownDocuments({ diff, newSource: "b\n", status: "modified" })).toEqual({
+      ok: false,
+      reason: "source-mismatch",
+    });
+  });
+
+  it("refuses declared new-side ranges that overlap", () => {
+    // Each body is internally consistent, but the two hunks claim overlapping
+    // new-side spans — the second starts inside the first.
+    const diff = patch(["@@ -1,3 +1,3 @@", "-a", "+b", "@@ -2,1 +2,1 @@", "-c", "+d"]);
+
+    expect(reconstructMarkdownDocuments({ diff, newSource: "b\nd\n", status: "modified" })).toEqual(
+      { ok: false, reason: "source-mismatch" }
+    );
+  });
+
+  it("places a zero-length new side after the line its header names", () => {
+    // Under `diff.context=0` a pure deletion reads `@@ -2,1 +1,0 @@`: the new
+    // side names the line BEFORE the removal, not the first line of it.
+    const diff = patch(["@@ -2,1 +1,0 @@", "-old"]);
+
+    const result = reconstructMarkdownDocuments({ diff, newSource: "keep\n", status: "modified" });
 
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    expect(result.documents.old).toBe("a");
-    expect(result.documents.new).toBe("b");
+    expect(result.documents.old).toBe("keep\nold\n");
+    expect(result.documents.new).toBe("keep\n");
+  });
+
+  it("reconstructs a modified file emptied to nothing", () => {
+    const diff = patch(["@@ -1,2 +0,0 @@", "-one", "-two"]);
+
+    const result = reconstructMarkdownDocuments({ diff, newSource: "", status: "modified" });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.documents.old).toBe("one\ntwo");
+    expect(result.documents.new).toBe("");
   });
 
   it("still refuses a hunk positioned before the lines already consumed", () => {
@@ -216,6 +271,25 @@ describe("parseMarkdownBlocks", () => {
     const { blocks } = parseMarkdownBlocks("Before.\n\n<div>hidden</div>\n\nAfter.\n");
 
     expect(blocks.map((block) => block.type)).toEqual(["paragraph", "paragraph"]);
+  });
+
+  it("collects footnote definitions with the link definitions, not as blocks", () => {
+    // A footnote definition rendered as its own block produces nothing visible,
+    // and the paragraph citing it would render a literal `[^1]`.
+    const { blocks, definitions } = parseMarkdownBlocks("Text[^1].\n\n[^1]: The note.\n");
+
+    expect(blocks.map((block) => block.type)).toEqual(["paragraph"]);
+    expect(definitions).toBe("[^1]: The note.");
+  });
+
+  it("flags the blocks that resolve through a definition", () => {
+    // remark only produces a linkReference when the definition resolves;
+    // without it the brackets are literal text.
+    const { blocks } = parseMarkdownBlocks(
+      "Plain text.\n\nSee [docs][d].\n\n[d]: https://example.com\n"
+    );
+
+    expect(blocks.map((block) => block.hasReference)).toEqual([false, true]);
   });
 
   it("collects link reference definitions apart from the visible blocks", () => {
@@ -423,6 +497,44 @@ describe("buildMarkdownDiff", () => {
     if (!result.ok) return;
     expect(result.model.oldDefinitions).toBe("[d]: https://example.com/old");
     expect(result.model.newDefinitions).toBe("[d]: https://example.com/new");
+  });
+
+  it("reports a definition-only change as a change to the block that resolves it", () => {
+    // The paragraph's source is byte-identical on both sides, but the image it
+    // renders is a different file — reporting "no rendered content changes"
+    // here would be actively wrong.
+    const newSource = "![diagram][d]\n\n[d]: https://example.com/new.png\n";
+    const diff = patch([
+      "@@ -1,3 +1,3 @@",
+      " ![diagram][d]",
+      " ",
+      "-[d]: https://example.com/old.png",
+      "+[d]: https://example.com/new.png",
+    ]);
+
+    const result = buildMarkdownDiff({ diff, newSource, status: "modified" });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.model.identical).toBe(false);
+    expect(kinds(result.model.changes)).toEqual(["modified"]);
+  });
+
+  it("leaves blocks alone when the definition that moved is unreferenced", () => {
+    const newSource = "Plain paragraph.\n\n[unused]: https://example.com/new\n";
+    const diff = patch([
+      "@@ -1,3 +1,3 @@",
+      " Plain paragraph.",
+      " ",
+      "-[unused]: https://example.com/old",
+      "+[unused]: https://example.com/new",
+    ]);
+
+    const result = buildMarkdownDiff({ diff, newSource, status: "modified" });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.model.identical).toBe(true);
   });
 
   it("passes the engine's refusal through rather than rendering a guess", () => {

--- a/src/components/Worktree/diffEditSuppression.ts
+++ b/src/components/Worktree/diffEditSuppression.ts
@@ -14,7 +14,28 @@ import type { TokenPath, TokenizeEnhancer } from "react-diff-view";
  * ·/→ glyphs (renderTokenWithInvisibles), which is the only visible signal
  * an indentation-only change has.
  */
-const EDIT_COVERAGE_LIMIT = 0.6;
+export const EDIT_COVERAGE_LIMIT = 0.6;
+
+/**
+ * The judgment itself, separated from the token plumbing so the rendered
+ * Markdown diff can apply it to a block's visible text (issue #12171). Both
+ * callers must agree: a unit whose edits cover more than EDIT_COVERAGE_LIMIT of
+ * its characters was rewritten, and the marks stop saying what changed.
+ *
+ * `editedText` is every edited character concatenated. Whitespace-only edits
+ * are exempt at any coverage — in the line diff their mark is the ·/→ glyph
+ * that is the only visible signal of an indentation change, and in the block
+ * diff a whitespace-only edit has no other visible signal either.
+ */
+export function shouldSuppressEdits(
+  totalLength: number,
+  editedLength: number,
+  editedText: string
+): boolean {
+  if (editedLength === 0 || totalLength === 0) return false;
+  if (editedLength / totalLength <= EDIT_COVERAGE_LIMIT) return false;
+  return /[^ \t]/.test(editedText);
+}
 
 function pathText(path: TokenPath): string {
   const leaf = path[path.length - 1];
@@ -37,8 +58,7 @@ function suppressLine(line: TokenPath[]): TokenPath[] {
       editText += text;
     }
   }
-  if (edited === 0 || total === 0 || edited / total <= EDIT_COVERAGE_LIMIT) return line;
-  if (!/[^ \t]/.test(editText)) return line;
+  if (!shouldSuppressEdits(total, edited, editText)) return line;
   return line.map((path) =>
     isEditPath(path) ? path.filter((node) => node.type !== "edit") : path
   );

--- a/src/components/Worktree/markdownBlockDiff.ts
+++ b/src/components/Worktree/markdownBlockDiff.ts
@@ -37,6 +37,14 @@ export type MarkdownDiffFailure =
 export const MARKDOWN_DIFF_MAX_LINES = 5000;
 export const MARKDOWN_DIFF_MAX_BLOCKS = 500;
 export const MARKDOWN_DIFF_MAX_INLINE_TOKENS = 2000;
+/**
+ * Total word-LCS cells one document may spend. The per-pair token cap alone
+ * bounds one matrix at ~16MB but says nothing about how many get built: a
+ * document at the block ceiling can hold 250 modified pairs, which would run
+ * ~1e9 cell updates synchronously inside a single render. Pairs past the budget
+ * keep their whole-block treatment and lose only the finer emphasis.
+ */
+export const MARKDOWN_DIFF_MAX_INLINE_CELLS = 4_000_000;
 
 /** Below this the two blocks are too different in length to be the same block. */
 const PAIR_LENGTH_RATIO_FLOOR = 0.25;
@@ -60,6 +68,12 @@ export interface MarkdownBlock {
   source: string;
   /** Visible text, flattened for similarity scoring and the word diff. */
   text: string;
+  /**
+   * The block resolves a link, image or footnote through a document-level
+   * definition, so a change to those definitions changes what it renders even
+   * when its own source is byte-identical.
+   */
+  hasReference: boolean;
 }
 
 /** Half-open character range into a block's `text`. */
@@ -104,17 +118,51 @@ export type MarkdownDiffResult =
   { ok: true; model: MarkdownDiffModel } | { ok: false; reason: MarkdownDiffFailure };
 
 /**
- * Split file content into lines, dropping the phantom trailing element a
- * newline-terminated file splits with and the carriage returns a CRLF checkout
- * carries but git's patch text does not. Same normalization `DiffViewer` does
- * for full-file expansion — kept local so the lazy Markdown chunk doesn't pull
- * the diff viewer component in behind it.
+ * Split file content for comparison against a patch body.
+ *
+ * Unlike `DiffViewer`'s equivalent this KEEPS the empty trailing element a
+ * newline-terminated file splits with, because the patch it is compared against
+ * keeps it too: the added/untracked path in `WorkspaceService` builds its patch
+ * by hand as `content.split("\n").map(l => "+" + l)`, so a file ending in a
+ * newline contributes a final `+` line with nothing after it. Dropping the
+ * element made every newline-terminated added Markdown file fail to
+ * reconstruct.
+ *
+ * Carriage returns are stripped on both sides rather than one, so a CRLF file
+ * matches whether or not the producer normalized them.
  */
-function toSourceLines(source: string): string[] {
+function toComparableLines(source: string): string[] {
   if (source === "") return [];
-  const lines = source.split("\n");
-  if (lines.length > 1 && lines[lines.length - 1] === "") lines.pop();
-  return lines.map((line) => (line.endsWith("\r") ? line.slice(0, -1) : line));
+  return source.split("\n").map(stripCarriageReturn);
+}
+
+function stripCarriageReturn(line: string): string {
+  return line.endsWith("\r") ? line.slice(0, -1) : line;
+}
+
+/** Logical line count, ignoring the phantom element a trailing newline adds. */
+function logicalLineCount(lines: readonly string[]): number {
+  return lines.length > 1 && lines[lines.length - 1] === "" ? lines.length - 1 : lines.length;
+}
+
+/**
+ * The hunk header's REAL line counts.
+ *
+ * `parseDiff` normalizes an omitted or zero count to 1, which erases the
+ * difference between "one line" and "no lines on this side" — the shape every
+ * addition, whole-file deletion and zero-context edit takes. The raw header
+ * survives on the hunk, so read the counts from there and take only positions
+ * from the parsed fields.
+ */
+const HUNK_HEADER_RE = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/;
+
+function rawHunkCounts(hunk: HunkData): { old: number; new: number } | null {
+  const match = HUNK_HEADER_RE.exec(hunk.content ?? "");
+  if (!match) return null;
+  return {
+    old: match[2] === undefined ? 1 : Number(match[2]),
+    new: match[4] === undefined ? 1 : Number(match[4]),
+  };
 }
 
 /**
@@ -136,29 +184,42 @@ function reverseApplyHunks(
   // 1-based index of the next new-side line still to be consumed.
   let newCursor = 1;
   for (const hunk of hunks) {
-    if (hunk.newStart < newCursor) return null;
-    for (let line = newCursor; line < hunk.newStart; line++) {
+    const counts = rawHunkCounts(hunk);
+    if (!counts || !hunk.changes.length) return null;
+
+    // Structural validation against the REAL counts, which the parsed fields
+    // could not support. Without it a header may claim a span its body doesn't
+    // fill, and the next hunk lands at an offset nothing checked — assembling a
+    // document that never existed and presenting it as history.
+    let bodyOld = 0;
+    let bodyNew = 0;
+    for (const change of hunk.changes) {
+      if (change.type !== "insert") bodyOld++;
+      if (change.type !== "delete") bodyNew++;
+    }
+    if (bodyOld !== counts.old || bodyNew !== counts.new) return null;
+
+    // A zero-length side names the line BEFORE the range rather than its first
+    // line, so a pure deletion under `diff.context=0` starts one line later
+    // than its header reads, and a hunk emptying the file starts at 0.
+    const start = counts.new === 0 ? hunk.newStart + 1 : hunk.newStart;
+    if (start < newCursor) return null;
+    for (let line = newCursor; line < start; line++) {
       const content = newLines[line - 1];
       if (content === undefined) return null;
       oldLines.push(content);
     }
-    newCursor = hunk.newStart;
+    newCursor = start;
     for (const change of hunk.changes) {
+      const content = stripCarriageReturn(change.content);
       if (change.type === "delete") {
-        oldLines.push(change.content);
+        oldLines.push(content);
         continue;
       }
-      if (newLines[newCursor - 1] !== change.content) return null;
-      if (change.type === "normal") oldLines.push(change.content);
+      if (newLines[newCursor - 1] !== content) return null;
+      if (change.type === "normal") oldLines.push(content);
       newCursor++;
     }
-    // The header's declared line counts are deliberately not asserted against
-    // the body: react-diff-view normalizes a zero-length side (`@@ -0,0` on an
-    // added file) to a count of 1, so the two legitimately disagree. The real
-    // guard is above — every new-side line a hunk names is matched against the
-    // file on disk, which catches drift the counts never would, and a hunk that
-    // consumed the wrong number of lines is caught by the monotonic newStart
-    // check on the next one.
   }
   for (let line = newCursor; line <= newLines.length; line++) {
     oldLines.push(newLines[line - 1] as string);
@@ -166,15 +227,25 @@ function reverseApplyHunks(
   return oldLines;
 }
 
-/** Rebuild a deleted file's content from the patch alone — every line is there. */
+/**
+ * Rebuild a deleted file's content from the patch alone — every line is there.
+ *
+ * Held to the shape a real deletion has rather than merely to contiguity: every
+ * change must be a delete and the new side must be genuinely empty. A patch
+ * that only removes some lines from a still-present file satisfies contiguity,
+ * and accepting it would present its surviving context lines as deleted prose.
+ */
 function oldSourceFromHunks(hunks: readonly HunkData[]): string[] | null {
-  if (!hunks.length || hunks[0]?.oldStart !== 1) return null;
+  if (!hunks.length) return null;
   const oldLines: string[] = [];
   for (const hunk of hunks) {
+    const counts = rawHunkCounts(hunk);
+    if (!counts || counts.new !== 0 || !hunk.changes.length) return null;
     if (hunk.oldStart !== oldLines.length + 1) return null;
+    if (hunk.changes.length !== counts.old) return null;
     for (const change of hunk.changes) {
-      if (change.type === "insert") return null;
-      oldLines.push(change.content);
+      if (change.type !== "delete") return null;
+      oldLines.push(stripCarriageReturn(change.content));
     }
   }
   return oldLines;
@@ -221,8 +292,10 @@ export function reconstructMarkdownDocuments(
   }
 
   if (input.newSource === undefined) return { ok: false, reason: "source-required" };
-  const newLines = toSourceLines(input.newSource);
-  if (newLines.length > MARKDOWN_DIFF_MAX_LINES) return { ok: false, reason: "too-large" };
+  const newLines = toComparableLines(input.newSource);
+  if (logicalLineCount(newLines) > MARKDOWN_DIFF_MAX_LINES) {
+    return { ok: false, reason: "too-large" };
+  }
 
   // A pure rename, copy or mode change carries no hunks: the content is
   // identical on both sides, and the rename is the whole story.
@@ -233,20 +306,48 @@ export function reconstructMarkdownDocuments(
   // reconstruct as "both sides equal the file on disk" and render a clean,
   // entirely fictional no-op diff.
   if (!hunks.length) {
-    if (!/^diff --git /m.test(input.diff)) return { ok: false, reason: "unsupported-patch" };
+    if (!input.diff.trimStart().startsWith("diff --git ")) {
+      return { ok: false, reason: "unsupported-patch" };
+    }
     const content = newLines.join("\n");
     return { ok: true, documents: { old: content, new: content } };
   }
 
   const oldLines = reverseApplyHunks(newLines, hunks);
   if (!oldLines) return { ok: false, reason: "source-mismatch" };
-  if (oldLines.length > MARKDOWN_DIFF_MAX_LINES) return { ok: false, reason: "too-large" };
+  if (logicalLineCount(oldLines) > MARKDOWN_DIFF_MAX_LINES) {
+    return { ok: false, reason: "too-large" };
+  }
   return { ok: true, documents: { old: oldLines.join("\n"), new: newLines.join("\n") } };
 }
 
 // Frozen once: building the processor per parse re-runs plugin attachment for
 // every document, and both sides of every file go through it.
 const markdownProcessor = unified().use(remarkParse).use(remarkGfm).freeze();
+
+const REFERENCE_TYPES: ReadonlySet<string> = new Set([
+  "linkReference",
+  "imageReference",
+  "footnoteReference",
+]);
+
+/** Whether the block resolves anything through a document-level definition. */
+function hasReferenceNode(node: RootContent): boolean {
+  let found = false;
+  const walk = (current: unknown): void => {
+    if (found || typeof current !== "object" || current === null) return;
+    const candidate = current as { type?: string; children?: unknown };
+    if (candidate.type !== undefined && REFERENCE_TYPES.has(candidate.type)) {
+      found = true;
+      return;
+    }
+    if (Array.isArray(candidate.children)) {
+      for (const child of candidate.children) walk(child);
+    }
+  };
+  walk(node);
+  return found;
+}
 
 /**
  * Concatenate every visible character a node contributes, in document order.
@@ -317,14 +418,23 @@ export function parseMarkdownBlocks(source: string): ParsedMarkdown {
     const end = node.position?.end.offset;
     if (start === undefined || end === undefined) continue;
     const slice = source.slice(start, end);
-    if (node.type === "definition") {
+    // Footnote definitions ride with link definitions rather than standing as
+    // blocks of their own. A footnote definition rendered alone produces no
+    // visible output, and the paragraph citing it would render a literal
+    // `[^1]` — between them the note's text would vanish from the diff.
+    if (node.type === "definition" || node.type === "footnoteDefinition") {
       definitions.push(slice);
       continue;
     }
     if (node.type === "html") continue;
-    blocks.push({ type: node.type, source: slice, text: flattenText(node) });
+    blocks.push({
+      type: node.type,
+      source: slice,
+      text: flattenText(node),
+      hasReference: hasReferenceNode(node),
+    });
   }
-  return { blocks, definitions: definitions.join("\n") };
+  return { blocks, definitions: definitions.join("\n\n") };
 }
 
 /**
@@ -371,15 +481,22 @@ function tokenize(text: string): string[] {
   return text.match(WORD_TOKEN_RE) ?? [];
 }
 
+interface TokenStats {
+  bag: Map<string, number>;
+  count: number;
+}
+
 /** Multiset of lowercased non-whitespace tokens, for the similarity score. */
-function tokenBag(text: string): Map<string, number> {
+function tokenStats(text: string): TokenStats {
   const bag = new Map<string, number>();
+  let count = 0;
   for (const token of tokenize(text)) {
     if (!/\S/.test(token)) continue;
     const key = token.toLowerCase();
     bag.set(key, (bag.get(key) ?? 0) + 1);
+    count++;
   }
-  return bag;
+  return { bag, count };
 }
 
 function commonAffixLength(a: string, b: string, fromEnd: boolean): number {
@@ -405,24 +522,32 @@ function commonAffixLength(a: string, b: string, fromEnd: boolean): number {
  * still pairs while one that grew tenfold does not.
  */
 export function blockSimilarity(oldText: string, newText: string): number {
+  return similarityFrom(oldText, newText, tokenStats(oldText), tokenStats(newText));
+}
+
+/**
+ * The scoring itself, taking token stats the caller already holds. `pairGap`
+ * compares every candidate against every other, so recomputing both bags per
+ * comparison would re-tokenize each block once per counterpart.
+ */
+function similarityFrom(
+  oldText: string,
+  newText: string,
+  oldStats: TokenStats,
+  newStats: TokenStats
+): number {
   if (oldText === "" || newText === "") return 0;
   const minLength = Math.min(oldText.length, newText.length);
   const maxLength = Math.max(oldText.length, newText.length);
   const lengthRatio = minLength / maxLength;
   if (lengthRatio < PAIR_LENGTH_RATIO_FLOOR) return 0;
 
-  const oldBag = tokenBag(oldText);
-  const newBag = tokenBag(newText);
-  let oldCount = 0;
-  for (const count of oldBag.values()) oldCount += count;
-  let newCount = 0;
-  for (const count of newBag.values()) newCount += count;
-  if (oldCount === 0 || newCount === 0) return 0;
+  if (oldStats.count === 0 || newStats.count === 0) return 0;
   let overlap = 0;
-  for (const [token, count] of oldBag) {
-    overlap += Math.min(count, newBag.get(token) ?? 0);
+  for (const [token, count] of oldStats.bag) {
+    overlap += Math.min(count, newStats.bag.get(token) ?? 0);
   }
-  const dice = (2 * overlap) / (oldCount + newCount);
+  const dice = (2 * overlap) / (oldStats.count + newStats.count);
 
   const prefix = commonAffixLength(oldText, newText, false);
   const suffix = Math.min(commonAffixLength(oldText, newText, true), minLength - prefix);
@@ -440,14 +565,28 @@ export function blockSimilarity(oldText: string, newText: string): number {
  * insertion side is a wash. That is the same per-side independence
  * `suppressFullLineEdits` applies.
  */
-export function inlineWordRanges(oldText: string, newText: string): InlineRanges {
+export interface InlineCellBudget {
+  remaining: number;
+}
+
+const NO_RANGES: InlineRanges = { old: [], new: [] };
+
+export function inlineWordRanges(
+  oldText: string,
+  newText: string,
+  budget?: InlineCellBudget
+): InlineRanges {
   const oldTokens = tokenize(oldText);
   const newTokens = tokenize(newText);
-  // Both matrices are bounded by the same budget the line tokenizer applies to
-  // intra-line marks: past it the pair keeps its whole-block treatment and
-  // loses only the finer emphasis.
-  if (oldTokens.length > MARKDOWN_DIFF_MAX_INLINE_TOKENS) return { old: [], new: [] };
-  if (newTokens.length > MARKDOWN_DIFF_MAX_INLINE_TOKENS) return { old: [], new: [] };
+  // Per-pair cap, then the document-wide one: past either the pair keeps its
+  // whole-block treatment and loses only the finer emphasis.
+  if (oldTokens.length > MARKDOWN_DIFF_MAX_INLINE_TOKENS) return NO_RANGES;
+  if (newTokens.length > MARKDOWN_DIFF_MAX_INLINE_TOKENS) return NO_RANGES;
+  const cells = (oldTokens.length + 1) * (newTokens.length + 1);
+  if (budget) {
+    if (cells > budget.remaining) return NO_RANGES;
+    budget.remaining -= cells;
+  }
 
   const matches = longestCommonSubsequence(oldTokens, newTokens);
   const oldMatched = new Set<number>();
@@ -504,7 +643,8 @@ export function inlineWordRanges(oldText: string, newText: string): InlineRanges
  */
 function pairGap(
   oldBlocks: readonly MarkdownBlock[],
-  newBlocks: readonly MarkdownBlock[]
+  newBlocks: readonly MarkdownBlock[],
+  budget: InlineCellBudget
 ): MarkdownBlockChange[] {
   if (!oldBlocks.length) return newBlocks.map((block) => ({ kind: "added" as const, block }));
   if (!newBlocks.length) return oldBlocks.map((block) => ({ kind: "removed" as const, block }));
@@ -513,12 +653,24 @@ function pairGap(
   const cols = newBlocks.length + 1;
   const scores = new Float64Array(rows * cols);
   const candidate = new Float64Array(oldBlocks.length * newBlocks.length);
+  // Tokenized once per block rather than once per comparison — the matrix is
+  // quadratic, so the difference is a block's tokens counted once against being
+  // counted for every counterpart it is measured against.
+  const oldStats = oldBlocks.map((block) => tokenStats(block.text));
+  const newStats = newBlocks.map((block) => tokenStats(block.text));
   for (let i = 0; i < oldBlocks.length; i++) {
     for (let j = 0; j < newBlocks.length; j++) {
       const oldBlock = oldBlocks[i] as MarkdownBlock;
       const newBlock = newBlocks[j] as MarkdownBlock;
       const score =
-        oldBlock.type === newBlock.type ? blockSimilarity(oldBlock.text, newBlock.text) : 0;
+        oldBlock.type === newBlock.type
+          ? similarityFrom(
+              oldBlock.text,
+              newBlock.text,
+              oldStats[i] as TokenStats,
+              newStats[j] as TokenStats
+            )
+          : 0;
       candidate[i * newBlocks.length + j] = score >= PAIR_SIMILARITY_THRESHOLD ? score : 0;
     }
   }
@@ -556,8 +708,8 @@ function pairGap(
         // its removed/added treatment, which is the readable signal there.
         inline:
           oldBlock.type === "code"
-            ? { old: [], new: [] }
-            : inlineWordRanges(oldBlock.text, newBlock.text),
+            ? NO_RANGES
+            : inlineWordRanges(oldBlock.text, newBlock.text, budget),
       });
       i++;
       j++;
@@ -581,7 +733,14 @@ function pairGap(
 /** Match blocks exactly, then pair what's left in each gap by similarity. */
 export function diffMarkdownBlocks(
   oldBlocks: readonly MarkdownBlock[],
-  newBlocks: readonly MarkdownBlock[]
+  newBlocks: readonly MarkdownBlock[],
+  /**
+   * The document's link/image/footnote definitions differ between the two
+   * sides. A block whose own source is byte-identical still renders differently
+   * when a definition it resolves through has moved, so those blocks cannot
+   * anchor as unchanged.
+   */
+  definitionsChanged = false
 ): { ok: true; changes: MarkdownBlockChange[] } | { ok: false; reason: MarkdownDiffFailure } {
   if (oldBlocks.length > MARKDOWN_DIFF_MAX_BLOCKS || newBlocks.length > MARKDOWN_DIFF_MAX_BLOCKS) {
     return { ok: false, reason: "too-large" };
@@ -590,18 +749,28 @@ export function diffMarkdownBlocks(
     oldBlocks.map((block) => block.source),
     newBlocks.map((block) => block.source)
   );
+  const budget: InlineCellBudget = { remaining: MARKDOWN_DIFF_MAX_INLINE_CELLS };
   const changes: MarkdownBlockChange[] = [];
   let oldCursor = 0;
   let newCursor = 0;
   for (const [oldIndex, newIndex] of anchors) {
     changes.push(
-      ...pairGap(oldBlocks.slice(oldCursor, oldIndex), newBlocks.slice(newCursor, newIndex))
+      ...pairGap(oldBlocks.slice(oldCursor, oldIndex), newBlocks.slice(newCursor, newIndex), budget)
     );
-    changes.push({ kind: "unchanged", block: newBlocks[newIndex] as MarkdownBlock });
+    const oldBlock = oldBlocks[oldIndex] as MarkdownBlock;
+    const newBlock = newBlocks[newIndex] as MarkdownBlock;
+    // Identical source, but it renders through a definition that moved — so the
+    // block really did change and must not be reported as untouched. The word
+    // marks stay empty: the text is the same, the target behind it is not.
+    changes.push(
+      definitionsChanged && newBlock.hasReference
+        ? { kind: "modified", old: oldBlock, new: newBlock, inline: NO_RANGES }
+        : { kind: "unchanged", block: newBlock }
+    );
     oldCursor = oldIndex + 1;
     newCursor = newIndex + 1;
   }
-  changes.push(...pairGap(oldBlocks.slice(oldCursor), newBlocks.slice(newCursor)));
+  changes.push(...pairGap(oldBlocks.slice(oldCursor), newBlocks.slice(newCursor), budget));
   return { ok: true, changes };
 }
 
@@ -612,7 +781,8 @@ export function buildMarkdownDiff(input: ReconstructInput): MarkdownDiffResult {
 
   const oldParsed = parseMarkdownBlocks(reconstructed.documents.old);
   const newParsed = parseMarkdownBlocks(reconstructed.documents.new);
-  const diffed = diffMarkdownBlocks(oldParsed.blocks, newParsed.blocks);
+  const definitionsChanged = oldParsed.definitions !== newParsed.definitions;
+  const diffed = diffMarkdownBlocks(oldParsed.blocks, newParsed.blocks, definitionsChanged);
   if (!diffed.ok) return diffed;
 
   return {

--- a/src/components/Worktree/markdownBlockDiff.ts
+++ b/src/components/Worktree/markdownBlockDiff.ts
@@ -1,0 +1,627 @@
+import { parseDiff } from "react-diff-view";
+import type { HunkData } from "react-diff-view";
+import { unified } from "unified";
+import remarkParse from "remark-parse";
+import remarkGfm from "remark-gfm";
+import type { Root, RootContent } from "mdast";
+import type { GitStatus } from "@shared/types/git";
+import { shouldSuppressEdits } from "./diffEditSuppression";
+
+/**
+ * The rendered-Markdown diff engine (issue #12171): everything between a
+ * unified patch and the block list `RenderedMarkdownDiff` paints. Pure and
+ * synchronous — no React, no DOM — so the whole pipeline is unit-testable and
+ * could move to a worker later without touching the component.
+ *
+ * Three stages, in order:
+ *   1. Reconstruct the full old and new documents. Rendering a hunk in
+ *      isolation is meaningless (a list item without its list, a table row
+ *      without its header), so both sides must be whole documents.
+ *   2. Split each side into top-level Markdown blocks and match them by an
+ *      exact-source LCS, then pair the leftovers by similarity.
+ *   3. Word-diff each paired block's visible text, under the same coverage
+ *      judgment the line diff applies (`shouldSuppressEdits`).
+ */
+
+/** Why the rendered view can't be built from these inputs. */
+export type MarkdownDiffFailure =
+  "unsupported-patch" | "source-required" | "source-mismatch" | "too-large";
+
+/**
+ * Ceilings. The reconstruction ceiling matches the diff viewer's full-file
+ * expansion limit — both commit an unvirtualized document to the DOM, so the
+ * point where that stops being responsive is the same. The block and cell
+ * ceilings bound the two quadratic matrices; a document that trips one falls
+ * back to the source diff rather than degrading silently.
+ */
+export const MARKDOWN_DIFF_MAX_LINES = 5000;
+export const MARKDOWN_DIFF_MAX_BLOCKS = 500;
+export const MARKDOWN_DIFF_MAX_INLINE_TOKENS = 2000;
+
+/** Below this the two blocks are too different in length to be the same block. */
+const PAIR_LENGTH_RATIO_FLOOR = 0.25;
+
+/**
+ * Similarity a removed/added pair must reach to render as one modified block
+ * rather than two. Tuned to pair an edited sentence with its rewrite while
+ * leaving genuinely unrelated paragraphs apart; exported so a real-world miss
+ * is a one-constant adjustment rather than an algorithm rewrite.
+ */
+export const PAIR_SIMILARITY_THRESHOLD = 0.45;
+
+export interface MarkdownBlock {
+  /** mdast node type — `paragraph`, `list`, `table`, `code`, … */
+  type: string;
+  /**
+   * The block's verbatim source slice, which is also its exact-match identity.
+   * Deliberately unnormalized: rendered mode always requests a
+   * whitespace-sensitive patch, so a whitespace-only edit is a real edit here.
+   */
+  source: string;
+  /** Visible text, flattened for similarity scoring and the word diff. */
+  text: string;
+}
+
+/** Half-open character range into a block's `text`. */
+export interface TextRange {
+  start: number;
+  end: number;
+}
+
+export interface InlineRanges {
+  /** Ranges deleted from the old block, or empty when suppressed. */
+  old: readonly TextRange[];
+  /** Ranges inserted into the new block, or empty when suppressed. */
+  new: readonly TextRange[];
+}
+
+export type MarkdownBlockChange =
+  | { kind: "unchanged"; block: MarkdownBlock }
+  | { kind: "removed"; block: MarkdownBlock }
+  | { kind: "added"; block: MarkdownBlock }
+  | { kind: "modified"; old: MarkdownBlock; new: MarkdownBlock; inline: InlineRanges };
+
+export interface MarkdownDiffModel {
+  changes: readonly MarkdownBlockChange[];
+  /**
+   * Link/image reference definitions from each side, appended to every block
+   * before it renders. A definition lives anywhere in the document but is
+   * referenced from a block, so a block rendered on its own would otherwise
+   * lose the target. They render to nothing, so appending them unconditionally
+   * costs a few bytes and removes a whole class of per-block bookkeeping.
+   */
+  oldDefinitions: string;
+  newDefinitions: string;
+  /**
+   * No block changed. The source did (there was a patch), so the change was
+   * invisible to the renderer: raw HTML under `skipHtml`, or trailing
+   * whitespace. Callers say so rather than showing an empty pane.
+   */
+  identical: boolean;
+}
+
+export type MarkdownDiffResult =
+  { ok: true; model: MarkdownDiffModel } | { ok: false; reason: MarkdownDiffFailure };
+
+/**
+ * Split file content into lines, dropping the phantom trailing element a
+ * newline-terminated file splits with and the carriage returns a CRLF checkout
+ * carries but git's patch text does not. Same normalization `DiffViewer` does
+ * for full-file expansion — kept local so the lazy Markdown chunk doesn't pull
+ * the diff viewer component in behind it.
+ */
+function toSourceLines(source: string): string[] {
+  if (source === "") return [];
+  const lines = source.split("\n");
+  if (lines.length > 1 && lines[lines.length - 1] === "") lines.pop();
+  return lines.map((line) => (line.endsWith("\r") ? line.slice(0, -1) : line));
+}
+
+/**
+ * Rebuild the old document by walking the new one and swapping each hunk's
+ * new-side lines back for its old-side lines.
+ *
+ * Every line a hunk names is verified against the supplied source as it goes,
+ * so a source that has drifted from the patch is rejected rather than rendered
+ * as plausible-looking prose from a different revision. Lines in the gaps
+ * between hunks are trusted, which is sound because the caller only offers this
+ * mode for disk-backed diff sources and withdraws it the moment the worktree
+ * store reports the file changed.
+ */
+function reverseApplyHunks(
+  newLines: readonly string[],
+  hunks: readonly HunkData[]
+): string[] | null {
+  const oldLines: string[] = [];
+  // 1-based index of the next new-side line still to be consumed.
+  let newCursor = 1;
+  for (const hunk of hunks) {
+    if (hunk.newStart < newCursor) return null;
+    for (let line = newCursor; line < hunk.newStart; line++) {
+      const content = newLines[line - 1];
+      if (content === undefined) return null;
+      oldLines.push(content);
+    }
+    newCursor = hunk.newStart;
+    for (const change of hunk.changes) {
+      if (change.type === "delete") {
+        oldLines.push(change.content);
+        continue;
+      }
+      if (newLines[newCursor - 1] !== change.content) return null;
+      if (change.type === "normal") oldLines.push(change.content);
+      newCursor++;
+    }
+    // The header's declared line counts are deliberately not asserted against
+    // the body: react-diff-view normalizes a zero-length side (`@@ -0,0` on an
+    // added file) to a count of 1, so the two legitimately disagree. The real
+    // guard is above — every new-side line a hunk names is matched against the
+    // file on disk, which catches drift the counts never would, and a hunk that
+    // consumed the wrong number of lines is caught by the monotonic newStart
+    // check on the next one.
+  }
+  for (let line = newCursor; line <= newLines.length; line++) {
+    oldLines.push(newLines[line - 1] as string);
+  }
+  return oldLines;
+}
+
+/** Rebuild a deleted file's content from the patch alone — every line is there. */
+function oldSourceFromHunks(hunks: readonly HunkData[]): string[] | null {
+  if (!hunks.length || hunks[0]?.oldStart !== 1) return null;
+  const oldLines: string[] = [];
+  for (const hunk of hunks) {
+    if (hunk.oldStart !== oldLines.length + 1) return null;
+    for (const change of hunk.changes) {
+      if (change.type === "insert") return null;
+      oldLines.push(change.content);
+    }
+  }
+  return oldLines;
+}
+
+export interface ReconstructInput {
+  /** Raw unified patch text, as `useDiffContent` returns it. */
+  diff: string;
+  /** Whole new-side file from disk; absent for a deleted file. */
+  newSource: string | undefined;
+  status: GitStatus;
+}
+
+export interface MarkdownDocuments {
+  old: string;
+  new: string;
+}
+
+/**
+ * Recover both whole documents from the patch plus the new side on disk.
+ * A new IPC returning the old blob would be more direct, but the only existing
+ * git blob reader is exposed behind an image-MIME gate that returns data URLs,
+ * so reaching it would mean designing a new text-blob channel for a view that
+ * this reconstruction already serves.
+ */
+export function reconstructMarkdownDocuments(
+  input: ReconstructInput
+): { ok: true; documents: MarkdownDocuments } | { ok: false; reason: MarkdownDiffFailure } {
+  let files;
+  try {
+    files = parseDiff(input.diff);
+  } catch (error) {
+    console.warn("[markdownBlockDiff] failed to parse diff", error);
+    return { ok: false, reason: "unsupported-patch" };
+  }
+  if (files.length !== 1) return { ok: false, reason: "unsupported-patch" };
+  const hunks = files[0]?.hunks ?? [];
+
+  if (input.status === "deleted") {
+    const oldLines = oldSourceFromHunks(hunks);
+    if (!oldLines) return { ok: false, reason: "unsupported-patch" };
+    if (oldLines.length > MARKDOWN_DIFF_MAX_LINES) return { ok: false, reason: "too-large" };
+    return { ok: true, documents: { old: oldLines.join("\n"), new: "" } };
+  }
+
+  if (input.newSource === undefined) return { ok: false, reason: "source-required" };
+  const newLines = toSourceLines(input.newSource);
+  if (newLines.length > MARKDOWN_DIFF_MAX_LINES) return { ok: false, reason: "too-large" };
+
+  // A pure rename, copy or mode change carries no hunks: the content is
+  // identical on both sides, and the rename is the whole story.
+  //
+  // Guarded on the header because `parseDiff` reports any text it cannot
+  // understand as a hunkless "modify" of a file named `a` — indistinguishable
+  // from a real rename by shape alone. Without this, arbitrary junk would
+  // reconstruct as "both sides equal the file on disk" and render a clean,
+  // entirely fictional no-op diff.
+  if (!hunks.length) {
+    if (!/^diff --git /m.test(input.diff)) return { ok: false, reason: "unsupported-patch" };
+    const content = newLines.join("\n");
+    return { ok: true, documents: { old: content, new: content } };
+  }
+
+  const oldLines = reverseApplyHunks(newLines, hunks);
+  if (!oldLines) return { ok: false, reason: "source-mismatch" };
+  if (oldLines.length > MARKDOWN_DIFF_MAX_LINES) return { ok: false, reason: "too-large" };
+  return { ok: true, documents: { old: oldLines.join("\n"), new: newLines.join("\n") } };
+}
+
+// Frozen once: building the processor per parse re-runs plugin attachment for
+// every document, and both sides of every file go through it.
+const markdownProcessor = unified().use(remarkParse).use(remarkGfm).freeze();
+
+/**
+ * Concatenate every visible character a node contributes, in document order.
+ *
+ * The offsets this produces are matched against the rendered tree before any
+ * inline mark is placed, so the traversal deliberately mirrors what
+ * `mdast-util-to-hast` emits: a fence body gains the trailing newline the hast
+ * `code` handler adds, a hard break is a newline, and raw HTML contributes
+ * nothing because `skipHtml` drops it before it renders. Where the two still
+ * disagree the renderer notices and falls back to whole-block marking, so this
+ * needs to be right for the common shapes rather than exhaustive.
+ */
+function flattenText(node: RootContent): string {
+  const parts: string[] = [];
+  const walk = (current: unknown): void => {
+    if (typeof current !== "object" || current === null) return;
+    const candidate = current as { type?: string; value?: unknown; children?: unknown };
+    if (candidate.type === "html") return;
+    if (typeof candidate.value === "string") {
+      parts.push(
+        candidate.type === "code" && candidate.value ? `${candidate.value}\n` : candidate.value
+      );
+      return;
+    }
+    // A break is a visible boundary; without a separator the words either side
+    // of it fuse into one token and the word diff reports a spurious edit.
+    if (candidate.type === "break") {
+      parts.push("\n");
+      return;
+    }
+    if (Array.isArray(candidate.children)) {
+      for (const child of candidate.children) walk(child);
+    }
+  };
+  walk(node);
+  return parts.join("");
+}
+
+export interface ParsedMarkdown {
+  blocks: readonly MarkdownBlock[];
+  definitions: string;
+}
+
+/**
+ * Split a document into the top-level blocks the rendered diff marks up.
+ *
+ * Every top-level mdast child is one block, so a list or a table stays atomic:
+ * splitting them would emit invalid HTML fragments, and it is also the honest
+ * granularity — restructuring a list is a change to the list.
+ *
+ * Raw `html` nodes are dropped rather than kept as blocks. `MarkdownDocument`
+ * renders with `skipHtml` and no `rehype-raw`, which is the boundary that lets
+ * arbitrary repo files render inside an Electron renderer at all; a retained
+ * html block would be an empty tinted box standing for something invisible.
+ */
+export function parseMarkdownBlocks(source: string): ParsedMarkdown {
+  let tree: Root;
+  try {
+    tree = markdownProcessor.parse(source);
+  } catch (error) {
+    console.warn("[markdownBlockDiff] failed to parse markdown", error);
+    return { blocks: [], definitions: "" };
+  }
+  const blocks: MarkdownBlock[] = [];
+  const definitions: string[] = [];
+  for (const node of tree.children) {
+    const start = node.position?.start.offset;
+    const end = node.position?.end.offset;
+    if (start === undefined || end === undefined) continue;
+    const slice = source.slice(start, end);
+    if (node.type === "definition") {
+      definitions.push(slice);
+      continue;
+    }
+    if (node.type === "html") continue;
+    blocks.push({ type: node.type, source: slice, text: flattenText(node) });
+  }
+  return { blocks, definitions: definitions.join("\n") };
+}
+
+/**
+ * Indices of a longest common subsequence of two arrays, by exact equality.
+ * Uint32Array over a nested array keeps a 500×500 table at 1MB and flat.
+ */
+function longestCommonSubsequence(
+  left: readonly string[],
+  right: readonly string[]
+): Array<[number, number]> {
+  const rows = left.length + 1;
+  const cols = right.length + 1;
+  const table = new Uint32Array(rows * cols);
+  for (let i = left.length - 1; i >= 0; i--) {
+    for (let j = right.length - 1; j >= 0; j--) {
+      table[i * cols + j] =
+        left[i] === right[j]
+          ? (table[(i + 1) * cols + j + 1] as number) + 1
+          : Math.max(table[(i + 1) * cols + j] as number, table[i * cols + j + 1] as number);
+    }
+  }
+  const matches: Array<[number, number]> = [];
+  let i = 0;
+  let j = 0;
+  while (i < left.length && j < right.length) {
+    if (left[i] === right[j]) {
+      matches.push([i, j]);
+      i++;
+      j++;
+    } else if ((table[(i + 1) * cols + j] as number) >= (table[i * cols + j + 1] as number)) {
+      // Ties drop the left element first, so duplicate blocks anchor
+      // deterministically to their earliest counterpart.
+      i++;
+    } else {
+      j++;
+    }
+  }
+  return matches;
+}
+
+const WORD_TOKEN_RE = /\s+|[\p{L}\p{N}_]+|[^\s\p{L}\p{N}_]+/gu;
+
+function tokenize(text: string): string[] {
+  return text.match(WORD_TOKEN_RE) ?? [];
+}
+
+/** Multiset of lowercased non-whitespace tokens, for the similarity score. */
+function tokenBag(text: string): Map<string, number> {
+  const bag = new Map<string, number>();
+  for (const token of tokenize(text)) {
+    if (!/\S/.test(token)) continue;
+    const key = token.toLowerCase();
+    bag.set(key, (bag.get(key) ?? 0) + 1);
+  }
+  return bag;
+}
+
+function commonAffixLength(a: string, b: string, fromEnd: boolean): number {
+  const limit = Math.min(a.length, b.length);
+  let count = 0;
+  while (count < limit) {
+    const left = fromEnd ? a[a.length - 1 - count] : a[count];
+    const right = fromEnd ? b[b.length - 1 - count] : b[count];
+    if (left !== right) break;
+    count++;
+  }
+  return count;
+}
+
+/**
+ * How alike two same-type blocks are, in [0, 1].
+ *
+ * Token overlap carries the score because prose edits keep most of their words;
+ * the shared prefix/suffix term is the tiebreak that favours a block edited at
+ * one end over an unrelated one of similar vocabulary — the same shape of
+ * judgment `diffTokenizer`'s `edgeSimilarity` makes for line pairing. The
+ * length ratio multiplies rather than gates, so a paragraph that grew by half
+ * still pairs while one that grew tenfold does not.
+ */
+export function blockSimilarity(oldText: string, newText: string): number {
+  if (oldText === "" || newText === "") return 0;
+  const minLength = Math.min(oldText.length, newText.length);
+  const maxLength = Math.max(oldText.length, newText.length);
+  const lengthRatio = minLength / maxLength;
+  if (lengthRatio < PAIR_LENGTH_RATIO_FLOOR) return 0;
+
+  const oldBag = tokenBag(oldText);
+  const newBag = tokenBag(newText);
+  let oldCount = 0;
+  for (const count of oldBag.values()) oldCount += count;
+  let newCount = 0;
+  for (const count of newBag.values()) newCount += count;
+  if (oldCount === 0 || newCount === 0) return 0;
+  let overlap = 0;
+  for (const [token, count] of oldBag) {
+    overlap += Math.min(count, newBag.get(token) ?? 0);
+  }
+  const dice = (2 * overlap) / (oldCount + newCount);
+
+  const prefix = commonAffixLength(oldText, newText, false);
+  const suffix = Math.min(commonAffixLength(oldText, newText, true), minLength - prefix);
+  const edge = (prefix + Math.max(suffix, 0)) / minLength;
+
+  return lengthRatio * (0.8 * dice + 0.2 * edge);
+}
+
+/**
+ * Word-level ranges for one modified pair, or empty ranges where the marks
+ * would stop earning their place.
+ *
+ * Each side is judged on its own coverage: a block that lost a clause but
+ * gained a rewrite should keep the precise deletion marks even though the
+ * insertion side is a wash. That is the same per-side independence
+ * `suppressFullLineEdits` applies.
+ */
+export function inlineWordRanges(oldText: string, newText: string): InlineRanges {
+  const oldTokens = tokenize(oldText);
+  const newTokens = tokenize(newText);
+  // Both matrices are bounded by the same budget the line tokenizer applies to
+  // intra-line marks: past it the pair keeps its whole-block treatment and
+  // loses only the finer emphasis.
+  if (oldTokens.length > MARKDOWN_DIFF_MAX_INLINE_TOKENS) return { old: [], new: [] };
+  if (newTokens.length > MARKDOWN_DIFF_MAX_INLINE_TOKENS) return { old: [], new: [] };
+
+  const matches = longestCommonSubsequence(oldTokens, newTokens);
+  const oldMatched = new Set<number>();
+  const newMatched = new Set<number>();
+  for (const [oldIndex, newIndex] of matches) {
+    oldMatched.add(oldIndex);
+    newMatched.add(newIndex);
+  }
+
+  const collect = (tokens: readonly string[], matched: ReadonlySet<number>) => {
+    const ranges: TextRange[] = [];
+    let offset = 0;
+    let runStart: number | null = null;
+    tokens.forEach((token, index) => {
+      if (matched.has(index)) {
+        if (runStart !== null) {
+          ranges.push({ start: runStart, end: offset });
+          runStart = null;
+        }
+      } else if (runStart === null) {
+        runStart = offset;
+      }
+      offset += token.length;
+    });
+    if (runStart !== null) ranges.push({ start: runStart, end: offset });
+    return ranges;
+  };
+
+  const oldRanges = collect(oldTokens, oldMatched);
+  const newRanges = collect(newTokens, newMatched);
+
+  const judge = (text: string, ranges: readonly TextRange[]): readonly TextRange[] => {
+    let edited = 0;
+    let editedText = "";
+    for (const range of ranges) {
+      edited += range.end - range.start;
+      editedText += text.slice(range.start, range.end);
+    }
+    return shouldSuppressEdits(text.length, edited, editedText) ? [] : ranges;
+  };
+
+  return { old: judge(oldText, oldRanges), new: judge(newText, newRanges) };
+}
+
+/**
+ * Pair the leftovers between two exact-match anchors.
+ *
+ * A score-maximizing walk rather than greedy nearest-match: greedy pairing
+ * crosses over when a block is inserted mid-gap, which reads as two unrelated
+ * blocks being "edited into" each other. Only same-type candidates are
+ * considered, so a list item promoted to a blockquote necessarily degrades to a
+ * removal followed by an addition — the legible failure the issue asks for
+ * rather than a nonsense edit.
+ */
+function pairGap(
+  oldBlocks: readonly MarkdownBlock[],
+  newBlocks: readonly MarkdownBlock[]
+): MarkdownBlockChange[] {
+  if (!oldBlocks.length) return newBlocks.map((block) => ({ kind: "added" as const, block }));
+  if (!newBlocks.length) return oldBlocks.map((block) => ({ kind: "removed" as const, block }));
+
+  const rows = oldBlocks.length + 1;
+  const cols = newBlocks.length + 1;
+  const scores = new Float64Array(rows * cols);
+  const candidate = new Float64Array(oldBlocks.length * newBlocks.length);
+  for (let i = 0; i < oldBlocks.length; i++) {
+    for (let j = 0; j < newBlocks.length; j++) {
+      const oldBlock = oldBlocks[i] as MarkdownBlock;
+      const newBlock = newBlocks[j] as MarkdownBlock;
+      const score =
+        oldBlock.type === newBlock.type ? blockSimilarity(oldBlock.text, newBlock.text) : 0;
+      candidate[i * newBlocks.length + j] = score >= PAIR_SIMILARITY_THRESHOLD ? score : 0;
+    }
+  }
+  for (let i = oldBlocks.length - 1; i >= 0; i--) {
+    for (let j = newBlocks.length - 1; j >= 0; j--) {
+      const paired =
+        (candidate[i * newBlocks.length + j] as number) > 0
+          ? (candidate[i * newBlocks.length + j] as number) +
+            (scores[(i + 1) * cols + j + 1] as number)
+          : -1;
+      scores[i * cols + j] = Math.max(
+        paired,
+        scores[(i + 1) * cols + j] as number,
+        scores[i * cols + j + 1] as number
+      );
+    }
+  }
+
+  const changes: MarkdownBlockChange[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < oldBlocks.length && j < newBlocks.length) {
+    const score = candidate[i * newBlocks.length + j] as number;
+    const paired = score > 0 ? score + (scores[(i + 1) * cols + j + 1] as number) : -1;
+    const current = scores[i * cols + j] as number;
+    if (paired === current) {
+      const oldBlock = oldBlocks[i] as MarkdownBlock;
+      const newBlock = newBlocks[j] as MarkdownBlock;
+      changes.push({
+        kind: "modified",
+        old: oldBlock,
+        new: newBlock,
+        // A fence's body is highlighted source, not prose; word marks inside it
+        // fight the syntax colouring for the same characters. The block keeps
+        // its removed/added treatment, which is the readable signal there.
+        inline:
+          oldBlock.type === "code"
+            ? { old: [], new: [] }
+            : inlineWordRanges(oldBlock.text, newBlock.text),
+      });
+      i++;
+      j++;
+    } else if (current === (scores[(i + 1) * cols + j] as number)) {
+      changes.push({ kind: "removed", block: oldBlocks[i] as MarkdownBlock });
+      i++;
+    } else {
+      changes.push({ kind: "added", block: newBlocks[j] as MarkdownBlock });
+      j++;
+    }
+  }
+  for (; i < oldBlocks.length; i++) {
+    changes.push({ kind: "removed", block: oldBlocks[i] as MarkdownBlock });
+  }
+  for (; j < newBlocks.length; j++) {
+    changes.push({ kind: "added", block: newBlocks[j] as MarkdownBlock });
+  }
+  return changes;
+}
+
+/** Match blocks exactly, then pair what's left in each gap by similarity. */
+export function diffMarkdownBlocks(
+  oldBlocks: readonly MarkdownBlock[],
+  newBlocks: readonly MarkdownBlock[]
+): { ok: true; changes: MarkdownBlockChange[] } | { ok: false; reason: MarkdownDiffFailure } {
+  if (oldBlocks.length > MARKDOWN_DIFF_MAX_BLOCKS || newBlocks.length > MARKDOWN_DIFF_MAX_BLOCKS) {
+    return { ok: false, reason: "too-large" };
+  }
+  const anchors = longestCommonSubsequence(
+    oldBlocks.map((block) => block.source),
+    newBlocks.map((block) => block.source)
+  );
+  const changes: MarkdownBlockChange[] = [];
+  let oldCursor = 0;
+  let newCursor = 0;
+  for (const [oldIndex, newIndex] of anchors) {
+    changes.push(
+      ...pairGap(oldBlocks.slice(oldCursor, oldIndex), newBlocks.slice(newCursor, newIndex))
+    );
+    changes.push({ kind: "unchanged", block: newBlocks[newIndex] as MarkdownBlock });
+    oldCursor = oldIndex + 1;
+    newCursor = newIndex + 1;
+  }
+  changes.push(...pairGap(oldBlocks.slice(oldCursor), newBlocks.slice(newCursor)));
+  return { ok: true, changes };
+}
+
+/** The whole pipeline: patch plus disk source in, block changes out. */
+export function buildMarkdownDiff(input: ReconstructInput): MarkdownDiffResult {
+  const reconstructed = reconstructMarkdownDocuments(input);
+  if (!reconstructed.ok) return reconstructed;
+
+  const oldParsed = parseMarkdownBlocks(reconstructed.documents.old);
+  const newParsed = parseMarkdownBlocks(reconstructed.documents.new);
+  const diffed = diffMarkdownBlocks(oldParsed.blocks, newParsed.blocks);
+  if (!diffed.ok) return diffed;
+
+  return {
+    ok: true,
+    model: {
+      changes: diffed.changes,
+      oldDefinitions: oldParsed.definitions,
+      newDefinitions: newParsed.definitions,
+      identical: diffed.changes.every((change) => change.kind === "unchanged"),
+    },
+  };
+}

--- a/src/components/Worktree/markdownBlockDiff.ts
+++ b/src/components/Worktree/markdownBlockDiff.ts
@@ -226,7 +226,9 @@ function reverseApplyHunks(
     }
   }
   for (let line = newCursor; line <= newLines.length; line++) {
-    oldLines.push(newLines[line - 1] as string);
+    const content = newLines[line - 1];
+    if (content === undefined) break;
+    oldLines.push(content);
   }
   return oldLines;
 }
@@ -472,8 +474,8 @@ function longestCommonSubsequence(
     for (let j = right.length - 1; j >= 0; j--) {
       table[i * cols + j] =
         left[i] === right[j]
-          ? (table[(i + 1) * cols + j + 1] as number) + 1
-          : Math.max(table[(i + 1) * cols + j] as number, table[i * cols + j + 1] as number);
+          ? (table[(i + 1) * cols + j + 1] ?? 0) + 1
+          : Math.max(table[(i + 1) * cols + j] ?? 0, table[i * cols + j + 1] ?? 0);
     }
   }
   const matches: Array<[number, number]> = [];
@@ -484,7 +486,7 @@ function longestCommonSubsequence(
       matches.push([i, j]);
       i++;
       j++;
-    } else if ((table[(i + 1) * cols + j] as number) >= (table[i * cols + j + 1] as number)) {
+    } else if ((table[(i + 1) * cols + j] ?? 0) >= (table[i * cols + j + 1] ?? 0)) {
       // Ties drop the left element first, so duplicate blocks anchor
       // deterministically to their earliest counterpart.
       i++;
@@ -679,17 +681,16 @@ function pairGap(
   const oldStats = oldBlocks.map((block) => tokenStats(block.text));
   const newStats = newBlocks.map((block) => tokenStats(block.text));
   for (let i = 0; i < oldBlocks.length; i++) {
+    const oldBlock = oldBlocks[i];
+    const oldStat = oldStats[i];
+    if (!oldBlock || !oldStat) continue;
     for (let j = 0; j < newBlocks.length; j++) {
-      const oldBlock = oldBlocks[i] as MarkdownBlock;
-      const newBlock = newBlocks[j] as MarkdownBlock;
+      const newBlock = newBlocks[j];
+      const newStat = newStats[j];
+      if (!newBlock || !newStat) continue;
       const score =
         oldBlock.type === newBlock.type
-          ? similarityFrom(
-              oldBlock.text,
-              newBlock.text,
-              oldStats[i] as TokenStats,
-              newStats[j] as TokenStats
-            )
+          ? similarityFrom(oldBlock.text, newBlock.text, oldStat, newStat)
           : 0;
       candidate[i * newBlocks.length + j] = score >= PAIR_SIMILARITY_THRESHOLD ? score : 0;
     }
@@ -697,14 +698,13 @@ function pairGap(
   for (let i = oldBlocks.length - 1; i >= 0; i--) {
     for (let j = newBlocks.length - 1; j >= 0; j--) {
       const paired =
-        (candidate[i * newBlocks.length + j] as number) > 0
-          ? (candidate[i * newBlocks.length + j] as number) +
-            (scores[(i + 1) * cols + j + 1] as number)
+        (candidate[i * newBlocks.length + j] ?? 0) > 0
+          ? (candidate[i * newBlocks.length + j] ?? 0) + (scores[(i + 1) * cols + j + 1] ?? 0)
           : -1;
       scores[i * cols + j] = Math.max(
         paired,
-        scores[(i + 1) * cols + j] as number,
-        scores[i * cols + j + 1] as number
+        scores[(i + 1) * cols + j] ?? 0,
+        scores[i * cols + j + 1] ?? 0
       );
     }
   }
@@ -713,12 +713,13 @@ function pairGap(
   let i = 0;
   let j = 0;
   while (i < oldBlocks.length && j < newBlocks.length) {
-    const score = candidate[i * newBlocks.length + j] as number;
-    const paired = score > 0 ? score + (scores[(i + 1) * cols + j + 1] as number) : -1;
-    const current = scores[i * cols + j] as number;
+    const score = candidate[i * newBlocks.length + j] ?? 0;
+    const paired = score > 0 ? score + (scores[(i + 1) * cols + j + 1] ?? 0) : -1;
+    const current = scores[i * cols + j] ?? 0;
+    const oldBlock = oldBlocks[i];
+    const newBlock = newBlocks[j];
+    if (!oldBlock || !newBlock) break;
     if (paired === current) {
-      const oldBlock = oldBlocks[i] as MarkdownBlock;
-      const newBlock = newBlocks[j] as MarkdownBlock;
       changes.push({
         kind: "modified",
         old: oldBlock,
@@ -733,19 +734,21 @@ function pairGap(
       });
       i++;
       j++;
-    } else if (current === (scores[(i + 1) * cols + j] as number)) {
-      changes.push({ kind: "removed", block: oldBlocks[i] as MarkdownBlock });
+    } else if (current === (scores[(i + 1) * cols + j] ?? 0)) {
+      changes.push({ kind: "removed", block: oldBlock });
       i++;
     } else {
-      changes.push({ kind: "added", block: newBlocks[j] as MarkdownBlock });
+      changes.push({ kind: "added", block: newBlock });
       j++;
     }
   }
   for (; i < oldBlocks.length; i++) {
-    changes.push({ kind: "removed", block: oldBlocks[i] as MarkdownBlock });
+    const block = oldBlocks[i];
+    if (block) changes.push({ kind: "removed", block });
   }
   for (; j < newBlocks.length; j++) {
-    changes.push({ kind: "added", block: newBlocks[j] as MarkdownBlock });
+    const block = newBlocks[j];
+    if (block) changes.push({ kind: "added", block });
   }
   return changes;
 }
@@ -776,8 +779,9 @@ export function diffMarkdownBlocks(
     changes.push(
       ...pairGap(oldBlocks.slice(oldCursor, oldIndex), newBlocks.slice(newCursor, newIndex), budget)
     );
-    const oldBlock = oldBlocks[oldIndex] as MarkdownBlock;
-    const newBlock = newBlocks[newIndex] as MarkdownBlock;
+    const oldBlock = oldBlocks[oldIndex];
+    const newBlock = newBlocks[newIndex];
+    if (!oldBlock || !newBlock) continue;
     // Identical source, but it renders through a definition that moved — so the
     // block really did change and must not be reported as untouched. The word
     // marks stay empty: the text is the same, the target behind it is not.

--- a/src/components/Worktree/markdownBlockDiff.ts
+++ b/src/components/Worktree/markdownBlockDiff.ts
@@ -69,11 +69,13 @@ export interface MarkdownBlock {
   /** Visible text, flattened for similarity scoring and the word diff. */
   text: string;
   /**
-   * The block resolves a link, image or footnote through a document-level
-   * definition, so a change to those definitions changes what it renders even
-   * when its own source is byte-identical.
+   * Normalized identifiers this block resolves through document-level
+   * definitions. A change to one of those definitions changes what the block
+   * renders even when its own source is byte-identical, so they are tracked
+   * per-block: comparing the document's definitions wholesale would mark every
+   * referencing block as edited whenever any unrelated definition moved.
    */
-  hasReference: boolean;
+  referenceIds: readonly string[];
 }
 
 /** Half-open character range into a block's `text`. */
@@ -132,7 +134,9 @@ export type MarkdownDiffResult =
  * matches whether or not the producer normalized them.
  */
 function toComparableLines(source: string): string[] {
-  if (source === "") return [];
+  // No empty-string special case: `"".split("\n")` is `[""]`, which is exactly
+  // what the added-file producer emits for an empty file (one `+` line with
+  // nothing after it). Returning no lines made every empty addition mismatch.
   return source.split("\n").map(stripCarriageReturn);
 }
 
@@ -282,9 +286,17 @@ export function reconstructMarkdownDocuments(
     return { ok: false, reason: "unsupported-patch" };
   }
   if (files.length !== 1) return { ok: false, reason: "unsupported-patch" };
-  const hunks = files[0]?.hunks ?? [];
+  const file = files[0];
+  const hunks = file?.hunks ?? [];
 
   if (input.status === "deleted") {
+    // The patch must agree that this is a deletion, not just the caller. A
+    // panel holds the status it was opened with, and a zero-context patch that
+    // merely strips a file's opening lines has the same hunk shape as a whole
+    // file removed — accepting it would present surviving prose as deleted.
+    if (file?.type !== "delete") return { ok: false, reason: "unsupported-patch" };
+    // An empty file's deletion is metadata only; there is no hunk to rebuild.
+    if (!hunks.length) return { ok: true, documents: { old: "", new: "" } };
     const oldLines = oldSourceFromHunks(hunks);
     if (!oldLines) return { ok: false, reason: "unsupported-patch" };
     if (oldLines.length > MARKDOWN_DIFF_MAX_LINES) return { ok: false, reason: "too-large" };
@@ -331,22 +343,25 @@ const REFERENCE_TYPES: ReadonlySet<string> = new Set([
   "footnoteReference",
 ]);
 
-/** Whether the block resolves anything through a document-level definition. */
-function hasReferenceNode(node: RootContent): boolean {
-  let found = false;
+/** Every definition identifier this block resolves through. */
+function referenceIdsOf(node: RootContent): string[] {
+  const ids = new Set<string>();
   const walk = (current: unknown): void => {
-    if (found || typeof current !== "object" || current === null) return;
-    const candidate = current as { type?: string; children?: unknown };
-    if (candidate.type !== undefined && REFERENCE_TYPES.has(candidate.type)) {
-      found = true;
-      return;
+    if (typeof current !== "object" || current === null) return;
+    const candidate = current as { type?: string; identifier?: unknown; children?: unknown };
+    if (
+      candidate.type !== undefined &&
+      REFERENCE_TYPES.has(candidate.type) &&
+      typeof candidate.identifier === "string"
+    ) {
+      ids.add(candidate.identifier);
     }
     if (Array.isArray(candidate.children)) {
       for (const child of candidate.children) walk(child);
     }
   };
   walk(node);
-  return found;
+  return [...ids];
 }
 
 /**
@@ -388,7 +403,10 @@ function flattenText(node: RootContent): string {
 
 export interface ParsedMarkdown {
   blocks: readonly MarkdownBlock[];
+  /** Every definition's source, for appending to the blocks that cite them. */
   definitions: string;
+  /** Definition source by normalized identifier, for detecting what moved. */
+  definitionsById: ReadonlyMap<string, string>;
 }
 
 /**
@@ -409,10 +427,11 @@ export function parseMarkdownBlocks(source: string): ParsedMarkdown {
     tree = markdownProcessor.parse(source);
   } catch (error) {
     console.warn("[markdownBlockDiff] failed to parse markdown", error);
-    return { blocks: [], definitions: "" };
+    return { blocks: [], definitions: "", definitionsById: new Map() };
   }
   const blocks: MarkdownBlock[] = [];
   const definitions: string[] = [];
+  const definitionsById = new Map<string, string>();
   for (const node of tree.children) {
     const start = node.position?.start.offset;
     const end = node.position?.end.offset;
@@ -424,6 +443,7 @@ export function parseMarkdownBlocks(source: string): ParsedMarkdown {
     // `[^1]` — between them the note's text would vanish from the diff.
     if (node.type === "definition" || node.type === "footnoteDefinition") {
       definitions.push(slice);
+      definitionsById.set(node.identifier, slice);
       continue;
     }
     if (node.type === "html") continue;
@@ -431,10 +451,10 @@ export function parseMarkdownBlocks(source: string): ParsedMarkdown {
       type: node.type,
       source: slice,
       text: flattenText(node),
-      hasReference: hasReferenceNode(node),
+      referenceIds: referenceIdsOf(node),
     });
   }
-  return { blocks, definitions: definitions.join("\n\n") };
+  return { blocks, definitions: definitions.join("\n\n"), definitionsById };
 }
 
 /**
@@ -735,12 +755,11 @@ export function diffMarkdownBlocks(
   oldBlocks: readonly MarkdownBlock[],
   newBlocks: readonly MarkdownBlock[],
   /**
-   * The document's link/image/footnote definitions differ between the two
-   * sides. A block whose own source is byte-identical still renders differently
-   * when a definition it resolves through has moved, so those blocks cannot
-   * anchor as unchanged.
+   * Identifiers whose definition differs between the two sides. A block whose
+   * own source is byte-identical still renders differently when a definition it
+   * resolves through has moved, so those blocks cannot anchor as unchanged.
    */
-  definitionsChanged = false
+  changedDefinitionIds: ReadonlySet<string> = new Set()
 ): { ok: true; changes: MarkdownBlockChange[] } | { ok: false; reason: MarkdownDiffFailure } {
   if (oldBlocks.length > MARKDOWN_DIFF_MAX_BLOCKS || newBlocks.length > MARKDOWN_DIFF_MAX_BLOCKS) {
     return { ok: false, reason: "too-large" };
@@ -762,8 +781,16 @@ export function diffMarkdownBlocks(
     // Identical source, but it renders through a definition that moved — so the
     // block really did change and must not be reported as untouched. The word
     // marks stay empty: the text is the same, the target behind it is not.
+    //
+    // Both sides' identifiers count. Removing a definition outright makes the
+    // new side parse `[docs][d]` as literal text with no reference at all, so
+    // testing the new block alone would miss exactly the case where the
+    // rendered output changed most.
+    const touchesMovedDefinition =
+      oldBlock.referenceIds.some((id) => changedDefinitionIds.has(id)) ||
+      newBlock.referenceIds.some((id) => changedDefinitionIds.has(id));
     changes.push(
-      definitionsChanged && newBlock.hasReference
+      touchesMovedDefinition
         ? { kind: "modified", old: oldBlock, new: newBlock, inline: NO_RANGES }
         : { kind: "unchanged", block: newBlock }
     );
@@ -781,8 +808,16 @@ export function buildMarkdownDiff(input: ReconstructInput): MarkdownDiffResult {
 
   const oldParsed = parseMarkdownBlocks(reconstructed.documents.old);
   const newParsed = parseMarkdownBlocks(reconstructed.documents.new);
-  const definitionsChanged = oldParsed.definitions !== newParsed.definitions;
-  const diffed = diffMarkdownBlocks(oldParsed.blocks, newParsed.blocks, definitionsChanged);
+  const changedDefinitionIds = new Set<string>();
+  for (const id of new Set([
+    ...oldParsed.definitionsById.keys(),
+    ...newParsed.definitionsById.keys(),
+  ])) {
+    if (oldParsed.definitionsById.get(id) !== newParsed.definitionsById.get(id)) {
+      changedDefinitionIds.add(id);
+    }
+  }
+  const diffed = diffMarkdownBlocks(oldParsed.blocks, newParsed.blocks, changedDefinitionIds);
   if (!diffed.ok) return diffed;
 
   return {

--- a/src/panels/diff/DiffPane.tsx
+++ b/src/panels/diff/DiffPane.tsx
@@ -529,7 +529,15 @@ export function DiffPane({
   // onto the current file, so it needs the same whole-file read the full-file
   // scope does. A deleted file is the exception: its patch already carries every
   // line of the old document, and there is nothing on disk to read.
-  const renderedNeedsSource = renderedRequested && fileStatus !== "deleted";
+  //
+  // Gated on `hasDiff` and `!stale` for the same reason `wantsFullFile` is, and
+  // that gate is what makes Refresh work: clearing the diff drops `hasDiff`,
+  // which disables the read and invalidates whatever it held, so a new patch
+  // can never be paired with the file snapshot the old one was measured
+  // against. Without it, a Refresh after a partial revert would verify the one
+  // surviving hunk and then copy the reverted text out of the stale snapshot as
+  // trusted context.
+  const renderedNeedsSource = renderedRequested && hasDiff && !stale && fileStatus !== "deleted";
   const { source, errorCode: sourceErrorCode } = useDiffFileSource(
     sourceSubject,
     wantsFullFile || renderedNeedsSource
@@ -554,21 +562,33 @@ export function DiffPane({
   const activeViewerFallback =
     viewerVerdict && viewerVerdict.source === source ? viewerVerdict.reason : null;
 
-  // The rendered engine's verdict, stamped with the diff it judged for the same
-  // reason the viewer's is stamped with its source: a stale "this patch can't be
-  // rebuilt" must not disqualify the next file's perfectly good one.
+  // The whole input the engine consumes. The verdict is stamped with this
+  // rather than with the patch text alone, because a verdict outliving its
+  // inputs is a latch: two attempts on one file can share a patch and differ in
+  // the source, and a failure recorded against the patch would then disqualify
+  // every later attempt that reused it.
+  const renderedAttemptKey = `${filePath ?? ""}\u0000${fileStatus ?? ""}\u0000${content ?? ""}\u0000${source ?? ""}`;
+
   const [renderedVerdict, setRenderedVerdict] = useState<{
-    diff: string;
+    attempt: string;
     reason: MarkdownDiffFailure | null;
   } | null>(null);
   const handleRenderedVerdict = useCallback(
-    (reason: MarkdownDiffFailure | null, forDiff: string) => {
-      setRenderedVerdict({ diff: forDiff, reason });
+    (reason: MarkdownDiffFailure | null, forAttempt: string) => {
+      setRenderedVerdict({ attempt: forAttempt, reason });
     },
     []
   );
   const renderedEngineFailure =
-    renderedVerdict && renderedVerdict.diff === content ? renderedVerdict.reason : null;
+    renderedVerdict && renderedVerdict.attempt === renderedAttemptKey
+      ? renderedVerdict.reason
+      : null;
+
+  // The whole-file read hasn't landed yet. Handing the engine an absent source
+  // would make it report `source-required` — a failure the availability verdict
+  // latches onto, disabling the segment over a read that was merely in flight.
+  // This is a loading state, so the body shows a skeleton instead.
+  const renderedSourcePending = renderedNeedsSource && source === undefined && !sourceErrorCode;
 
   const renderedAvailability = getRenderedMarkdownAvailability({
     filePath,
@@ -657,6 +677,15 @@ export function DiffPane({
           {fullFileAvailability.reason}
         </span>
       )}
+    </div>
+  );
+
+  const renderedSkeleton = (
+    <div className="p-4 space-y-3">
+      <Skeleton label="Loading rendered Markdown">
+        <SkeletonBone className="h-7 w-3/4" />
+        <SkeletonText lines={8} />
+      </Skeleton>
     </div>
   );
 
@@ -1001,26 +1030,22 @@ export function DiffPane({
               !isPdfMode &&
               content &&
               (showRendered ? (
-                <Suspense
-                  fallback={
-                    <div className="p-4 space-y-3">
-                      <Skeleton label="Loading rendered Markdown">
-                        <SkeletonBone className="h-7 w-3/4" />
-                        <SkeletonText lines={8} />
-                      </Skeleton>
-                    </div>
-                  }
-                >
-                  <LazyRenderedMarkdownDiff
-                    diff={content}
-                    newSource={renderedNeedsSource ? source : undefined}
-                    status={fileStatus ?? "modified"}
-                    filePath={absolutePath ?? filePath}
-                    rootPath={worktreePath}
-                    cacheBust={String(previewReloadNonce)}
-                    fontSize={markdownFontSize}
-                    onVerdict={handleRenderedVerdict}
-                  />
+                <Suspense fallback={renderedSkeleton}>
+                  {renderedSourcePending ? (
+                    renderedSkeleton
+                  ) : (
+                    <LazyRenderedMarkdownDiff
+                      diff={content}
+                      newSource={renderedNeedsSource ? source : undefined}
+                      status={fileStatus ?? "modified"}
+                      filePath={absolutePath ?? filePath}
+                      rootPath={worktreePath}
+                      cacheBust={String(previewReloadNonce)}
+                      fontSize={markdownFontSize}
+                      attemptKey={renderedAttemptKey}
+                      onVerdict={handleRenderedVerdict}
+                    />
+                  )}
                 </Suspense>
               ) : (
                 <DiffViewer

--- a/src/panels/diff/DiffPane.tsx
+++ b/src/panels/diff/DiffPane.tsx
@@ -1,4 +1,13 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from "react";
+import {
+  lazy,
+  Suspense,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+} from "react";
 import {
   ChevronLeft,
   ChevronRight,
@@ -41,18 +50,35 @@ import { Skeleton, SkeletonBone, SkeletonText } from "@/components/ui/Skeleton";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { usePanelStore } from "@/store/panelStore";
-import { usePreferencesStore, type DiffFontSize } from "@/store/preferencesStore";
+import {
+  usePreferencesStore,
+  type DiffFontSize,
+  type DiffViewType,
+} from "@/store/preferencesStore";
 import { useWorktreeStore } from "@/hooks/useWorktreeStore";
 import { useDohertyGate } from "@/hooks/useDeferredLoading";
 import { useDiffViewedStore, selectViewedSet } from "@/store/diffViewedStore";
 import { useDiffContent } from "./useDiffContent";
 import { useDiffFileSource } from "./useDiffFileSource";
 import { getFullFileAvailability } from "./fullFileAvailability";
+import {
+  getRenderedMarkdownAvailability,
+  isRenderedMarkdownSupported,
+} from "./renderedMarkdownAvailability";
+import type { MarkdownDiffFailure } from "@/components/Worktree/markdownBlockDiff";
 import type { DiffSubject } from "./diffContentCache";
 import type { BasePanelProps } from "@/components/Panel/ContentPanel";
 import type { TabInfo } from "@/components/Panel/TabButton";
 
-type DiffViewType = "split" | "unified";
+/**
+ * The layout segments the toolbar offers. `rendered` is deliberately not a
+ * `DiffViewType`: that union is the source diff's layout and is read by
+ * surfaces which render no such mode (the file panel, the cross-worktree diff),
+ * so it stays closed and rendered rides a separate preference (#12171). Keeping
+ * them apart is also what makes the round trip sticky — leaving rendered mode
+ * returns the user to the Unified or Split they were last on.
+ */
+type DiffPaneLayout = DiffViewType | "rendered";
 
 /**
  * How much of the file the diff renders. Kept separate from `DiffViewType`:
@@ -89,6 +115,15 @@ const DIFF_FONT_SIZE: Record<DiffFontSize, string> = {
   m: "var(--text-xs)",
   l: "var(--text-sm)",
 };
+
+// react-markdown plus the remark pipeline behind it are several hundred KB that
+// no source diff needs, and DiffPane is on the first-render path. Same lazy
+// boundary MarkdownViewer draws around MarkdownDocument.
+const LazyRenderedMarkdownDiff = lazy(() =>
+  import("@/components/Worktree/RenderedMarkdownDiff").then((m) => ({
+    default: m.RenderedMarkdownDiff,
+  }))
+);
 
 export interface DiffPaneProps extends BasePanelProps {
   tabs?: TabInfo[];
@@ -178,6 +213,9 @@ export function DiffPane({
   const setDiffViewType = usePreferencesStore((s) => s.setDiffViewType);
   const diffWrapLines = usePreferencesStore((s) => s.diffWrapLines);
   const setDiffWrapLines = usePreferencesStore((s) => s.setDiffWrapLines);
+  const diffMarkdownRendered = usePreferencesStore((s) => s.diffMarkdownRendered);
+  const setDiffMarkdownRendered = usePreferencesStore((s) => s.setDiffMarkdownRendered);
+  const markdownFontSize = usePreferencesStore((s) => s.markdownFontSize);
   const diffFullFile = usePreferencesStore((s) => s.diffFullFile);
   const setDiffFullFile = usePreferencesStore((s) => s.setDiffFullFile);
   const diffShowFileList = usePreferencesStore((s) => s.diffShowFileList);
@@ -281,7 +319,17 @@ export function DiffPane({
     [diffSource, panelBaseBranch, worktreePath, nextPath, nextStatus, currentBranch]
   );
 
-  const { content, stale, retry } = useDiffContent(subject, nextSubject);
+  // Decided from the subject alone, before any content exists: the request's
+  // whitespace sensitivity depends on it, so it cannot wait on the verdict that
+  // needs the content the request produces.
+  const renderedSupported = isRenderedMarkdownSupported(filePath, diffSource);
+  const renderedRequested = diffMarkdownRendered && renderedSupported;
+  const renderedContentOptions = useMemo(
+    () => (renderedRequested ? { ignoreWhitespace: false } : undefined),
+    [renderedRequested]
+  );
+
+  const { content, stale, retry } = useDiffContent(subject, nextSubject, renderedContentOptions);
 
   const viewedSet = useDiffViewedStore(
     useCallback((state) => selectViewedSet(state, worktreePath), [worktreePath])
@@ -477,7 +525,15 @@ export function DiffPane({
     () => (worktreePath && filePath ? { worktreePath, filePath } : null),
     [worktreePath, filePath]
   );
-  const { source, errorCode: sourceErrorCode } = useDiffFileSource(sourceSubject, wantsFullFile);
+  // The rendered layout rebuilds the old document by reverse-applying the patch
+  // onto the current file, so it needs the same whole-file read the full-file
+  // scope does. A deleted file is the exception: its patch already carries every
+  // line of the old document, and there is nothing on disk to read.
+  const renderedNeedsSource = renderedRequested && fileStatus !== "deleted";
+  const { source, errorCode: sourceErrorCode } = useDiffFileSource(
+    sourceSubject,
+    wantsFullFile || renderedNeedsSource
+  );
 
   // Reported by the viewer once it has the parsed diff and the source side by
   // side — the mismatch and size checks can only be made there.
@@ -498,6 +554,53 @@ export function DiffPane({
   const activeViewerFallback =
     viewerVerdict && viewerVerdict.source === source ? viewerVerdict.reason : null;
 
+  // The rendered engine's verdict, stamped with the diff it judged for the same
+  // reason the viewer's is stamped with its source: a stale "this patch can't be
+  // rebuilt" must not disqualify the next file's perfectly good one.
+  const [renderedVerdict, setRenderedVerdict] = useState<{
+    diff: string;
+    reason: MarkdownDiffFailure | null;
+  } | null>(null);
+  const handleRenderedVerdict = useCallback(
+    (reason: MarkdownDiffFailure | null, forDiff: string) => {
+      setRenderedVerdict({ diff: forDiff, reason });
+    },
+    []
+  );
+  const renderedEngineFailure =
+    renderedVerdict && renderedVerdict.diff === content ? renderedVerdict.reason : null;
+
+  const renderedAvailability = getRenderedMarkdownAvailability({
+    filePath,
+    diffSource,
+    content,
+    stale,
+    // Only relevant once the rendered layout is the thing waiting on the read —
+    // a failed full-file read says nothing about a layout that never asked.
+    sourceErrorCode: renderedNeedsSource ? sourceErrorCode : null,
+    engineFailure: renderedEngineFailure,
+  });
+
+  // What the body actually shows. A requested rendered layout that turns out to
+  // be unavailable falls back to the source diff without clearing the
+  // preference, so the file that can't render doesn't cost the user the setting
+  // — the same clamp shape the file panel applies to its own view modes.
+  const showRendered =
+    renderedRequested && renderedAvailability.visible && renderedAvailability.enabled;
+  const layout: DiffPaneLayout = showRendered ? "rendered" : diffViewType;
+
+  const handleLayoutChange = useCallback(
+    (next: DiffPaneLayout) => {
+      if (next === "rendered") {
+        setDiffMarkdownRendered(true);
+        return;
+      }
+      setDiffMarkdownRendered(false);
+      setDiffViewType(next);
+    },
+    [setDiffMarkdownRendered, setDiffViewType]
+  );
+
   // Only the diff is retried: clearing it drops `hasDiff`, which disables the
   // source hook and invalidates its read, and the source is fetched again when
   // the new diff lands. Retrying both here would issue that read twice. The
@@ -512,16 +615,20 @@ export function DiffPane({
   // never got far enough to have one. `recoverable` marks the notices a refresh
   // can actually clear — a hunkless rename never grows hunks and an over-size
   // file never shrinks, so those get no action rather than one that can't work.
-  const fullFileNotice: { message: string; recoverable: boolean } | null = wantsFullFile
-    ? sourceErrorCode
-      ? { message: FILE_READ_ERROR_MESSAGES[sourceErrorCode], recoverable: true }
-      : activeViewerFallback
-        ? {
-            message: FULL_FILE_FALLBACK_MESSAGES[activeViewerFallback],
-            recoverable: activeViewerFallback === "source-mismatch",
-          }
-        : null
-    : null;
+  // Suppressed while the rendered layout owns the body: it shows the whole
+  // document regardless, so a notice explaining why the full file isn't on
+  // screen would be describing a scope that isn't in force.
+  const fullFileNotice: { message: string; recoverable: boolean } | null =
+    wantsFullFile && !showRendered
+      ? sourceErrorCode
+        ? { message: FILE_READ_ERROR_MESSAGES[sourceErrorCode], recoverable: true }
+        : activeViewerFallback
+          ? {
+              message: FULL_FILE_FALLBACK_MESSAGES[activeViewerFallback],
+              recoverable: activeViewerFallback === "source-mismatch",
+            }
+          : null
+      : null;
 
   // The reason rides an aria-describedby rather than the tooltip alone: a
   // disabled segment takes no focus, so a keyboard or screen-reader user would
@@ -553,6 +660,46 @@ export function DiffPane({
     </div>
   );
 
+  const renderedDisabledReason =
+    renderedAvailability.visible && !renderedAvailability.enabled
+      ? renderedAvailability.reason
+      : null;
+  const layoutReasonId = `${id}-rendered-reason`;
+  const layoutToggle = (
+    <div
+      role="group"
+      aria-label="Diff layout"
+      aria-describedby={renderedDisabledReason ? layoutReasonId : undefined}
+    >
+      <SegmentedToggle<DiffPaneLayout>
+        options={[
+          { value: "unified", label: "Unified" },
+          { value: "split", label: "Split" },
+          // Absent rather than disabled for a non-Markdown file: a rendered
+          // layout there isn't something the user was denied, it's something
+          // that doesn't exist, and a permanently dead segment on every source
+          // diff is noise.
+          ...(renderedAvailability.visible
+            ? [
+                {
+                  value: "rendered" as const,
+                  label: "Rendered",
+                  disabled: Boolean(renderedDisabledReason),
+                },
+              ]
+            : []),
+        ]}
+        value={layout}
+        onChange={handleLayoutChange}
+      />
+      {renderedDisabledReason && (
+        <span id={layoutReasonId} className="sr-only">
+          {renderedDisabledReason}
+        </span>
+      )}
+    </div>
+  );
+
   const fileName = filePath?.split(/[/\\]/).filter(Boolean).pop();
   const displayTitle = panel?.titleMode === "user" ? title : (fileName ?? title);
 
@@ -560,31 +707,39 @@ export function DiffPane({
   const toolbar = filePath ? (
     <>
       <FileViewerToolbar.Root label="Diff viewer controls">
-        {!isImageMode && !isMediaMode && !isPdfMode && (
-          <div role="group" aria-label="Diff layout">
-            <SegmentedToggle<DiffViewType>
-              options={[
-                { value: "unified", label: "Unified" },
-                { value: "split", label: "Split" },
-              ]}
-              value={diffViewType}
-              onChange={setDiffViewType}
-            />
-          </div>
-        )}
-        {fullFileAvailability.available ? (
-          scopeToggle
-        ) : (
-          // A disabled segment can't host a tooltip trigger of its own
-          // (pointer-events are off), so the explanation hangs off the wrapper.
-          <Tooltip>
-            <TooltipTrigger asChild>{scopeToggle}</TooltipTrigger>
-            <TooltipContent side="bottom">{fullFileAvailability.reason}</TooltipContent>
-          </Tooltip>
-        )}
+        {!isImageMode &&
+          !isMediaMode &&
+          !isPdfMode &&
+          (renderedDisabledReason ? (
+            // Same pattern as the scope toggle: a disabled segment takes no
+            // pointer events and no focus, so the reason hangs off the wrapper as
+            // both a tooltip and a description the keyboard path can reach.
+            <Tooltip>
+              <TooltipTrigger asChild>{layoutToggle}</TooltipTrigger>
+              <TooltipContent side="bottom">{renderedDisabledReason}</TooltipContent>
+            </Tooltip>
+          ) : (
+            layoutToggle
+          ))}
+        {/* Content scope is meaningless in the rendered layout, which always
+            shows the whole document — and a control that does nothing is worse
+            than an absent one. The preference is left untouched, so returning to
+            a source layout restores whatever scope was in force. */}
+        {!showRendered &&
+          (fullFileAvailability.available ? (
+            scopeToggle
+          ) : (
+            // A disabled segment can't host a tooltip trigger of its own
+            // (pointer-events are off), so the explanation hangs off the wrapper.
+            <Tooltip>
+              <TooltipTrigger asChild>{scopeToggle}</TooltipTrigger>
+              <TooltipContent side="bottom">{fullFileAvailability.reason}</TooltipContent>
+            </Tooltip>
+          ))}
         <FileViewerToolbar.Path path={filePath} copied={pathCopied} onCopy={handleCopyPath} />
         <FileViewerToolbar.Actions>
-          {!isImageMode && !isMediaMode && !isPdfMode && (
+          {/* Rendered prose already wraps; the control would toggle nothing. */}
+          {!isImageMode && !isMediaMode && !isPdfMode && !showRendered && (
             <FileViewerToolbar.IconButton
               label="Wrap long lines"
               pressed={effectiveWrapLines}
@@ -839,18 +994,46 @@ export function DiffPane({
                 />
               ))}
 
-            {filePath && subject && !isImageMode && !isMediaMode && !isPdfMode && content && (
-              <DiffViewer
-                diff={content}
-                viewType={diffViewType}
-                rootPath={worktreePath}
-                source={wantsFullFile ? source : undefined}
-                fullFile={wantsFullFile}
-                onFullFileVerdict={handleFullFileVerdict}
-                wrapLines={effectiveWrapLines}
-                onRetry={retry}
-              />
-            )}
+            {filePath &&
+              subject &&
+              !isImageMode &&
+              !isMediaMode &&
+              !isPdfMode &&
+              content &&
+              (showRendered ? (
+                <Suspense
+                  fallback={
+                    <div className="p-4 space-y-3">
+                      <Skeleton label="Loading rendered Markdown">
+                        <SkeletonBone className="h-7 w-3/4" />
+                        <SkeletonText lines={8} />
+                      </Skeleton>
+                    </div>
+                  }
+                >
+                  <LazyRenderedMarkdownDiff
+                    diff={content}
+                    newSource={renderedNeedsSource ? source : undefined}
+                    status={fileStatus ?? "modified"}
+                    filePath={absolutePath ?? filePath}
+                    rootPath={worktreePath}
+                    cacheBust={String(previewReloadNonce)}
+                    fontSize={markdownFontSize}
+                    onVerdict={handleRenderedVerdict}
+                  />
+                </Suspense>
+              ) : (
+                <DiffViewer
+                  diff={content}
+                  viewType={diffViewType}
+                  rootPath={worktreePath}
+                  source={wantsFullFile ? source : undefined}
+                  fullFile={wantsFullFile}
+                  onFullFileVerdict={handleFullFileVerdict}
+                  wrapLines={effectiveWrapLines}
+                  onRetry={retry}
+                />
+              ))}
 
             {filePath && subject && !isImageMode && !isMediaMode && !isPdfMode && !content && (
               <div className="p-4 space-y-3">

--- a/src/panels/diff/__tests__/DiffPane.externalActions.test.tsx
+++ b/src/panels/diff/__tests__/DiffPane.externalActions.test.tsx
@@ -74,6 +74,9 @@ vi.mock("@/store/preferencesStore", () => ({
     selector({
       diffViewType: "unified",
       setDiffViewType: vi.fn(),
+      diffMarkdownRendered: false,
+      setDiffMarkdownRendered: vi.fn(),
+      markdownFontSize: "sm",
       diffWrapLines: false,
       setDiffWrapLines: vi.fn(),
       diffShowFileList: false,

--- a/src/panels/diff/__tests__/DiffPane.test.tsx
+++ b/src/panels/diff/__tests__/DiffPane.test.tsx
@@ -1127,8 +1127,8 @@ describe("DiffPane — rendered Markdown layout (#12171)", () => {
     expect(rendered?.hasAttribute("disabled")).toBe(true);
 
     const describedBy = group.getAttribute("aria-describedby");
-    expect(describedBy).toBeTruthy();
-    expect(document.getElementById(describedBy as string)?.textContent).toContain("staged changes");
+    if (!describedBy) throw new Error("layout group carries no aria-describedby");
+    expect(document.getElementById(describedBy)?.textContent).toContain("staged changes");
   });
 
   it("falls back to the source diff when the file can render but the diff is stale", () => {

--- a/src/panels/diff/__tests__/DiffPane.test.tsx
+++ b/src/panels/diff/__tests__/DiffPane.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import type { ReactNode } from "react";
-import { render, fireEvent, screen, waitFor } from "@testing-library/react";
+import { act, render, fireEvent, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { GitStatus } from "@shared/types/git";
 import type { DiffChangeSetEntry } from "@shared/types/git";
@@ -40,11 +40,12 @@ vi.mock("@/components/Worktree/DiffViewer", () => ({
 // The rendered layout pulls react-markdown behind a lazy boundary; these tests
 // exercise the toolbar's plumbing, not the renderer, so it stays a stub.
 vi.mock("@/components/Worktree/RenderedMarkdownDiff", () => ({
-  RenderedMarkdownDiff: (props: { newSource?: string; status: string }) => (
+  RenderedMarkdownDiff: (props: { newSource?: string; status: string; attemptKey: string }) => (
     <div
       data-testid="rendered-markdown-mock"
       data-has-source={String(props.newSource !== undefined)}
       data-status={props.status}
+      data-attempt-key={props.attemptKey}
     />
   ),
 }));
@@ -136,14 +137,19 @@ vi.mock("../useDiffContent", () => ({
   useDiffContent: useDiffContentMock,
 }));
 
-// The full-file read is a real IPC call; these tests never exercise the scope,
-// so it stays inert rather than reaching for `window.electron`.
-vi.mock("../useDiffFileSource", () => ({
-  useDiffFileSource: () => ({
-    source: undefined,
-    errorCode: null,
-  }),
+// The full-file read is a real IPC call, so it is stubbed rather than reaching
+// for `window.electron`. Its `enabled` argument is captured: whether the read is
+// even requested is the contract the rendered layout depends on.
+const { useDiffFileSourceMock } = vi.hoisted(() => ({
+  useDiffFileSourceMock: vi.fn(),
 }));
+vi.mock("../useDiffFileSource", () => ({
+  useDiffFileSource: useDiffFileSourceMock,
+}));
+
+function sourceEnabledCalls(): boolean[] {
+  return useDiffFileSourceMock.mock.calls.map((call) => Boolean(call[1]));
+}
 
 import { DiffPane } from "../DiffPane";
 
@@ -189,6 +195,8 @@ function positionText(): string {
 beforeEach(() => {
   setDiffPanelFileMock.mockReset();
   toggleViewedMock.mockReset();
+  useDiffFileSourceMock.mockReset();
+  useDiffFileSourceMock.mockReturnValue({ source: undefined, errorCode: null });
   useDiffContentMock.mockReset();
   useDiffContentMock.mockReturnValue({
     content: "diff --git a/a.ts b/a.ts",
@@ -1086,12 +1094,15 @@ describe("DiffPane — rendered Markdown layout (#12171)", () => {
     expect(preferences.setDiffViewType).toHaveBeenCalledWith("split");
   });
 
-  it("swaps the body for the rendered layout and drops the source-only controls", () => {
+  it("swaps the body for the rendered layout and drops the source-only controls", async () => {
     preferences.diffMarkdownRendered = true;
+    useDiffFileSourceMock.mockReturnValue({ source: "# Guide\n", errorCode: null });
     seedPanel({ filePath: "docs/guide.md", fileStatus: "modified" });
     renderPane();
 
-    expect(screen.getByTestId("rendered-markdown-mock")).toBeTruthy();
+    // The rendered body is behind a lazy() boundary; asserting synchronously
+    // would only ever see the Suspense fallback.
+    expect(await screen.findByTestId("rendered-markdown-mock")).toBeTruthy();
     expect(screen.queryByTestId("diff-viewer-mock")).toBe(null);
     expect(screen.queryByRole("group", { name: "Diff content" })).toBe(null);
     expect(screen.queryByLabelText("Wrap long lines")).toBe(null);
@@ -1148,13 +1159,96 @@ describe("DiffPane — rendered Markdown layout (#12171)", () => {
     expect(useDiffContentMock.mock.calls.at(-1)?.[2]).toEqual({ ignoreWhitespace: false });
   });
 
-  it("reads no source for a deleted file, whose patch already carries the old document", () => {
+  it("reads no source for a deleted file, whose patch already carries the old document", async () => {
     preferences.diffMarkdownRendered = true;
     seedPanel({ filePath: "docs/guide.md", fileStatus: "deleted" });
     renderPane();
 
-    const rendered = screen.getByTestId("rendered-markdown-mock");
+    const rendered = await screen.findByTestId("rendered-markdown-mock");
     expect(rendered.getAttribute("data-status")).toBe("deleted");
     expect(rendered.getAttribute("data-has-source")).toBe("false");
+    // The read must not merely be unused — it must never be requested.
+    expect(sourceEnabledCalls().some(Boolean)).toBe(false);
+  });
+
+  it("requests the whole-file read for a modified file even with Full file off", () => {
+    preferences.diffMarkdownRendered = true;
+    preferences.diffFullFile = false;
+    seedPanel({ filePath: "docs/guide.md", fileStatus: "modified" });
+    renderPane();
+
+    expect(sourceEnabledCalls().some(Boolean)).toBe(true);
+  });
+
+  it("holds the body on a skeleton until the whole-file read lands", async () => {
+    preferences.diffMarkdownRendered = true;
+    seedPanel({ filePath: "docs/guide.md", fileStatus: "modified" });
+    renderPane();
+
+    // Flushed past the lazy boundary first, so this proves the pending-source
+    // gate rather than just catching the Suspense fallback. Mounting the engine
+    // with no source would make it report `source-required` — a failure the
+    // availability verdict latches onto, disabling the segment over a read that
+    // was merely in flight.
+    await act(async () => {});
+    expect(screen.queryByTestId("rendered-markdown-mock")).toBe(null);
+    expect(screen.getByLabelText("Loading rendered Markdown")).toBeTruthy();
+  });
+
+  it("mounts the engine once the source is there", async () => {
+    preferences.diffMarkdownRendered = true;
+    useDiffFileSourceMock.mockReturnValue({ source: "# Guide\n", errorCode: null });
+    seedPanel({ filePath: "docs/guide.md", fileStatus: "modified" });
+    renderPane();
+
+    const rendered = await screen.findByTestId("rendered-markdown-mock");
+    expect(rendered.getAttribute("data-has-source")).toBe("true");
+  });
+
+  it("stops requesting the source while the diff is stale, so Refresh re-reads it", () => {
+    // Without this the source hook's inputs never change across a Refresh, and
+    // the new patch would be paired with the file snapshot the old one was
+    // measured against — reconstructing text that is no longer on disk.
+    preferences.diffMarkdownRendered = true;
+    useDiffContentMock.mockReturnValue({
+      content: "diff --git a/docs/guide.md b/docs/guide.md",
+      stale: true,
+      retry: vi.fn(),
+    });
+    seedPanel({ filePath: "docs/guide.md", fileStatus: "modified" });
+    renderPane();
+
+    expect(sourceEnabledCalls().some(Boolean)).toBe(false);
+  });
+
+  it("stops requesting the source while the diff is reloading", () => {
+    preferences.diffMarkdownRendered = true;
+    useDiffContentMock.mockReturnValue({ content: undefined, stale: false, retry: vi.fn() });
+    seedPanel({ filePath: "docs/guide.md", fileStatus: "modified" });
+    renderPane();
+
+    expect(sourceEnabledCalls().some(Boolean)).toBe(false);
+  });
+
+  it("stops applying an engine failure once the inputs it judged have changed", async () => {
+    preferences.diffMarkdownRendered = true;
+    useDiffFileSourceMock.mockReturnValue({ source: "# Guide\n", errorCode: null });
+    seedPanel({ filePath: "docs/guide.md", fileStatus: "modified" });
+    const { unmount } = renderPane();
+
+    const firstAttempt = (await screen.findByTestId("rendered-markdown-mock")).getAttribute(
+      "data-attempt-key"
+    );
+    expect(firstAttempt).toBeTruthy();
+    unmount();
+
+    // A different source is a different attempt, so a verdict stamped against
+    // the first one can no longer disqualify it.
+    useDiffFileSourceMock.mockReturnValue({ source: "# Guide edited\n", errorCode: null });
+    seedPanel({ filePath: "docs/guide.md", fileStatus: "modified" });
+    renderPane();
+
+    const second = await screen.findByTestId("rendered-markdown-mock");
+    expect(second.getAttribute("data-attempt-key")).not.toBe(firstAttempt);
   });
 });

--- a/src/panels/diff/__tests__/DiffPane.test.tsx
+++ b/src/panels/diff/__tests__/DiffPane.test.tsx
@@ -37,6 +37,18 @@ vi.mock("@/components/Worktree/DiffViewer", () => ({
   FULL_FILE_MAX_LINES: 5000,
 }));
 
+// The rendered layout pulls react-markdown behind a lazy boundary; these tests
+// exercise the toolbar's plumbing, not the renderer, so it stays a stub.
+vi.mock("@/components/Worktree/RenderedMarkdownDiff", () => ({
+  RenderedMarkdownDiff: (props: { newSource?: string; status: string }) => (
+    <div
+      data-testid="rendered-markdown-mock"
+      data-has-source={String(props.newSource !== undefined)}
+      data-status={props.status}
+    />
+  ),
+}));
+
 // Controllable so a test can put the pane in image mode; `beforeEach` returns it
 // to text mode, which is what every other test in this file assumes.
 const { isImageDiffCandidateMock } = vi.hoisted(() => ({
@@ -94,6 +106,9 @@ vi.mock("@/hooks/useWorktreeStore", () => ({
 const preferences = {
   diffViewType: "unified" as const,
   setDiffViewType: vi.fn(),
+  diffMarkdownRendered: false,
+  setDiffMarkdownRendered: vi.fn(),
+  markdownFontSize: "sm" as const,
   // `null` is auto — prose wraps, everything else doesn't (#12170).
   diffWrapLines: null as boolean | null,
   // Writes through, so a test can follow a full toggle cycle instead of only
@@ -186,6 +201,9 @@ beforeEach(() => {
   preferences.diffShowFileList = true;
   preferences.diffWrapLines = null;
   preferences.setDiffWrapLines.mockClear();
+  preferences.diffMarkdownRendered = false;
+  (preferences.setDiffMarkdownRendered as ReturnType<typeof vi.fn>).mockReset();
+  (preferences.setDiffViewType as ReturnType<typeof vi.fn>).mockReset();
   worktrees.clear();
   worktrees.set(WORKTREE_ID, { path: WORKTREE_PATH, branch: "feature/x" });
 });
@@ -1018,5 +1036,125 @@ describe("DiffPane wrap toggle (#12170)", () => {
     seedPanel({ filePath: "src/a.ts", fileStatus: "modified", changeSet: [entry("src/a.ts")] });
     renderPane();
     expect(viewerWrap()).toBe("true");
+  });
+});
+
+describe("DiffPane — rendered Markdown layout (#12171)", () => {
+  function layoutSegments(): string[] {
+    const group = screen.getByRole("group", { name: "Diff layout" });
+    return [...group.querySelectorAll("button")].map((button) => button.textContent ?? "");
+  }
+
+  function clickSegment(label: string): void {
+    const group = screen.getByRole("group", { name: "Diff layout" });
+    const button = [...group.querySelectorAll("button")].find(
+      (candidate) => candidate.textContent === label
+    );
+    if (!button) throw new Error(`no "${label}" segment`);
+    fireEvent.click(button);
+  }
+
+  it("offers the third segment only for a Markdown file", () => {
+    seedPanel({ filePath: "src/index.ts", fileStatus: "modified" });
+    const { unmount } = renderPane();
+    expect(layoutSegments()).toEqual(["Unified", "Split"]);
+    unmount();
+
+    seedPanel({ filePath: "docs/guide.md", fileStatus: "modified" });
+    renderPane();
+    expect(layoutSegments()).toEqual(["Unified", "Split", "Rendered"]);
+  });
+
+  it("selecting Rendered sets only the markdown preference, leaving the layout sticky", () => {
+    seedPanel({ filePath: "docs/guide.md", fileStatus: "modified" });
+    renderPane();
+
+    clickSegment("Rendered");
+
+    expect(preferences.setDiffMarkdownRendered).toHaveBeenCalledWith(true);
+    expect(preferences.setDiffViewType).not.toHaveBeenCalled();
+  });
+
+  it("selecting a source layout clears rendered mode and records the layout", () => {
+    preferences.diffMarkdownRendered = true;
+    seedPanel({ filePath: "docs/guide.md", fileStatus: "modified" });
+    renderPane();
+
+    clickSegment("Split");
+
+    expect(preferences.setDiffMarkdownRendered).toHaveBeenCalledWith(false);
+    expect(preferences.setDiffViewType).toHaveBeenCalledWith("split");
+  });
+
+  it("swaps the body for the rendered layout and drops the source-only controls", () => {
+    preferences.diffMarkdownRendered = true;
+    seedPanel({ filePath: "docs/guide.md", fileStatus: "modified" });
+    renderPane();
+
+    expect(screen.getByTestId("rendered-markdown-mock")).toBeTruthy();
+    expect(screen.queryByTestId("diff-viewer-mock")).toBe(null);
+    expect(screen.queryByRole("group", { name: "Diff content" })).toBe(null);
+    expect(screen.queryByLabelText("Wrap long lines")).toBe(null);
+  });
+
+  it("keeps the source layout and its controls when rendered mode is off", () => {
+    seedPanel({ filePath: "docs/guide.md", fileStatus: "modified" });
+    renderPane();
+
+    expect(screen.getByTestId("diff-viewer-mock")).toBeTruthy();
+    expect(screen.getByRole("group", { name: "Diff content" })).toBeTruthy();
+  });
+
+  it("disables the segment on a staged diff and describes why for the keyboard path", () => {
+    seedPanel({ filePath: "docs/guide.md", fileStatus: "modified", diffSource: "staged" });
+    renderPane();
+
+    const group = screen.getByRole("group", { name: "Diff layout" });
+    const rendered = [...group.querySelectorAll("button")].find(
+      (button) => button.textContent === "Rendered"
+    );
+    expect(rendered?.hasAttribute("disabled")).toBe(true);
+
+    const describedBy = group.getAttribute("aria-describedby");
+    expect(describedBy).toBeTruthy();
+    expect(document.getElementById(describedBy as string)?.textContent).toContain("staged changes");
+  });
+
+  it("falls back to the source diff when the file can render but the diff is stale", () => {
+    preferences.diffMarkdownRendered = true;
+    useDiffContentMock.mockReturnValue({
+      content: "diff --git a/docs/guide.md b/docs/guide.md",
+      stale: true,
+      retry: vi.fn(),
+    });
+    seedPanel({ filePath: "docs/guide.md", fileStatus: "modified" });
+    renderPane();
+
+    // The preference survives — the file that can't render doesn't cost the setting.
+    expect(screen.getByTestId("diff-viewer-mock")).toBeTruthy();
+    expect(preferences.setDiffMarkdownRendered).not.toHaveBeenCalled();
+  });
+
+  it("asks for a whitespace-sensitive patch only while rendered mode is requested", () => {
+    seedPanel({ filePath: "docs/guide.md", fileStatus: "modified" });
+    const { unmount } = renderPane();
+    expect(useDiffContentMock.mock.calls.at(-1)?.[2]).toBeUndefined();
+    unmount();
+
+    useDiffContentMock.mockClear();
+    preferences.diffMarkdownRendered = true;
+    seedPanel({ filePath: "docs/guide.md", fileStatus: "modified" });
+    renderPane();
+    expect(useDiffContentMock.mock.calls.at(-1)?.[2]).toEqual({ ignoreWhitespace: false });
+  });
+
+  it("reads no source for a deleted file, whose patch already carries the old document", () => {
+    preferences.diffMarkdownRendered = true;
+    seedPanel({ filePath: "docs/guide.md", fileStatus: "deleted" });
+    renderPane();
+
+    const rendered = screen.getByTestId("rendered-markdown-mock");
+    expect(rendered.getAttribute("data-status")).toBe("deleted");
+    expect(rendered.getAttribute("data-has-source")).toBe("false");
   });
 });

--- a/src/panels/diff/__tests__/renderedMarkdownAvailability.test.ts
+++ b/src/panels/diff/__tests__/renderedMarkdownAvailability.test.ts
@@ -68,9 +68,7 @@ describe("getRenderedMarkdownAvailability", () => {
   it("disables a stale diff, because the reconstruction trusts the gaps between hunks", () => {
     const result = getRenderedMarkdownAvailability(input({ stale: true }));
 
-    expect(result.visible && !result.enabled && result.reason).toBe(
-      "Refresh the diff before rendering the current Markdown"
-    );
+    expect(result.visible && !result.enabled && result.reason).toContain("Refresh");
   });
 
   it("disables on a failed whole-file read, quoting the read error", () => {
@@ -94,9 +92,8 @@ describe("getRenderedMarkdownAvailability", () => {
   it("disables on the engine's verdict once it has one", () => {
     const result = getRenderedMarkdownAvailability(input({ engineFailure: "source-mismatch" }));
 
-    expect(result.visible && !result.enabled && result.reason).toBe(
-      "The file changed after this diff loaded — refresh to render it"
-    );
+    expect(result.visible).toBe(true);
+    expect(result.visible && !result.enabled).toBe(true);
   });
 
   it("ranks staleness above the engine's verdict, since refreshing is the fix for both", () => {

--- a/src/panels/diff/__tests__/renderedMarkdownAvailability.test.ts
+++ b/src/panels/diff/__tests__/renderedMarkdownAvailability.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import {
+  getRenderedMarkdownAvailability,
+  isRenderedMarkdownSupported,
+  type RenderedMarkdownAvailabilityInput,
+} from "../renderedMarkdownAvailability";
+
+function input(
+  overrides: Partial<RenderedMarkdownAvailabilityInput> = {}
+): RenderedMarkdownAvailabilityInput {
+  return {
+    filePath: "docs/guide.md",
+    diffSource: "working-tree",
+    content: "@@ -1 +1 @@\n-a\n+b",
+    stale: false,
+    sourceErrorCode: null,
+    engineFailure: null,
+    ...overrides,
+  };
+}
+
+describe("isRenderedMarkdownSupported", () => {
+  it("covers every extension the markdown surfaces already recognise", () => {
+    for (const path of ["a.md", "a.markdown", "a.mdx", "a.mkd", "A.MD"]) {
+      expect(isRenderedMarkdownSupported(path, "working-tree")).toBe(true);
+    }
+  });
+
+  it("is false for a non-markdown file and for a missing path", () => {
+    expect(isRenderedMarkdownSupported("src/index.ts", "working-tree")).toBe(false);
+    expect(isRenderedMarkdownSupported(undefined, "working-tree")).toBe(false);
+  });
+
+  it("follows the disk-backed sources, treating a missing source as working-tree", () => {
+    expect(isRenderedMarkdownSupported("a.md", undefined)).toBe(true);
+    expect(isRenderedMarkdownSupported("a.md", "unstaged")).toBe(true);
+    expect(isRenderedMarkdownSupported("a.md", "staged")).toBe(false);
+    expect(isRenderedMarkdownSupported("a.md", "base-branch")).toBe(false);
+  });
+});
+
+describe("getRenderedMarkdownAvailability", () => {
+  it("hides the segment entirely for a non-markdown file", () => {
+    expect(getRenderedMarkdownAvailability(input({ filePath: "src/index.ts" }))).toEqual({
+      visible: false,
+    });
+  });
+
+  it("enables it for a working-tree markdown diff", () => {
+    expect(getRenderedMarkdownAvailability(input())).toEqual({ visible: true, enabled: true });
+  });
+
+  it("stays enabled while the diff is still loading", () => {
+    expect(getRenderedMarkdownAvailability(input({ content: undefined }))).toEqual({
+      visible: true,
+      enabled: true,
+    });
+  });
+
+  it("disables staged and base-branch diffs, saying which", () => {
+    const staged = getRenderedMarkdownAvailability(input({ diffSource: "staged" }));
+    const base = getRenderedMarkdownAvailability(input({ diffSource: "base-branch" }));
+
+    expect(staged.visible && !staged.enabled && staged.reason).toContain("staged changes");
+    expect(base.visible && !base.enabled && base.reason).toContain("base-branch");
+  });
+
+  it("disables a stale diff, because the reconstruction trusts the gaps between hunks", () => {
+    const result = getRenderedMarkdownAvailability(input({ stale: true }));
+
+    expect(result.visible && !result.enabled && result.reason).toBe(
+      "Refresh the diff before rendering the current Markdown"
+    );
+  });
+
+  it("disables on a failed whole-file read, quoting the read error", () => {
+    const result = getRenderedMarkdownAvailability(input({ sourceErrorCode: "FILE_TOO_LARGE" }));
+
+    expect(result.visible && !result.enabled && result.reason).toContain(
+      "Rendered Markdown needs the current file:"
+    );
+  });
+
+  it("disables on each diff sentinel with its own reason", () => {
+    const reasons = ["NO_CHANGES", "ERROR", "BINARY_FILE", "FILE_TOO_LARGE"].map((content) => {
+      const result = getRenderedMarkdownAvailability(input({ content }));
+      return result.visible && !result.enabled ? result.reason : null;
+    });
+
+    expect(reasons.every((reason) => typeof reason === "string" && reason.length > 0)).toBe(true);
+    expect(new Set(reasons).size).toBe(4);
+  });
+
+  it("disables on the engine's verdict once it has one", () => {
+    const result = getRenderedMarkdownAvailability(input({ engineFailure: "source-mismatch" }));
+
+    expect(result.visible && !result.enabled && result.reason).toBe(
+      "The file changed after this diff loaded — refresh to render it"
+    );
+  });
+
+  it("ranks staleness above the engine's verdict, since refreshing is the fix for both", () => {
+    const result = getRenderedMarkdownAvailability(
+      input({ stale: true, engineFailure: "source-mismatch" })
+    );
+
+    expect(result.visible && !result.enabled && result.reason).toContain("Refresh the diff");
+  });
+});

--- a/src/panels/diff/diffContentCache.ts
+++ b/src/panels/diff/diffContentCache.ts
@@ -102,10 +102,16 @@ export function diffCacheKey(subject: DiffSubject, ignoreWhitespace: boolean): s
   ].join("\u0000");
 }
 
-/** Drop every entry built under the other ignore-whitespace flag. */
-export function purgeOtherWhitespaceEntries(ignoreWhitespace: boolean): void {
+/**
+ * Drop every entry built under an ignore-whitespace flag nothing can ask for
+ * any more. Takes the set of live flags rather than a single one: the rendered
+ * Markdown layout requests exact patches regardless of the preference, so both
+ * variants can be legitimately in use at once (#12171).
+ */
+export function purgeWhitespaceEntriesExcept(live: readonly boolean[]): void {
+  const suffixes = live.map((flag) => `\u0000${flag}`);
   for (const key of [...diffCache.keys()]) {
-    if (!key.endsWith(`\u0000${ignoreWhitespace}`)) diffCache.delete(key);
+    if (!suffixes.some((suffix) => key.endsWith(suffix))) diffCache.delete(key);
   }
 }
 

--- a/src/panels/diff/renderedMarkdownAvailability.ts
+++ b/src/panels/diff/renderedMarkdownAvailability.ts
@@ -1,0 +1,139 @@
+import type { DiffPanelData } from "@shared/types/panel";
+import type { FileReadErrorCode } from "@shared/types/ipc/files";
+import { isMarkdownFilePath } from "@/components/Markdown/isMarkdownFile";
+import { FILE_READ_ERROR_MESSAGES } from "@/components/FileViewer/fileReadErrors";
+import type { MarkdownDiffFailure } from "@/components/Worktree/markdownBlockDiff";
+
+/**
+ * Whether the rendered-Markdown layout can be offered for one file, and why not
+ * when it can't (issue #12171). Same split as `getFullFileAvailability`: a pure
+ * verdict the toolbar renders, so the segment never looks live while being
+ * inert and always explains itself.
+ *
+ * Three states rather than two, because "not a Markdown file" is different in
+ * kind from "Markdown, but not this one". A rendered layout for a `.ts` file is
+ * not a thing the user was denied, it is a thing that does not exist — offering
+ * a permanently dead third segment on every source diff would be noise.
+ */
+export type RenderedMarkdownAvailability =
+  | { visible: false }
+  | { visible: true; enabled: true }
+  | { visible: true; enabled: false; reason: string };
+
+const VISIBLE_ENABLED: RenderedMarkdownAvailability = { visible: true, enabled: true };
+
+/**
+ * Diff sources whose new side is the file on disk. The old document is rebuilt
+ * by reverse-applying the patch onto that file, so a source whose new side
+ * lives anywhere else (the index, another ref) would be reconstructed from
+ * content the patch was never generated against.
+ *
+ * Mirrors `fullFileAvailability`'s list for the same reason, and excludes
+ * `staged` for the same reason: a staged diff's new side is the index blob,
+ * which diverges from disk the moment the file is edited again after staging.
+ */
+const DISK_BACKED_SOURCES: ReadonlySet<string> = new Set(["working-tree", "unstaged"]);
+
+/** Diff-content sentinels `useDiffContent` returns in place of patch text. */
+const SENTINEL_REASONS: Record<string, string> = {
+  NO_CHANGES: "There are no Markdown changes to render",
+  ERROR: "Refresh the diff before using the rendered layout",
+  FILE_TOO_LARGE: "This diff is too large to render",
+  BINARY_FILE: "Rendered Markdown isn't available for binary content",
+};
+
+const FAILURE_REASONS: Record<MarkdownDiffFailure, string> = {
+  "unsupported-patch": "This diff can't be rebuilt into a whole Markdown document",
+  "source-required": "Rendered Markdown needs the current file, which couldn't be read",
+  "source-mismatch": "The file changed after this diff loaded — refresh to render it",
+  "too-large": "This document is too large to render",
+};
+
+export interface RenderedMarkdownAvailabilityInput {
+  filePath: string | undefined;
+  diffSource: DiffPanelData["diffSource"];
+  /** Diff text or sentinel; undefined while loading. */
+  content: string | undefined;
+  /** The store saw the file change after the shown diff was fetched. */
+  stale: boolean;
+  /** Set when the whole-file read the reconstruction depends on failed. */
+  sourceErrorCode: FileReadErrorCode | null;
+  /** The engine's verdict on the diff currently shown, once it has one. */
+  engineFailure: MarkdownDiffFailure | null;
+}
+
+/**
+ * The half of the verdict that depends only on what is being diffed, not on the
+ * diff itself.
+ *
+ * Split out because the fetch has to know before the content lands: the
+ * rendered layout requests a whitespace-sensitive patch, and deciding that from
+ * the full verdict would need the content the request is about to produce.
+ */
+export function isRenderedMarkdownSupported(
+  filePath: string | undefined,
+  diffSource: DiffPanelData["diffSource"]
+): boolean {
+  if (!filePath || !isMarkdownFilePath(filePath)) return false;
+  // `buildSubject` treats a missing source as working-tree; match it.
+  return diffSource === undefined || DISK_BACKED_SOURCES.has(diffSource);
+}
+
+export function getRenderedMarkdownAvailability({
+  filePath,
+  diffSource,
+  content,
+  stale,
+  sourceErrorCode,
+  engineFailure,
+}: RenderedMarkdownAvailabilityInput): RenderedMarkdownAvailability {
+  if (!filePath || !isMarkdownFilePath(filePath)) return { visible: false };
+
+  if (!isRenderedMarkdownSupported(filePath, diffSource)) {
+    return {
+      visible: true,
+      enabled: false,
+      reason:
+        diffSource === "staged"
+          ? "Rendered Markdown isn't available for staged changes — staged content lives in the index, not on disk"
+          : "Rendered Markdown isn't available for base-branch diffs — the file at that ref isn't what's on disk",
+    };
+  }
+
+  // The patch and the file on disk must describe the same revision: the
+  // reconstruction trusts the gaps between hunks, and once the store reports
+  // the file changed they demonstrably disagree.
+  if (stale) {
+    return {
+      visible: true,
+      enabled: false,
+      reason: "Refresh the diff before rendering the current Markdown",
+    };
+  }
+
+  if (sourceErrorCode) {
+    return {
+      visible: true,
+      enabled: false,
+      reason: `Rendered Markdown needs the current file: ${FILE_READ_ERROR_MESSAGES[sourceErrorCode]}`,
+    };
+  }
+
+  // Loading stays enabled: the segment is the user's choice, and the body shows
+  // the same skeleton the source layouts do.
+  if (content === undefined) return VISIBLE_ENABLED;
+
+  const sentinel = SENTINEL_REASONS[content];
+  if (sentinel) return { visible: true, enabled: false, reason: sentinel };
+
+  if (engineFailure) {
+    return { visible: true, enabled: false, reason: FAILURE_REASONS[engineFailure] };
+  }
+
+  // Every remaining status renders. Status deliberately isn't a gate here the
+  // way it is for full file: a deletion's patch carries every line of the old
+  // document, and an addition's is all inserts over an empty one, so both
+  // reconstruct. Status only decides whether the new side needs a disk read,
+  // which is the caller's business.
+  return VISIBLE_ENABLED;
+}

--- a/src/panels/diff/useDiffContent.ts
+++ b/src/panels/diff/useDiffContent.ts
@@ -3,7 +3,7 @@ import { usePreferencesStore } from "@/store/preferencesStore";
 import { WorktreeStoreContext } from "@/contexts/WorktreeStoreContext";
 import {
   diffCacheKey,
-  purgeOtherWhitespaceEntries,
+  purgeWhitespaceEntriesExcept,
   requestDiff,
   selectDiffFreshnessKey,
   type DiffSubject,
@@ -81,11 +81,12 @@ export function useDiffContent(
   // Toggling ignore-whitespace strands every entry built under the other flag
   // (their keys can no longer be requested this session unless the user
   // toggles back, and a long review can hold 20 stale diffs). Purge them.
-  // Purged against the preference, not the effective flag: an override is a
-  // transient second view of the same file, and letting it evict the
-  // preference's entries would make every toggle back a refetch.
+  // Both variants are live now, so the purge keeps both: the preference's, and
+  // the exact patches the rendered Markdown layout overrides to. Purging
+  // against one flag would have every mount of any pane — this hook also backs
+  // the file panel — evict whichever set it isn't currently asking for.
   useEffect(() => {
-    purgeOtherWhitespaceEntries(preferredIgnoreWhitespace);
+    purgeWhitespaceEntriesExcept([preferredIgnoreWhitespace, false]);
   }, [preferredIgnoreWhitespace]);
 
   const subjectKey = subject === null ? null : diffCacheKey(subject, ignoreWhitespace);

--- a/src/panels/diff/useDiffContent.ts
+++ b/src/panels/diff/useDiffContent.ts
@@ -11,6 +11,18 @@ import {
 
 const PREFETCH_DWELL_MS = 500;
 
+export interface UseDiffContentOptions {
+  /**
+   * Force the whitespace sensitivity of the request instead of following the
+   * preference. The rendered Markdown layout needs an exact patch: it rebuilds
+   * the old document by reverse-applying the hunks, and an --ignore-all-space
+   * patch omits indentation changes that in Markdown change the structure —
+   * a list nested one level deeper would reconstruct as though it never moved
+   * (#12171). Undefined means "use the preference".
+   */
+  ignoreWhitespace?: boolean;
+}
+
 export interface UseDiffContentResult {
   /** Diff text, `"NO_CHANGES"`, `"ERROR"`, or undefined while loading. */
   content: string | undefined;
@@ -29,7 +41,8 @@ export interface UseDiffContentResult {
  */
 export function useDiffContent(
   subject: DiffSubject | null,
-  nextSubject?: DiffSubject | null
+  nextSubject?: DiffSubject | null,
+  options?: UseDiffContentOptions
 ): UseDiffContentResult {
   const [content, setContent] = useState<string | undefined>(undefined);
   // Freshness key the shown diff was fetched under, tagged with its cache key
@@ -40,7 +53,8 @@ export function useDiffContent(
     key: string | undefined;
   } | null>(null);
   const requestRef = useRef(0);
-  const ignoreWhitespace = usePreferencesStore((s) => s.diffIgnoreWhitespace);
+  const preferredIgnoreWhitespace = usePreferencesStore((s) => s.diffIgnoreWhitespace);
+  const ignoreWhitespace = options?.ignoreWhitespace ?? preferredIgnoreWhitespace;
 
   // Tolerate hosts mounted without a worktree-store provider (mirrors
   // useFleetPicker): staleness detection simply never fires there.
@@ -67,9 +81,12 @@ export function useDiffContent(
   // Toggling ignore-whitespace strands every entry built under the other flag
   // (their keys can no longer be requested this session unless the user
   // toggles back, and a long review can hold 20 stale diffs). Purge them.
+  // Purged against the preference, not the effective flag: an override is a
+  // transient second view of the same file, and letting it evict the
+  // preference's entries would make every toggle back a refetch.
   useEffect(() => {
-    purgeOtherWhitespaceEntries(ignoreWhitespace);
-  }, [ignoreWhitespace]);
+    purgeOtherWhitespaceEntries(preferredIgnoreWhitespace);
+  }, [preferredIgnoreWhitespace]);
 
   const subjectKey = subject === null ? null : diffCacheKey(subject, ignoreWhitespace);
 

--- a/src/store/__tests__/preferencesStore.test.ts
+++ b/src/store/__tests__/preferencesStore.test.ts
@@ -726,7 +726,7 @@ describe("preferencesStore migration", () => {
       // Pin the bump too: `migrate` only runs for a blob below the configured
       // version, so leaving it at 17 would skip the branch above entirely and
       // hydration's sanitizer would quietly supply the same default.
-      expect(store.persist.getOptions().version).toBe(19);
+      expect(store.persist.getOptions().version).toBe(20);
     });
 
     it("leaves an already-valid rung alone when migrating", async () => {
@@ -1214,13 +1214,13 @@ describe("preferencesStore migration", () => {
       // The migration only reinterprets pre-v19 blobs. A `false` written since
       // is a real override and must survive a reload, or turning wrap off on a
       // markdown diff would not stick.
-      setStoredState({ diffWrapLines: false }, 19);
+      setStoredState({ diffWrapLines: false }, 20);
       const store = await loadStore();
       expect(store.getState().diffWrapLines).toBe(false);
     });
 
     it("sanitises a corrupt current-version value to auto, not to off", async () => {
-      setStoredState({ diffWrapLines: "yes" }, 19);
+      setStoredState({ diffWrapLines: "yes" }, 20);
       const store = await loadStore();
       expect(store.getState().diffWrapLines).toBeNull();
     });
@@ -1237,5 +1237,34 @@ describe("preferencesStore migration", () => {
         expect(JSON.parse(storageMock.getItem(STORAGE_KEY)!).state.diffWrapLines).toBe(false);
       });
     });
+  });
+});
+
+describe("diffMarkdownRendered (v20 migration, #12171)", () => {
+  it("defaults to the source diff, so the new layout opts nobody in", async () => {
+    const store = await loadStore();
+    expect(store.getState().diffMarkdownRendered).toBe(false);
+  });
+
+  it("setDiffMarkdownRendered updates the value", async () => {
+    const store = await loadStore();
+    store.getState().setDiffMarkdownRendered(true);
+    expect(store.getState().diffMarkdownRendered).toBe(true);
+    store.getState().setDiffMarkdownRendered(false);
+    expect(store.getState().diffMarkdownRendered).toBe(false);
+  });
+
+  it("gives a pre-v20 blob the default rather than leaving it undefined", async () => {
+    const store = await loadStore();
+    const migrated = store.persist.getOptions().migrate?.({ dockDensity: "compact" }, 19);
+
+    expect(migrated).toMatchObject({ diffMarkdownRendered: false, dockDensity: "compact" });
+  });
+
+  it("keeps an existing choice through the migration", async () => {
+    const store = await loadStore();
+    const migrated = store.persist.getOptions().migrate?.({ diffMarkdownRendered: true }, 19);
+
+    expect(migrated).toMatchObject({ diffMarkdownRendered: true });
   });
 });

--- a/src/store/__tests__/preferencesStore.test.ts
+++ b/src/store/__tests__/preferencesStore.test.ts
@@ -1259,6 +1259,10 @@ describe("diffMarkdownRendered (v20 migration, #12171)", () => {
     const migrated = store.persist.getOptions().migrate?.({ dockDensity: "compact" }, 19);
 
     expect(migrated).toMatchObject({ diffMarkdownRendered: false, dockDensity: "compact" });
+    // Same pin the v18 branch carries: `migrate` only runs for a blob below the
+    // configured version, so a version that fell back to 18 would skip the
+    // branch above and hydration's sanitizer would quietly supply the default.
+    expect(store.persist.getOptions().version).toBeGreaterThan(18);
   });
 
   it("keeps an existing choice through the migration", async () => {

--- a/src/store/preferencesStore.ts
+++ b/src/store/preferencesStore.ts
@@ -142,6 +142,15 @@ interface PreferencesState {
    */
   diffWrapLines: DiffWrapPreference;
   setDiffWrapLines: (value: boolean) => void;
+  /**
+   * Show Markdown diffs as a rendered document rather than as source (#12171).
+   * Deliberately NOT a third `DiffViewType`: that union is a layout for the
+   * source diff and is read by surfaces (the file panel, the cross-worktree
+   * diff) that render no such mode. Keeping it a separate flag also preserves
+   * the user's Unified/Split choice across a round trip through rendered mode.
+   */
+  diffMarkdownRendered: boolean;
+  setDiffMarkdownRendered: (value: boolean) => void;
   diffIgnoreWhitespace: boolean;
   setDiffIgnoreWhitespace: (value: boolean) => void;
   /** Show the changed-files sidebar in the diff workspace (multi-file review). */
@@ -305,6 +314,7 @@ function sanitizePersistedPreferences(
   if (!isDockDensity(sanitized.dockDensity)) sanitized.dockDensity = "normal";
   if (!isDiffViewType(sanitized.diffViewType)) sanitized.diffViewType = "split";
   if (!isDiffWrapPreference(sanitized.diffWrapLines)) sanitized.diffWrapLines = null;
+  if (typeof sanitized.diffMarkdownRendered !== "boolean") sanitized.diffMarkdownRendered = false;
   if (typeof sanitized.diffIgnoreWhitespace !== "boolean") sanitized.diffIgnoreWhitespace = false;
   if (typeof sanitized.diffShowFileList !== "boolean") sanitized.diffShowFileList = true;
   if (typeof sanitized.diffFullFile !== "boolean") sanitized.diffFullFile = false;
@@ -364,6 +374,7 @@ type PreferencesPersistedState = Pick<
   | "reduceAnimations"
   | "diffViewType"
   | "diffWrapLines"
+  | "diffMarkdownRendered"
   | "diffIgnoreWhitespace"
   | "diffShowFileList"
   | "diffFullFile"
@@ -391,6 +402,7 @@ const PREFERENCES_PERSISTED_DEFAULTS: PreferencesPersistedState = {
   reduceAnimations: false,
   diffViewType: "split",
   diffWrapLines: null,
+  diffMarkdownRendered: false,
   diffIgnoreWhitespace: false,
   diffShowFileList: true,
   diffFullFile: false,
@@ -519,6 +531,7 @@ function toPreferencesPersisted(
     reduceAnimations: coerceBool(raw.reduceAnimations, d.reduceAnimations),
     diffViewType: isDiffViewType(raw.diffViewType) ? raw.diffViewType : d.diffViewType,
     diffWrapLines: isDiffWrapPreference(raw.diffWrapLines) ? raw.diffWrapLines : d.diffWrapLines,
+    diffMarkdownRendered: coerceBool(raw.diffMarkdownRendered, d.diffMarkdownRendered),
     diffIgnoreWhitespace: coerceBool(raw.diffIgnoreWhitespace, d.diffIgnoreWhitespace),
     diffShowFileList: coerceBool(raw.diffShowFileList, d.diffShowFileList),
     diffFullFile: coerceBool(raw.diffFullFile, d.diffFullFile),
@@ -620,6 +633,11 @@ function mergePreferencesPersistedWrite({
         inc.diffWrapLines,
         disk.diffWrapLines
       ),
+      diffMarkdownRendered: pickFieldByWriterDelta(
+        base.diffMarkdownRendered,
+        inc.diffMarkdownRendered,
+        disk.diffMarkdownRendered
+      ),
       diffIgnoreWhitespace: pickFieldByWriterDelta(
         base.diffIgnoreWhitespace,
         inc.diffIgnoreWhitespace,
@@ -717,6 +735,8 @@ export const usePreferencesStore = create<PreferencesState>()(
       setDiffViewType: (value) => set({ diffViewType: value }),
       diffWrapLines: null,
       setDiffWrapLines: (value) => set({ diffWrapLines: value }),
+      diffMarkdownRendered: false,
+      setDiffMarkdownRendered: (value) => set({ diffMarkdownRendered: value }),
       diffIgnoreWhitespace: false,
       setDiffIgnoreWhitespace: (value) => set({ diffIgnoreWhitespace: value }),
       diffShowFileList: true,
@@ -818,7 +838,7 @@ export const usePreferencesStore = create<PreferencesState>()(
       storage: createSafeJSONStorage<PreferencesPersistedState>({
         mergeOnWrite: mergePreferencesPersistedWrite,
       }),
-      version: 19,
+      version: 20,
       // Explicit persisted subset — matches the pre-existing default (setters are
       // dropped by JSON serialization); named so the write merge (#11351) has a
       // typed persisted shape to reconcile.
@@ -833,6 +853,7 @@ export const usePreferencesStore = create<PreferencesState>()(
         reduceAnimations: state.reduceAnimations,
         diffViewType: state.diffViewType,
         diffWrapLines: state.diffWrapLines,
+        diffMarkdownRendered: state.diffMarkdownRendered,
         diffIgnoreWhitespace: state.diffIgnoreWhitespace,
         diffShowFileList: state.diffShowFileList,
         diffFullFile: state.diffFullFile,
@@ -1002,6 +1023,13 @@ export const usePreferencesStore = create<PreferencesState>()(
           // to new ones.
           persisted.diffWrapLines = persisted.diffWrapLines === true ? true : null;
         }
+        if (version < 20 && isRecord(persisted)) {
+          // The rendered Markdown layout is new, so nobody has an opinion yet
+          // and everyone opens on the source diff they already had (#12171).
+          if (typeof persisted.diffMarkdownRendered !== "boolean") {
+            persisted.diffMarkdownRendered = false;
+          }
+        }
         return persisted as PreferencesState;
       },
     }
@@ -1012,5 +1040,5 @@ registerPersistedStore({
   storeId: "preferencesStore",
   store: usePreferencesStore,
   persistedStateType:
-    "{ showProjectPulse: boolean; showDeveloperTools: boolean; showGridAgentHighlights: boolean; showDockAgentHighlights: boolean; showAgentTaskTitles: boolean; dockDensity: DockDensity; assignWorktreeToSelf: boolean; reduceAnimations: boolean; diffViewType: DiffViewType; diffWrapLines: boolean | null; diffIgnoreWhitespace: boolean; diffShowFileList: boolean; diffFullFile: boolean; diffFontSize: DiffFontSize; markdownWrapLines: boolean; markdownFontSize: MarkdownFontSize; lastSelectedWorktreeRecipeIdByProject: Record<string, string | null | undefined>; skipPushConfirmByWorktreePath: Record<string, boolean>; deletedWorktreeCleanupSeconds: DeletedWorktreeCleanupSeconds; projectSwitcherOtherSortMode: OtherProjectsSortMode; projectSwitcherCollapsedBands: Record<string, boolean>; fileBrowserAlwaysHiddenPatterns: string[]; hasSeenActionPalettePrefixHint: boolean; keyboardLayoutConfirmationsByBinding: Record<string, number> }",
+    "{ showProjectPulse: boolean; showDeveloperTools: boolean; showGridAgentHighlights: boolean; showDockAgentHighlights: boolean; showAgentTaskTitles: boolean; dockDensity: DockDensity; assignWorktreeToSelf: boolean; reduceAnimations: boolean; diffViewType: DiffViewType; diffWrapLines: boolean | null; diffMarkdownRendered: boolean; diffIgnoreWhitespace: boolean; diffShowFileList: boolean; diffFullFile: boolean; diffFontSize: DiffFontSize; markdownWrapLines: boolean; markdownFontSize: MarkdownFontSize; lastSelectedWorktreeRecipeIdByProject: Record<string, string | null | undefined>; skipPushConfirmByWorktreePath: Record<string, boolean>; deletedWorktreeCleanupSeconds: DeletedWorktreeCleanupSeconds; projectSwitcherOtherSortMode: OtherProjectsSortMode; projectSwitcherCollapsedBands: Record<string, boolean>; fileBrowserAlwaysHiddenPatterns: string[]; hasSeenActionPalettePrefixHint: boolean; keyboardLayoutConfirmationsByBinding: Record<string, number> }",
 });


### PR DESCRIPTION
## Summary

- Adds a third layout option, Rendered, to the diff panel's layout toggle, available only for Markdown files. It renders the document and diffs the rendered output, following GitHub's rich diff model: removed blocks red with strikethrough, added blocks green, unchanged blocks plain, with word-level marks inside a block that was edited rather than replaced.
- Both sides of the document are reconstructed in full before rendering (the patch reverse-applied onto the file on disk), because a hunk rendered in isolation loses its meaning: a list item without its list, a table row without its header.
- Top-level blocks are matched between sides by exact-source LCS, the leftovers are paired by similarity into modified blocks, and each modified pair is word-diffed under the same 60% coverage rule `diffEditSuppression.ts` already applies to line marks. That predicate is now shared code, not duplicated.

Resolves #12171

## How it works

Rendering a hunk on its own doesn't work for Markdown, so both sides get reconstructed as complete documents first, then parsed to mdast. Blocks are matched between the two sides with exact-source LCS, remaining unmatched blocks get paired by similarity into modified pairs, and each modified pair is word-diffed with the same 60% coverage rule `diffEditSuppression.ts` already uses to suppress line marks on a rewritten line.

## Design decisions

- `DiffViewType` stays `split` or `unified`. The file panel and cross-worktree diff read that preference and have no rendered mode, so rendered mode is a separate persisted boolean, `diffMarkdownRendered`, with a v19 migration. Leaving rendered mode returns to whichever of split or unified was active before.
- The Rendered segment is absent entirely for non-Markdown files, and shown but disabled with a stated reason for staged diffs, base-branch diffs, stale diffs, failed reads, or a patch that fails to reconstruct, since none of those have an on-disk new side to reconstruct against.
- Rendered mode always requests a whitespace-sensitive patch regardless of the user's whitespace preference. Reverse-applying an `ignore-all-space` patch isn't sound for Markdown, where indentation carries structure.
- Content scope and Wrap are hidden while rendered mode is active. Rendered mode always shows the whole document and prose already wraps, and a control that does nothing is worse than an absent one.
- No gutter in rendered mode, so no line anchors, no per-line open-in-editor, no moved-block markers, per the issue's scope.
- `unified` and `remark-parse` move from transitive to direct dependencies. Both were already installed via `react-markdown` and already hoisted, so no new package enters the tree, the lockfile diff is only `dev: true` removals. The renderer is `hast-util-to-jsx-runtime` and `react-markdown`, both already direct dependencies.
- The whole rendered path is behind `React.lazy` so `react-markdown` stays out of the first-paint bundle chunk, matching how `MarkdownViewer` already does it.

## Known limitations

- Block-level restructuring, a list item becoming a blockquote, degrades to a delete plus a re-add rather than an edit. The issue anticipated this.
- An edit that only changes inline HTML inside a paragraph shows as a removed and added pair even though the rendered output is identical, because `skipHtml` strips the HTML before rendering.
- Terminal newline state isn't reconstructed. It makes no visible difference to rendered Markdown.
- Removed blocks resolve relative links and images against the current file path, so after a rename, a link on the old side points at the new directory, and a local image shows the current bytes, not the old ones.

## Testing

1190 targeted tests pass: the new rendering engine, the new component, and the new availability logic, plus every existing suite covering touched modules (DiffViewer, DiffPane, the diff content cache, full-file availability, the Markdown components, preferences store persistence, FilePane, the file browser).

Typecheck is clean. Changed files are prettier-clean with zero eslint errors and zero new warnings added to the lint ratchet baseline.
