### PR TITLE
fix(plugins): distinguish unavailable worktree reads from empty

### DIFF
--- a/docs/plugins/host-api.md
+++ b/docs/plugins/host-api.md
@@ -281,7 +281,7 @@ type PluginWorktreesUnavailableReason =
   | "fetch-failed"; // a live host was asked and the read threw
 ```
 
-`status: "ok"` is the only authoritative answer, and it names the project it describes. That second half matters as much as the first: an app-global (unbound) plugin reads whichever project is focused, and mid-switch that can still be the *outgoing* project — so a populated list that omits the worktree you are looking for may simply belong to a different project rather than confirm a mismatch. Compare `projectId` before drawing any conclusion from the contents.
+`status: "ok"` is the only authoritative answer, and it names the project it describes. That second half matters as much as the first: an app-global (unbound) plugin reads whichever project is focused, and mid-switch that can still be the _outgoing_ project — so a populated list that omits the worktree you are looking for may simply belong to a different project rather than confirm a mismatch. Compare `projectId` before drawing any conclusion from the contents.
 
 Guard a binding validator like this:
 

--- a/docs/plugins/host-api.md
+++ b/docs/plugins/host-api.md
@@ -53,6 +53,7 @@ interface PluginHostApi {
   // Worktree observation
   getActiveWorktree(): Promise<PluginWorktreeSnapshot | null>;
   getWorktrees(): Promise<PluginWorktreeSnapshot[]>;
+  getWorktreesResult(): Promise<PluginWorktreesResult>;
   getWorktreeStatus(path: string): Promise<PluginWorktreeStatus | null>;
   onDidChangeActiveWorktree(
     callback: (snapshot: PluginWorktreeSnapshot | null) => void
@@ -260,6 +261,46 @@ const dispose = await host.onDidChangeActiveWorktree((snapshot) => {
 
 // Later: dispose() to unsubscribe (automatic on plugin unload)
 ```
