### PR TITLE
fix(sound): route sound triggers away from cached project views

### DIFF
--- a/electron/ipc/utils.ts
+++ b/electron/ipc/utils.ts
@@ -417,13 +417,17 @@ export function broadcastToProjectRenderers(
  * - High-frequency streams the renderer can re-fetch on activation (e.g. log
  *   batches via LOGS_GET_ALL) — cached renderers are CPU-throttled or frozen,
  *   so pushed messages would queue unbounded in their task queues.
- * - Ephemeral effects where dropping the event for a cached view is the
- *   correct outcome, not a gap to backfill (e.g. SOUND_TRIGGER — every view
- *   owns an AudioContext, so a global broadcast plays one copy per open
- *   project and un-freezes cached renderers).
+ * - Visibility-scoped effects whose audience is *defined* as the non-cached
+ *   renderers at emission time (e.g. SOUND_TRIGGER — every view owns an
+ *   AudioContext, so a global broadcast plays one copy per open project and
+ *   un-freezes cached renderers). Dropping one must leave no stale state, no
+ *   pending cleanup, and no missed user-significant information.
  *
- * State broadcasts must keep using broadcastToRenderer: cached views have no
- * replay path on warm reactivation (#9490).
+ * If you cannot prove all three, use broadcastToRenderer. "Ephemeral" is not
+ * the test: sound:cancel is a one-shot with nothing to replay, yet it must
+ * reach cached views to stop a voice that started before caching. State
+ * broadcasts likewise stay global — cached views have no replay path on warm
+ * reactivation (#9490).
  */
 export function broadcastToVisibleRenderers(channel: string, ...args: unknown[]): void {
   for (const wc of getAllAppWebContents()) {

--- a/electron/ipc/utils.ts
+++ b/electron/ipc/utils.ts
@@ -412,12 +412,18 @@ export function broadcastToProjectRenderers(
 }
 
 /**
- * Broadcast that skips cached (deactivated) project views. Only for
- * high-frequency streams the renderer can re-fetch on activation (e.g. log
- * batches via LOGS_GET_ALL) — cached renderers are CPU-throttled or frozen, so
- * pushed messages would queue unbounded in their task queues. State broadcasts
- * must keep using broadcastToRenderer: cached views have no replay path on
- * warm reactivation (#9490).
+ * Broadcast that skips cached (deactivated) project views. Two valid uses:
+ *
+ * - High-frequency streams the renderer can re-fetch on activation (e.g. log
+ *   batches via LOGS_GET_ALL) — cached renderers are CPU-throttled or frozen,
+ *   so pushed messages would queue unbounded in their task queues.
+ * - Ephemeral effects where dropping the event for a cached view is the
+ *   correct outcome, not a gap to backfill (e.g. SOUND_TRIGGER — every view
+ *   owns an AudioContext, so a global broadcast plays one copy per open
+ *   project and un-freezes cached renderers).
+ *
+ * State broadcasts must keep using broadcastToRenderer: cached views have no
+ * replay path on warm reactivation (#9490).
  */
 export function broadcastToVisibleRenderers(channel: string, ...args: unknown[]): void {
   for (const wc of getAllAppWebContents()) {

--- a/electron/services/SoundService.ts
+++ b/electron/services/SoundService.ts
@@ -127,12 +127,14 @@ class SoundService {
     this.activeVoices = [];
 
     // Skip the renderer broadcast when no window is listening.
-    // Stays a GLOBAL broadcast even though triggers are visible-only: a view
-    // can be cached after it started (or began decoding) a sound, and caching
-    // never unmounts the listener or disposes its AudioContext. Cancelling is
-    // also what ends the audible state keeping such a renderer awake. Cheap to
-    // send everywhere — cancelSound() returns before touching the context when
-    // a view has nothing playing, so it creates no audio in idle renderers.
+    // Intentionally GLOBAL; do not "make this consistent" with the visible-only
+    // triggers above. A view can be cached after receiving a trigger, and
+    // caching neither unmounts the listener nor disposes its AudioContext, so
+    // cancelSound() must reach it to fade a live voice and advance that view's
+    // cancelGeneration (which is what aborts a pre-cache fetch/decode from
+    // starting a stale sound). Idle receivers return before touching their
+    // context, so this creates no audio; frozen receivers queue the message
+    // until reactivation rather than thawing on it.
     if (BrowserWindow.getAllWindows().length > 0) {
       broadcastToRenderer(CHANNELS.EVENTS_PUSH, { name: "sound:cancel", payload: undefined });
     }
@@ -162,8 +164,7 @@ class SoundService {
     // and falls through gracefully on a miss, so no need to stat here.
     // Visible-only: every project view owns an AudioContext, so a global
     // broadcast plays one copy per open project and wakes frozen cached
-    // renderers (Chromium won't keep an audible page frozen). A missed
-    // trigger is correct — sound is ephemeral with nothing to replay.
+    // renderers — Chromium won't keep an audible page frozen (#12177).
     if (BrowserWindow.getAllWindows().length > 0) {
       const payload: { soundFile: string; detune?: number } = { soundFile };
       if (detune !== undefined) payload.detune = detune;
@@ -196,8 +197,7 @@ class SoundService {
 
     // Try Web Audio via renderer first — renderer fetches via daintree-file://
     // and falls through gracefully on a miss, so no need to stat here.
-    // Visible-only for the same reason as playBypassed: one copy per open
-    // project, and audio playback un-freezes cached renderers.
+    // Visible-only for the same reason as playBypassed (#12177).
     if (BrowserWindow.getAllWindows().length > 0) {
       broadcastToVisibleRenderers(CHANNELS.SOUND_TRIGGER, {
         soundFile,

--- a/electron/services/SoundService.ts
+++ b/electron/services/SoundService.ts
@@ -2,7 +2,7 @@ import path from "path";
 import { existsSync, readdirSync } from "fs";
 import { app, BrowserWindow } from "electron";
 import { playSound, type SoundHandle } from "../utils/soundPlayer.js";
-import { broadcastToRenderer } from "../ipc/utils.js";
+import { broadcastToRenderer, broadcastToVisibleRenderers } from "../ipc/utils.js";
 import { CHANNELS } from "../ipc/channels.js";
 
 export function getSoundsDir(): string {
@@ -127,6 +127,12 @@ class SoundService {
     this.activeVoices = [];
 
     // Skip the renderer broadcast when no window is listening.
+    // Stays a GLOBAL broadcast even though triggers are visible-only: a view
+    // can be cached after it started (or began decoding) a sound, and caching
+    // never unmounts the listener or disposes its AudioContext. Cancelling is
+    // also what ends the audible state keeping such a renderer awake. Cheap to
+    // send everywhere — cancelSound() returns before touching the context when
+    // a view has nothing playing, so it creates no audio in idle renderers.
     if (BrowserWindow.getAllWindows().length > 0) {
       broadcastToRenderer(CHANNELS.EVENTS_PUSH, { name: "sound:cancel", payload: undefined });
     }
@@ -154,10 +160,14 @@ class SoundService {
   private playBypassed(soundFile: string, detune?: number): void {
     // Try Web Audio via renderer first — renderer fetches via daintree-file://
     // and falls through gracefully on a miss, so no need to stat here.
+    // Visible-only: every project view owns an AudioContext, so a global
+    // broadcast plays one copy per open project and wakes frozen cached
+    // renderers (Chromium won't keep an audible page frozen). A missed
+    // trigger is correct — sound is ephemeral with nothing to replay.
     if (BrowserWindow.getAllWindows().length > 0) {
       const payload: { soundFile: string; detune?: number } = { soundFile };
       if (detune !== undefined) payload.detune = detune;
-      broadcastToRenderer(CHANNELS.SOUND_TRIGGER, payload);
+      broadcastToVisibleRenderers(CHANNELS.SOUND_TRIGGER, payload);
       return;
     }
 
@@ -186,8 +196,10 @@ class SoundService {
 
     // Try Web Audio via renderer first — renderer fetches via daintree-file://
     // and falls through gracefully on a miss, so no need to stat here.
+    // Visible-only for the same reason as playBypassed: one copy per open
+    // project, and audio playback un-freezes cached renderers.
     if (BrowserWindow.getAllWindows().length > 0) {
-      broadcastToRenderer(CHANNELS.SOUND_TRIGGER, {
+      broadcastToVisibleRenderers(CHANNELS.SOUND_TRIGGER, {
         soundFile,
         volume: effectiveVolume,
       });

--- a/electron/services/__tests__/SoundService.test.ts
+++ b/electron/services/__tests__/SoundService.test.ts
@@ -124,7 +124,7 @@ describe("SoundService", () => {
 
   // -- Web Audio IPC routing --
 
-  it("sends sound:trigger IPC when renderer is available", () => {
+  it("routes sound:trigger to visible renderers only, never the global broadcast", () => {
     mockGetAllWindows.mockReturnValue([{ id: 1 }]);
 
     soundService.preview("error");
@@ -132,12 +132,7 @@ describe("SoundService", () => {
     expect(mockBroadcastToVisibleRenderers).toHaveBeenCalledWith("sound:trigger", {
       soundFile: "error.wav",
     });
-    // Cached project views each own an AudioContext — a global broadcast would
-    // play one copy per open project and wake frozen renderers (#12177).
-    expect(mockBroadcastToRenderer).not.toHaveBeenCalledWith(
-      "sound:trigger",
-      expect.anything()
-    );
+    expect(mockBroadcastToRenderer).not.toHaveBeenCalled();
     expect(mockPlaySound).not.toHaveBeenCalled();
   });
 
@@ -169,8 +164,7 @@ describe("SoundService", () => {
       name: "sound:cancel",
       payload: undefined,
     });
-    // Cancel stays global on purpose: a view can be cached after starting or
-    // decoding a sound, and caching never disposes its AudioContext (#12177).
+    // Cancel must reach cached views too — see the WHY in SoundService.cancel().
     expect(mockBroadcastToVisibleRenderers).not.toHaveBeenCalled();
     expect(mockCancel).not.toHaveBeenCalled();
   });
@@ -232,7 +226,7 @@ describe("SoundService", () => {
     });
   });
 
-  it("broadcasts sound:trigger with volume via playDampened when windows are available", () => {
+  it("routes dampened sound:trigger to visible renderers only, never the global broadcast", () => {
     mockGetAllWindows.mockReturnValue([{ id: 1 }]);
 
     soundService.play("error");
@@ -241,6 +235,8 @@ describe("SoundService", () => {
       soundFile: "error.wav",
       volume: 1,
     });
+    // Catches an accidental dual-send, which the positive assertion alone would not.
+    expect(mockBroadcastToRenderer).not.toHaveBeenCalled();
     expect(mockPlaySound).not.toHaveBeenCalled();
   });
 

--- a/electron/services/__tests__/SoundService.test.ts
+++ b/electron/services/__tests__/SoundService.test.ts
@@ -46,6 +46,7 @@ const appMock = vi.hoisted(() => ({
 }));
 
 const mockBroadcastToRenderer = vi.hoisted(() => vi.fn());
+const mockBroadcastToVisibleRenderers = vi.hoisted(() => vi.fn());
 const mockGetAllWindows = vi.hoisted(() => vi.fn<() => unknown[]>(() => []));
 
 vi.mock("fs", () => ({
@@ -64,6 +65,7 @@ vi.mock("../../utils/soundPlayer.js", () => ({
 
 vi.mock("../../ipc/utils.js", () => ({
   broadcastToRenderer: mockBroadcastToRenderer,
+  broadcastToVisibleRenderers: mockBroadcastToVisibleRenderers,
 }));
 
 const originalResourcesPath = process.resourcesPath;
@@ -127,9 +129,15 @@ describe("SoundService", () => {
 
     soundService.preview("error");
 
-    expect(mockBroadcastToRenderer).toHaveBeenCalledWith("sound:trigger", {
+    expect(mockBroadcastToVisibleRenderers).toHaveBeenCalledWith("sound:trigger", {
       soundFile: "error.wav",
     });
+    // Cached project views each own an AudioContext — a global broadcast would
+    // play one copy per open project and wake frozen renderers (#12177).
+    expect(mockBroadcastToRenderer).not.toHaveBeenCalledWith(
+      "sound:trigger",
+      expect.anything()
+    );
     expect(mockPlaySound).not.toHaveBeenCalled();
   });
 
@@ -149,6 +157,7 @@ describe("SoundService", () => {
 
     expect(mockPlaySound).toHaveBeenCalled();
     expect(mockBroadcastToRenderer).not.toHaveBeenCalled();
+    expect(mockBroadcastToVisibleRenderers).not.toHaveBeenCalled();
   });
 
   it("cancel sends sound:cancel IPC via broadcast when renderer windows exist", () => {
@@ -160,6 +169,9 @@ describe("SoundService", () => {
       name: "sound:cancel",
       payload: undefined,
     });
+    // Cancel stays global on purpose: a view can be cached after starting or
+    // decoding a sound, and caching never disposes its AudioContext (#12177).
+    expect(mockBroadcastToVisibleRenderers).not.toHaveBeenCalled();
     expect(mockCancel).not.toHaveBeenCalled();
   });
 
@@ -215,7 +227,7 @@ describe("SoundService", () => {
 
     soundService.preview("chime");
 
-    expect(mockBroadcastToRenderer).toHaveBeenCalledWith("sound:trigger", {
+    expect(mockBroadcastToVisibleRenderers).toHaveBeenCalledWith("sound:trigger", {
       soundFile: "chime.wav",
     });
   });
@@ -225,7 +237,7 @@ describe("SoundService", () => {
 
     soundService.play("error");
 
-    expect(mockBroadcastToRenderer).toHaveBeenCalledWith("sound:trigger", {
+    expect(mockBroadcastToVisibleRenderers).toHaveBeenCalledWith("sound:trigger", {
       soundFile: "error.wav",
       volume: 1,
     });
@@ -249,7 +261,7 @@ describe("SoundService", () => {
 
     soundService.playPulse("pulse.wav", 12);
 
-    expect(mockBroadcastToRenderer).toHaveBeenCalledWith("sound:trigger", {
+    expect(mockBroadcastToVisibleRenderers).toHaveBeenCalledWith("sound:trigger", {
       soundFile: "pulse.wav",
       detune: 12,
     });
@@ -261,7 +273,7 @@ describe("SoundService", () => {
 
     soundService.playPulse("pulse.wav");
 
-    expect(mockBroadcastToRenderer).toHaveBeenCalledWith("sound:trigger", {
+    expect(mockBroadcastToVisibleRenderers).toHaveBeenCalledWith("sound:trigger", {
       soundFile: "pulse.wav",
     });
   });
@@ -271,7 +283,7 @@ describe("SoundService", () => {
 
     soundService.playPulse("pulse.wav", 0);
 
-    expect(mockBroadcastToRenderer).toHaveBeenCalledWith("sound:trigger", {
+    expect(mockBroadcastToVisibleRenderers).toHaveBeenCalledWith("sound:trigger", {
       soundFile: "pulse.wav",
       detune: 0,
     });
@@ -283,6 +295,7 @@ describe("SoundService", () => {
     soundService.playPulse("pulse.wav", 12);
 
     expect(mockBroadcastToRenderer).not.toHaveBeenCalled();
+    expect(mockBroadcastToVisibleRenderers).not.toHaveBeenCalled();
     expect(mockPlaySound).toHaveBeenCalledWith(expect.stringContaining("pulse.wav"));
     expect(mockPlaySound.mock.calls[0][1]).toBeUndefined();
   });

--- a/electron/window/webContentsRegistry.ts
+++ b/electron/window/webContentsRegistry.ts
@@ -43,11 +43,13 @@ const projectViewDestroyListeners = new Map<
   { webContents: WebContents; listener: () => void }
 >();
 
-// Cached (deactivated) project views. High-frequency, replayable streams (log
-// batches) skip these renderers — a CPU-throttled/frozen renderer has no
-// backpressure, so pushed messages pile up in its task queue. State broadcasts
-// (project added/updated/removed, etc.) must NOT consult this set: cached views
-// have no replay path on warm reactivation (#9490).
+// Cached (deactivated) project views. Two kinds of send skip these renderers:
+// high-frequency replayable streams (log batches), because a CPU-throttled/
+// frozen renderer has no backpressure and pushed messages pile up in its task
+// queue; and visibility-scoped effects (sound triggers), where a cached view
+// playing along is the bug itself (#12177). State broadcasts and cleanup
+// commands must NOT consult this set: cached views have no replay path on warm
+// reactivation (#9490).
 const cachedViewWebContents = new Set<number>();
 
 // Memoized getAllAppWebContents() result. broadcastToRenderer() calls it on


### PR DESCRIPTION
Summary: SoundService sent `sound:trigger` through `broadcastToRenderer`, which reaches every window's active app view AND every cached project view. Each project view is its own WebContentsView with its own module-level AudioContext and its own `useSoundPlaybackListener`, so one notification played the same WAV once per open project, simultaneously — louder and phasier the more projects were open. Worse, Web Audio playback sets Chromium's `is_audible` flag, and Chromium will not keep an audible page frozen, so every sound jolted every backgrounded project renderer awake — the exact opposite of what the efficiency-freeze path is for.

The fix: both `SOUND_TRIGGER` sends (in `playBypassed` and `playDampened`) now go through `broadcastToVisibleRenderers`, which skips cached views. `sound:cancel` deliberately stays on `broadcastToRenderer`.

Why cancel stays global (the load-bearing decision): a view can be cached after it received a trigger, and caching neither unmounts the listener nor disposes the AudioContext. `cancelSound()` must reach it to fade a live voice and advance that view's `cancelGeneration`, which is what stops an in-flight fetch/decode from starting a stale sound. It is cheap to send everywhere — `cancelSound()` returns before touching the context when a view has nothing playing, so it creates no audio in idle renderers, and a frozen renderer queues the message until reactivation rather than thawing on it. Note that `MAX_SOUND_DURATION_MS = 600` is not a playback cap — it only prunes main-process OS-fallback bookkeeping, and `all-clear.wav` outlives it — so "the sound would have ended anyway" is not a safe assumption.

The `broadcastToVisibleRenderers` doc contract previously read as forbidding this use ("only for high-frequency streams the renderer can re-fetch"). It now describes two valid categories and is explicit that "ephemeral" is the wrong test — `sound:cancel` is a one-shot with nothing to replay, yet must stay global. The `cachedViewWebContents` comment in webContentsRegistry.ts got a matching update.

Verified no silent-drop regression: the OS-fallback decision is still gated on `BrowserWindow.getAllWindows().length > 0` while the delivery set is now "minus cached views", so I checked whether that set can be empty while a window exists. It cannot on any normal path — `getAllAppWebContents()` falls back to raw BrowserWindow webContents when nothing is registered (never marked cached), `activateView()` does `registerAppView` then `unregisterCachedViewWebContents` with no await between them, and the close/destroy/LRU-eviction/hibernation paths all exclude the active and outgoing bridge views. Confirmed independently by two Codex review passes.

Known limitations (deliberately out of scope, worth separate issues): (1) during a warm project switch the incoming view becomes non-cached before the outgoing view is cached, so for roughly 500-1500 ms a trigger still reaches both and plays twice in one window; exact-once needs a per-window "ready audio owner" with a real renderer-readiness signal, which is a new subsystem rather than a bugfix. (2) `SOUND_TRIGGER` is a direct, non-buffered subscription mounted only after hydration, so a non-cached but not-yet-hydrated renderer can drop a trigger with no OS fallback — largely pre-existing, though this change removes the accidental masking a cached sibling used to provide. (3) Unrelated pre-existing bug spotted in passing: `playDampened` sends a `volume` field that the preload bridge, the hook, and `WebAudioService.playSound()` all drop, so main-process volume dampening is currently inert; the `unknown[]` broadcast signature hides it from typecheck.

The screen-flash observation in the issue is untouched — it was flagged as a hypothesis, not a diagnosis, and nothing here confirms or refutes it.

Testing: `npm test` on SoundService, ipc/utils, webContentsRegistry and the three AgentNotificationService suites — 235 tests pass. eslint and prettier clean on all four changed files. The six positive `sound:trigger` assertions moved to the visible-broadcast mock, and cross-negative assertions now pin the split in both directions (triggers never use the global helper on either the bypassed or dampened path; cancel never uses the visible one).

Resolves #12177

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XrnMF3MsP81PcPSPX9eRLg