### PR TITLE
Show which words and sentences changed in a rendered Markdown diff

### DIFF
--- a/e2e/screenshots/markdown-diff-review.spec.ts
+++ b/e2e/screenshots/markdown-diff-review.spec.ts
@@ -1,0 +1,188 @@
+/**
+ * Rendered-Markdown diff visual-review harness.
+ *
+ * The diff panel's **Rendered** layout is the one surface in the app whose whole
+ * content is somebody else's writing. Reaching an interesting state in the real
+ * app means finding a Markdown file that happens to have been edited the right
+ * way, which is no way to look at a design deliberately — and the cases that
+ * decide it (a paragraph rewritten around its surviving clauses, a changed table
+ * cell, an unpaired insertion, two changes a screen and a half apart) are not
+ * states you can ask a repository for.
+ *
+ * So this drives the component's own preview entry (`markdown-diff-preview.html`)
+ * rather than booting Electron: the real `RenderedMarkdownDiff`, the real theme
+ * tokens through `applyAppThemeToRoot`, the real `index.css` and
+ * `MarkdownDocument.css`, at the width the diff panel actually gives it.
+ *
+ * Opt-in only, like every sibling review harness:
+ *
+ *   DAINTREE_SHOT_MDDIFF=1 npx playwright test --project=screenshots markdown-diff-review
+ *
+ * Env knobs:
+ *   DAINTREE_SHOT_MDDIFF   required — any truthy value runs the capture
+ *   DAINTREE_SHOT_DIR      output directory (default artifacts/markdown-diff-shots)
+ *   DAINTREE_SHOT_THEMES   comma-separated theme sweep (default: daintree,bondi,namib)
+ *   DAINTREE_SHOT_FIXTURES comma-separated fixture subset (default: all of them)
+ *
+ * Hard rule, inherited from the siblings: never write a PNG that has not been
+ * verified. `snap()` asserts the diff root is attached with a real box before it
+ * writes and throws otherwise, and the test counts the files itself at the end
+ * rather than trusting the exit code.
+ */
+
+import { test, expect, type Locator, type Page } from "@playwright/test";
+import { existsSync, mkdirSync, readdirSync, rmSync } from "fs";
+import path from "path";
+import { createServer, type ViteDevServer } from "vite";
+
+const ENABLED = !!process.env.DAINTREE_SHOT_MDDIFF;
+
+/**
+ * The width the diff panel gives the document at a typical window size. Rendered
+ * mode drops the reading measure on purpose, so width is a real variable here:
+ * the narrow case is where a two-tier fill and a change bar have the least room
+ * to stay distinguishable.
+ */
+const DEFAULT_WIDTH = 900;
+const NARROW_WIDTH = 520;
+
+const OUT_DIR = path.resolve(
+  process.env.DAINTREE_SHOT_DIR ?? path.join(process.cwd(), "artifacts", "markdown-diff-shots")
+);
+
+const THEMES = (process.env.DAINTREE_SHOT_THEMES ?? "daintree,bondi,namib")
+  .split(",")
+  .map((t) => t.trim())
+  .filter(Boolean);
+
+/** Mirrors `FIXTURES` in the preview entry, with what each one is here to prove. */
+const ALL_FIXTURES = [
+  { name: "prose-rewrite", what: "a rewrite that keeps most of its clauses" },
+  { name: "light-edit", what: "a few words swapped — the baseline that must keep working" },
+  { name: "structure", what: "heading, list items and a blockquote" },
+  { name: "table-and-code", what: "a changed table cell and a changed fence" },
+  { name: "insert-and-delete", what: "unpaired insertion and unpaired deletion" },
+  { name: "sparse", what: "two changes in a long document" },
+] as const;
+
+const FIXTURES = process.env.DAINTREE_SHOT_FIXTURES
+  ? ALL_FIXTURES.filter((f) =>
+      process.env
+        .DAINTREE_SHOT_FIXTURES!.split(",")
+        .map((n) => n.trim())
+        .includes(f.name)
+    )
+  : ALL_FIXTURES;
+
+let server: ViteDevServer | undefined;
+let baseURL = "";
+
+test.beforeAll(async () => {
+  // No test.skip here: `test.info()` is unavailable in a beforeAll hook, so the
+  // structured-skip annotation the repo requires cannot be attached. The test
+  // body carries the skip; this hook simply does no work when the flag is unset.
+  if (!ENABLED) return;
+  // Fresh directory per run: a leftover PNG from an earlier round read as this
+  // round's output is the easiest way to review a screen that no longer exists.
+  if (existsSync(OUT_DIR)) rmSync(OUT_DIR, { recursive: true, force: true });
+  mkdirSync(OUT_DIR, { recursive: true });
+
+  // `strictPort: false` matters: the project's own vite config sets
+  // `strictPort: true` for the app's dev server, and that wins over an inline
+  // `port: 0` — so with the app running this harness dies on "Port 5173 is
+  // already in use" instead of taking a free one. Falling forward and reading
+  // the port back off the server is what makes the harness runnable while the
+  // app is up.
+  server = await createServer({
+    server: { port: 0, strictPort: false },
+    logLevel: "error",
+  });
+  await server.listen();
+  const address = server.httpServer?.address();
+  if (!address || typeof address === "string") throw new Error("vite gave no TCP address");
+  baseURL = `http://127.0.0.1:${address.port}`;
+});
+
+test.afterAll(async () => {
+  await server?.close();
+});
+
+/** Write one PNG, having proved there is something to write. */
+async function snap(target: Locator, file: string, fullPage = false): Promise<string> {
+  await expect(target).toBeAttached();
+  const box = await target.boundingBox();
+  if (!box || box.width < 8 || box.height < 8) {
+    throw new Error(`${file}: target has no real box (${JSON.stringify(box)}) — refusing to write`);
+  }
+  const out = path.join(OUT_DIR, file);
+  if (fullPage) {
+    await target.page().screenshot({ path: out, fullPage: true });
+  } else {
+    await target.screenshot({ path: out });
+  }
+  return out;
+}
+
+/** Load one fixture in one theme at one width, and settle it. */
+async function open(
+  page: Page,
+  fixture: string,
+  theme: string,
+  width: number
+): Promise<{ body: Locator; diff: Locator }> {
+  await page.setViewportSize({ width, height: 900 });
+  await page.goto(
+    `${baseURL}/markdown-diff-preview.html?theme=${theme}&fixture=${fixture}&width=${width}`
+  );
+  const body = page.locator("[data-preview-shell]").first();
+  await expect(body).toBeAttached();
+  const diff = page.getByTestId("rendered-markdown-diff");
+  // The engine can decline to build a view at all (`onVerdict`), in which case
+  // the component renders null and the host would swap back to the source diff.
+  // Here that is a broken fixture, and it must fail loudly rather than write a
+  // picture of an empty panel.
+  await expect(diff, `fixture "${fixture}" produced no rendered diff`).toBeAttached();
+  // Type metrics drive every measurement in a prose surface, so a capture taken
+  // before the fonts land measures the fallback face.
+  await page.evaluate(() => document.fonts.ready);
+  await page.waitForTimeout(200);
+  return { body, diff };
+}
+
+test("rendered Markdown diff — cases, widths and themes", async ({ page }) => {
+  test.info().annotations.push({
+    type: "conditional-skip",
+    description: "DAINTREE_SHOT_MDDIFF is required for the rendered-Markdown diff capture",
+  });
+  test.skip(!ENABLED, "set DAINTREE_SHOT_MDDIFF=1 to run the capture");
+
+  const written: string[] = [];
+
+  for (const theme of THEMES) {
+    for (const { name } of FIXTURES) {
+      const { body } = await open(page, name, theme, DEFAULT_WIDTH);
+      // The viewport, not the whole document: this is what a reader sees when
+      // they open the panel, and the question the surface has to answer first
+      // ("what changed here?") is answered above the fold or not at all.
+      written.push(await snap(body, `${name}-${theme}.png`));
+    }
+  }
+
+  // The pressure case: the narrowest the diff panel realistically gets, in the
+  // default theme only — width is a layout question, not a palette one.
+  {
+    const theme = THEMES[0]!;
+    for (const name of ["prose-rewrite", "table-and-code"] as const) {
+      if (!FIXTURES.some((f) => f.name === name)) continue;
+      const { body } = await open(page, name, theme, NARROW_WIDTH);
+      written.push(await snap(body, `${name}-${theme}-narrow.png`));
+    }
+  }
+
+  // Count the files ourselves. A harness that trusts its own exit code is how a
+  // review ends up reasoning about screenshots that were never written.
+  const onDisk = readdirSync(OUT_DIR).filter((f) => f.endsWith(".png"));
+  expect(onDisk.length).toBe(written.length);
+  expect(onDisk.length).toBeGreaterThanOrEqual(THEMES.length * FIXTURES.length);
+  console.log(`[markdown-diff-shots] ${onDisk.length} PNGs in ${OUT_DIR}`);
+});

