### PR TITLE
feat(codex): resolve `codex resume --last` to an exact session id at restore

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -507,6 +507,7 @@ export const CHANNELS = {
 
   CODEX_LIST_SUBAGENTS: "codex:list-subagents",
   CODEX_READ_SUBAGENT_TRANSCRIPT: "codex:read-subagent-transcript",
+  CODEX_RESOLVE_RESUME_LATEST_SESSION: "codex:resolve-resume-latest-session",
 
   CLAUDE_LIST_SUBAGENTS: "claude:list-subagents",
   CLAUDE_READ_SUBAGENT_TRANSCRIPT: "claude:read-subagent-transcript",

--- a/electron/ipc/handlers/__tests__/codex.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/codex.handlers.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const ipcHandlers = vi.hoisted(() => new Map<string, unknown>());
+const ipcMainMock = vi.hoisted(() => ({
+  handle: vi.fn((channel: string, fn: unknown) => ipcHandlers.set(channel, fn)),
+  removeHandler: vi.fn((channel: string) => ipcHandlers.delete(channel)),
+}));
+
+const serviceMock = vi.hoisted(() => ({
+  listCodexSubagents: vi.fn(),
+  readCodexSubagentTranscript: vi.fn(),
+  resolveCodexResumeLatestSession: vi.fn(),
+}));
+
+vi.mock("electron", () => ({ ipcMain: ipcMainMock }));
+vi.mock("../../../services/codex/CodexSubagentService.js", () => serviceMock);
+
+import { registerCodexHandlers } from "../codex.js";
+import { CHANNELS } from "../../channels.js";
+
+type Handler = (event: Electron.IpcMainInvokeEvent, ...args: unknown[]) => Promise<unknown>;
+
+function getHandler(channel: string): Handler {
+  const fn = ipcHandlers.get(channel);
+  if (!fn) throw new Error(`handler not registered: ${channel}`);
+  return fn as Handler;
+}
+
+function fakeEvent(): Electron.IpcMainInvokeEvent {
+  return { sender: {} as Electron.WebContents } as Electron.IpcMainInvokeEvent;
+}
+
+const resolveChannel = CHANNELS.CODEX_RESOLVE_RESUME_LATEST_SESSION;
+
+describe("codex IPC handlers", () => {
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    ipcHandlers.clear();
+    vi.clearAllMocks();
+    cleanup = registerCodexHandlers();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe("resolveResumeLatestSession", () => {
+    it("passes an absolute cwd through and returns the resolved session id", async () => {
+      serviceMock.resolveCodexResumeLatestSession.mockResolvedValue("session-uuid");
+
+      const result = await getHandler(resolveChannel)(fakeEvent(), { cwd: "/repo/worktree" });
+
+      expect(result).toBe("session-uuid");
+      expect(serviceMock.resolveCodexResumeLatestSession).toHaveBeenCalledWith("/repo/worktree");
+    });
+
+    it("returns null unchanged when the directory has nothing to resume", async () => {
+      serviceMock.resolveCodexResumeLatestSession.mockResolvedValue(null);
+
+      expect(await getHandler(resolveChannel)(fakeEvent(), { cwd: "/repo" })).toBeNull();
+    });
+
+    it("does not normalize the cwd, because Codex matches it as an exact string", async () => {
+      serviceMock.resolveCodexResumeLatestSession.mockResolvedValue(null);
+
+      await getHandler(resolveChannel)(fakeEvent(), { cwd: "/repo/./worktree/" });
+
+      expect(serviceMock.resolveCodexResumeLatestSession).toHaveBeenCalledWith("/repo/./worktree/");
+    });
+
+    it.each([
+      ["a relative path", { cwd: "relative/path" }],
+      ["an empty path", { cwd: "" }],
+      ["a non-string path", { cwd: 42 }],
+      ["a missing payload field", {}],
+      ["an oversized path", { cwd: `/${"a".repeat(5000)}` }],
+    ])("rejects %s before reaching the service", async (_label, payload) => {
+      await expect(getHandler(resolveChannel)(fakeEvent(), payload)).rejects.toThrow();
+
+      expect(serviceMock.resolveCodexResumeLatestSession).not.toHaveBeenCalled();
+    });
+
+    it("propagates a service failure rather than reporting a resolved session", async () => {
+      serviceMock.resolveCodexResumeLatestSession.mockRejectedValue(new Error("app-server down"));
+
+      await expect(getHandler(resolveChannel)(fakeEvent(), { cwd: "/repo" })).rejects.toThrow(
+        "app-server down"
+      );
+    });
+  });
+
+  it("removes every codex handler on cleanup", () => {
+    expect(ipcHandlers.has(resolveChannel)).toBe(true);
+    expect(ipcHandlers.has(CHANNELS.CODEX_LIST_SUBAGENTS)).toBe(true);
+
+    cleanup();
+
+    expect(ipcHandlers.size).toBe(0);
+    // Registered again in afterEach's cleanup call, which must stay safe to repeat.
+    cleanup = () => {};
+  });
+});

--- a/electron/ipc/handlers/codex.preload.ts
+++ b/electron/ipc/handlers/codex.preload.ts
@@ -3,6 +3,7 @@ import type { IpcInvokeMap } from "../../types/index.js";
 export const CODEX_METHOD_CHANNELS = {
   listSubagents: "codex:list-subagents",
   readSubagentTranscript: "codex:read-subagent-transcript",
+  resolveResumeLatestSession: "codex:resolve-resume-latest-session",
 } as const satisfies Record<string, keyof IpcInvokeMap>;
 
 type Methods = typeof CODEX_METHOD_CHANNELS;

--- a/electron/ipc/handlers/codex.ts
+++ b/electron/ipc/handlers/codex.ts
@@ -18,6 +18,30 @@ const id = z.string().trim().min(1).max(ID_MAX);
 const listSchema = z.object({ terminalId: id });
 const readSchema = z.object({ terminalId: id, subagentId: id });
 
+/**
+ * Restore is the one caller that cannot name a terminal: it runs before the PTY
+ * exists, so the folder is all it has (#12178). The cwd it sends comes from the
+ * app's own persisted snapshot rather than anything a user typed, and the reply
+ * is a single session id — never a cwd, a preview, a timestamp or a thread list
+ * — so a caller that pointed this at someone else's folder would learn only
+ * whether a Codex session id exists there, not what is in it.
+ *
+ * Bound it to a plausible absolute path anyway, so a malformed payload is
+ * refused at the boundary instead of being carried into a protocol query.
+ */
+const CWD_MAX = 4096;
+const resolveResumeLatestSchema = z.object({
+  cwd: z
+    .string()
+    .min(1)
+    .max(CWD_MAX)
+    .refine((value) => !value.includes("\0"), "cwd must not contain a NUL byte")
+    .refine(
+      (value) => value.startsWith("/") || /^[A-Za-z]:[\\/]/.test(value) || value.startsWith("\\\\"),
+      "cwd must be an absolute path"
+    ),
+});
+
 export const codexNamespace = defineIpcNamespace({
   name: "codex",
   ops: {
@@ -38,6 +62,15 @@ export const codexNamespace = defineIpcNamespace({
         const { readCodexSubagentTranscript } =
           await import("../../services/codex/CodexSubagentService.js");
         return readCodexSubagentTranscript(terminalId, subagentId);
+      }
+    ),
+    resolveResumeLatestSession: opValidated(
+      CODEX_METHOD_CHANNELS.resolveResumeLatestSession,
+      resolveResumeLatestSchema,
+      async ({ cwd }): Promise<string | null> => {
+        const { resolveCodexResumeLatestSession } =
+          await import("../../services/codex/CodexSubagentService.js");
+        return resolveCodexResumeLatestSession(cwd);
       }
     ),
   },

--- a/electron/services/codex/CodexAppServerClient.ts
+++ b/electron/services/codex/CodexAppServerClient.ts
@@ -43,7 +43,7 @@ export function isAllowedCodexAppServerMethod(method: string): boolean {
   return (ALLOWED_METHODS as readonly string[]).includes(method);
 }
 
-/** Whole-session budget: spawn, handshake, every query, teardown. */
+/** Whole-session budget: the wait for a slot, spawn, handshake, every query, teardown. */
 const SESSION_TIMEOUT_MS = 15_000;
 /** Per-request budget, so one wedged call can't eat the whole session. */
 const REQUEST_TIMEOUT_MS = 10_000;
@@ -80,16 +80,38 @@ const MAX_CONCURRENT_SESSIONS = 2;
 let activeSessions = 0;
 const sessionQueue: Array<() => void> = [];
 
-function acquireSessionSlot(): Promise<void> {
+/**
+ * The wait for a slot counts against the caller's budget, not on top of it.
+ * A restore-time lookup queued behind two wedged sessions would otherwise sit
+ * here for as long as they take, which is precisely when the gate is busiest —
+ * the cap above exists because a restore mounts every Codex pane at once.
+ */
+function acquireSessionSlot(deadlineAt: number): Promise<void> {
   if (activeSessions < MAX_CONCURRENT_SESSIONS) {
     activeSessions++;
     return Promise.resolve();
   }
-  return new Promise<void>((resolve) => {
-    sessionQueue.push(() => {
+  return new Promise<void>((resolve, reject) => {
+    // Whichever of these two runs first disarms the other: the waiter clears
+    // the timer, and the timer drops the waiter from the queue. So a slot can
+    // never be handed to a caller that already gave up and left it leaked.
+    // `waiter` closes over `timer` before it is assigned, which is safe — it
+    // only ever runs from the queue, long after this function has returned.
+    const waiter = (): void => {
+      clearTimeout(timer);
       activeSessions++;
       resolve();
-    });
+    };
+    const timer = setTimeout(
+      () => {
+        const index = sessionQueue.indexOf(waiter);
+        if (index !== -1) sessionQueue.splice(index, 1);
+        reject(new CodexAppServerError("timeout", "Codex app-server timed out awaiting a slot"));
+      },
+      Math.max(0, deadlineAt - Date.now())
+    );
+    timer.unref?.();
+    sessionQueue.push(waiter);
   });
 }
 
@@ -145,9 +167,14 @@ export async function runCodexAppServerSession<T>(
   run: (call: CodexAppServerCall) => Promise<T>,
   options: CodexAppServerSessionOptions = {}
 ): Promise<T> {
-  await acquireSessionSlot();
+  const deadlineAt = Date.now() + (options.timeoutMs ?? SESSION_TIMEOUT_MS);
+  await acquireSessionSlot(deadlineAt);
   try {
-    return await spawnCodexAppServerSession(run, options);
+    const remainingMs = deadlineAt - Date.now();
+    if (remainingMs <= 0) {
+      throw new CodexAppServerError("timeout", "Codex app-server timed out awaiting a slot");
+    }
+    return await spawnCodexAppServerSession(run, { ...options, timeoutMs: remainingMs });
   } finally {
     releaseSessionSlot();
   }

--- a/electron/services/codex/CodexSubagentService.ts
+++ b/electron/services/codex/CodexSubagentService.ts
@@ -1,6 +1,14 @@
 /**
- * Resolves which Codex thread a live terminal is running, then reads that
- * thread's spawned subagents. Read-only throughout — see CodexAppServerClient.
+ * Resolves which Codex thread a terminal is running, then reads that thread's
+ * spawned subagents. Read-only throughout — see CodexAppServerClient.
+ *
+ * Two resolutions live here and they answer different questions. The subagent
+ * one asks "which conversation is this LIVE terminal in", and refuses to guess.
+ * `resolveCodexResumeLatestSession` asks "which conversation would `codex resume
+ * --last` open in this folder" for a pane being restored cold (#12178), where
+ * there is no terminal to ask and the answer is a fact about the CLI's own
+ * selection rule rather than an attribution. They share the protocol plumbing
+ * below and nothing else.
  *
  * Everything leaves here in the provider-neutral shape from
  * `shared/types/ipc/agentSubagents`, so the renderer's list and transcript are
@@ -64,6 +72,12 @@ function secondsToMs(seconds: unknown): number {
 /** Shape of the protocol's `Thread`, narrowed to the fields this feature reads. */
 interface RawThread {
   id?: unknown;
+  /**
+   * The session tree this thread belongs to — the value `codex resume` takes.
+   * Distinct from `id` in the protocol (a subagent thread has its own id but
+   * shares its root's session), though for a root the two coincide.
+   */
+  sessionId?: unknown;
   parentThreadId?: unknown;
   preview?: unknown;
   cwd?: unknown;
@@ -283,18 +297,29 @@ async function resolveTerminal(
   }
   if (!info.cwd) return { status: "unavailable", reason: "terminal-unknown" };
 
-  // `thread/list`'s cwd filter is an exact string match, so a path recorded
-  // through a symlink (macOS `/tmp` → `/private/tmp` being the common one)
-  // would match nothing. Query both spellings when they differ.
-  const cwds = [info.cwd];
+  return {
+    cwds: await resolveCwdSpellings(info.cwd),
+    spawnedAtMs: info.spawnedAt,
+    agentSessionId: info.agentSessionId ?? null,
+  };
+}
+
+/**
+ * Every spelling of one directory that `thread/list` might have recorded.
+ *
+ * Its cwd filter is an exact string match, so a path recorded through a symlink
+ * (macOS `/tmp` → `/private/tmp` being the common one) would match nothing.
+ * Query both spellings when they differ.
+ */
+async function resolveCwdSpellings(cwd: string): Promise<string[]> {
+  const cwds = [cwd];
   try {
-    const resolved = await realpath(info.cwd);
-    if (resolved && resolved !== info.cwd) cwds.push(resolved);
+    const resolved = await realpath(cwd);
+    if (resolved && resolved !== cwd) cwds.push(resolved);
   } catch {
     // A deleted or unreadable worktree just means the literal path is all we have.
   }
-
-  return { cwds, spawnedAtMs: info.spawnedAt, agentSessionId: info.agentSessionId ?? null };
+  return cwds;
 }
 
 async function listThreadsInCwd(call: CodexAppServerCall, cwds: string[]): Promise<RawThread[]> {
@@ -449,5 +474,97 @@ export async function readCodexSubagentTranscript(
     });
   } catch (error) {
     return toUnavailable(error);
+  }
+}
+
+/**
+ * A session id is about to be interpolated into a shell command by
+ * `buildResumeCommand`. It arrives as JSON from another process, so it is
+ * checked against the same shape Codex itself prints in its `codex resume <id>`
+ * footer (the agent config's `sessionIdPattern`) before it can get there.
+ */
+const CODEX_SESSION_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
+
+export type ResumeLatestSelection = { sessionId: string } | { sessionId: null };
+
+/**
+ * Which session `codex resume --last` would open, given one page of that
+ * folder's threads.
+ *
+ * `--last` is "the most recent session in this directory", so the rule is a
+ * ranking, not the strict attribution filter `selectParentThread` applies — that
+ * one exists to refuse to guess which of two live sessions a terminal owns, and
+ * calling it here would decline the very question this answers.
+ *
+ * Only subagent threads are excluded (`--last` opens a root), and only the tie
+ * at the top is refused: a single most-recent root is exactly what the CLI would
+ * pick, while two roots sharing that timestamp is a coin-flip whose tie-break
+ * lives inside Codex. Refusing there costs nothing, since the fallback is to let
+ * the CLI make the same choice itself.
+ */
+export function selectResumeLatestThread(threads: readonly RawThread[]): ResumeLatestSelection {
+  let best: { sessionId: string; activity: number } | undefined;
+  let tied = false;
+  const seen = new Set<string>();
+
+  for (const thread of threads) {
+    const threadId = asString(thread.id);
+    if (threadId === null) continue;
+    // A subagent's row carries its parent's `sessionId`, so an unfiltered scan
+    // could rank a child's activity and hand back the root it belongs to.
+    if (asString(thread.parentThreadId) !== null) continue;
+    // One page should not repeat a thread, but ranking a duplicate against
+    // itself would read as a tie and refuse a session that has no rival.
+    if (seen.has(threadId)) continue;
+    seen.add(threadId);
+
+    // `sessionId` is the value `codex resume` accepts; for a root it equals the
+    // thread id, and an older server that omits it falls back to that.
+    const sessionId = asString(thread.sessionId) ?? threadId;
+    if (!CODEX_SESSION_ID_PATTERN.test(sessionId)) continue;
+
+    const activity = activityOf(thread);
+    if (best === undefined || activity > best.activity) {
+      best = { sessionId, activity };
+      tied = false;
+    } else if (activity === best.activity && sessionId !== best.sessionId) {
+      tied = true;
+    }
+  }
+
+  if (best === undefined || tied) return { sessionId: null };
+  return { sessionId: best.sessionId };
+}
+
+/**
+ * Resolve the session `codex resume --last` would open in `cwd`, or null.
+ *
+ * Called at restore for a cold pane that would otherwise launch with `--last`
+ * and run a conversation whose id Daintree never learns (#12178). Freezing the
+ * choice here is only correct if the query reproduces the CLI's own selection,
+ * which the request shape below does exactly — verified against codex-cli
+ * 0.153.0's generated protocol schema and `codex resume --help`:
+ *
+ *   - `--last` is cwd-scoped: `--all` is documented as "disables cwd filtering".
+ *   - `--last` skips non-interactive sessions unless `--include-non-interactive`
+ *     is passed, and `ThreadListParams.sourceKinds` "defaults to interactive
+ *     sources" when omitted. So `sourceKinds` must stay ABSENT here — naming
+ *     the kinds explicitly would change the filter rather than restate it.
+ *   - `archived` omitted returns only non-archived threads, matching the picker.
+ *
+ * Never throws: a missing CLI, a wedged server or a timeout resolves to null,
+ * and the caller launches with plain `--last` exactly as it does today.
+ */
+export async function resolveCodexResumeLatestSession(cwd: string): Promise<string | null> {
+  try {
+    const cwds = await resolveCwdSpellings(cwd);
+    return await runCodexAppServerSession(async (call) => {
+      const threads = await listThreadsInCwd(call, cwds);
+      return selectResumeLatestThread(threads).sessionId;
+    });
+  } catch {
+    // Degrading to `--last` loses the id capture; failing the restore would lose
+    // the pane. The pane is worth more.
+    return null;
   }
 }

--- a/electron/services/codex/CodexSubagentService.ts
+++ b/electron/services/codex/CodexSubagentService.ts
@@ -57,6 +57,14 @@ type CodexSubagentMatch = "session-id" | "spawn-time";
 
 /** How many root threads in the cwd are considered as parent candidates. */
 const PARENT_CANDIDATE_LIMIT = 25;
+
+/**
+ * Whole budget for the restore-time resume-latest lookup, well under the
+ * transport's 15s default. Restore waits on this before it can launch the pane,
+ * and the answer is an optimisation over an already-working fallback — so it
+ * has to give up long before a user would notice the pane is late.
+ */
+const RESUME_LATEST_LOOKUP_TIMEOUT_MS = 2_000;
 /**
  * A session whose last activity is older than this at the moment the terminal
  * launched cannot be the one the terminal is running — it went quiet before the
@@ -557,11 +565,16 @@ export function selectResumeLatestThread(threads: readonly RawThread[]): ResumeL
  */
 export async function resolveCodexResumeLatestSession(cwd: string): Promise<string | null> {
   try {
-    const cwds = await resolveCwdSpellings(cwd);
-    return await runCodexAppServerSession(async (call) => {
-      const threads = await listThreadsInCwd(call, cwds);
-      return selectResumeLatestThread(threads).sessionId;
-    });
+    return await runCodexAppServerSession(
+      async (call) => {
+        // Resolved inside the session so the transport's deadline covers it
+        // too: realpath hangs indefinitely on a dead network mount, and this
+        // runs on the restore path.
+        const threads = await listThreadsInCwd(call, await resolveCwdSpellings(cwd));
+        return selectResumeLatestThread(threads).sessionId;
+      },
+      { timeoutMs: RESUME_LATEST_LOOKUP_TIMEOUT_MS }
+    );
   } catch {
     // Degrading to `--last` loses the id capture; failing the restore would lose
     // the pane. The pane is worth more.

--- a/electron/services/codex/__tests__/CodexAppServerClient.test.ts
+++ b/electron/services/codex/__tests__/CodexAppServerClient.test.ts
@@ -391,3 +391,80 @@ describe("runCodexAppServerSession", () => {
     }
   });
 });
+
+describe("session slot queue", () => {
+  it("counts the wait for a slot against the caller's own budget", async () => {
+    // Two sessions hold the gate. A third must not sit here unbounded: at
+    // restore every Codex pane asks at once, which is exactly when a
+    // restore-time lookup with a short budget needs to give up on time.
+    vi.useFakeTimers();
+    vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const children: FakeChild[] = [];
+    spawnMock.mockImplementation(() => {
+      const next = new FakeChild();
+      children.push(next);
+      return next;
+    });
+
+    let releaseFirst: (() => void) | undefined;
+    let releaseSecond: (() => void) | undefined;
+    const held = [
+      runCodexAppServerSession(() => new Promise<void>((resolve) => (releaseFirst = resolve)), {
+        command: "codex-test",
+        timeoutMs: 60_000,
+      }),
+      runCodexAppServerSession(() => new Promise<void>((resolve) => (releaseSecond = resolve)), {
+        command: "codex-test",
+        timeoutMs: 60_000,
+      }),
+    ];
+    await vi.advanceTimersByTimeAsync(0);
+    for (const occupant of children) occupant.respondTo("initialize", { userAgent: "codex" });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(children).toHaveLength(2);
+
+    const run = vi.fn(async () => "never");
+    const queued = runCodexAppServerSession(run, { command: "codex-test", timeoutMs: 2_000 });
+    const outcome = queued.then(
+      () => "resolved",
+      (error: unknown) => (error as CodexAppServerError).reason
+    );
+
+    await vi.advanceTimersByTimeAsync(2_001);
+
+    try {
+      expect(await outcome).toBe("timeout");
+      // Gave up in the queue: it never got a process, and never ran the caller.
+      expect(children).toHaveLength(2);
+      expect(run).not.toHaveBeenCalled();
+    } finally {
+      // Released even if an assertion above threw: `activeSessions` is module
+      // state, and leaving it pinned would time out every later session here.
+      releaseFirst?.();
+      releaseSecond?.();
+      await vi.advanceTimersByTimeAsync(0);
+      for (const occupant of children) occupant.emit("exit", 0, null);
+      await vi.advanceTimersByTimeAsync(500);
+      await Promise.allSettled(held);
+    }
+
+    // The abandoned waiter must not have kept the slot it gave up on. Counting
+    // spawns is the only way to see that: a leaked waiter resolves a promise
+    // that is already rejected, so it is invisible except as a slot that never
+    // comes back. Both fresh sessions must therefore start immediately.
+    const spawnedBefore = children.length;
+    const probes = [
+      runCodexAppServerSession(async () => "a", { command: "codex-test", timeoutMs: 60_000 }),
+      runCodexAppServerSession(async () => "b", { command: "codex-test", timeoutMs: 60_000 }),
+    ];
+    await vi.advanceTimersByTimeAsync(0);
+    expect(children.length - spawnedBefore).toBe(2);
+
+    for (const probe of children.slice(spawnedBefore)) {
+      probe.respondTo("initialize", { userAgent: "codex" });
+    }
+    await vi.advanceTimersByTimeAsync(0);
+    await Promise.allSettled(probes);
+  });
+});

--- a/electron/services/codex/__tests__/CodexSubagentService.test.ts
+++ b/electron/services/codex/__tests__/CodexSubagentService.test.ts
@@ -24,7 +24,9 @@ import { CodexAppServerError } from "../CodexAppServerClient.js";
 import {
   listCodexSubagents,
   readCodexSubagentTranscript,
+  resolveCodexResumeLatestSession,
   selectParentThread,
+  selectResumeLatestThread,
   toSubagent,
   toSubagentStatus,
   toSubagentMessages,
@@ -473,5 +475,136 @@ describe("readCodexSubagentTranscript", () => {
     expect(result.messages).toEqual([{ role: "reply", text: "done" }]);
     expect(turnParams.itemsView).toBe("summary");
     expect(turnParams.sortDirection).toBe("desc");
+  });
+});
+
+describe("selectResumeLatestThread", () => {
+  it("picks the most recent root, which is what `codex resume --last` opens", () => {
+    expect(
+      selectResumeLatestThread([
+        { id: "older", sessionId: "older", recencyAt: 100 },
+        { id: "newest", sessionId: "newest", recencyAt: 300 },
+        { id: "middle", sessionId: "middle", recencyAt: 200 },
+      ])
+    ).toEqual({ sessionId: "newest" });
+  });
+
+  it("returns the session id, not the thread id, when the protocol distinguishes them", () => {
+    expect(
+      selectResumeLatestThread([{ id: "thread-abc", sessionId: "session-xyz", recencyAt: 10 }])
+    ).toEqual({ sessionId: "session-xyz" });
+  });
+
+  it("falls back to the thread id when a server omits sessionId", () => {
+    expect(selectResumeLatestThread([{ id: "thread-abc", recencyAt: 10 }])).toEqual({
+      sessionId: "thread-abc",
+    });
+  });
+
+  it("ignores subagent threads, which `--last` never opens", () => {
+    expect(
+      selectResumeLatestThread([
+        { id: "child", sessionId: "root", parentThreadId: "root", recencyAt: 900 },
+        { id: "root", sessionId: "root", recencyAt: 100 },
+      ])
+    ).toEqual({ sessionId: "root" });
+  });
+
+  it("refuses a tie at the top rather than guessing Codex's own tie-break", () => {
+    expect(
+      selectResumeLatestThread([
+        { id: "a", sessionId: "a", recencyAt: 500 },
+        { id: "b", sessionId: "b", recencyAt: 500 },
+      ])
+    ).toEqual({ sessionId: null });
+  });
+
+  it("is not made ambiguous by a tie below the winner", () => {
+    expect(
+      selectResumeLatestThread([
+        { id: "winner", sessionId: "winner", recencyAt: 900 },
+        { id: "a", sessionId: "a", recencyAt: 500 },
+        { id: "b", sessionId: "b", recencyAt: 500 },
+      ])
+    ).toEqual({ sessionId: "winner" });
+  });
+
+  it("does not read a repeated row as a rival to itself", () => {
+    expect(
+      selectResumeLatestThread([
+        { id: "same", sessionId: "same", recencyAt: 500 },
+        { id: "same", sessionId: "same", recencyAt: 500 },
+      ])
+    ).toEqual({ sessionId: "same" });
+  });
+
+  it("ranks on updatedAt then createdAt when recencyAt is absent", () => {
+    expect(
+      selectResumeLatestThread([
+        { id: "created-only", sessionId: "created-only", createdAt: 800 },
+        { id: "updated", sessionId: "updated", updatedAt: 900 },
+      ])
+    ).toEqual({ sessionId: "updated" });
+  });
+
+  it("reports nothing for an empty or unusable page", () => {
+    expect(selectResumeLatestThread([])).toEqual({ sessionId: null });
+    expect(selectResumeLatestThread([{ recencyAt: 5 }, { id: 42 }])).toEqual({ sessionId: null });
+  });
+
+  it("drops an id that could not be spliced into a shell command safely", () => {
+    expect(
+      selectResumeLatestThread([{ id: "a; rm -rf /", sessionId: "a; rm -rf /", recencyAt: 900 }])
+    ).toEqual({ sessionId: null });
+  });
+});
+
+describe("resolveCodexResumeLatestSession", () => {
+  it("queries the folder the way `--last` selects, and answers with the session id", async () => {
+    let listParams: QueryParams = {};
+    scriptSession((method, params) => {
+      if (method === "thread/list") {
+        listParams = params;
+        return { data: [{ id: "root", sessionId: "root", recencyAt: 10 }] };
+      }
+      return {};
+    });
+
+    await expect(resolveCodexResumeLatestSession("/repo")).resolves.toBe("root");
+
+    expect(listParams.cwd).toEqual(["/repo"]);
+    expect(listParams.sortKey).toBe("recency_at");
+    expect(listParams.sortDirection).toBe("desc");
+    expect(listParams.useStateDbOnly).toBe(true);
+    // `sourceKinds` omitted means the server's interactive-only default, which
+    // is exactly what `--last` uses without `--include-non-interactive`. Naming
+    // the kinds would change the filter rather than restate it.
+    expect(listParams).not.toHaveProperty("sourceKinds");
+    expect(listParams).not.toHaveProperty("archived");
+  });
+
+  it("asks under both spellings of a symlinked path, since the cwd filter is exact", async () => {
+    let listParams: QueryParams = {};
+    scriptSession((method, params) => {
+      if (method === "thread/list") {
+        listParams = params;
+        return { data: [] };
+      }
+      return {};
+    });
+
+    await resolveCodexResumeLatestSession("/tmp/repo");
+
+    expect(listParams.cwd).toEqual(["/tmp/repo", "/private/tmp/repo"]);
+  });
+
+  it("answers null when the folder has no session, so restore keeps plain --last", async () => {
+    scriptSession(() => ({ data: [] }));
+    await expect(resolveCodexResumeLatestSession("/repo")).resolves.toBeNull();
+  });
+
+  it("answers null rather than throwing when Codex cannot be reached", async () => {
+    runSession.mockRejectedValue(new CodexAppServerError("cli-missing", "no codex"));
+    await expect(resolveCodexResumeLatestSession("/repo")).resolves.toBeNull();
   });
 });

--- a/electron/services/codex/__tests__/CodexSubagentService.test.ts
+++ b/electron/services/codex/__tests__/CodexSubagentService.test.ts
@@ -608,3 +608,16 @@ describe("resolveCodexResumeLatestSession", () => {
     await expect(resolveCodexResumeLatestSession("/repo")).resolves.toBeNull();
   });
 });
+
+describe("resolveCodexResumeLatestSession budget", () => {
+  it("runs on a restore-sized budget rather than the transport default", async () => {
+    // Restore blocks on this before it can launch the pane, so it has to give
+    // up long before the transport's 15s whole-session default would.
+    scriptSession(() => ({ data: [] }));
+
+    await resolveCodexResumeLatestSession("/repo");
+
+    const options = runSession.mock.calls[0]?.[1] as { timeoutMs?: number } | undefined;
+    expect(options?.timeoutMs).toBe(2_000);
+  });
+});

--- a/shared/types/ipc/generated-api.ts
+++ b/shared/types/ipc/generated-api.ts
@@ -81,6 +81,9 @@ export interface GeneratedElectronAPI {
     readSubagentTranscript(
       ...args: IpcInvokeMap["codex:read-subagent-transcript"]["args"]
     ): Promise<IpcInvokeMap["codex:read-subagent-transcript"]["result"]>;
+    resolveResumeLatestSession(
+      ...args: IpcInvokeMap["codex:resolve-resume-latest-session"]["args"]
+    ): Promise<IpcInvokeMap["codex:resolve-resume-latest-session"]["result"]>;
   };
   commands: {
     execute(

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -162,6 +162,10 @@ export interface GeneratedIpcInvokeMap {
     args: [__0: { terminalId: string; subagentId: string }];
     result: import("./agentSubagents.js").AgentSubagentTranscriptResult;
   };
+  "codex:resolve-resume-latest-session": {
+    args: [__0: { cwd: string }];
+    result: string | null;
+  };
   "commands:execute": {
     args: [payload: import("../commands.js").CommandExecutePayload];
     result: import("../commands.js").CommandResult<unknown>;

--- a/src/clients/codexClient.ts
+++ b/src/clients/codexClient.ts
@@ -19,4 +19,13 @@ export const codexClient = {
   }): Promise<AgentSubagentTranscriptResult> => {
     return window.electron.codex.readSubagentTranscript(payload);
   },
+
+  /**
+   * Which session `codex resume --last` would open in `cwd`, or null when the
+   * folder has none, two are tied for most recent, or Codex can't be asked
+   * (#12178). Null is a normal answer: restore falls back to plain `--last`.
+   */
+  resolveResumeLatestSession: (payload: { cwd: string }): Promise<string | null> => {
+    return window.electron.codex.resolveResumeLatestSession(payload);
+  },
 } as const;

--- a/src/utils/stateHydration/__tests__/panelRestorePhase.test.ts
+++ b/src/utils/stateHydration/__tests__/panelRestorePhase.test.ts
@@ -26,11 +26,14 @@ const reconnectWithTimeoutMock = vi.hoisted(() => vi.fn());
 // Restore asks Codex which session `--last` would open before it builds the
 // respawn command (#12178). Defaults to "no answer", which is the fallback every
 // pre-existing case here already expects.
-const resolveResumeLatestSessionMock = vi.hoisted(() => vi.fn(async () => null));
+const resolveResumeLatestSessionMock = vi.hoisted(() =>
+  vi.fn(async (_payload: { cwd: string }): Promise<string | null> => null)
+);
 
 vi.mock("@/clients/codexClient", () => ({
   codexClient: {
-    resolveResumeLatestSession: (...args: unknown[]) => resolveResumeLatestSessionMock(...args),
+    resolveResumeLatestSession: (payload: { cwd: string }) =>
+      resolveResumeLatestSessionMock(payload),
   },
 }));
 
@@ -2197,20 +2200,44 @@ describe("restorePanelsPhase — naming the resume-latest session (#12178)", () 
 
   it("resolves before the pane is added, so the id is never a later patch", async () => {
     let released: (value: string) => void = () => {};
-    resolveResumeLatestSessionMock.mockReturnValue(
-      new Promise<string>((resolve) => {
+    let markAsked: () => void = () => {};
+    // Waiting on the lookup actually being reached, rather than ticking the
+    // microtask queue: `addPanel` is several awaits past the reconnect probe, so
+    // a bare tick would assert nothing and pass with the feature deleted.
+    const asked = new Promise<void>((resolve) => {
+      markAsked = resolve;
+    });
+    resolveResumeLatestSessionMock.mockImplementation(() => {
+      markAsked();
+      return new Promise<string>((resolve) => {
         released = resolve;
-      })
-    );
+      });
+    });
     const ctx = makeContext();
 
     const phase = restorePanelsPhase([codexPanel("a", { cwd: "/repo" })], ctx);
-    await Promise.resolve();
+    await asked;
     expect(ctx.addPanel).not.toHaveBeenCalled();
 
     released("sess-9");
     await phase;
 
     expect(resolvedIdById(ctx).get("a")).toBe("sess-9");
+  });
+
+  it("asks once per directory, so panes in separate worktrees each get their own", async () => {
+    resolveResumeLatestSessionMock.mockImplementation(async ({ cwd }: { cwd: string }) =>
+      cwd === "/repo-a" ? "sess-a" : "sess-b"
+    );
+    const ctx = makeContext();
+
+    await restorePanelsPhase(
+      [codexPanel("a", { cwd: "/repo-a" }), codexPanel("b", { cwd: "/repo-b" })],
+      ctx
+    );
+
+    expect(resolveResumeLatestSessionMock).toHaveBeenCalledTimes(2);
+    expect(resolvedIdById(ctx).get("a")).toBe("sess-a");
+    expect(resolvedIdById(ctx).get("b")).toBe("sess-b");
   });
 });

--- a/src/utils/stateHydration/__tests__/panelRestorePhase.test.ts
+++ b/src/utils/stateHydration/__tests__/panelRestorePhase.test.ts
@@ -2240,4 +2240,15 @@ describe("restorePanelsPhase — naming the resume-latest session (#12178)", () 
     expect(resolvedIdById(ctx).get("a")).toBe("sess-a");
     expect(resolvedIdById(ctx).get("b")).toBe("sess-b");
   });
