### PR TITLE
fix(shutdown): keep a project's captured session ids when one pane is slow

### DIFF
--- a/electron/lifecycle/__tests__/shutdown.test.ts
+++ b/electron/lifecycle/__tests__/shutdown.test.ts
@@ -274,6 +274,7 @@ vi.mock("../../utils/performanceTrace.js", () => performanceTraceMock);
 import type { ShutdownDeps } from "../shutdown.js";
 import {
   CLEANUP_TIMEOUT_MS,
+  PROJECT_GRACEFUL_KILL_TIMEOUT_MS,
   SHUTDOWN_DEADLINE_MS,
   SHUTDOWN_TAIL_TIMEOUT_MS,
 } from "../shutdownConfig.js";
@@ -1149,6 +1150,7 @@ describe("registerShutdownHandler", () => {
     function makePtyClient(overrides?: Record<string, unknown>) {
       return {
         gracefulKillByProject: vi.fn(async () => []),
+        getPartialGracefulKillResults: vi.fn(() => []),
         getAllTerminalsAsync: vi.fn(async () => []),
         dispose: vi.fn(),
         ...overrides,
@@ -1347,6 +1349,59 @@ describe("registerShutdownHandler", () => {
       expect((persistAgentSessionMock.mock.calls[0][0] as Record<string, unknown>).sessionId).toBe(
         "sess-2"
       );
+    });
+
+    it("keeps a project's streamed captures when its graceful kill outruns the deadline", async () => {
+      // #12180. One pane running its full budget used to push the project's
+      // whole kill past the 4s race, which resolved to `[]` — so the ids that
+      // HAD been captured were dropped from both the snapshot writeback and the
+      // journal, and those panes came back unreachable on the next launch.
+      vi.useFakeTimers();
+      projectStoreMock.getAllProjects.mockReturnValue([{ id: "proj-1" }] as never);
+      const getPartialGracefulKillResults = vi.fn(() => [{ id: "t1", agentSessionId: "sess-1" }]);
+      const ptyClient = makePtyClient({
+        getAllTerminalsAsync: vi.fn(async () => [agentTerminal]),
+        // Never settles: the slow pane is still going when the deadline fires.
+        gracefulKillByProject: vi.fn(() => new Promise(() => {})),
+        getPartialGracefulKillResults,
+      });
+      const { beforeQuitCb } = await setup({ getPtyClient: () => ptyClient });
+
+      const quit = beforeQuitCb(makeEvent());
+      await vi.advanceTimersByTimeAsync(PROJECT_GRACEFUL_KILL_TIMEOUT_MS);
+      await vi.runAllTimersAsync();
+      await quit;
+
+      expect(getPartialGracefulKillResults).toHaveBeenCalledWith("proj-1");
+      expect(projectStoreMock.enqueueProjectStateUpdate).toHaveBeenCalledWith(
+        "proj-1",
+        expect.any(Function)
+      );
+      expect(persistAgentSessionMock).toHaveBeenCalledTimes(1);
+      expect((persistAgentSessionMock.mock.calls[0][0] as Record<string, unknown>).sessionId).toBe(
+        "sess-1"
+      );
+      vi.useRealTimers();
+    });
+
+    it("writes nothing for a project that outran the deadline with no streamed captures", async () => {
+      vi.useFakeTimers();
+      projectStoreMock.getAllProjects.mockReturnValue([{ id: "proj-1" }] as never);
+      const ptyClient = makePtyClient({
+        getAllTerminalsAsync: vi.fn(async () => [agentTerminal]),
+        gracefulKillByProject: vi.fn(() => new Promise(() => {})),
+        getPartialGracefulKillResults: vi.fn(() => []),
+      });
+      const { beforeQuitCb } = await setup({ getPtyClient: () => ptyClient });
+
+      const quit = beforeQuitCb(makeEvent());
+      await vi.advanceTimersByTimeAsync(PROJECT_GRACEFUL_KILL_TIMEOUT_MS);
+      await vi.runAllTimersAsync();
+      await quit;
+
+      expect(projectStoreMock.enqueueProjectStateUpdate).not.toHaveBeenCalled();
+      expect(persistAgentSessionMock).not.toHaveBeenCalled();
+      vi.useRealTimers();
     });
 
     it("still journals when persisting a project's captures rejects", async () => {

--- a/electron/lifecycle/shutdown.ts
+++ b/electron/lifecycle/shutdown.ts
@@ -52,7 +52,11 @@ import { closeTelemetry } from "../services/TelemetryService.js";
 import { isSmokeTest } from "../setup/environment.js";
 import { stopPerformanceTraceIfActive } from "../utils/performanceTrace.js";
 import { isSignalShutdown, clearSafetyBeltTimer } from "./signalShutdownState.js";
-import { CLEANUP_TIMEOUT_MS, SHUTDOWN_TAIL_TIMEOUT_MS } from "./shutdownConfig.js";
+import {
+  CLEANUP_TIMEOUT_MS,
+  PROJECT_GRACEFUL_KILL_TIMEOUT_MS,
+  SHUTDOWN_TAIL_TIMEOUT_MS,
+} from "./shutdownConfig.js";
 import {
   getActiveShutdown,
   setShutdownRunner,
@@ -245,14 +249,21 @@ async function runShutdownChain(deps: ShutdownDeps): Promise<ShutdownOutcome> {
       const allProjects = projectStore.getAllProjects();
       const projectIds = allProjects.map((p) => p.id);
       // Cap each project's graceful kill independently (in parallel) rather
-      // than racing the whole batch against one 4s deadline: a single slow
+      // than racing the whole batch against one shared deadline: a single slow
       // project must not discard the captured sessions of projects that did
       // finish in time — both the projectStore write and the resume journal
-      // below depend on those partial results. Wall-clock stays ~4s (parallel).
+      // below depend on those partial results. Wall-clock stays at one
+      // project's budget, not the sum (parallel).
       // A rejected kill is isolated the same way and for the same reason: one
       // project's IPC failing must cost only that project's captures, not every
       // project's (an unhandled rejection here would escape to the outer catch
       // and skip the state write and the journal wholesale).
+      //
+      // Inside a project the same isolation runs one level down (#12180): the
+      // host streams each terminal's capture as it lands and bounds each
+      // terminal's teardown on its own, so a pane that outruns the budget —
+      // Codex mid-turn, or one sitting behind a modal — costs its own id and
+      // not the whole project's.
       const allResults = await Promise.all(
         projectIds.map((pid) => {
           let timer: ReturnType<typeof setTimeout> | undefined;
@@ -265,7 +276,14 @@ async function runShutdownChain(deps: ShutdownDeps): Promise<ShutdownOutcome> {
             // and the next launch is supposed to restore the project as it was.
             ptyClient.gracefulKillByProject(pid, { preserveSession: true }),
             new Promise<Array<{ id: string; agentSessionId: string | null }>>((resolve) => {
-              timer = setTimeout(() => resolve([]), 4000);
+              // Whatever the host streamed before this fired, not `[]`. The
+              // aggregate reply waits on the slowest pane in the project, so a
+              // pane that runs its full budget used to take every sibling's
+              // already-captured id down with it.
+              timer = setTimeout(
+                () => resolve(ptyClient.getPartialGracefulKillResults(pid)),
+                PROJECT_GRACEFUL_KILL_TIMEOUT_MS
+              );
             }),
           ])
             .catch((error) => {

--- a/electron/lifecycle/shutdown.ts
+++ b/electron/lifecycle/shutdown.ts
@@ -227,7 +227,8 @@ async function runShutdownChain(deps: ShutdownDeps): Promise<ShutdownOutcome> {
     try {
       // Snapshot terminal infos before the kills — info is gone once the PTY
       // exits — so each captured agent session can be journaled below. Outside
-      // the 4s kill race; a failed snapshot just no-ops the journal step.
+      // PROJECT_GRACEFUL_KILL_TIMEOUT_MS; a failed snapshot just no-ops the
+      // journal step.
       let terminalInfoById = new Map<
         string,
         Awaited<ReturnType<PtyClient["getAllTerminalsAsync"]>>[number]

--- a/electron/lifecycle/shutdownConfig.ts
+++ b/electron/lifecycle/shutdownConfig.ts
@@ -3,6 +3,18 @@
 // in the full shutdown.ts service graph (ProjectStore, TelemetryService, etc).
 export const CLEANUP_TIMEOUT_MS = 10_000;
 
+// How long the quit chain waits for one project's graceful kill before taking
+// whatever the pty-host has streamed back so far. Sits above the host's own
+// per-terminal budget (GRACEFUL_KILL_TERMINAL_BUDGET_MS, 3250ms) with room for
+// the RPC round-trip, and well inside CLEANUP_TIMEOUT_MS — the chain still has
+// a database-worker drain and a maintenance drain to run after it, so this
+// cannot grow much without risking the hard timeout and its dirty exit.
+//
+// Missing it is no longer all-or-nothing: the host reports each terminal as it
+// settles and the timeout branch keeps those, so this bounds how long a project
+// is waited on, not what survives (#12180).
+export const PROJECT_GRACEFUL_KILL_TIMEOUT_MS = 4_000;
+
 // Bounds the post-cleanup tail — the telemetry flush and perf-trace flush that run
 // AFTER the cleanup race resolves and are therefore NOT covered by
 // CLEANUP_TIMEOUT_MS. Sized for the worst-case closeTelemetry(): the Sentry

--- a/electron/pty-host/handlers/__tests__/lifecycle.test.ts
+++ b/electron/pty-host/handlers/__tests__/lifecycle.test.ts
@@ -316,9 +316,11 @@ describe("lifecycle kill handlers — trackKilledPid", () => {
 
     await dispatch({ type: "graceful-kill-by-project", projectId: "proj-1", requestId: "r1" });
 
-    expect(ctx.ptyManager.gracefulKillByProject).toHaveBeenCalledWith("proj-1", {
-      preserveSession: undefined,
-    });
+    expect(ctx.ptyManager.gracefulKillByProject).toHaveBeenCalledWith(
+      "proj-1",
+      { preserveSession: undefined },
+      expect.any(Function)
+    );
     expect(ctx.resourceGovernor.trackKilledPid).toHaveBeenCalledTimes(2);
     expect(ctx.resourceGovernor.trackKilledPid).toHaveBeenCalledWith(300);
     expect(ctx.resourceGovernor.trackKilledPid).toHaveBeenCalledWith(400);
@@ -337,9 +339,55 @@ describe("lifecycle kill handlers — trackKilledPid", () => {
       preserveSession: true,
     });
 
-    expect(ctx.ptyManager.gracefulKillByProject).toHaveBeenCalledWith("proj-1", {
-      preserveSession: true,
-    });
+    expect(ctx.ptyManager.gracefulKillByProject).toHaveBeenCalledWith(
+      "proj-1",
+      { preserveSession: true },
+      expect.any(Function)
+    );
+  });
+
+  it("graceful-kill-by-project streams a progress event per terminal (#12180)", async () => {
+    const ctx = makeCtx();
+    (ctx.ptyManager.getTerminalsForProject as ReturnType<typeof vi.fn>).mockReturnValue(["t1"]);
+    (ctx.ptyManager.getTerminal as ReturnType<typeof vi.fn>).mockReturnValue(termInfo(300));
+    // Report both terminals through the callback, then resolve with only the
+    // aggregate — the main process has to be able to act on the streamed ones
+    // without ever seeing this return value.
+    (ctx.ptyManager.gracefulKillByProject as ReturnType<typeof vi.fn>).mockImplementation(
+      async (
+        _projectId: string,
+        _options: unknown,
+        onTerminalSettled?: (result: { id: string; agentSessionId: string | null }) => void
+      ) => {
+        onTerminalSettled?.({ id: "t1", agentSessionId: "s1" });
+        onTerminalSettled?.({ id: "t2", agentSessionId: null });
+        return [
+          { id: "t1", agentSessionId: "s1" },
+          { id: "t2", agentSessionId: null },
+        ];
+      }
+    );
+    const dispatch = createPtyHostMessageDispatcher(ctx);
+
+    await dispatch({ type: "graceful-kill-by-project", projectId: "proj-1", requestId: "r1" });
+
+    const progress = (ctx.sendEvent as ReturnType<typeof vi.fn>).mock.calls
+      .map(([event]) => event)
+      .filter((e) => e.type === "graceful-kill-by-project-progress");
+    expect(progress).toEqual([
+      {
+        type: "graceful-kill-by-project-progress",
+        requestId: "r1",
+        projectId: "proj-1",
+        result: { id: "t1", agentSessionId: "s1" },
+      },
+      {
+        type: "graceful-kill-by-project-progress",
+        requestId: "r1",
+        projectId: "proj-1",
+        result: { id: "t2", agentSessionId: null },
+      },
+    ]);
   });
 
   it("graceful-kill-by-project handles empty project", async () => {

--- a/electron/pty-host/handlers/lifecycle.ts
+++ b/electron/pty-host/handlers/lifecycle.ts
@@ -206,9 +206,23 @@ export function createLifecycleHandlers(ctx: HostContext): HandlerMap {
         const pid = ptyManager.getTerminal(id)?.ptyProcess.pid;
         if (isValidPid(pid)) pids.push(pid);
       }
-      const results = await ptyManager.gracefulKillByProject(msg.projectId, {
-        preserveSession: msg.preserveSession,
-      });
+      const results = await ptyManager.gracefulKillByProject(
+        msg.projectId,
+        { preserveSession: msg.preserveSession },
+        // Streamed per terminal so the main process already holds every capture
+        // that landed before its own deadline: the aggregate reply below waits
+        // on the slowest pane in the project, and a caller that gave up waiting
+        // used to throw the finished captures away with the unfinished ones
+        // (#12180).
+        (result) => {
+          sendEvent({
+            type: "graceful-kill-by-project-progress",
+            requestId: msg.requestId,
+            projectId: msg.projectId,
+            result,
+          });
+        }
+      );
       for (const pid of pids) {
         resourceGovernor.trackKilledPid(pid);
       }

--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -1978,8 +1978,10 @@ export class PtyClient extends EventEmitter {
     options?: { preserveSession?: boolean }
   ): Promise<GracefulKillByProjectOutcome> {
     const shard = this.shardForProjectQuery(projectId);
-    const inFlight: { requestId: string | null; results: Array<{ id: string; agentSessionId: string | null }> } =
-      { requestId: null, results: [] };
+    const inFlight: {
+      requestId: string | null;
+      results: Array<{ id: string; agentSessionId: string | null }>;
+    } = { requestId: null, results: [] };
     this.partialGracefulKills.set(projectId, inFlight);
     try {
       const sessions = await sendPtyHostRpc<Array<{ id: string; agentSessionId: string | null }>>(

--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -336,6 +336,13 @@ export class PtyClient extends EventEmitter {
   private pendingSpawns: Map<string, PtyHostSpawnOptions> = new Map();
   private ipcDataMirrorIds = new Set<string>();
   private pendingKillCount: Map<string, number> = new Map();
+  // Captures streamed back for a graceful kill that is still in flight, keyed
+  // by project. Seeded when the call starts and dropped when it settles, so an
+  // entry existing IS the "in flight" signal the router checks (#12180).
+  private partialGracefulKills = new Map<
+    string,
+    Array<{ id: string; agentSessionId: string | null }>
+  >();
   private activeProjectId: string | null = null;
   private windowProjectContexts = new Map<
     number,
@@ -580,6 +587,13 @@ export class PtyClient extends EventEmitter {
           if (generation !== undefined && ledger.currentGeneration(id) !== undefined) {
             ledger.recordClose(id, generation, "exit", exitCode);
           }
+        },
+        // Per-terminal captures streamed while a graceful kill is still
+        // running (#12180). Recorded only while a call for that project is in
+        // flight, so a late event from an abandoned request can't seed a stale
+        // entry for the next one.
+        onGracefulKillProgress: (projectId, result) => {
+          this.partialGracefulKills.get(projectId)?.push(result);
         },
         onSpawnResult: (id, result) => {
           const ledger = getLifecycleLedger();
@@ -1936,11 +1950,15 @@ export class PtyClient extends EventEmitter {
    *
    * Mirrors the single-terminal {@link gracefulKill} triage: a typed
    * BrokerError of HOST_EXITED/APP_SHUTDOWN (or a locally-observed dead/disposed
-   * client) means the host is gone and teardown is real — confirmed, just with
-   * no sessions to capture. A per-request TIMEOUT with a live host means the
+   * client) means the host is gone and teardown is real — confirmed, with
+   * nothing further to capture. A per-request TIMEOUT with a live host means the
    * teardown is NOT confirmed: agents may still be running, so the caller must
    * keep the project's restoration state and let the user retry. Unexpected
    * errors reject; callers treat that as fail-closed too.
+   *
+   * Both failure paths still return whatever the host streamed before it went
+   * quiet (#12180) — `sessions` says what was captured, `confirmed` says whether
+   * the teardown was acknowledged, and the two are independent.
    *
    * Contract of `confirmed: true`: the host acknowledged and ran the teardown
    * (graceful shutdown + a fallback hard kill per terminal, see
@@ -1955,6 +1973,7 @@ export class PtyClient extends EventEmitter {
     options?: { preserveSession?: boolean }
   ): Promise<GracefulKillByProjectOutcome> {
     const shard = this.shardForProjectQuery(projectId);
+    this.partialGracefulKills.set(projectId, []);
     try {
       const sessions = await sendPtyHostRpc<Array<{ id: string; agentSessionId: string | null }>>(
         shard,
@@ -1971,18 +1990,40 @@ export class PtyClient extends EventEmitter {
       );
       return { confirmed: true, sessions };
     } catch (error) {
+      // Whatever the host streamed before it stopped answering are real ids:
+      // the failure says the teardown wasn't acknowledged, not that nothing was
+      // captured. Returning them costs nothing (`confirmed` is reported
+      // separately and unchanged) and saves a resume (#12180).
+      const streamed = this.getPartialGracefulKillResults(projectId);
       const isHostGoneBrokerError = error instanceof BrokerError && error.code !== "TIMEOUT";
       if (isHostGoneBrokerError || !shard.lifecycle.child || this.isDisposed) {
         // Host is gone: its terminals are gone with it. Teardown is confirmed;
-        // no sessions were capturable.
-        return { confirmed: true, sessions: [] };
+        // nothing further was capturable.
+        return { confirmed: true, sessions: streamed };
       }
       if (error instanceof BrokerError && error.code === "TIMEOUT") {
         // Live host, per-request timeout — the kill was not acknowledged.
-        return { confirmed: false, sessions: [] };
+        return { confirmed: false, sessions: streamed };
       }
       throw error;
+    } finally {
+      this.partialGracefulKills.delete(projectId);
     }
+  }
+
+  /**
+   * Per-terminal captures the host has streamed for a `gracefulKillByProject`
+   * that is still in flight.
+   *
+   * The aggregate reply waits on the slowest pane in the project, so a caller
+   * that races it against a shorter deadline — the quit chain does, per project
+   * — reads this on timeout rather than discarding the captures that did land
+   * (#12180). Empty once the call settles, and when none is running.
+   */
+  getPartialGracefulKillResults(
+    projectId: string
+  ): Array<{ id: string; agentSessionId: string | null }> {
+    return [...(this.partialGracefulKills.get(projectId) ?? [])];
   }
 
   async gracefulKillByProject(

--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -338,10 +338,13 @@ export class PtyClient extends EventEmitter {
   private pendingKillCount: Map<string, number> = new Map();
   // Captures streamed back for a graceful kill that is still in flight, keyed
   // by project. Seeded when the call starts and dropped when it settles, so an
-  // entry existing IS the "in flight" signal the router checks (#12180).
+  // entry existing IS the "in flight" signal the router checks (#12180). The
+  // owning `requestId` rides along so a straggling event from an abandoned
+  // earlier kill of the same project can't file a dead terminal's id against
+  // the current one.
   private partialGracefulKills = new Map<
     string,
-    Array<{ id: string; agentSessionId: string | null }>
+    { requestId: string | null; results: Array<{ id: string; agentSessionId: string | null }> }
   >();
   private activeProjectId: string | null = null;
   private windowProjectContexts = new Map<
@@ -592,8 +595,9 @@ export class PtyClient extends EventEmitter {
         // running (#12180). Recorded only while a call for that project is in
         // flight, so a late event from an abandoned request can't seed a stale
         // entry for the next one.
-        onGracefulKillProgress: (projectId, result) => {
-          this.partialGracefulKills.get(projectId)?.push(result);
+        onGracefulKillProgress: (projectId, requestId, result) => {
+          const inFlight = this.partialGracefulKills.get(projectId);
+          if (inFlight?.requestId === requestId) inFlight.results.push(result);
         },
         onSpawnResult: (id, result) => {
           const ledger = getLifecycleLedger();
@@ -1961,10 +1965,11 @@ export class PtyClient extends EventEmitter {
    * the teardown was acknowledged, and the two are independent.
    *
    * Contract of `confirmed: true`: the host acknowledged and ran the teardown
-   * (graceful shutdown + a fallback hard kill per terminal, see
-   * PtyManager.gracefulKillByProject), or the host is gone. It is NOT a
-   * guarantee that every OS process was reaped, and it does not reconcile with
-   * pty-host crash recovery, which can replay an in-flight `pendingSpawns`
+   * (graceful shutdown + a hard kill per terminal, issued for every terminal
+   * before the aggregate resolves — including a terminal that outran its own
+   * budget, see PtyManager.gracefulKillByProject), or the host is gone. It is
+   * NOT a guarantee that every OS process was reaped, and it does not reconcile
+   * with pty-host crash recovery, which can replay an in-flight `pendingSpawns`
    * terminal as a fresh incarnation after a host exit — that race is owned by
    * the crash-recovery path (#11339), not this method.
    */
@@ -1973,19 +1978,26 @@ export class PtyClient extends EventEmitter {
     options?: { preserveSession?: boolean }
   ): Promise<GracefulKillByProjectOutcome> {
     const shard = this.shardForProjectQuery(projectId);
-    this.partialGracefulKills.set(projectId, []);
+    const inFlight: { requestId: string | null; results: Array<{ id: string; agentSessionId: string | null }> } =
+      { requestId: null, results: [] };
+    this.partialGracefulKills.set(projectId, inFlight);
     try {
       const sessions = await sendPtyHostRpc<Array<{ id: string; agentSessionId: string | null }>>(
         shard,
         `graceful-kill-by-project-${projectId}`,
-        (requestId) => ({
-          type: "graceful-kill-by-project",
-          projectId,
-          requestId,
-          ...(options?.preserveSession !== undefined
-            ? { preserveSession: options.preserveSession }
-            : {}),
-        }),
+        (requestId) => {
+          // Set before the request goes out, so no progress event can arrive
+          // uncorrelated. `sendPtyHostRpc` builds exactly once.
+          inFlight.requestId = requestId;
+          return {
+            type: "graceful-kill-by-project",
+            projectId,
+            requestId,
+            ...(options?.preserveSession !== undefined
+              ? { preserveSession: options.preserveSession }
+              : {}),
+          };
+        },
         { method: "graceful-kill-by-project", timeoutMs: PTY_TIMEOUTS["graceful-kill-by-project"] }
       );
       return { confirmed: true, sessions };
@@ -2005,9 +2017,18 @@ export class PtyClient extends EventEmitter {
         // Live host, per-request timeout — the kill was not acknowledged.
         return { confirmed: false, sessions: streamed };
       }
+      // Genuinely unexpected — not a broker outcome at all. Rejecting is the
+      // fail-closed contract callers are written against, and it costs
+      // `streamed`, which has nowhere to ride out on this path.
       throw error;
     } finally {
-      this.partialGracefulKills.delete(projectId);
+      // Only our own entry: a second kill of the same project (hibernation or
+      // idle auto-close racing the quit) has already replaced it, and dropping
+      // its captures here would hand it the empty array this fix exists to
+      // avoid.
+      if (this.partialGracefulKills.get(projectId) === inFlight) {
+        this.partialGracefulKills.delete(projectId);
+      }
     }
   }
 
@@ -2023,7 +2044,7 @@ export class PtyClient extends EventEmitter {
   getPartialGracefulKillResults(
     projectId: string
   ): Array<{ id: string; agentSessionId: string | null }> {
-    return [...(this.partialGracefulKills.get(projectId) ?? [])];
+    return [...(this.partialGracefulKills.get(projectId)?.results ?? [])];
   }
 
   async gracefulKillByProject(

--- a/electron/services/PtyManager.ts
+++ b/electron/services/PtyManager.ts
@@ -31,6 +31,9 @@ import {
   type PtyManagerEvents,
   MAX_PRESERVED_TERMINAL_SNAPSHOTS,
 } from "./pty/index.js";
+// From ./pty/types.js rather than the ./pty/index.js barrel above: the
+// PtyManager unit tests mock that barrel wholesale, which would leave this
+// undefined and fire the budget timer on the next tick.
 import { GRACEFUL_KILL_TERMINAL_BUDGET_MS } from "./pty/types.js";
 import { computeSpawnContext, acquirePtyProcess } from "./pty/terminalSpawn.js";
 import { disposeTerminalSerializerService } from "./pty/TerminalSerializerService.js";
@@ -1162,10 +1165,17 @@ export class PtyManager extends EventEmitter {
    * One terminal's slot in {@link gracefulKillByProject}, capped at
    * GRACEFUL_KILL_TERMINAL_BUDGET_MS.
    *
-   * Timing out abandons the wait, not the teardown: the losing chain keeps
-   * running and still tears the terminal down — `gracefulShutdown` kills on its
-   * own timeout, and the fallback below covers the terminals it returns without
-   * killing — so giving up on a capture never leaves a live pane behind.
+   * Timing out abandons the wait, not the teardown, and kills on the way out —
+   * mirroring the single-terminal timeout in `PtyClient.gracefulKill`. Leaving
+   * the kill to the abandoned chain would have been enough to reap the pane
+   * eventually, but not before this method returned, and callers read the
+   * acknowledged teardown as licence to delete a project's restoration state
+   * (#11340). The kill has to have been issued for every terminal by the time
+   * the aggregate resolves.
+   *
+   * Double-killing is not a hazard: `kill` re-reads the registry and no-ops on a
+   * terminal that is already gone, and `gracefulShutdown` latches its own
+   * teardown, so whichever path lands second does nothing.
    */
   private gracefulKillWithinBudget(
     terminalId: string,
@@ -1190,10 +1200,15 @@ export class PtyManager extends EventEmitter {
     return Promise.race([
       settled,
       new Promise<{ id: string; agentSessionId: string | null }>((resolve) => {
-        timer = setTimeout(
-          () => resolve({ id: terminalId, agentSessionId: null }),
-          GRACEFUL_KILL_TERMINAL_BUDGET_MS
-        );
+        timer = setTimeout(() => {
+          logWarn(`Graceful kill outran its budget for terminal ${terminalId}; killing`);
+          try {
+            this.kill(terminalId, "graceful-kill-timeout", options);
+          } catch {
+            // already dead
+          }
+          resolve({ id: terminalId, agentSessionId: null });
+        }, GRACEFUL_KILL_TERMINAL_BUDGET_MS);
       }),
     ]).finally(() => {
       if (timer) clearTimeout(timer);

--- a/electron/services/PtyManager.ts
+++ b/electron/services/PtyManager.ts
@@ -31,6 +31,7 @@ import {
   type PtyManagerEvents,
   MAX_PRESERVED_TERMINAL_SNAPSHOTS,
 } from "./pty/index.js";
+import { GRACEFUL_KILL_TERMINAL_BUDGET_MS } from "./pty/types.js";
 import { computeSpawnContext, acquirePtyProcess } from "./pty/terminalSpawn.js";
 import { disposeTerminalSerializerService } from "./pty/TerminalSerializerService.js";
 import { deleteSessionFile } from "./pty/terminalSessionPersistence.js";
@@ -1119,10 +1120,22 @@ export class PtyManager extends EventEmitter {
 
   /**
    * Gracefully kill all terminals for a project, capturing session IDs.
+   *
+   * Each terminal is bounded on its own rather than the batch sharing one
+   * deadline. `Promise.all` doesn't settle until the slowest member does, so a
+   * pane whose teardown drifts past its internal budget used to hold every
+   * sibling's already-captured id hostage until the caller gave up and threw
+   * the whole project's results away (#12180). A pane that runs out of time now
+   * costs its own capture and nothing else.
+   *
+   * `onTerminalSettled` reports each result the moment it lands. The aggregate
+   * below is all-or-nothing across an IPC boundary; a caller on the far side
+   * uses this to keep whatever arrived before its own deadline.
    */
   async gracefulKillByProject(
     projectId: string,
-    options?: { preserveSession?: boolean }
+    options?: { preserveSession?: boolean },
+    onTerminalSettled?: (result: { id: string; agentSessionId: string | null }) => void
   ): Promise<Array<{ id: string; agentSessionId: string | null }>> {
     const terminalIds = this.registry.getForProject(projectId);
     if (terminalIds.length === 0) return [];
@@ -1131,22 +1144,60 @@ export class PtyManager extends EventEmitter {
 
     const results = await Promise.all(
       terminalIds.map(async (terminalId) => {
+        const result = await this.gracefulKillWithinBudget(terminalId, options);
         try {
-          const { sessionId } = await this.gracefulKill(terminalId, options);
-          return { id: terminalId, agentSessionId: sessionId };
+          onTerminalSettled?.(result);
         } catch (error) {
-          logError(`Failed to graceful-kill terminal ${terminalId}`, error);
-          try {
-            this.kill(terminalId, "graceful-kill-fallback", options);
-          } catch {
-            // already dead
-          }
-          return { id: terminalId, agentSessionId: null };
+          // A throwing reporter must not cost the capture it was reporting.
+          logError(`Graceful-kill progress report failed for terminal ${terminalId}`, error);
         }
+        return result;
       })
     );
 
     return results;
+  }
+
+  /**
+   * One terminal's slot in {@link gracefulKillByProject}, capped at
+   * GRACEFUL_KILL_TERMINAL_BUDGET_MS.
+   *
+   * Timing out abandons the wait, not the teardown: the losing chain keeps
+   * running and still tears the terminal down — `gracefulShutdown` kills on its
+   * own timeout, and the fallback below covers the terminals it returns without
+   * killing — so giving up on a capture never leaves a live pane behind.
+   */
+  private gracefulKillWithinBudget(
+    terminalId: string,
+    options?: { preserveSession?: boolean }
+  ): Promise<{ id: string; agentSessionId: string | null }> {
+    const settled: Promise<{ id: string; agentSessionId: string | null }> = this.gracefulKill(
+      terminalId,
+      options
+    )
+      .then(({ sessionId }) => ({ id: terminalId, agentSessionId: sessionId }))
+      .catch((error: unknown) => {
+        logError(`Failed to graceful-kill terminal ${terminalId}`, error);
+        try {
+          this.kill(terminalId, "graceful-kill-fallback", options);
+        } catch {
+          // already dead
+        }
+        return { id: terminalId, agentSessionId: null };
+      });
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    return Promise.race([
+      settled,
+      new Promise<{ id: string; agentSessionId: string | null }>((resolve) => {
+        timer = setTimeout(
+          () => resolve({ id: terminalId, agentSessionId: null }),
+          GRACEFUL_KILL_TERMINAL_BUDGET_MS
+        );
+      }),
+    ]).finally(() => {
+      if (timer) clearTimeout(timer);
+    });
   }
 
   /**

--- a/electron/services/__tests__/PtyClient.adversarial.test.ts
+++ b/electron/services/__tests__/PtyClient.adversarial.test.ts
@@ -452,6 +452,79 @@ describe("PtyClient adversarial", () => {
     expect(killByProjectCall).toBeUndefined();
   });
 
+  it("GRACEFUL_KILL_BY_PROJECT_EXPOSES_STREAMED_CAPTURES_WHILE_IN_FLIGHT", async () => {
+    const client = createReadyClient();
+
+    expect(client.getPartialGracefulKillResults("proj-a")).toEqual([]);
+
+    const promise = client.gracefulKillByProjectConfirmed("proj-a");
+    const request = mockChild.postMessage.mock.calls
+      .map((call: unknown[]) => call[0] as { type?: string; requestId?: string })
+      .find((msg) => msg?.type === "graceful-kill-by-project");
+
+    // #12180: the quit chain races this call against a deadline shorter than
+    // the RPC timeout. When that deadline fires the call is still open, so the
+    // captures that already landed have to be readable right here.
+    mockChild.emit("message", {
+      type: "graceful-kill-by-project-progress",
+      requestId: request!.requestId,
+      projectId: "proj-a",
+      result: { id: "t1", agentSessionId: "sess-1" },
+    });
+
+    expect(client.getPartialGracefulKillResults("proj-a")).toEqual([
+      { id: "t1", agentSessionId: "sess-1" },
+    ]);
+
+    mockChild.emit("message", {
+      type: "graceful-kill-by-project-result",
+      requestId: request!.requestId,
+      results: [{ id: "t1", agentSessionId: "sess-1" }],
+    });
+    await promise;
+
+    // Dropped once the call settles, so the next quit can't read this one's ids.
+    expect(client.getPartialGracefulKillResults("proj-a")).toEqual([]);
+  });
+
+  it("GRACEFUL_KILL_BY_PROJECT_IGNORES_PROGRESS_WITH_NO_CALL_IN_FLIGHT", async () => {
+    const client = createReadyClient();
+
+    mockChild.emit("message", {
+      type: "graceful-kill-by-project-progress",
+      requestId: "stale",
+      projectId: "proj-a",
+      result: { id: "t1", agentSessionId: "sess-stale" },
+    });
+
+    // A late event from an abandoned request must not seed the next call.
+    expect(client.getPartialGracefulKillResults("proj-a")).toEqual([]);
+  });
+
+  it("GRACEFUL_KILL_BY_PROJECT_CONFIRMED_RETURNS_STREAMED_SESSIONS_ON_TIMEOUT", async () => {
+    const client = createReadyClient();
+
+    const promise = client.gracefulKillByProjectConfirmed("proj-a");
+    const request = mockChild.postMessage.mock.calls
+      .map((call: unknown[]) => call[0] as { type?: string; requestId?: string })
+      .find((msg) => msg?.type === "graceful-kill-by-project");
+    mockChild.emit("message", {
+      type: "graceful-kill-by-project-progress",
+      requestId: request!.requestId,
+      projectId: "proj-a",
+      result: { id: "t1", agentSessionId: "sess-1" },
+    });
+
+    await vi.advanceTimersByTimeAsync(11000);
+
+    // `confirmed` still reports the unacknowledged teardown; the id the host
+    // did stream is real and is kept anyway (#12180).
+    await expect(promise).resolves.toEqual({
+      confirmed: false,
+      sessions: [{ id: "t1", agentSessionId: "sess-1" }],
+    });
+  });
+
   it("GRACEFUL_KILL_BY_PROJECT_CONFIRMED_TREATS_HOST_EXIT_AS_CONFIRMED", async () => {
     const client = createReadyClient();
     // A fresh child for the restart so the exited emitter isn't reused.

--- a/electron/services/__tests__/PtyClient.adversarial.test.ts
+++ b/electron/services/__tests__/PtyClient.adversarial.test.ts
@@ -501,6 +501,81 @@ describe("PtyClient adversarial", () => {
     expect(client.getPartialGracefulKillResults("proj-a")).toEqual([]);
   });
 
+  it("GRACEFUL_KILL_BY_PROJECT_IGNORES_PROGRESS_FROM_A_STALE_REQUEST", async () => {
+    const client = createReadyClient();
+
+    void client.gracefulKillByProjectConfirmed("proj-a");
+
+    // A straggler from an earlier, abandoned kill of the same project. Filing
+    // it against the live call would resume a dead terminal's conversation.
+    mockChild.emit("message", {
+      type: "graceful-kill-by-project-progress",
+      requestId: "some-earlier-request",
+      projectId: "proj-a",
+      result: { id: "t1", agentSessionId: "sess-stale" },
+    });
+
+    expect(client.getPartialGracefulKillResults("proj-a")).toEqual([]);
+  });
+
+  it("GRACEFUL_KILL_BY_PROJECT_OVERLAPPING_CALLS_KEEP_THEIR_OWN_CAPTURES", async () => {
+    const client = createReadyClient();
+
+    function requestIds() {
+      return mockChild.postMessage.mock.calls
+        .map((call: unknown[]) => call[0] as { type?: string; requestId?: string })
+        .filter((msg) => msg?.type === "graceful-kill-by-project")
+        .map((msg) => msg.requestId!);
+    }
+
+    // Two teardowns of one project overlap in practice — a quit landing on top
+    // of an idle auto-close sweep, or a double-clicked sleep. Neither may
+    // silently take over or clear the other's accumulator.
+    const first = client.gracefulKillByProjectConfirmed("proj-a");
+    const [firstRequest] = requestIds();
+    const second = client.gracefulKillByProjectConfirmed("proj-a");
+    const secondRequest = requestIds()[1]!;
+    expect(secondRequest).not.toBe(firstRequest);
+
+    mockChild.emit("message", {
+      type: "graceful-kill-by-project-progress",
+      requestId: secondRequest,
+      projectId: "proj-a",
+      result: { id: "t2", agentSessionId: "sess-2" },
+    });
+    // Addressed to the first call, which is no longer the live record — it must
+    // not be filed against the second.
+    mockChild.emit("message", {
+      type: "graceful-kill-by-project-progress",
+      requestId: firstRequest,
+      projectId: "proj-a",
+      result: { id: "t1", agentSessionId: "sess-1" },
+    });
+
+    expect(client.getPartialGracefulKillResults("proj-a")).toEqual([
+      { id: "t2", agentSessionId: "sess-2" },
+    ]);
+
+    // The first call settling must leave the second's captures readable.
+    mockChild.emit("message", {
+      type: "graceful-kill-by-project-result",
+      requestId: firstRequest,
+      results: [],
+    });
+    await first;
+    expect(client.getPartialGracefulKillResults("proj-a")).toEqual([
+      { id: "t2", agentSessionId: "sess-2" },
+    ]);
+
+    mockChild.emit("message", {
+      type: "graceful-kill-by-project-result",
+      requestId: secondRequest,
+      results: [{ id: "t2", agentSessionId: "sess-2" }],
+    });
+    await second;
+    expect(client.getPartialGracefulKillResults("proj-a")).toEqual([]);
+  });
+
   it("GRACEFUL_KILL_BY_PROJECT_CONFIRMED_RETURNS_STREAMED_SESSIONS_ON_TIMEOUT", async () => {
     const client = createReadyClient();
 

--- a/electron/services/__tests__/PtyManager.adversarial.test.ts
+++ b/electron/services/__tests__/PtyManager.adversarial.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { IPty } from "node-pty";
 import type { PtyHostSpawnOptions } from "../../../shared/types/pty-host.js";
 
@@ -244,6 +244,7 @@ vi.mock("../../utils/logger.js", () => ({
 }));
 
 const { PtyManager } = await import("../PtyManager.js");
+const { GRACEFUL_KILL_TERMINAL_BUDGET_MS } = await import("../pty/types.js");
 
 function createPtyProcess(): MockPtyProcess {
   return {
@@ -625,5 +626,125 @@ describe("PtyManager adversarial", () => {
     expect(shared.created[0]!.info.cols).toBe(80);
     expect(shared.created[0]!.info.rows).toBe(24);
     expect(logWarn).toHaveBeenCalledWith(expect.stringContaining("invalid dims"));
+  });
+});
+
+describe("PtyManager gracefulKillByProject partial capture (#12180)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    shared.terminals.clear();
+    shared.created.length = 0;
+    shared.computeSpawnContext.mockReturnValue({ env: {}, shell: "/bin/zsh", args: ["-l"] });
+    shared.acquirePtyProcess.mockImplementation(() => createPtyProcess());
+    shared.agentTransitionState.mockReturnValue(true);
+    shared.deleteSessionFile.mockResolvedValue(undefined);
+    shared.persistAgentSession.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /** Two panes in one project: the first captures at once, the second hangs. */
+  function spawnFastAndHung(manager: InstanceType<typeof PtyManager>): void {
+    manager.spawn("fast", spawnOptions({ projectId: "project-a" }));
+    manager.spawn("hung", spawnOptions({ projectId: "project-a" }));
+    shared.created[0]!.gracefulShutdown = () => Promise.resolve("sess-fast");
+    shared.created[1]!.gracefulShutdown = () => new Promise<string | null>(() => {});
+  }
+
+  it("keeps a fast pane's capture when a sibling outruns the per-terminal budget", async () => {
+    vi.useFakeTimers();
+    const manager = new PtyManager();
+    spawnFastAndHung(manager);
+
+    const promise = manager.gracefulKillByProject("project-a");
+    await vi.advanceTimersByTimeAsync(GRACEFUL_KILL_TERMINAL_BUDGET_MS);
+
+    // The whole point of #12180: the hung pane costs its own id and nothing
+    // more. Before the per-terminal budget, `Promise.all` held "sess-fast"
+    // until the caller gave up and discarded the project wholesale.
+    await expect(promise).resolves.toEqual([
+      { id: "fast", agentSessionId: "sess-fast" },
+      { id: "hung", agentSessionId: null },
+    ]);
+  });
+
+  it("does not resolve a hung pane before its budget elapses", async () => {
+    vi.useFakeTimers();
+    const manager = new PtyManager();
+    spawnFastAndHung(manager);
+
+    let settled = false;
+    void manager.gracefulKillByProject("project-a").then(() => {
+      settled = true;
+    });
+
+    // One tick short: the budget must not be truncating captures early.
+    await vi.advanceTimersByTimeAsync(GRACEFUL_KILL_TERMINAL_BUDGET_MS - 1);
+    expect(settled).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(settled).toBe(true);
+  });
+
+  it("reports the fast pane through onTerminalSettled before the batch resolves", async () => {
+    vi.useFakeTimers();
+    const manager = new PtyManager();
+    spawnFastAndHung(manager);
+
+    const reported: Array<{ id: string; agentSessionId: string | null }> = [];
+    const promise = manager.gracefulKillByProject("project-a", undefined, (result) => {
+      reported.push(result);
+    });
+
+    // Nothing advanced yet, so the batch is still waiting on the hung pane —
+    // this is exactly the window in which the quit chain's deadline fires, and
+    // the capture has to already be out.
+    await vi.advanceTimersByTimeAsync(0);
+    expect(reported).toEqual([{ id: "fast", agentSessionId: "sess-fast" }]);
+
+    await vi.advanceTimersByTimeAsync(GRACEFUL_KILL_TERMINAL_BUDGET_MS);
+    await promise;
+    expect(reported).toEqual([
+      { id: "fast", agentSessionId: "sess-fast" },
+      { id: "hung", agentSessionId: null },
+    ]);
+  });
+
+  it("keeps the capture when the progress reporter throws", async () => {
+    vi.useFakeTimers();
+    const manager = new PtyManager();
+    manager.spawn("fast", spawnOptions({ projectId: "project-a" }));
+    shared.created[0]!.gracefulShutdown = () => Promise.resolve("sess-fast");
+
+    const promise = manager.gracefulKillByProject("project-a", undefined, () => {
+      throw new Error("transport gone");
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    await expect(promise).resolves.toEqual([{ id: "fast", agentSessionId: "sess-fast" }]);
+    expect(logError).toHaveBeenCalledWith(
+      expect.stringContaining("progress report failed"),
+      expect.any(Error)
+    );
+  });
+
+  it("isolates a rejecting pane from its siblings and still falls back to kill", async () => {
+    vi.useFakeTimers();
+    const manager = new PtyManager();
+    manager.spawn("ok", spawnOptions({ projectId: "project-a" }));
+    manager.spawn("bad", spawnOptions({ projectId: "project-a" }));
+    shared.created[0]!.gracefulShutdown = () => Promise.resolve("sess-ok");
+    shared.created[1]!.gracefulShutdown = () => Promise.reject(new Error("pty gone"));
+
+    const promise = manager.gracefulKillByProject("project-a");
+    await vi.advanceTimersByTimeAsync(0);
+
+    await expect(promise).resolves.toEqual([
+      { id: "ok", agentSessionId: "sess-ok" },
+      { id: "bad", agentSessionId: null },
+    ]);
+    expect(shared.created[1]!.kill).toHaveBeenCalled();
   });
 });

--- a/electron/services/__tests__/PtyManager.adversarial.test.ts
+++ b/electron/services/__tests__/PtyManager.adversarial.test.ts
@@ -712,6 +712,22 @@ describe("PtyManager gracefulKillByProject partial capture (#12180)", () => {
     ]);
   });
 
+  it("kills a pane that outran its budget before the batch resolves", async () => {
+    vi.useFakeTimers();
+    const manager = new PtyManager();
+    spawnFastAndHung(manager);
+
+    const promise = manager.gracefulKillByProject("project-a");
+    await vi.advanceTimersByTimeAsync(GRACEFUL_KILL_TERMINAL_BUDGET_MS);
+    await promise;
+
+    // Callers read the resolved batch as an acknowledged teardown and delete a
+    // project's restoration state on it (#11340), so the kill cannot be left to
+    // the abandoned chain to issue after we have already answered.
+    expect(shared.created[1]!.kill).toHaveBeenCalled();
+    expect(logWarn).toHaveBeenCalledWith(expect.stringContaining("outran its budget"));
+  });
+
   it("keeps the capture when the progress reporter throws", async () => {
     vi.useFakeTimers();
     const manager = new PtyManager();

--- a/electron/services/pty/PtyEventRouter.ts
+++ b/electron/services/pty/PtyEventRouter.ts
@@ -73,6 +73,16 @@ export interface PtyEventRouterCallbacks {
    */
   onTerminalExit?: (id: string, exitCode: number, launchGeneration?: number) => void;
   /**
+   * Optional. Fires for each terminal a `graceful-kill-by-project` captures, as
+   * it settles rather than when the whole project has. Lets PtyClient answer
+   * with partial results for a call that is still in flight (#12180). Pure side
+   * effect.
+   */
+  onGracefulKillProgress?: (
+    projectId: string,
+    result: { id: string; agentSessionId: string | null }
+  ) => void;
+  /**
    * Optional. Fires on every `spawn-result` (after `pendingSpawns` cleanup on
    * failure) so the lifecycle ledger can record spawn resolution. Pure side
    * effect.
@@ -246,6 +256,15 @@ export function routeHostEvent(event: PtyHostEvent, deps: PtyEventRouterDeps): b
 
     case "graceful-kill-by-project-result":
       broker.resolve(event.requestId, event.results ?? []);
+      return true;
+
+    case "graceful-kill-by-project-progress":
+      // Not a broker resolve: the request stays open until the aggregate result
+      // arrives. This only records the capture so a caller that abandons the
+      // wait still has it (#12180).
+      if (callbacks.onGracefulKillProgress) {
+        callbacks.onGracefulKillProgress(event.projectId, event.result);
+      }
       return true;
 
     case "project-stats": {

--- a/electron/services/pty/PtyEventRouter.ts
+++ b/electron/services/pty/PtyEventRouter.ts
@@ -80,6 +80,7 @@ export interface PtyEventRouterCallbacks {
    */
   onGracefulKillProgress?: (
     projectId: string,
+    requestId: string,
     result: { id: string; agentSessionId: string | null }
   ) => void;
   /**
@@ -263,7 +264,7 @@ export function routeHostEvent(event: PtyHostEvent, deps: PtyEventRouterDeps): b
       // arrives. This only records the capture so a caller that abandons the
       // wait still has it (#12180).
       if (callbacks.onGracefulKillProgress) {
-        callbacks.onGracefulKillProgress(event.projectId, event.result);
+        callbacks.onGracefulKillProgress(event.projectId, event.requestId, event.result);
       }
       return true;
 

--- a/electron/services/pty/types.ts
+++ b/electron/services/pty/types.ts
@@ -312,14 +312,28 @@ export { TRASH_TTL_MS } from "../../../shared/config/trash.js";
 // part of its budget waiting for the agent's confirm-to-quit footer between
 // presses before the resume hint can even arrive (measured at 0.76-1.16s).
 //
-// The real ceiling is the 4000ms per-project race in `electron/lifecycle/
-// shutdown.ts` — a terminal that outlives it has its captured id discarded.
-// 3000ms leaves 1000ms for the PtyClient RPC round-trip on either side of this
-// window. Both layers are `Promise.all` (terminals within a project, projects
-// within the quit), so this budget is parallel, not additive: ten terminals
-// cost one terminal's wall clock, not ten. Raise it only against that 4000ms
-// number, and only with the RPC round-trip still covered.
+// The real ceiling is PROJECT_GRACEFUL_KILL_TIMEOUT_MS (4000ms) in
+// `electron/lifecycle/shutdown.ts`. A terminal that outlives it no longer costs
+// its project the captures that did land — the host streams each one as it
+// settles (#12180) — but it still costs its own. 3000ms leaves 1000ms for the
+// PtyClient RPC round-trip on either side of this window. Both layers are
+// `Promise.all` (terminals within a project, projects within the quit), so this
+// budget is parallel, not additive: ten terminals cost one terminal's wall
+// clock, not ten. Raise it only against that 4000ms number, and only with the
+// RPC round-trip still covered.
 export const GRACEFUL_SHUTDOWN_TIMEOUT_MS = 3000;
+
+// Outer bound on one terminal's slot in `PtyManager.gracefulKillByProject`.
+// `gracefulShutdown` already stops itself at the budget above, so this only
+// catches a teardown that drifts past its own timer — the pty-host's event loop
+// is at its most contended during a quit, when every terminal escalates at
+// once. Without it one drifting pane holds the project's whole `Promise.all`
+// open, and every sibling's already-captured id with it (#12180).
+//
+// 250ms above the inner budget: enough that a merely late scrape still lands,
+// while the aggregate stays under the per-project race in `electron/lifecycle/
+// shutdown.ts` with its RPC round-trip still covered.
+export const GRACEFUL_KILL_TERMINAL_BUDGET_MS = GRACEFUL_SHUTDOWN_TIMEOUT_MS + 250;
 export const GRACEFUL_SHUTDOWN_BUFFER_SIZE = 8 * 1024;
 // Delay between writing the input-clear prelude and the quit command. Without this gap,
 // the target CLI's async event loop can drop or corrupt the quit command bytes under load.

--- a/electron/services/pty/types.ts
+++ b/electron/services/pty/types.ts
@@ -315,8 +315,9 @@ export { TRASH_TTL_MS } from "../../../shared/config/trash.js";
 // The real ceiling is PROJECT_GRACEFUL_KILL_TIMEOUT_MS (4000ms) in
 // `electron/lifecycle/shutdown.ts`. A terminal that outlives it no longer costs
 // its project the captures that did land — the host streams each one as it
-// settles (#12180) — but it still costs its own. 3000ms leaves 1000ms for the
-// PtyClient RPC round-trip on either side of this window. Both layers are
+// settles (#12180) — but it still costs its own. The host's aggregate is capped
+// at GRACEFUL_KILL_TERMINAL_BUDGET_MS below, so 750ms of that 4000ms is left for
+// the PtyClient RPC round-trip on either side of this window. Both layers are
 // `Promise.all` (terminals within a project, projects within the quit), so this
 // budget is parallel, not additive: ten terminals cost one terminal's wall
 // clock, not ten. Raise it only against that 4000ms number, and only with the

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -722,6 +722,16 @@ export type PtyHostEvent =
       results: Array<{ id: string; agentSessionId: string | null }>;
     }
   | {
+      // One terminal's capture, streamed the moment it lands. The aggregate
+      // result above only arrives once every terminal in the project has
+      // settled, so a main-process caller that stops waiting for it reads these
+      // instead of discarding the project's finished captures too (#12180).
+      type: "graceful-kill-by-project-progress";
+      requestId: string;
+      projectId: string;
+      result: { id: string; agentSessionId: string | null };
+    }
+  | {
       type: "fd-leak-warning";
       fdCount: number;
       activeTerminals: number;

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -776,8 +776,17 @@ export interface FdLeakWarningPayload {
  * without `as any` casts: the discriminant union of `PtyHostEvent` already types
  * `requestId` on every response member, but a switch case can't reach it without
  * narrowing first.
+ *
+ * A `requestId` is a correlation token, not a response marker: progress events
+ * carry one to say which call they belong to while that call is still open.
+ * Resolving the broker off one would settle the request on its FIRST terminal
+ * and drop every sibling's id — #12180 with a wider blast radius — so they are
+ * excluded here rather than left to a future caller to notice.
  */
-export type PtyHostResponseEvent = Extract<PtyHostEvent, { requestId: string }>;
+export type PtyHostResponseEvent = Exclude<
+  Extract<PtyHostEvent, { requestId: string }>,
+  { type: "graceful-kill-by-project-progress" }
+>;
 
 /**
  * Result of a graceful kill: the captured resume `sessionId` (null when there is
@@ -835,7 +844,11 @@ export interface TrimStateSummary extends TrimStateResult {
 }
 
 export function isPtyHostResponseEvent(event: PtyHostEvent): event is PtyHostResponseEvent {
-  return "requestId" in event && typeof (event as { requestId?: unknown }).requestId === "string";
+  return (
+    "requestId" in event &&
+    typeof (event as { requestId?: unknown }).requestId === "string" &&
+    event.type !== "graceful-kill-by-project-progress"
+  );
 }
 
 /** Terminal info sent from Host → Main for getTerminal queries */


### PR DESCRIPTION
## Summary

The bug: at quit, `electron/lifecycle/shutdown.ts` raced each project's `gracefulKillByProject` against a 4s timer that resolved to `[]`, and the kill itself awaited `Promise.all` over every terminal in the project. One pane running its full 3s `GRACEFUL_SHUTDOWN_TIMEOUT_MS` budget — Codex mid-turn, or a pane sitting behind a modal — pushed the whole project past the deadline, so the race returned an empty array and every id already captured for the project's other panes was thrown away. Nothing was written back to the snapshots and nothing was journaled. The terminals still died, so it looked like a clean quit, and the panes came back "Session no longer reachable" on the next launch. Fleet-style use, many agent panes in one project, is where it bites.

Why the obvious fix doesn't work: raising the 4s deadline just moves the threshold, and there is no room for it anyway — the cleanup chain still has a 5s database-worker drain and a 2s maintenance drain to run inside `CLEANUP_TIMEOUT_MS` (10s), and overrunning that means a dirty exit. A per-terminal cap alone doesn't fix it either: the failure is a pane using its *full* budget, so a cap above 3s never fires in that case and the aggregate still lands after the deadline. The captures have to survive the deadline instead.

Resolves #12180

## Changes

- The pty-host now streams each terminal's capture as it settles, via a new `graceful-kill-by-project-progress` event. `PtyClient` accumulates them for the call's lifetime, keyed by the owning requestId so overlapping kills of one project (a quit landing on an idle auto-close sweep) can't clobber each other.
- shutdown.ts's timeout branch reads those partials instead of discarding the project.
- Each terminal's slot in `PtyManager.gracefulKillByProject` is bounded by `GRACEFUL_KILL_TERMINAL_BUDGET_MS` (3250ms) so a drifting pane can't hold its siblings' resolved results open, and it is killed when that budget wins — callers read an acknowledged teardown as licence to delete a project's restoration state (#11340), so the kill has to have been issued before the aggregate resolves. This also covers the non-quit callers (hibernation, idle auto-close, relocation), which sit behind the 10s RPC timeout with no partial-result path of their own.
- `gracefulKillByProjectConfirmed`'s failure paths return whatever was streamed; `confirmed` reports the teardown, `sessions` reports what was captured, and the two are independent.
- The 4s literal is now `PROJECT_GRACEFUL_KILL_TIMEOUT_MS` so the budget hierarchy (3000 → 3250 → 4000 → 10000) is legible in one place.
- Progress events are excluded from `PtyHostResponseEvent`: a requestId on one is a correlation token, not a response marker, and resolving the broker off it would settle the request on its first terminal and drop every sibling. No call sites today — the type was the trap.

## Testing

722 tests across 25 files plus `npm run typecheck`, all green locally. New coverage for the intra-project isolation, the streamed-partial path through PtyClient and the pty-host handler, overlapping kills of one project, and the kill-on-budget-timeout. Note that `shutdown.test.ts` previously always mocked `gracefulKillByProject` to resolve instantly, so the 4s race literal had never been exercised by any test; it is now.

Found by reading the code, not reproduced.