### PR TITLE
fix(project): capture the assistant's session when sleeping or closing a project

### DIFF
--- a/electron/ipc/handlers/__tests__/project.close.test.ts
+++ b/electron/ipc/handlers/__tests__/project.close.test.ts
@@ -55,8 +55,9 @@ vi.mock("../../../services/pty/projectSessionJournal.js", () => teardownMock);
 
 // `isPanelVisible`/`getSlotForTerminal` are here because ProjectStatsService —
 // started by the full CRUD registrar below — value-imports this same singleton
-// and projects through both on every stats tick. A revoke-only mock leaves them
-// undefined and the poller throws asynchronously.
+// and projects through both. A revoke-only mock leaves them undefined, and any
+// tick that reaches assistant projection then dies inside the service's own
+// catch: no test failure, just a silently degraded poller.
 const helpSessionServiceMock = vi.hoisted(() => ({
   revokeByProjectId: vi.fn<(projectId: string) => Promise<void>>(async () => {}),
   isPanelVisible: vi.fn<(projectId: string) => boolean>(() => false),
@@ -83,6 +84,9 @@ describe("project:close handler", () => {
       confirmed: true,
       terminalsKilled: 0,
     });
+    // `clearAllMocks` clears calls but not a queued `...Once`, so a rejection a
+    // test sets up but never reaches would leak into the next one.
+    helpSessionServiceMock.revokeByProjectId.mockReset().mockResolvedValue(undefined);
   });
 
   it("allows killing terminals for the active project and clears it", async () => {
@@ -409,6 +413,12 @@ describe("project:close handler", () => {
         ptyClient,
         undefined
       );
+      // The capture is keyed on the requested project, not the pointer — the
+      // one arrangement where reading the wrong one is visible.
+      expect(helpSessionServiceMock.revokeByProjectId).toHaveBeenCalledTimes(1);
+      expect(helpSessionServiceMock.revokeByProjectId).toHaveBeenCalledWith(
+        "project-second-window"
+      );
       // The DB pointer names a different project, so it must NOT be cleared —
       // that bookkeeping tracks the pointer, not visibility.
       expect(projectStoreMock.clearCurrentProject).not.toHaveBeenCalled();
@@ -447,6 +457,41 @@ describe("project:close handler", () => {
       expect(projectStoreMock.updateProjectStatus).not.toHaveBeenCalled();
     });
 
+    it("waits for the capture to settle before tearing the project down", async () => {
+      // Invocation order can't tell an awaited capture from a fire-and-forget
+      // one, and fire-and-forget IS the bug: the teardown would kill the
+      // assistant's PTY out from under an unresolved `gracefulKill`.
+      projectStoreMock.getCurrentProjectId.mockReturnValue("project-active");
+      projectStoreMock.getProjectById.mockReturnValue({
+        id: "project-active",
+        name: "Active Project",
+        status: "active",
+        path: "/test/project-active",
+      } as ReturnType<typeof projectStoreMock.getProjectById>);
+      projectStoreMock.clearProjectState.mockResolvedValue(undefined);
+
+      let releaseCapture!: () => void;
+      helpSessionServiceMock.revokeByProjectId.mockReturnValueOnce(
+        new Promise<void>((resolve) => {
+          releaseCapture = resolve;
+        })
+      );
+
+      const deps = {
+        mainWindow: {} as unknown,
+        ptyClient: makePtyClient(),
+      } as unknown as HandlerDependencies;
+
+      const handler = getCloseHandler(deps);
+      const pending = handler(EVENT, "project-active", { killTerminals: true });
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      expect(teardownMock.gracefulTeardownAndJournalProject).not.toHaveBeenCalled();
+
+      releaseCapture();
+      await pending;
+      expect(teardownMock.gracefulTeardownAndJournalProject).toHaveBeenCalled();
+    });
+
     it("still closes when the assistant capture fails", async () => {
       // A lost resume entry costs the assistant its conversation, nothing more.
       // Left uncaught it would be relabelled INTERNAL and abort the close.
@@ -471,6 +516,10 @@ describe("project:close handler", () => {
         handler(EVENT, "project-active", { killTerminals: true })
       ).resolves.toMatchObject({ terminalsKilled: 0 });
 
+      // Without this the test passes under a full revert: the queued rejection
+      // is simply never consumed and the close succeeds for the wrong reason.
+      expect(helpSessionServiceMock.revokeByProjectId).toHaveBeenCalledTimes(1);
+      expect(helpSessionServiceMock.revokeByProjectId).toHaveBeenCalledWith("project-active");
       expect(teardownMock.gracefulTeardownAndJournalProject).toHaveBeenCalled();
       expect(projectStoreMock.clearProjectState).toHaveBeenCalledWith("project-active");
       expect(projectStoreMock.updateProjectStatus).toHaveBeenCalledWith("project-active", "closed");

--- a/electron/ipc/handlers/__tests__/project.close.test.ts
+++ b/electron/ipc/handlers/__tests__/project.close.test.ts
@@ -53,6 +53,19 @@ const teardownMock = vi.hoisted(() => ({
 }));
 vi.mock("../../../services/pty/projectSessionJournal.js", () => teardownMock);
 
+// `isPanelVisible`/`getSlotForTerminal` are here because ProjectStatsService —
+// started by the full CRUD registrar below — value-imports this same singleton
+// and projects through both on every stats tick. A revoke-only mock leaves them
+// undefined and the poller throws asynchronously.
+const helpSessionServiceMock = vi.hoisted(() => ({
+  revokeByProjectId: vi.fn<(projectId: string) => Promise<void>>(async () => {}),
+  isPanelVisible: vi.fn<(projectId: string) => boolean>(() => false),
+  getSlotForTerminal: vi.fn<(terminalId: string) => number | null>(() => null),
+}));
+vi.mock("../../../services/HelpSessionService.js", () => ({
+  helpSessionService: helpSessionServiceMock,
+}));
+
 import { ipcMain } from "electron";
 import { CHANNELS } from "../../channels.js";
 import { createProjectCrudRegistrar } from "./helpers/projectCrudLifecycle.js";
@@ -127,6 +140,13 @@ describe("project:close handler", () => {
       "project-active",
       ptyClient,
       undefined
+    );
+    // The assistant's session is captured first: the teardown above kills its
+    // PTY too, and the resume id can only be read off a live one (#12181).
+    expect(helpSessionServiceMock.revokeByProjectId).toHaveBeenCalledTimes(1);
+    expect(helpSessionServiceMock.revokeByProjectId).toHaveBeenCalledWith("project-active");
+    expect(helpSessionServiceMock.revokeByProjectId.mock.invocationCallOrder[0]!).toBeLessThan(
+      teardownMock.gracefulTeardownAndJournalProject.mock.invocationCallOrder[0]!
     );
     expect(projectStoreMock.clearProjectState).toHaveBeenCalledWith("project-active");
     expect(projectStoreMock.clearCurrentProject).toHaveBeenCalled();
@@ -419,9 +439,41 @@ describe("project:close handler", () => {
 
       await expect(handler(EVENT, "project-active", { killTerminals: true })).rejects.toThrow();
 
+      // The capture runs ahead of the confirmation gate, so it still happened —
+      // the project keeps its state, and a reopened assistant panel resumes.
+      expect(helpSessionServiceMock.revokeByProjectId).toHaveBeenCalledWith("project-active");
       expect(projectStoreMock.clearProjectState).not.toHaveBeenCalled();
       expect(projectStoreMock.clearCurrentProject).not.toHaveBeenCalled();
       expect(projectStoreMock.updateProjectStatus).not.toHaveBeenCalled();
+    });
+
+    it("still closes when the assistant capture fails", async () => {
+      // A lost resume entry costs the assistant its conversation, nothing more.
+      // Left uncaught it would be relabelled INTERNAL and abort the close.
+      projectStoreMock.getCurrentProjectId.mockReturnValue("project-active");
+      projectStoreMock.getProjectById.mockReturnValue({
+        id: "project-active",
+        name: "Active Project",
+        status: "active",
+        path: "/test/project-active",
+      } as ReturnType<typeof projectStoreMock.getProjectById>);
+      projectStoreMock.clearProjectState.mockResolvedValue(undefined);
+      helpSessionServiceMock.revokeByProjectId.mockRejectedValueOnce(new Error("no pty host"));
+
+      const deps = {
+        mainWindow: {} as unknown,
+        ptyClient: makePtyClient(),
+      } as unknown as HandlerDependencies;
+
+      const handler = getCloseHandler(deps);
+
+      await expect(
+        handler(EVENT, "project-active", { killTerminals: true })
+      ).resolves.toMatchObject({ terminalsKilled: 0 });
+
+      expect(teardownMock.gracefulTeardownAndJournalProject).toHaveBeenCalled();
+      expect(projectStoreMock.clearProjectState).toHaveBeenCalledWith("project-active");
+      expect(projectStoreMock.updateProjectStatus).toHaveBeenCalledWith("project-active", "closed");
     });
 
     it("fails closed when the teardown throws unexpectedly: keeps state and rejects", async () => {
@@ -504,6 +556,9 @@ describe("project:close handler", () => {
     expect(result.terminalsKilled).toBe(0);
     expect(projectStoreMock.updateProjectStatus).toHaveBeenCalledWith("project-bg", "background");
     expect(worktreeService.pauseProject).toHaveBeenCalledWith("/test/project-bg");
+    // Backgrounding leaves every terminal running, the assistant's included —
+    // revoking here would kill the live session it is meant to preserve.
+    expect(helpSessionServiceMock.revokeByProjectId).not.toHaveBeenCalled();
   });
 
   it("does NOT call pauseProject when killing terminals", async () => {

--- a/electron/ipc/handlers/__tests__/project.sleep.test.ts
+++ b/electron/ipc/handlers/__tests__/project.sleep.test.ts
@@ -37,6 +37,13 @@ const teardownMock = vi.hoisted(() => ({
 }));
 vi.mock("../../../services/pty/projectSessionJournal.js", () => teardownMock);
 
+const helpSessionServiceMock = vi.hoisted(() => ({
+  revokeByProjectId: vi.fn<(projectId: string) => Promise<void>>(async () => {}),
+}));
+vi.mock("../../../services/HelpSessionService.js", () => ({
+  helpSessionService: helpSessionServiceMock,
+}));
+
 const hibernationMock = vi.hoisted(() => ({
   evictProjectRenderer: vi.fn<(projectId: string) => number>(),
 }));
@@ -162,6 +169,7 @@ describe("project:sleep", () => {
         workspaceEvicted: false,
       });
       expect(teardownMock.gracefulTeardownAndJournalProject).not.toHaveBeenCalled();
+      expect(helpSessionServiceMock.revokeByProjectId).not.toHaveBeenCalled();
       expect(persistenceMock.writeHibernatedMarker).not.toHaveBeenCalled();
       expect(hibernationMock.evictProjectRenderer).not.toHaveBeenCalled();
       expect(projectStoreMock.updateProjectStatus).not.toHaveBeenCalled();
@@ -179,6 +187,33 @@ describe("project:sleep", () => {
       const [scopeId, , , options] = teardownMock.gracefulTeardownAndJournalProject.mock.calls[0]!;
       expect(scopeId).toBe("proj-1");
       expect(options).toEqual({ preserveSession: true, writeBackSessionIds: true });
+    });
+
+    it("capture-revokes the assistant's session before tearing the project down", async () => {
+      const { invoke } = setup();
+
+      await invoke("proj-1");
+
+      // The generic teardown kills the assistant's PTY along with everything
+      // else, and `revokeSession` needs it alive to read the resume id — so the
+      // capture has to land first or there is nothing left to capture (#12181).
+      expect(helpSessionServiceMock.revokeByProjectId).toHaveBeenCalledTimes(1);
+      expect(helpSessionServiceMock.revokeByProjectId).toHaveBeenCalledWith("proj-1");
+      expect(helpSessionServiceMock.revokeByProjectId.mock.invocationCallOrder[0]!).toBeLessThan(
+        teardownMock.gracefulTeardownAndJournalProject.mock.invocationCallOrder[0]!
+      );
+    });
+
+    it("still sleeps when the assistant capture fails", async () => {
+      helpSessionServiceMock.revokeByProjectId.mockRejectedValueOnce(new Error("no pty host"));
+      const { invoke } = setup();
+
+      await expect(invoke("proj-1")).resolves.toMatchObject({ terminalsKilled: 2 });
+
+      // A lost resume entry costs the assistant its conversation, nothing more —
+      // it must never turn the user's sleep into an INTERNAL failure.
+      expect(teardownMock.gracefulTeardownAndJournalProject).toHaveBeenCalled();
+      expect(projectStoreMock.updateProjectStatus).toHaveBeenCalledWith("proj-1", "closed");
     });
 
     it("marks every killed terminal hibernated, agent or not", async () => {
@@ -287,6 +322,11 @@ describe("project:sleep", () => {
       const { invoke } = setup();
 
       await expect(invoke("proj-1")).rejects.toBeInstanceOf(AppError);
+
+      // The capture runs ahead of the confirmation gate on purpose: the row
+      // stays open, and the pending entry is what lets an assistant panel that
+      // reopens there resume instead of starting cold.
+      expect(helpSessionServiceMock.revokeByProjectId).toHaveBeenCalledWith("proj-1");
 
       // Nothing downstream may run: marking it closed would hide still-running
       // agents behind a "reopen to resume" that has nothing to resume.

--- a/electron/ipc/handlers/__tests__/project.sleep.test.ts
+++ b/electron/ipc/handlers/__tests__/project.sleep.test.ts
@@ -71,6 +71,9 @@ import { AppError } from "../../../utils/errorTypes.js";
 import type { HandlerDependencies } from "../../types.js";
 import type { ProjectSleepResult } from "../../../../shared/types/ipc/project.js";
 
+/** Let the handler run up to its first real suspension point. */
+const flushMicrotasks = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
 const PROJECT: StoredProject = {
   id: "proj-1",
   name: "One",
@@ -134,6 +137,9 @@ describe("project:sleep", () => {
       ],
     });
     hibernationMock.evictProjectRenderer.mockReturnValue(1);
+    // `clearAllMocks` clears calls but not a queued `...Once`, so a rejection a
+    // test sets up but never reaches would leak into the next one.
+    helpSessionServiceMock.revokeByProjectId.mockReset().mockResolvedValue(undefined);
   });
 
   describe("validation", () => {
@@ -148,6 +154,7 @@ describe("project:sleep", () => {
       // A silent fallback to "the current project" here would tear down the
       // wrong one — the invalid arg must reach validation as invalid (#7880).
       expect(teardownMock.gracefulTeardownAndJournalProject).not.toHaveBeenCalled();
+      expect(helpSessionServiceMock.revokeByProjectId).not.toHaveBeenCalled();
       expect(projectStoreMock.updateProjectStatus).not.toHaveBeenCalled();
     });
 
@@ -157,6 +164,9 @@ describe("project:sleep", () => {
 
       await expect(invoke("ghost")).rejects.toThrow(/Project not found/);
       expect(teardownMock.gracefulTeardownAndJournalProject).not.toHaveBeenCalled();
+      // A scratch scope or a stale id lands here, so the revoke never runs
+      // against a scope `revokeByProjectId` could not match anyway.
+      expect(helpSessionServiceMock.revokeByProjectId).not.toHaveBeenCalled();
     });
 
     it("no-ops on an already-sleeping project instead of re-journaling it", async () => {
@@ -204,11 +214,38 @@ describe("project:sleep", () => {
       );
     });
 
+    it("waits for the capture to settle before tearing the project down", async () => {
+      // Invocation order can't tell an awaited capture from a fire-and-forget
+      // one, and fire-and-forget IS the bug: the teardown would kill the
+      // assistant's PTY out from under an unresolved `gracefulKill`, leaving
+      // the placeholder entry with no resume id to overwrite it.
+      let releaseCapture!: () => void;
+      helpSessionServiceMock.revokeByProjectId.mockReturnValueOnce(
+        new Promise<void>((resolve) => {
+          releaseCapture = resolve;
+        })
+      );
+      const { invoke } = setup();
+
+      const pending = invoke("proj-1");
+      await flushMicrotasks();
+      expect(teardownMock.gracefulTeardownAndJournalProject).not.toHaveBeenCalled();
+
+      releaseCapture();
+      await pending;
+      expect(teardownMock.gracefulTeardownAndJournalProject).toHaveBeenCalled();
+    });
+
     it("still sleeps when the assistant capture fails", async () => {
       helpSessionServiceMock.revokeByProjectId.mockRejectedValueOnce(new Error("no pty host"));
       const { invoke } = setup();
 
       await expect(invoke("proj-1")).resolves.toMatchObject({ terminalsKilled: 2 });
+
+      // Without this the test passes under a full revert: the queued rejection
+      // is simply never consumed and the sleep succeeds for the wrong reason.
+      expect(helpSessionServiceMock.revokeByProjectId).toHaveBeenCalledTimes(1);
+      expect(helpSessionServiceMock.revokeByProjectId).toHaveBeenCalledWith("proj-1");
 
       // A lost resume entry costs the assistant its conversation, nothing more —
       // it must never turn the user's sleep into an INTERNAL failure.
@@ -353,6 +390,10 @@ describe("project:sleep", () => {
       await invoke("proj-1");
 
       expect(projectStoreMock.clearCurrentProject).not.toHaveBeenCalled();
+      // The capture is keyed on the requested project, not the pointer — the
+      // one arrangement where reading the wrong one is visible.
+      expect(helpSessionServiceMock.revokeByProjectId).toHaveBeenCalledTimes(1);
+      expect(helpSessionServiceMock.revokeByProjectId).toHaveBeenCalledWith("proj-1");
     });
 
     it("clears the pointer when it does", async () => {

--- a/electron/ipc/handlers/projectCrud/crud.ts
+++ b/electron/ipc/handlers/projectCrud/crud.ts
@@ -20,6 +20,7 @@ import { AppError } from "../../../utils/errorTypes.js";
 import { pruneWindowStateForPath } from "../../../windowState.js";
 import { gracefulTeardownAndJournalProject } from "../../../services/pty/projectSessionJournal.js";
 import { helpSessionService } from "../../../services/HelpSessionService.js";
+import { logError } from "../../../utils/logger.js";
 
 /**
  * Rejection copy for a destructive teardown (close+kill / remove) the pty-host
@@ -329,10 +330,7 @@ export function registerProjectCrudCoreHandlers(deps: HandlerDependencies): () =
         try {
           await helpSessionService.revokeByProjectId(projectId);
         } catch (revokeError) {
-          console.warn(
-            `[IPC] project:close: assistant hibernation capture failed for ${projectId}:`,
-            revokeError
-          );
+          logError("project-close-help-revoke-failed", revokeError, { projectId });
         }
 
         // Gracefully tear down and journal each agent session before wiping the

--- a/electron/ipc/handlers/projectCrud/crud.ts
+++ b/electron/ipc/handlers/projectCrud/crud.ts
@@ -19,6 +19,7 @@ import { formatErrorMessage } from "../../../../shared/utils/errorMessage.js";
 import { AppError } from "../../../utils/errorTypes.js";
 import { pruneWindowStateForPath } from "../../../windowState.js";
 import { gracefulTeardownAndJournalProject } from "../../../services/pty/projectSessionJournal.js";
+import { helpSessionService } from "../../../services/HelpSessionService.js";
 
 /**
  * Rejection copy for a destructive teardown (close+kill / remove) the pty-host
@@ -317,6 +318,23 @@ export function registerProjectCrudCoreHandlers(deps: HandlerDependencies): () =
 
     try {
       if (killTerminals) {
+        // Capture the assistant's session before the project-wide teardown:
+        // `revokeSession` reads its resume id off a still-live PTY, and the
+        // generic kill below would already have taken it, so a reopen would
+        // start the assistant cold instead of resuming (#12181). Only this
+        // branch needs it — the background branch leaves terminals running.
+        //
+        // Best-effort: an uncaught rejection would be relabelled INTERNAL by
+        // the catch below and abort a close the user asked for.
+        try {
+          await helpSessionService.revokeByProjectId(projectId);
+        } catch (revokeError) {
+          console.warn(
+            `[IPC] project:close: assistant hibernation capture failed for ${projectId}:`,
+            revokeError
+          );
+        }
+
         // Gracefully tear down and journal each agent session before wiping the
         // project's restoration state, so agent conversations stay resumable
         // from the picker. Fail closed: if the host can't confirm the kills,

--- a/electron/ipc/handlers/projectSleep.ts
+++ b/electron/ipc/handlers/projectSleep.ts
@@ -82,10 +82,7 @@ export function registerProjectSleepHandlers(deps: HandlerDependencies): () => v
             try {
               await helpSessionService.revokeByProjectId(projectId);
             } catch (revokeError) {
-              console.warn(
-                `[IPC] project:sleep: assistant hibernation capture failed for ${projectId}:`,
-                revokeError
-              );
+              logError("project-sleep-help-revoke-failed", revokeError, { projectId });
             }
 
             // Graceful, session-preserving kill + snapshot writeback + journal, in

--- a/electron/ipc/handlers/projectSleep.ts
+++ b/electron/ipc/handlers/projectSleep.ts
@@ -6,6 +6,7 @@ import { getHibernationService } from "../../services/HibernationService.js";
 import { logError } from "../../utils/logger.js";
 import { writeHibernatedMarker } from "../../services/pty/terminalSessionPersistence.js";
 import { gracefulTeardownAndJournalProject } from "../../services/pty/projectSessionJournal.js";
+import { helpSessionService } from "../../services/HelpSessionService.js";
 import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
 import { AppError } from "../../utils/errorTypes.js";
 import { defineIpcNamespace, op } from "../define.js";
@@ -67,6 +68,26 @@ export function registerProjectSleepHandlers(deps: HandlerDependencies): () => v
           }
 
           try {
+            // Capture the assistant's session BEFORE the project-wide teardown,
+            // the same order the idle-background sweep uses: `revokeSession`
+            // needs the assistant's PTY still alive to read its resume id, and
+            // the generic kill below would already have taken it. Deliberately
+            // ahead of the `confirmed` gate too — an unconfirmed teardown leaves
+            // the row open, and a captured pending entry is what lets a panel
+            // that reopens there resume rather than start cold (#12181).
+            //
+            // Best-effort: losing the resume entry must not fail the sleep, and
+            // an uncaught rejection here would surface as an INTERNAL error from
+            // the catch below.
+            try {
+              await helpSessionService.revokeByProjectId(projectId);
+            } catch (revokeError) {
+              console.warn(
+                `[IPC] project:sleep: assistant hibernation capture failed for ${projectId}:`,
+                revokeError
+              );
+            }
+
             // Graceful, session-preserving kill + snapshot writeback + journal, in
             // that order — the same three steps a quit performs per project, via
             // the shared helper rather than a fourth copy of them.

--- a/electron/services/HelpSessionService.ts
+++ b/electron/services/HelpSessionService.ts
@@ -1109,6 +1109,15 @@ export class HelpSessionService {
     // resume entry. A best-effort capture is strictly an improvement over
     // the previous behaviour of always losing the conversation.
     let capturedAgentSessionId: string | null = null;
+    // Whether THIS call claimed the lane's capture below. `revoked` is only set
+    // after the gracefulKill await, so a concurrent revoke of the same session —
+    // the renderer's no-capture `handleTerminalPanelMissing` path, which now
+    // races us whenever the project view outlives the kill (project sleep and
+    // close+kill both keep it alive) — passes the guard at the top and reaches
+    // the finalize block below. Without this flag it would release OUR ownership
+    // and the real resume id would be dropped for the empty-sentinel placeholder,
+    // silently demoting the resume to latest-conversation.
+    let ownsCapture = false;
     if (opts?.captureHibernation && terminalId && this.ptyClient) {
       // #9639: write a placeholder resume entry SYNCHRONOUSLY (memory-first
       // via `set`) before the gracefulKill round-trip. The eviction path that
@@ -1121,6 +1130,7 @@ export class HelpSessionService {
       // placeholder with the agent's real resume ID (below).
       if (this.pendingHibernationStore) {
         this.pendingCapturesBySlotKey.set(slotKey, sessionId);
+        ownsCapture = true;
         const panelWasOpen = this.panelOpenByProjectId.get(record.projectId) === true;
         void this.pendingHibernationStore
           .set(slotKey, {
@@ -1204,7 +1214,11 @@ export class HelpSessionService {
     // took the lane. When we still own it: overwrite with the real resume ID
     // if gracefulKill yielded one, otherwise leave the empty-sentinel in place
     // (resume-latest beats a fresh launch). Then release ownership.
-    if (this.pendingHibernationStore && this.pendingCapturesBySlotKey.get(slotKey) === sessionId) {
+    if (
+      ownsCapture &&
+      this.pendingHibernationStore &&
+      this.pendingCapturesBySlotKey.get(slotKey) === sessionId
+    ) {
       if (capturedAgentSessionId) {
         const panelWasOpen = this.panelOpenByProjectId.get(record.projectId) === true;
         void this.pendingHibernationStore

--- a/electron/services/HelpSessionService.ts
+++ b/electron/services/HelpSessionService.ts
@@ -1528,19 +1528,24 @@ export class HelpSessionService {
   }
 
   /**
-   * Idle-background auto-close (#10830): the sweep capture-revokes a project's
-   * help sessions before reclaiming it — the same conversation-preserving path
-   * as LRU eviction, so the next open resumes where the user left off. The
-   * renderer's own hibernate timer can't do this itself, because a parked
-   * project view freezes timers (the #10739 class).
+   * Three entry points capture-revoke a project's help sessions ahead of a
+   * project-wide teardown: the idle-background auto-close sweep (#10830),
+   * `project:sleep`, and `project:close` with `killTerminals` (#12181). All
+   * three take the same conversation-preserving path as LRU eviction, so the
+   * next open resumes where the user left off. The renderer's own hibernate
+   * timer can't do this itself, because a parked project view freezes timers
+   * (the #10739 class).
    *
-   * A LIVE assistant no longer reaches here: since #11807 the sweep treats one
-   * as a hard floor and skips the project entirely, because nothing tells main
+   * The sweep never hands us a LIVE assistant: since #11807 it treats one as a
+   * hard floor and skips the project entirely, because nothing tells main
    * whether an idle-looking assistant is merely at its prompt or sitting on a
-   * scheduled wakeup. So the records this settles are the non-live ones — a
-   * terminal that exited under its own steam (nothing drops that binding), or
-   * a session provisioned but never bound. Only the former has a conversation
-   * to capture; an unbound record writes no pending-hibernation entry.
+   * scheduled wakeup. Its records are the non-live ones — a terminal that
+   * exited under its own steam (nothing drops that binding), or a session
+   * provisioned but never bound. Sleep and close are the opposite: the user
+   * asked for the teardown, so a live assistant behind a still-live project
+   * view is the normal case and the capture path really runs. That is what
+   * makes the renderer's own no-capture revoke of the same session racing us
+   * reachable, and why `revokeSession` finalizes only under the ownership flag.
    */
   async revokeByProjectId(projectId: string): Promise<void> {
     const targets = [...this.sessionsById.values()].filter(

--- a/electron/services/__tests__/HelpSessionService.test.ts
+++ b/electron/services/__tests__/HelpSessionService.test.ts
@@ -2250,6 +2250,69 @@ describe("HelpSessionService", () => {
 
       expect(backing.get(slotKey("proj-no-take", 0))?.agentSessionId).toBe("real-resume-id-abc");
     });
+
+    it("keeps the real resume id when a no-capture revoke of the same session races the capture (#12181)", async () => {
+      // A session is not marked revoked until AFTER gracefulKill resolves, so a
+      // second revoke of the same id passes the top guard and reaches the
+      // finalize block. Only the call that CLAIMED the capture may release it —
+      // otherwise the renderer's no-capture revoke (fired by
+      // `handleTerminalPanelMissing` when the assistant's PTY exits) hands
+      // ownership back mid-capture and the real resume id is dropped for the
+      // empty sentinel, silently demoting the resume to latest-conversation.
+      // Newly reachable via project sleep / close+kill, which keep the project
+      // view alive and observing while main tears the assistant down.
+      type PendingHelpHibernationLike = {
+        agentId: string;
+        agentSessionId: string;
+        cwd: string;
+        capturedAt: number;
+      };
+      const backing = new Map<string, PendingHelpHibernationLike>();
+      const statefulStore = {
+        get: vi.fn((projectId: string) => backing.get(projectId) ?? null),
+        set: vi.fn((projectId: string, entry: PendingHelpHibernationLike) => {
+          backing.set(projectId, entry);
+          return Promise.resolve();
+        }),
+        clear: vi.fn((projectId: string) => {
+          backing.delete(projectId);
+          return Promise.resolve();
+        }),
+      };
+      service.setPendingHibernationStore(statefulStore as never);
+
+      let resolveGraceful: (value: string | null) => void = () => {};
+      mockPtyGracefulKill.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveGraceful = resolve;
+          })
+      );
+
+      const result = await service.provisionSession({
+        ...provisionInput(),
+        projectViewWebContentsId: 91,
+        projectId: "proj-double-revoke",
+      });
+      if (!result) throw new Error("expected provision");
+      expect(service.markTerminalForToken(result.token, "term-double-revoke")).toBe(true);
+
+      // Main's capture-revoke parks on gracefulKill, holding the lane.
+      const capturePromise = service.revokeByProjectId("proj-double-revoke");
+      expect(backing.get(slotKey("proj-double-revoke", 0))?.agentSessionId).toBe("");
+
+      // The renderer revokes the SAME session with no capture flag while that
+      // await is still outstanding. It must not release main's ownership.
+      await service.revokeSession(result.sessionId);
+
+      resolveGraceful("real-resume-id-race");
+      await capturePromise;
+      await Promise.resolve();
+
+      expect(backing.get(slotKey("proj-double-revoke", 0))?.agentSessionId).toBe(
+        "real-resume-id-race"
+      );
+    });
   });
 
   describe("isHelpTerminal (#7526)", () => {


### PR DESCRIPTION
## Summary

`project:sleep` and `project:close --killTerminals` killed the Daintree Assistant's terminal through the generic per-project teardown (`gracefulTeardownAndJournalProject`) without ever capturing its session into the pending-hibernation store.
LRU eviction (`revokeByWebContentsId`), window close (`revokeByWindowId`), and the idle-background auto-close sweep (`revokeByProjectId`) all already capture-revoke, so these two paths were the only gap left.
Net effect: sleep or close a project, reopen it, and the assistant starts cold instead of resuming the conversation.

Resolves #12181

## Changes

Added a best-effort `await helpSessionService.revokeByProjectId(projectId)` immediately before the existing teardown in both handlers (`electron/ipc/handlers/projectSleep.ts` and `electron/ipc/handlers/projectCrud/crud.ts`), modelled on `IdleBackgroundAutoCloseService.closeProject`.
It's wrapped in its own try/catch so a lost resume entry degrades to "assistant starts fresh" rather than failing the user's sleep or close action. Without that, both handlers' outer catch would relabel a capture failure as an INTERNAL error and abort the teardown entirely.

The one judgment call worth calling out: the capture has to run ahead of the fail-closed confirmation gate. `revokeSession` needs the assistant's PTY still alive to read its resume id, and the generic teardown kills the PTY, so a capture placed after the `confirmed` check could only ever write the empty sentinel. On the unconfirmed path the row stays open with a captured pending entry, which is the recoverable state: `HibernationManager.seedFromMain` re-seeds it and a reopened panel resumes.

What was deliberately left alone:

- The background branch of `project:close` leaves terminals alive, so revoking there would kill the very session it's supposed to preserve.
- Both `removeProjectWithCleanup` and scratch remove delete the row immediately, so a captured entry would just be orphaned.
- No live-assistant gate was added. That floor is a sweep-specific heuristic that belongs to `IdleBackgroundAutoCloseService`, not a precondition on `revokeByProjectId`, and the sibling unconditional revokes (`revokeByWebContentsId`/`revokeByWindowId`) are the right precedent for explicit user actions.

Adjacent gaps noticed along the way, out of scope for this issue: `HibernationService.hibernateProject` (scheduled/memory-pressure hibernation and the idle-terminal "Close Them" action) has zero `helpSessionService` references and has the same missing capture, through a different mechanism, worth its own issue. `ProjectRelocationCoordinator` only reads `getAssistantBackends` as a guard. `revokeAll` on app quit is deliberately left uncaptured by design.

## Testing

The new assertions were mutation-tested rather than assumed. A fire-and-forget `void revoke(...)` mutant fails exactly the two new "waits for the capture to settle" tests and nothing else; a full revert of the production change fails all 10 capture assertions. The second test commit exists because the first round of ordering assertions only pinned invocation order (which fire-and-forget still satisfies), and both "still completes when capture fails" tests passed vacuously under a revert.

Locally: 189 targeted tests green across `project.sleep`, `project.close`, `IdleBackgroundAutoCloseService`, `project.remove`, `project.bulkStats`, `project.switch`, and `handlers.registry`. `prettier --check` exits 0 and eslint reports 0 errors on all four changed files (the 9 warnings in `crud.ts` are pre-existing `typedHandle`/#8577 registrations, untouched by this change).


## Follow-up commit: the capture-ownership race

Capturing on sleep and close makes an existing race in `HelpSessionService.revokeSession` reachable, so it's fixed here rather than left for the field to find.

A session isn't marked revoked until *after* the `gracefulKill` await. So while main's capture is parked on that await, the renderer's own no-capture revoke of the same session — fired by `handleTerminalPanelMissing` when the assistant's PTY exits — passes the `!record.revoked` guard at the top, reaches the finalize block, matches `pendingCapturesBySlotKey.get(slotKey) === sessionId`, and releases main's ownership. Main's capture then resumes, fails its own ownership check, and skips writing the real resume id: the empty sentinel stands and the resume silently degrades to latest-conversation.

This wasn't reachable before. LRU eviction and window close destroy the renderer, so nothing was left observing the exit, and the idle sweep never has a live assistant to capture. Sleep and close+kill both keep the project view alive and watching, which is what opens the door.

The fix is a local `ownsCapture` flag, set only where the lane is claimed and ANDed into the finalize guard, so only the call that actually claimed the capture may write the resume id and release it. Because it's ANDed in it can only make finalize *skip*, never fire where it previously wouldn't, so the #9639 displacement property is untouched — `displacePriorSessions` still wins that race on the second conjunct, and its regression test passes unchanged.

Mutation-tested: dropping `ownsCapture &&` makes the new concurrent-double-revoke test fail with `''` instead of the resume id.

Also swaps the two capture-failure `console.warn`s for `logError` with the established `<entry-point>-help-revoke-failed` key, matching `IdleBackgroundAutoCloseService` and `projectSleep.ts`'s own neighbours.

Verification for this commit: 575 targeted tests green (adds `HelpSessionService`'s own 163-test suite plus the pending-hibernation/help service suites to the runs above), `prettier --check` and `npm run typecheck` clean, eslint 0 errors on all six changed files.

One more adjacent gap, out of scope: main's `PendingHelpHibernationStore` is never cleared on project remove — only the renderer's mirror is — so close then remove then re-add the same folder can resurrect a discarded conversation, since project ids are a hash of the normalized path.