+
+### Telling "unavailable" from "empty"
+
+`getWorktrees()` answers `[]` for seven different situations, and `getActiveWorktree()` answers `null` for the same set: the plugin is unloading, no workspace client is wired, no window scope resolves, the host's binding names a project with no root, the bound project has closed, the read failed — and, legitimately, the project genuinely has no worktrees. That sentinel is deliberate and stays: it fails closed, so a plugin never receives some other project's worktrees by accident (#11297, #9492). But it means a plugin cannot tell an unavailable answer from an authoritative empty one, and a validator that treats "my worktree isn't in this list" as "my worktree is gone" will fire spuriously during a project switch or after the machine wakes.
+
+`getWorktreesResult()` is the same read with that ambiguity removed (#12174):
+
+```ts
+type PluginWorktreesResult =
+  | { status: "ok"; projectId: string; worktrees: PluginWorktreeSnapshot[] }
+  | { status: "unavailable"; reason: PluginWorktreesUnavailableReason };
+
+type PluginWorktreesUnavailableReason =
+  | "plugin-unloaded" // unloaded, or replaced by a same-id reload, mid-read
+  | "workspace-unavailable" // no workspace client yet, or the host missed its readiness gate
+  | "scope-unresolved" // an app-global plugin found no focused project view
+  | "project-unavailable" // a bound host's project has no root, or has closed
+  | "fetch-failed"; // a live host was asked and the read threw
+```
+
+`status: "ok"` is the only authoritative answer, and it names the project it describes. That second half matters as much as the first: an app-global (unbound) plugin reads whichever project is focused, and mid-switch that can still be the *outgoing* project — so a populated list that omits the worktree you are looking for may simply belong to a different project rather than confirm a mismatch. Compare `projectId` before drawing any conclusion from the contents.
+
+Guard a binding validator like this:
+
+```ts
+const result = await host.getWorktreesResult();
+
+// No answer — keep whatever you cached and try again later. Do not diagnose.
+if (result.status !== "ok") return;
+
+// A valid answer, but about a different project than the one you care about.
+if (result.projectId !== storedProjectId) return;
+
+const match = result.worktrees.find((w) => w.worktreeId === storedWorktreeId);
+if (!match) {
+  // Only now is the absence authoritative.
+}
+```
+
+Like `getWorktrees()`, this never throws: once the plugin unloads it degrades to `{ status: "unavailable", reason: "plugin-unloaded" }`. `getWorktrees()` and `getActiveWorktree()` are unchanged and remain the right call when a missing worktree is not load-bearing.
 
 **`PluginWorktreeSnapshot` shape:**
 

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -127,6 +127,7 @@ import {
   createHost as createPluginHost,
   type PluginHostFactoryDeps,
   type PluginWorktreeEventPayload,
+  type PluginWorktreeSnapshotFetchResult,
 } from "./plugin/PluginHostFactory.js";
 import type {
   LoadedPlugin,
@@ -2751,9 +2752,9 @@ export class PluginService {
       getHostGitFactory: () => this.hostGitFactory,
       getProcessManager: () => this.getProcessManager(),
       declaredCapabilities: (pluginId) => this.declaredCapabilities(pluginId),
-      fetchAllWorktreeSnapshots: () => this.fetchAllWorktreeSnapshots(),
-      fetchWorktreeSnapshotsForProject: (projectId, projectRoot) =>
-        this.fetchWorktreeSnapshotsForProject(projectId, projectRoot),
+      fetchWorktreeSnapshotsResult: () => this.fetchAllWorktreeSnapshotsResult(),
+      fetchWorktreeSnapshotsForProjectResult: (projectId, projectRoot) =>
+        this.fetchWorktreeSnapshotsForProjectResult(projectId, projectRoot),
       recordPluginLog: (boundPlugin, pluginId, level, message, fields) =>
         this.recordPluginLog(boundPlugin, pluginId, level, message, fields),
       serializePluginBadges: (pluginId) => this.serializePluginBadges(pluginId),
@@ -3127,15 +3128,33 @@ export class PluginService {
    * project's worktree, which is exactly the bug being fixed.
    */
   private async fetchAllWorktreeSnapshots(): Promise<WorktreeSnapshot[]> {
+    const result = await this.fetchAllWorktreeSnapshotsResult();
+    return result.status === "ok" ? result.snapshots : [];
+  }
+
+  /**
+   * {@link fetchAllWorktreeSnapshots} keeping the reason it has nothing and the
+   * project the snapshots belong to (#12174), for `host.getWorktreesResult()`.
+   *
+   * Every branch that flattens to `[]` above maps to a distinct `reason` here.
+   * Nothing about the containment posture changes: this still never widens to
+   * the cross-project aggregate, and the array-shaped read above is unchanged
+   * for storage, `${worktree}`/`${project}` allowlist roots and the spawn cwd —
+   * they keep failing closed on an empty list rather than learning a new shape.
+   */
+  private async fetchAllWorktreeSnapshotsResult(): Promise<PluginWorktreeSnapshotFetchResult> {
     const client = this.workspaceClient;
-    if (!client) return [];
+    if (!client) return { status: "unavailable", reason: "workspace-unavailable" };
     const windowId = this.resolveScopeWindowId();
-    if (windowId === undefined) return [];
+    if (windowId === undefined) return { status: "unavailable", reason: "scope-unresolved" };
     try {
-      return await client.getAllStatesAsync(windowId);
+      const result = await client.getAllStatesResultAsync(windowId);
+      return result.status === "ok"
+        ? { status: "ok", projectId: result.projectId, snapshots: result.states }
+        : { status: "unavailable", reason: result.reason };
     } catch (err) {
       console.error("[PluginService] Failed to fetch worktree snapshots:", err);
-      return [];
+      return { status: "unavailable", reason: "fetch-failed" };
     }
   }
 
@@ -3158,16 +3177,34 @@ export class PluginService {
     projectId: string,
     projectRoot: string
   ): Promise<WorktreeSnapshot[]> {
+    const result = await this.fetchWorktreeSnapshotsForProjectResult(projectId, projectRoot);
+    return result.status === "ok" ? result.snapshots : [];
+  }
+
+  /**
+   * {@link fetchWorktreeSnapshotsForProject} keeping the reason it has nothing
+   * (#12174). A closed project — pool entry gone, or the path reopened as a
+   * different project so `expectedProjectId` no longer matches — reports
+   * `project-unavailable` instead of the `[]` a live project with no worktrees
+   * returns, which is the whole distinction the plugin side was missing.
+   */
+  private async fetchWorktreeSnapshotsForProjectResult(
+    projectId: string,
+    projectRoot: string
+  ): Promise<PluginWorktreeSnapshotFetchResult> {
     const client = this.workspaceClient;
-    if (!client) return [];
+    if (!client) return { status: "unavailable", reason: "workspace-unavailable" };
     try {
-      return await client.getAllStatesForProjectAsync(projectRoot, projectId);
+      const result = await client.getAllStatesForProjectResultAsync(projectRoot, projectId);
+      return result.status === "ok"
+        ? { status: "ok", projectId: result.projectId, snapshots: result.states }
+        : { status: "unavailable", reason: result.reason };
     } catch (err) {
       console.error(
         `[PluginService] Failed to fetch worktree snapshots for project ${projectId}:`,
         err
       );
-      return [];
+      return { status: "unavailable", reason: "fetch-failed" };
     }
   }
 

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -3145,9 +3145,12 @@ export class PluginService {
   private async fetchAllWorktreeSnapshotsResult(): Promise<PluginWorktreeSnapshotFetchResult> {
     const client = this.workspaceClient;
     if (!client) return { status: "unavailable", reason: "workspace-unavailable" };
-    const windowId = this.resolveScopeWindowId();
-    if (windowId === undefined) return { status: "unavailable", reason: "scope-unresolved" };
     try {
+      // Inside the try: scope resolution walks the live window/view registries,
+      // and a throw there must degrade like any other failed read rather than
+      // reject into a plugin's timer.
+      const windowId = this.resolveScopeWindowId();
+      if (windowId === undefined) return { status: "unavailable", reason: "scope-unresolved" };
       const result = await client.getAllStatesResultAsync(windowId);
       return result.status === "ok"
         ? { status: "ok", projectId: result.projectId, snapshots: result.states }

--- a/electron/services/WorkspaceClient.ts
+++ b/electron/services/WorkspaceClient.ts
@@ -113,6 +113,20 @@ export interface HostWorktreeStates {
   gitBacked: boolean | null;
 }
 
+/**
+ * A states read that keeps *why* it has nothing to say (#12174).
+ *
+ * The array-shaped reads collapse "no host for this project", "the host never
+ * became ready" and "this project has no worktrees" all to `[]`, which is the
+ * right sentinel for callers that must fail closed but leaves a plugin unable
+ * to tell an unavailable answer from an authoritative empty one. This shape
+ * keeps the distinction, and names the project from the entry that actually
+ * served the read so an in-flight project switch cannot relabel it.
+ */
+export type WorkspaceStatesResult =
+  | { status: "ok"; projectId: string; states: WorktreeSnapshot[] }
+  | { status: "unavailable"; reason: "workspace-unavailable" | "project-unavailable" };
+
 export class WorkspaceClient extends EventEmitter {
   private isDisposed = false;
   private pool: WorkspaceHostPool;
@@ -121,6 +135,7 @@ export class WorkspaceClient extends EventEmitter {
 
   private readonly _statesInflight = new Map<string, Promise<WorktreeSnapshot[]>>();
   private readonly _statesWithGitBackedInflight = new Map<string, Promise<HostWorktreeStates>>();
+  private readonly _statesResultInflight = new Map<string, Promise<WorkspaceStatesResult>>();
 
   constructor(config: WorkspaceClientConfig = {}) {
     super();
@@ -130,6 +145,7 @@ export class WorkspaceClient extends EventEmitter {
       emit: this.emit.bind(this),
       onProjectSwitch: (windowId) => {
         this._statesInflight.delete(`w:${windowId}`);
+        this._statesResultInflight.delete(`w:${windowId}`);
       },
     });
 
@@ -655,6 +671,111 @@ export class WorkspaceClient extends EventEmitter {
     );
     this._statesInflight.set(key, promise);
     return promise;
+  }
+
+  /**
+   * {@link getAllStatesAsync} for one window, keeping *why* it has no states
+   * and which project the states it does have belong to (#12174).
+   *
+   * The array-shaped read answers `[]` for a window that maps to no host, a
+   * host that never became ready, and a project with no worktrees alike. The
+   * plugin host API needs those apart: a plugin that reads "not in the list" as
+   * "deleted" false-positives during a project switch, when the focused view
+   * this window resolves through can still be the outgoing project's.
+   *
+   * `projectId` comes from the entry captured for this read, so a switch that
+   * lands mid-flight cannot relabel an already-captured answer as the incoming
+   * project's.
+   *
+   * Coalesced through its own map for the same reason
+   * {@link getAllStatesWithGitBackedForProjectAsync} is: callers of the
+   * array-shaped methods rely on getting the same promise object back for
+   * concurrent equivalent calls, which deriving one from the other would break.
+   */
+  getAllStatesResultAsync(windowId: number): Promise<WorkspaceStatesResult> {
+    return this._coalesceStatesResult(`w:${windowId}`, () => {
+      if (this.isDisposed) {
+        return Promise.resolve({ status: "unavailable", reason: "workspace-unavailable" as const });
+      }
+      const entry = this.pool.resolveEntryForWindow(windowId);
+      if (!entry) {
+        return Promise.resolve({ status: "unavailable", reason: "project-unavailable" as const });
+      }
+      return this._readStatesResultWhenReady(entry);
+    });
+  }
+
+  /**
+   * {@link getAllStatesForProjectAsync} in the {@link WorkspaceStatesResult}
+   * shape (#12174). Same entry resolution and same `expectedProjectId` guard —
+   * a missing pool entry and an id mismatch both report `project-unavailable`
+   * rather than the `[]` that reads as "this project has no worktrees".
+   */
+  getAllStatesForProjectResultAsync(
+    projectPath: string,
+    expectedProjectId: string
+  ): Promise<WorkspaceStatesResult> {
+    const normalized = this.pool.normalizeProjectPath(projectPath);
+    return this._coalesceStatesResult(`p:${expectedProjectId}:${normalized}`, () => {
+      if (this.isDisposed) {
+        return Promise.resolve({ status: "unavailable", reason: "workspace-unavailable" as const });
+      }
+      const entry = this.pool.entries.get(normalized);
+      if (entry === undefined || entry.projectId !== expectedProjectId) {
+        return Promise.resolve({ status: "unavailable", reason: "project-unavailable" as const });
+      }
+      return this._readStatesResultWhenReady(entry);
+    });
+  }
+
+  /**
+   * Shared coalescing for the result-shaped reads, mirroring the array-shaped
+   * methods: a resolved entry lingers for the short overlap window so a burst
+   * of equivalent calls shares one host round trip, a rejected one is evicted
+   * immediately so the next call retries rather than replaying the failure.
+   */
+  private _coalesceStatesResult(
+    key: string,
+    read: () => Promise<WorkspaceStatesResult>
+  ): Promise<WorkspaceStatesResult> {
+    const existing = this._statesResultInflight.get(key);
+    if (existing) return existing;
+    const promise = read().then(
+      (result) => {
+        setTimeout(
+          () => this._statesResultInflight.delete(key),
+          STATES_INFLIGHT_COALESCE_WINDOW_MS
+        );
+        return result;
+      },
+      (error: unknown) => {
+        this._statesResultInflight.delete(key);
+        throw error;
+      }
+    );
+    this._statesResultInflight.set(key, promise);
+    return promise;
+  }
+
+  /**
+   * {@link _readStatesWhenReady} keeping the readiness verdict instead of
+   * flattening it into the same `[]` a genuinely empty host returns.
+   *
+   * A host that failed or hung past the ready gate reports
+   * `workspace-unavailable` — "unknown, ask again" — never an empty list, which
+   * a plugin would read as "this project has no worktrees". The RPC itself is
+   * left to reject so the caller can log and report it separately.
+   */
+  private async _readStatesResultWhenReady(entry: ProcessEntry): Promise<WorkspaceStatesResult> {
+    if (!(await this._awaitHostReady(entry))) {
+      return { status: "unavailable", reason: "workspace-unavailable" };
+    }
+    const requestId = entry.host.generateRequestId();
+    const result = await entry.host.sendWithResponse<{ states: WorktreeSnapshot[] }>({
+      type: "get-all-states",
+      requestId,
+    });
+    return { status: "ok", projectId: entry.projectId, states: result.states };
   }
 
   /**
@@ -1221,6 +1342,7 @@ export class WorkspaceClient extends EventEmitter {
     this.pool.dispose();
     this._statesInflight.clear();
     this._statesWithGitBackedInflight.clear();
+    this._statesResultInflight.clear();
     this.removeAllListeners();
   }
 }

--- a/electron/services/WorkspaceClient.ts
+++ b/electron/services/WorkspaceClient.ts
@@ -698,8 +698,14 @@ export class WorkspaceClient extends EventEmitter {
         return Promise.resolve({ status: "unavailable", reason: "workspace-unavailable" as const });
       }
       const entry = this.pool.resolveEntryForWindow(windowId);
+      // No host serves this window *yet* — the mapping is established at the end
+      // of `loadProject`, so a window mid-open lands here. That is the workspace
+      // layer not being ready, not a project that has gone away.
       if (!entry) {
-        return Promise.resolve({ status: "unavailable", reason: "project-unavailable" as const });
+        return Promise.resolve({
+          status: "unavailable",
+          reason: "workspace-unavailable" as const,
+        });
       }
       return this._readStatesResultWhenReady(entry);
     });
@@ -740,16 +746,21 @@ export class WorkspaceClient extends EventEmitter {
   ): Promise<WorkspaceStatesResult> {
     const existing = this._statesResultInflight.get(key);
     if (existing) return existing;
-    const promise = read().then(
+    // Identity-guarded: a project switch (or any other invalidation) can delete
+    // this key and a fresh read insert its own promise under it before this
+    // one's eviction fires, and the old promise must not drop the new entry.
+    const evict = (): void => {
+      if (this._statesResultInflight.get(key) === promise) {
+        this._statesResultInflight.delete(key);
+      }
+    };
+    const promise: Promise<WorkspaceStatesResult> = read().then(
       (result) => {
-        setTimeout(
-          () => this._statesResultInflight.delete(key),
-          STATES_INFLIGHT_COALESCE_WINDOW_MS
-        );
+        setTimeout(evict, STATES_INFLIGHT_COALESCE_WINDOW_MS);
         return result;
       },
       (error: unknown) => {
-        this._statesResultInflight.delete(key);
+        evict();
         throw error;
       }
     );

--- a/electron/services/__tests__/PluginService.hostApiMisc.test.ts
+++ b/electron/services/__tests__/PluginService.hostApiMisc.test.ts
@@ -516,6 +516,11 @@ describe("Plugin worktree host API", () => {
     _secret?: string;
   };
 
+  /** Mirror of WorkspaceClient's WorkspaceStatesResult over the local snapshot shape. */
+  type StatesResultLike =
+    | { status: "ok"; projectId: string; states: WorktreeSnapshotLike[] }
+    | { status: "unavailable"; reason: "workspace-unavailable" | "project-unavailable" };
+
   function mkSnap(over: Partial<WorktreeSnapshotLike> & { id: string }): WorktreeSnapshotLike {
     return {
       worktreeId: over.id,
@@ -544,8 +549,14 @@ describe("Plugin worktree host API", () => {
     const getAllStatesAsync = vi.fn((windowId?: number) =>
       Promise.resolve(windowId === undefined ? foreign : states)
     );
+    // The result-shaped read behind `host.getWorktreesResult()` (#12174). Same
+    // states, plus the id of the project the serving host belongs to.
+    const getAllStatesResultAsync = vi.fn((_windowId: number): Promise<StatesResultLike> =>
+      Promise.resolve({ status: "ok", projectId: "project-1", states })
+    );
     const client = Object.assign(emitter, {
       getAllStatesAsync,
+      getAllStatesResultAsync,
       setStates: (next: WorktreeSnapshotLike[]) => {
         states = next;
       },
@@ -559,6 +570,7 @@ describe("Plugin worktree host API", () => {
     broadcastToRenderer: (c: string, p: unknown) => void;
     getActiveWorktree: () => Promise<unknown>;
     getWorktrees: () => Promise<unknown[]>;
+    getWorktreesResult: () => Promise<unknown>;
     getWorktreeStatus: (path: string) => Promise<unknown>;
     onDidChangeActiveWorktree: (cb: (s: unknown) => void) => () => void;
     onDidChangeWorktrees: (cb: (list: unknown[]) => void) => () => void;
@@ -608,7 +620,7 @@ describe("Plugin worktree host API", () => {
     await host.getActiveWorktree();
     // Not called bare: an unscoped fetch aggregates every open project and
     // hands back whichever `isCurrent` snapshot happens to sort first.
-    expect(client.getAllStatesAsync).toHaveBeenCalledWith(1);
+    expect(client.getAllStatesResultAsync).toHaveBeenCalledWith(1);
   });
 
   it("returns empty rather than a cross-project aggregate when no window resolves", async () => {
@@ -618,6 +630,7 @@ describe("Plugin worktree host API", () => {
     expect(await host.getWorktrees()).toEqual([]);
     expect(await host.getActiveWorktree()).toBeNull();
     // The unscoped call is the bug — it must never be reached.
+    expect(client.getAllStatesResultAsync).not.toHaveBeenCalled();
     expect(client.getAllStatesAsync).not.toHaveBeenCalled();
   });
 
@@ -626,6 +639,7 @@ describe("Plugin worktree host API", () => {
     webContentsRegistryMock.getWindowForWebContents.mockReturnValue(null);
 
     expect(await host.getWorktrees()).toEqual([]);
+    expect(client.getAllStatesResultAsync).not.toHaveBeenCalled();
     expect(client.getAllStatesAsync).not.toHaveBeenCalled();
   });
 
@@ -690,6 +704,95 @@ describe("Plugin worktree host API", () => {
     await expect(
       (service as unknown as ServiceWithWindowLookup).getActiveWorktreeIdForWindow(7)
     ).resolves.toBeNull();
+  });
+
+  // ── #12174: telling an unavailable read from an empty project ──
+
+  it("names the project a successful read describes", async () => {
+    const { host, client } = await setup([mkSnap({ id: "b", isCurrent: true })]);
+
+    expect(await host.getWorktreesResult()).toEqual({
+      status: "ok",
+      projectId: "project-1",
+      worktrees: [expect.objectContaining({ id: "b" })],
+    });
+    expect(client.getAllStatesResultAsync).toHaveBeenCalledWith(1);
+  });
+
+  it("reports an authoritative empty project rather than an unavailable one", async () => {
+    const { host } = await setup([]);
+
+    expect(await host.getWorktreesResult()).toEqual({
+      status: "ok",
+      projectId: "project-1",
+      worktrees: [],
+    });
+    // The legacy surface still cannot tell this from any of the failures below.
+    expect(await host.getWorktrees()).toEqual([]);
+  });
+
+  it("reports scope-unresolved when no window resolves", async () => {
+    const { host, client } = await setup([mkSnap({ id: "b", isCurrent: true })]);
+    windowRefMock.getProjectViewManager.mockReturnValue(null);
+
+    expect(await host.getWorktreesResult()).toEqual({
+      status: "unavailable",
+      reason: "scope-unresolved",
+    });
+    expect(await host.getWorktrees()).toEqual([]);
+    expect(client.getAllStatesResultAsync).not.toHaveBeenCalled();
+  });
+
+  it("reports scope-unresolved when the resolved webContents maps to no window", async () => {
+    const { host, client } = await setup([mkSnap({ id: "b", isCurrent: true })]);
+    webContentsRegistryMock.getWindowForWebContents.mockReturnValue(null);
+
+    expect(await host.getWorktreesResult()).toEqual({
+      status: "unavailable",
+      reason: "scope-unresolved",
+    });
+    expect(client.getAllStatesResultAsync).not.toHaveBeenCalled();
+  });
+
+  it("passes the workspace layer's own unavailability through", async () => {
+    const { host, client } = await setup([mkSnap({ id: "b", isCurrent: true })]);
+    client.getAllStatesResultAsync.mockResolvedValueOnce({
+      status: "unavailable",
+      reason: "workspace-unavailable",
+    });
+
+    expect(await host.getWorktreesResult()).toEqual({
+      status: "unavailable",
+      reason: "workspace-unavailable",
+    });
+  });
+
+  it("reports fetch-failed when the workspace read throws", async () => {
+    const { host, client } = await setup([mkSnap({ id: "b", isCurrent: true })]);
+    client.getAllStatesResultAsync.mockRejectedValueOnce(new Error("workspace host down"));
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    expect(await host.getWorktreesResult()).toEqual({
+      status: "unavailable",
+      reason: "fetch-failed",
+    });
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
+  it("labels a populated list with the project it actually came from", async () => {
+    // The switch race: the focused view can still be the outgoing project's, so
+    // a plugin that looked for its worktree in this list and missed would read
+    // a confirmed mismatch. The label is what lets it tell the difference.
+    const { host, client } = await setup([mkSnap({ id: "outgoing", isCurrent: true })]);
+    client.getAllStatesResultAsync.mockResolvedValueOnce({
+      status: "ok",
+      projectId: "project-outgoing",
+      states: [mkSnap({ id: "outgoing", isCurrent: true })],
+    });
+
+    const result = await host.getWorktreesResult();
+    expect(result).toMatchObject({ status: "ok", projectId: "project-outgoing" });
   });
 
   it("getWorktrees returns frozen snapshots for every worktree", async () => {

--- a/electron/services/__tests__/PluginService.hostApiMisc.test.ts
+++ b/electron/services/__tests__/PluginService.hostApiMisc.test.ts
@@ -860,6 +860,11 @@ describe("Plugin worktree host API", () => {
     ).createHost("acme.wt-nowsc");
     expect(await host.getActiveWorktree()).toBeNull();
     expect(await host.getWorktrees()).toEqual([]);
+    // …and the result surface says which of the seven collapses this is.
+    expect(await host.getWorktreesResult()).toEqual({
+      status: "unavailable",
+      reason: "workspace-unavailable",
+    });
   });
 
   it("onDidChangeActiveWorktree fires with the new active snapshot", async () => {

--- a/electron/services/__tests__/PluginService.hostFsGit.test.ts
+++ b/electron/services/__tests__/PluginService.hostFsGit.test.ts
@@ -80,6 +80,13 @@ function dataDir(): string {
 function setWorktrees(snapshots: Array<Partial<WorktreeSnapshot> & { path: string }>): void {
   (svc as unknown as { setWorkspaceClient(c: unknown): void }).setWorkspaceClient({
     getAllStatesAsync: async () => snapshots,
+    // The result-shaped read the plugin host's worktree surfaces go through
+    // (#12174) — same states, plus the project they belong to.
+    getAllStatesResultAsync: async () => ({
+      status: "ok",
+      projectId: "project-1",
+      states: snapshots,
+    }),
     // The real WorkspaceClient is an EventEmitter; setWorkspaceClient wires the
     // #10621 worktree-scope cache-eviction listener through on/off.
     on: vi.fn(),
@@ -390,9 +397,12 @@ describe("host.fs ${worktree}/${project} token expansion", () => {
     await expect(host.fs.readFile(join(baseDir, "x.txt"))).rejects.toThrow(/PATH_NOT_ALLOWED/);
   });
 
-  it("fails closed (no fallback) when getAllStatesAsync rejects", async () => {
+  it("fails closed (no fallback) when the states read rejects", async () => {
     (svc as unknown as { setWorkspaceClient(c: unknown): void }).setWorkspaceClient({
       getAllStatesAsync: async () => {
+        throw new Error("client unavailable");
+      },
+      getAllStatesResultAsync: async () => {
         throw new Error("client unavailable");
       },
       on: vi.fn(),
@@ -592,7 +602,18 @@ describe("a bound plugin's ${project}/${worktree} allowlist roots", () => {
     );
     (svc as unknown as { setWorkspaceClient(c: unknown): void }).setWorkspaceClient({
       getAllStatesAsync: async () => asCurrent(ambient),
+      getAllStatesResultAsync: async () => ({
+        status: "ok",
+        projectId: "project-ambient",
+        states: asCurrent(ambient),
+      }),
       getAllStatesForProjectAsync: forProject,
+      getAllStatesForProjectResultAsync: async (root: string, projectId: string) => {
+        const states = await forProject(root, projectId);
+        return states.length > 0
+          ? { status: "ok", projectId, states }
+          : { status: "unavailable", reason: "project-unavailable" };
+      },
       on: vi.fn(),
       off: vi.fn(),
     });

--- a/electron/services/__tests__/PluginService.hostFsGit.test.ts
+++ b/electron/services/__tests__/PluginService.hostFsGit.test.ts
@@ -609,10 +609,14 @@ describe("a bound plugin's ${project}/${worktree} allowlist roots", () => {
       }),
       getAllStatesForProjectAsync: forProject,
       getAllStatesForProjectResultAsync: async (root: string, projectId: string) => {
-        const states = await forProject(root, projectId);
-        return states.length > 0
-          ? { status: "ok", projectId, states }
-          : { status: "unavailable", reason: "project-unavailable" };
+        // Availability is entry existence, NOT list length — the real client
+        // answers `ok` with `states: []` for a live project that has no
+        // worktrees, and only reports unavailable when the pool entry is
+        // missing or its immutable id mismatches.
+        if (!(projectId in perProject)) {
+          return { status: "unavailable", reason: "project-unavailable" };
+        }
+        return { status: "ok", projectId, states: await forProject(root, projectId) };
       },
       on: vi.fn(),
       off: vi.fn(),

--- a/electron/services/__tests__/WorkspaceClient.resilience.test.ts
+++ b/electron/services/__tests__/WorkspaceClient.resilience.test.ts
@@ -579,10 +579,13 @@ describe("WorkspaceClient multi-process manager", () => {
       expect(h(0).sendWithResponse.mock.calls.length).toBe(callsBefore);
     });
 
-    it("reports project-unavailable when a window maps to no host", async () => {
+    it("reports workspace-unavailable when no host serves the window yet", async () => {
+      // Not project-unavailable: the window->project mapping is established at
+      // the end of loadProject, so a window mid-open lands here and "the
+      // workspace cannot answer yet" is the honest reason.
       expect(await client.getAllStatesResultAsync(99)).toEqual({
         status: "unavailable",
-        reason: "project-unavailable",
+        reason: "workspace-unavailable",
       });
     });
 
@@ -603,6 +606,46 @@ describe("WorkspaceClient multi-process manager", () => {
         projectId: idFor("/project-a"),
         states: [{ id: "wt-a" }],
       });
+    });
+
+    it("keeps a window read labelled with the project it started on across a switch", async () => {
+      // The race #12174 is really about. Start a read while window 1 is on A,
+      // complete the switch to B with the state RPC still pending, then answer
+      // it. The captured entry must still label the answer A — re-resolving the
+      // window after the await would mislabel A's worktrees as B's, which is
+      // strictly worse than the [] the old surface returned.
+      const loadA = client.loadProject("/project-a", 1);
+      await readyAndResolveLoad(0);
+      await loadA;
+
+      const promise = client.getAllStatesResultAsync(1);
+      await tick();
+      const req = h(0)
+        .getAllRequests()
+        .find((r: any) => r.type === "get-all-states")!;
+      expect(req).toBeDefined();
+
+      const loadB = client.loadProject("/project-b", 1);
+      await readyAndResolveLoad(1);
+      await loadB;
+
+      h(0).resolveRequest(req.requestId, { states: [{ id: "wt-a" }] });
+      expect(await promise).toEqual({
+        status: "ok",
+        projectId: idFor("/project-a"),
+        states: [{ id: "wt-a" }],
+      });
+
+      // And the switch invalidated the cache, so the next read reaches B rather
+      // than replaying A's coalesced answer.
+      const after = client.getAllStatesResultAsync(1);
+      await tick();
+      const reqB = h(1)
+        .getAllRequests()
+        .find((r: any) => r.type === "get-all-states")!;
+      expect(reqB).toBeDefined();
+      h(1).resolveRequest(reqB.requestId, { states: [{ id: "wt-b" }] });
+      expect(await after).toMatchObject({ projectId: idFor("/project-b") });
     });
 
     it("reports workspace-unavailable when readiness fails, and never reads a partial map", async () => {

--- a/electron/services/__tests__/WorkspaceClient.resilience.test.ts
+++ b/electron/services/__tests__/WorkspaceClient.resilience.test.ts
@@ -509,6 +509,152 @@ describe("WorkspaceClient multi-process manager", () => {
     });
   });
 
+  describe("result-shaped state reads (#12174)", () => {
+    const idFor = (p: string) => `id-for-${path.resolve(p)}`;
+
+    it("names the serving project on a successful project-scoped read", async () => {
+      const loadA = client.loadProject("/project-a", 1);
+      await readyAndResolveLoad(0);
+      await loadA;
+
+      const promise = client.getAllStatesForProjectResultAsync("/project-a", idFor("/project-a"));
+      await tick();
+      const req = h(0)
+        .getAllRequests()
+        .find((r: any) => r.type === "get-all-states")!;
+      h(0).resolveRequest(req.requestId, { states: [{ id: "wt-a", name: "A" }] });
+
+      expect(await promise).toEqual({
+        status: "ok",
+        projectId: idFor("/project-a"),
+        states: [{ id: "wt-a", name: "A" }],
+      });
+    });
+
+    it("reports an authoritative empty project, not an unavailable one", async () => {
+      const loadA = client.loadProject("/project-a", 1);
+      await readyAndResolveLoad(0);
+      await loadA;
+
+      const promise = client.getAllStatesForProjectResultAsync("/project-a", idFor("/project-a"));
+      await tick();
+      const req = h(0)
+        .getAllRequests()
+        .find((r: any) => r.type === "get-all-states")!;
+      h(0).resolveRequest(req.requestId, { states: [] });
+
+      // The whole point: a live host that genuinely has no worktrees is a
+      // successful answer, distinguishable from every failure below.
+      expect(await promise).toEqual({
+        status: "ok",
+        projectId: idFor("/project-a"),
+        states: [],
+      });
+    });
+
+    it("reports project-unavailable for an unknown path, without contacting any host", async () => {
+      const loadA = client.loadProject("/project-a", 1);
+      await readyAndResolveLoad(0);
+      await loadA;
+
+      const callsBefore = h(0).sendWithResponse.mock.calls.length;
+      expect(
+        await client.getAllStatesForProjectResultAsync(
+          "/no-such-project",
+          idFor("/no-such-project")
+        )
+      ).toEqual({ status: "unavailable", reason: "project-unavailable" });
+      expect(h(0).sendWithResponse.mock.calls.length).toBe(callsBefore);
+    });
+
+    it("reports project-unavailable on an immutable-projectId mismatch", async () => {
+      const loadA = client.loadProject("/project-a", 1);
+      await readyAndResolveLoad(0);
+      await loadA;
+
+      const callsBefore = h(0).sendWithResponse.mock.calls.length;
+      expect(
+        await client.getAllStatesForProjectResultAsync("/project-a", idFor("/project-b"))
+      ).toEqual({ status: "unavailable", reason: "project-unavailable" });
+      expect(h(0).sendWithResponse.mock.calls.length).toBe(callsBefore);
+    });
+
+    it("reports project-unavailable when a window maps to no host", async () => {
+      expect(await client.getAllStatesResultAsync(99)).toEqual({
+        status: "unavailable",
+        reason: "project-unavailable",
+      });
+    });
+
+    it("names the project a window-scoped read landed on", async () => {
+      const loadA = client.loadProject("/project-a", 1);
+      await readyAndResolveLoad(0);
+      await loadA;
+
+      const promise = client.getAllStatesResultAsync(1);
+      await tick();
+      const req = h(0)
+        .getAllRequests()
+        .find((r: any) => r.type === "get-all-states")!;
+      h(0).resolveRequest(req.requestId, { states: [{ id: "wt-a" }] });
+
+      expect(await promise).toEqual({
+        status: "ok",
+        projectId: idFor("/project-a"),
+        states: [{ id: "wt-a" }],
+      });
+    });
+
+    it("reports workspace-unavailable when readiness fails, and never reads a partial map", async () => {
+      const loadA = client.loadProject("/project-a", 1);
+      h(0).simulateReady();
+      await tick();
+      const loadReq = h(0).getLastRequest()!;
+      expect(loadReq.type).toBe("load-project");
+
+      const promise = client.getAllStatesForProjectResultAsync("/project-a", idFor("/project-a"));
+      await tick();
+
+      h(0).rejectRequest(loadReq.requestId, new Error("load failed"));
+      await loadA.catch(() => {});
+
+      expect(await promise).toEqual({
+        status: "unavailable",
+        reason: "workspace-unavailable",
+      });
+      // "unknown", never a partial list — get-all-states was never sent.
+      expect(
+        h(0)
+          .getAllRequests()
+          .filter((r: any) => r.type === "get-all-states")
+      ).toHaveLength(0);
+    });
+
+    it("evicts a rejected read so the next call retries instead of replaying it", async () => {
+      const loadA = client.loadProject("/project-a", 1);
+      await readyAndResolveLoad(0);
+      await loadA;
+
+      const first = client.getAllStatesForProjectResultAsync("/project-a", idFor("/project-a"));
+      await tick();
+      const req1 = h(0)
+        .getAllRequests()
+        .find((r: any) => r.type === "get-all-states")!;
+      h(0).rejectRequest(req1.requestId, new Error("host down"));
+      await expect(first).rejects.toThrow("host down");
+
+      const second = client.getAllStatesForProjectResultAsync("/project-a", idFor("/project-a"));
+      await tick();
+      const req2 = h(0)
+        .getAllRequests()
+        .filter((r: any) => r.type === "get-all-states")
+        .at(-1)!;
+      expect(req2.requestId).not.toBe(req1.requestId);
+      h(0).resolveRequest(req2.requestId, { states: [] });
+      expect(await second).toMatchObject({ status: "ok" });
+    });
+  });
+
   describe("getAllStatesForProjectAsync", () => {
     // Mirrors the ProjectStore mock: entry.projectId is minted from
     // resolveProjectIdForPath(normalizedPath) at host construction.

--- a/electron/services/plugin/PluginDevWorkerMainBridge.ts
+++ b/electron/services/plugin/PluginDevWorkerMainBridge.ts
@@ -395,6 +395,8 @@ export class PluginDevWorkerMainBridge {
         return this.host.getActiveWorktree();
       case "getWorktrees":
         return this.host.getWorktrees();
+      case "getWorktreesResult":
+        return this.host.getWorktreesResult();
       case "getWorktreeStatus":
         return this.host.getWorktreeStatus(params as string, { signal });
       case "getAgentState":

--- a/electron/services/plugin/PluginHostFactory.ts
+++ b/electron/services/plugin/PluginHostFactory.ts
@@ -50,6 +50,8 @@ import type { PluginDiagnosticsLogLine } from "../../../shared/types/ipc/pluginD
 import type {
   PluginIpcHandler,
   PluginHostApi,
+  PluginWorktreesResult,
+  PluginWorktreesUnavailableReason,
   PluginActionContribution,
   PluginActionDescriptor,
   PluginChannelSchema,
@@ -230,6 +232,22 @@ function sanitizeConfirmOptions(options: PluginConfirmOptions): PluginConfirmOpt
 }
 
 /**
+ * A worktree read the factory's dependencies performed, keeping the reason it
+ * came back with nothing (#12174).
+ *
+ * The internal twin of {@link PluginWorktreesResult}: same discriminant, but
+ * carrying raw `WorktreeSnapshot`s, which the factory projects through
+ * `toPluginWorktreeSnapshot` before a plugin ever sees them. `plugin-unloaded`
+ * is excluded because only the factory can observe it.
+ */
+export type PluginWorktreeSnapshotFetchResult =
+  | { status: "ok"; projectId: string; snapshots: WorktreeSnapshot[] }
+  | {
+      status: "unavailable";
+      reason: Exclude<PluginWorktreesUnavailableReason, "plugin-unloaded">;
+    };
+
+/**
  * Live collaborators and shared registries `createHost` and the fs/git/process/
  * clipboard API builders read and write. Every Map/Set/collaborator field here
  * is the SAME live reference `PluginService` holds — never a snapshot — so the
@@ -257,16 +275,26 @@ export interface PluginHostFactoryDeps {
   getHostGitFactory: () => HostGitFactory | undefined;
   getProcessManager: () => PluginProcessManager;
   declaredCapabilities: (pluginId: string) => Set<BuiltInPluginCapability>;
-  fetchAllWorktreeSnapshots: () => Promise<WorktreeSnapshot[]>;
   /**
-   * Worktree snapshots for one named project, for a project-bound host. Reads
-   * the workspace host that owns `projectRoot` directly instead of the focused
-   * window's, and resolves `[]` once that project closes.
+   * Worktree snapshots for the host's project, carrying why there are none and
+   * which project the ones there are belong to (#12174).
+   *
+   * Result-shaped rather than `WorktreeSnapshot[]` because `[]` is the same
+   * answer for "this project has no worktrees" and for five ways of having no
+   * answer at all, and the host API has to be able to tell a plugin apart. The
+   * `plugin-unloaded` reason is not reachable here — liveness is the factory's
+   * own concern, checked around this call — so it is excluded from the shape.
    */
-  fetchWorktreeSnapshotsForProject: (
+  fetchWorktreeSnapshotsResult: () => Promise<PluginWorktreeSnapshotFetchResult>;
+  /**
+   * The same read for one named project, for a project-bound host. Reads the
+   * workspace host that owns `projectRoot` directly instead of the focused
+   * window's, and reports `project-unavailable` once that project closes.
+   */
+  fetchWorktreeSnapshotsForProjectResult: (
     projectId: string,
     projectRoot: string
-  ) => Promise<WorktreeSnapshot[]>;
+  ) => Promise<PluginWorktreeSnapshotFetchResult>;
   recordPluginLog: (
     boundPlugin: LoadedPlugin,
     pluginId: string,
@@ -350,17 +378,34 @@ export function createHost(
   const { projectId: boundProjectId, projectRoot: boundProjectRoot } = binding;
 
   /**
-   * The worktree set this host may see. Unbound stays ambient on purpose: an
-   * app-global plugin has no project of its own, so the focused window's
-   * worktrees are the only set its argument-less getters can mean.
+   * The worktree set this host may see, with the reason it may see none.
+   *
+   * Unbound stays ambient on purpose: an app-global plugin has no project of
+   * its own, so the focused window's worktrees are the only set its
+   * argument-less getters can mean — which is exactly why the result names the
+   * project it landed on, so a plugin can notice when focus moved under it.
    */
-  const fetchWorktreeSnapshots = (): Promise<WorktreeSnapshot[]> => {
-    if (boundProjectId === null) return deps.fetchAllWorktreeSnapshots();
+  const fetchWorktreeSnapshotsResult = (): Promise<PluginWorktreeSnapshotFetchResult> => {
+    if (boundProjectId === null) return deps.fetchWorktreeSnapshotsResult();
     // Bound with no root is a malformed binding. Fail closed rather than fall
     // back to the ambient read, which would hand this plugin whichever project
     // happens to be focused — the confused-deputy bug the binding exists for.
-    if (boundProjectRoot === null) return Promise.resolve([]);
-    return deps.fetchWorktreeSnapshotsForProject(boundProjectId, boundProjectRoot);
+    if (boundProjectRoot === null) {
+      return Promise.resolve({ status: "unavailable", reason: "project-unavailable" });
+    }
+    return deps.fetchWorktreeSnapshotsForProjectResult(boundProjectId, boundProjectRoot);
+  };
+
+  /**
+   * The array-shaped read the pre-#12174 surfaces still use. Every unavailable
+   * reason flattens back to `[]` here, which is the fail-closed sentinel those
+   * surfaces are built on: worktree storage finds no target, `${worktree}` and
+   * `${project}` allowlist roots drop so containment denies (#9492), and
+   * `getWorktreeStatus` answers `null`.
+   */
+  const fetchWorktreeSnapshots = async (): Promise<WorktreeSnapshot[]> => {
+    const result = await fetchWorktreeSnapshotsResult();
+    return result.status === "ok" ? result.snapshots : [];
   };
 
   /**
@@ -437,6 +482,34 @@ export function createHost(
   // onDidChangeAgentState. The host keeps no pre-subscription history, so
   // getAgentState() returns null until the first transition is observed.
   let lastAgentSnapshot: PluginAgentSnapshot | null = null;
+  /**
+   * The availability- and scope-aware worktree read behind
+   * {@link PluginHostApi.getWorktreesResult}, and the single source the
+   * `[]`/`null`-shaped `getWorktrees` and `getActiveWorktree` project from, so
+   * the three can never disagree about what this host can see (#12174).
+   */
+  const getWorktreesResult = async (): Promise<PluginWorktreesResult> => {
+    if (!isBound()) return { status: "unavailable", reason: "plugin-unloaded" };
+    const result = await fetchWorktreeSnapshotsResult();
+    // Re-checked after the await: an unload (or a same-id reload) that landed
+    // while the read was in flight makes these snapshots the previous
+    // instance's, so they are discarded rather than handed to whatever still
+    // holds this stale host.
+    if (!isBound()) return { status: "unavailable", reason: "plugin-unloaded" };
+    if (result.status !== "ok") return { status: "unavailable", reason: result.reason };
+    // Belt and braces on the binding: a dependency answering for some other
+    // project would be the confused deputy (#11297) arriving through the new
+    // shape, so refuse it rather than relabel it.
+    if (boundProjectId !== null && result.projectId !== boundProjectId) {
+      return { status: "unavailable", reason: "project-unavailable" };
+    }
+    return {
+      status: "ok",
+      projectId: result.projectId,
+      worktrees: result.snapshots.map(toPluginWorktreeSnapshot),
+    };
+  };
+
   const host: PluginHostApi = {
     get pluginId() {
       return pluginId;
@@ -584,18 +657,15 @@ export function createHost(
       return Promise.resolve();
     },
     getActiveWorktree: async () => {
-      if (!isBound()) return null;
-      const snapshots = await fetchWorktreeSnapshots();
-      if (!isBound()) return null;
-      const active = snapshots.find((s) => s.isCurrent === true);
-      return active ? toPluginWorktreeSnapshot(active) : null;
+      const result = await getWorktreesResult();
+      if (result.status !== "ok") return null;
+      return result.worktrees.find((w) => w.isCurrent) ?? null;
     },
     getWorktrees: async () => {
-      if (!isBound()) return [];
-      const snapshots = await fetchWorktreeSnapshots();
-      if (!isBound()) return [];
-      return snapshots.map(toPluginWorktreeSnapshot);
+      const result = await getWorktreesResult();
+      return result.status === "ok" ? result.worktrees : [];
     },
+    getWorktreesResult,
     getWorktreeStatus: async (path, options) => {
       options?.signal?.throwIfAborted();
       if (!isBound()) return null;

--- a/electron/services/plugin/PluginHostFactory.ts
+++ b/electron/services/plugin/PluginHostFactory.ts
@@ -411,9 +411,14 @@ export function createHost(
   /**
    * The array-shaped read the pre-#12174 surfaces still use. Every unavailable
    * reason flattens back to `[]` here, which is the fail-closed sentinel those
-   * surfaces are built on: worktree storage finds no target, `${worktree}` and
-   * `${project}` allowlist roots drop so containment denies (#9492), and
-   * `getWorktreeStatus` answers `null`.
+   * surfaces are built on: `${worktree}` and `${project}` allowlist roots drop
+   * so containment denies (#9492), `getWorktreeStatus` answers `null`, and the
+   * default spawn cwd falls back rather than pointing into another project.
+   *
+   * Not every worktree-derived surface routes through here — worktree-scoped
+   * *storage* resolves its target through `PluginStorageManager`'s own active-
+   * worktree callback, which is still ambient for a bound host. That is a
+   * separate pre-existing gap, not something this read covers.
    */
   const fetchWorktreeSnapshots = async (): Promise<WorktreeSnapshot[]> => {
     const result = await fetchWorktreeSnapshotsResult();
@@ -502,29 +507,27 @@ export function createHost(
    */
   const getWorktreesResult = async (): Promise<PluginWorktreesResult> => {
     if (!isBound()) return { status: "unavailable", reason: "plugin-unloaded" };
-    let result: PluginWorktreeSnapshotFetchResult;
     try {
-      result = await fetchWorktreeSnapshotsResult();
+      const result = await fetchWorktreeSnapshotsResult();
+      // Re-checked after the await: an unload (or a same-id reload) that landed
+      // while the read was in flight makes these snapshots the previous
+      // instance's, so they are discarded rather than handed to whatever still
+      // holds this stale host.
+      if (!isBound()) return { status: "unavailable", reason: "plugin-unloaded" };
+      if (result.status !== "ok") return { status: "unavailable", reason: result.reason };
+      // Projection is inside the boundary too: toPluginWorktreeSnapshot throws
+      // on a malformed snapshot, and this method's contract is to answer with
+      // data rather than reject into whatever timer called it.
+      return {
+        status: "ok",
+        projectId: result.projectId,
+        worktrees: result.snapshots.map(toPluginWorktreeSnapshot),
+      };
     } catch {
-      // The documented contract is that this method answers with data and never
-      // throws, so an unexpected rejection (a dependency that escaped its own
-      // catch, a malformed snapshot) becomes a reason rather than an unhandled
-      // rejection in whatever timer called it.
       return isBound()
         ? { status: "unavailable", reason: "fetch-failed" }
         : { status: "unavailable", reason: "plugin-unloaded" };
     }
-    // Re-checked after the await: an unload (or a same-id reload) that landed
-    // while the read was in flight makes these snapshots the previous
-    // instance's, so they are discarded rather than handed to whatever still
-    // holds this stale host.
-    if (!isBound()) return { status: "unavailable", reason: "plugin-unloaded" };
-    if (result.status !== "ok") return { status: "unavailable", reason: result.reason };
-    return {
-      status: "ok",
-      projectId: result.projectId,
-      worktrees: result.snapshots.map(toPluginWorktreeSnapshot),
-    };
   };
 
   const host: PluginHostApi = {

--- a/electron/services/plugin/PluginHostFactory.ts
+++ b/electron/services/plugin/PluginHostFactory.ts
@@ -385,15 +385,27 @@ export function createHost(
    * argument-less getters can mean — which is exactly why the result names the
    * project it landed on, so a plugin can notice when focus moved under it.
    */
-  const fetchWorktreeSnapshotsResult = (): Promise<PluginWorktreeSnapshotFetchResult> => {
+  const fetchWorktreeSnapshotsResult = async (): Promise<PluginWorktreeSnapshotFetchResult> => {
     if (boundProjectId === null) return deps.fetchWorktreeSnapshotsResult();
     // Bound with no root is a malformed binding. Fail closed rather than fall
     // back to the ambient read, which would hand this plugin whichever project
     // happens to be focused — the confused-deputy bug the binding exists for.
     if (boundProjectRoot === null) {
-      return Promise.resolve({ status: "unavailable", reason: "project-unavailable" });
+      return { status: "unavailable", reason: "project-unavailable" };
     }
-    return deps.fetchWorktreeSnapshotsForProjectResult(boundProjectId, boundProjectRoot);
+    const result = await deps.fetchWorktreeSnapshotsForProjectResult(
+      boundProjectId,
+      boundProjectRoot
+    );
+    // Belt and braces on the binding, enforced here rather than in one getter so
+    // every surface downstream of this read inherits it: a dependency answering
+    // for another project would be the confused deputy (#11297) wearing the new
+    // shape, and it must not reach `getWorktreeStatus`, the worktree
+    // subscriptions or the default spawn cwd either.
+    if (result.status === "ok" && result.projectId !== boundProjectId) {
+      return { status: "unavailable", reason: "project-unavailable" };
+    }
+    return result;
   };
 
   /**
@@ -490,19 +502,24 @@ export function createHost(
    */
   const getWorktreesResult = async (): Promise<PluginWorktreesResult> => {
     if (!isBound()) return { status: "unavailable", reason: "plugin-unloaded" };
-    const result = await fetchWorktreeSnapshotsResult();
+    let result: PluginWorktreeSnapshotFetchResult;
+    try {
+      result = await fetchWorktreeSnapshotsResult();
+    } catch {
+      // The documented contract is that this method answers with data and never
+      // throws, so an unexpected rejection (a dependency that escaped its own
+      // catch, a malformed snapshot) becomes a reason rather than an unhandled
+      // rejection in whatever timer called it.
+      return isBound()
+        ? { status: "unavailable", reason: "fetch-failed" }
+        : { status: "unavailable", reason: "plugin-unloaded" };
+    }
     // Re-checked after the await: an unload (or a same-id reload) that landed
     // while the read was in flight makes these snapshots the previous
     // instance's, so they are discarded rather than handed to whatever still
     // holds this stale host.
     if (!isBound()) return { status: "unavailable", reason: "plugin-unloaded" };
     if (result.status !== "ok") return { status: "unavailable", reason: result.reason };
-    // Belt and braces on the binding: a dependency answering for some other
-    // project would be the confused deputy (#11297) arriving through the new
-    // shape, so refuse it rather than relabel it.
-    if (boundProjectId !== null && result.projectId !== boundProjectId) {
-      return { status: "unavailable", reason: "project-unavailable" };
-    }
     return {
       status: "ok",
       projectId: result.projectId,

--- a/electron/services/plugin/__tests__/PluginDevWorkerMainBridge.test.ts
+++ b/electron/services/plugin/__tests__/PluginDevWorkerMainBridge.test.ts
@@ -27,6 +27,11 @@ function makeHost() {
     broadcastToRenderer: vi.fn(),
     getActiveWorktree: vi.fn(async () => null),
     getWorktrees: vi.fn(async () => [{ id: "w1" }]),
+    getWorktreesResult: vi.fn(async () => ({
+      status: "ok",
+      projectId: "project-1",
+      worktrees: [{ id: "w1" }],
+    })),
     onDidChangeActiveWorktree: vi.fn((_cb: any) => vi.fn()),
     onDidChangeWorktrees: vi.fn((_cb: any) => vi.fn()),
     registerForgeProvider: vi.fn(() => vi.fn()),
@@ -176,6 +181,23 @@ describe("PluginDevWorkerMainBridge", () => {
     expect(host.getWorktrees).toHaveBeenCalled();
     const result = workerHost.sent.find((m) => m.type === "host-result" && m.requestId === "c1");
     expect(result).toMatchObject({ ok: true, result: [{ id: "w1" }] });
+  });
+
+  it("relays getWorktreesResult and returns the union object unchanged (#12174)", async () => {
+    const { host, workerHost } = makeBridge();
+    workerHost.emit("worker-message", {
+      type: "host-call",
+      requestId: "c-wr",
+      method: "getWorktreesResult",
+      params: undefined,
+    });
+    await flush();
+    expect(host.getWorktreesResult).toHaveBeenCalled();
+    const result = workerHost.sent.find((m) => m.type === "host-result" && m.requestId === "c-wr");
+    expect(result).toMatchObject({
+      ok: true,
+      result: { status: "ok", projectId: "project-1", worktrees: [{ id: "w1" }] },
+    });
   });
 
   it("routes clipboard.writeText to the host and replies with undefined", async () => {

--- a/electron/services/plugin/__tests__/PluginHostFactory.binding.test.ts
+++ b/electron/services/plugin/__tests__/PluginHostFactory.binding.test.ts
@@ -226,14 +226,18 @@ describe("createHost worktree surfaces", () => {
     expect(h.projectFetch).not.toHaveBeenCalled();
   });
 
-  it("degrades to null/[] once the bound project is gone", async () => {
+  it("degrades every worktree surface once the bound project is gone", async () => {
     const h = makeHarness();
-    h.projectFetch.mockResolvedValue(okFetch([]));
+    h.projectFetch.mockResolvedValue({ status: "unavailable", reason: "project-unavailable" });
     const { host } = createHost(h.deps, PLUGIN_ID, BOUND);
 
     expect(await host.getActiveWorktree()).toBeNull();
     expect(await host.getWorktrees()).toEqual([]);
     expect(await host.getWorktreeStatus(path.join(ROOT_A, "feature"))).toBeNull();
+    expect(await host.getWorktreesResult()).toEqual({
+      status: "unavailable",
+      reason: "project-unavailable",
+    });
   });
 
   it("names the project a successful read describes", async () => {
@@ -329,6 +333,52 @@ describe("createHost worktree surfaces", () => {
     expect(await host.getWorktreesResult()).toEqual({
       status: "unavailable",
       reason: "project-unavailable",
+    });
+    expect(await host.getWorktrees()).toEqual([]);
+  });
+
+  it("keeps a foreign-project answer out of getWorktreeStatus, not just the getters", async () => {
+    const h = makeHarness();
+    // The refusal lives in the shared fetch, so every surface downstream of it
+    // fails closed — a getter-only guard would let B's status through here.
+    const foreign = path.join(ROOT_B, "feature");
+    h.projectFetch.mockResolvedValue(
+      okFetch([worktree({ id: "wt-b", isCurrent: true, path: foreign })], "project-b")
+    );
+    const { host } = createHost(h.deps, PLUGIN_ID, BOUND);
+
+    expect(await host.getWorktreeStatus(foreign)).toBeNull();
+    expect(await host.getActiveWorktree()).toBeNull();
+    expect(await host.getWorktrees()).toEqual([]);
+  });
+
+  it("treats a same-id reload as unloaded, not as the same plugin", async () => {
+    const h = makeHarness();
+    let release: (value: PluginWorktreeSnapshotFetchResult) => void = () => {};
+    h.projectFetch.mockReturnValue(
+      new Promise<PluginWorktreeSnapshotFetchResult>((resolve) => {
+        release = resolve;
+      })
+    );
+    const { host } = createHost(h.deps, PLUGIN_ID, BOUND);
+
+    const pending = host.getWorktreesResult();
+    // Identity, not membership: the id is still in the map, but it now names a
+    // different instance, so this host's read belongs to the previous one.
+    h.plugins.set(PLUGIN_ID, fakePlugin());
+    release(okFetch([worktree({ id: "wt-a", isCurrent: true })]));
+
+    expect(await pending).toEqual({ status: "unavailable", reason: "plugin-unloaded" });
+  });
+
+  it("answers fetch-failed rather than rejecting when the read throws", async () => {
+    const h = makeHarness();
+    h.projectFetch.mockRejectedValue(new Error("dependency blew up"));
+    const { host } = createHost(h.deps, PLUGIN_ID, BOUND);
+
+    expect(await host.getWorktreesResult()).toEqual({
+      status: "unavailable",
+      reason: "fetch-failed",
     });
     expect(await host.getWorktrees()).toEqual([]);
   });

--- a/electron/services/plugin/__tests__/PluginHostFactory.binding.test.ts
+++ b/electron/services/plugin/__tests__/PluginHostFactory.binding.test.ts
@@ -41,7 +41,11 @@ vi.mock("../../forge/forgeCredentialUtils.js", () => ({
   buildStoredCredentials: vi.fn(() => null),
 }));
 
-import { createHost, type PluginHostFactoryDeps } from "../PluginHostFactory.js";
+import {
+  createHost,
+  type PluginHostFactoryDeps,
+  type PluginWorktreeSnapshotFetchResult,
+} from "../PluginHostFactory.js";
 import { CHANNELS } from "../../../ipc/channels.js";
 import { events } from "../../events.js";
 import { AppError } from "../../../utils/errorTypes.js";
@@ -51,6 +55,12 @@ import type { WorktreeSnapshot } from "../../../../shared/types/workspace-host.j
 import type { LoadedPlugin } from "../PluginServiceTypes.js";
 
 const PLUGIN_ID = "acme";
+
+/** An available, project-scoped read — the shape the factory deps now return. */
+const okFetch = (
+  snapshots: WorktreeSnapshot[],
+  projectId = PROJECT_A
+): PluginWorktreeSnapshotFetchResult => ({ status: "ok", projectId, snapshots });
 const PROJECT_A = "project-a";
 const ROOT_A = path.join(path.sep, "repos", "alpha");
 const ROOT_B = path.join(path.sep, "repos", "beta");
@@ -85,6 +95,7 @@ type WorktreeHandler = (payload?: { projectPath?: string }) => void;
 
 interface Harness {
   deps: PluginHostFactoryDeps;
+  plugins: Map<string, LoadedPlugin>;
   ambientFetch: ReturnType<typeof vi.fn>;
   projectFetch: ReturnType<typeof vi.fn>;
   recordPluginLog: ReturnType<typeof vi.fn>;
@@ -99,8 +110,8 @@ function makeHarness(): Harness {
   const plugins = new Map<string, LoadedPlugin>([[PLUGIN_ID, fakePlugin()]]);
   const handlers = new Map<string, WorktreeHandler[]>();
 
-  const ambientFetch = vi.fn(async (): Promise<WorktreeSnapshot[]> => []);
-  const projectFetch = vi.fn(async (): Promise<WorktreeSnapshot[]> => []);
+  const ambientFetch = vi.fn(async (): Promise<PluginWorktreeSnapshotFetchResult> => okFetch([]));
+  const projectFetch = vi.fn(async (): Promise<PluginWorktreeSnapshotFetchResult> => okFetch([]));
   const recordPluginLog = vi.fn();
   const sendDispatchToRenderer = vi.fn(async () => ({ ok: true, data: undefined }));
   const sendActionsListToRenderer = vi.fn(async () => []);
@@ -129,8 +140,8 @@ function makeHarness(): Harness {
     getHostGitFactory: () => undefined,
     getProcessManager: vi.fn(),
     declaredCapabilities: () => new Set(["agent:input", "agent:read"]),
-    fetchAllWorktreeSnapshots: ambientFetch,
-    fetchWorktreeSnapshotsForProject: projectFetch,
+    fetchWorktreeSnapshotsResult: ambientFetch,
+    fetchWorktreeSnapshotsForProjectResult: projectFetch,
     recordPluginLog,
     serializePluginBadges: () => ({}),
     pluginDataDir: () => path.join(path.sep, "tmp", "data"),
@@ -150,6 +161,7 @@ function makeHarness(): Harness {
 
   return {
     deps,
+    plugins,
     ambientFetch,
     projectFetch,
     recordPluginLog,
@@ -180,9 +192,9 @@ beforeEach(() => {
 describe("createHost worktree surfaces", () => {
   it("reads the bound project's worktrees, never the focus-resolved set", async () => {
     const h = makeHarness();
-    h.projectFetch.mockResolvedValue([
-      worktree({ id: "wt-a", isCurrent: true, path: path.join(ROOT_A, "feature") }),
-    ]);
+    h.projectFetch.mockResolvedValue(
+      okFetch([worktree({ id: "wt-a", isCurrent: true, path: path.join(ROOT_A, "feature") })])
+    );
     const { host } = createHost(h.deps, PLUGIN_ID, BOUND);
 
     expect((await host.getActiveWorktree())?.id).toBe("wt-a");
@@ -195,7 +207,7 @@ describe("createHost worktree surfaces", () => {
 
   it("leaves the unbound path on the ambient read", async () => {
     const h = makeHarness();
-    h.ambientFetch.mockResolvedValue([worktree({ id: "wt-focus", isCurrent: true })]);
+    h.ambientFetch.mockResolvedValue(okFetch([worktree({ id: "wt-focus", isCurrent: true })]));
     const { host } = createHost(h.deps, PLUGIN_ID, UNBOUND_PLUGIN_HOST_BINDING);
 
     expect((await host.getActiveWorktree())?.id).toBe("wt-focus");
@@ -205,7 +217,7 @@ describe("createHost worktree surfaces", () => {
 
   it("fails closed rather than widening when a binding has no root", async () => {
     const h = makeHarness();
-    h.ambientFetch.mockResolvedValue([worktree({ id: "wt-focus", isCurrent: true })]);
+    h.ambientFetch.mockResolvedValue(okFetch([worktree({ id: "wt-focus", isCurrent: true })]));
     const { host } = createHost(h.deps, PLUGIN_ID, { projectId: PROJECT_A, projectRoot: null });
 
     expect(await host.getActiveWorktree()).toBeNull();
@@ -216,19 +228,132 @@ describe("createHost worktree surfaces", () => {
 
   it("degrades to null/[] once the bound project is gone", async () => {
     const h = makeHarness();
-    h.projectFetch.mockResolvedValue([]);
+    h.projectFetch.mockResolvedValue(okFetch([]));
     const { host } = createHost(h.deps, PLUGIN_ID, BOUND);
 
     expect(await host.getActiveWorktree()).toBeNull();
     expect(await host.getWorktrees()).toEqual([]);
     expect(await host.getWorktreeStatus(path.join(ROOT_A, "feature"))).toBeNull();
   });
+
+  it("names the project a successful read describes", async () => {
+    const h = makeHarness();
+    h.projectFetch.mockResolvedValue(okFetch([worktree({ id: "wt-a", isCurrent: true })]));
+    const { host } = createHost(h.deps, PLUGIN_ID, BOUND);
+
+    expect(await host.getWorktreesResult()).toEqual({
+      status: "ok",
+      projectId: PROJECT_A,
+      worktrees: [expect.objectContaining({ id: "wt-a" })],
+    });
+  });
+
+  it("reports an authoritative empty project, not an unavailable one", async () => {
+    const h = makeHarness();
+    h.projectFetch.mockResolvedValue(okFetch([]));
+    const { host } = createHost(h.deps, PLUGIN_ID, BOUND);
+
+    // The distinction #12174 exists for: this project really has no worktrees,
+    // and says so, while the legacy surface still answers the ambiguous [].
+    expect(await host.getWorktreesResult()).toEqual({
+      status: "ok",
+      projectId: PROJECT_A,
+      worktrees: [],
+    });
+    expect(await host.getWorktrees()).toEqual([]);
+    expect(await host.getActiveWorktree()).toBeNull();
+  });
+
+  it("reports project-unavailable for a rootless binding without reading anything", async () => {
+    const h = makeHarness();
+    const { host } = createHost(h.deps, PLUGIN_ID, { projectId: PROJECT_A, projectRoot: null });
+
+    expect(await host.getWorktreesResult()).toEqual({
+      status: "unavailable",
+      reason: "project-unavailable",
+    });
+    expect(h.ambientFetch).not.toHaveBeenCalled();
+    expect(h.projectFetch).not.toHaveBeenCalled();
+  });
+
+  it("passes a closed project's unavailability through instead of flattening it", async () => {
+    const h = makeHarness();
+    h.projectFetch.mockResolvedValue({ status: "unavailable", reason: "project-unavailable" });
+    const { host } = createHost(h.deps, PLUGIN_ID, BOUND);
+
+    expect(await host.getWorktreesResult()).toEqual({
+      status: "unavailable",
+      reason: "project-unavailable",
+    });
+    expect(await host.getWorktrees()).toEqual([]);
+  });
+
+  it("reports plugin-unloaded before it reads anything", async () => {
+    const h = makeHarness();
+    h.plugins.delete(PLUGIN_ID);
+    const { host } = createHost(h.deps, PLUGIN_ID, BOUND);
+
+    expect(await host.getWorktreesResult()).toEqual({
+      status: "unavailable",
+      reason: "plugin-unloaded",
+    });
+    expect(h.projectFetch).not.toHaveBeenCalled();
+  });
+
+  it("discards snapshots that arrive after the plugin unloaded", async () => {
+    const h = makeHarness();
+    let release: (value: PluginWorktreeSnapshotFetchResult) => void = () => {};
+    h.projectFetch.mockReturnValue(
+      new Promise<PluginWorktreeSnapshotFetchResult>((resolve) => {
+        release = resolve;
+      })
+    );
+    const { host } = createHost(h.deps, PLUGIN_ID, BOUND);
+
+    const pending = host.getWorktreesResult();
+    h.plugins.delete(PLUGIN_ID);
+    release(okFetch([worktree({ id: "wt-a", isCurrent: true })]));
+
+    expect(await pending).toEqual({ status: "unavailable", reason: "plugin-unloaded" });
+  });
+
+  it("refuses a successful read that names another project", async () => {
+    const h = makeHarness();
+    // The confused deputy arriving through the new shape: a dependency that
+    // answered for B must not be relabelled as A's.
+    h.projectFetch.mockResolvedValue(
+      okFetch([worktree({ id: "wt-b", isCurrent: true })], "project-b")
+    );
+    const { host } = createHost(h.deps, PLUGIN_ID, BOUND);
+
+    expect(await host.getWorktreesResult()).toEqual({
+      status: "unavailable",
+      reason: "project-unavailable",
+    });
+    expect(await host.getWorktrees()).toEqual([]);
+  });
+
+  it("names the focus-resolved project on the unbound path", async () => {
+    const h = makeHarness();
+    // Mid-switch the focused view can still be the outgoing project's, so an
+    // unbound host is told which project its populated list actually belongs to.
+    h.ambientFetch.mockResolvedValue(
+      okFetch([worktree({ id: "wt-outgoing", isCurrent: true })], "project-outgoing")
+    );
+    const { host } = createHost(h.deps, PLUGIN_ID, UNBOUND_PLUGIN_HOST_BINDING);
+
+    expect(await host.getWorktreesResult()).toEqual({
+      status: "ok",
+      projectId: "project-outgoing",
+      worktrees: [expect.objectContaining({ id: "wt-outgoing" })],
+    });
+  });
 });
 
 describe("createHost worktree subscriptions", () => {
   it("fires onDidChangeActiveWorktree only for the bound project", async () => {
     const h = makeHarness();
-    h.projectFetch.mockResolvedValue([worktree({ id: "wt-a", isCurrent: true })]);
+    h.projectFetch.mockResolvedValue(okFetch([worktree({ id: "wt-a", isCurrent: true })]));
     const { host } = createHost(h.deps, PLUGIN_ID, BOUND);
     const callback = vi.fn();
     await host.onDidChangeActiveWorktree(callback);
@@ -245,7 +370,7 @@ describe("createHost worktree subscriptions", () => {
 
   it("fires onDidChangeWorktrees only for the bound project", async () => {
     const h = makeHarness();
-    h.projectFetch.mockResolvedValue([worktree({ id: "wt-a" })]);
+    h.projectFetch.mockResolvedValue(okFetch([worktree({ id: "wt-a" })]));
     const { host } = createHost(h.deps, PLUGIN_ID, BOUND);
     const callback = vi.fn();
     await host.onDidChangeWorktrees(callback);
@@ -262,7 +387,7 @@ describe("createHost worktree subscriptions", () => {
 
   it("keeps an unbound subscription firing for every project", async () => {
     const h = makeHarness();
-    h.ambientFetch.mockResolvedValue([worktree({ id: "wt-focus" })]);
+    h.ambientFetch.mockResolvedValue(okFetch([worktree({ id: "wt-focus" })]));
     const { host } = createHost(h.deps, PLUGIN_ID, UNBOUND_PLUGIN_HOST_BINDING);
     const callback = vi.fn();
     await host.onDidChangeWorktrees(callback);

--- a/electron/services/plugin/__tests__/PluginHostFactory.binding.test.ts
+++ b/electron/services/plugin/__tests__/PluginHostFactory.binding.test.ts
@@ -383,6 +383,29 @@ describe("createHost worktree surfaces", () => {
     expect(await host.getWorktrees()).toEqual([]);
   });
 
+  it("answers fetch-failed when projecting a malformed snapshot throws", async () => {
+    const h = makeHarness();
+    // `worktreeChanges` present but with no `changes` array — toPluginWorktree
+    // Snapshot iterates it and throws. The projection sits inside the boundary,
+    // so this is data, not a rejection into whatever timer called it.
+    h.projectFetch.mockResolvedValue(
+      okFetch([
+        {
+          ...worktree({ id: "wt-a", isCurrent: true }),
+          worktreeChanges: {} as never,
+        },
+      ])
+    );
+    const { host } = createHost(h.deps, PLUGIN_ID, BOUND);
+
+    expect(await host.getWorktreesResult()).toEqual({
+      status: "unavailable",
+      reason: "fetch-failed",
+    });
+    expect(await host.getWorktrees()).toEqual([]);
+    expect(await host.getActiveWorktree()).toBeNull();
+  });
+
   it("names the focus-resolved project on the unbound path", async () => {
     const h = makeHarness();
     // Mid-switch the focused view can still be the outgoing project's, so an

--- a/electron/services/plugin/__tests__/confusedDeputy.test.ts
+++ b/electron/services/plugin/__tests__/confusedDeputy.test.ts
@@ -206,8 +206,16 @@ function fakePlugin(): LoadedPlugin {
  * `webContents.send` and a `host.settings.set` all the way to a file on disk.
  */
 function makeHostDeps(): PluginHostFactoryDeps {
-  ambientWorktreeFetch = vi.fn(async () => []);
-  projectWorktreeFetch = vi.fn(async () => []);
+  ambientWorktreeFetch = vi.fn(async () => ({
+    status: "ok",
+    projectId: PROJECT_B,
+    snapshots: [],
+  }));
+  projectWorktreeFetch = vi.fn(async () => ({
+    status: "ok",
+    projectId: PROJECT_A,
+    snapshots: [],
+  }));
   return {
     plugins: new Map<string, LoadedPlugin>([[PLUGIN_ID, fakePlugin()]]),
     pluginEventCleanups: new Map(),
@@ -226,8 +234,8 @@ function makeHostDeps(): PluginHostFactoryDeps {
     getHostGitFactory: () => undefined,
     getProcessManager: vi.fn(),
     declaredCapabilities: () => new Set(["agent:input", "agent:read"]),
-    fetchAllWorktreeSnapshots: ambientWorktreeFetch,
-    fetchWorktreeSnapshotsForProject: projectWorktreeFetch,
+    fetchWorktreeSnapshotsResult: ambientWorktreeFetch,
+    fetchWorktreeSnapshotsForProjectResult: projectWorktreeFetch,
     recordPluginLog: vi.fn(),
     serializePluginBadges: () => ({}),
     pluginDataDir: () => path.join(tmpDir, "plugin-data"),
@@ -441,6 +449,44 @@ describe("a malformed binding fails closed", () => {
     expect(await host.getWorktrees()).toEqual([]);
     expect(ambientWorktreeFetch).not.toHaveBeenCalled();
     expect(projectWorktreeFetch).not.toHaveBeenCalled();
+
+    // #12174 rides on the same guard: the result surface says WHY it is empty
+    // rather than letting the plugin read the [] as "A has no worktrees", and
+    // still never reaches for the focused project's set to fill the gap.
+    expect(await host.getWorktreesResult()).toEqual({
+      status: "unavailable",
+      reason: "project-unavailable",
+    });
+    expect(ambientWorktreeFetch).not.toHaveBeenCalled();
+  });
+
+  it("will not let a read that answered for B escape through an A-bound host", async () => {
+    // The confused deputy in the shape #12174 adds: a dependency answering with
+    // B's project id must fail closed, never be relabelled as A's.
+    const host = hostBoundTo({ projectId: PROJECT_A, projectRoot: projectRootOf(PROJECT_A) });
+    projectWorktreeFetch.mockResolvedValue({
+      status: "ok",
+      projectId: PROJECT_B,
+      snapshots: [],
+    });
+
+    expect(await host.getWorktreesResult()).toEqual({
+      status: "unavailable",
+      reason: "project-unavailable",
+    });
+    expect(await host.getWorktrees()).toEqual([]);
+  });
+
+  it("names A while B is focused, and never consults the ambient read", async () => {
+    const host = hostBoundTo({ projectId: PROJECT_A, projectRoot: projectRootOf(PROJECT_A) });
+
+    expect(await host.getWorktreesResult()).toEqual({
+      status: "ok",
+      projectId: PROJECT_A,
+      worktrees: [],
+    });
+    expect(projectWorktreeFetch).toHaveBeenCalledWith(PROJECT_A, projectRootOf(PROJECT_A));
+    expect(ambientWorktreeFetch).not.toHaveBeenCalled();
   });
 });
 

--- a/electron/services/plugin/__tests__/pluginDevWorkerHostProxy.test.ts
+++ b/electron/services/plugin/__tests__/pluginDevWorkerHostProxy.test.ts
@@ -145,6 +145,34 @@ function resolveCall(proxy: any, sent: any[], method: string, result: unknown): 
   proxy.handleMessage({ type: "host-result", requestId: call.requestId, ok: true, result });
 }
 
+describe("PluginDevWorkerHostProxy getWorktreesResult (#12174)", () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.restoreAllMocks());
+
+  it("relays the call and resolves with the union unchanged", async () => {
+    const { proxy, sent } = makeProxy();
+    const promise = proxy.host.getWorktreesResult();
+    expect(
+      sent.find((m) => m.type === "host-call" && m.method === "getWorktreesResult")
+    ).toBeDefined();
+    const envelope = { status: "ok", projectId: "project-1", worktrees: [] };
+    resolveCall(proxy, sent, "getWorktreesResult", envelope);
+    await expect(promise).resolves.toEqual(envelope);
+  });
+
+  it("resolves an in-flight call to plugin-unloaded when the proxy is disposed", async () => {
+    // The real host degrades rather than throwing once the plugin unloads, so a
+    // dev-hosted plugin must observe the same contract.
+    const { proxy } = makeProxy();
+    const promise = proxy.host.getWorktreesResult();
+    proxy.dispose();
+    await expect(promise).resolves.toEqual({
+      status: "unavailable",
+      reason: "plugin-unloaded",
+    });
+  });
+});
+
 describe("PluginDevWorkerHostProxy host.actions (#10561)", () => {
   beforeEach(() => vi.clearAllMocks());
   afterEach(() => vi.restoreAllMocks());

--- a/electron/services/plugin/__tests__/pluginDevWorkerHostProxy.test.ts
+++ b/electron/services/plugin/__tests__/pluginDevWorkerHostProxy.test.ts
@@ -160,6 +160,18 @@ describe("PluginDevWorkerHostProxy getWorktreesResult (#12174)", () => {
     await expect(promise).resolves.toEqual(envelope);
   });
 
+  it("resolves to plugin-unloaded for a call made after disposal", async () => {
+    // The other callWithGrace branch: nothing is in flight, so the grace value
+    // is returned without anything crossing the port.
+    const { proxy, sent } = makeProxy();
+    proxy.dispose();
+    await expect(proxy.host.getWorktreesResult()).resolves.toEqual({
+      status: "unavailable",
+      reason: "plugin-unloaded",
+    });
+    expect(sent.find((m) => m.type === "host-call")).toBeUndefined();
+  });
+
   it("resolves an in-flight call to plugin-unloaded when the proxy is disposed", async () => {
     // The real host degrades rather than throwing once the plugin unloads, so a
     // dev-hosted plugin must observe the same contract.

--- a/electron/services/plugin/pluginDevWorkerHostProxy.ts
+++ b/electron/services/plugin/pluginDevWorkerHostProxy.ts
@@ -28,6 +28,7 @@ import type {
   PluginTypedIpcHandler,
   PluginWorktreeSnapshot,
   PluginWorktreeStatus,
+  PluginWorktreesResult,
   PluginAgentSnapshot,
   PluginPanelLifecycleEvent,
   PluginFsDirEntry,
@@ -440,6 +441,15 @@ export class PluginDevWorkerHostProxy {
       getActiveWorktree: () =>
         this.call<PluginWorktreeSnapshot | null>("getActiveWorktree", undefined),
       getWorktrees: () => this.call<PluginWorktreeSnapshot[]>("getWorktrees", undefined),
+      // callWithGrace, not call: the host contract for this method is that it
+      // degrades to an `unavailable` result on unload rather than throwing, so a
+      // dev-worker call in flight when the proxy is disposed must resolve the
+      // same way the real host would (#12174).
+      getWorktreesResult: () =>
+        this.callWithGrace<PluginWorktreesResult>("getWorktreesResult", undefined, {
+          status: "unavailable",
+          reason: "plugin-unloaded",
+        }),
       getWorktreeStatus: (path, options) =>
         this.call<PluginWorktreeStatus | null>("getWorktreeStatus", path, options?.signal),
       getAgentState: () => this.call<PluginAgentSnapshot | null>("getAgentState", undefined),

--- a/packages/plugin-sdk/api-report/index.d.ts
+++ b/packages/plugin-sdk/api-report/index.d.ts
@@ -2491,6 +2491,68 @@ interface PluginWorktreeSnapshot {
     readonly status: PluginWorktreeStatus | null;
 }
 /**
+ * Why {@link PluginWorktreesResult} could not name a worktree set (#12174).
+ *
+ * The argument-less {@link PluginHostApi.getWorktrees} collapses every one of
+ * these to `[]`, which a plugin cannot tell apart from a project that genuinely
+ * has no worktrees. The reasons are deliberately semantic rather than one
+ * literal per internal branch: a plugin can act on "retry later" versus "this
+ * project is gone", but nothing it can do differs between a workspace client
+ * that is not wired yet and a workspace host that missed its readiness gate.
+ * The finer diagnosis stays in Daintree's logs.
+ *
+ * - `plugin-unloaded` — the plugin unloaded (or was replaced by a same-id
+ *   reload) before or during the read; a stale timer sees this
+ * - `workspace-unavailable` — the workspace subsystem cannot answer yet: no
+ *   client wired, or the owning workspace host never finished populating
+ * - `scope-unresolved` — an unbound host found no focused project view to read
+ *   on behalf of (common mid-project-switch)
+ * - `project-unavailable` — a bound host's project cannot be resolved: the
+ *   binding carries no root, or the project has closed and its workspace-host
+ *   entry is gone
+ * - `fetch-failed` — a read was attempted against a live host and threw
+ */
+type PluginWorktreesUnavailableReason = "plugin-unloaded" | "workspace-unavailable" | "scope-unresolved" | "project-unavailable" | "fetch-failed";
+/**
+ * Availability- and scope-aware outcome of a worktree read (#12174). Returned
+ * as plain data (never thrown), like {@link PluginCheckUpdateResult} and
+ * {@link PluginActivationResult}, so the structured result survives Electron's
+ * structured-clone IPC boundary.
+ *
+ * This exists because `[]` is overloaded. {@link PluginHostApi.getWorktrees}
+ * answers `[]` for an unloaded plugin, an unwired workspace client, an
+ * unresolved window scope, a rootless or closed project, a failed read, *and*
+ * for a project that really has no worktrees — seven states behind one value.
+ * A plugin that treats "no match in the list" as proof its stored worktree is
+ * gone will therefore false-positive during a project switch or after a wake.
+ *
+ * `status: "ok"` is the only authoritative answer, and it names `projectId` so
+ * a plugin can also tell *which* project the list describes. That matters on
+ * the unbound path: mid-switch the focused view can still be the outgoing
+ * project, so a populated list that omits the worktree you are looking for may
+ * simply belong to another project rather than confirm a mismatch. Compare
+ * `projectId` before concluding anything from the contents.
+ *
+ * The `unavailable` variant deliberately carries no `projectId`: there is no
+ * authoritative answer in that branch, so there is no project the absent
+ * worktrees can be said to be absent *from*.
+ */
+type PluginWorktreesResult = {
+    readonly status: "ok";
+    /**
+     * The project whose workspace host produced `worktrees`, as the host
+     * itself knows it — captured from the entry that served this read, not
+     * re-resolved from focus afterwards, so a switch that lands while the
+     * read is in flight cannot relabel it.
+     */
+    readonly projectId: string;
+    /** Authoritative for `projectId`. Empty means the project has no worktrees. */
+    readonly worktrees: PluginWorktreeSnapshot[];
+} | {
+    readonly status: "unavailable";
+    readonly reason: PluginWorktreesUnavailableReason;
+};
+/**
  * Read-only, frozen projection of an agent session's coarse state, exposed to
  * plugins behind the `agent:read` capability. This is an explicit allowlist of
  * fields from the internal `agent:state-changed` event payload; do NOT add
@@ -3346,14 +3408,41 @@ interface PluginHostApi extends PluginActivationApi {
      */
     postToPanel(channel: string, payload: unknown, panelId?: string | null): Promise<void>;
     /**
-     * Returns the currently-active worktree (`isCurrent === true`) across all
-     * projects as a frozen snapshot, or `null` if none is active. In multi-project
-     * sessions this returns the first match; plugins needing per-project scoping
-     * should filter from `getWorktrees()`.
+     * Returns the currently-active worktree (`isCurrent === true`) of the project
+     * this host reads for, as a frozen snapshot, or `null` if none is active.
+     *
+     * `null` is overloaded exactly as `[]` is on {@link getWorktrees} — it means
+     * "no active worktree" *or* "no answer available". Use
+     * {@link getWorktreesResult} and pick out `isCurrent` yourself when the
+     * difference matters.
      */
     getActiveWorktree(): Promise<PluginWorktreeSnapshot | null>;
-    /** Returns all worktrees across all loaded projects as frozen snapshots. */
+    /**
+     * Returns the worktrees of the project this host reads for, as frozen
+     * snapshots — the project named by a project-bound host's binding, or the
+     * focused window's project for an app-global one.
+     *
+     * Resolves `[]` both when the project has no worktrees and when no answer is
+     * available at all; {@link getWorktreesResult} separates the two.
+     */
     getWorktrees(): Promise<PluginWorktreeSnapshot[]>;
+    /**
+     * The same read as {@link getWorktrees}, but able to say when it has no
+     * answer and which project the answer it does have describes (#12174).
+     *
+     * `getWorktrees()` collapses an unloaded plugin, an unwired workspace client,
+     * an unresolved window scope, a rootless or closed project and a failed read
+     * all to the same `[]` a genuinely empty project returns. Prefer this method
+     * wherever the absence of a worktree drives a decision — a stored binding
+     * that looks broken, a panel that looks orphaned — and only treat a
+     * `status: "ok"` result whose `projectId` matches your expectation as
+     * evidence. See {@link PluginWorktreesResult}.
+     *
+     * Like {@link getWorktrees} this is not revoke-guarded and never throws: once
+     * the plugin unloads it degrades to `{ status: "unavailable", reason:
+     * "plugin-unloaded" }`.
+     */
+    getWorktreesResult(): Promise<PluginWorktreesResult>;
     /**
      * Returns the changed-file / git-status projection for the worktree at the
      * given absolute `path` (the same {@link PluginWorktreeStatus} carried on
@@ -3738,4 +3827,4 @@ type PluginProcessStreamEvent = {
     signal: string | null;
 };
 
-export { type ActionDanger, type ActionDispatchError, type ActionDispatchResult, type ActionDispatchSuccess, type ActionError, type ActionErrorCode, type ActionExample, type ActionHandler, type ActionId, type ActionKind, type AgentState, type AuthValidation, type BuiltInActionId, type BuiltInPluginCapability, type CIStatus, type CheckRun, type CheckRunConclusion, type CheckRunStatus, type ChecksCapability, type ContextMenuContribution, type ContextMenuLocation, type CreateIssueInput, type Credentials, type FetchOptions, type FileDecoration, type FileDecorationContribution, type FileDecorationProviderDescriptor, type FileDecorationProviderImpl, type ForgeLabel, type ForgeProviderContribution, type ForgeProviderDescriptor, type ForgeProviderImpl, type ForgeProviderKind, type ForgeUser, type Issue, type KeybindingContribution, type ListOptions, type McpServerContribution, type MenuItemContribution, type MenuItemLocation, type NormalizedIssueState, type NormalizedPRState, PLUGIN_PROCESS_STREAM_CHANNEL, type PR, type Page, type PanelContribution, type PanelViewProps, type PluginActionContribution, type PluginActionManifestEntry, type PluginActivate, type PluginActivationApi, type PluginAgentSnapshot, type PluginAuthor, type PluginCanDispatchResult, type PluginCapability, type PluginChannelSchema, type PluginClipboardApi, type PluginConfirmOptions, type PluginDuplexProcessHandle, type PluginDuplexProcessSpawnOptions, type PluginFsApi, type PluginFsDirEntry, type PluginFsScope, type PluginFsStat, type PluginGitApi, type PluginGitCommitOptions, type PluginGitCommitResult, type PluginGitStatus, type PluginGitStatusFile, type PluginHostActionsApi, type PluginHostApi, type PluginHostCallOptions, type PluginHostSubscriptionOptions, type PluginInputBoxOptions, type PluginIpcContext, type PluginIpcHandler, type PluginLocalSocketScope, type PluginLogger, type PluginManifest, type PluginManifestScopes, type PluginNetworkScope, type PluginPanelBadge, type PluginPanelBadgeColor, type PluginPanelLifecycleEvent, type PluginPanelLifecyclePhase, type PluginProcessApi, type PluginProcessDataChunk, type PluginProcessHandle, type PluginProcessMode, type PluginProcessSpawnOptions, type PluginProcessStreamEvent, type PluginPtyProcessHandle, type PluginPtyProcessSpawnOptions, type PluginQuickPickItem, type PluginQuickPickOptions, type PluginSettingsScope, type PluginStorageScope, type PluginSystemApi, type PluginToastOptions, type PluginTypedIpcHandler, type PluginWorktreeFileState, type PluginWorktreeLinked, type PluginWorktreeLinkedIssue, type PluginWorktreeLinkedPR, type PluginWorktreeSnapshot, type PluginWorktreeStatus, type PluginWorktreeStatusFile, type RateLimitInfo, type RepoMetadata, type RepoRef, type ResourceRef, type SettingDefinition, type SettingFieldType, type SettingsApi, type StorageApi, type ToolbarButtonContribution, type ViewContribution, type ViewLocation, type WaitingReason, localAuthStubs };
+export { type ActionDanger, type ActionDispatchError, type ActionDispatchResult, type ActionDispatchSuccess, type ActionError, type ActionErrorCode, type ActionExample, type ActionHandler, type ActionId, type ActionKind, type AgentState, type AuthValidation, type BuiltInActionId, type BuiltInPluginCapability, type CIStatus, type CheckRun, type CheckRunConclusion, type CheckRunStatus, type ChecksCapability, type ContextMenuContribution, type ContextMenuLocation, type CreateIssueInput, type Credentials, type FetchOptions, type FileDecoration, type FileDecorationContribution, type FileDecorationProviderDescriptor, type FileDecorationProviderImpl, type ForgeLabel, type ForgeProviderContribution, type ForgeProviderDescriptor, type ForgeProviderImpl, type ForgeProviderKind, type ForgeUser, type Issue, type KeybindingContribution, type ListOptions, type McpServerContribution, type MenuItemContribution, type MenuItemLocation, type NormalizedIssueState, type NormalizedPRState, PLUGIN_PROCESS_STREAM_CHANNEL, type PR, type Page, type PanelContribution, type PanelViewProps, type PluginActionContribution, type PluginActionManifestEntry, type PluginActivate, type PluginActivationApi, type PluginAgentSnapshot, type PluginAuthor, type PluginCanDispatchResult, type PluginCapability, type PluginChannelSchema, type PluginClipboardApi, type PluginConfirmOptions, type PluginDuplexProcessHandle, type PluginDuplexProcessSpawnOptions, type PluginFsApi, type PluginFsDirEntry, type PluginFsScope, type PluginFsStat, type PluginGitApi, type PluginGitCommitOptions, type PluginGitCommitResult, type PluginGitStatus, type PluginGitStatusFile, type PluginHostActionsApi, type PluginHostApi, type PluginHostCallOptions, type PluginHostSubscriptionOptions, type PluginInputBoxOptions, type PluginIpcContext, type PluginIpcHandler, type PluginLocalSocketScope, type PluginLogger, type PluginManifest, type PluginManifestScopes, type PluginNetworkScope, type PluginPanelBadge, type PluginPanelBadgeColor, type PluginPanelLifecycleEvent, type PluginPanelLifecyclePhase, type PluginProcessApi, type PluginProcessDataChunk, type PluginProcessHandle, type PluginProcessMode, type PluginProcessSpawnOptions, type PluginProcessStreamEvent, type PluginPtyProcessHandle, type PluginPtyProcessSpawnOptions, type PluginQuickPickItem, type PluginQuickPickOptions, type PluginSettingsScope, type PluginStorageScope, type PluginSystemApi, type PluginToastOptions, type PluginTypedIpcHandler, type PluginWorktreeFileState, type PluginWorktreeLinked, type PluginWorktreeLinkedIssue, type PluginWorktreeLinkedPR, type PluginWorktreeSnapshot, type PluginWorktreeStatus, type PluginWorktreeStatusFile, type PluginWorktreesResult, type PluginWorktreesUnavailableReason, type RateLimitInfo, type RepoMetadata, type RepoRef, type ResourceRef, type SettingDefinition, type SettingFieldType, type SettingsApi, type StorageApi, type ToolbarButtonContribution, type ViewContribution, type ViewLocation, type WaitingReason, localAuthStubs };

--- a/packages/plugin-sdk/api-report/index.d.ts
+++ b/packages/plugin-sdk/api-report/index.d.ts
@@ -2504,7 +2504,8 @@ interface PluginWorktreeSnapshot {
  * - `plugin-unloaded` — the plugin unloaded (or was replaced by a same-id
  *   reload) before or during the read; a stale timer sees this
  * - `workspace-unavailable` — the workspace subsystem cannot answer yet: no
- *   client wired, or the owning workspace host never finished populating
+ *   client wired, no host serving the resolved window (a project still opening),
+ *   or a host that never finished populating
  * - `scope-unresolved` — an unbound host found no focused project view to read
  *   on behalf of (common mid-project-switch)
  * - `project-unavailable` — a bound host's project cannot be resolved: the

--- a/shared/testing/__tests__/createMockHost.test.ts
+++ b/shared/testing/__tests__/createMockHost.test.ts
@@ -350,11 +350,28 @@ describe("createMockHost", () => {
       status: "unavailable",
       reason: "scope-unresolved",
     });
-    // Deliberately untouched: the ambiguity of the old surface is the point.
-    expect(await host.getWorktrees()).toEqual([sampleSnapshot]);
+    // Coupled, as production is: one unavailable read cannot leave the legacy
+    // getters handing back a list the real host would have flattened to [].
+    expect(await host.getWorktrees()).toEqual([]);
+    expect(await host.getActiveWorktree()).toBeNull();
 
     host.simulateWorktreesResult(null);
-    expect(await host.getWorktreesResult()).toMatchObject({ status: "ok" });
+    expect(await host.getWorktreesResult()).toEqual({
+      status: "ok",
+      projectId: "test-project",
+      worktrees: [sampleSnapshot],
+    });
+    expect(await host.getWorktrees()).toEqual([sampleSnapshot]);
+  });
+
+  it("keeps the derived result in step with simulateWorktreesChange", async () => {
+    const host = createMockHost({ worktrees: [sampleSnapshot] });
+    host.simulateWorktreesChange([]);
+    expect(await host.getWorktreesResult()).toEqual({
+      status: "ok",
+      projectId: "test-project",
+      worktrees: [],
+    });
   });
 
   it("delivers active-worktree updates and supports idempotent disposal", async () => {

--- a/shared/testing/__tests__/createMockHost.test.ts
+++ b/shared/testing/__tests__/createMockHost.test.ts
@@ -343,6 +343,9 @@ describe("createMockHost", () => {
 
   it("can be driven to an unavailable result without disturbing the legacy getters", async () => {
     const host = createMockHost({
+      // Both seeded, so the assertions below fail if the override stops driving
+      // the legacy getters rather than passing on an already-null default.
+      activeWorktree: sampleSnapshot,
       worktrees: [sampleSnapshot],
       worktreesResult: { status: "unavailable", reason: "scope-unresolved" },
     });

--- a/shared/testing/__tests__/createMockHost.test.ts
+++ b/shared/testing/__tests__/createMockHost.test.ts
@@ -332,6 +332,31 @@ describe("createMockHost", () => {
     expect(await host.getWorktrees()).toEqual([sampleSnapshot]);
   });
 
+  it("derives an authoritative worktrees result from the seeded snapshots", async () => {
+    const host = createMockHost({ worktrees: [sampleSnapshot] });
+    expect(await host.getWorktreesResult()).toEqual({
+      status: "ok",
+      projectId: "test-project",
+      worktrees: [sampleSnapshot],
+    });
+  });
+
+  it("can be driven to an unavailable result without disturbing the legacy getters", async () => {
+    const host = createMockHost({
+      worktrees: [sampleSnapshot],
+      worktreesResult: { status: "unavailable", reason: "scope-unresolved" },
+    });
+    expect(await host.getWorktreesResult()).toEqual({
+      status: "unavailable",
+      reason: "scope-unresolved",
+    });
+    // Deliberately untouched: the ambiguity of the old surface is the point.
+    expect(await host.getWorktrees()).toEqual([sampleSnapshot]);
+
+    host.simulateWorktreesResult(null);
+    expect(await host.getWorktreesResult()).toMatchObject({ status: "ok" });
+  });
+
   it("delivers active-worktree updates and supports idempotent disposal", async () => {
     const host = createMockHost();
     const cb = vi.fn();

--- a/shared/testing/createMockHost.ts
+++ b/shared/testing/createMockHost.ts
@@ -44,6 +44,7 @@ import type {
   PluginToastOptions,
   PluginTypedIpcHandler,
   PluginWorktreeSnapshot,
+  PluginWorktreesResult,
   PluginAgentSnapshot,
   PluginPanelLifecycleEvent,
   PluginGitCommitResult,
@@ -242,6 +243,11 @@ export interface MockHostState {
   simulateQuickPickResponse(result: PluginQuickPickItem | PluginQuickPickItem[] | undefined): void;
   /** Configure what `showInputBox` resolves to (default `undefined` = dismissed). */
   simulateInputBoxResponse(result: string | undefined): void;
+  /**
+   * Force what `getWorktreesResult()` answers, or pass `null` to go back to the
+   * `ok` result derived from the mock's current worktrees.
+   */
+  simulateWorktreesResult(result: PluginWorktreesResult | null): void;
   /** Configure what `showConfirm` resolves to (default `false` = cancelled). */
   simulateConfirmResponse(result: boolean): void;
 }
@@ -250,6 +256,20 @@ export interface CreateMockHostOptions {
   pluginId?: string;
   activeWorktree?: PluginWorktreeSnapshot | null;
   worktrees?: PluginWorktreeSnapshot[];
+  /**
+   * Seed `getWorktreesResult()` with a specific outcome (#12174) — an
+   * `unavailable` reason, or an `ok` result naming a particular project. Omit
+   * it and the mock derives `{ status: "ok", projectId: "test-project" }` from
+   * `worktrees`, so an author who only cares about the happy path gets the
+   * authoritative answer for free. Override it with
+   * {@link MockHostState.simulateWorktreesResult} to exercise the guards a
+   * plugin should have around an unavailable read.
+   *
+   * Deliberately does not feed `getWorktrees()` / `getActiveWorktree()`: those
+   * keep their `[]`/`null` contract off `worktrees` / `activeWorktree`, which
+   * is exactly the ambiguity this result shape exists to sit beside.
+   */
+  worktreesResult?: PluginWorktreesResult;
   settings?: {
     user?: Record<string, unknown>;
     project?: Record<string, unknown>;
@@ -452,6 +472,7 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
   const pluginId = options.pluginId ?? "test.mock";
   let activeWorktree: PluginWorktreeSnapshot | null = options.activeWorktree ?? null;
   let worktrees: PluginWorktreeSnapshot[] = options.worktrees ?? [];
+  let worktreesResult: PluginWorktreesResult | null = options.worktreesResult ?? null;
 
   const registeredActions: RegisteredActionRecord[] = [];
   const registeredHandlers: RegisteredHandlerRecord[] = [];
@@ -834,6 +855,9 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
     },
     async getWorktrees() {
       return worktrees;
+    },
+    async getWorktreesResult() {
+      return worktreesResult ?? { status: "ok", projectId: "test-project", worktrees };
     },
     async getWorktreeStatus(path, options) {
       options?.signal?.throwIfAborted();
@@ -1317,6 +1341,9 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
     simulateWorktreesChange(snapshots) {
       worktrees = snapshots;
       for (const cb of worktreesSubs) cb(snapshots);
+    },
+    simulateWorktreesResult(result) {
+      worktreesResult = result;
     },
     simulateAgentStateChange(snapshot) {
       lastAgentSnapshot = snapshot;

--- a/shared/testing/createMockHost.ts
+++ b/shared/testing/createMockHost.ts
@@ -265,9 +265,11 @@ export interface CreateMockHostOptions {
    * {@link MockHostState.simulateWorktreesResult} to exercise the guards a
    * plugin should have around an unavailable read.
    *
-   * Deliberately does not feed `getWorktrees()` / `getActiveWorktree()`: those
-   * keep their `[]`/`null` contract off `worktrees` / `activeWorktree`, which
-   * is exactly the ambiguity this result shape exists to sit beside.
+   * While an override is set the legacy `getWorktrees()` / `getActiveWorktree()`
+   * project from it too — the real host derives all three from one read, so a
+   * mock that answered `unavailable` here while still handing back a populated
+   * list there would let a plugin's fallback pass a test it cannot pass in
+   * production.
    */
   worktreesResult?: PluginWorktreesResult;
   settings?: {
@@ -851,9 +853,21 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
       return Promise.resolve();
     },
     async getActiveWorktree() {
+      if (worktreesResult) {
+        return worktreesResult.status === "ok"
+          ? (worktreesResult.worktrees.find((w) => w.isCurrent) ?? null)
+          : null;
+      }
       return activeWorktree;
     },
     async getWorktrees() {
+      // Projected from the override when one is set: the real host derives all
+      // three getters from a single read, so a mock that let `getWorktrees()`
+      // stay populated while the result says `unavailable` would bless a
+      // fallback that cannot work in production.
+      if (worktreesResult) {
+        return worktreesResult.status === "ok" ? worktreesResult.worktrees : [];
+      }
       return worktrees;
     },
     async getWorktreesResult() {

--- a/shared/types/__tests__/plugin-sdk.test.ts
+++ b/shared/types/__tests__/plugin-sdk.test.ts
@@ -288,6 +288,16 @@ describe("plugin-sdk boundary", () => {
       expectTypeOf<"project-unavailable">().toMatchTypeOf<PluginWorktreesUnavailableReason>();
       expectTypeOf<"fetch-failed">().toMatchTypeOf<PluginWorktreesUnavailableReason>();
       expectTypeOf<"whatever">().not.toMatchTypeOf<PluginWorktreesUnavailableReason>();
+      // Exact, not merely inclusive: an unintended sixth literal would widen the
+      // public vocabulary plugins have to switch on, and membership checks alone
+      // would not notice.
+      expectTypeOf<PluginWorktreesUnavailableReason>().toEqualTypeOf<
+        | "plugin-unloaded"
+        | "workspace-unavailable"
+        | "scope-unresolved"
+        | "project-unavailable"
+        | "fetch-failed"
+      >();
     });
 
     it("PluginHostApi.getWorktreeStatus takes a path and returns the status projection or null", () => {

--- a/shared/types/__tests__/plugin-sdk.test.ts
+++ b/shared/types/__tests__/plugin-sdk.test.ts
@@ -3,6 +3,8 @@ import type {
   PluginManifest,
   PluginHostApi,
   PluginActivationApi,
+  PluginWorktreesResult,
+  PluginWorktreesUnavailableReason,
   PluginSettingsScope,
   PluginStorageScope,
   PluginHostCallOptions,
@@ -253,6 +255,41 @@ describe("plugin-sdk boundary", () => {
       >();
     });
 
+    it("PluginHostApi.getWorktreesResult returns the availability-aware result (#12174)", () => {
+      const host = {} as PluginHostApi;
+      expectTypeOf(host.getWorktreesResult).toEqualTypeOf<() => Promise<PluginWorktreesResult>>();
+      // The ambiguous siblings keep their shape — the result method sits beside
+      // them rather than replacing them.
+      expectTypeOf(host.getWorktrees).toEqualTypeOf<() => Promise<PluginWorktreeSnapshot[]>>();
+    });
+
+    it("PluginWorktreesResult narrows on status", () => {
+      const result = {} as PluginWorktreesResult;
+      if (result.status === "ok") {
+        expectTypeOf(result.projectId).toEqualTypeOf<string>();
+        expectTypeOf(result.worktrees).toEqualTypeOf<PluginWorktreeSnapshot[]>();
+        // No `reason` on the authoritative branch.
+        expectTypeOf<Extract<PluginWorktreesResult, { status: "ok" }>>().not.toHaveProperty(
+          "reason"
+        );
+      } else {
+        expectTypeOf(result.reason).toEqualTypeOf<PluginWorktreesUnavailableReason>();
+        // …and no project identity on the branch that has no authoritative answer.
+        expectTypeOf<
+          Extract<PluginWorktreesResult, { status: "unavailable" }>
+        >().not.toHaveProperty("projectId");
+      }
+    });
+
+    it("PluginWorktreesUnavailableReason names every collapse the sentinel hid", () => {
+      expectTypeOf<"plugin-unloaded">().toMatchTypeOf<PluginWorktreesUnavailableReason>();
+      expectTypeOf<"workspace-unavailable">().toMatchTypeOf<PluginWorktreesUnavailableReason>();
+      expectTypeOf<"scope-unresolved">().toMatchTypeOf<PluginWorktreesUnavailableReason>();
+      expectTypeOf<"project-unavailable">().toMatchTypeOf<PluginWorktreesUnavailableReason>();
+      expectTypeOf<"fetch-failed">().toMatchTypeOf<PluginWorktreesUnavailableReason>();
+      expectTypeOf<"whatever">().not.toMatchTypeOf<PluginWorktreesUnavailableReason>();
+    });
+
     it("PluginHostApi.getWorktreeStatus takes a path and returns the status projection or null", () => {
       const host = {} as PluginHostApi;
       expectTypeOf(host.getWorktreeStatus).toEqualTypeOf<
@@ -393,6 +430,8 @@ describe("plugin-sdk boundary", () => {
       const _getActive = activation.getActiveWorktree;
       // @ts-expect-error — getWorktrees (the accessor) is not on the slice
       const _getAll = activation.getWorktrees;
+      // @ts-expect-error — getWorktreesResult (the accessor) is not on the slice
+      const _getAllResult = activation.getWorktreesResult;
       // @ts-expect-error — settings accessor is not on the slice
       const _settings = activation.settings;
       // @ts-expect-error — storage accessor is not on the slice
@@ -407,10 +446,11 @@ describe("plugin-sdk boundary", () => {
         _pluginId,
         _getActive,
         _getAll,
+        _getAllResult,
         _settings,
         _storage,
         _process,
-      ]).toHaveLength(10);
+      ]).toHaveLength(11);
     });
 
     it("PluginProcessHandle carries the lifecycle controls", () => {

--- a/shared/types/plugin-sdk.ts
+++ b/shared/types/plugin-sdk.ts
@@ -116,6 +116,8 @@ export type {
 
 export type {
   PluginWorktreeSnapshot,
+  PluginWorktreesResult,
+  PluginWorktreesUnavailableReason,
   PluginWorktreeLinked,
   PluginWorktreeLinkedIssue,
   PluginWorktreeLinkedPR,

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -1516,7 +1516,8 @@ export interface PluginWorktreeSnapshot {
  * - `plugin-unloaded` — the plugin unloaded (or was replaced by a same-id
  *   reload) before or during the read; a stale timer sees this
  * - `workspace-unavailable` — the workspace subsystem cannot answer yet: no
- *   client wired, or the owning workspace host never finished populating
+ *   client wired, no host serving the resolved window (a project still opening),
+ *   or a host that never finished populating
  * - `scope-unresolved` — an unbound host found no focused project view to read
  *   on behalf of (common mid-project-switch)
  * - `project-unavailable` — a bound host's project cannot be resolved: the

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -1503,6 +1503,77 @@ export interface PluginWorktreeSnapshot {
 }
 
 /**
+ * Why {@link PluginWorktreesResult} could not name a worktree set (#12174).
+ *
+ * The argument-less {@link PluginHostApi.getWorktrees} collapses every one of
+ * these to `[]`, which a plugin cannot tell apart from a project that genuinely
+ * has no worktrees. The reasons are deliberately semantic rather than one
+ * literal per internal branch: a plugin can act on "retry later" versus "this
+ * project is gone", but nothing it can do differs between a workspace client
+ * that is not wired yet and a workspace host that missed its readiness gate.
+ * The finer diagnosis stays in Daintree's logs.
+ *
+ * - `plugin-unloaded` — the plugin unloaded (or was replaced by a same-id
+ *   reload) before or during the read; a stale timer sees this
+ * - `workspace-unavailable` — the workspace subsystem cannot answer yet: no
+ *   client wired, or the owning workspace host never finished populating
+ * - `scope-unresolved` — an unbound host found no focused project view to read
+ *   on behalf of (common mid-project-switch)
+ * - `project-unavailable` — a bound host's project cannot be resolved: the
+ *   binding carries no root, or the project has closed and its workspace-host
+ *   entry is gone
+ * - `fetch-failed` — a read was attempted against a live host and threw
+ */
+export type PluginWorktreesUnavailableReason =
+  | "plugin-unloaded"
+  | "workspace-unavailable"
+  | "scope-unresolved"
+  | "project-unavailable"
+  | "fetch-failed";
+
+/**
+ * Availability- and scope-aware outcome of a worktree read (#12174). Returned
+ * as plain data (never thrown), like {@link PluginCheckUpdateResult} and
+ * {@link PluginActivationResult}, so the structured result survives Electron's
+ * structured-clone IPC boundary.
+ *
+ * This exists because `[]` is overloaded. {@link PluginHostApi.getWorktrees}
+ * answers `[]` for an unloaded plugin, an unwired workspace client, an
+ * unresolved window scope, a rootless or closed project, a failed read, *and*
+ * for a project that really has no worktrees — seven states behind one value.
+ * A plugin that treats "no match in the list" as proof its stored worktree is
+ * gone will therefore false-positive during a project switch or after a wake.
+ *
+ * `status: "ok"` is the only authoritative answer, and it names `projectId` so
+ * a plugin can also tell *which* project the list describes. That matters on
+ * the unbound path: mid-switch the focused view can still be the outgoing
+ * project, so a populated list that omits the worktree you are looking for may
+ * simply belong to another project rather than confirm a mismatch. Compare
+ * `projectId` before concluding anything from the contents.
+ *
+ * The `unavailable` variant deliberately carries no `projectId`: there is no
+ * authoritative answer in that branch, so there is no project the absent
+ * worktrees can be said to be absent *from*.
+ */
+export type PluginWorktreesResult =
+  | {
+      readonly status: "ok";
+      /**
+       * The project whose workspace host produced `worktrees`, as the host
+       * itself knows it — captured from the entry that served this read, not
+       * re-resolved from focus afterwards, so a switch that lands while the
+       * read is in flight cannot relabel it.
+       */
+      readonly projectId: string;
+      /** Authoritative for `projectId`. Empty means the project has no worktrees. */
+      readonly worktrees: PluginWorktreeSnapshot[];
+    }
+  | {
+      readonly status: "unavailable";
+      readonly reason: PluginWorktreesUnavailableReason;
+    };
+
+/**
  * Read-only, frozen projection of an agent session's coarse state, exposed to
  * plugins behind the `agent:read` capability. This is an explicit allowlist of
  * fields from the internal `agent:state-changed` event payload; do NOT add
@@ -2408,14 +2479,41 @@ export interface PluginHostApi extends PluginActivationApi {
    */
   postToPanel(channel: string, payload: unknown, panelId?: string | null): Promise<void>;
   /**
-   * Returns the currently-active worktree (`isCurrent === true`) across all
-   * projects as a frozen snapshot, or `null` if none is active. In multi-project
-   * sessions this returns the first match; plugins needing per-project scoping
-   * should filter from `getWorktrees()`.
+   * Returns the currently-active worktree (`isCurrent === true`) of the project
+   * this host reads for, as a frozen snapshot, or `null` if none is active.
+   *
+   * `null` is overloaded exactly as `[]` is on {@link getWorktrees} — it means
+   * "no active worktree" *or* "no answer available". Use
+   * {@link getWorktreesResult} and pick out `isCurrent` yourself when the
+   * difference matters.
    */
   getActiveWorktree(): Promise<PluginWorktreeSnapshot | null>;
-  /** Returns all worktrees across all loaded projects as frozen snapshots. */
+  /**
+   * Returns the worktrees of the project this host reads for, as frozen
+   * snapshots — the project named by a project-bound host's binding, or the
+   * focused window's project for an app-global one.
+   *
+   * Resolves `[]` both when the project has no worktrees and when no answer is
+   * available at all; {@link getWorktreesResult} separates the two.
+   */
   getWorktrees(): Promise<PluginWorktreeSnapshot[]>;
+  /**
+   * The same read as {@link getWorktrees}, but able to say when it has no
+   * answer and which project the answer it does have describes (#12174).
+   *
+   * `getWorktrees()` collapses an unloaded plugin, an unwired workspace client,
+   * an unresolved window scope, a rootless or closed project and a failed read
+   * all to the same `[]` a genuinely empty project returns. Prefer this method
+   * wherever the absence of a worktree drives a decision — a stored binding
+   * that looks broken, a panel that looks orphaned — and only treat a
+   * `status: "ok"` result whose `projectId` matches your expectation as
+   * evidence. See {@link PluginWorktreesResult}.
+   *
+   * Like {@link getWorktrees} this is not revoke-guarded and never throws: once
+   * the plugin unloads it degrades to `{ status: "unavailable", reason:
+   * "plugin-unloaded" }`.
+   */
+  getWorktreesResult(): Promise<PluginWorktreesResult>;
   /**
    * Returns the changed-file / git-status projection for the worktree at the
    * given absolute `path` (the same {@link PluginWorktreeStatus} carried on

--- a/shared/types/pluginDevWorker.ts
+++ b/shared/types/pluginDevWorker.ts
@@ -37,6 +37,7 @@ import type {
 export type PluginHostCallMethod =
   | "getActiveWorktree"
   | "getWorktrees"
+  | "getWorktreesResult"
   | "getWorktreeStatus"
   | "getAgentState"
   | "sendToActiveAgent"


### PR DESCRIPTION
## Summary

`host.getWorktrees()` returned `[]` for seven distinct situations: plugin unloaded, no workspace client, no resolved window scope, a bound host whose binding carries no root, a closed project, a failed read, and a project that genuinely has no worktrees. A plugin guarding on "my worktree isn't in this list" had no way to tell a real mismatch from a momentary absence. `getActiveWorktree()` collapsed to `null` the same way.

On the unbound path it was worse than ambiguous. Mid project switch, the focused view can still be the outgoing project's, so the list could be populated and simply describe the wrong project. That reads as a confirmed mismatch to a plugin, not a possible one.

Resolves #12174

## Changes

Adds `host.getWorktreesResult()`, a status discriminated result alongside the existing getters, following the repo's existing `PluginCheckUpdateResult` precedent: plain data, never thrown, survives the structured clone IPC boundary.

```ts
type PluginWorktreesResult =
  | { status: "ok"; projectId: string; worktrees: PluginWorktreeSnapshot[] }
  | { status: "unavailable"; reason: PluginWorktreesUnavailableReason };

type PluginWorktreesUnavailableReason =
  | "plugin-unloaded"
  | "workspace-unavailable"
  | "scope-unresolved"
  | "project-unavailable"
  | "fetch-failed";
```

`status: "ok"` is the only authoritative answer, and it names the project it describes, captured from the workspace-host entry that served the read, so a switch landing mid flight can't relabel it. Five semantic reasons rather than one literal per internal branch: a plugin can act differently on retry later versus this project is gone, but nothing it can do differs between an unwired client and a host that missed its readiness gate, so the finer diagnosis stays in the logs.

Key points:

- `getWorktrees()` / `getActiveWorktree()` are behaviourally unchanged (still fail closed to `[]` / `null`), now projected from the same source so the three can never disagree.
- `WorkspaceClient` gains result-shaped reads that keep the readiness verdict and the serving entry's immutable project id, coalesced through their own map so the array-shaped reads keep the promise identity their callers rely on.
- The foreign-project refusal lives in the shared bound fetch, so `getWorktreeStatus`, the worktree subscriptions, and the default spawn cwd inherit it too, not just the getters.
- Wired through the plugin-dev-worker proxy and main bridge, degrading to `plugin-unloaded` on disposal like the real host.
- `createMockHost` gains the method plus a `worktreesResult` override that also drives the legacy getters, so the mock can't present a combination production can't produce.
- The fail-closed posture is untouched: no path widens to the cross-project aggregate, and a dependency answering for another project is refused rather than relabelled (#11297, #9492).

The motivating consumer, from the issue: the SynthOps plugin's panel-binding validator, which renders a persistent "this pane no longer has a valid Daintree worktree binding" warning on transient false positives after a project switch or a macOS wake.

## Testing

- `npm run typecheck` passes.
- 833 targeted tests across 21 files pass: `PluginHostFactory.binding`, `confusedDeputy` (the #11297 regression guard), several `PluginService` suites (`hostApiMisc`, `hostFsGit`, `builtinLifecycle`, `createHostCore`, `agentHostApi`, `actionRegistry`, `hostClipboard`, `hostSystem`, `createHostDispatchActions`, `hostSettingsInitHotReload`), `WorkspaceClient.resilience`, both dev-worker suites, the plugin-sdk type contract, `createMockHost`, and both builtin-github suites.
- `npm run check:api-surface` passes, with the report regenerated via `npm run api-surface:update`.
- `prettier --check` and `eslint` on changed files pass: 0 errors, 1 pre-existing warning outside the changed lines at `shared/testing/createMockHost.ts:1110`.
- No end to end tests. This is a main-process plugin host API change with no UI surface.

## Follow-ups (out of scope here)

Codex review surfaced these as pre-existing and this PR deliberately doesn't touch them:

- Worktree-scoped plugin storage resolves its target through `PluginStorageManager`'s own active-worktree callback, which is still ambient for a project-bound host, so a bound plugin's `storage.set(..., "worktree")` can land under the focused project. Pre-existing confused-deputy gap, worth its own issue.
- A project marked closed whose workspace-host pool entry outlives it (the sleep path) still reads as available. Pre-existing; the new API is strictly more informative there than `getWorktrees()` was.
- `_statesInflight` (the older coalescing map) still evicts unguarded, so a late read can drop a pending one inserted after an invalidation, costing a duplicate RPC. Only the newly added map is identity guarded here.
- Structured clone doesn't preserve `Object.freeze` across the dev-worker bridge, so worker-hosted snapshots aren't frozen. Already true of the existing getters.
