### PR TITLE
feat(plugins): expose a machine wake signal on PluginHostApi

### DIFF
--- a/docs/plugins/architecture.md
+++ b/docs/plugins/architecture.md
@@ -308,7 +308,7 @@ Adding a field to the plugin snapshot requires:
 
 Plugins consuming worktree events during `activate()` — before the WorkspaceClient is fully initialized — get their subscriptions queued in `pendingWorktreeSubs` and replayed once the client connects. Your callback never misses the early events.
 
-Plugin-supplied listeners across the host (`onDidChangeAgentState`, `storage.onDidChange`, `settings.onDidChange`, and the worktree subscriptions above) are dispatched through `invokeTrackedListener`, which quarantines a misbehaving callback. Each throw — synchronous or a rejected async return — increments a per-listener counter that is logged with its position (`1/3`, `2/3`, …); a single successful invocation resets it to zero, so intermittent failures never accumulate. After three consecutive throws the listener is auto-unsubscribed via its own disposer, so a buggy or adversarial plugin can't spam the log with a repeating error on every event.
+Plugin-supplied listeners across the host (`onDidChangeAgentState`, `onDidWake`, `storage.onDidChange`, `settings.onDidChange`, and the worktree subscriptions above) are dispatched through `invokeTrackedListener`, which quarantines a misbehaving callback. Each throw — synchronous or a rejected async return — increments a per-listener counter that is logged with its position (`1/3`, `2/3`, …); a single successful invocation resets it to zero, so intermittent failures never accumulate. After three consecutive throws the listener is auto-unsubscribed via its own disposer, so a buggy or adversarial plugin can't spam the log with a repeating error on every event.
 
 ## Capability disclosure
 

--- a/docs/plugins/host-api.md
+++ b/docs/plugins/host-api.md
@@ -71,6 +71,9 @@ interface PluginHostApi {
     callback: (event: PluginPanelLifecycleEvent) => void
   ): Promise<() => void>;
 