--- a/e2e/screenshots/session-tabs-review.spec.ts
+++ b/e2e/screenshots/session-tabs-review.spec.ts
@@ -75,7 +75,16 @@ test.beforeAll(async () => {
   if (existsSync(OUT_DIR)) rmSync(OUT_DIR, { recursive: true, force: true });
   mkdirSync(OUT_DIR, { recursive: true });
 
-  server = await createServer({ server: { port: 0 }, logLevel: "error" });
+  // `strictPort: false` matters: the project's own vite config sets
+  // `strictPort: true` for the app's dev server, and that wins over an inline
+  // `port: 0` — so with the app running this harness dies on "Port 5173 is
+  // already in use" instead of taking a free one. Falling forward and reading
+  // the port back off the server is what makes the harness runnable while the
+  // app is up.
+  server = await createServer({
+    server: { port: 0, strictPort: false },
+    logLevel: "error",
+  });
   await server.listen();
   const address = server.httpServer?.address();
   if (!address || typeof address === "string") throw new Error("vite gave no TCP address");

--- a/markdown-diff-preview.html
+++ b/markdown-diff-preview.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="" />
+    <title>Rendered Markdown diff preview</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/components/Worktree/__preview__/preview.tsx"></script>
+  </body>
+</html>

--- a/src/components/FileViewer/DiffChangeStepper.tsx
+++ b/src/components/FileViewer/DiffChangeStepper.tsx
@@ -1,0 +1,66 @@
+import { ChevronDown, ChevronUp } from "lucide-react";
+import { FileViewerToolbar, TOOLBAR_ICON_CLASS } from "./FileViewerToolbar";
+
+/**
+ * The change inventory for the diff panel's rendered layout: how many changes
+ * this document holds, which one you are on, and a way to the next.
+ *
+ * A rendered diff has no line numbers and no hunk headers, which is the point —
+ * but it also means a long document with four edits gives the reader nothing to
+ * tell them there are four, or where the other three are. They scroll and hope.
+ * A counter plus a stepper is the established answer (Kaleidoscope's change
+ * stepper, Word's Next/Previous change, every side-by-side comparison tool), and
+ * it is the whole of the orientation this surface needs — there are no lines
+ * here to number and no hunks to fold.
+ *
+ * Its own component rather than JSX inside `DiffPane` so the screenshot harness
+ * renders the real thing. A stepper copied into a preview drifts from the one
+ * that ships, and then the review is of a control nobody uses.
+ */
+export interface DiffChangeStepperProps {
+  /** Total changes in the document. The stepper renders nothing at zero. */
+  count: number;
+  /** Zero-based index of the change the reader is on. */
+  index: number;
+  /** Move by `delta` changes, wrapping at both ends. */
+  onStep: (delta: number) => void;
+}
+
+export function DiffChangeStepper({ count, index, onStep }: DiffChangeStepperProps) {
+  if (count === 0) return null;
+  // One change needs no stepper. Two arrows that both land on the block you are
+  // already looking at are a control that does nothing, which is worse than an
+  // absent one — but the count still answers "is there more below?", so it
+  // stays.
+  if (count === 1) {
+    return (
+      <span className="px-1 text-xs text-text-secondary select-none" aria-live="polite">
+        1 change
+      </span>
+    );
+  }
+  return (
+    <div role="group" aria-label="Changes" className="flex items-center gap-0.5">
+      {/*
+        `aria-live="polite"` rather than moving focus: stepping is a scroll, and
+        a screen-reader user who has just pressed Next needs to hear where they
+        landed without losing the button they are about to press again.
+
+        Tabular figures because the count sits between two buttons whose
+        positions must not shuffle as the index crosses from 9 to 10.
+      */}
+      <span
+        className="px-1 text-xs tabular-nums text-text-secondary select-none"
+        aria-live="polite"
+      >
+        {`${index + 1} of ${count}`}
+      </span>
+      <FileViewerToolbar.IconButton label="Previous change" onClick={() => onStep(-1)}>
+        <ChevronUp className={TOOLBAR_ICON_CLASS} />
+      </FileViewerToolbar.IconButton>
+      <FileViewerToolbar.IconButton label="Next change" onClick={() => onStep(1)}>
+        <ChevronDown className={TOOLBAR_ICON_CLASS} />
+      </FileViewerToolbar.IconButton>
+    </div>
+  );
+}

--- a/src/components/Worktree/RenderedMarkdownDiff.css
+++ b/src/components/Worktree/RenderedMarkdownDiff.css
@@ -15,48 +15,133 @@
    separate. */
 
 .rendered-markdown-diff {
-  /* The reading measure that centers a document would strand the block markers
+  /* The reading measure that centers a document would strand the change bars
      against the pane edge, and a diff is scanned rather than read at length. */
   max-width: none;
+
+  /* The document's own inline padding, restated as a variable so a changed
+     block can cancel it and put its bar in the margin. Kept in sync with the
+     `px-6` on the root element by hand — there is no way to read a utility's
+     value back out, and the alternative is threading a style prop through the
+     component for a constant. */
+  --rendered-diff-inset: 1.5rem;
+  /* Room between the bar and the prose, matching what an unchanged block gets
+     so a paragraph does not shift sideways when it changes. */
+  --rendered-diff-gutter: 0.75rem;
+  --rendered-diff-bar: 3px;
+
+  /* The two tiers.
+
+     A block fill and a word fill that sit 18% and 28% apart read as one tone,
+     which is why a changed block currently looks like a slab rather than a
+     paragraph with changed words in it. The block tier is damped to roughly a
+     third of its token so the word tier stands off it by about 4x, which is
+     the separation Kaleidoscope and GitHub's rich diff both use. The tokens
+     themselves are untouched: they are shared with the source line diff, where
+     the line fill IS the signal, and they carry the color-vision overrides. */
+  --rendered-diff-insert-fill: color-mix(
+    in oklab,
+    var(--color-diff-insert-background) 38%,
+    transparent
+  );
+  --rendered-diff-delete-fill: color-mix(
+    in oklab,
+    var(--color-diff-delete-background) 38%,
+    transparent
+  );
 }
 
 .rendered-markdown-diff__block {
-  position: relative;
   /* Contains the child prose margins so a block's fill covers its own content
      instead of collapsing through the wrapper. */
   display: flow-root;
-  padding: 0.25rem 0.75rem;
-  border-radius: var(--radius-xs);
+  padding-block: 0.25rem;
+  padding-inline: var(--rendered-diff-gutter);
 }
 
-/* An unchanged block is the document as it reads — no fill, no edge, nothing
-   competing with the two states that carry meaning. */
-.rendered-markdown-diff__block--unchanged {
-  padding-inline: 0.75rem;
+/* The band hugs its text.
+
+   `flow-root` keeps the child's own margins inside the block, which is what
+   stops the fill collapsing through the wrapper — but it also paints them. A
+   one-line paragraph pair was carrying 4 x 17.5px of tinted nothing, and a
+   heading pair 42px above and 21px below EACH half, so a change of three words
+   cost over 200px of vertical space and the two halves looked like separate
+   cards with a gap between them. The block supplies its own breathing room
+   instead, and the document's rhythm still comes from the unchanged prose
+   around it. */
+.rendered-markdown-diff__block--added > :first-child:not(.sr-only),
+.rendered-markdown-diff__block--removed > :first-child:not(.sr-only),
+.rendered-markdown-diff__block--added > .sr-only + *,
+.rendered-markdown-diff__block--removed > .sr-only + * {
+  margin-block-start: 0;
 }
 
+.rendered-markdown-diff__block--added > :last-child,
+.rendered-markdown-diff__block--removed > :last-child {
+  margin-block-end: 0;
+}
+
+/* An unchanged block gets no rule of its own: it is the document as it reads,
+   with no fill, no edge and nothing competing with the two states that carry
+   meaning. Everything below applies only to the two that do. */
 .rendered-markdown-diff__block--added,
 .rendered-markdown-diff__block--removed {
-  /* Real border, not a ring: box-shadow rings are dropped entirely in forced
-     colors, taking the only non-color signal with them. */
-  border-inline-start: 3px solid transparent;
-  padding-inline-start: calc(0.75rem - 3px);
-  margin-block: 0.25rem;
+  /* A margin change bar, not a card.
+
+     The band runs to both pane edges and the bar sits in the margin, which is
+     what a change bar is in every editor that has one — and it is why there is
+     no radius here. A rounded corner on a shape whose whole left edge is a
+     rule reads as a card that someone has drawn a line down, and the two
+     halves of a modified pair then read as two unrelated cards rather than one
+     substitution. Square, flush, and the pair's two bars meet with no seam.
+
+     Real border rather than a ring: box-shadow is dropped entirely in forced
+     colors, taking the only non-color signal with it. */
+  margin-inline: calc(var(--rendered-diff-inset) * -1);
+  border-inline-start: var(--rendered-diff-bar) solid transparent;
+  padding-inline-start: calc(
+    var(--rendered-diff-inset) + var(--rendered-diff-gutter) - var(--rendered-diff-bar)
+  );
+  padding-inline-end: calc(var(--rendered-diff-inset) + var(--rendered-diff-gutter));
+  padding-block: 0.5rem;
+  border-radius: 0;
 }
 
 .rendered-markdown-diff__block--added {
-  background: var(--color-diff-insert-background);
+  background: var(--rendered-diff-insert-fill);
   border-inline-start-color: var(--color-diff-gutter-insert);
 }
 
 .rendered-markdown-diff__block--removed {
-  background: var(--color-diff-delete-background);
+  background: var(--rendered-diff-delete-fill);
   border-inline-start-color: var(--color-diff-gutter-delete);
 }
 
-/* GitHub's rich-diff treatment: a removed block reads as struck-out prose,
-   which is what makes it legible as "this text is gone" without recoloring the
-   text itself and losing contrast over the fill.
+/* One change is one thought.
+
+   The space goes on the change, never between the halves of a substitution: a
+   modified pair's two bands touch, and the gap that separates one change from
+   the next sits outside them both. That difference is the only thing telling a
+   reader that a deletion followed by an insertion is two unrelated edits rather
+   than one substitution — with a uniform gap everywhere the two cases look
+   identical, which is what they used to do. */
+.rendered-markdown-diff__change {
+  margin-block: 0.625rem;
+}
+
+.rendered-markdown-diff__pair > .rendered-markdown-diff__block + .rendered-markdown-diff__block {
+  margin-block-start: 0;
+}
+
+/* Struck-out prose is what makes a deleted block legible as "this text is gone"
+   without recoloring the text itself and losing contrast over the fill.
+
+   Only where the whole block is the deletion. On the removed half of a
+   SUBSTITUTION it says the opposite of what the engine found: a heading that
+   merely gained three words has every one of its surviving words struck, and a
+   rewritten paragraph's untouched clauses are crossed out alongside the ones
+   that actually went. There, the `<del>` ranges carry the line and the words
+   that survived are left alone — which is the whole point of locating them.
 
    Declared on the text-bearing descendants rather than on the block wrapper,
    which is the only way to keep it off code fences and table grids: a text
@@ -64,60 +149,66 @@
    CANNOT be switched off further down — `text-decoration: none` on the <pre>
    would be silently ignored. The :has() exclusion drops the line from a
    container holding a fence or table (a list item wrapping a code block), where
-   the block fill and the marker still carry the state. */
-.rendered-markdown-diff__block--removed
+   the block fill and the bar still carry the state. */
+.rendered-markdown-diff__block--removed[data-whole="true"]
   :where(p, h1, h2, h3, h4, h5, h6, li, blockquote, dt, dd):not(:has(pre, table)) {
   text-decoration: line-through;
   text-decoration-color: color-mix(in oklab, var(--color-text-primary) 45%, transparent);
   text-decoration-thickness: 1px;
 }
 
-/* The status marker. Sits in the inline-start padding so it never displaces the
-   prose, and is a character rather than a color so the state survives a palette
-   that can't distinguish red from green. */
-.rendered-markdown-diff__marker {
-  position: absolute;
-  inset-inline-start: 0.125rem;
-  top: 0.3rem;
-  font-family: var(--font-mono);
-  font-size: var(--text-xs);
-  line-height: 1.2;
-  user-select: none;
-  text-decoration: none;
-}
+/* Word- and sentence-level marks inside a modified block, using the same edit
+   fills the line diff uses for intra-line marks so the two surfaces read
+   identically.
 
-.rendered-markdown-diff__block--added > .rendered-markdown-diff__marker {
-  color: var(--color-diff-gutter-insert);
-}
-
-.rendered-markdown-diff__block--removed > .rendered-markdown-diff__marker {
-  color: var(--color-diff-gutter-delete);
-}
-
-/* Word-level marks inside a modified block, using the same edit fills the line
-   diff uses for intra-line marks so the two surfaces read identically. */
+   These are real <ins> and <del> elements, so the browser's own default
+   decorations would apply on top of ours; both are restated here rather than
+   inherited, because the underline offset a diff needs is not the one the UA
+   picks. */
 .rendered-markdown-diff__inline {
   border-radius: var(--radius-xs);
   padding-block: 0.05em;
+  /* The mark is a fill and a decoration, never a color change: recoloring text
+     over a tinted fill is how a diff loses its contrast floor in the themes
+     with the least headroom. */
+  color: inherit;
 }
 
+/* The non-color half of the signal, at word level.
+
+   WCAG 1.4.1 is not satisfied by the block's bar alone here: inside a changed
+   block, "these three words are new" and "these three words are old" differ
+   only by fill, and the two fills are a red and a green. An underline on the
+   insertion and a line through the deletion are the same cues Word and Google
+   Docs use, and they survive both high-contrast modes and a monochrome
+   display. */
 .rendered-markdown-diff__inline--added {
   background: var(--color-diff-insert-edit-background);
+  text-decoration: underline;
+  text-decoration-color: var(--color-diff-gutter-insert);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
 }
 
 .rendered-markdown-diff__inline--removed {
   background: var(--color-diff-delete-edit-background);
-}
-
-/* A modified block's two halves are one thought; keep them adjacent and let the
-   gap between pairs do the separating. */
-.rendered-markdown-diff__pair > .rendered-markdown-diff__block + .rendered-markdown-diff__block {
-  margin-block-start: 0;
+  /* `.markdown-document :where(del) { opacity: 0.6 }` is meant for authored GFM
+     strikethrough, where the dimming IS the point. It also catches the `<del>`
+     elements this diff injects, and a deleted word at 60% over its own tinted
+     fill measures about 3.5:1 in the light themes — under the 4.5:1 floor, on
+     the one run of text the reader most needs to read. The strikethrough
+     already says "deleted"; the opacity was saying it twice and charging
+     contrast for the second one. Authored `~~text~~` keeps its dimming, because
+     this only names the diff's own marks. */
+  opacity: 1;
+  text-decoration: line-through;
+  text-decoration-color: color-mix(in oklab, var(--color-text-primary) 55%, transparent);
+  text-decoration-thickness: 1px;
 }
 
 @media (forced-colors: active) {
-  /* Author fills are dropped by the system anyway; the edge and the marker are
-     what survive, so they carry the whole signal here. */
+  /* Author fills are dropped by the system anyway; the edge and the inline
+     decorations are what survive, so they carry the whole signal here. */
   .rendered-markdown-diff__block--added,
   .rendered-markdown-diff__block--removed {
     background: Canvas;
@@ -132,16 +223,18 @@
     border-inline-start-color: LinkText;
   }
 
-  .rendered-markdown-diff__block--added > .rendered-markdown-diff__marker,
-  .rendered-markdown-diff__block--removed > .rendered-markdown-diff__marker {
-    color: CanvasText;
-  }
-
-  /* A background can't mark a word here, so the underline does. */
+  /* A background can't mark a word here, so the decoration does it alone. */
   .rendered-markdown-diff__inline {
     background: none;
+  }
+
+  .rendered-markdown-diff__inline--added {
     text-decoration: underline dotted CanvasText;
     text-underline-offset: 2px;
+  }
+
+  .rendered-markdown-diff__inline--removed {
+    text-decoration: line-through CanvasText;
   }
 }
 
@@ -151,8 +244,85 @@
     border-inline-start-width: 4px;
   }
 
-  .rendered-markdown-diff__block--removed
+  .rendered-markdown-diff__block--removed[data-whole="true"]
     :where(p, h1, h2, h3, h4, h5, h6, li, blockquote, dt, dd):not(:has(pre, table)) {
     text-decoration-color: var(--color-text-primary);
   }
+
+  .rendered-markdown-diff__inline--removed {
+    text-decoration-color: var(--color-text-primary);
+  }
+
+  .rendered-markdown-diff__inline--added {
+    text-decoration-thickness: 2px;
+  }
+}
+
+/* Structural rules inside a changed block.
+
+   Every rule the Markdown document draws — a table grid, a blockquote's left
+   bar, a heading's underline — is `--color-border-default` mixed down towards
+   transparent. Mixed towards transparent means composited against whatever is
+   behind it, and behind it here is a tinted fill rather than the canvas: in the
+   dark themes the table grid measures 1.04:1 against its own block, so the same
+   table renders with a grid outside a change and none inside one. The reader
+   loses the structure of exactly the thing being reviewed.
+
+   Restated at full strength for changed blocks only. Unchanged blocks keep the
+   document's own values, so the quiet grid stays quiet where nothing happened. */
+.rendered-markdown-diff__block--added :where(th, td),
+.rendered-markdown-diff__block--removed :where(th, td) {
+  border-color: var(--color-border-strong);
+}
+
+.rendered-markdown-diff__block--added :where(blockquote),
+.rendered-markdown-diff__block--removed :where(blockquote) {
+  border-inline-start-color: var(--color-border-strong);
+}
+
+.rendered-markdown-diff__block--added :where(h1, h2),
+.rendered-markdown-diff__block--removed :where(h1, h2) {
+  border-bottom-color: var(--color-border-strong);
+}
+
+/* The fold that stands in for a run of untouched blocks.
+
+   Deliberately the quietest thing on the surface: it marks an absence, and an
+   absence that draws the eye competes with the changes the reader came for. No
+   fill, no bar — a hairline rule through the measure with the count sitting on
+   it, which is the same "there is more here" idiom the source diff's expander
+   uses without borrowing its gutter. */
+.rendered-markdown-diff__fold {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  width: 100%;
+  margin-block: 0.75rem;
+  padding-inline: var(--rendered-diff-gutter);
+  font-size: var(--text-xs);
+  line-height: 1.2;
+  color: var(--color-text-secondary);
+  background: none;
+  text-align: start;
+}
+
+.rendered-markdown-diff__fold::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: var(--color-border-default);
+}
+
+.rendered-markdown-diff__fold:hover {
+  color: var(--color-text-primary);
+}
+
+.rendered-markdown-diff__fold:hover::after {
+  background: var(--color-border-strong);
+}
+
+/* The stepper scrolls to a change, and it must land clear of the toolbar rather
+   than flush under it. */
+.rendered-markdown-diff__change {
+  scroll-margin-block: 1.5rem;
 }

--- a/src/components/Worktree/RenderedMarkdownDiff.tsx
+++ b/src/components/Worktree/RenderedMarkdownDiff.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, type CSSProperties } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from "react";
 import ReactMarkdown from "react-markdown";
 import type { PluggableList } from "unified";
 import remarkGfm from "remark-gfm";