+
+  it("does not ask for a pane that carries its own CODEX_HOME", async () => {
+    // The app-server answers from main's profile while the pane spawns against
+    // its own, so an id from here is one the pane cannot open — and it would be
+    // recorded and replayed, where `--last` just falls through.
+    const ctx = makeContext();
+
+    await restorePanelsPhase([codexPanel("solo", { env: { CODEX_HOME: "/custom/home" } })], ctx);
+
+    expect(resolveResumeLatestSessionMock).not.toHaveBeenCalled();
+  });
 });

--- a/src/utils/stateHydration/__tests__/panelRestorePhase.test.ts
+++ b/src/utils/stateHydration/__tests__/panelRestorePhase.test.ts
@@ -23,6 +23,17 @@ vi.mock("@/services/TerminalInstanceService", () => ({
 
 const reconnectWithTimeoutMock = vi.hoisted(() => vi.fn());
 
+// Restore asks Codex which session `--last` would open before it builds the
+// respawn command (#12178). Defaults to "no answer", which is the fallback every
+// pre-existing case here already expects.
+const resolveResumeLatestSessionMock = vi.hoisted(() => vi.fn(async () => null));
+
+vi.mock("@/clients/codexClient", () => ({
+  codexClient: {
+    resolveResumeLatestSession: (...args: unknown[]) => resolveResumeLatestSessionMock(...args),
+  },
+}));
+
 vi.mock("../reconnectManager", () => ({
   reconnectWithTimeout: (...args: unknown[]) => reconnectWithTimeoutMock(...args),
 }));
@@ -68,7 +79,11 @@ vi.mock("../statePatcher", () => ({
     reconnectTimedOut?: boolean,
     _clipboardDirectory?: string,
     _projectPresetsByAgent?: unknown,
-    options?: { allowResumeLatest?: boolean; allowSessionIdResume?: boolean }
+    options?: {
+      allowResumeLatest?: boolean;
+      allowSessionIdResume?: boolean;
+      resolvedResumeLatestSessionId?: string;
+    }
   ) => ({
     cwd: s.cwd ?? "/cwd",
     kind,
@@ -82,6 +97,7 @@ vi.mock("../statePatcher", () => ({
     // resume election (#11461) is assertable through addPanel's args.
     allowResumeLatest: options?.allowResumeLatest ?? true,
     allowSessionIdResume: options?.allowSessionIdResume ?? true,
+    resolvedResumeLatestSessionId: options?.resolvedResumeLatestSessionId,
   }),
   // Mirrors the real resolver's title recovery (same agent order) so the
   // election's identity resolution can't silently diverge from production.
@@ -226,6 +242,8 @@ beforeEach(() => {
   initializeBackendTierMock.mockReset();
   setTargetSizeMock.mockReset();
   reconnectWithTimeoutMock.mockReset();
+  resolveResumeLatestSessionMock.mockReset();
+  resolveResumeLatestSessionMock.mockResolvedValue(null);
   getRestoreBatchParamsMock.mockClear();
   getRestoreBatchParamsMock.mockReturnValue({ batchSize: 2, delayMs: 0 });
 });
@@ -2072,5 +2090,127 @@ describe("restorePanelsPhase — one resume-latest per agent+cwd (issue #11461)"
 
     expect(allowanceById(ctx).get("t1")).toBe(true);
     expect(allowanceById(ctx).get("t2")).toBe(true);
+  });
+});
+
+describe("restorePanelsPhase — naming the resume-latest session (#12178)", () => {
+  const codexPanel = (id: string, overrides: Partial<TerminalState> = {}): TerminalState =>
+    panel(id, { kind: "agent", launchAgentId: "codex", ...overrides });
+
+  /** id → the resolved session id the respawn builder was handed. */
+  function resolvedIdById(ctx: MockedContext): Map<string, string | undefined> {
+    const byId = new Map<string, string | undefined>();
+    for (const [args] of ctx.addPanel.mock.calls as [
+      { requestedId?: string; resolvedResumeLatestSessionId?: string },
+    ][]) {
+      if (args.requestedId !== undefined) {
+        byId.set(args.requestedId, args.resolvedResumeLatestSessionId);
+      }
+    }
+    return byId;
+  }
+
+  beforeEach(() => {
+    reconnectWithTimeoutMock.mockResolvedValue({ status: "not_found" });
+  });
+
+  it("asks Codex for the pane's folder and hands the answer to the respawn builder", async () => {
+    resolveResumeLatestSessionMock.mockResolvedValue("sess-9");
+    const ctx = makeContext();
+
+    await restorePanelsPhase([codexPanel("a", { cwd: "/repo" })], ctx);
+
+    expect(resolveResumeLatestSessionMock).toHaveBeenCalledWith({ cwd: "/repo" });
+    expect(resolvedIdById(ctx).get("a")).toBe("sess-9");
+  });
+
+  it("falls back to the project root when the snapshot recorded no cwd", async () => {
+    const ctx = makeContext();
+
+    await restorePanelsPhase([codexPanel("a", { cwd: undefined })], ctx);
+
+    expect(resolveResumeLatestSessionMock).toHaveBeenCalledWith({ cwd: "/proj" });
+  });
+
+  it("does not ask for a pane that already carries an exact session id", async () => {
+    const ctx = makeContext();
+
+    await restorePanelsPhase([codexPanel("a", { agentSessionId: "saved-1" })], ctx);
+
+    expect(resolveResumeLatestSessionMock).not.toHaveBeenCalled();
+  });
+
+  it("asks only for the pane that won the scope, never for a suppressed sibling", async () => {
+    const ctx = makeContext();
+
+    await restorePanelsPhase(
+      [
+        codexPanel("a", { cwd: "/repo", lastActiveAt: 100 }),
+        codexPanel("b", { cwd: "/repo", lastActiveAt: 300 }),
+      ],
+      ctx
+    );
+
+    // The loser is denied the fallback, so naming the winner's conversation for
+    // it would put a second writer on the very transcript the election protects.
+    expect(resolveResumeLatestSessionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves other agents' rolling-history fallbacks alone", async () => {
+    const ctx = makeContext();
+
+    await restorePanelsPhase([panel("a", { kind: "agent", launchAgentId: "claude" })], ctx);
+
+    expect(resolveResumeLatestSessionMock).not.toHaveBeenCalled();
+  });
+
+  it("does not ask for a pane whose PTY survived — it is already attached", async () => {
+    reconnectWithTimeoutMock.mockResolvedValue({
+      status: "found",
+      terminal: { id: "a", cwd: "/repo", title: "a" },
+    });
+    const ctx = makeContext();
+
+    await restorePanelsPhase([codexPanel("a", { cwd: "/repo" })], ctx);
+
+    expect(resolveResumeLatestSessionMock).not.toHaveBeenCalled();
+  });
+
+  it("still restores the pane when the lookup finds nothing", async () => {
+    const ctx = makeContext();
+
+    await restorePanelsPhase([codexPanel("a", { cwd: "/repo" })], ctx);
+
+    expect(ctx.addPanel).toHaveBeenCalledTimes(1);
+    expect(resolvedIdById(ctx).get("a")).toBeUndefined();
+  });
+
+  it("still restores the pane when the lookup rejects", async () => {
+    resolveResumeLatestSessionMock.mockRejectedValue(new Error("main is gone"));
+    const ctx = makeContext();
+
+    await restorePanelsPhase([codexPanel("a", { cwd: "/repo" })], ctx);
+
+    expect(ctx.addPanel).toHaveBeenCalledTimes(1);
+    expect(resolvedIdById(ctx).get("a")).toBeUndefined();
+  });
+
+  it("resolves before the pane is added, so the id is never a later patch", async () => {
+    let released: (value: string) => void = () => {};
+    resolveResumeLatestSessionMock.mockReturnValue(
+      new Promise<string>((resolve) => {
+        released = resolve;
+      })
+    );
+    const ctx = makeContext();
+
+    const phase = restorePanelsPhase([codexPanel("a", { cwd: "/repo" })], ctx);
+    await Promise.resolve();
+    expect(ctx.addPanel).not.toHaveBeenCalled();
+
+    released("sess-9");
+    await phase;
+
+    expect(resolvedIdById(ctx).get("a")).toBe("sess-9");
   });
 });

--- a/src/utils/stateHydration/__tests__/statePatcher.test.ts
+++ b/src/utils/stateHydration/__tests__/statePatcher.test.ts
@@ -3372,3 +3372,148 @@ describe("buildArgsForRespawn — assigned session id", () => {
     expect(result.agentSessionId).toBeUndefined();
   });
 });
+
+describe("buildArgsForRespawn — a named resume-latest session (#12178)", () => {
+  const codexPane = {
+    id: "t1",
+    kind: "terminal" as const,
+    agentId: "codex",
+    cwd: "/p",
+    location: "grid" as const,
+  };
+
+  it("launches the resolved session by name instead of `--last`", () => {
+    buildResumeCommandMock.mockReturnValue("codex resume sess-9");
+    buildResumeLatestCommandMock.mockReturnValue("codex resume --last");
+
+    const result = buildArgsForRespawn(
+      codexPane,
+      "terminal",
+      "/p",
+      { agents: { codex: {} } },
+      false,
+      "/tmp",
+      undefined,
+      { resolvedResumeLatestSessionId: "sess-9" }
+    );
+
+    expect(result.command).toBe("codex resume sess-9");
+    expect(buildResumeCommandMock.mock.calls[0]?.slice(0, 2)).toEqual(["codex", "sess-9"]);
+    expect(buildResumeLatestCommandMock).not.toHaveBeenCalled();
+  });
+
+  it("records the id on the pane, so the PTY is never an unknown writer", () => {
+    buildResumeCommandMock.mockReturnValue("codex resume sess-9");
+
+    const result = buildArgsForRespawn(
+      codexPane,
+      "terminal",
+      "/p",
+      { agents: { codex: {} } },
+      false,
+      "/tmp",
+      undefined,
+      { resolvedResumeLatestSessionId: "sess-9" }
+    );
+
+    expect(result.agentSessionId).toBe("sess-9");
+    expect(result.sessionLostOnRestore).toBeUndefined();
+  });
+
+  it("passes the resolved executable and reconciled flags through, like the exact-id branch", () => {
+    buildResumeCommandMock.mockReturnValue("/bin/codex resume sess-9");
+
+    const result = buildArgsForRespawn(
+      { ...codexPane, agentLaunchFlags: ["--yolo"] },
+      "terminal",
+      "/p",
+      { agents: { codex: {} } },
+      false,
+      "/tmp",
+      undefined,
+      { resolvedResumeLatestSessionId: "sess-9", resolvedAgentBaseCommand: "/bin/codex" }
+    );
+
+    // Flags are the reconciled set, not the raw saved array — the same ones the
+    // `--last` branch would have prepended, which is the point of the swap.
+    const [agentId, sessionId, flags, baseCommand] = buildResumeCommandMock.mock.calls[0] ?? [];
+    expect([agentId, sessionId, baseCommand]).toEqual(["codex", "sess-9", "/bin/codex"]);
+    expect(flags).toEqual(expect.arrayContaining(["--yolo"]));
+    expect(result.command).toBe("/bin/codex resume sess-9");
+  });
+
+  it("keeps today's `--last` behaviour when the lookup resolved nothing", () => {
+    buildResumeLatestCommandMock.mockReturnValue("codex resume --last");
+
+    const result = buildArgsForRespawn(
+      codexPane,
+      "terminal",
+      "/p",
+      { agents: { codex: {} } },
+      false,
+      "/tmp"
+    );
+
+    expect(result.command).toBe("codex resume --last");
+    expect(result.agentSessionId).toBeUndefined();
+  });
+
+  it("falls back to `--last` if the exact resume cannot be built, and attaches no id", () => {
+    buildResumeCommandMock.mockReturnValue(undefined);
+    buildResumeLatestCommandMock.mockReturnValue("codex resume --last");
+
+    const result = buildArgsForRespawn(
+      codexPane,
+      "terminal",
+      "/p",
+      { agents: { codex: {} } },
+      false,
+      "/tmp",
+      undefined,
+      { resolvedResumeLatestSessionId: "sess-9" }
+    );
+
+    expect(result.command).toBe("codex resume --last");
+    expect(result.agentSessionId).toBeUndefined();
+  });
+
+  it("is ignored when the election suppressed this pane's resume-latest slot (#11461)", () => {
+    buildResumeCommandMock.mockReturnValue("codex resume sess-9");
+    buildResumeLatestCommandMock.mockReturnValue("codex resume --last");
+
+    const result = buildArgsForRespawn(
+      codexPane,
+      "terminal",
+      "/p",
+      { agents: { codex: {} } },
+      false,
+      "/tmp",
+      undefined,
+      { resolvedResumeLatestSessionId: "sess-9", allowResumeLatest: false }
+    );
+
+    expect(result.command).toBe("codex --generated");
+    expect(result.agentSessionId).not.toBe("sess-9");
+    expect(result.sessionLostOnRestore).toBe(true);
+  });
+
+  it("never displaces the exact id a snapshot already carries", () => {
+    buildResumeCommandMock.mockImplementation(
+      (_agentId: string, sessionId: string) => `codex resume ${sessionId}`
+    );
+
+    const result = buildArgsForRespawn(
+      { ...codexPane, agentSessionId: "saved-1" },
+      "terminal",
+      "/p",
+      { agents: { codex: {} } },
+      false,
+      "/tmp",
+      undefined,
+      { resolvedResumeLatestSessionId: "sess-9" }
+    );
+
+    expect(result.command).toBe("codex resume saved-1");
+    expect(result.agentSessionId).toBe("saved-1");
+  });
+});

--- a/src/utils/stateHydration/panelRestorePhase.ts
+++ b/src/utils/stateHydration/panelRestorePhase.ts
@@ -352,6 +352,14 @@ const CODEX_AGENT_ID = "codex";
  * election suppressed must not learn what the winner is holding, since the
  * whole point of suppressing it was to keep a second writer off that transcript.
  * Every failure is answered with `undefined`, which is today's behaviour.
+ *
+ * Which is also why a pane with its own `CODEX_HOME` is skipped outright. The
+ * app-server answers from MAIN's profile while the pane spawns against its own
+ * (the captured launch env is replayed on respawn, #10922), so a hit there
+ * names a session the pane cannot open — and unlike `--last`, which resolves to
+ * nothing and falls through, that id would be recorded and replayed on every
+ * later restore. It is the one case where naming the session could be worse
+ * than leaving it anonymous, so it does not run at all.
  */
 async function resolveNamedResumeLatestSession(
   saved: TerminalState,
@@ -365,6 +373,11 @@ async function resolveNamedResumeLatestSession(
   // The same capability probe the election and the respawn builder use, so a
   // Codex build whose config drops the fallback can't be queried for one.
   if (buildResumeLatestCommand(agentId) === undefined) return undefined;
+  // The launch env is captured and persisted (#10922), so a pane that ever ran
+  // under a redirected profile still carries it here — preset envs included.
+  if (Object.keys(saved.env ?? {}).some((key) => key.toUpperCase() === "CODEX_HOME")) {
+    return undefined;
+  }
   const cwd = saved.cwd || projectRoot;
   if (!cwd) return undefined;
 

--- a/src/utils/stateHydration/panelRestorePhase.ts
+++ b/src/utils/stateHydration/panelRestorePhase.ts
@@ -10,6 +10,7 @@ import type {
 import type { AgentSettings } from "@shared/types/agentSettings";
 import type { WorktreeState } from "@shared/types";
 import type { AgentPreset } from "@/config/agents";
+import type { PanelKind } from "@shared/types/panel";
 import type { ResourceProfile } from "@shared/types/resourceProfile";
 import { type TerminalRestoreTask, getRestoreBatchParams, delay } from "./batchScheduler";
 import { reconnectWithTimeout } from "./reconnectManager";
@@ -38,6 +39,7 @@ import {
   getCurrentLaunchCliDetail,
   resolveAgentLaunchBaseCommand,
 } from "@/utils/agentLaunchCommand";
+import { codexClient } from "@/clients/codexClient";
 import { isValidTerminalGeometry } from "@shared/types/terminal";
 import type { TerminalGeometry } from "@shared/types/terminal";
 
@@ -326,6 +328,52 @@ function electResumeSuppression(
     }
   }
   return { resumeLatest, sessionId };
+}
+
+/**
+ * The only agent whose resume-latest fallback can be resolved to a name before
+ * launch. Claude's `--continue` and Gemini's `-r latest` have no equivalent
+ * read-only index to ask, so they keep the anonymous fallback.
+ */
+const CODEX_AGENT_ID = "codex";
+
+/**
+ * Name the conversation a pane's resume-latest fallback is about to open, so it
+ * launches as `codex resume <id>` rather than `codex resume --last` (#12178).
+ *
+ * `--last` leaves the pane running a session Daintree never learns the id of,
+ * which is how the id was lost to begin with: the next teardown scrape becomes
+ * the only capture path all over again. Asking Codex's own index which session
+ * `--last` resolves to freezes that choice — the same conversation, on the
+ * record from the moment the PTY exists.
+ *
+ * Deliberately narrow. Only a pane that is actually going to run the fallback
+ * asks: one already carrying an exact id resumes that instead, and one the
+ * election suppressed must not learn what the winner is holding, since the
+ * whole point of suppressing it was to keep a second writer off that transcript.
+ * Every failure is answered with `undefined`, which is today's behaviour.
+ */
+async function resolveNamedResumeLatestSession(
+  saved: TerminalState,
+  kind: PanelKind,
+  projectRoot: string,
+  allowResumeLatest: boolean
+): Promise<string | undefined> {
+  if (!allowResumeLatest || saved.agentSessionId) return undefined;
+  const agentId = resolveRespawnAgentId(saved, kind);
+  if (agentId !== CODEX_AGENT_ID) return undefined;
+  // The same capability probe the election and the respawn builder use, so a
+  // Codex build whose config drops the fallback can't be queried for one.
+  if (buildResumeLatestCommand(agentId) === undefined) return undefined;
+  const cwd = saved.cwd || projectRoot;
+  if (!cwd) return undefined;
+
+  try {
+    return (await codexClient.resolveResumeLatestSession({ cwd })) ?? undefined;
+  } catch {
+    // A restore that can't reach main still has a pane to bring back.
+    return undefined;
+  }
 }
 
 /**
@@ -837,12 +885,27 @@ export async function restorePanelsPhase(
                 // not_found on cold app restart means the PTY process was killed
                 // on quit and needs to be respawned.
                 const savedAgentId = resolveAgentId(saved.launchAgentId);
-                const resolvedAgentBaseCommand = savedAgentId
-                  ? resolveAgentLaunchBaseCommand(
-                      getAgentConfig(savedAgentId)?.command ?? savedAgentId,
-                      await getCurrentLaunchCliDetail(savedAgentId)
-                    )
-                  : undefined;
+                const allowResumeLatest = !resumeSuppression.resumeLatest.has(saved.id);
+                // Both are lookups this respawn needs and neither depends on the
+                // other, so they overlap rather than queue. The election already
+                // ran synchronously over the saved array — nothing awaited here
+                // can change who won a resume slot (#11052).
+                const [resolvedAgentBaseCommand, resolvedResumeLatestSessionId] = await Promise.all([
+                  savedAgentId
+                    ? getCurrentLaunchCliDetail(savedAgentId).then((detail) =>
+                        resolveAgentLaunchBaseCommand(
+                          getAgentConfig(savedAgentId)?.command ?? savedAgentId,
+                          detail
+                        )
+                      )
+                    : Promise.resolve(undefined),
+                  resolveNamedResumeLatestSession(
+                    saved,
+                    kind,
+                    projectRoot || "",
+                    allowResumeLatest
+                  ),
+                ]);
                 const respawnArgs = buildArgsForRespawn(
                   saved,
                   kind,
@@ -853,8 +916,9 @@ export async function restorePanelsPhase(
                   projectPresetsByAgent,
                   {
                     resolvedAgentBaseCommand,
-                    allowResumeLatest: !resumeSuppression.resumeLatest.has(saved.id),
+                    allowResumeLatest,
                     allowSessionIdResume: !resumeSuppression.sessionId.has(saved.id),
+                    resolvedResumeLatestSessionId,
                   }
                 );
 

--- a/src/utils/stateHydration/panelRestorePhase.ts
+++ b/src/utils/stateHydration/panelRestorePhase.ts
@@ -890,22 +890,25 @@ export async function restorePanelsPhase(
                 // other, so they overlap rather than queue. The election already
                 // ran synchronously over the saved array — nothing awaited here
                 // can change who won a resume slot (#11052).
-                const [resolvedAgentBaseCommand, resolvedResumeLatestSessionId] = await Promise.all([
-                  savedAgentId
-                    ? getCurrentLaunchCliDetail(savedAgentId).then((detail) =>
-                        resolveAgentLaunchBaseCommand(
-                          getAgentConfig(savedAgentId)?.command ?? savedAgentId,
-                          detail
-                        )
+                const baseCommandPromise = savedAgentId
+                  ? getCurrentLaunchCliDetail(savedAgentId).then((detail) =>
+                      resolveAgentLaunchBaseCommand(
+                        getAgentConfig(savedAgentId)?.command ?? savedAgentId,
+                        detail
                       )
-                    : Promise.resolve(undefined),
-                  resolveNamedResumeLatestSession(
-                    saved,
-                    kind,
-                    projectRoot || "",
-                    allowResumeLatest
-                  ),
-                ]);
+                    )
+                  : Promise.resolve(undefined);
+                const [resolvedAgentBaseCommand, resolvedResumeLatestSessionId] = await Promise.all(
+                  [
+                    baseCommandPromise,
+                    resolveNamedResumeLatestSession(
+                      saved,
+                      kind,
+                      projectRoot || "",
+                      allowResumeLatest
+                    ),
+                  ]
+                );
                 const respawnArgs = buildArgsForRespawn(
                   saved,
                   kind,

--- a/src/utils/stateHydration/statePatcher.ts
+++ b/src/utils/stateHydration/statePatcher.ts
@@ -462,6 +462,18 @@ export interface BuildArgsForRespawnOptions {
    * two writers on one transcript, so the loser resumes nothing.
    */
   allowSessionIdResume?: boolean;
+  /**
+   * The session the agent's resume-latest fallback would itself have resolved
+   * to, looked up before this call (#12178). Present only for a pane that was
+   * actually going to use that fallback, so it upgrades `codex resume --last`
+   * to `codex resume <id>`: the same conversation, but named — which puts the id
+   * on the pane from the moment the PTY exists instead of leaving it for a
+   * teardown to observe, the way it was lost in the first place.
+   *
+   * Undefined whenever the lookup found nothing, could not choose, or failed;
+   * the fallback then runs exactly as it does today.
+   */
+  resolvedResumeLatestSessionId?: string;
 }
 
 export function buildArgsForRespawn(
@@ -622,8 +634,23 @@ export function buildArgsForRespawn(
       // not reach that same conversation through the back door, since the owner
       // replaying it is exactly what resume-latest would resolve to.
       let resumeLatestCmd: string | undefined;
+      // The id the fallback would have resolved to, when the caller looked it up
+      // (#12178). Naming it turns an anonymous "whatever is most recent" launch
+      // into the same conversation on the record, so this pane stops being an
+      // unknown live writer. Falls through to the bare fallback if the agent
+      // can't build an exact resume, which leaves today's behaviour intact.
+      const namedResumeLatestId = options?.resolvedResumeLatestSessionId;
       if (allowResumeLatest && !resumeWithheld) {
-        resumeLatestCmd = resolvedAgentBaseCommand
+        if (namedResumeLatestId) {
+          const namedCmd = resolvedAgentBaseCommand
+            ? buildResumeCommand(agentId, namedResumeLatestId, resumeFlags, baseCommand)
+            : buildResumeCommand(agentId, namedResumeLatestId, resumeFlags);
+          if (namedCmd) {
+            resumeLatestCmd = namedCmd;
+            respawnSessionId = namedResumeLatestId;
+          }
+        }
+        resumeLatestCmd ??= resolvedAgentBaseCommand
           ? buildResumeLatestCommand(agentId, resumeFlags, baseCommand)
           : buildResumeLatestCommand(agentId, resumeFlags);
       }


### PR DESCRIPTION
## Summary

- A restored Codex pane with no saved session id used to launch with `codex resume --last`, dropping it into an unknown running conversation whose id could be lost again the same way it was lost the first time.
- The restore election that grants one pane per (agent, cwd) the `--last` slot had no idea what the winner was actually holding, so the losers got nothing useful.
- Restore now asks Codex's own read-only app-server index which session `--last` would resolve to for that folder, launches `codex resume <sessionId>` instead, and records that id on the pane immediately.

Resolves #12178

## Changes

**Selection logic.** `selectResumeLatestThread` and `resolveCodexResumeLatestSession` in `electron/services/codex/CodexSubagentService.ts` reproduce the CLI's own selection: the most recent root thread in the folder. This deliberately does not reuse `selectParentThread`, which applies an activity-based staleness cutoff and refuses whenever two roots survive. That's the right behavior for subagent attribution, not for this.

**IPC.** A new cwd-keyed op, `codex:resolve-resume-latest-session`. The sibling ops key on `terminalId` so main can resolve the folder itself, but at restore there's no terminal yet, so the cwd comes from the app's own persisted snapshot instead. The reply is a single session id, nothing else (no cwd, preview, timestamps, or thread list).

**Wiring.** The lookup runs inside the restore phase's already-async respawn branch, so `electResumeSuppression` stays synchronous (per #11052). The resolved id is threaded into `buildArgsForRespawn` through a new option rather than making that builder async.

**Selection parity**, verified against the installed `codex-cli` 0.153.0:

- `codex resume --all` is documented as disabling cwd filtering, so `--last` is cwd-scoped by default.
- `--include-non-interactive` is documented as adding non-interactive sessions to the `--last` selection, so `--last` is interactive-only by default.
- `codex app-server generate-json-schema` confirms `ThreadListParams.sourceKinds` defaults to interactive sources when omitted, and that omitting `archived` returns only non-archived threads. The existing query shape already matches `--last`'s filters, so `sourceKinds` stays absent rather than being named explicitly.
- The schema also shows `Thread` carries both `id` and a required `sessionId` (shared across a session tree). The code reads `sessionId`, the value `codex resume` accepts, falling back to `id` when a server omits it. A live probe confirmed the two coincide for all 7 root threads.

**Fallback.** Every failure degrades to today's plain `codex resume --last` and never blocks the pane restore: zero roots, a tie at the most recent timestamp (Codex's own tie-break), a missing CLI, a wedged server, a timeout. Suppressed sibling panes are deliberately told nothing, since the whole point of suppressing them is to keep a second writer off that transcript.

## Testing

- Typecheck: clean
- 479 tests across `src/utils/stateHydration/__tests__/` and `electron/services/codex/__tests__/`
- 101 tests across `src/clients/__tests__/`
- `prettier` and `eslint` clean on all changed files
- `npm run check:ipc-handwritten` unchanged at 237 entries
- IPC types regenerated with `npm run codegen:ipc && npm run codegen:ipc-renderer`

Codex review was unavailable (usage limit reached), so the adversarial review pass was done inline instead.

---

## Follow-up hardening (`926a6df`)

A second review pass on the above found three things worth fixing before this lands, plus one gap in the tests.

**The lookup's budget was unenforceable.** `runCodexAppServerSession` awaited `acquireSessionSlot()` *before* starting its deadline, and the gate caps at 2 concurrent sessions. That cap's own comment explains why it exists — "a project restore mounts every Codex pane at once, and each asks for its own subagents" — which is exactly when this new lookup runs. So a restore-time query could queue behind two wedged sessions indefinitely, and any timeout it set was fiction. The wait now counts against the caller's own budget: a queued caller gives up on time, drops itself from the queue, and never spawns.

**The lookup had no budget of its own.** It was running on the transport's 15s whole-session default. Restore blocks on this before it can launch the pane, and the answer is an optimisation over a fallback that already works, so it now gets 2s. Realistically the handshake is ~40ms and a `useStateDbOnly` query is single-digit ms, so that is ~20x headroom.

**`realpath` ran outside the deadline.** Moved inside the session, so the transport's timeout covers it. It hangs indefinitely on a dead network mount, and this is the restore path.

**A pane with its own `CODEX_HOME` is now skipped entirely.** This is the one case where naming the session could be *worse* than leaving it anonymous. The app-server inherits main's `CODEX_HOME` while the pane spawns against its own — `buildArgsForRespawn` replays the captured launch env (#10922), and `sanitizeAgentEnv` passes `CODEX_HOME` through. So a hit in main's profile names a session that pane cannot open, `codex resume <id>` fails outright, and unlike `--last` (which would resolve to nothing and fall through) the bad id gets recorded and replayed on every later restore. `--last` self-corrects; this would not have.

### Tests

- **The IPC op had no tests.** Added `electron/ipc/handlers/__tests__/codex.handlers.test.ts`: cwd passthrough, no normalisation (Codex matches the filter as an exact string), the null-byte / relative / empty / non-string / oversized rejections all landing before the service is reached, service rejection propagating rather than reporting a resolved session, and handler cleanup.
- **The queue-budget test was initially vacuous.** A leaked waiter calls `resolve()` on an already-rejected promise, so nothing spawns and the caller never runs — the leak is invisible except as a slot that never comes back. It now counts spawns, and I confirmed it works by deleting the queue-splice in production and watching it fail (`expected 1 to be 2`) before restoring.
- Also pinned the 2s budget and the `CODEX_HOME` skip, and released the held sessions in a `finally` so a failed assertion can't pin the module's session counter for every later test in the file.

593 tests across the touched suites, typecheck clean, `check:ipc-handwritten` and the lint ratchet green, `prettier`/`eslint` clean on changed files.

## Pre-existing issues found, deliberately not fixed here

None of these are caused by this change, but two become more visible because of it:

- **`fleetActions.countSessionLoss` is inverted.** It counts panes *carrying* an `agentSessionId` as ones that will lose their session, but `restart.ts` builds `codex resume <id>` from exactly that field, so the conversation survives. Wrong for every agent, not just Codex. Before this change a restored Codex pane only had an id when a teardown scrape landed — the case #12178 exists because it often doesn't — so this change takes the false "N agents will lose their session" warning from occasional to routine. Worth its own issue.
- **`CodexSubagentService` reads `agentSessionId` as a thread id** in `verifySessionThread` and the `listChildren` parent filter, while this change establishes it is a *session* id. They coincide for an unforked root, and it degrades safely (verification fails, falls through to the pre-existing spawn-time filter), but this is now the one file that both documents the distinction and violates it.
- **The resolved id doesn't reach `projectSessionJournal`**, which journals only what the teardown scrape returns. That's #12179's territory.