+  // Machine resumed from sleep — no capability
+  onDidWake(callback: (event: PluginSystemWakeEvent) => void): Promise<() => void>;
+
   // Forge / file-decoration providers
   registerForgeProvider(
     descriptor: ForgeProviderDescriptor,
@@ -126,7 +129,7 @@ The authoritative definition is in `shared/types/plugin.ts` in the Daintree repo
 
 Nearly every host method now returns a Promise — the API became fully async in the move to the out-of-process worker model, so `registerAction`, `postToPanel`, `setPanelBadge`, and the rest resolve `Promise<void>`, and the subscription methods resolve `Promise<() => void>`. Always `await` a registration before assuming it took effect, and `await` the subscription methods to get the disposer. The synchronous `logger` accessor is the lone exception — its `info`/`warn`/`error` calls return `void`.
 
-The revoke-guarded methods — `registerAction`, `registerHandler`, `broadcastToRenderer`, `registerForgeProvider`, `registerFileDecorationProvider`, `onDidChangeActiveWorktree`, `onDidChangeWorktrees`, `onDidChangeAgentState`, `onDidChangePanelLifecycle`, and `settings.onDidChange` — must be called during `activate()` and throw once the host is revoked. Subscribing counts as an activation-window operation even though the callback fires later: register all your subscriptions during `activate()`, then react to them for the plugin's lifetime. `postToPanel`, `setPanelBadge`, `getActiveWorktree`, `getWorktrees`, `getWorktreeStatus`, `getAgentState`, `invalidateFileDecorations`, `showToast`, `dispatch`, `sendToActiveAgent`, `process.spawn`, `fs.*`, `git.*`, `settings.get`/`settings.set`, and `logger` are deliberately NOT revoke-guarded: plugins call them from post-activation subscription callbacks and timers, so they stay callable for the plugin's lifetime and become a silent no-op (or, for `process.spawn`/`fs.*`/`git.*`, a rejection) after unload. This split is the load-bearing distinction between the activation-window registration surface and the live runtime surface — `postToPanel` is the canonical post-activation push: a plugin's `activate()` subscribes once (revoke-guarded `registerHandler`/worktree subscriptions), then streams live data into its panels with `postToPanel` for the rest of its lifetime.
+The revoke-guarded methods — `registerAction`, `registerHandler`, `broadcastToRenderer`, `registerForgeProvider`, `registerFileDecorationProvider`, `onDidChangeActiveWorktree`, `onDidChangeWorktrees`, `onDidChangeAgentState`, `onDidChangePanelLifecycle`, `onDidWake`, and `settings.onDidChange` — must be called during `activate()` and throw once the host is revoked. Subscribing counts as an activation-window operation even though the callback fires later: register all your subscriptions during `activate()`, then react to them for the plugin's lifetime. `postToPanel`, `setPanelBadge`, `getActiveWorktree`, `getWorktrees`, `getWorktreeStatus`, `getAgentState`, `invalidateFileDecorations`, `showToast`, `dispatch`, `sendToActiveAgent`, `process.spawn`, `fs.*`, `git.*`, `settings.get`/`settings.set`, and `logger` are deliberately NOT revoke-guarded: plugins call them from post-activation subscription callbacks and timers, so they stay callable for the plugin's lifetime and become a silent no-op (or, for `process.spawn`/`fs.*`/`git.*`, a rejection) after unload. This split is the load-bearing distinction between the activation-window registration surface and the live runtime surface — `postToPanel` is the canonical post-activation push: a plugin's `activate()` subscribes once (revoke-guarded `registerHandler`/worktree subscriptions), then streams live data into its panels with `postToPanel` for the rest of its lifetime.
 
 **Where validation errors surface.** The two groups report errors differently. A revoke-guarded activation-window method (`registerAction`, `registerHandler`, the subscriptions) throws synchronously at the call site on a bad descriptor or a revoked host — wrap the `activate()` body in `try`/`catch` if you want to handle it. The post-activation runtime-surface methods (`postToPanel`, `setPanelBadge`, `invalidateFileDecorations`, `broadcastToRenderer` on an invalid channel) instead reject the returned Promise rather than throwing synchronously, so handle their validation errors with `await` + `.catch()`:
 
@@ -415,6 +418,33 @@ On subscribe the host **replays the current phase of every live panel** of your 
 A renderer being destroyed or evicted never synthesizes `removed`: a cached project view says nothing about whether the user closed the panel, and a false terminal event is the exact misreading this API exists to prevent.
 
 Like the other `onDidChange*` methods this is revoke-guarded — subscribe during `activate()`. Events themselves fire for the plugin's whole lifetime and fall silent after unload. Events are frozen before delivery.
+
+## `onDidWake`
+
+Observe the machine waking from sleep. No capability is required — the event describes the machine's own suspend/resume timing and nothing about the workspace, the user, or any other plugin.
+
+```ts
+export async function activate(host: PluginHostApi) {
+  await host.onDidWake(({ sleepDuration }) => {
+    // Anything cached before the sleep is now suspect.
+    void refreshIssueCache();
+    if (sleepDuration > 60 * 60 * 1000) void reauthenticate();
+  });
+}
+```
+
+| Field | Meaning |
+| --- | --- |
+| `sleepDuration` | Milliseconds from the observed suspend to the moment the wake was published, so it includes the host's settle delay — a coarse staleness figure, not a precise hardware sleep time. `0` is a sentinel meaning the matching suspend edge was never observed; treat it as *unknown*, not as a short sleep. |
+| `timestamp` | `Date.now()` at the moment the wake was published. |
+
+**This is the signal background work has no other way to get.** `onDidChangePanelLifecycle` gives a *view* a re-validation point, but your timers, forge providers, and reconciliation passes keep running against state frozen at suspend. The host's own resume path only re-enables workspace polling if a window is focused, so a machine that wakes while Daintree is blurred — lid opened, user not back at the desk — leaves that state stale for an unbounded stretch with nothing else announcing the wake.
+
+Delivered once per resume, after the host has resynced its pty and workspace hosts, so re-reading worktree state from the callback sees post-wake data rather than racing the host's own recovery. A rapid suspend during that settle window cancels the wake entirely rather than emitting a spurious one.
+
+Nothing is replayed on subscribe: a wake is a one-shot pulse with no resting state. The event is machine-scoped, not project-scoped — every loaded instance of your plugin receives it, including one bound to a project whose window is not focused.
+
+Like the other subscriptions this is revoke-guarded — subscribe during `activate()`. Events fire for the plugin's whole lifetime and fall silent after unload. Events are frozen before delivery.
 
 ## `registerForgeProvider`
 

--- a/docs/plugins/host-api.md
+++ b/docs/plugins/host-api.md
@@ -435,10 +435,10 @@ export async function activate(host: PluginHostApi) {
 
 | Field | Meaning |
 | --- | --- |
-| `sleepDuration` | Milliseconds from the observed suspend to the moment the wake was published, so it includes the host's settle delay — a coarse staleness figure, not a precise hardware sleep time. `0` is a sentinel meaning the matching suspend edge was never observed; treat it as *unknown*, not as a short sleep. |
+| `sleepDuration` | Milliseconds from the observed suspend to the moment the wake was published, so it includes the host's settle delay — a coarse staleness figure, not a precise hardware sleep time. `0` is a sentinel meaning the matching suspend edge was never observed; treat it as _unknown_, not as a short sleep. |
 | `timestamp` | `Date.now()` at the moment the wake was published. |
 
-**This is the signal background work has no other way to get.** `onDidChangePanelLifecycle` gives a *view* a re-validation point, but your timers, forge providers, and reconciliation passes keep running against state frozen at suspend. The host's own resume path only re-enables workspace polling if a window is focused, so a machine that wakes while Daintree is blurred — lid opened, user not back at the desk — leaves that state stale for an unbounded stretch with nothing else announcing the wake.
+**This is the signal background work has no other way to get.** `onDidChangePanelLifecycle` gives a _view_ a re-validation point, but your timers, forge providers, and reconciliation passes keep running against state frozen at suspend. The host's own resume path only re-enables workspace polling if a window is focused, so a machine that wakes while Daintree is blurred — lid opened, user not back at the desk — leaves that state stale for an unbounded stretch with nothing else announcing the wake.
 
 Delivered once per resume, after the host has resynced its pty and workspace hosts, so re-reading worktree state from the callback sees post-wake data rather than racing the host's own recovery. A rapid suspend during that settle window cancels the wake entirely rather than emitting a spurious one.
 

--- a/docs/plugins/host-api.md
+++ b/docs/plugins/host-api.md
@@ -428,19 +428,20 @@ export async function activate(host: PluginHostApi) {
   await host.onDidWake(({ sleepDuration }) => {
     // Anything cached before the sleep is now suspect.
     void refreshIssueCache();
-    if (sleepDuration > 60 * 60 * 1000) void reauthenticate();
+    // `0` means "unknown", so it must reauthenticate too — not be read as short.
+    if (sleepDuration === 0 || sleepDuration > 60 * 60 * 1000) void reauthenticate();
   });
 }
 ```
 
 | Field | Meaning |
 | --- | --- |
-| `sleepDuration` | Milliseconds from the observed suspend to the moment the wake was published, so it includes the host's settle delay — a coarse staleness figure, not a precise hardware sleep time. `0` is a sentinel meaning the matching suspend edge was never observed; treat it as _unknown_, not as a short sleep. |
+| `sleepDuration` | Milliseconds from the observed suspend to the start of the host's post-wake recovery, so it includes the settle delay but not however long recovery itself took — a coarse staleness figure, not a precise hardware sleep time. `0` is a sentinel meaning the matching suspend edge was never observed; treat it as _unknown_, not as a short sleep. |
 | `timestamp` | `Date.now()` at the moment the wake was published. |
 
 **This is the signal background work has no other way to get.** `onDidChangePanelLifecycle` gives a _view_ a re-validation point, but your timers, forge providers, and reconciliation passes keep running against state frozen at suspend. The host's own resume path only re-enables workspace polling if a window is focused, so a machine that wakes while Daintree is blurred — lid opened, user not back at the desk — leaves that state stale for an unbounded stretch with nothing else announcing the wake.
 
-Delivered once per resume, after the host has resynced its pty and workspace hosts, so re-reading worktree state from the callback sees post-wake data rather than racing the host's own recovery. A rapid suspend during that settle window cancels the wake entirely rather than emitting a spurious one.
+Delivered at most once per resume, after the host has attempted to resync its pty and workspace hosts, so re-reading worktree state from the callback is not racing the host's own recovery. That recovery is best-effort — the wake is announced even when part of it failed, because a half-recovered host is exactly when you need to revalidate. Rapid resumes coalesce into one delivery, and a re-suspend during the settle window cancels the wake outright rather than emitting a spurious one.
 
 Nothing is replayed on subscribe: a wake is a one-shot pulse with no resting state. The event is machine-scoped, not project-scoped — every loaded instance of your plugin receives it, including one bound to a project whose window is not focused.
 

--- a/electron/services/events.ts
+++ b/electron/services/events.ts
@@ -123,6 +123,12 @@ export const EVENT_META: Record<keyof DaintreeEventMap, EventMetadata> = {
     requiresTimestamp: true,
     description: "Repo's git remotes changed — forge provider must be re-resolved",
   },
+  "sys:wake": {
+    category: "system",
+    requiresContext: false,
+    requiresTimestamp: true,
+    description: "Machine resumed from sleep, after the host's settle delay",
+  },
 
   // File events
   "file:open": {
@@ -559,6 +565,18 @@ export type DaintreeEventMap = {
    * worktree update must not.
    */
   "sys:forge:remote-changed": {
+    timestamp: number;
+  };
+
+  /**
+   * Machine resumed from sleep, emitted from the same debounced resume handler
+   * that pushes `system:wake` to the renderer — after the pty and workspace
+   * hosts have been resynced, so a listener that re-reads state sees post-wake
+   * data. `sleepDuration` is `0` when the matching suspend edge was never
+   * observed, which means "unknown", not "a short sleep".
+   */
+  "sys:wake": {
+    sleepDuration: number;
     timestamp: number;
   };
 
@@ -1012,6 +1030,7 @@ export const ALL_EVENT_TYPES: Array<keyof DaintreeEventMap> = [
   "sys:pr:detection-state",
   "sys:issue:detected",
   "sys:issue:not-found",
+  "sys:wake",
   "agent:spawned",
   "agent:state-changed",
   "agent:state-transition-dropped",

--- a/electron/services/plugin/PluginDevWorkerMainBridge.ts
+++ b/electron/services/plugin/PluginDevWorkerMainBridge.ts
@@ -774,6 +774,8 @@ export class PluginDevWorkerMainBridge {
         dispose = await this.host.onDidChangeAgentState((snapshot) => push(snapshot));
       } else if (kind === "panel-lifecycle") {
         dispose = await this.host.onDidChangePanelLifecycle((event) => push(event));
+      } else if (kind === "system-wake") {
+        dispose = await this.host.onDidWake((event) => push(event));
       } else if (kind === "process-exit" || kind === "process-crash" || kind === "process-data") {
         if (!msg.processId) {
           logger.warn(`[${this.pluginId}] ${kind} subscribe missing processId`);

--- a/electron/services/plugin/PluginHostFactory.ts
+++ b/electron/services/plugin/PluginHostFactory.ts
@@ -939,6 +939,44 @@ export function createHost(
       teardown.dispose = dispose;
       return Promise.resolve(dispose);
     },
+    onDidWake: (callback) => {
+      if (revoked) {
+        throw new Error(
+          `Plugin "${pluginId}" host revoked: onDidWake called after activate() returned or timed out`
+        );
+      }
+      // No capability gate: the payload is the machine's own suspend/resume
+      // timing and nothing else — no workspace, user, or cross-plugin data. It
+      // is also strictly less than every renderer window already receives
+      // unconditionally on the same wake (#12175).
+      const failures = createListenerFailureState();
+      const handler = (payload: { sleepDuration: number; timestamp: number }): void => {
+        // Deliberately NOT filtered by the host's project binding, unlike
+        // `onDidChangeAgentState`: a wake is machine-scoped, so every loaded
+        // instance of the plugin must hear it, including one bound to a project
+        // whose window is not focused — which is exactly the stale-state case
+        // this event exists for.
+        if (!deps.plugins.has(pluginId)) return;
+        invokeTrackedListener(
+          failures,
+          pluginId,
+          "onDidWake",
+          () =>
+            callback(
+              Object.freeze({
+                sleepDuration: payload.sleepDuration,
+                timestamp: payload.timestamp,
+              })
+            ),
+          () => dispose()
+        );
+      };
+      // No replay on subscribe: a wake is a one-shot pulse with no resting
+      // state to hand a late subscriber.
+      const unsub = events.on("sys:wake", handler);
+      const dispose = trackPluginDisposer(deps.pluginEventCleanups, pluginId, () => unsub());
+      return Promise.resolve(dispose);
+    },
     registerForgeProvider: (descriptor, impl) => {
       if (revoked) {
         throw new Error(

--- a/electron/services/plugin/__tests__/PluginDevWorkerMainBridge.test.ts
+++ b/electron/services/plugin/__tests__/PluginDevWorkerMainBridge.test.ts
@@ -34,6 +34,7 @@ function makeHost() {
     })),
     onDidChangeActiveWorktree: vi.fn((_cb: any) => vi.fn()),
     onDidChangeWorktrees: vi.fn((_cb: any) => vi.fn()),
+    onDidWake: vi.fn((_cb: any) => vi.fn()),
     registerForgeProvider: vi.fn(() => vi.fn()),
     registerFileDecorationProvider: vi.fn(() => vi.fn()),
     invalidateFileDecorations: vi.fn(),
@@ -391,6 +392,27 @@ describe("PluginDevWorkerMainBridge", () => {
     emitActive?.({ id: "w9" });
     const evt = workerHost.sent.find((m) => m.type === "subscription-event");
     expect(evt).toMatchObject({ subscriptionId: "s1", payload: { id: "w9" } });
+  });
+
+  it("routes a system-wake subscription to host.onDidWake (#12175)", async () => {
+    const { host, workerHost } = makeBridge();
+    let emitWake: ((e: unknown) => void) | undefined;
+    host.onDidWake.mockImplementation((cb: any) => {
+      emitWake = cb;
+      return vi.fn();
+    });
+    workerHost.emit("worker-message", {
+      type: "subscribe",
+      subscriptionId: "s-wake",
+      kind: "system-wake",
+    });
+    expect(host.onDidWake).toHaveBeenCalled();
+    emitWake?.({ sleepDuration: 42_000, timestamp: 1234 });
+    const evt = workerHost.sent.find((m) => m.type === "subscription-event");
+    expect(evt).toMatchObject({
+      subscriptionId: "s-wake",
+      payload: { sleepDuration: 42_000, timestamp: 1234 },
+    });
   });
 
   it("disposes a subscription on unsubscribe", async () => {

--- a/electron/services/plugin/__tests__/PluginHostFactory.binding.test.ts
+++ b/electron/services/plugin/__tests__/PluginHostFactory.binding.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import path from "path";
 
 const ipcUtilsMock = vi.hoisted(() => ({
@@ -703,5 +703,131 @@ describe("createHost onDidChangeAgentState", () => {
       timestamp: 1,
     } as never);
     expect(callback).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("createHost onDidWake (#12175)", () => {
+  const WAKE = { sleepDuration: 42_000, timestamp: 1234 };
+
+  // Subscriptions live on the module-level bus, so a listener left behind by
+  // one case would still be attached when the next emits.
+  afterEach(() => events.removeAllListeners());
+
+  it("delivers a frozen wake to a project-bound host", async () => {
+    const h = makeHarness();
+    const { host } = createHost(h.deps, PLUGIN_ID, BOUND);
+    const received: unknown[] = [];
+    await host.onDidWake((event) => received.push(event));
+
+    events.emit("sys:wake", WAKE);
+
+    expect(received).toHaveLength(1);
+    expect(received[0]).toEqual(WAKE);
+    // Frozen so a plugin that mutates the event fails here, not in the wild.
+    expect(Object.isFrozen(received[0])).toBe(true);
+  });
+
+  it("delivers to a bound host regardless of which project woke — a wake is machine-scoped", async () => {
+    const h = makeHarness();
+    const boundHost = createHost(h.deps, PLUGIN_ID, BOUND).host;
+    const unboundHost = createHost(h.deps, PLUGIN_ID, UNBOUND_PLUGIN_HOST_BINDING).host;
+    const boundCb = vi.fn();
+    const unboundCb = vi.fn();
+    await boundHost.onDidWake(boundCb);
+    await unboundHost.onDidWake(unboundCb);
+
+    events.emit("sys:wake", WAKE);
+
+    // Unlike agent state, there is no project filter: the blurred, non-current
+    // project is exactly the one whose plugin state went stale over the sleep.
+    expect(boundCb).toHaveBeenCalledTimes(1);
+    expect(unboundCb).toHaveBeenCalledTimes(1);
+  });
+
+  it("requires no capability", async () => {
+    const h = makeHarness();
+    h.deps.declaredCapabilities = () => new Set();
+    const { host } = createHost(h.deps, PLUGIN_ID, BOUND);
+    const callback = vi.fn();
+
+    await expect(host.onDidWake(callback)).resolves.toBeTypeOf("function");
+    events.emit("sys:wake", WAKE);
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not replay a wake that happened before the subscription", async () => {
+    const h = makeHarness();
+    const { host } = createHost(h.deps, PLUGIN_ID, BOUND);
+
+    events.emit("sys:wake", WAKE);
+    const callback = vi.fn();
+    await host.onDidWake(callback);
+
+    // A pulse has no resting state; replaying it would make a stale wake look
+    // fresh and trigger a duplicate reconciliation pass.
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it("stops delivering once the disposer runs", async () => {
+    const h = makeHarness();
+    const { host } = createHost(h.deps, PLUGIN_ID, BOUND);
+    const callback = vi.fn();
+    const dispose = await host.onDidWake(callback);
+
+    dispose();
+    dispose();
+    events.emit("sys:wake", WAKE);
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it("falls silent once the plugin is unloaded, without needing its disposer", async () => {
+    const h = makeHarness();
+    const { host } = createHost(h.deps, PLUGIN_ID, BOUND);
+    const callback = vi.fn();
+    await host.onDidWake(callback);
+
+    h.deps.plugins.delete(PLUGIN_ID);
+    events.emit("sys:wake", WAKE);
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it("keeps delivering to a sibling listener when one throws", async () => {
+    const h = makeHarness();
+    const { host } = createHost(h.deps, PLUGIN_ID, BOUND);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const healthy = vi.fn();
+    await host.onDidWake(() => {
+      throw new Error("plugin boom");
+    });
+    await host.onDidWake(healthy);
+
+    events.emit("sys:wake", WAKE);
+
+    expect(healthy).toHaveBeenCalledTimes(1);
+  });
+
+  it("quarantines a listener that throws on three consecutive wakes", async () => {
+    const h = makeHarness();
+    const { host } = createHost(h.deps, PLUGIN_ID, BOUND);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const callback = vi.fn(() => {
+      throw new Error("plugin boom");
+    });
+    await host.onDidWake(callback);
+
+    for (let i = 0; i < 4; i++) events.emit("sys:wake", WAKE);
+
+    expect(callback).toHaveBeenCalledTimes(3);
+  });
+
+  it("throws once the host is revoked", async () => {
+    const h = makeHarness();
+    const { host, revoke } = createHost(h.deps, PLUGIN_ID, BOUND);
+    revoke();
+
+    expect(() => host.onDidWake(vi.fn())).toThrow(/onDidWake/);
   });
 });

--- a/electron/services/plugin/__tests__/PluginHostFactory.binding.test.ts
+++ b/electron/services/plugin/__tests__/PluginHostFactory.binding.test.ts
@@ -710,8 +710,13 @@ describe("createHost onDidWake (#12175)", () => {
   const WAKE = { sleepDuration: 42_000, timestamp: 1234 };
 
   // Subscriptions live on the module-level bus, so a listener left behind by
-  // one case would still be attached when the next emits.
-  afterEach(() => events.removeAllListeners());
+  // one case would still be attached when the next emits. Spies are restored
+  // here too: this file's `beforeEach` only clears mocks, so a console spy
+  // would otherwise stay installed for every later test.
+  afterEach(() => {
+    events.removeAllListeners();
+    vi.restoreAllMocks();
+  });
 
   it("delivers a frozen wake to a project-bound host", async () => {
     const h = makeHarness();
@@ -793,18 +798,37 @@ describe("createHost onDidWake (#12175)", () => {
     expect(callback).not.toHaveBeenCalled();
   });
 
+  it("registers its teardown in pluginEventCleanups and clears it on dispose", async () => {
+    const h = makeHarness();
+    const { host } = createHost(h.deps, PLUGIN_ID, BOUND);
+    const dispose = await host.onDidWake(vi.fn());
+
+    // The membership guard alone would keep the "unloaded" test above green
+    // even if the subscription stopped being tracked — at which point a
+    // same-id reload would revive the stale listener. Assert the tracking.
+    expect(h.deps.pluginEventCleanups.get(PLUGIN_ID)).toHaveLength(1);
+
+    dispose();
+
+    expect(h.deps.pluginEventCleanups.get(PLUGIN_ID)).toBeUndefined();
+  });
+
   it("keeps delivering to a sibling listener when one throws", async () => {
     const h = makeHarness();
     const { host } = createHost(h.deps, PLUGIN_ID, BOUND);
     vi.spyOn(console, "error").mockImplementation(() => {});
     const healthy = vi.fn();
-    await host.onDidWake(() => {
+    const thrower = vi.fn(() => {
       throw new Error("plugin boom");
     });
+    await host.onDidWake(thrower);
     await host.onDidWake(healthy);
 
     events.emit("sys:wake", WAKE);
 
+    // Assert the thrower ran: without it, a first subscription that silently
+    // never registered would leave this test green.
+    expect(thrower).toHaveBeenCalledTimes(1);
     expect(healthy).toHaveBeenCalledTimes(1);
   });
 

--- a/electron/services/plugin/__tests__/pluginDevWorkerHostProxy.test.ts
+++ b/electron/services/plugin/__tests__/pluginDevWorkerHostProxy.test.ts
@@ -493,6 +493,58 @@ describe("PluginDevWorkerHostProxy panel lifecycle (#11301)", () => {
   });
 });
 
+describe("PluginDevWorkerHostProxy system wake (#12175)", () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.restoreAllMocks());
+
+  it("opens a system-wake subscription and routes events to the callback", async () => {
+    const { proxy, sent } = makeProxy();
+    const onEvent = vi.fn();
+    const dispose = await proxy.host.onDidWake(onEvent);
+
+    // The kind is the routing key on main — a wrong or missing one would fall
+    // through the bridge's chain and be wired to an unrelated host event.
+    const sub = sent.find((m) => m.type === "subscribe" && m.kind === "system-wake");
+    expect(sub).toBeDefined();
+
+    proxy.handleMessage({
+      type: "subscription-event",
+      subscriptionId: sub.subscriptionId,
+      payload: { sleepDuration: 42_000, timestamp: 1234 },
+    } as any);
+
+    expect(onEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ sleepDuration: 42_000, timestamp: 1234 })
+    );
+
+    dispose();
+    expect(
+      sent.find((m) => m.type === "unsubscribe" && m.subscriptionId === sub.subscriptionId)
+    ).toBeDefined();
+  });
+
+  it("freezes the delivered event even though the port hop strips main's freeze", async () => {
+    const { proxy, sent } = makeProxy();
+    const received: any[] = [];
+    await proxy.host.onDidWake((e) => received.push(e));
+    const sub = sent.find((m) => m.type === "subscribe" && m.kind === "system-wake");
+
+    proxy.handleMessage({
+      type: "subscription-event",
+      subscriptionId: sub.subscriptionId,
+      payload: { sleepDuration: 0, timestamp: 7 },
+    } as any);
+
+    expect(Object.isFrozen(received[0])).toBe(true);
+  });
+
+  it("rejects a subscription opened after the activation window closes", async () => {
+    const { proxy } = makeProxy();
+    proxy.revoke();
+    expect(() => proxy.host.onDidWake(vi.fn())).toThrow(/onDidWake/);
+  });
+});
+
 describe("PluginDevWorkerHostProxy host.fs.watch (#10526)", () => {
   beforeEach(() => vi.clearAllMocks());
   afterEach(() => vi.restoreAllMocks());

--- a/electron/services/plugin/__tests__/pluginDevWorkerHostProxy.test.ts
+++ b/electron/services/plugin/__tests__/pluginDevWorkerHostProxy.test.ts
@@ -535,6 +535,9 @@ describe("PluginDevWorkerHostProxy system wake (#12175)", () => {
       payload: { sleepDuration: 0, timestamp: 7 },
     } as any);
 
+    // Length first: `Object.isFrozen(undefined)` is `true`, so a callback that
+    // never fired would pass the freeze assertion on its own.
+    expect(received).toHaveLength(1);
     expect(Object.isFrozen(received[0])).toBe(true);
   });
 

--- a/electron/services/plugin/pluginDevWorkerHostProxy.ts
+++ b/electron/services/plugin/pluginDevWorkerHostProxy.ts
@@ -31,6 +31,7 @@ import type {
   PluginWorktreesResult,
   PluginAgentSnapshot,
   PluginPanelLifecycleEvent,
+  PluginSystemWakeEvent,
   PluginFsDirEntry,
   PluginFsStat,
   PluginGitStatus,
@@ -473,6 +474,17 @@ export class PluginDevWorkerHostProxy {
         // hold for every user-installed plugin, which all run in a worker.
         const dispose = this.subscribe("panel-lifecycle", (payload) =>
           callback(Object.freeze(payload as PluginPanelLifecycleEvent))
+        );
+        return Promise.resolve(dispose);
+      },
+      onDidWake: (callback) => {
+        this.assertActivationOpen("onDidWake");
+        // Subscription wired synchronously; only the disposer is async. Same
+        // re-freeze as panel-lifecycle above: the port's structured clone hands
+        // back a plain mutable object, so main's freeze does not survive the
+        // hop and the documented contract has to be re-established here.
+        const dispose = this.subscribe("system-wake", (payload) =>
+          callback(Object.freeze(payload as PluginSystemWakeEvent))
         );
         return Promise.resolve(dispose);
       },

--- a/electron/window/__tests__/powerMonitor.test.ts
+++ b/electron/window/__tests__/powerMonitor.test.ts
@@ -398,7 +398,9 @@ describe("setupPowerMonitor", () => {
     // the machine slept.
     const pushPayload = wc.send.mock.calls[0]?.[1]?.payload;
     expect(busPayload).toEqual(pushPayload);
-    expect(busPayload.sleepDuration).toBeGreaterThanOrEqual(5_000);
+    // Exactly the 5s sleep plus the 2s settle debounce: pins the documented
+    // "includes the settle delay" claim, which a `>=` assertion would not.
+    expect(busPayload.sleepDuration).toBe(7_000);
   });
 
   it("emits sys:wake even with no window to broadcast to", async () => {
@@ -443,9 +445,10 @@ describe("setupPowerMonitor", () => {
     const workspaceClient = createMockWorkspaceClient();
     const { win, wc } = createMockWindow();
     mockGetAllWindows.mockReturnValue([win]);
-    events.on("sys:wake", () => {
+    const thrower = vi.fn(() => {
       throw new Error("listener boom");
     });
+    events.on("sys:wake", thrower);
     vi.spyOn(console, "error").mockImplementation(() => {});
 
     setupPowerMonitor({
@@ -456,7 +459,59 @@ describe("setupPowerMonitor", () => {
     powerHandlers.get("resume")!();
     await vi.advanceTimersByTimeAsync(2000);
 
+    // Assert the thrower actually ran — otherwise deleting the emit entirely
+    // would leave the renderer assertions below green.
+    expect(thrower).toHaveBeenCalledTimes(1);
     expect(wc.send).toHaveBeenCalledTimes(1);
     expect(workspaceClient.refreshOnWake).toHaveBeenCalledTimes(1);
+  });
+
+  it("still announces the wake when post-wake recovery fails", async () => {
+    const workspaceClient = createMockWorkspaceClient({
+      refreshOnWake: vi.fn().mockRejectedValue(new Error("refresh failed")),
+    });
+    const { win, wc } = createMockWindow();
+    mockGetAllWindows.mockReturnValue([win]);
+    const onWake = vi.fn();
+    events.on("sys:wake", onWake);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    setupPowerMonitor({
+      getPtyClient: () => createMockPtyClient(),
+      getWorkspaceClient: () => workspaceClient,
+    });
+
+    powerHandlers.get("resume")!();
+    await vi.advanceTimersByTimeAsync(2000);
+
+    // A half-recovered host is precisely when a listener needs to revalidate;
+    // swallowing the wake there would strand everyone on suspend-era state.
+    expect(onWake).toHaveBeenCalledTimes(1);
+    expect(wc.send).toHaveBeenCalledTimes(1);
+  });
+
+  it("announces the next wake after one was cancelled by a re-suspend", async () => {
+    const workspaceClient = createMockWorkspaceClient();
+    const onWake = vi.fn();
+    events.on("sys:wake", onWake);
+
+    setupPowerMonitor({
+      getPtyClient: () => createMockPtyClient(),
+      getWorkspaceClient: () => workspaceClient,
+    });
+
+    // Cancelled cycle: resume, then re-suspend before the debounce fires.
+    powerHandlers.get("resume")!();
+    await vi.advanceTimersByTimeAsync(1000);
+    powerHandlers.get("suspend")!();
+    await vi.advanceTimersByTimeAsync(3_000);
+    expect(onWake).not.toHaveBeenCalled();
+
+    // The real wake that follows must still land, timed from the newer suspend.
+    powerHandlers.get("resume")!();
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(onWake).toHaveBeenCalledTimes(1);
+    expect(onWake.mock.calls[0]?.[0].sleepDuration).toBe(5_000);
   });
 });

--- a/electron/window/__tests__/powerMonitor.test.ts
+++ b/electron/window/__tests__/powerMonitor.test.ts
@@ -47,6 +47,7 @@ function createMockWorkspaceClient(overrides: Partial<WorkspaceClient> = {}): Wo
 
 let setupPowerMonitor: typeof import("../powerMonitor.js").setupPowerMonitor;
 let clearResumeTimeout: typeof import("../powerMonitor.js").clearResumeTimeout;
+let events: typeof import("../../services/events.js").events;
 
 describe("setupPowerMonitor", () => {
   beforeEach(async () => {
@@ -85,10 +86,15 @@ describe("setupPowerMonitor", () => {
     const mod = await import("../powerMonitor.js");
     setupPowerMonitor = mod.setupPowerMonitor;
     clearResumeTimeout = mod.clearResumeTimeout;
+    // Imported after `resetModules` + the powerMonitor import so this is the
+    // same bus instance powerMonitor closed over; the top-level singleton from
+    // a previous registry would silently never receive the emit.
+    events = (await import("../../services/events.js")).events;
   });
 
   afterEach(() => {
     clearResumeTimeout();
+    events.removeAllListeners();
     vi.useRealTimers();
     vi.restoreAllMocks();
   });
@@ -366,5 +372,91 @@ describe("setupPowerMonitor", () => {
     await vi.advanceTimersByTimeAsync(2000);
 
     expect(wc.send).not.toHaveBeenCalled();
+  });
+
+  it("emits sys:wake on the internal bus with the same values as the renderer push (#12175)", async () => {
+    const workspaceClient = createMockWorkspaceClient();
+    const { win, wc } = createMockWindow();
+    mockGetAllWindows.mockReturnValue([win]);
+    const onWake = vi.fn();
+    events.on("sys:wake", onWake);
+
+    setupPowerMonitor({
+      getPtyClient: () => createMockPtyClient(),
+      getWorkspaceClient: () => workspaceClient,
+    });
+
+    powerHandlers.get("suspend")!();
+    await vi.advanceTimersByTimeAsync(5_000);
+    powerHandlers.get("resume")!();
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(onWake).toHaveBeenCalledTimes(1);
+    const busPayload = onWake.mock.calls[0]?.[0];
+    // One wake, one set of numbers: a plugin reacting to the bus and a renderer
+    // reacting to the push must not disagree about when it happened or how long
+    // the machine slept.
+    const pushPayload = wc.send.mock.calls[0]?.[1]?.payload;
+    expect(busPayload).toEqual(pushPayload);
+    expect(busPayload.sleepDuration).toBeGreaterThanOrEqual(5_000);
+  });
+
+  it("emits sys:wake even with no window to broadcast to", async () => {
+    const workspaceClient = createMockWorkspaceClient();
+    mockGetAllWindows.mockReturnValue([]);
+    mockGetFocusedWindow.mockReturnValue(null);
+    const onWake = vi.fn();
+    events.on("sys:wake", onWake);
+
+    setupPowerMonitor({
+      getPtyClient: () => createMockPtyClient(),
+      getWorkspaceClient: () => workspaceClient,
+    });
+
+    powerHandlers.get("resume")!();
+    await vi.advanceTimersByTimeAsync(2000);
+
+    // The blurred, windowless wake is precisely the case the renderer push
+    // cannot serve — a plugin must still hear it.
+    expect(onWake).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not emit sys:wake when the resume is cancelled by a re-suspend", async () => {
+    const workspaceClient = createMockWorkspaceClient();
+    const onWake = vi.fn();
+    events.on("sys:wake", onWake);
+
+    setupPowerMonitor({
+      getPtyClient: () => createMockPtyClient(),
+      getWorkspaceClient: () => workspaceClient,
+    });
+
+    powerHandlers.get("resume")!();
+    await vi.advanceTimersByTimeAsync(1000);
+    powerHandlers.get("suspend")!();
+    await vi.advanceTimersByTimeAsync(5000);
+
+    expect(onWake).not.toHaveBeenCalled();
+  });
+
+  it("still broadcasts to windows when a sys:wake subscriber throws", async () => {
+    const workspaceClient = createMockWorkspaceClient();
+    const { win, wc } = createMockWindow();
+    mockGetAllWindows.mockReturnValue([win]);
+    events.on("sys:wake", () => {
+      throw new Error("listener boom");
+    });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    setupPowerMonitor({
+      getPtyClient: () => createMockPtyClient(),
+      getWorkspaceClient: () => workspaceClient,
+    });
+
+    powerHandlers.get("resume")!();
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(wc.send).toHaveBeenCalledTimes(1);
+    expect(workspaceClient.refreshOnWake).toHaveBeenCalledTimes(1);
   });
 });

--- a/electron/window/powerMonitor.ts
+++ b/electron/window/powerMonitor.ts
@@ -45,6 +45,40 @@ function refreshForgeTokenHealth(options?: { force?: boolean }): void {
   }
 }
 
+/**
+ * Announce one completed wake to every renderer window and to the internal
+ * bus, with a single shared timestamp so no two consumers disagree about when
+ * the machine came back.
+ */
+function publishWake(sleepDuration: number): void {
+  const timestamp = Date.now();
+  for (const win of BrowserWindow.getAllWindows()) {
+    try {
+      if (!win || win.isDestroyed()) continue;
+      const wc = getAppWebContents(win);
+      if (wc.isDestroyed()) continue;
+      wc.send(CHANNELS.EVENTS_PUSH, {
+        name: "system:wake",
+        payload: { sleepDuration, timestamp },
+      });
+    } catch {
+      // A window tearing down mid-broadcast must not cost the others theirs —
+      // the whole lookup is guarded, not just the send.
+    }
+  }
+  // Same wake, same numbers, on the internal bus — this is what reaches
+  // main-process listeners the renderer push cannot serve, plugins via
+  // `host.onDidWake` above all (#12175). Emitted after the renderer fan-out so
+  // a throwing bus subscriber cannot cost a window its push. A throw still
+  // aborts the remaining bus listeners, which is why every plugin-facing
+  // listener contains its own callback rather than relying on this guard.
+  try {
+    events.emit("sys:wake", { sleepDuration, timestamp });
+  } catch (error) {
+    console.error("[MAIN] sys:wake listener threw during resume:", error);
+  }
+}
+
 export interface PowerMonitorDeps {
   getPtyClient: () => PtyClient | null;
   getWorkspaceClient: () => WorkspaceClient | null;
@@ -113,38 +147,15 @@ export function setupPowerMonitor(deps: PowerMonitorDeps): void {
         // expired during a long laptop sleep would otherwise sit undetected
         // until the provider's next scheduled probe.
         refreshForgeTokenHealth({ force: true });
-        const wakeTimestamp = Date.now();
-        BrowserWindow.getAllWindows().forEach((win) => {
-          if (win && !win.isDestroyed()) {
-            const wc = getAppWebContents(win);
-            if (!wc.isDestroyed()) {
-              try {
-                wc.send(CHANNELS.EVENTS_PUSH, {
-                  name: "system:wake",
-                  payload: {
-                    sleepDuration,
-                    timestamp: wakeTimestamp,
-                  },
-                });
-              } catch {
-                // Silently ignore send failures during window disposal.
-              }
-            }
-          }
-        });
-        // Same wake, same numbers, on the internal bus — this is what reaches
-        // main-process listeners the renderer push cannot serve, plugins via
-        // `host.onDidWake` above all (#12175). Emitted last and guarded: a
-        // throwing bus subscriber must not swallow the renderer broadcast that
-        // has always happened here.
-        try {
-          events.emit("sys:wake", { sleepDuration, timestamp: wakeTimestamp });
-        } catch (error) {
-          console.error("[MAIN] sys:wake listener threw during resume:", error);
-        }
       } catch (error) {
         console.error("[MAIN] Error during resume:", error);
       }
+      // Announced whether or not the recovery above succeeded. A failed or
+      // partial recovery is exactly when a listener most needs to know the
+      // machine woke: suppressing the signal there would strand every renderer
+      // and every plugin on suspend-era state with nothing to tell them, which
+      // is the unbounded staleness this event exists to end (#12175).
+      publishWake(sleepDuration);
     }, 2000);
   });
 }

--- a/electron/window/powerMonitor.ts
+++ b/electron/window/powerMonitor.ts
@@ -8,6 +8,7 @@ import type { IdleTerminalNotificationService } from "../services/IdleTerminalNo
 import { CHANNELS } from "../ipc/channels.js";
 import { getAppWebContents } from "./webContentsRegistry.js";
 import { getForgeProviderImplEntries } from "../services/forgeProviderRegistry.js";
+import { events } from "../services/events.js";
 import {
   setDiskSpaceMonitorPollInterval,
   refreshDiskSpaceMonitor,
@@ -112,6 +113,7 @@ export function setupPowerMonitor(deps: PowerMonitorDeps): void {
         // expired during a long laptop sleep would otherwise sit undetected
         // until the provider's next scheduled probe.
         refreshForgeTokenHealth({ force: true });
+        const wakeTimestamp = Date.now();
         BrowserWindow.getAllWindows().forEach((win) => {
           if (win && !win.isDestroyed()) {
             const wc = getAppWebContents(win);
@@ -121,7 +123,7 @@ export function setupPowerMonitor(deps: PowerMonitorDeps): void {
                   name: "system:wake",
                   payload: {
                     sleepDuration,
-                    timestamp: Date.now(),
+                    timestamp: wakeTimestamp,
                   },
                 });
               } catch {
@@ -130,6 +132,16 @@ export function setupPowerMonitor(deps: PowerMonitorDeps): void {
             }
           }
         });
+        // Same wake, same numbers, on the internal bus — this is what reaches
+        // main-process listeners the renderer push cannot serve, plugins via
+        // `host.onDidWake` above all (#12175). Emitted last and guarded: a
+        // throwing bus subscriber must not swallow the renderer broadcast that
+        // has always happened here.
+        try {
+          events.emit("sys:wake", { sleepDuration, timestamp: wakeTimestamp });
+        } catch (error) {
+          console.error("[MAIN] sys:wake listener threw during resume:", error);
+        }
       } catch (error) {
         console.error("[MAIN] Error during resume:", error);
       }

--- a/packages/plugin-sdk/api-report/index.d.ts
+++ b/packages/plugin-sdk/api-report/index.d.ts
@@ -1821,6 +1821,34 @@ interface PluginPanelLifecycleEvent {
     readonly phase: PluginPanelLifecyclePhase;
 }
 /**
+ * One machine wake observation delivered to a plugin (#12175). Frozen before
+ * delivery, and carries only timing — never what the machine was doing while
+ * suspended.
+ *
+ * Emitted once per resume, after the host's own settle delay, so the pty and
+ * workspace hosts have already been resynced by the time a plugin reacts.
+ * Suspend has no counterpart event: a plugin cannot reliably run work between
+ * the OS signalling suspend and the process freezing, so only the wake edge is
+ * exposed.
+ */
+interface PluginSystemWakeEvent {
+    /**
+     * Milliseconds the machine spent suspended.
+     *
+     * Measured from the observed suspend to the moment the wake is published, so
+     * it includes the host's settle delay — a coarse "how stale is my state"
+     * figure, not a precise hardware sleep time.
+     *
+     * `0` is a sentinel, not a measurement: it means the matching suspend edge
+     * was never observed (the host started mid-sleep, or the OS delivered resume
+     * without a preceding suspend). Treat `0` as "unknown duration" — do not
+     * compare it against a staleness threshold and conclude the sleep was short.
+     */
+    readonly sleepDuration: number;
+    /** `Date.now()` at the moment the wake was published. */
+    readonly timestamp: number;
+}
+/**
  * Lazily-spawned MCP server contribution (#9235). The declared `command` is
  * launched as a real subprocess the first time its tools are enumerated (not at
  * load time), inheriting `args` and `env`. `${settings:*}` templates inside
@@ -3338,6 +3366,41 @@ interface PluginActivationApi {
      *   is revoked and the subscription is rejected.
      */
     onDidChangePanelLifecycle(callback: (event: PluginPanelLifecycleEvent) => void): Promise<() => void>;
+    /**
+     * Subscribe to the machine waking from sleep (#12175). No capability is
+     * required — the event describes the machine's own suspend/resume timing and
+     * carries nothing about the workspace, the user, or any other plugin.
+     *
+     * This is the signal background work has no other way to get.
+     * {@link onDidChangePanelLifecycle} gives a *view* a re-validation point, but
+     * a plugin's timers, forge providers, and reconciliation passes keep running
+     * against state frozen at suspend. The host's own resume path only re-enables
+     * workspace polling if a window is focused, so a machine that wakes while the
+     * app is blurred leaves that state stale until the user comes back — for an
+     * unbounded stretch, with nothing else announcing the wake.
+     *
+     * Delivered once per resume, after the host has resynced its pty and
+     * workspace hosts, so a plugin that re-reads worktree state from the callback
+     * sees post-wake data rather than racing the host's own recovery. Nothing is
+     * replayed on subscribe: a wake is a one-shot pulse with no resting state, so
+     * a plugin that subscribes after a wake simply waits for the next one.
+     *
+     * The event is machine-scoped, not project-scoped: every loaded instance of
+     * the plugin receives it, including one bound to a project whose window is
+     * not focused.
+     *
+     * Callbacks receive a frozen {@link PluginSystemWakeEvent}. Resolves to a
+     * disposer; calling it more than once is a no-op, and all subscriptions are
+     * disposed automatically when the plugin is unloaded.
+     *
+     * Subscribing is revoke-guarded — call it during `activate()`. The callback
+     * itself fires for the plugin's whole lifetime; only the act of subscribing
+     * is restricted to the activation window.
+     *
+     * @throws {Error} If called after activation resolves or times out — the host
+     *   is revoked and the subscription is rejected.
+     */
+    onDidWake(callback: (event: PluginSystemWakeEvent) => void): Promise<() => void>;
 }
 /**
  * The full host surface handed to a plugin's `activate()`. Extends
@@ -3828,4 +3891,4 @@ type PluginProcessStreamEvent = {
     signal: string | null;
 };
 
-export { type ActionDanger, type ActionDispatchError, type ActionDispatchResult, type ActionDispatchSuccess, type ActionError, type ActionErrorCode, type ActionExample, type ActionHandler, type ActionId, type ActionKind, type AgentState, type AuthValidation, type BuiltInActionId, type BuiltInPluginCapability, type CIStatus, type CheckRun, type CheckRunConclusion, type CheckRunStatus, type ChecksCapability, type ContextMenuContribution, type ContextMenuLocation, type CreateIssueInput, type Credentials, type FetchOptions, type FileDecoration, type FileDecorationContribution, type FileDecorationProviderDescriptor, type FileDecorationProviderImpl, type ForgeLabel, type ForgeProviderContribution, type ForgeProviderDescriptor, type ForgeProviderImpl, type ForgeProviderKind, type ForgeUser, type Issue, type KeybindingContribution, type ListOptions, type McpServerContribution, type MenuItemContribution, type MenuItemLocation, type NormalizedIssueState, type NormalizedPRState, PLUGIN_PROCESS_STREAM_CHANNEL, type PR, type Page, type PanelContribution, type PanelViewProps, type PluginActionContribution, type PluginActionManifestEntry, type PluginActivate, type PluginActivationApi, type PluginAgentSnapshot, type PluginAuthor, type PluginCanDispatchResult, type PluginCapability, type PluginChannelSchema, type PluginClipboardApi, type PluginConfirmOptions, type PluginDuplexProcessHandle, type PluginDuplexProcessSpawnOptions, type PluginFsApi, type PluginFsDirEntry, type PluginFsScope, type PluginFsStat, type PluginGitApi, type PluginGitCommitOptions, type PluginGitCommitResult, type PluginGitStatus, type PluginGitStatusFile, type PluginHostActionsApi, type PluginHostApi, type PluginHostCallOptions, type PluginHostSubscriptionOptions, type PluginInputBoxOptions, type PluginIpcContext, type PluginIpcHandler, type PluginLocalSocketScope, type PluginLogger, type PluginManifest, type PluginManifestScopes, type PluginNetworkScope, type PluginPanelBadge, type PluginPanelBadgeColor, type PluginPanelLifecycleEvent, type PluginPanelLifecyclePhase, type PluginProcessApi, type PluginProcessDataChunk, type PluginProcessHandle, type PluginProcessMode, type PluginProcessSpawnOptions, type PluginProcessStreamEvent, type PluginPtyProcessHandle, type PluginPtyProcessSpawnOptions, type PluginQuickPickItem, type PluginQuickPickOptions, type PluginSettingsScope, type PluginStorageScope, type PluginSystemApi, type PluginToastOptions, type PluginTypedIpcHandler, type PluginWorktreeFileState, type PluginWorktreeLinked, type PluginWorktreeLinkedIssue, type PluginWorktreeLinkedPR, type PluginWorktreeSnapshot, type PluginWorktreeStatus, type PluginWorktreeStatusFile, type PluginWorktreesResult, type PluginWorktreesUnavailableReason, type RateLimitInfo, type RepoMetadata, type RepoRef, type ResourceRef, type SettingDefinition, type SettingFieldType, type SettingsApi, type StorageApi, type ToolbarButtonContribution, type ViewContribution, type ViewLocation, type WaitingReason, localAuthStubs };
+export { type ActionDanger, type ActionDispatchError, type ActionDispatchResult, type ActionDispatchSuccess, type ActionError, type ActionErrorCode, type ActionExample, type ActionHandler, type ActionId, type ActionKind, type AgentState, type AuthValidation, type BuiltInActionId, type BuiltInPluginCapability, type CIStatus, type CheckRun, type CheckRunConclusion, type CheckRunStatus, type ChecksCapability, type ContextMenuContribution, type ContextMenuLocation, type CreateIssueInput, type Credentials, type FetchOptions, type FileDecoration, type FileDecorationContribution, type FileDecorationProviderDescriptor, type FileDecorationProviderImpl, type ForgeLabel, type ForgeProviderContribution, type ForgeProviderDescriptor, type ForgeProviderImpl, type ForgeProviderKind, type ForgeUser, type Issue, type KeybindingContribution, type ListOptions, type McpServerContribution, type MenuItemContribution, type MenuItemLocation, type NormalizedIssueState, type NormalizedPRState, PLUGIN_PROCESS_STREAM_CHANNEL, type PR, type Page, type PanelContribution, type PanelViewProps, type PluginActionContribution, type PluginActionManifestEntry, type PluginActivate, type PluginActivationApi, type PluginAgentSnapshot, type PluginAuthor, type PluginCanDispatchResult, type PluginCapability, type PluginChannelSchema, type PluginClipboardApi, type PluginConfirmOptions, type PluginDuplexProcessHandle, type PluginDuplexProcessSpawnOptions, type PluginFsApi, type PluginFsDirEntry, type PluginFsScope, type PluginFsStat, type PluginGitApi, type PluginGitCommitOptions, type PluginGitCommitResult, type PluginGitStatus, type PluginGitStatusFile, type PluginHostActionsApi, type PluginHostApi, type PluginHostCallOptions, type PluginHostSubscriptionOptions, type PluginInputBoxOptions, type PluginIpcContext, type PluginIpcHandler, type PluginLocalSocketScope, type PluginLogger, type PluginManifest, type PluginManifestScopes, type PluginNetworkScope, type PluginPanelBadge, type PluginPanelBadgeColor, type PluginPanelLifecycleEvent, type PluginPanelLifecyclePhase, type PluginProcessApi, type PluginProcessDataChunk, type PluginProcessHandle, type PluginProcessMode, type PluginProcessSpawnOptions, type PluginProcessStreamEvent, type PluginPtyProcessHandle, type PluginPtyProcessSpawnOptions, type PluginQuickPickItem, type PluginQuickPickOptions, type PluginSettingsScope, type PluginStorageScope, type PluginSystemApi, type PluginSystemWakeEvent, type PluginToastOptions, type PluginTypedIpcHandler, type PluginWorktreeFileState, type PluginWorktreeLinked, type PluginWorktreeLinkedIssue, type PluginWorktreeLinkedPR, type PluginWorktreeSnapshot, type PluginWorktreeStatus, type PluginWorktreeStatusFile, type PluginWorktreesResult, type PluginWorktreesUnavailableReason, type RateLimitInfo, type RepoMetadata, type RepoRef, type ResourceRef, type SettingDefinition, type SettingFieldType, type SettingsApi, type StorageApi, type ToolbarButtonContribution, type ViewContribution, type ViewLocation, type WaitingReason, localAuthStubs };

--- a/packages/plugin-sdk/api-report/index.d.ts
+++ b/packages/plugin-sdk/api-report/index.d.ts
@@ -1825,19 +1825,20 @@ interface PluginPanelLifecycleEvent {
  * delivery, and carries only timing — never what the machine was doing while
  * suspended.
  *
- * Emitted once per resume, after the host's own settle delay, so the pty and
- * workspace hosts have already been resynced by the time a plugin reacts.
- * Suspend has no counterpart event: a plugin cannot reliably run work between
- * the OS signalling suspend and the process freezing, so only the wake edge is
+ * Emitted at most once per resume, after the host's own settle delay and after
+ * it has attempted to resync its pty and workspace hosts. Suspend has no
+ * counterpart event: a plugin cannot reliably run work between the OS
+ * signalling suspend and the process freezing, so only the wake edge is
  * exposed.
  */
 interface PluginSystemWakeEvent {
     /**
      * Milliseconds the machine spent suspended.
      *
-     * Measured from the observed suspend to the moment the wake is published, so
-     * it includes the host's settle delay — a coarse "how stale is my state"
-     * figure, not a precise hardware sleep time.
+     * Measured from the observed suspend to the start of the host's post-wake
+     * recovery, so it includes the settle delay but not however long recovery
+     * itself took — a coarse "how stale is my state" figure, not a precise
+     * hardware sleep time.
      *
      * `0` is a sentinel, not a measurement: it means the matching suspend edge
      * was never observed (the host started mid-sleep, or the OS delivered resume
@@ -3379,11 +3380,17 @@ interface PluginActivationApi {
      * app is blurred leaves that state stale until the user comes back — for an
      * unbounded stretch, with nothing else announcing the wake.
      *
-     * Delivered once per resume, after the host has resynced its pty and
-     * workspace hosts, so a plugin that re-reads worktree state from the callback
-     * sees post-wake data rather than racing the host's own recovery. Nothing is
-     * replayed on subscribe: a wake is a one-shot pulse with no resting state, so
-     * a plugin that subscribes after a wake simply waits for the next one.
+     * Delivered at most once per resume, after the host has attempted to resync
+     * its pty and workspace hosts, so a plugin re-reading worktree state from the
+     * callback is not racing the host's own recovery. That recovery is
+     * best-effort: the wake is announced even when part of it failed, because a
+     * half-recovered host is when a plugin most needs to revalidate. Rapid
+     * resumes coalesce into one delivery, and a re-suspend during the settle
+     * window cancels the wake outright rather than emitting a spurious one.
+     *
+     * Nothing is replayed on subscribe: a wake is a one-shot pulse with no
+     * resting state, so a plugin that subscribes after a wake waits for the next
+     * one.
      *
      * The event is machine-scoped, not project-scoped: every loaded instance of
      * the plugin receives it, including one bound to a project whose window is

--- a/shared/testing/__tests__/createMockHost.test.ts
+++ b/shared/testing/__tests__/createMockHost.test.ts
@@ -429,6 +429,7 @@ describe("createMockHost", () => {
     const dispose = await host.onDidWake(cb);
 
     host.simulateSystemWake({ sleepDuration: 42_000, timestamp: 1234 });
+    expect(cb).toHaveBeenCalledTimes(1);
     expect(cb).toHaveBeenCalledWith({ sleepDuration: 42_000, timestamp: 1234 });
     expect(Object.isFrozen(cb.mock.calls[0]?.[0])).toBe(true);
 

--- a/shared/testing/__tests__/createMockHost.test.ts
+++ b/shared/testing/__tests__/createMockHost.test.ts
@@ -423,6 +423,31 @@ describe("createMockHost", () => {
     expect(cb).toHaveBeenCalledTimes(1);
   });
 
+  it("pushes a frozen wake to onDidWake subscribers and stops on dispose (#12175)", async () => {
+    const host = createMockHost();
+    const cb = vi.fn();
+    const dispose = await host.onDidWake(cb);
+
+    host.simulateSystemWake({ sleepDuration: 42_000, timestamp: 1234 });
+    expect(cb).toHaveBeenCalledWith({ sleepDuration: 42_000, timestamp: 1234 });
+    expect(Object.isFrozen(cb.mock.calls[0]?.[0])).toBe(true);
+
+    dispose();
+    dispose(); // no-op
+    host.simulateSystemWake({ sleepDuration: 1, timestamp: 2 });
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not replay an earlier wake to a later onDidWake subscriber", async () => {
+    const host = createMockHost();
+    host.simulateSystemWake({ sleepDuration: 42_000, timestamp: 1234 });
+
+    const cb = vi.fn();
+    await host.onDidWake(cb);
+
+    expect(cb).not.toHaveBeenCalled();
+  });
+
   it("registers forge providers and unregisters via disposer", async () => {
     const host = createMockHost();
     const impl = { parseRemote: vi.fn() } as unknown as Parameters<

--- a/shared/testing/createMockHost.ts
+++ b/shared/testing/createMockHost.ts
@@ -47,6 +47,7 @@ import type {
   PluginWorktreesResult,
   PluginAgentSnapshot,
   PluginPanelLifecycleEvent,
+  PluginSystemWakeEvent,
   PluginGitCommitResult,
   PluginPanelBadge,
   SettingDefinition,
@@ -207,6 +208,13 @@ export interface MockHostState {
    * `disposeSignal` could not express (#11301).
    */
   simulatePanelLifecycleChange(event: PluginPanelLifecycleEvent): void;
+
+  /**
+   * Push a machine wake to every `onDidWake` subscriber (#12175). Use it to
+   * prove a plugin re-validates state it cached before a sleep, rather than
+   * waiting for a window to regain focus.
+   */
+  simulateSystemWake(event: PluginSystemWakeEvent): void;
 
   /**
    * Pre-seed a deterministic `dispatch()` result for one action id. Overrides
@@ -506,6 +514,7 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
   let lastAgentSnapshot: PluginAgentSnapshot | null = null;
   const agentStateSubs = new Set<(snapshot: PluginAgentSnapshot) => void>();
   const panelLifecycleSubs = new Set<(event: PluginPanelLifecycleEvent) => void>();
+  const systemWakeSubs = new Set<(event: PluginSystemWakeEvent) => void>();
 
   // Capability gating + active-agent presence for the agent APIs (#10617).
   // Default permissive so manifest-free tests are unaffected; restrict to assert
@@ -954,6 +963,18 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
       };
       return Promise.resolve(dispose);
     },
+    onDidWake(callback) {
+      // No capability gate and no replay, matching production: a wake is a
+      // one-shot pulse, so tests drive it explicitly via `simulateSystemWake`.
+      systemWakeSubs.add(callback);
+      let disposed = false;
+      const dispose = () => {
+        if (disposed) return;
+        disposed = true;
+        systemWakeSubs.delete(callback);
+      };
+      return Promise.resolve(dispose);
+    },
     registerForgeProvider(descriptor, impl) {
       // Mirrors PluginService.createHost L1738-L1817. Validation order matches
       // production: non-object descriptor, non-empty string id, non-object impl.
@@ -1368,6 +1389,11 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
       // fails in tests rather than in the wild.
       const frozen = Object.freeze({ ...event });
       for (const cb of [...panelLifecycleSubs]) cb(frozen);
+    },
+    simulateSystemWake(event) {
+      // Frozen like production delivery, for the same reason.
+      const frozen = Object.freeze({ ...event });
+      for (const cb of [...systemWakeSubs]) cb(frozen);
     },
     setDispatchResult(actionId, result) {
       dispatchOverrides.set(actionId, result);

--- a/shared/types/__tests__/plugin-sdk.test.ts
+++ b/shared/types/__tests__/plugin-sdk.test.ts
@@ -20,6 +20,7 @@ import type {
   PanelViewProps,
   PluginPanelLifecycleEvent,
   PluginPanelLifecyclePhase,
+  PluginSystemWakeEvent,
   McpServerContribution,
   PluginCapability,
   BuiltInPluginCapability,
@@ -562,6 +563,20 @@ describe("plugin-sdk boundary", () => {
       expectTypeOf(activation.onDidChangePanelLifecycle).returns.toEqualTypeOf<
         Promise<() => void>
       >();
+    });
+
+    it("exposes the system wake contract as a named SDK type (#12175)", () => {
+      // Named export, not just structural presence: the docs tell authors to
+      // `import type { PluginSystemWakeEvent } from "@daintreehq/plugin-sdk"`.
+      const event = {} as PluginSystemWakeEvent;
+      expectTypeOf(event.sleepDuration).toEqualTypeOf<number>();
+      expectTypeOf(event.timestamp).toEqualTypeOf<number>();
+    });
+
+    it("PluginActivationApi revoke-guards the wake subscription", () => {
+      const activation = {} as PluginActivationApi;
+      expectTypeOf(activation.onDidWake).toBeFunction();
+      expectTypeOf(activation.onDidWake).returns.toEqualTypeOf<Promise<() => void>>();
     });
 
     it("PluginIpcContext has required fields", () => {

--- a/shared/types/plugin-sdk.ts
+++ b/shared/types/plugin-sdk.ts
@@ -47,6 +47,10 @@ export type { PanelViewProps } from "./plugin.js";
 
 export type { PluginPanelLifecycleEvent, PluginPanelLifecyclePhase } from "./plugin.js";
 
+// ── System wake (worker-facing) ─────────────────────────────────────
+
+export type { PluginSystemWakeEvent } from "./plugin.js";
+
 // ── Manifest root ───────────────────────────────────────────────────
 
 export type { PluginManifest, PluginAuthor } from "./plugin.js";

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -314,6 +314,35 @@ export interface PluginPanelLifecycleEvent {
 }
 
 /**
+ * One machine wake observation delivered to a plugin (#12175). Frozen before
+ * delivery, and carries only timing — never what the machine was doing while
+ * suspended.
+ *
+ * Emitted once per resume, after the host's own settle delay, so the pty and
+ * workspace hosts have already been resynced by the time a plugin reacts.
+ * Suspend has no counterpart event: a plugin cannot reliably run work between
+ * the OS signalling suspend and the process freezing, so only the wake edge is
+ * exposed.
+ */
+export interface PluginSystemWakeEvent {
+  /**
+   * Milliseconds the machine spent suspended.
+   *
+   * Measured from the observed suspend to the moment the wake is published, so
+   * it includes the host's settle delay — a coarse "how stale is my state"
+   * figure, not a precise hardware sleep time.
+   *
+   * `0` is a sentinel, not a measurement: it means the matching suspend edge
+   * was never observed (the host started mid-sleep, or the OS delivered resume
+   * without a preceding suspend). Treat `0` as "unknown duration" — do not
+   * compare it against a staleness threshold and conclude the sleep was short.
+   */
+  readonly sleepDuration: number;
+  /** `Date.now()` at the moment the wake was published. */
+  readonly timestamp: number;
+}
+
+/**
  * Lazily-spawned MCP server contribution (#9235). The declared `command` is
  * launched as a real subprocess the first time its tools are enumerated (not at
  * load time), inheriting `args` and `env`. `${settings:*}` templates inside
@@ -2407,6 +2436,41 @@ export interface PluginActivationApi {
   onDidChangePanelLifecycle(
     callback: (event: PluginPanelLifecycleEvent) => void
   ): Promise<() => void>;
+  /**
+   * Subscribe to the machine waking from sleep (#12175). No capability is
+   * required — the event describes the machine's own suspend/resume timing and
+   * carries nothing about the workspace, the user, or any other plugin.
+   *
+   * This is the signal background work has no other way to get.
+   * {@link onDidChangePanelLifecycle} gives a *view* a re-validation point, but
+   * a plugin's timers, forge providers, and reconciliation passes keep running
+   * against state frozen at suspend. The host's own resume path only re-enables
+   * workspace polling if a window is focused, so a machine that wakes while the
+   * app is blurred leaves that state stale until the user comes back — for an
+   * unbounded stretch, with nothing else announcing the wake.
+   *
+   * Delivered once per resume, after the host has resynced its pty and
+   * workspace hosts, so a plugin that re-reads worktree state from the callback
+   * sees post-wake data rather than racing the host's own recovery. Nothing is
+   * replayed on subscribe: a wake is a one-shot pulse with no resting state, so
+   * a plugin that subscribes after a wake simply waits for the next one.
+   *
+   * The event is machine-scoped, not project-scoped: every loaded instance of
+   * the plugin receives it, including one bound to a project whose window is
+   * not focused.
+   *
+   * Callbacks receive a frozen {@link PluginSystemWakeEvent}. Resolves to a
+   * disposer; calling it more than once is a no-op, and all subscriptions are
+   * disposed automatically when the plugin is unloaded.
+   *
+   * Subscribing is revoke-guarded — call it during `activate()`. The callback
+   * itself fires for the plugin's whole lifetime; only the act of subscribing
+   * is restricted to the activation window.
+   *
+   * @throws {Error} If called after activation resolves or times out — the host
+   *   is revoked and the subscription is rejected.
+   */
+  onDidWake(callback: (event: PluginSystemWakeEvent) => void): Promise<() => void>;
 }
 
 /**

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -318,19 +318,20 @@ export interface PluginPanelLifecycleEvent {
  * delivery, and carries only timing — never what the machine was doing while
  * suspended.
  *
- * Emitted once per resume, after the host's own settle delay, so the pty and
- * workspace hosts have already been resynced by the time a plugin reacts.
- * Suspend has no counterpart event: a plugin cannot reliably run work between
- * the OS signalling suspend and the process freezing, so only the wake edge is
+ * Emitted at most once per resume, after the host's own settle delay and after
+ * it has attempted to resync its pty and workspace hosts. Suspend has no
+ * counterpart event: a plugin cannot reliably run work between the OS
+ * signalling suspend and the process freezing, so only the wake edge is
  * exposed.
  */
 export interface PluginSystemWakeEvent {
   /**
    * Milliseconds the machine spent suspended.
    *
-   * Measured from the observed suspend to the moment the wake is published, so
-   * it includes the host's settle delay — a coarse "how stale is my state"
-   * figure, not a precise hardware sleep time.
+   * Measured from the observed suspend to the start of the host's post-wake
+   * recovery, so it includes the settle delay but not however long recovery
+   * itself took — a coarse "how stale is my state" figure, not a precise
+   * hardware sleep time.
    *
    * `0` is a sentinel, not a measurement: it means the matching suspend edge
    * was never observed (the host started mid-sleep, or the OS delivered resume
@@ -2449,11 +2450,17 @@ export interface PluginActivationApi {
    * app is blurred leaves that state stale until the user comes back — for an
    * unbounded stretch, with nothing else announcing the wake.
    *
-   * Delivered once per resume, after the host has resynced its pty and
-   * workspace hosts, so a plugin that re-reads worktree state from the callback
-   * sees post-wake data rather than racing the host's own recovery. Nothing is
-   * replayed on subscribe: a wake is a one-shot pulse with no resting state, so
-   * a plugin that subscribes after a wake simply waits for the next one.
+   * Delivered at most once per resume, after the host has attempted to resync
+   * its pty and workspace hosts, so a plugin re-reading worktree state from the
+   * callback is not racing the host's own recovery. That recovery is
+   * best-effort: the wake is announced even when part of it failed, because a
+   * half-recovered host is when a plugin most needs to revalidate. Rapid
+   * resumes coalesce into one delivery, and a re-suspend during the settle
+   * window cancels the wake outright rather than emitting a spurious one.
+   *
+   * Nothing is replayed on subscribe: a wake is a one-shot pulse with no
+   * resting state, so a plugin that subscribes after a wake waits for the next
+   * one.
    *
    * The event is machine-scoped, not project-scoped: every loaded instance of
    * the plugin receives it, including one bound to a project whose window is

--- a/shared/types/pluginDevWorker.ts
+++ b/shared/types/pluginDevWorker.ts
@@ -96,7 +96,8 @@ export type PluginHostNotifyMethod =
  * process's lifecycle and output callbacks back to the worker, keyed by the
  * handle id carried in `processId`. `panel-lifecycle` streams this plugin's
  * own panel transitions (#11301) — the host replays each live panel's current
- * phase at subscribe time.
+ * phase at subscribe time. `system-wake` streams machine resume pulses
+ * (#12175); nothing is replayed for it, since a pulse has no resting state.
  */
 export type PluginWorkerSubscriptionKind =
   | "active-worktree"
@@ -105,6 +106,7 @@ export type PluginWorkerSubscriptionKind =
   | "storage"
   | "agent-state"
   | "panel-lifecycle"
+  | "system-wake"
   | "process-exit"
   | "process-crash"
   | "process-data";


### PR DESCRIPTION
Resolves #12175

`system:wake` reached every renderer window on resume but never reached a plugin. That left a plugin's timers, forge providers, and reconciliation passes running against state frozen at suspend — and unbounded, because the resume path only re-enables workspace polling when a window is focused. Wake the machine while Daintree is blurred and nothing tells a plugin anything until the user comes back.

## What's here

`host.onDidWake(cb)` on `PluginActivationApi`. Ungated, revoke-guarded, no replay, machine-scoped, frozen `PluginSystemWakeEvent { sleepDuration, timestamp }`.

No capability gate, following `onDidChangePanelLifecycle` rather than `onDidChangeAgentState`: the payload is the machine's own suspend/resume timing, carries nothing about the workspace or the user, and is strictly less than every renderer window already receives unconditionally on the same wake. No existing capability token fits, and inventing one would be disclosure bureaucracy for no authority.

Not project-filtered, unlike agent state. A wake is machine-scoped, and the blurred non-current project is exactly the one whose plugin state went stale.

Backed by a new internal `sys:wake` bus event emitted from the existing debounced resume handler — same values already computed for the renderer push, no second wake-detection path. Mirrored across the dev-worker transport (new `system-wake` subscription kind, re-freeze after the structured-clone hop) so user-installed out-of-process plugins get the same event as builtins, plus `simulateSystemWake` on the mock host.

## One behaviour change worth calling out

The wake is now published whether or not post-wake recovery succeeded. Previously a rejected `waitForReady()` or `refreshOnWake()` swallowed the renderer push too, so a half-recovered host told nobody it had woken — which is the staleness this issue is about. Each window's whole lookup is guarded now, not just `wc.send`.

## Tested

409 targeted tests green across the host factory, the dev-worker proxy and bridge, the mock host, the power monitor, the SDK type surface and EventBuffer. Plus typecheck, scoped eslint/prettier, and a regenerated `api-report`.

## Found while in here, not fixed

Two pre-existing dev-worker issues that affect every subscription kind, not just this one — worth their own issue:

- worker-side plugin callbacks bypass the `invokeTrackedListener` quarantine; a rejected async callback reaches `unhandledRejection` and exits the worker instead of counting toward the 3-failure budget
- an *unexpected* worker respawn doesn't advance `reloadGeneration` the way a deliberate hot reload does, so a replacement proxy's reset subscription ids can overwrite a live disposer

Also: `sys:forge:remote-changed` is missing from `ALL_EVENT_TYPES`, so `EventBuffer` never records it.