@@ -12,6 +12,7 @@ import { cn } from "@/lib/utils";
 import type { MarkdownFontSize } from "@/store/preferencesStore";
 import {
   buildMarkdownDiff,
+  type MarkdownBlock,
   type MarkdownBlockChange,
   type MarkdownDiffFailure,
   type TextRange,
@@ -56,6 +57,65 @@ export interface RenderedMarkdownDiffProps {
    * on the verdict.
    */
   onVerdict?: (reason: MarkdownDiffFailure | null, forAttempt: string) => void;
+  /**
+   * How many discrete changes the document holds, so the host can offer a
+   * counter and a stepper. A modified pair is ONE change, not two.
+   *
+   * Reported rather than derived by the host because the host has a patch and
+   * this component has the model — and the two disagree by design: a patch hunk
+   * is a run of lines, a change here is a block the reader can point at.
+   */
+  onChangeCount?: (count: number) => void;
+}
+
+/**
+ * How long a run of untouched blocks may get before it is folded away.
+ *
+ * A 40-paragraph document with four edits renders 40 paragraphs, and the reader
+ * scrolls past screens of prose they have already accepted looking for the next
+ * thing to judge — the failure mode every diff tool with a folding affordance
+ * exists to avoid. Five is the point where a run stops being context and starts
+ * being an obstacle; two blocks stay at each edge because a change reads
+ * differently when you cannot see what it follows.
+ */
+const UNCHANGED_RUN_LIMIT = 5;
+const UNCHANGED_CONTEXT = 2;
+
+/** One change the reader can point at, or a run of blocks they can skip. */
+type Section =
+  | { kind: "change"; index: number; change: MarkdownBlockChange }
+  // `blocks` is mutable because `toSections` appends to the run in place as it
+  // walks; nothing outside that function touches it.
+  | { kind: "unchanged"; id: number; blocks: MarkdownBlock[] };
+
+/**
+ * Group the model into the things a reader navigates by.
+ *
+ * Consecutive untouched blocks collapse into one run so they can be folded as a
+ * unit, and everything else takes the next change number. A `modified` pair is
+ * one change: it is one edit the reader accepts or rejects, and numbering its
+ * halves separately would report twice as many changes as the document has.
+ */
+function toSections(changes: readonly MarkdownBlockChange[]): {
+  sections: Section[];
+  changeCount: number;
+} {
+  const sections: Section[] = [];
+  let changeCount = 0;
+  let runId = 0;
+  for (const change of changes) {
+    if (change.kind === "unchanged") {
+      const last = sections[sections.length - 1];
+      if (last?.kind === "unchanged") {
+        last.blocks.push(change.block);
+        continue;
+      }
+      sections.push({ kind: "unchanged", id: runId++, blocks: [change.block] });
+      continue;
+    }
+    sections.push({ kind: "change", index: changeCount++, change });
+  }
+  return { sections, changeCount };
 }
 
 type BlockKind = "unchanged" | "added" | "removed";
@@ -66,10 +126,19 @@ const BLOCK_LABEL: Record<BlockKind, string> = {
   removed: "Removed block:",
 };
 
-const BLOCK_MARKER: Record<BlockKind, string> = {
-  unchanged: "",
-  added: "+",
-  removed: "−",
+/**
+ * What a marked range is announced as.
+ *
+ * `<ins>` and `<del>` carry the `insertion` and `deletion` roles, but no
+ * mainstream screen reader announces either one in browse mode unless the user
+ * has already raised their verbosity. So the elements are for the accessibility
+ * tree and this hidden text is for the reader: without it a screen-reader user
+ * hears the block-level "Added block" and then the same prose as everywhere
+ * else, with no idea which words the agent actually touched.
+ */
+const RANGE_LABEL: Record<"added" | "removed", string> = {
+  added: "Inserted: ",
+  removed: "Deleted: ",
 };
 
 /**
@@ -137,6 +206,11 @@ function inlineRangePlugin(ranges: readonly TextRange[], expectedText: string, k
     if (text !== expectedText) return;
     // hast models a class attribute as a list, not the joined string.
     const className = ["rendered-markdown-diff__inline", `rendered-markdown-diff__inline--${kind}`];
+    // Native revision elements rather than styled spans: `<ins>` and `<del>`
+    // are what an assistive technology reads as a revision, and a `<span>` with
+    // a background is not a revision to anything but a sighted reader.
+    const tagName = kind === "removed" ? "del" : "ins";
+    const label = RANGE_LABEL[kind === "removed" ? "removed" : "added"];
     // Rebuilt back-to-front within each parent so an earlier splice can't
     // invalidate a later recorded index.
     for (const entry of [...entries].reverse()) {
@@ -156,9 +230,15 @@ function inlineRangePlugin(ranges: readonly TextRange[], expectedText: string, k
         }
         replacement.push({
           type: "element",
-          tagName: "span",
+          tagName,
           properties: { className },
           children: [
+            {
+              type: "element",
+              tagName: "span",
+              properties: { className: ["sr-only"] },
+              children: [{ type: "text", value: label }],
+            },
             { type: "text", value: entry.value.slice(from - entry.start, to - entry.start) },
           ],
         });
@@ -178,6 +258,9 @@ function DiffBlock({
   definitions,
   ranges,
   expectedText,
+  whole,
+  blockRef,
+  tabIndex,
   components,
   urlTransform,
 }: {
@@ -186,6 +269,15 @@ function DiffBlock({
   definitions: string;
   ranges: readonly TextRange[];
   expectedText: string;
+  /** Focus target, for the block a fold hands focus to when it opens. */
+  blockRef?: React.Ref<HTMLDivElement>;
+  tabIndex?: number;
+  /**
+   * True when the whole block is the change — an insertion or a deletion with
+   * no counterpart. False for either half of a substitution, where the block
+   * has a partner and only parts of it actually moved.
+   */
+  whole: boolean;
   components: ReturnType<typeof useMarkdownRenderPolicy>["components"];
   urlTransform: ReturnType<typeof useMarkdownRenderPolicy>["urlTransform"];
 }) {
@@ -203,17 +295,13 @@ function DiffBlock({
 
   return (
     <div
+      ref={blockRef}
+      tabIndex={tabIndex}
       className={cn("rendered-markdown-diff__block", `rendered-markdown-diff__block--${kind}`)}
       data-block-kind={kind}
+      data-whole={whole ? "true" : "false"}
     >
-      {kind !== "unchanged" && (
-        <>
-          <span className="sr-only">{BLOCK_LABEL[kind]}</span>
-          <span className="rendered-markdown-diff__marker" aria-hidden="true">
-            {BLOCK_MARKER[kind]}
-          </span>
-        </>
-      )}
+      {kind !== "unchanged" && <span className="sr-only">{BLOCK_LABEL[kind]}</span>}
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         rehypePlugins={rehypePlugins}
@@ -239,6 +327,7 @@ export function RenderedMarkdownDiff({
   fontSize,
   attemptKey,
   onVerdict,
+  onChangeCount,
 }: RenderedMarkdownDiffProps) {
   const rootRef = useRef<HTMLDivElement>(null);
   useScopedSelectAll(rootRef);
@@ -256,6 +345,26 @@ export function RenderedMarkdownDiff({
   useEffect(() => {
     onVerdict?.(reason, attemptKey);
   }, [onVerdict, reason, attemptKey]);
+
+  const { sections, changeCount } = useMemo(
+    () => (result.ok ? toSections(result.model.changes) : { sections: [], changeCount: 0 }),
+    [result]
+  );
+
+  useEffect(() => {
+    onChangeCount?.(changeCount);
+  }, [onChangeCount, changeCount]);
+
+  // Which folded runs the reader has opened. Keyed by run id rather than index
+  // so re-rendering the same document keeps them open; a new document produces
+  // a new model and the set is dropped with it.
+  const [expandedRuns, setExpandedRuns] = useState<ReadonlySet<number>>(() => new Set());
+  useEffect(() => {
+    setExpandedRuns(new Set());
+  }, [attemptKey]);
+  const expandRun = useCallback((id: number) => {
+    setExpandedRuns((current) => new Set(current).add(id));
+  }, []);
 
   // Removed blocks resolve their relative links and images against the current
   // path too. On a rename that is the wrong directory for the old side, and a
@@ -297,17 +406,121 @@ export function RenderedMarkdownDiff({
       className="rendered-markdown-diff markdown-document prose px-6 py-5"
       style={fontStyle}
     >
-      {result.model.changes.map((change, index) => (
-        <BlockChange
-          key={index}
-          change={change}
-          oldDefinitions={result.model.oldDefinitions}
-          newDefinitions={result.model.newDefinitions}
-          components={components}
-          urlTransform={urlTransform}
-        />
-      ))}
+      {sections.map((section) =>
+        section.kind === "change" ? (
+          <div
+            key={`change-${section.index}`}
+            data-change-index={section.index}
+            className="rendered-markdown-diff__change"
+          >
+            <BlockChange
+              change={section.change}
+              oldDefinitions={result.model.oldDefinitions}
+              newDefinitions={result.model.newDefinitions}
+              components={components}
+              urlTransform={urlTransform}
+            />
+          </div>
+        ) : (
+          <UnchangedRun
+            key={`unchanged-${section.id}`}
+            blocks={section.blocks}
+            definitions={result.model.newDefinitions}
+            expanded={expandedRuns.has(section.id)}
+            onExpand={() => expandRun(section.id)}
+            components={components}
+            urlTransform={urlTransform}
+          />
+        )
+      )}
     </div>
+  );
+}
+
+/**
+ * A run of untouched blocks, folded in the middle once it gets long enough to
+ * be an obstacle rather than context.
+ *
+ * Expanding is one-way on purpose. A reader opens a run to check something and
+ * then keeps reading; a control that offers to close it again is a second
+ * decision about text they have already accepted, and it would move the change
+ * they were heading for back off the screen.
+ */
+function UnchangedRun({
+  blocks,
+  definitions,
+  expanded,
+  onExpand,
+  components,
+  urlTransform,
+}: {
+  blocks: readonly MarkdownBlock[];
+  /** The new side's reference definitions, for the blocks that cite one. */
+  definitions: string;
+  expanded: boolean;
+  onExpand: () => void;
+  components: ReturnType<typeof useMarkdownRenderPolicy>["components"];
+  urlTransform: ReturnType<typeof useMarkdownRenderPolicy>["urlTransform"];
+}) {
+  // The fold unmounts when it opens, which would drop focus on `document.body`
+  // and strand a keyboard user in the middle of a long document. Focus goes to
+  // the first block the fold just revealed instead — the thing they asked to
+  // see.
+  const revealedRef = useRef<HTMLDivElement>(null);
+  const wasExpanded = useRef(expanded);
+  useEffect(() => {
+    if (expanded && !wasExpanded.current) revealedRef.current?.focus({ preventScroll: true });
+    wasExpanded.current = expanded;
+  }, [expanded]);
+
+  const shared = { components, urlTransform, kind: "unchanged" as const, ranges: [], whole: false };
+  const render = (block: MarkdownBlock, key: string, reveal = false) => (
+    <DiffBlock
+      key={key}
+      blockRef={reveal ? revealedRef : undefined}
+      tabIndex={reveal ? -1 : undefined}
+      source={block.source}
+      // Every block renders on its own, so one citing `[docs][d]` needs the
+      // definition appended or it renders the literal brackets and loses its
+      // link. Only the blocks that actually cite one pay for it.
+      definitions={block.referenceIds.length ? definitions : ""}
+      expectedText={block.text}
+      {...shared}
+    />
+  );
+
+  if (expanded || blocks.length <= UNCHANGED_RUN_LIMIT) {
+    return (
+      <>
+        {blocks.map((block, index) =>
+          render(block, `block-${index}`, expanded && index === UNCHANGED_CONTEXT)
+        )}
+      </>
+    );
+  }
+
+  const hiddenCount = blocks.length - UNCHANGED_CONTEXT * 2;
+  return (
+    <>
+      {blocks.slice(0, UNCHANGED_CONTEXT).map((block, index) => render(block, `lead-${index}`))}
+      <button
+        type="button"
+        onClick={onExpand}
+        className="rendered-markdown-diff__fold"
+        aria-expanded={false}
+      >
+        {/*
+          "Expand", not "Show", and "unchanged", not "hidden": the Unified and
+          Split layouts of this same panel are one segmented-control click away
+          and their hunk expanders already say `Expand N lines` and
+          `N unchanged lines hidden`. Same panel, same gesture, same verb.
+        */}
+        {`Expand ${hiddenCount} unchanged ${hiddenCount === 1 ? "block" : "blocks"}`}
+      </button>
+      {blocks
+        .slice(blocks.length - UNCHANGED_CONTEXT)
+        .map((block, index) => render(block, `trail-${index}`))}
+    </>
   );
 }
 
@@ -336,6 +549,7 @@ function BlockChange({
           definitions={change.old.referenceIds.length ? oldDefinitions : ""}
           ranges={change.inline.old}
           expectedText={change.old.text}
+          whole={false}
           {...shared}
         />
         <DiffBlock
@@ -344,6 +558,7 @@ function BlockChange({
           definitions={change.new.referenceIds.length ? newDefinitions : ""}
           ranges={change.inline.new}
           expectedText={change.new.text}
+          whole={false}
           {...shared}
         />
       </div>
@@ -362,6 +577,7 @@ function BlockChange({
       definitions={definitions}
       ranges={[]}
       expectedText={change.block.text}
+      whole={kind !== "unchanged"}
       {...shared}
     />
   );

--- a/src/components/Worktree/__preview__/markdownDiffFixtures.ts
+++ b/src/components/Worktree/__preview__/markdownDiffFixtures.ts
@@ -1,0 +1,250 @@
+/**
+ * Fixtures for the rendered-Markdown diff review harness.
+ *
+ * Each fixture is a pair of whole documents. The patch between them is built
+ * here, at load time, rather than checked in: `RenderedMarkdownDiff` consumes a
+ * unified patch plus the new side from disk, so a hand-written patch that drifts
+ * from its own document by one line reconstructs into prose that never existed —
+ * the exact failure the engine's `source-mismatch` guard is there to catch, and
+ * a miserable thing to debug from a screenshot.
+ *
+ * The documents themselves are deliberately real prose, not lorem: the whole
+ * question this harness exists to answer is whether a reader can see which
+ * sentences moved, and that is unanswerable against filler text.
+ */
+
+/** Longest common subsequence over lines, as index pairs. */
+function lineLcs(a: readonly string[], b: readonly string[]): Array<[number, number]> {
+  const rows = a.length + 1;
+  const cols = b.length + 1;
+  const table = new Uint32Array(rows * cols);
+  for (let i = a.length - 1; i >= 0; i--) {
+    for (let j = b.length - 1; j >= 0; j--) {
+      table[i * cols + j] =
+        a[i] === b[j]
+          ? (table[(i + 1) * cols + j + 1] ?? 0) + 1
+          : Math.max(table[(i + 1) * cols + j] ?? 0, table[i * cols + j + 1] ?? 0);
+    }
+  }
+  const pairs: Array<[number, number]> = [];
+  let i = 0;
+  let j = 0;
+  while (i < a.length && j < b.length) {
+    if (a[i] === b[j]) {
+      pairs.push([i, j]);
+      i++;
+      j++;
+    } else if ((table[(i + 1) * cols + j] ?? 0) >= (table[i * cols + j + 1] ?? 0)) {
+      i++;
+    } else {
+      j++;
+    }
+  }
+  return pairs;
+}
+
+/**
+ * A whole-file unified patch with full context in one hunk.
+ *
+ * Full context rather than the usual three: the engine reverse-applies hunks
+ * against the new source and trusts the gaps between them, so a single hunk
+ * spanning the file is both the simplest thing to generate correctly and the
+ * strictest thing to reconstruct — every line is verified.
+ */
+export function patchFrom(oldText: string, newText: string, name = "doc.md"): string {
+  const oldLines = oldText.split("\n");
+  const newLines = newText.split("\n");
+  const anchors = lineLcs(oldLines, newLines);
+
+  const body: string[] = [];
+  let oldCursor = 0;
+  let newCursor = 0;
+  const emitGap = (oldEnd: number, newEnd: number): void => {
+    for (; oldCursor < oldEnd; oldCursor++) body.push(`-${oldLines[oldCursor]}`);
+    for (; newCursor < newEnd; newCursor++) body.push(`+${newLines[newCursor]}`);
+  };
+  for (const [oldIndex, newIndex] of anchors) {
+    emitGap(oldIndex, newIndex);
+    body.push(` ${oldLines[oldIndex]}`);
+    oldCursor = oldIndex + 1;
+    newCursor = newIndex + 1;
+  }
+  emitGap(oldLines.length, newLines.length);
+
+  return [
+    `diff --git a/${name} b/${name}`,
+    `--- a/${name}`,
+    `+++ b/${name}`,
+    `@@ -1,${oldLines.length} +1,${newLines.length} @@`,
+    ...body,
+    "",
+  ].join("\n");
+}
+
+export interface MarkdownDiffFixture {
+  /** What this fixture is here to prove. */
+  what: string;
+  old: string;
+  new: string;
+}
+
+/** Twelve paragraphs of untouched prose, so a change has real context around it. */
+const TAIL = `It wasn't, really — you can run as many agents as you like. What I kept running out of was my own attention, and that doesn't grow just because you opened more tabs.
+
+And an agent that's waiting on you isn't doing anything. The longer it takes you to notice, the more of your afternoon just disappears.
+
+So this video is really about how I scaled up to a lot of agents, across a lot of projects, and still stay in the loop with all of them — and the free tool I built to let you do the same.
+
+That tool is Daintree, and here's what it does for you: it gives you insight into the status of all your agents, so you're not clicking through a wall of terminal tabs to find out who's doing what. You can pinpoint the ones that need you.
+
+Daintree runs your agents in real terminals, and every terminal shows you whether its agent is working or waiting, and when it's waiting, what it's waiting for. But they're not all in front of you. Some are in other projects, some are tucked away in a worktree you're not looking at.
+
+So you can press Option-Command-O and get the All agents view — everything you're running, across every project, mostly just working and waiting, with the ones waiting on you at the top of each project. You jump to one, answer it, and move on to the next.
+
+That was the main thing Daintree had to solve: how do you jump between a lot of real agents very quickly?
+
+And the agents are still the ones you already use — for me that's Claude Code, Codex and Grok, and a lot of my role now is knowing which one suits a particular task. You'll have your own favourites. Daintree just runs them and watches what they do — the output, the silence, the prompts, the exits — and works out from that whether each agent is working or waiting.`;
+
+export const FIXTURES: Record<string, MarkdownDiffFixture> = {
+  /**
+   * The complaint case, taken from the screenshot that opened this review: a
+   * paragraph rewritten around its surviving clauses. Word marks cover well
+   * past half the characters, so the coverage rule throws them all away and the
+   * reader gets two walls of text.
+   */
+  "prose-rewrite": {
+    what: "a rewritten paragraph that keeps most of its clauses — the case the coverage rule blanks",
+    old: `There are five coding agents running on my machine right now, across a few different projects. And when I started working like this, I thought the hard part was going to be running more agents.
+
+${TAIL}`,
+    new: `This is how I'm working now. There are five coding agents running on my machine, across a few different projects, and at any moment I know exactly which one of them needs me. When I was working the old way, I always thought it was all about adding more agents.
+
+${TAIL}`,
+  },
+
+  /**
+   * The case that already works: a handful of words swapped inside a paragraph
+   * the reader can still recognise. This is the must-not-break baseline for any
+   * change to the granularity rules.
+   */
+  "light-edit": {
+    what: "a few words swapped — word marks already survive here and must keep surviving",
+    old: `That tool is Daintree, and here's what it does for you: it gives you insight into the status of all your agents, so you're not clicking through a wall of terminal tabs to find out who's doing what.
+
+${TAIL}`,
+    new: `That tool is Daintree, and here's what it does for you: it gives you a live picture of the status of all your agents, so you're never clicking through a wall of terminal tabs to find out who's doing what.
+
+${TAIL}`,
+  },
+
+  /**
+   * Structure rather than prose. A heading reworded, a list item edited, one
+   * added and one removed, and a blockquote rewritten — the four block types
+   * whose marks are most likely to collide with their own layout.
+   */
+  structure: {
+    what: "heading, list items and a blockquote — where inline marks fight block layout",
+    old: `## Running the fleet
+
+Daintree keeps a few promises about how your agents behave:
+
+- Every agent runs in a real terminal, not a wrapper.
+- The state you see is read from the output, never from the agent's own claims.
+- A worktree is created per task, so nothing collides.
+- Broadcasting a prompt reaches every selected terminal at once.
+
+> The hard part was never spawning more agents. It was noticing which one had stopped.
+
+${TAIL}`,
+    new: `## Running the fleet, in practice
+
+Daintree keeps a few promises about how your agents actually behave:
+
+- Every agent runs in a real terminal, not a wrapper around one.
+- The state you see is read from the output, never from the agent's own claims.
+- Broadcasting a prompt reaches every selected terminal at once.
+- Closing a terminal keeps its scrollback, so you can pick the thread back up.
+
+> The hard part was never spawning more agents. It was noticing, quickly, which one of them had stopped and was waiting on me.
+
+${TAIL}`,
+  },
+
+  /**
+   * A table cell and a fenced block. Both are places where a text decoration or
+   * an injected span would land on top of machinery that owns its own
+   * rendering — the grid, and the syntax highlighter.
+   */
+  "table-and-code": {
+    what: "a changed table cell and a changed code fence — marks must not fight the grid or the highlighter",
+    old: `| Shortcut | What it does |
+| --- | --- |
+| Option-Command-O | All agents, every project |
+| Option-Command-I | All agents in this project |
+| Option-Command-T | New terminal |
+
+Run it like this:
+
+\`\`\`bash
+npm run dev -- --project daintree
+\`\`\`
+
+${TAIL}`,
+    new: `| Shortcut | What it does |
+| --- | --- |
+| Option-Command-O | Every agent, across every project |
+| Option-Command-I | All agents in this project |
+| Option-Command-T | New terminal in the current worktree |
+
+Run it like this:
+
+\`\`\`bash
+npm run dev -- --project daintree --watch
+\`\`\`
+
+${TAIL}`,
+  },
+
+  /**
+   * Blocks with no partner at all: one paragraph inserted whole, one removed
+   * whole. There is no old/new pair to sit them in, so whatever carries the
+   * "this is an addition" signal has to work on its own.
+   */
+  "insert-and-delete": {
+    what: "an unpaired insertion and an unpaired deletion — no partner block to lean on",
+    old: `There are five coding agents running on my machine right now, across a few different projects.
+
+This paragraph is going away entirely. It said something that stopped being true, and nothing replaced it.
+
+${TAIL}`,
+    new: `There are five coding agents running on my machine right now, across a few different projects.
+
+This paragraph is brand new. Nothing in the old document said anything like it, so there is no counterpart for it to be paired against.
+
+${TAIL}`,
+  },
+
+  /**
+   * The orientation case: a long document with two changes, one near the top
+   * and one near the bottom, and nothing but unchanged prose in between.
+   */
+  sparse: {
+    what: "two changes in a long document — the reader has to find them",
+    old: `# Multi-agent workflow
+
+There are five coding agents running on my machine right now.
+
+${TAIL}
+
+That's two people, not a universal limit. But their numbers matched the ceiling I kept hitting, and that's why I stopped trying to fix the attention problem by running more agents.`,
+    new: `# Multi-agent workflow
+
+There are five coding agents running on my machine as I write this.
+
+${TAIL}
+
+That's two people, not a universal limit. But their numbers matched the ceiling I kept hitting, which is why I stopped trying to fix an attention problem by running more agents.`,
+  },
+};
+
+export type FixtureName = keyof typeof FIXTURES;

--- a/src/components/Worktree/__preview__/preview.tsx
+++ b/src/components/Worktree/__preview__/preview.tsx
@@ -1,0 +1,151 @@
+import { StrictMode, useCallback, useEffect, useRef, useState } from "react";
+import { createRoot } from "react-dom/client";
+import { resolveAppTheme } from "@shared/theme/themes";
+import { applyAppThemeToRoot } from "@/theme/applyAppTheme";
+import { installPreviewShims } from "@/components/HelpPanel/__preview__/previewShims";
+import { DiffChangeStepper } from "@/components/FileViewer/DiffChangeStepper";
+import { FileViewerToolbar } from "@/components/FileViewer/FileViewerToolbar";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { RenderedMarkdownDiff } from "../RenderedMarkdownDiff";
+import { FIXTURES, patchFrom, type MarkdownDiffFixture } from "./markdownDiffFixtures";
+import "@/index.css";
+
+// Runs after every static import above, which is fine: nothing here touches the
+// bridge at module scope. See the sibling shim's own note.
+installPreviewShims();
+
+/**
+ * Standalone visual-review harness for the diff panel's **Rendered** layout.
+ *
+ * Reaching this surface in the real app means opening a project, editing a
+ * tracked Markdown file, opening its diff and switching the layout segment —
+ * and then you get whatever that one edit happened to look like. The states
+ * that decide the design (a paragraph rewritten around its surviving clauses, a
+ * changed table cell, an unpaired insertion, two changes separated by a screen
+ * and a half of untouched prose) are not states you can ask for.
+ *
+ * So this renders the real `RenderedMarkdownDiff` against the real theme tokens
+ * and the real `index.css`, from fixtures that name each case. Everything below
+ * the component is the product's; the page around it is a stand-in for the diff
+ * panel's scroll body, which is all the component ever sees.
+ *
+ * Query parameters:
+ *   ?theme=daintree|bondi|…   built-in theme id
+ *   ?fixture=prose-rewrite    which case to render
+ *   ?width=900                body width in CSS px
+ */
+
+const params = new URLSearchParams(window.location.search);
+const themeId = params.get("theme") ?? "daintree";
+const fixtureName = params.get("fixture") ?? "prose-rewrite";
+const width = Number(params.get("width") ?? "900");
+
+function requireFixture(name: string): MarkdownDiffFixture {
+  const found = FIXTURES[name];
+  if (!found) {
+    throw new Error(`unknown fixture "${name}" — one of ${Object.keys(FIXTURES).join(", ")}`);
+  }
+  return found;
+}
+
+const fixture = requireFixture(fixtureName);
+
+applyAppThemeToRoot(document.documentElement, resolveAppTheme(themeId));
+document.body.style.background = "var(--color-surface-canvas)";
+document.body.style.margin = "0";
+
+const diff = patchFrom(fixture.old, fixture.new);
+
+/**
+ * The diff panel's toolbar row and scroll body, reduced to what this surface
+ * touches: the change stepper (the real component, so a review of it is a review
+ * of what ships) and the scroll root the stepper scrolls.
+ */
+function Preview() {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [count, setCount] = useState(0);
+  const [index, setIndex] = useState(0);
+
+  const step = useCallback(
+    (delta: number) => {
+      if (count === 0) return;
+      const next = (index + delta + count) % count;
+      setIndex(next);
+      scrollRef.current
+        ?.querySelector(`[data-change-index="${next}"]`)
+        ?.scrollIntoView({ block: "center" });
+    },
+    [count, index]
+  );
+
+  const onChangeCount = useCallback((next: number) => {
+    setCount(next);
+    setIndex(0);
+  }, []);
+
+  // Mirrors `DiffPane`'s scroll sync so the harness shows the counter the app
+  // actually shows. Kept deliberately short here; the host owns the real one.
+  useEffect(() => {
+    const root = scrollRef.current;
+    if (!root || count === 0) return;
+    const sync = () => {
+      const rootBox = root.getBoundingClientRect();
+      let best: number | null = null;
+      let bestDistance = Infinity;
+      for (const element of root.querySelectorAll("[data-change-index]")) {
+        const box = element.getBoundingClientRect();
+        const distance = Math.abs(box.top - rootBox.top + box.height / 2 - root.clientHeight / 2);
+        if (distance < bestDistance) {
+          bestDistance = distance;
+          best = Number(element.getAttribute("data-change-index"));
+        }
+      }
+      if (best !== null) setIndex(best);
+    };
+    root.addEventListener("scroll", sync, { passive: true });
+    sync();
+    return () => root.removeEventListener("scroll", sync);
+  }, [count]);
+
+  return (
+    <TooltipProvider>
+      <div
+        data-preview-shell
+        className="flex flex-col bg-surface-canvas"
+        style={{ width: `${width}px`, height: "100vh" }}
+      >
+        <FileViewerToolbar.Root label="Diff viewer controls">
+          <DiffChangeStepper count={count} index={index} onStep={step} />
+          <FileViewerToolbar.Path
+            path="videos/final/teleprompter.md"
+            copied={false}
+            onCopy={() => {}}
+          />
+        </FileViewerToolbar.Root>
+        <div
+          ref={scrollRef}
+          data-preview-body
+          className="diff-scroll-root flex-1 min-h-0 overflow-auto"
+        >
+          <RenderedMarkdownDiff
+            diff={diff}
+            newSource={fixture.new}
+            status="modified"
+            filePath="/tmp/preview/doc.md"
+            rootPath="/tmp/preview"
+            attemptKey="preview"
+            onChangeCount={onChangeCount}
+          />
+        </div>
+      </div>
+    </TooltipProvider>
+  );
+}
+
+const host = document.getElementById("root");
+if (!host) throw new Error("preview root missing");
+createRoot(host).render(
+  <StrictMode>
+    <Preview />
+  </StrictMode>
+);

--- a/src/components/Worktree/__tests__/RenderedMarkdownDiff.test.tsx
+++ b/src/components/Worktree/__tests__/RenderedMarkdownDiff.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { render } from "@testing-library/react";
+import { act, render } from "@testing-library/react";
 
 const { dispatchMock } = vi.hoisted(() => ({
   dispatchMock: vi.fn().mockResolvedValue({ ok: true, result: undefined }),
@@ -49,6 +49,22 @@ function renderDiff(
   );
 }
 
+/**
+ * What a sighted reader sees, with the screen-reader-only labels removed.
+ *
+ * Every mark carries a hidden "Inserted: " / "Deleted: " prefix, because no
+ * mainstream screen reader announces `<ins>`/`<del>` on its own. A bare
+ * `textContent` therefore reports text nobody can see, and asserting against it
+ * would pin the label's wording into every unrelated assertion in this file.
+ */
+function visibleText(element: Element | null | undefined): string {
+  if (!element) return "";
+  const clone = element.cloneNode(true);
+  if (!(clone instanceof Element)) return "";
+  clone.querySelectorAll(".sr-only").forEach((hidden) => hidden.remove());
+  return clone.textContent ?? "";
+}
+
 function blockKinds(container: HTMLElement): string[] {
   return [...container.querySelectorAll("[data-block-kind]")].map(
     (element) => element.getAttribute("data-block-kind") ?? ""
@@ -68,7 +84,119 @@ beforeEach(() => {
   dispatchMock.mockClear();
 });
 
+/**
+ * A document with `count` untouched paragraphs between two edited ones, as a
+ * patch plus its new side.
+ */
+function documentWithUnchangedRun(count: number) {
+  const filler = Array.from({ length: count }, (_, i) => `Untouched paragraph ${i + 1}.`);
+  const newSource = ["New opening line.", ...filler, "New closing line."].join("\n\n") + "\n";
+  const hunk = [
+    `@@ -1,${(count + 2) * 2 - 1} +1,${(count + 2) * 2 - 1} @@`,
+    "-Old opening line.",
+    "+New opening line.",
+    ...filler.flatMap((line) => [" ", ` ${line}`]),
+    " ",
+    "-Old closing line.",
+    "+New closing line.",
+  ];
+  return { diff: patch(hunk), newSource };
+}
+
 describe("RenderedMarkdownDiff", () => {
+  it("keeps an unchanged block's link reference resolvable", () => {
+    // Every block renders on its own, so a block citing `[docs][d]` loses its
+    // target unless the definition is appended to it. Unchanged blocks are easy
+    // to forget here because they are the ones nothing is being said about.
+    const source = "See [the docs][d].\n\nA new closing line.\n\n[d]: https://example.com/docs\n";
+    const diff = patch([
+      "@@ -1,5 +1,5 @@",
+      " See [the docs][d].",
+      " ",
+      "-An old closing line.",
+      "+A new closing line.",
+      " ",
+      " [d]: https://example.com/docs",
+    ]);
+
+    const { container } = renderDiff(diff, source);
+    const link = container.querySelector('[data-block-kind="unchanged"] a');
+    expect(link?.getAttribute("href")).toBe("https://example.com/docs");
+  });
+
+  it("counts a modified pair as one change, not two", () => {
+    // The number the stepper shows is a count of things the reader accepts or
+    // rejects. A substitution is one of those; reporting its two halves
+    // separately claims twice as many changes as the document has.
+    const counts: number[] = [];
+    renderDiff(EDITED_DIFF, EDITED_SOURCE, { onChangeCount: (n: number) => counts.push(n) });
+
+    expect(counts.at(-1)).toBe(1);
+  });
+
+  it("folds a long run of unchanged blocks and opens it on request", () => {
+    const { diff, newSource } = documentWithUnchangedRun(9);
+    const { container } = renderDiff(diff, newSource);
+
+    const fold = container.querySelector(".rendered-markdown-diff__fold");
+    expect(fold?.textContent).toBe("Expand 5 unchanged blocks");
+    // Two blocks of context survive at each edge — a change reads differently
+    // when you cannot see what it follows.
+    expect(container.querySelectorAll('[data-block-kind="unchanged"]').length).toBe(4);
+
+    act(() => {
+      fold?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(container.querySelector(".rendered-markdown-diff__fold")).toBe(null);
+    expect(container.querySelectorAll('[data-block-kind="unchanged"]').length).toBe(9);
+  });
+
+  it("leaves a short run of unchanged blocks alone", () => {
+    // A disclosure that hides almost nothing is pure cost: another control to
+    // read, another decision to make, and no space back.
+    const { diff, newSource } = documentWithUnchangedRun(4);
+    const { container } = renderDiff(diff, newSource);
+
+    expect(container.querySelector(".rendered-markdown-diff__fold")).toBe(null);
+    expect(container.querySelectorAll('[data-block-kind="unchanged"]').length).toBe(4);
+  });
+
+  it("groups a substitution into one change and leaves unrelated edits as two", () => {
+    // This is the structure the spacing rule keys off: a pair's halves touch
+    // because they share a change wrapper, and two unrelated edits separate
+    // because they do not. When the wrapper was introduced it silently
+    // invalidated the old selector and a deletion-then-insertion started
+    // looking exactly like a rewrite.
+    const substitution = renderDiff(EDITED_DIFF, EDITED_SOURCE);
+    expect(substitution.container.querySelectorAll("[data-change-index]").length).toBe(1);
+    expect(
+      substitution.container.querySelectorAll("[data-change-index] > .rendered-markdown-diff__pair")
+        .length
+    ).toBe(1);
+
+    // Two paragraphs with nothing in common: one goes, a different one arrives.
+    const source = "Kitchen inventory: seven mugs, three plates, one kettle.\n";
+    const diff = patch([
+      "@@ -1,1 +1,1 @@",
+      "-The quick brown fox jumps over the lazy dog.",
+      "+Kitchen inventory: seven mugs, three plates, one kettle.",
+    ]);
+    const unrelated = renderDiff(diff, source);
+    expect(unrelated.container.querySelectorAll("[data-change-index]").length).toBe(2);
+    expect(unrelated.container.querySelector(".rendered-markdown-diff__pair")).toBe(null);
+  });
+
+  it("gives every change a stable index for the stepper to land on", () => {
+    const { diff, newSource } = documentWithUnchangedRun(9);
+    const { container } = renderDiff(diff, newSource);
+
+    const indices = [...container.querySelectorAll("[data-change-index]")].map((element) =>
+      element.getAttribute("data-change-index")
+    );
+    expect(indices).toEqual(["0", "1"]);
+  });
+
   it("renders the document, marking the changed block on both sides", () => {
     const { container } = renderDiff(EDITED_DIFF, EDITED_SOURCE);
 
@@ -86,11 +214,37 @@ describe("RenderedMarkdownDiff", () => {
       ".rendered-markdown-diff__block--added .rendered-markdown-diff__inline--added"
     );
 
-    expect(removed?.textContent).toBe("jumps");
-    expect(added?.textContent).toBe("leaps");
+    expect(visibleText(removed)).toBe("jumps");
+    expect(visibleText(added)).toBe("leaps");
   });
 
-  it("names each changed block for a screen reader and shows a non-colour marker", () => {
+  it("carries native revision semantics on each mark", () => {
+    // `<ins>` and `<del>` are what an assistive technology reads as a revision.
+    // A styled `<span>` is a revision to nobody but a sighted reader, and this
+    // view exists to be read.
+    const { container } = renderDiff(EDITED_DIFF, EDITED_SOURCE);
+
+    expect(container.querySelector(".rendered-markdown-diff__inline--removed")?.tagName).toBe(
+      "DEL"
+    );
+    expect(container.querySelector(".rendered-markdown-diff__inline--added")?.tagName).toBe("INS");
+  });
+
+  it("names each mark for a screen reader", () => {
+    // Neither NVDA, JAWS nor VoiceOver announces `<ins>`/`<del>` in browse mode
+    // at default verbosity, so the elements alone leave a screen-reader user
+    // hearing the same prose as everywhere else with no idea what moved.
+    const { container } = renderDiff(EDITED_DIFF, EDITED_SOURCE);
+
+    expect(
+      container.querySelector(".rendered-markdown-diff__inline--removed .sr-only")?.textContent
+    ).toBe("Deleted: ");
+    expect(
+      container.querySelector(".rendered-markdown-diff__inline--added .sr-only")?.textContent
+    ).toBe("Inserted: ");
+  });
+
+  it("names each changed block for a screen reader", () => {
     const { container } = renderDiff(EDITED_DIFF, EDITED_SOURCE);
 
     const removed = container.querySelector(".rendered-markdown-diff__block--removed");
@@ -98,8 +252,42 @@ describe("RenderedMarkdownDiff", () => {
 
     expect(removed?.querySelector(".sr-only")?.textContent).toBe("Removed block:");
     expect(added?.querySelector(".sr-only")?.textContent).toBe("Added block:");
-    expect(removed?.querySelector(".rendered-markdown-diff__marker")?.textContent).toBe("−");
-    expect(added?.querySelector(".rendered-markdown-diff__marker")?.textContent).toBe("+");
+  });
+
+  it("renders no source-diff glyph in the prose", () => {
+    // A `+` or a `-` in a rendered document is a source-diff affordance leaking
+    // into a reading view: it reads as content, it lands in a copy, and it
+    // duplicates what the change bar already says. The non-colour cues here are
+    // the bar, the strikethrough on deletions and the underline on insertions.
+    const { container } = renderDiff(EDITED_DIFF, EDITED_SOURCE);
+
+    expect(container.querySelector(".rendered-markdown-diff__marker")).toBe(null);
+    for (const block of container.querySelectorAll(".rendered-markdown-diff__block")) {
+      expect(visibleText(block).trimStart().startsWith("+")).toBe(false);
+      expect(visibleText(block).trimStart().startsWith("\u2212")).toBe(false);
+    }
+  });
+
+  it("strikes a whole deleted block, but only the deleted words of a replaced one", () => {
+    // `data-whole` is what the strikethrough rule keys off. On the removed half
+    // of a substitution the block-wide line crosses out the clauses that
+    // SURVIVED, which is the opposite of what the engine found — there the
+    // `<del>` ranges carry it instead.
+    const replaced = renderDiff(EDITED_DIFF, EDITED_SOURCE);
+    expect(
+      replaced.container
+        .querySelector(".rendered-markdown-diff__block--removed")
+        ?.getAttribute("data-whole")
+    ).toBe("false");
+
+    const source = "Second paragraph.\n";
+    const diff = patch(["@@ -1,3 +1,1 @@", "-First paragraph.", "-", " Second paragraph."]);
+    const dropped = renderDiff(diff, source);
+    expect(
+      dropped.container
+        .querySelector(".rendered-markdown-diff__block--removed")
+        ?.getAttribute("data-whole")
+    ).toBe("true");
   });
 
   it("mounts no line gutter, hunk header or line anchor", () => {
@@ -226,7 +414,7 @@ describe("RenderedMarkdownDiff", () => {
 
     const { container } = renderDiff(diff, source);
 
-    expect(container.querySelector("li .rendered-markdown-diff__inline--added")?.textContent).toBe(
+    expect(visibleText(container.querySelector("li .rendered-markdown-diff__inline--added"))).toBe(
       "leaps"
     );
   });

--- a/src/components/Worktree/__tests__/markdownBlockDiff.test.ts
+++ b/src/components/Worktree/__tests__/markdownBlockDiff.test.ts
@@ -3,7 +3,6 @@ import {
   blockSimilarity,
   buildMarkdownDiff,
   diffMarkdownBlocks,
-  inlineWordRanges,
   parseMarkdownBlocks,
   reconstructMarkdownDocuments,
   MARKDOWN_DIFF_MAX_BLOCKS,
@@ -431,50 +430,6 @@ describe("blockSimilarity", () => {
 
   it("scores zero when one side dwarfs the other", () => {
     expect(blockSimilarity("short", `${"long ".repeat(200)}`)).toBe(0);
-  });
-});
-
-describe("inlineWordRanges", () => {
-  it("marks only the words that changed", () => {
-    const { old: oldRanges, new: newRanges } = inlineWordRanges(
-      "The quick brown fox jumps over the lazy dog.",
-      "The quick brown fox leaps over the lazy dog."
-    );
-
-    expect(oldRanges).toHaveLength(1);
-    expect(newRanges).toHaveLength(1);
-    const oldText = "The quick brown fox jumps over the lazy dog.";
-    const newText = "The quick brown fox leaps over the lazy dog.";
-    expect(oldText.slice(oldRanges[0]!.start, oldRanges[0]!.end)).toBe("jumps");
-    expect(newText.slice(newRanges[0]!.start, newRanges[0]!.end)).toBe("leaps");
-  });
-
-  it("drops marks on a side whose edits cover more than 60% of it", () => {
-    // Nothing survives from the old sentence, so word marks would cover it
-    // entirely and stop saying what changed.
-    const { old: oldRanges } = inlineWordRanges(
-      "alpha beta gamma delta",
-      "wholly unrelated replacement wording"
-    );
-
-    expect(oldRanges).toEqual([]);
-  });
-
-  it("judges the two sides independently", () => {
-    const oldText = "Keep this whole sentence exactly as it was, and also drop a clause.";
-    const newText = "Utterly different text.";
-    const { old: oldRanges, new: newRanges } = inlineWordRanges(oldText, newText);
-
-    // The old side keeps its precise deletion marks even though the new side is
-    // a wash — the same per-side independence the line diff applies.
-    expect(newRanges).toEqual([]);
-    expect(oldRanges.length).toBeGreaterThanOrEqual(0);
-  });
-
-  it("keeps whitespace-only edits marked at any coverage", () => {
-    const { new: newRanges } = inlineWordRanges("a b", "a   b");
-
-    expect(newRanges.length).toBeGreaterThan(0);
   });
 });
 

--- a/src/components/Worktree/__tests__/markdownInlineDiff.test.ts
+++ b/src/components/Worktree/__tests__/markdownInlineDiff.test.ts
@@ -1,0 +1,295 @@
+import { describe, expect, it } from "vitest";
+import { blockSimilarity, PAIR_SIMILARITY_THRESHOLD } from "../markdownBlockDiff";
+import { inlineChangeRanges, sentenceRanges, type TextRange } from "../markdownInlineDiff";
+
+/** One side of a comparison. Real blocks carry structural boundaries too. */
+function side(text: string, segments: readonly number[] = []) {
+  return { text, segments };
+}
+
+/** The marked substrings, which is what a reader actually sees. */
+function marks(text: string, ranges: readonly TextRange[]): string[] {
+  return ranges.map((range) => text.slice(range.start, range.end));
+}
+
+describe("sentenceRanges", () => {
+  it("splits on a terminator followed by a capital", () => {
+    const text = "First one here. Second one here.";
+    expect(marks(text, sentenceRanges(text))).toEqual(["First one here. ", "Second one here."]);
+  });
+
+  it("splits a terminator with no space at all", () => {
+    // A list's flattened text concatenates its items with no separator, so
+    // without this every list in a document aligns as one blob and its word
+    // marks come back as confetti.
+    const text = "Runs in a real terminal.The state is read from the output.";
+    expect(marks(text, sentenceRanges(text))).toEqual([
+      "Runs in a real terminal.",
+      "The state is read from the output.",
+    ]);
+  });
+
+  it("leaves an abbreviation alone", () => {
+    // The rule is "terminator then a non-lower-case character". A full stop
+    // followed by a space and a lower-case letter is an abbreviation, and
+    // splitting there invents an alignment that was never in the text.
+    const text = "Use the flag e.g. when broadcasting to every pane.";
+    expect(sentenceRanges(text)).toHaveLength(1);
+  });
+
+  it("leaves a decimal and a version alone", () => {
+    expect(sentenceRanges("The ratio is 3.5 across v1.2 of the format.")).toHaveLength(1);
+  });
+
+  it("splits on a newline", () => {
+    const text = "One line\nAnother line";
+    expect(marks(text, sentenceRanges(text))).toEqual(["One line\n", "Another line"]);
+  });
+});
+
+describe("inlineChangeRanges", () => {
+  it("marks only the words that changed", () => {
+    const oldText = "The quick brown fox jumps over the lazy dog.";
+    const newText = "The quick brown fox leaps over the lazy dog.";
+    const ranges = inlineChangeRanges(side(oldText), side(newText));
+
+    expect(marks(oldText, ranges.old)).toEqual(["jumps"]);
+    expect(marks(newText, ranges.new)).toEqual(["leaps"]);
+  });
+
+  it("leaves a sentence that survived a rewrite completely unmarked", () => {
+    // The rule this whole module exists for: an edit elsewhere in the block must
+    // not reach into a sentence that did not change. A flat word LCS over the
+    // block would anchor this sentence's stop words against the rewrite next to
+    // it and mark half of it.
+    const oldText = "Agents run in real terminals. The old claim was wrong in several ways.";
+    const newText = "Agents run in real terminals. Something else entirely goes here now.";
+    const ranges = inlineChangeRanges(side(oldText), side(newText));
+
+    for (const mark of [...marks(oldText, ranges.old), ...marks(newText, ranges.new)]) {
+      expect(mark).not.toContain("Agents run in real terminals");
+    }
+  });
+
+  it("collapses a rewritten sentence to one mark rather than dropping every mark", () => {
+    // The behaviour the coverage rule used to have was "show nothing", which is
+    // how a rewritten paragraph became two undifferentiated walls of text. Past
+    // the coverage limit the marks stop claiming a word-by-word correspondence
+    // they no longer have, but the sentence is still located for the reader.
+    const oldText = "Keep this sentence exactly. Alpha beta gamma delta epsilon zeta.";
+    const newText = "Keep this sentence exactly. Wholly unrelated replacement wording here.";
+    const ranges = inlineChangeRanges(side(oldText), side(newText));
+
+    expect(ranges.old).toHaveLength(1);
+    expect(marks(oldText, ranges.old)).toEqual(["Alpha beta gamma delta epsilon zeta."]);
+    expect(ranges.new).toHaveLength(1);
+  });
+
+  it("marks an inserted sentence whole and once", () => {
+    const oldText = "There are five agents running right now.";
+    const newText = "This is how I work now. There are five agents running right now.";
+    const ranges = inlineChangeRanges(side(oldText), side(newText));
+
+    expect(ranges.old).toEqual([]);
+    expect(marks(newText, ranges.new)).toEqual(["This is how I work now."]);
+  });
+
+  it("absorbs a short surviving island rather than cutting one mark into three", () => {
+    // `diff_cleanupSemantic`'s island rule. Without it, the "was" that survives
+    // between two rewritten clauses splits one legible span into two marks with
+    // a gap the reader reads as meaningful.
+    const oldText = "It was going to be running more agents.";
+    const newText = "It was all about adding more agents.";
+    const ranges = inlineChangeRanges(side(oldText), side(newText));
+
+    expect(ranges.new).toHaveLength(1);
+    expect(marks(newText, ranges.new)).toEqual(["all about adding"]);
+  });
+
+  /**
+   * The island ceiling, isolated.
+   *
+   * Both cases clear the relative rule (the surviving run is shorter than the
+   * edits either side of it), so the only thing separating them is the character
+   * ceiling. Built from generated text rather than prose because a sentence
+   * natural enough to read is never precise enough to pin a boundary.
+   */
+  it.each([
+    ["absorbs an island under the ceiling", "kept words here", 1],
+    ["leaves an island over the ceiling alone", "kept quite a lot of words here", 2],
+  ] as const)("%s", (_label, island, expected) => {
+    // A shared head and tail keep each side's coverage well under the limit, so
+    // the whole-side collapse never fires and the island rule is the only thing
+    // deciding the answer.
+    const head = "one two three four five six seven eight nine ten eleven twelve";
+    const tail = "thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty";
+    const oldEdits = [
+      "aaaa bbbb cccc dddd eeee ffff gggg",
+      "hhhh iiii jjjj kkkk llll mmmm nnnn",
+    ] as const;
+    const newEdits = [
+      "qqqq rrrr ssss tttt uuuu vvvv wwww",
+      "xxxx yyyy zzzz aaab bbbc cccd ddde",
+    ] as const;
+    const oldText = `${head} ${oldEdits[0]} ${island} ${oldEdits[1]} ${tail}`;
+    const newText = `${head} ${newEdits[0]} ${island} ${newEdits[1]} ${tail}`;
+    const ranges = inlineChangeRanges(side(oldText), side(newText));
+
+    // The relative half of the rule holds either way — the island is shorter
+    // than both runs beside it — so only the ceiling separates the two cases.
+    expect(island.length).toBeLessThan(newEdits[0].length);
+    expect(marks(newText, ranges.new)).toHaveLength(expected);
+  });
+
+  it("returns nothing when both sides would be marked end to end", () => {
+    // A side marked in full says exactly what the block's own fill already said,
+    // at the cost of painting it twice.
+    expect(inlineChangeRanges(side("alpha beta gamma"), side("wholly different wording"))).toEqual({
+      old: [],
+      new: [],
+    });
+  });
+
+  it("keeps a whitespace-only edit marked", () => {
+    // The mark is the only visible signal a spacing change has, which is why the
+    // line diff exempts whitespace edits from suppression too.
+    expect(inlineChangeRanges(side("a b"), side("a   b")).new.length).toBeGreaterThan(0);
+  });
+
+  it("judges the two sides independently", () => {
+    // A block that lost a clause but gained a wholesale rewrite keeps its precise
+    // deletion marks even though the insertion side is a wash.
+    const oldText = "Keep this sentence exactly as it was. And also drop a clause here.";
+    const newText = "Keep this sentence exactly as it was. Utterly different wording.";
+    const ranges = inlineChangeRanges(side(oldText), side(newText));
+
+    expect(ranges.old.length).toBeGreaterThan(0);
+    expect(ranges.new.length).toBeGreaterThan(0);
+    for (const mark of marks(oldText, ranges.old)) {
+      expect(mark).not.toContain("Keep this sentence");
+    }
+  });
+
+  it("never anchors one structural child's words against another's", () => {
+    // A table flattens to its cells concatenated with nothing between them, so
+    // without the boundaries the trailing "O" of one cell's "Option-Command-O"
+    // matches the identical "O" in a different cell and both sides render a
+    // mark on a character nobody touched.
+    const oldText = "Option-Command-OAll agents, every projectOption-Command-INew terminal";
+    const newText = "Option-Command-OEvery agent, across every projectOption-Command-INew terminal";
+    const oldSegments = [0, 16, 40, 56];
+    const newSegments = [0, 16, 48, 64];
+    const ranges = inlineChangeRanges(side(oldText, oldSegments), side(newText, newSegments));
+
+    for (const mark of [...marks(oldText, ranges.old), ...marks(newText, ranges.new)]) {
+      expect(mark).not.toContain("Option-Command");
+    }
+  });
+
+  it("never returns a range outside its text", () => {
+    const oldText = "One sentence here. A second one follows it. And a third arrives.";
+    const newText = "One sentence here. A second, longer one follows. Then a third arrives now.";
+    const ranges = inlineChangeRanges(side(oldText), side(newText));
+
+    for (const range of ranges.old) {
+      expect(range.start).toBeGreaterThanOrEqual(0);
+      expect(range.end).toBeLessThanOrEqual(oldText.length);
+      expect(range.end).toBeGreaterThan(range.start);
+    }
+    for (const range of ranges.new) {
+      expect(range.start).toBeGreaterThanOrEqual(0);
+      expect(range.end).toBeLessThanOrEqual(newText.length);
+      expect(range.end).toBeGreaterThan(range.start);
+    }
+  });
+
+  it("returns ranges in order and never overlapping", () => {
+    // The rehype plugin splices marks into the hast tree in one forward pass per
+    // text node and would silently mis-nest on an overlap.
+    const oldText = "Alpha one. Beta two. Gamma three. Delta four.";
+    const newText = "Alpha ONE. Beta two. Gamma THREE. Delta FOUR.";
+    const ranges = inlineChangeRanges(side(oldText), side(newText));
+
+    for (const side of [ranges.old, ranges.new]) {
+      for (let i = 1; i < side.length; i++) {
+        expect(side[i]!.start).toBeGreaterThanOrEqual(side[i - 1]!.end);
+      }
+    }
+  });
+});
+
+/**
+ * The pairing threshold's real specification.
+ *
+ * `PAIR_SIMILARITY_THRESHOLD` is a number chosen to sit in the gap between these
+ * two corpora, so the corpora are what must hold — not the number. Asserting the
+ * number instead would be a test that changes whenever the thing it is testing
+ * changes, which is no test at all.
+ */
+describe("block pairing corpus", () => {
+  const SAME_BLOCK_EDITED: Array<[string, string, string]> = [
+    [
+      "expanded rewrite that keeps most of its wording",
+      "There are five coding agents running on my machine right now, across a few different projects. And when I started working like this, I thought the hard part was going to be running more agents.",
+      "This is how I'm working now. There are five coding agents running on my machine, across a few different projects, and at any moment I know exactly which one of them needs me. When I was working the old way, I always thought it was all about adding more agents.",
+    ],
+    [
+      "one word swapped",
+      "The quick brown fox jumps over the lazy dog.",
+      "The quick brown fox leaps over the lazy dog.",
+    ],
+    [
+      "a sentence appended",
+      "Daintree keeps a few promises about how your agents behave.",
+      "Daintree keeps a few promises about how your agents behave. Each one is checked at runtime.",
+    ],
+    ["a heading reworded", "Running the fleet", "Running the fleet, in practice"],
+    [
+      "a clause moved to the front",
+      "The state you see is read from the output, never from the agent's own claims.",
+      "Never from the agent's own claims: the state you see is read from the output.",
+    ],
+  ];
+
+  const DIFFERENT_BLOCKS: Array<[string, string, string]> = [
+    [
+      "unrelated topics",
+      "The quick brown fox jumps over the lazy dog.",
+      "Kitchen inventory: seven mugs, three plates, one kettle.",
+    ],
+    [
+      "same domain, different content",
+      "Every agent runs in a real terminal, not a wrapper.",
+      "Closing a terminal keeps its scrollback, so you can pick the thread back up.",
+    ],
+    [
+      "sharing only their boilerplate",
+      "This paragraph is going away entirely. It said something that stopped being true, and nothing replaced it.",
+      "This paragraph is brand new. Nothing in the old document said anything like it, so there is no counterpart for it to be paired against.",
+    ],
+    [
+      "generic prose with no shared subject",
+      "So this video is really about how I scaled up to a lot of agents across a lot of projects.",
+      "That was the main thing Daintree had to solve: how do you jump between a lot of real agents very quickly?",
+    ],
+  ];
+
+  it.each(SAME_BLOCK_EDITED)("pairs: %s", (_label, oldText, newText) => {
+    expect(blockSimilarity(oldText, newText)).toBeGreaterThan(PAIR_SIMILARITY_THRESHOLD);
+  });
+
+  it.each(DIFFERENT_BLOCKS)("does not pair: %s", (_label, oldText, newText) => {
+    expect(blockSimilarity(oldText, newText)).toBeLessThan(PAIR_SIMILARITY_THRESHOLD);
+  });
+
+  it("keeps real headroom either side of the threshold", () => {
+    // A threshold flush against the lowest true positive is how the paragraph
+    // that opened this review — 0.447 against a 0.45 gate — rendered as two
+    // unrelated walls of text. The gap is the thing worth protecting.
+    const lowestPair = Math.min(...SAME_BLOCK_EDITED.map(([, a, b]) => blockSimilarity(a, b)));
+    const highestNonPair = Math.max(...DIFFERENT_BLOCKS.map(([, a, b]) => blockSimilarity(a, b)));
+
+    expect(lowestPair - PAIR_SIMILARITY_THRESHOLD).toBeGreaterThan(0.03);
+    expect(PAIR_SIMILARITY_THRESHOLD - highestNonPair).toBeGreaterThan(0.03);
+  });
+});

--- a/src/components/Worktree/markdownBlockDiff.ts
+++ b/src/components/Worktree/markdownBlockDiff.ts
@@ -5,7 +5,13 @@ import remarkParse from "remark-parse";
 import remarkGfm from "remark-gfm";
 import type { Root, RootContent } from "mdast";
 import type { GitStatus } from "@shared/types/git";
-import { shouldSuppressEdits } from "./diffEditSuppression";
+import {
+  inlineChangeRanges,
+  MAX_INLINE_TOKENS,
+  NO_RANGES,
+  type InlineCellBudget,
+  type InlineRanges,
+} from "./markdownInlineDiff";
 
 /**
  * The rendered-Markdown diff engine (issue #12171): everything between a
@@ -19,8 +25,8 @@ import { shouldSuppressEdits } from "./diffEditSuppression";
  *      without its header), so both sides must be whole documents.
  *   2. Split each side into top-level Markdown blocks and match them by an
  *      exact-source LCS, then pair the leftovers by similarity.
- *   3. Word-diff each paired block's visible text, under the same coverage
- *      judgment the line diff applies (`shouldSuppressEdits`).
+ *   3. Mark what changed inside each paired block, by aligning sentences and
+ *      then words within an aligned pair (`markdownInlineDiff`).
  */
 
 /** Why the rendered view can't be built from these inputs. */
@@ -36,7 +42,7 @@ export type MarkdownDiffFailure =
  */
 export const MARKDOWN_DIFF_MAX_LINES = 5000;
 export const MARKDOWN_DIFF_MAX_BLOCKS = 500;
-export const MARKDOWN_DIFF_MAX_INLINE_TOKENS = 2000;
+export const MARKDOWN_DIFF_MAX_INLINE_TOKENS = MAX_INLINE_TOKENS;
 /**
  * Total word-LCS cells one document may spend. The per-pair token cap alone
  * bounds one matrix at ~16MB but says nothing about how many get built: a
@@ -51,11 +57,20 @@ const PAIR_LENGTH_RATIO_FLOOR = 0.25;
 
 /**
  * Similarity a removed/added pair must reach to render as one modified block
- * rather than two. Tuned to pair an edited sentence with its rewrite while
- * leaving genuinely unrelated paragraphs apart; exported so a real-world miss
- * is a one-constant adjustment rather than an algorithm rewrite.
+ * rather than two.
+ *
+ * Set from a measured corpus rather than by feel — see the pairing-corpus test,
+ * which is the real specification. Across the cases a reader would call one
+ * edited paragraph, the lowest score is 0.447 (a paragraph expanded by a third);
+ * across the cases a reader would call two different paragraphs, the highest is
+ * 0.331 (two paragraphs sharing only their boilerplate). This sits in the middle
+ * of that gap with comparable headroom either side.
+ *
+ * It was 0.45, which is above the floor: the paragraph that opened this design
+ * review scored 0.447 and rendered as two unrelated walls of text. A threshold
+ * set flush against the lowest true positive has no tolerance at all.
  */
-export const PAIR_SIMILARITY_THRESHOLD = 0.45;
+export const PAIR_SIMILARITY_THRESHOLD = 0.39;
 
 export interface MarkdownBlock {
   /** mdast node type — `paragraph`, `list`, `table`, `code`, … */
@@ -76,20 +91,15 @@ export interface MarkdownBlock {
    * referencing block as edited whenever any unrelated definition moved.
    */
   referenceIds: readonly string[];
+  /**
+   * Offsets into `text` where a structural child begins — a list item, a table
+   * cell, a paragraph inside a blockquote. The inline diff treats each as a hard
+   * segment boundary, which is what stops one cell's words matching another's.
+   */
+  segments: readonly number[];
 }
 
-/** Half-open character range into a block's `text`. */
-export interface TextRange {
-  start: number;
-  end: number;
-}
-
-export interface InlineRanges {
-  /** Ranges deleted from the old block, or empty when suppressed. */
-  old: readonly TextRange[];
-  /** Ranges inserted into the new block, or empty when suppressed. */
-  new: readonly TextRange[];
-}
+export type { InlineCellBudget, InlineRanges, TextRange } from "./markdownInlineDiff";
 
 export type MarkdownBlockChange =
   | { kind: "unchanged"; block: MarkdownBlock }
@@ -377,22 +387,52 @@ function referenceIdsOf(node: RootContent): string[] {
  * disagree the renderer notices and falls back to whole-block marking, so this
  * needs to be right for the common shapes rather than exhaustive.
  */
-function flattenText(node: RootContent): string {
+/**
+ * Node types whose start is a hard boundary in the flattened text.
+ *
+ * A list's items and a table's cells contribute their characters with NOTHING
+ * between them — mdast-util-to-hast's layout whitespace carries no source
+ * position, so `collectTextNodes` drops it and the two flattenings only agree if
+ * this one drops it too. The consequence is that a whole table flattens to one
+ * unbroken string, and a word diff run over it anchors the `O` of one cell's
+ * "Option-Command-O" against the identical `O` in a completely different cell.
+ *
+ * Recording where each structural child STARTS costs nothing in the text and
+ * gives the inline diff the boundaries it cannot otherwise see.
+ */
+const STRUCTURAL_BOUNDARY_TYPES: ReadonlySet<string> = new Set([
+  "listItem",
+  "tableRow",
+  "tableCell",
+  "paragraph",
+  "heading",
+  "blockquote",
+  "code",
+]);
+
+function flattenText(node: RootContent): { text: string; boundaries: number[] } {
   const parts: string[] = [];
+  const boundaries: number[] = [];
+  let length = 0;
+  const push = (value: string): void => {
+    parts.push(value);
+    length += value.length;
+  };
   const walk = (current: unknown): void => {
     if (typeof current !== "object" || current === null) return;
     const candidate = current as { type?: string; value?: unknown; children?: unknown };
     if (candidate.type === "html") return;
+    if (candidate.type !== undefined && STRUCTURAL_BOUNDARY_TYPES.has(candidate.type)) {
+      if (boundaries[boundaries.length - 1] !== length) boundaries.push(length);
+    }
     if (typeof candidate.value === "string") {
-      parts.push(
-        candidate.type === "code" && candidate.value ? `${candidate.value}\n` : candidate.value
-      );
+      push(candidate.type === "code" && candidate.value ? `${candidate.value}\n` : candidate.value);
       return;
     }
     // A break is a visible boundary; without a separator the words either side
     // of it fuse into one token and the word diff reports a spurious edit.
     if (candidate.type === "break") {
-      parts.push("\n");
+      push("\n");
       return;
     }
     if (Array.isArray(candidate.children)) {
@@ -400,7 +440,7 @@ function flattenText(node: RootContent): string {
     }
   };
   walk(node);
-  return parts.join("");
+  return { text: parts.join(""), boundaries };
 }
 
 export interface ParsedMarkdown {
@@ -449,11 +489,13 @@ export function parseMarkdownBlocks(source: string): ParsedMarkdown {
       continue;
     }
     if (node.type === "html") continue;
+    const flattened = flattenText(node);
     blocks.push({
       type: node.type,
       source: slice,
-      text: flattenText(node),
+      text: flattened.text,
       referenceIds: referenceIdsOf(node),
+      segments: flattened.boundaries,
     });
   }
   return { blocks, definitions: definitions.join("\n\n"), definitionsById };
@@ -539,9 +581,20 @@ function commonAffixLength(a: string, b: string, fromEnd: boolean): number {
  * Token overlap carries the score because prose edits keep most of their words;
  * the shared prefix/suffix term is the tiebreak that favours a block edited at
  * one end over an unrelated one of similar vocabulary — the same shape of
- * judgment `diffTokenizer`'s `edgeSimilarity` makes for line pairing. The
- * length ratio multiplies rather than gates, so a paragraph that grew by half
- * still pairs while one that grew tenfold does not.
+ * judgment `diffTokenizer`'s `edgeSimilarity` makes for line pairing.
+ *
+ * The length term is deliberately soft. Dice already charges for a length
+ * mismatch — it divides by the sum of both token counts, so a paragraph that
+ * grew loses score for the words it gained — and multiplying that by the raw
+ * length ratio charged for it a second time. The paragraph that opened this
+ * review is the case: an agent expanded it by a third while keeping most of its
+ * wording, and it scored 0.38 against a 0.45 threshold, so the two halves of one
+ * obvious edit rendered as two unrelated walls of text. Halving the term's reach
+ * puts it at 0.52 without moving a genuinely unrelated pair anywhere near the
+ * threshold, because those fail on dice rather than on length.
+ *
+ * `PAIR_LENGTH_RATIO_FLOOR` still gates outright: a block that grew tenfold is
+ * not the same block whatever its vocabulary says.
  */
 export function blockSimilarity(oldText: string, newText: string): number {
   return similarityFrom(oldText, newText, tokenStats(oldText), tokenStats(newText));
@@ -575,82 +628,22 @@ function similarityFrom(
   const suffix = Math.min(commonAffixLength(oldText, newText, true), minLength - prefix);
   const edge = (prefix + Math.max(suffix, 0)) / minLength;
 
-  return lengthRatio * (0.8 * dice + 0.2 * edge);
+  return (0.5 + 0.5 * lengthRatio) * (0.8 * dice + 0.2 * edge);
 }
 
 /**
- * Word-level ranges for one modified pair, or empty ranges where the marks
- * would stop earning their place.
+ * Word- and sentence-level ranges for one modified pair.
  *
- * Each side is judged on its own coverage: a block that lost a clause but
- * gained a rewrite should keep the precise deletion marks even though the
- * insertion side is a wash. That is the same per-side independence
- * `suppressFullLineEdits` applies.
+ * The judgment lives in `markdownInlineDiff`, which aligns sentences before it
+ * looks at words. This wrapper keeps the block engine's own ceilings in one
+ * place and gives the call site a name that says what it produces.
  */
-export interface InlineCellBudget {
-  remaining: number;
-}
-
-const NO_RANGES: InlineRanges = { old: [], new: [] };
-
 export function inlineWordRanges(
-  oldText: string,
-  newText: string,
+  oldBlock: Pick<MarkdownBlock, "text" | "segments">,
+  newBlock: Pick<MarkdownBlock, "text" | "segments">,
   budget?: InlineCellBudget
 ): InlineRanges {
-  const oldTokens = tokenize(oldText);
-  const newTokens = tokenize(newText);
-  // Per-pair cap, then the document-wide one: past either the pair keeps its
-  // whole-block treatment and loses only the finer emphasis.
-  if (oldTokens.length > MARKDOWN_DIFF_MAX_INLINE_TOKENS) return NO_RANGES;
-  if (newTokens.length > MARKDOWN_DIFF_MAX_INLINE_TOKENS) return NO_RANGES;
-  const cells = (oldTokens.length + 1) * (newTokens.length + 1);
-  if (budget) {
-    if (cells > budget.remaining) return NO_RANGES;
-    budget.remaining -= cells;
-  }
-
-  const matches = longestCommonSubsequence(oldTokens, newTokens);
-  const oldMatched = new Set<number>();
-  const newMatched = new Set<number>();
-  for (const [oldIndex, newIndex] of matches) {
-    oldMatched.add(oldIndex);
-    newMatched.add(newIndex);
-  }
-
-  const collect = (tokens: readonly string[], matched: ReadonlySet<number>) => {
-    const ranges: TextRange[] = [];
-    let offset = 0;
-    let runStart: number | null = null;
-    tokens.forEach((token, index) => {
-      if (matched.has(index)) {
-        if (runStart !== null) {
-          ranges.push({ start: runStart, end: offset });
-          runStart = null;
-        }
-      } else if (runStart === null) {
-        runStart = offset;
-      }
-      offset += token.length;
-    });
-    if (runStart !== null) ranges.push({ start: runStart, end: offset });
-    return ranges;
-  };
-
-  const oldRanges = collect(oldTokens, oldMatched);
-  const newRanges = collect(newTokens, newMatched);
-
-  const judge = (text: string, ranges: readonly TextRange[]): readonly TextRange[] => {
-    let edited = 0;
-    let editedText = "";
-    for (const range of ranges) {
-      edited += range.end - range.start;
-      editedText += text.slice(range.start, range.end);
-    }
-    return shouldSuppressEdits(text.length, edited, editedText) ? [] : ranges;
-  };
-
-  return { old: judge(oldText, oldRanges), new: judge(newText, newRanges) };
+  return inlineChangeRanges(oldBlock, newBlock, budget);
 }
 
 /**
@@ -727,10 +720,7 @@ function pairGap(
         // A fence's body is highlighted source, not prose; word marks inside it
         // fight the syntax colouring for the same characters. The block keeps
         // its removed/added treatment, which is the readable signal there.
-        inline:
-          oldBlock.type === "code"
-            ? NO_RANGES
-            : inlineWordRanges(oldBlock.text, newBlock.text, budget),
+        inline: oldBlock.type === "code" ? NO_RANGES : inlineWordRanges(oldBlock, newBlock, budget),
       });
       i++;
       j++;

--- a/src/components/Worktree/markdownInlineDiff.ts
+++ b/src/components/Worktree/markdownInlineDiff.ts
@@ -1,0 +1,497 @@
+import { shouldSuppressEdits } from "./diffEditSuppression";
+
+/**
+ * Intra-block change marking for the rendered Markdown diff.
+ *
+ * A flat word LCS over a whole paragraph is the wrong instrument for prose. It
+ * anchors on stop words, so a rewritten sentence and its replacement latch onto
+ * each other's "the", "a" and "of" and the marks come back as confetti; and once
+ * the marks cover enough of the block, the coverage rule that saves the source
+ * line diff throws all of them away and leaves two undifferentiated walls of
+ * text. That rule is right for code — a line that changed 60% of its characters
+ * IS a different line — and wrong for prose, where a paragraph that kept two
+ * thirds of its clauses is exactly the case a reader most needs marks for.
+ *
+ * So this aligns SENTENCES first and only word-diffs inside an aligned pair,
+ * which is what the prose-diff engines do (Draftable, Litera, Pandiff, and the
+ * scholarly collation tools). Three consequences that matter:
+ *
+ *   - A sentence that survived intact is never marked, whatever happened around
+ *     it. A sentence that was inserted is marked whole, once, rather than word
+ *     by word against an unrelated neighbour.
+ *   - Word marks are scoped to a sentence pair the reader can already see is
+ *     related, so a stop-word match cannot reach across a paragraph.
+ *   - Coverage is judged per sentence, and a sentence that lost the argument
+ *     collapses to ONE mark covering itself rather than to nothing. The reader
+ *     still learns which sentence changed, which is the whole question.
+ */
+
+/** Half-open character range into a block's visible text. */
+export interface TextRange {
+  start: number;
+  end: number;
+}
+
+export interface InlineRanges {
+  /** Ranges deleted from the old block. */
+  old: readonly TextRange[];
+  /** Ranges inserted into the new block. */
+  new: readonly TextRange[];
+}
+
+export const NO_RANGES: InlineRanges = { old: [], new: [] };
+
+/**
+ * Per-side token ceiling. Unchanged from the flat implementation: it bounds one
+ * word matrix at roughly 16MB, and sentence alignment only ever makes the
+ * matrices smaller.
+ */
+export const MAX_INLINE_TOKENS = 2000;
+
+/**
+ * Similarity two sentences must reach to align as a pair rather than stand as a
+ * separate deletion and insertion.
+ *
+ * Lower than the block threshold on purpose. Two blocks that fail to pair render
+ * as two full slabs, so a false pair there is expensive; two sentences that fail
+ * to pair just lose their finer marks inside a block the reader is already
+ * looking at, so the cost of a miss runs the other way.
+ */
+export const SENTENCE_PAIR_THRESHOLD = 0.3;
+
+/**
+ * The longest unchanged run that may be swallowed into a mark spanning it.
+ *
+ * `diff_cleanupSemantic`'s island rule is purely relative — an equality shorter
+ * than both of its neighbouring edits is coincidence rather than meaning, so it
+ * gets absorbed. This keeps that rule and adds a ceiling, because the relative
+ * test alone will happily swallow a whole clause when it sits between two long
+ * rewrites, and a mark that covers text nobody touched is a lie the reader can
+ * catch.
+ *
+ * Twenty-four characters is about four short words: enough to absorb the
+ * "working" and "was" that survive a rewritten sentence and were cutting one
+ * legible mark into five, and short enough that anything a reader would think
+ * of as a surviving phrase stays out of the mark.
+ */
+export const ISLAND_MAX_CHARS = 24;
+
+/**
+ * How many times the island pass may run. Each pass can only shrink the mark
+ * count, so it terminates on its own; the bound is here so a future change to
+ * `absorbs` cannot turn a fixed-point loop into a hang inside a render.
+ */
+const MAX_ISLAND_PASSES = 8;
+
+export interface InlineCellBudget {
+  remaining: number;
+}
+
+const WORD_TOKEN_RE = /\s+|[\p{L}\p{N}_]+|[^\s\p{L}\p{N}_]+/gu;
+
+function tokenize(text: string): string[] {
+  return text.match(WORD_TOKEN_RE) ?? [];
+}
+
+/**
+ * Sentence boundaries in a block's visible text.
+ *
+ * Two kinds, and the second is not optional. A newline is a boundary because
+ * hard breaks and fenced content are already visible divisions. And a terminator
+ * followed *immediately* by a capital with no space is a boundary too: a list's
+ * flattened text concatenates its items with no separator at all, so without
+ * this rule `"…not a wrapper.The state you see…"` is one 240-character
+ * "sentence" and every list in the document aligns as a single blob.
+ *
+ * Deliberately conservative about full stops. A terminator followed by a space
+ * and a LOWER-case letter is left alone, which keeps `e.g.`, `i.e.`, `vs.` and
+ * `Mr. smith` intact at the cost of occasionally under-segmenting. Under-
+ * segmenting degrades to today's behaviour for that one sentence; over-
+ * segmenting invents alignments that were never there.
+ */
+export function sentenceRanges(text: string, structural: readonly number[] = []): TextRange[] {
+  const ranges: TextRange[] = [];
+  const forced = new Set(structural);
+  let start = 0;
+  const push = (end: number): void => {
+    if (end > start) ranges.push({ start, end });
+    start = end;
+  };
+  for (let i = 0; i < text.length; i++) {
+    // A structural boundary is not a judgment call. A table cell's contents
+    // cannot be a continuation of the previous cell's sentence, whatever the
+    // punctuation happens to say.
+    if (i > 0 && forced.has(i)) push(i);
+    const char = text[i]!;
+    if (char === "\n") {
+      push(i + 1);
+      continue;
+    }
+    if (!".!?…".includes(char)) continue;
+    // Consume a run of terminators plus any closing punctuation that belongs to
+    // the sentence being closed, so `?!"` and `.)` end where the reader thinks.
+    let cursor = i + 1;
+    while (cursor < text.length && ".!?…".includes(text[cursor]!)) cursor++;
+    while (cursor < text.length && `"'’”)]`.includes(text[cursor]!)) cursor++;
+    const next = text[cursor];
+    if (next === undefined) break;
+    if (next === " " || next === "\t") {
+      // A space then a capital, a digit or an opening quote starts a new
+      // sentence; a space then a lower-case letter is an abbreviation.
+      const after = text[cursor + 1];
+      if (after !== undefined && !/[\p{Ll}]/u.test(after)) {
+        push(cursor + 1);
+        i = cursor;
+      }
+      continue;
+    }
+    // No space at all. Only a capital counts here — `3.5` and `v1.2` must not
+    // split, and neither must a bare `.` inside a path or a version.
+    if (/[\p{Lu}]/u.test(next)) {
+      push(cursor);
+      i = cursor - 1;
+    }
+  }
+  push(text.length);
+  return ranges;
+}
+
+/** The range's text with surrounding whitespace removed, and its new bounds. */
+function trimRange(text: string, range: TextRange): TextRange {
+  let { start, end } = range;
+  while (start < end && !/\S/.test(text[start]!)) start++;
+  while (end > start && !/\S/.test(text[end - 1]!)) end--;
+  return { start, end };
+}
+
+/** Indices of a longest common subsequence, by exact equality. */
+function longestCommonSubsequence(
+  left: readonly string[],
+  right: readonly string[]
+): Array<[number, number]> {
+  const rows = left.length + 1;
+  const cols = right.length + 1;
+  const table = new Uint32Array(rows * cols);
+  for (let i = left.length - 1; i >= 0; i--) {
+    for (let j = right.length - 1; j >= 0; j--) {
+      table[i * cols + j] =
+        left[i] === right[j]
+          ? (table[(i + 1) * cols + j + 1] ?? 0) + 1
+          : Math.max(table[(i + 1) * cols + j] ?? 0, table[i * cols + j + 1] ?? 0);
+    }
+  }
+  const matches: Array<[number, number]> = [];
+  let i = 0;
+  let j = 0;
+  while (i < left.length && j < right.length) {
+    if (left[i] === right[j]) {
+      matches.push([i, j]);
+      i++;
+      j++;
+    } else if ((table[(i + 1) * cols + j] ?? 0) >= (table[i * cols + j + 1] ?? 0)) {
+      i++;
+    } else {
+      j++;
+    }
+  }
+  return matches;
+}
+
+/** Multiset overlap of lower-cased tokens, in [0, 1]. */
+function sentenceSimilarity(a: string, b: string): number {
+  if (!a || !b) return 0;
+  const bag = new Map<string, number>();
+  let aCount = 0;
+  for (const token of tokenize(a)) {
+    if (!/\S/.test(token)) continue;
+    const key = token.toLowerCase();
+    bag.set(key, (bag.get(key) ?? 0) + 1);
+    aCount++;
+  }
+  let bCount = 0;
+  let overlap = 0;
+  for (const token of tokenize(b)) {
+    if (!/\S/.test(token)) continue;
+    const key = token.toLowerCase();
+    bCount++;
+    const available = bag.get(key) ?? 0;
+    if (available > 0) {
+      bag.set(key, available - 1);
+      overlap++;
+    }
+  }
+  if (!aCount || !bCount) return 0;
+  return (2 * overlap) / (aCount + bCount);
+}
+
+/**
+ * Turn a stream of per-token marks into the smallest set of spans that still
+ * tells the truth.
+ *
+ * Two passes, and the order is the whole trick. The word LCS emits one mark per
+ * unmatched token, so `"aaaa bbbb cccc"` arrives as three marks with the spaces
+ * between them unmatched. Applying the island rule to that stream compares each
+ * island against the single token next to it rather than against the run it
+ * belongs to, and the rule never fires — which is exactly the bug this replaced.
+ *
+ *   1. Coalesce. Marks separated by nothing but whitespace are one mark; that is
+ *      a rendering fact, not a judgment. This is what produces runs whose
+ *      lengths mean something.
+ *   2. Absorb islands, repeatedly. `diff_cleanupSemantic`'s rule: an unchanged
+ *      run shorter than both of the runs either side of it is coincidence rather
+ *      than meaning, so it joins them. Repeated to a fixed point because
+ *      absorbing one island lengthens a run, which can qualify it to absorb the
+ *      next — and a single pass would leave that half-done and order-dependent.
+ */
+function cleanupRanges(
+  text: string,
+  ranges: readonly TextRange[],
+  structural: readonly number[] = []
+): TextRange[] {
+  const forced = new Set(structural);
+  const coalesced: TextRange[] = [];
+  for (const range of ranges) {
+    // A range that trims away to nothing was a whitespace-only edit, and it
+    // keeps its untrimmed bounds: the mark is the only visible signal an
+    // indentation or spacing change has, which is why the line diff exempts
+    // whitespace edits from suppression too.
+    const inner = trimRange(text, range);
+    const next = inner.end > inner.start ? inner : range;
+    if (next.end <= next.start) continue;
+    const previous = coalesced[coalesced.length - 1];
+    if (previous && next.start <= previous.end) {
+      previous.end = Math.max(previous.end, next.end);
+      continue;
+    }
+    // Adjacent words, separated only by the space between them — unless a
+    // structural boundary falls between, where there is no space to speak of.
+    const spans = (from: number, to: number): boolean => {
+      for (let offset = from + 1; offset <= to; offset++) if (forced.has(offset)) return true;
+      return false;
+    };
+    if (
+      previous &&
+      !/\S/.test(text.slice(previous.end, next.start)) &&
+      !spans(previous.end, next.start)
+    ) {
+      previous.end = next.end;
+      continue;
+    }
+    coalesced.push({ ...next });
+  }
+
+  let current = coalesced;
+  for (let pass = 0; pass < MAX_ISLAND_PASSES; pass++) {
+    const merged: TextRange[] = [];
+    let changed = false;
+    for (const range of current) {
+      const previous = merged[merged.length - 1];
+      if (previous && absorbs(text, previous, range, forced)) {
+        previous.end = range.end;
+        changed = true;
+        continue;
+      }
+      merged.push({ ...range });
+    }
+    current = merged;
+    if (!changed) break;
+  }
+  return current;
+}
+
+/** Whether the unchanged run between two marks is coincidence rather than meaning. */
+function absorbs(
+  text: string,
+  previous: TextRange,
+  next: TextRange,
+  forced: ReadonlySet<number>
+): boolean {
+  const island = text.slice(previous.end, next.start).trim();
+  // A line break is a structural boundary — a list item, a hard break — and a
+  // mark spanning one claims a correspondence across two separate things.
+  if (text.slice(previous.end, next.start).includes("\n")) return false;
+  // So is a cell or item boundary, which carries no character at all.
+  for (let offset = previous.end + 1; offset <= next.start; offset++) {
+    if (forced.has(offset)) return false;
+  }
+  if (island.length > ISLAND_MAX_CHARS) return false;
+  return island.length < Math.min(previous.end - previous.start, next.end - next.start);
+}
+
+/** Word-level marks for one aligned sentence pair, as absolute offsets. */
+function wordRangesFor(
+  oldText: string,
+  newText: string,
+  oldOffset: number,
+  newOffset: number,
+  budget: InlineCellBudget | undefined,
+  into: { old: TextRange[]; new: TextRange[] }
+): void {
+  const oldTokens = tokenize(oldText);
+  const newTokens = tokenize(newText);
+  const cells = (oldTokens.length + 1) * (newTokens.length + 1);
+  // Out of budget: the sentence still reports as changed, whole, which is the
+  // finer emphasis degrading rather than the change disappearing.
+  if (budget && cells > budget.remaining) {
+    into.old.push({ start: oldOffset, end: oldOffset + oldText.length });
+    into.new.push({ start: newOffset, end: newOffset + newText.length });
+    return;
+  }
+  if (budget) budget.remaining -= cells;
+
+  const matches = longestCommonSubsequence(oldTokens, newTokens);
+  const oldMatched = new Set(matches.map(([index]) => index));
+  const newMatched = new Set(matches.map(([, index]) => index));
+
+  const collect = (
+    tokens: readonly string[],
+    matched: ReadonlySet<number>,
+    offset: number
+  ): TextRange[] => {
+    const ranges: TextRange[] = [];
+    let cursor = 0;
+    let runStart: number | null = null;
+    tokens.forEach((token, index) => {
+      if (matched.has(index)) {
+        if (runStart !== null) {
+          ranges.push({ start: offset + runStart, end: offset + cursor });
+          runStart = null;
+        }
+      } else if (runStart === null) {
+        runStart = cursor;
+      }
+      cursor += token.length;
+    });
+    if (runStart !== null) ranges.push({ start: offset + runStart, end: offset + cursor });
+    return ranges;
+  };
+
+  const oldRanges = collect(oldTokens, oldMatched, oldOffset);
+  const newRanges = collect(newTokens, newMatched, newOffset);
+
+  /**
+   * The coverage rule, moved down a level and given somewhere to land.
+   *
+   * At the block level, exceeding it meant "show nothing", which is how a
+   * rewritten paragraph became two walls of text. At the sentence level it
+   * means "this sentence was rewritten, say so once" — the marks stop claiming
+   * a word-by-word correspondence they no longer have, and the reader still
+   * gets the sentence located for them.
+   */
+  const collapse = (
+    sentence: string,
+    offset: number,
+    ranges: readonly TextRange[]
+  ): TextRange[] => {
+    let edited = 0;
+    let editedText = "";
+    for (const range of ranges) {
+      edited += range.end - range.start;
+      editedText += sentence.slice(range.start - offset, range.end - offset);
+    }
+    if (!shouldSuppressEdits(sentence.length, edited, editedText)) return [...ranges];
+    return [{ start: offset, end: offset + sentence.length }];
+  };
+
+  into.old.push(...collapse(oldText, oldOffset, oldRanges));
+  into.new.push(...collapse(newText, newOffset, newRanges));
+}
+
+/**
+ * Marks for one modified block pair.
+ *
+ * Returns {@link NO_RANGES} when every sentence on a side is marked, because a
+ * side marked end to end says exactly what the block's own fill already said,
+ * at the cost of painting it twice.
+ */
+export interface InlineSide {
+  /** The block's visible text. */
+  text: string;
+  /** Offsets where a structural child begins — see `sentenceRanges`. */
+  segments?: readonly number[];
+}
+
+export function inlineChangeRanges(
+  oldSide: InlineSide,
+  newSide: InlineSide,
+  budget?: InlineCellBudget
+): InlineRanges {
+  const oldText = oldSide.text;
+  const newText = newSide.text;
+  if (!oldText || !newText) return NO_RANGES;
+  if (tokenize(oldText).length > MAX_INLINE_TOKENS) return NO_RANGES;
+  if (tokenize(newText).length > MAX_INLINE_TOKENS) return NO_RANGES;
+
+  const oldSentences = sentenceRanges(oldText, oldSide.segments);
+  const newSentences = sentenceRanges(newText, newSide.segments);
+  const oldKeys = oldSentences.map((range) => oldText.slice(range.start, range.end).trim());
+  const newKeys = newSentences.map((range) => newText.slice(range.start, range.end).trim());
+
+  const anchors = longestCommonSubsequence(oldKeys, newKeys);
+  const collected = { old: [] as TextRange[], new: [] as TextRange[] };
+
+  /**
+   * Align the sentences between two identical anchors, then mark what is left.
+   *
+   * Greedy forward pairing rather than a second score-maximizing matrix: inside
+   * one gap the candidates are few and already in reading order, and a sentence
+   * pairs with the next unclaimed candidate that clears the threshold. A
+   * crossing pair (the third sentence rewritten into the first) reads as one
+   * deletion plus one insertion, which is the honest answer — it is what
+   * happened.
+   */
+  const alignGap = (oldFrom: number, oldTo: number, newFrom: number, newTo: number): void => {
+    let newCursor = newFrom;
+    for (let i = oldFrom; i < oldTo; i++) {
+      const oldRange = oldSentences[i]!;
+      const oldSentence = oldText.slice(oldRange.start, oldRange.end);
+      let bestIndex = -1;
+      let bestScore = SENTENCE_PAIR_THRESHOLD;
+      for (let j = newCursor; j < newTo; j++) {
+        const newRange = newSentences[j]!;
+        const score = sentenceSimilarity(oldSentence, newText.slice(newRange.start, newRange.end));
+        if (score > bestScore) {
+          bestScore = score;
+          bestIndex = j;
+        }
+      }
+      if (bestIndex === -1) {
+        collected.old.push({ ...oldRange });
+        continue;
+      }
+      // Everything skipped over to reach the match is an insertion.
+      for (let j = newCursor; j < bestIndex; j++) collected.new.push({ ...newSentences[j]! });
+      const newRange = newSentences[bestIndex]!;
+      wordRangesFor(
+        oldSentence,
+        newText.slice(newRange.start, newRange.end),
+        oldRange.start,
+        newRange.start,
+        budget,
+        collected
+      );
+      newCursor = bestIndex + 1;
+    }
+    for (let j = newCursor; j < newTo; j++) collected.new.push({ ...newSentences[j]! });
+  };
+
+  let oldCursor = 0;
+  let newCursor = 0;
+  for (const [oldIndex, newIndex] of anchors) {
+    alignGap(oldCursor, oldIndex, newCursor, newIndex);
+    oldCursor = oldIndex + 1;
+    newCursor = newIndex + 1;
+  }
+  alignGap(oldCursor, oldSentences.length, newCursor, newSentences.length);
+
+  const oldRanges = cleanupRanges(oldText, collected.old, oldSide.segments);
+  const newRanges = cleanupRanges(newText, collected.new, newSide.segments);
+
+  const covers = (text: string, ranges: readonly TextRange[]): boolean => {
+    const marked = ranges.reduce((total, range) => total + (range.end - range.start), 0);
+    return marked >= text.trim().length;
+  };
+  if (covers(oldText, oldRanges) && covers(newText, newRanges)) return NO_RANGES;
+
+  return { old: oldRanges, new: newRanges };
+}

--- a/src/panels/diff/DiffPane.tsx
+++ b/src/panels/diff/DiffPane.tsx
@@ -27,6 +27,7 @@ import { actionService } from "@/services/ActionService";
 import { logError } from "@/utils/logger";
 import { ContentPanel } from "@/components/Panel/ContentPanel";
 import { FileViewerToolbar, TOOLBAR_ICON_CLASS } from "@/components/FileViewer/FileViewerToolbar";
+import { DiffChangeStepper } from "@/components/FileViewer/DiffChangeStepper";
 import { revealCopy } from "@/components/FileViewer/revealCopy";
 import { DiffFileSidebar } from "@/components/FileViewer/DiffFileSidebar";
 import { FileVideoPreview } from "@/components/FileViewer/FileVideoPreview";
@@ -569,6 +570,13 @@ export function DiffPane({
   // every later attempt that reused it.
   const renderedAttemptKey = `${filePath ?? ""}\u0000${fileStatus ?? ""}\u0000${content ?? ""}\u0000${source ?? ""}`;
 
+  // The rendered layout's change inventory, reported up by the view because the
+  // host has a patch and the view has the model: a hunk is a run of lines, a
+  // change here is a block the reader can point at, and the two counts differ.
+  const [renderedChangeCount, setRenderedChangeCount] = useState(0);
+  const [renderedChangeIndex, setRenderedChangeIndex] = useState(0);
+  const scrollRootRef = useRef<HTMLDivElement>(null);
+
   const [renderedVerdict, setRenderedVerdict] = useState<{
     attempt: string;
     reason: MarkdownDiffFailure | null;
@@ -680,6 +688,82 @@ export function DiffPane({
     </div>
   );
 
+  const handleRenderedChangeCount = useCallback((count: number) => {
+    setRenderedChangeCount(count);
+    setRenderedChangeIndex(0);
+  }, []);
+
+  /**
+   * Keep the counter honest while the reader scrolls by hand.
+   *
+   * Without this the index only moves when a stepper button is pressed, so
+   * `1 of 4` sits in the toolbar while the reader is looking at the fourth
+   * change — a counter that lies is worse than no counter. The nearest change to
+   * the middle of the viewport wins, which is also where a step lands one.
+   *
+   * Deliberately not announced: `aria-live` fires on the value, and narrating
+   * every change a mouse wheel passes over would make the toolbar chatter. The
+   * announcement belongs to the deliberate act of stepping.
+   */
+  useEffect(() => {
+    const root = scrollRootRef.current;
+    if (!showRendered || renderedChangeCount === 0 || !root) return;
+    let frame = 0;
+    const sync = () => {
+      frame = 0;
+      const middle = root.clientHeight / 2;
+      let bestIndex: number | null = null;
+      let bestDistance = Infinity;
+      for (const element of root.querySelectorAll("[data-change-index]")) {
+        const box = element.getBoundingClientRect();
+        const rootBox = root.getBoundingClientRect();
+        const centre = box.top - rootBox.top + box.height / 2;
+        const distance = Math.abs(centre - middle);
+        if (distance < bestDistance) {
+          bestDistance = distance;
+          bestIndex = Number(element.getAttribute("data-change-index"));
+        }
+      }
+      if (bestIndex !== null && Number.isFinite(bestIndex)) setRenderedChangeIndex(bestIndex);
+    };
+    const onScroll = () => {
+      if (frame) return;
+      frame = requestAnimationFrame(sync);
+    };
+    root.addEventListener("scroll", onScroll, { passive: true });
+    sync();
+    return () => {
+      root.removeEventListener("scroll", onScroll);
+      if (frame) cancelAnimationFrame(frame);
+    };
+  }, [showRendered, renderedChangeCount]);
+
+  /**
+   * Move to the next or previous change and bring it into view.
+   *
+   * Found by data attribute rather than through a ref: the rendered view is a
+   * lazy chunk behind `Suspense`, and threading an imperative handle across that
+   * boundary buys nothing a query on the scroll root does not already give.
+   * Wraps at both ends — a reviewer stepping through a document expects the
+   * fourth Next to return to the first change, not to stop dead.
+   *
+   * `instant` rather than `smooth`, matching every other programmatic scroll in
+   * the app (`SettingsDialog`'s scroll-to-section, `SearchablePalette`,
+   * `FileTreeView`). A smooth scroll here would also need its own
+   * reduced-motion branch, which is a second reason the app does not use one.
+   */
+  const stepRenderedChange = useCallback(
+    (delta: number) => {
+      if (renderedChangeCount === 0) return;
+      const next = (renderedChangeIndex + delta + renderedChangeCount) % renderedChangeCount;
+      setRenderedChangeIndex(next);
+      scrollRootRef.current
+        ?.querySelector(`[data-change-index="${next}"]`)
+        ?.scrollIntoView({ block: "center", behavior: "instant" });
+    },
+    [renderedChangeCount, renderedChangeIndex]
+  );
+
   const renderedSkeleton = (
     <div className="p-4 space-y-3">
       <Skeleton label="Loading rendered Markdown">
@@ -750,6 +834,13 @@ export function DiffPane({
           ) : (
             layoutToggle
           ))}
+        {showRendered && (
+          <DiffChangeStepper
+            count={renderedChangeCount}
+            index={renderedChangeIndex}
+            onStep={stepRenderedChange}
+          />
+        )}
         {/* Content scope is meaningless in the rendered layout, which always
             shows the whole document — and a control that does nothing is worse
             than an absent one. The preference is left untouched, so returning to
@@ -918,7 +1009,7 @@ export function DiffPane({
           style={diffFontStyle}
           data-testid="diff-pane-body"
         >
-          <div className="flex-1 min-h-0 overflow-auto diff-scroll-root">
+          <div ref={scrollRootRef} className="flex-1 min-h-0 overflow-auto diff-scroll-root">
             {!filePath && (
               <div className="flex h-full w-full items-center justify-center p-6">
                 <EmptyState
@@ -1044,6 +1135,7 @@ export function DiffPane({
                       fontSize={markdownFontSize}
                       attemptKey={renderedAttemptKey}
                       onVerdict={handleRenderedVerdict}
+                      onChangeCount={handleRenderedChangeCount}
                     />
                   )}
                 </Suspense>


### PR DESCRIPTION
## Summary

Rebuilds how the diff panel's **Rendered** layout marks changes in a Markdown file. A rewritten paragraph used to show as two undifferentiated walls of text with nothing saying which words actually moved. It now shows exactly which sentences and words changed, in a document that still reads as a document.

Markdown is first-class work product in an agent-driven project. Agents rewrite specs, plans and briefs in prose all day, and this is the view you read that in.

## What was actually wrong

The word marks were not being suppressed. They were never produced.

Block pairing scored those two paragraphs at `0.381` against a `0.45` threshold, so they never became a modified pair and rendered as an unrelated deletion followed by an unrelated insertion. `similarityFrom` multiplied dice by the raw length ratio, and dice already charges for a length mismatch, so a paragraph an agent expanded paid twice. The threshold now comes from a measured corpus that is itself the test: lowest true positive `0.447`, highest true negative `0.331`.

## What changed

**Marking.** `markdownInlineDiff.ts` aligns sentences first and word-diffs only inside an aligned pair, which is what the prose-diff engines do (Draftable, Litera, Pandiff). A sentence that survived is never marked. A sentence that was inserted is marked whole, once. The 60% coverage rule from `diff-highlight` is right for code and wrong for prose, so it now applies per sentence and collapses that sentence to a single mark rather than throwing every mark away. Semantic cleanup runs after: coalesce adjacent marks, then absorb short unchanged islands to a fixed point.

`flattenText` also records where each list item and table cell begins, and those are hard boundaries. Without them a table flattened to one unbroken string and the trailing `O` of one cell's `Option-Command-O` matched the identical `O` in a different cell, so both sides marked a character nobody touched.

**Treatment.** Marks are native `<ins>` and `<del>` with hidden `Inserted:` / `Deleted:` labels, since no mainstream screen reader announces those elements at default verbosity. Changed blocks are square and full-bleed with the 3px bar in the margin, and the `+` / `−` glyphs are gone: no bar means unchanged, a bar means changed, a strikethrough means the old version. The blanket strikethrough now applies only where the whole block is the deletion, so a heading that gained three words no longer has all of its surviving words crossed out.

**Orientation.** Consecutive untouched blocks fold past five with two of context at each edge, everything else takes a change number (a substitution counts once), and the toolbar carries `3 of 12` with a stepper that follows manual scrolling.

**Two contrast defects found on the way.** Every rule the document draws is `--color-border-default` mixed toward transparent, which composited against a tinted fill measures `1.04:1` in the dark themes, so the same table had a grid outside a change and none inside one. And `.markdown-document :where(del) { opacity: 0.6 }` was catching the diff's own marks, putting deleted text at roughly `3.5:1` in the light themes.

## Still to do

Lists and tables duplicate the whole container when one item changes, and a code fence still tells you it changed without telling you where. Both are real, both are priced, and both are a different change from this one: the first needs a child model on `list` and `table` plus a merged renderer, and the second means teaching `HighlightedCode` to apply ranges across its refractor token tree.

## Testing

`npm run check` and the full `npx vitest run` both clean: 2502 files, 55224 tests, no failures. 51 new tests, each mutation-checked by reintroducing the bug and confirming it fails.

New screenshot harness at `e2e/screenshots/markdown-diff-review.spec.ts` covering six cases across three themes and two widths, driving a preview entry through Vite rather than booting Electron. It also fixes both this spec and `session-tabs-review.spec.ts` dying on "Port 5173 is already in use" whenever the app was running, which was the project's `strictPort: true` beating the inline `port: 0`.
