### PR TITLE
fix(pty): capture the Codex resume hint when an agent exits on its own

### DIFF
--- a/electron/ipc/handlers/terminal/events.ts
+++ b/electron/ipc/handlers/terminal/events.ts
@@ -179,7 +179,8 @@ export function registerTerminalEventHandlers(deps: HandlerDependencies): () => 
   });
   handlers.push(unsubTerminalRestored);
 
-  // Resume records captured by the pty-host (trash expiry). Main is the
+  // Resume records captured by the pty-host (trash expiry, natural agent
+  // exit, `/quit` demotion). Main is the
   // journal's single writer — the pty-host writing the file itself would race
   // main's own close-path writes (two processes, two write queues, one file)
   // — so persist here through the exactly-once journal funnel, keyed by the

--- a/electron/services/events.ts
+++ b/electron/services/events.ts
@@ -881,17 +881,22 @@ export type DaintreeEventMap = {
   };
 
   /**
-   * Emitted in the pty-host when trash expiry captures a resumable session,
-   * and re-emitted on the Main bus by PtyEventsBridge. Main persists the
-   * record (single journal writer — the pty-host writing the file itself
-   * would race Main's own close-path writes) and then emits
-   * `agent-session:recorded`.
+   * Emitted in the pty-host when a capture path finds a resumable session —
+   * trash expiry, a natural agent exit, or a `/quit`-style demotion — and
+   * re-emitted on the Main bus by PtyEventsBridge. Main persists the record
+   * (single journal writer — the pty-host writing the file itself would race
+   * Main's own close-path writes) and then emits `agent-session:recorded`.
    */
   "agent-session:captured": {
     /** Terminal whose close produced the record — keys ledger dedupe. */
     terminalId: string;
-    /** Launch generation of that terminal incarnation, when known. */
-    launchGeneration?: number;
+    /**
+     * Launch generation of that terminal incarnation, when known. `null`
+     * deliberately opts out of generation gating for a capture that is not a
+     * terminal close (a demotion), where one generation can legitimately
+     * produce several records.
+     */
+    launchGeneration?: number | null;
     record: Omit<
       import("../../shared/types/ipc/agentSessionHistory.js").AgentSessionRecord,
       "savedAt"

--- a/electron/services/pty/TerminalAgentDetection.ts
+++ b/electron/services/pty/TerminalAgentDetection.ts
@@ -6,10 +6,12 @@ import type { PatternDetectionConfig } from "./AgentPatternDetector.js";
 import type { ActivityHeadlineGenerator } from "../ActivityHeadlineGenerator.js";
 import type { AgentStateService } from "./AgentStateService.js";
 import type { SemanticBufferManager } from "./SemanticBufferManager.js";
+import type { TerminalForensicsBuffer } from "./TerminalForensicsBuffer.js";
 import type { TerminalInfo } from "./types.js";
 import { computeDefaultTitle } from "./terminalTitle.js";
 import { logIdentityDebug } from "./identityDebug.js";
 import { buildPatternConfig } from "./terminalActivityPatterns.js";
+import { captureAgentEndSession } from "./agentEndCapture.js";
 
 export interface TerminalAgentDetectionHost {
   readonly id: string;
@@ -17,6 +19,7 @@ export interface TerminalAgentDetectionHost {
   readonly agentStateService: AgentStateService;
   readonly headlineGenerator: ActivityHeadlineGenerator;
   readonly semanticBufferManager: SemanticBufferManager;
+  readonly forensicsBuffer: TerminalForensicsBuffer;
   readonly hasActivityMonitor: boolean;
   lastDetectedProcessIconId: string | undefined;
   reconfigureActivityMonitor(agentId: string, patternConfig?: PatternDetectionConfig): void;
@@ -172,6 +175,17 @@ export function handleAgentDetection(
           `reason=${result.evidenceSource === "shell_command" ? "prompt-return" : "no-agent-detected"} ` +
           `agent=${previousAgent} runtime=${terminal.launchAgentId ? "launch-anchored" : "runtime-promoted"}`
       );
+      // The agent ended on its own but the pane survives as a shell, so no close
+      // path ever sees this session — quitting Codex by hand left it invisible to
+      // the resume palette (#12179). Runs before the identity and title rewrites
+      // below, which the record reads.
+      captureAgentEndSession({
+        terminalId: host.id,
+        terminal,
+        agentId: previousAgent,
+        boundary: "demotion",
+        recentOutput: host.forensicsBuffer.getRecentOutput(),
+      });
       host.agentStateService.updateAgentState(terminal, { type: "exit", code: 0 });
       terminal.detectedAgentId = undefined;
       justClearedDetection = true;

--- a/electron/services/pty/TerminalAgentDetection.ts
+++ b/electron/services/pty/TerminalAgentDetection.ts
@@ -11,7 +11,7 @@ import type { TerminalInfo } from "./types.js";
 import { computeDefaultTitle } from "./terminalTitle.js";
 import { logIdentityDebug } from "./identityDebug.js";
 import { buildPatternConfig } from "./terminalActivityPatterns.js";
-import { captureAgentEndSession } from "./agentEndCapture.js";
+import { CAPTURE_SCAN_ROWS, captureAgentEndSession } from "./agentEndCapture.js";
 
 export interface TerminalAgentDetectionHost {
   readonly id: string;
@@ -21,6 +21,7 @@ export interface TerminalAgentDetectionHost {
   readonly semanticBufferManager: SemanticBufferManager;
   readonly forensicsBuffer: TerminalForensicsBuffer;
   readonly hasActivityMonitor: boolean;
+  getLastNLines(n: number): string[];
   lastDetectedProcessIconId: string | undefined;
   reconfigureActivityMonitor(agentId: string, patternConfig?: PatternDetectionConfig): void;
   startActivityMonitor(): void;
@@ -184,6 +185,7 @@ export function handleAgentDetection(
         terminal,
         agentId: previousAgent,
         boundary: "demotion",
+        renderedLines: host.getLastNLines(CAPTURE_SCAN_ROWS),
         recentOutput: host.forensicsBuffer.getRecentOutput(),
       });
       host.agentStateService.updateAgentState(terminal, { type: "exit", code: 0 });

--- a/electron/services/pty/TerminalAgentDetection.ts
+++ b/electron/services/pty/TerminalAgentDetection.ts
@@ -11,7 +11,7 @@ import type { TerminalInfo } from "./types.js";
 import { computeDefaultTitle } from "./terminalTitle.js";
 import { logIdentityDebug } from "./identityDebug.js";
 import { buildPatternConfig } from "./terminalActivityPatterns.js";
-import { CAPTURE_SCAN_ROWS, captureAgentEndSession } from "./agentEndCapture.js";
+import { captureAgentEndSession } from "./agentEndCapture.js";
 
 export interface TerminalAgentDetectionHost {
   readonly id: string;
@@ -21,7 +21,6 @@ export interface TerminalAgentDetectionHost {
   readonly semanticBufferManager: SemanticBufferManager;
   readonly forensicsBuffer: TerminalForensicsBuffer;
   readonly hasActivityMonitor: boolean;
-  getLastNLines(n: number): string[];
   lastDetectedProcessIconId: string | undefined;
   reconfigureActivityMonitor(agentId: string, patternConfig?: PatternDetectionConfig): void;
   startActivityMonitor(): void;
@@ -185,7 +184,6 @@ export function handleAgentDetection(
         terminal,
         agentId: previousAgent,
         boundary: "demotion",
-        renderedLines: host.getLastNLines(CAPTURE_SCAN_ROWS),
         recentOutput: host.forensicsBuffer.getRecentOutput(),
       });
       host.agentStateService.updateAgentState(terminal, { type: "exit", code: 0 });

--- a/electron/services/pty/TerminalExitHandler.ts
+++ b/electron/services/pty/TerminalExitHandler.ts
@@ -6,7 +6,7 @@ import type { IdentityWatcher } from "./IdentityWatcher.js";
 import type { TerminalForensicsBuffer } from "./TerminalForensicsBuffer.js";
 import type { TerminalProcessLifecycle } from "./TerminalProcessLifecycle.js";
 import type { SessionSnapshotter } from "./SessionSnapshotter.js";
-import { CAPTURE_SCAN_ROWS, captureAgentEndSession } from "./agentEndCapture.js";
+import { captureAgentEndSession } from "./agentEndCapture.js";
 import { computeDefaultTitle } from "./terminalTitle.js";
 
 export interface TerminalExitHandlerHost {
@@ -17,7 +17,6 @@ export interface TerminalExitHandlerHost {
   readonly forensicsBuffer: TerminalForensicsBuffer;
   readonly lifecycle: TerminalProcessLifecycle;
   readonly sessionSnapshotter: SessionSnapshotter;
-  getLastNLines(n: number): string[];
   lastDetectedProcessIconId: string | undefined;
   teardown(reason: ExitReason): boolean;
   emitTerminalExited(args: TerminalExitArgs): void;
@@ -73,21 +72,24 @@ export class TerminalExitHandler {
     // unrecorded and invisible to the resume palette (#12179). Runs before the
     // title and identity rewrites below, which the record reads.
     //
-    // Skipped only when a Daintree teardown ALREADY HOLDS the id, not merely
-    // because one ran: `gracefulShutdown` kills on every outcome but writes
-    // `agentSessionId` only on a real capture, so gating on `wasKilled` alone
-    // would switch this backstop off over exactly the teardowns whose scrape
-    // failed — a quit signal swallowed by a running turn or an approval modal,
-    // which is the documented common failure for Codex.
-    if (previousAgent && !(terminal.wasKilled && terminal.agentSessionId)) {
+    // Skipped only when a Daintree teardown ALREADY HOLDS THIS AGENT'S id, not
+    // merely because one ran: `gracefulShutdown` kills on every outcome but
+    // writes `agentSessionId` only on a real capture, so gating on `wasKilled`
+    // alone would switch this backstop off over exactly the teardowns whose
+    // scrape failed — a quit signal swallowed by a running turn or an approval
+    // modal, the documented common failure for Codex. The agent has to match
+    // too: `agentSessionId` is also stamped at launch for agents that mint their
+    // id up front, and that id outlives the agent, so a pane whose user quit the
+    // launched agent and started another by hand would otherwise skip the
+    // backstop on the strength of the previous conversation's id.
+    const teardownHoldsThisSession =
+      terminal.wasKilled && !!terminal.agentSessionId && previousAgent === terminal.launchAgentId;
+    if (previousAgent && !teardownHoldsThisSession) {
       captureAgentEndSession({
         terminalId: this.host.id,
         terminal,
         agentId: previousAgent,
         boundary: "exit",
-        // Empty once kill() has torn the mirror down, which is the failed-
-        // teardown case above; `recentOutput` is the surviving evidence there.
-        renderedLines: this.host.getLastNLines(CAPTURE_SCAN_ROWS),
         recentOutput,
       });
     }

--- a/electron/services/pty/TerminalExitHandler.ts
+++ b/electron/services/pty/TerminalExitHandler.ts
@@ -6,7 +6,7 @@ import type { IdentityWatcher } from "./IdentityWatcher.js";
 import type { TerminalForensicsBuffer } from "./TerminalForensicsBuffer.js";
 import type { TerminalProcessLifecycle } from "./TerminalProcessLifecycle.js";
 import type { SessionSnapshotter } from "./SessionSnapshotter.js";
-import { captureAgentEndSession } from "./agentEndCapture.js";
+import { CAPTURE_SCAN_ROWS, captureAgentEndSession } from "./agentEndCapture.js";
 import { computeDefaultTitle } from "./terminalTitle.js";
 
 export interface TerminalExitHandlerHost {
@@ -17,6 +17,7 @@ export interface TerminalExitHandlerHost {
   readonly forensicsBuffer: TerminalForensicsBuffer;
   readonly lifecycle: TerminalProcessLifecycle;
   readonly sessionSnapshotter: SessionSnapshotter;
+  getLastNLines(n: number): string[];
   lastDetectedProcessIconId: string | undefined;
   teardown(reason: ExitReason): boolean;
   emitTerminalExited(args: TerminalExitArgs): void;
@@ -70,15 +71,23 @@ export class TerminalExitHandler {
     // teardown scrapes its own id (`gracefulShutdown`), but a user quitting the
     // agent — Ctrl-C twice, or the process ending on its own — left the session
     // unrecorded and invisible to the resume palette (#12179). Runs before the
-    // title and identity rewrites below, which the record reads. `wasKilled`
-    // excludes the teardown path: it has already captured and journaled through
-    // its own funnel.
-    if (previousAgent && !terminal.wasKilled) {
+    // title and identity rewrites below, which the record reads.
+    //
+    // Skipped only when a Daintree teardown ALREADY HOLDS the id, not merely
+    // because one ran: `gracefulShutdown` kills on every outcome but writes
+    // `agentSessionId` only on a real capture, so gating on `wasKilled` alone
+    // would switch this backstop off over exactly the teardowns whose scrape
+    // failed — a quit signal swallowed by a running turn or an approval modal,
+    // which is the documented common failure for Codex.
+    if (previousAgent && !(terminal.wasKilled && terminal.agentSessionId)) {
       captureAgentEndSession({
         terminalId: this.host.id,
         terminal,
         agentId: previousAgent,
         boundary: "exit",
+        // Empty once kill() has torn the mirror down, which is the failed-
+        // teardown case above; `recentOutput` is the surviving evidence there.
+        renderedLines: this.host.getLastNLines(CAPTURE_SCAN_ROWS),
         recentOutput,
       });
     }

--- a/electron/services/pty/TerminalExitHandler.ts
+++ b/electron/services/pty/TerminalExitHandler.ts
@@ -6,6 +6,7 @@ import type { IdentityWatcher } from "./IdentityWatcher.js";
 import type { TerminalForensicsBuffer } from "./TerminalForensicsBuffer.js";
 import type { TerminalProcessLifecycle } from "./TerminalProcessLifecycle.js";
 import type { SessionSnapshotter } from "./SessionSnapshotter.js";
+import { captureAgentEndSession } from "./agentEndCapture.js";
 import { computeDefaultTitle } from "./terminalTitle.js";
 
 export interface TerminalExitHandlerHost {
@@ -64,6 +65,24 @@ export class TerminalExitHandler {
       previousAgent !== undefined ||
       terminal.detectedProcessIconId !== undefined ||
       this.host.lastDetectedProcessIconId !== undefined;
+
+    // The agent printed its resume hint on the way out. Daintree-initiated
+    // teardown scrapes its own id (`gracefulShutdown`), but a user quitting the
+    // agent — Ctrl-C twice, or the process ending on its own — left the session
+    // unrecorded and invisible to the resume palette (#12179). Runs before the
+    // title and identity rewrites below, which the record reads. `wasKilled`
+    // excludes the teardown path: it has already captured and journaled through
+    // its own funnel.
+    if (previousAgent && !terminal.wasKilled) {
+      captureAgentEndSession({
+        terminalId: this.host.id,
+        terminal,
+        agentId: previousAgent,
+        boundary: "exit",
+        recentOutput,
+      });
+    }
+
     if (hadDetectedIdentity && !terminal.wasKilled) {
       terminal.detectedAgentId = undefined;
       terminal.detectedProcessIconId = undefined;

--- a/electron/services/pty/TerminalGracefulShutdown.ts
+++ b/electron/services/pty/TerminalGracefulShutdown.ts
@@ -9,6 +9,7 @@ import {
   GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS,
   type TerminalInfo,
 } from "./types.js";
+import { createSessionIdMatcher } from "./sessionIdCapture.js";
 import { getLiveAgentId } from "./terminalTitle.js";
 import { normalizeSubmitEnterDelay } from "./terminalInput.js";
 import { createLogger } from "../../utils/logger.js";
@@ -205,7 +206,11 @@ export async function gracefulShutdown(host: TerminalGracefulShutdownHost): Prom
   // case (#11851): it resumes by an id this tree can hold but never observes
   // one being printed, so a pattern would be a ghost regex too.
   const sessionIdPattern = resume.kind === "session-id" ? resume.sessionIdPattern : undefined;
-  const pattern = sessionIdPattern ? new RegExp(sessionIdPattern) : null;
+  // First match, not last: this buffer starts empty at the quit signal, so it is
+  // already scoped to the teardown and the earliest match in it is the agent's
+  // own hint. The passive boundaries (#12179) scan a rolling buffer instead and
+  // take the last match for exactly the opposite reason.
+  const matcher = createSessionIdMatcher(sessionIdPattern);
 
   let shutdownBuffer = "";
   let resolved = false;
@@ -316,7 +321,7 @@ export async function gracefulShutdown(host: TerminalGracefulShutdownHost): Prom
           shutdownSignal !== undefined &&
           stripAnsiCodes(gateProbe).includes(shutdownSignal.gateText);
 
-        if (!pattern) {
+        if (!matcher) {
           if (gateMatched) settleGateArm(true);
           return;
         }
@@ -326,9 +331,8 @@ export async function gracefulShutdown(host: TerminalGracefulShutdownHost): Prom
           shutdownBuffer = shutdownBuffer.slice(-GRACEFUL_SHUTDOWN_BUFFER_SIZE);
         }
 
-        const stripped = stripAnsiCodes(shutdownBuffer);
-        const match = pattern.exec(stripped);
-        if (match?.[1]) {
+        const match = matcher(shutdownBuffer, { occurrence: "first", boundary: "stream" });
+        if (match.kind !== "none") {
           // A session id in this chunk means the agent is already on its way
           // out, so this chunk must never also read as permission to press
           // again — including when the capture below turns out to be
@@ -339,18 +343,11 @@ export async function gracefulShutdown(host: TerminalGracefulShutdownHost): Prom
           // takes EOF as the boundary, or the per-press timer stops the
           // escalation without ending the teardown.
           if (gateArm) settleGateArm(false);
-          // Guard against truncated captures when the PTY delivers the
-          // session-ID line in chunks. Every `sessionIdPattern` ends with a
-          // greedy `[\w-]+` capture group — if that group ends at the buffer
-          // tail, the regex's character class may still be consuming a token
-          // that is mid-arrival. Wait for at least one trailing character
-          // (newline, space, prompt glyph) that confirms the token boundary
-          // has been seen. Without this, Gemini's resume hint can be captured
-          // as "fc1c3a37-2294-4" instead of the full 36-char UUID, leaving
-          // restore-on-restart to hand the agent an invalid identifier.
-          const captureEnd = match.index + match[0].length;
-          if (captureEnd < stripped.length) {
-            finish(match[1], "captured");
+          // `needs-boundary` means the id may still be mid-arrival, so keep
+          // listening: the next chunk completes the capture, or `onExit` takes
+          // EOF as the boundary. See the truncation guard in `sessionIdCapture`.
+          if (match.kind === "match") {
+            finish(match.sessionId, "captured");
             return;
           }
         }
@@ -359,13 +356,12 @@ export async function gracefulShutdown(host: TerminalGracefulShutdownHost): Prom
       });
 
       origOnExit = terminal.ptyProcess.onExit(() => {
-        if (!pattern) {
+        if (!matcher) {
           finish(null, "exited-no-pattern");
           return;
         }
-        const stripped = stripAnsiCodes(shutdownBuffer);
-        const match = pattern.exec(stripped);
-        const sessionId = match?.[1] ?? null;
+        const match = matcher(shutdownBuffer, { occurrence: "first", boundary: "eof" });
+        const sessionId = match.kind === "match" ? match.sessionId : null;
         finish(sessionId, sessionId ? "captured" : "exited-no-match");
       });
 

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -563,7 +563,6 @@ export class TerminalProcess {
       get sessionSnapshotter() {
         return self.sessionSnapshotter;
       },
-      getLastNLines: (n) => self.getLastNLines(n),
       get lastDetectedProcessIconId() {
         return self.lastDetectedProcessIconId;
       },
@@ -2020,7 +2019,6 @@ export class TerminalProcess {
         get hasActivityMonitor() {
           return self.analysis.hasMonitor();
         },
-        getLastNLines: (n) => self.getLastNLines(n),
         reconfigureActivityMonitor: (agentId, patternConfig) =>
           this.analysis.reconfigureMonitor(agentId, patternConfig),
         get lastDetectedProcessIconId() {

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -2013,6 +2013,9 @@ export class TerminalProcess {
         agentStateService: this.deps.agentStateService,
         headlineGenerator: this.headlineGenerator,
         semanticBufferManager: this.semanticBufferManager,
+        get forensicsBuffer() {
+          return self.forensicsBuffer;
+        },
         get hasActivityMonitor() {
           return self.analysis.hasMonitor();
         },

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -563,6 +563,7 @@ export class TerminalProcess {
       get sessionSnapshotter() {
         return self.sessionSnapshotter;
       },
+      getLastNLines: (n) => self.getLastNLines(n),
       get lastDetectedProcessIconId() {
         return self.lastDetectedProcessIconId;
       },
@@ -2019,6 +2020,7 @@ export class TerminalProcess {
         get hasActivityMonitor() {
           return self.analysis.hasMonitor();
         },
+        getLastNLines: (n) => self.getLastNLines(n),
         reconfigureActivityMonitor: (agentId, patternConfig) =>
           this.analysis.reconfigureMonitor(agentId, patternConfig),
         get lastDetectedProcessIconId() {

--- a/electron/services/pty/__tests__/PtyEventsBridge.test.ts
+++ b/electron/services/pty/__tests__/PtyEventsBridge.test.ts
@@ -193,7 +193,7 @@ describe("bridgePtyEvent", () => {
       sessionId: string;
       worktreeId: string | null;
       terminalId: string;
-      launchGeneration: number | undefined;
+      launchGeneration: number | null | undefined;
     }> = [];
     events.on("agent-session:captured", (payload) => {
       payloads.push({

--- a/electron/services/pty/__tests__/TerminalProcess.passiveSessionCapture.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.passiveSessionCapture.test.ts
@@ -283,6 +283,24 @@ describe("passive agent session capture", () => {
       expect(captured).toHaveLength(0);
     });
 
+    it("captures for a hand-started agent even though a launch id is on file", async () => {
+      // Claude was launched with an assigned id and quit; the user ran Codex by
+      // hand; Daintree closed the pane and the quit signal was swallowed. The
+      // stale Claude id must not be read as "the teardown already has this one".
+      const terminal = track(
+        createTerminal({ launchAgentId: "claude", agentSessionId: "assigned-at-launch" })
+      );
+      promoteCodex(terminal);
+      mockPty(terminal).__emitData(`${codexHint(SESSION_ID)}\n`);
+      terminal.kill("graceful-shutdown");
+      mockPty(terminal).__emitExit(0);
+
+      await flushCapture();
+      expect(captured).toHaveLength(1);
+      expect(captured[0].record.sessionId).toBe(SESSION_ID);
+      expect(captured[0].record.agentId).toBe("codex");
+    });
+
     it("still captures when a graceful teardown ran but captured nothing", async () => {
       const terminal = track(createTerminal());
       promoteCodex(terminal);
@@ -372,6 +390,20 @@ describe("passive agent session capture", () => {
 
       await flushCapture();
       expect(captured).toHaveLength(0);
+    });
+
+    it("captures a hint that soft-wrapped in a narrow pane", async () => {
+      const terminal = track(createTerminal());
+      promoteCodex(terminal);
+      // A soft wrap is a rendering artifact — the pty emits no byte for it — so
+      // the id must survive intact. Scanning rendered terminal rows instead
+      // would split it here and journal a truncated id.
+      mockPty(terminal).__emitData(`${codexHint(SESSION_ID)}\n$ `);
+      demote(terminal);
+
+      await flushCapture();
+      expect(captured[0].record.sessionId).toBe(SESSION_ID);
+      expect(captured[0].record.sessionId).toHaveLength(SESSION_ID.length);
     });
 
     it("holds a hint that is still mid-arrival on a live PTY", async () => {
@@ -483,8 +515,8 @@ describe("passive agent session capture", () => {
       promoteCodex(terminal);
       // A ratatui frame positions each row with CUP instead of writing newlines.
       // stripAnsiCodes deletes those escapes with no replacement, so the whole
-      // frame is ONE logical line in the raw byte stream — the rendered mirror
-      // is what turns it back into rows the window can actually bound.
+      // frame is ONE logical line and the line budget bounds nothing here — the
+      // character budget is what rejects this.
       const rows = [
         "  Sure — you can pick that back up with:",
         `      codex resume ${SESSION_ID}`,

--- a/electron/services/pty/__tests__/TerminalProcess.passiveSessionCapture.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.passiveSessionCapture.test.ts
@@ -185,7 +185,8 @@ describe("passive agent session capture", () => {
   });
 
   afterEach(() => {
-    unsubscribe();
+    // Dispose before unsubscribing: a capture emitted during teardown should be
+    // attributable to the test that caused it rather than silently dropped.
     for (const terminal of terminals) {
       try {
         terminal.dispose();
@@ -193,6 +194,7 @@ describe("passive agent session capture", () => {
         // Already torn down by the test.
       }
     }
+    unsubscribe();
     vi.clearAllMocks();
   });
 
@@ -201,18 +203,25 @@ describe("passive agent session capture", () => {
     return terminal;
   }
 
-  async function settle(): Promise<void> {
-    await vi.waitFor(() => expect(captured.length).toBeGreaterThan(0));
+  /**
+   * Drain `emitCapture`'s unawaited branch-probe IIFE. `setImmediate` runs after
+   * the whole microtask queue, so this stays sound if the emit path ever grows
+   * another `await` — a single-microtask flush would silently turn every
+   * "stays silent" assertion below into an unconditional pass.
+   */
+  async function flushCapture(): Promise<void> {
+    await new Promise((resolve) => setImmediate(resolve));
   }
 
   describe("natural PTY exit", () => {
     it("captures the resume hint the agent printed on its way out", async () => {
       const terminal = track(createTerminal());
       promoteCodex(terminal);
+      terminal.getInfo().lastObservedTitle = "Fixing the parser";
       mockPty(terminal).__emitData(`${codexHint(SESSION_ID)}\n`);
       mockPty(terminal).__emitExit(0);
 
-      await settle();
+      await flushCapture();
       expect(captured).toHaveLength(1);
       expect(captured[0].terminalId).toBe("t-passive");
       // A PTY exit is one close per incarnation, so it keeps the ledger gate.
@@ -221,7 +230,7 @@ describe("passive agent session capture", () => {
         sessionId: SESSION_ID,
         agentId: "codex",
         worktreeId: "wt-1",
-        title: expect.anything(),
+        title: "Fixing the parser",
         projectId: "proj-1",
         agentLaunchFlags: ["--yolo"],
         agentModelId: "gpt-5",
@@ -236,7 +245,7 @@ describe("passive agent session capture", () => {
       mockPty(terminal).__emitData(codexHint(SESSION_ID));
       mockPty(terminal).__emitExit(0);
 
-      await settle();
+      await flushCapture();
       expect(captured[0].record.sessionId).toBe(SESSION_ID);
     });
 
@@ -247,7 +256,7 @@ describe("passive agent session capture", () => {
       mockPty(terminal).__emitData(`${codexHint(SESSION_ID)}\n`);
       mockPty(terminal).__emitExit(0);
 
-      await settle();
+      await flushCapture();
       expect(captured[0].record.sessionId).toBe(SESSION_ID);
     });
 
@@ -257,19 +266,37 @@ describe("passive agent session capture", () => {
       mockPty(terminal).__emitData(`\x1b[2m${codexHint(SESSION_ID)}\x1b[0m\r\n`);
       mockPty(terminal).__emitExit(0);
 
-      await settle();
+      await flushCapture();
       expect(captured[0].record.sessionId).toBe(SESSION_ID);
     });
 
-    it("stays silent when the terminal was killed — teardown already captured", async () => {
+    it("stays silent when the graceful teardown already holds the id", async () => {
       const terminal = track(createTerminal());
       promoteCodex(terminal);
       mockPty(terminal).__emitData(`${codexHint(SESSION_ID)}\n`);
+      // What gracefulShutdown's finish() does on a successful capture.
+      terminal.getInfo().agentSessionId = SESSION_ID;
       terminal.kill("graceful-shutdown");
       mockPty(terminal).__emitExit(0);
 
-      await vi.waitFor(() => expect(true).toBe(true));
+      await flushCapture();
       expect(captured).toHaveLength(0);
+    });
+
+    it("still captures when a graceful teardown ran but captured nothing", async () => {
+      const terminal = track(createTerminal());
+      promoteCodex(terminal);
+      mockPty(terminal).__emitData(`${codexHint(SESSION_ID)}\n`);
+      // gracefulShutdown kills on EVERY outcome but writes agentSessionId only
+      // on a real capture, so a swallowed quit signal lands here — the case this
+      // backstop exists for. kill() tears the mirror down, leaving the raw
+      // forensic tail as the only surviving evidence.
+      terminal.kill("graceful-shutdown");
+      mockPty(terminal).__emitExit(0);
+
+      await flushCapture();
+      expect(captured).toHaveLength(1);
+      expect(captured[0].record.sessionId).toBe(SESSION_ID);
     });
 
     it("stays silent when the agent printed no hint", async () => {
@@ -278,7 +305,7 @@ describe("passive agent session capture", () => {
       mockPty(terminal).__emitData("goodbye\n$ \n");
       mockPty(terminal).__emitExit(0);
 
-      await vi.waitFor(() => expect(true).toBe(true));
+      await flushCapture();
       expect(captured).toHaveLength(0);
     });
 
@@ -287,7 +314,7 @@ describe("passive agent session capture", () => {
       mockPty(terminal).__emitData(`${codexHint(SESSION_ID)}\n`);
       mockPty(terminal).__emitExit(0);
 
-      await vi.waitFor(() => expect(true).toBe(true));
+      await flushCapture();
       expect(captured).toHaveLength(0);
     });
   });
@@ -299,7 +326,7 @@ describe("passive agent session capture", () => {
       mockPty(terminal).__emitData(`${codexHint(SESSION_ID)}\n\nuser@host project % `);
       demote(terminal);
 
-      await settle();
+      await flushCapture();
       expect(captured).toHaveLength(1);
       expect(captured[0].record.sessionId).toBe(SESSION_ID);
       // Deliberately ungated: a surviving shell can host several agent runs in
@@ -316,7 +343,7 @@ describe("passive agent session capture", () => {
         mockPty(terminal).__emitData(`${codexHint(SESSION_ID)}\n$ `);
         demote(terminal);
 
-        await settle();
+        await flushCapture();
         expect(terminal.getInfo().detectedAgentId).toBeUndefined();
         expect(exited).toHaveLength(1);
       } finally {
@@ -334,12 +361,16 @@ describe("passive agent session capture", () => {
           "  ok 1 - first",
           "  ok 2 - second",
           "  ok 3 - third",
+          "  ok 4 - fourth",
+          "  ok 5 - fifth",
+          "  ok 6 - sixth",
+          "  ok 7 - seventh",
           "user@host project % ",
         ].join("\n")
       );
       demote(terminal);
 
-      await vi.waitFor(() => expect(true).toBe(true));
+      await flushCapture();
       expect(captured).toHaveLength(0);
     });
 
@@ -351,7 +382,7 @@ describe("passive agent session capture", () => {
       mockPty(terminal).__emitData(codexHint(SESSION_ID.slice(0, 18)));
       demote(terminal);
 
-      await vi.waitFor(() => expect(true).toBe(true));
+      await flushCapture();
       expect(captured).toHaveLength(0);
     });
 
@@ -360,13 +391,13 @@ describe("passive agent session capture", () => {
       promoteCodex(terminal);
       mockPty(terminal).__emitData(`${codexHint(SESSION_ID)}\n$ `);
       demote(terminal);
-      await settle();
+      await flushCapture();
 
       promoteCodex(terminal);
       mockPty(terminal).__emitData(`${codexHint("second-run-session-id")}\n$ `);
       demote(terminal);
 
-      await vi.waitFor(() => expect(captured).toHaveLength(2));
+      await flushCapture();
       expect(captured.map((c) => c.record.sessionId)).toEqual([
         SESSION_ID,
         "second-run-session-id",
@@ -380,7 +411,7 @@ describe("passive agent session capture", () => {
       mockPty(terminal).__emitData(`${codexHint(SESSION_ID)}\n$ `);
       demote(terminal);
 
-      await vi.waitFor(() => expect(true).toBe(true));
+      await flushCapture();
       expect(captured).toHaveLength(0);
     });
 
@@ -394,8 +425,82 @@ describe("passive agent session capture", () => {
       mockPty(terminal).__emitData(`${codexHint(SESSION_ID)}\nthinking...\n`);
       detect(terminal, makeNoAgentResult({ evidenceSource: "shell_command" }), 1);
 
-      await vi.waitFor(() => expect(true).toBe(true));
+      await flushCapture();
       expect(terminal.getInfo().detectedAgentId).toBe("codex");
+      expect(captured).toHaveLength(0);
+    });
+  });
+
+  describe("preassigned session ids", () => {
+    it("journals the launch-assigned id without scraping", async () => {
+      const terminal = track(
+        createTerminal({ launchAgentId: "claude", agentSessionId: "assigned-at-launch" })
+      );
+      detect(terminal, makeAgentResult({ agentType: "claude", processIconId: "claude" }));
+      // Deliberately no hint in the output — the assigned id needs no scrape.
+      mockPty(terminal).__emitData("bye\n$ ");
+      demote(terminal);
+
+      await flushCapture();
+      expect(captured).toHaveLength(1);
+      expect(captured[0].record.sessionId).toBe("assigned-at-launch");
+      expect(captured[0].record.agentId).toBe("claude");
+    });
+
+    it("does not file the launch agent's id under a different agent", async () => {
+      // Claude was launched and assigned an id; the user quit it and ran Codex
+      // by hand. The assigned id belongs to the previous conversation.
+      const terminal = track(
+        createTerminal({ launchAgentId: "claude", agentSessionId: "assigned-at-launch" })
+      );
+      promoteCodex(terminal);
+      mockPty(terminal).__emitData(`${codexHint(SESSION_ID)}\n$ `);
+      demote(terminal);
+
+      await flushCapture();
+      expect(captured).toHaveLength(1);
+      expect(captured[0].record.sessionId).toBe(SESSION_ID);
+      expect(captured[0].record.agentId).toBe("codex");
+    });
+  });
+
+  describe("false-positive resistance", () => {
+    it("rejects the echoed launch command of a resume-latest pane", async () => {
+      const terminal = track(createTerminal());
+      promoteCodex(terminal);
+      // Daintree types the launch command into the shell, so `resumeLatestArgs`
+      // puts a literal `codex resume --last` in the pane's own output. `[\w-]+`
+      // matches `--last`, and the agent then exited without printing a hint.
+      mockPty(terminal).__emitData("$ codex resume --last\nerror: no sessions found\n$ ");
+      demote(terminal);
+
+      await flushCapture();
+      expect(captured).toHaveLength(0);
+    });
+
+    it("rejects a mention buried in a full-screen TUI repaint", async () => {
+      const terminal = track(createTerminal());
+      promoteCodex(terminal);
+      // A ratatui frame positions each row with CUP instead of writing newlines.
+      // stripAnsiCodes deletes those escapes with no replacement, so the whole
+      // frame is ONE logical line in the raw byte stream — the rendered mirror
+      // is what turns it back into rows the window can actually bound.
+      const rows = [
+        "  Sure — you can pick that back up with:",
+        `      codex resume ${SESSION_ID}`,
+        "  Anything else?",
+        ...Array.from(
+          { length: 14 },
+          (_, i) => `  and then it explained step ${i + 1} of the migration plan`
+        ),
+      ];
+      const frame = rows.map((row, i) => `\x1b[${i + 1};1H\x1b[K${row}`).join("");
+      mockPty(terminal).__emitData(frame);
+      // Agent crashes without printing a hint; alt screen closes, prompt returns.
+      mockPty(terminal).__emitData("\x1b[?1049l\r\n$ ");
+      demote(terminal);
+
+      await flushCapture();
       expect(captured).toHaveLength(0);
     });
   });
@@ -408,13 +513,26 @@ describe("passive agent session capture", () => {
       mockPty(terminal).__emitData(`${codexHint(SESSION_ID)}\n$ `);
       demote(terminal);
 
-      await settle();
+      await flushCapture();
       expect(captured[0].record.agentId).toBe("codex");
       expect(captured[0].record.agentLaunchFlags).toBeUndefined();
       expect(captured[0].record.agentModelId).toBeUndefined();
     });
 
-    it("prefers the observed task title unless the user locked the title", async () => {
+    it("keeps the user's locked title instead of the observed one", async () => {
+      const terminal = track(createTerminal({ titleMode: "user" }));
+      promoteCodex(terminal);
+      const info = terminal.getInfo();
+      info.title = "My pinned pane";
+      info.lastObservedTitle = "Fixing the parser";
+      mockPty(terminal).__emitData(`${codexHint(SESSION_ID)}\n$ `);
+      demote(terminal);
+
+      await flushCapture();
+      expect(captured[0].record.title).toBe("My pinned pane");
+    });
+
+    it("prefers the observed task title when the title is not locked", async () => {
       const terminal = track(createTerminal());
       promoteCodex(terminal);
       const info = terminal.getInfo();
@@ -422,7 +540,7 @@ describe("passive agent session capture", () => {
       mockPty(terminal).__emitData(`${codexHint(SESSION_ID)}\n$ `);
       demote(terminal);
 
-      await settle();
+      await flushCapture();
       expect(captured[0].record.title).toBe("Fixing the parser");
     });
   });
@@ -434,9 +552,12 @@ describe("passive agent session capture", () => {
       mockPty(terminal).__emitData(`${codexHint(SESSION_ID)}\n$ `);
       demote(terminal);
 
-      await settle();
+      await flushCapture();
       const { logBuffer } = await import("../../LogBuffer.js");
       const serialized = JSON.stringify(logBuffer.getAll());
+      // Positive control: without it this assertion cannot tell "the id was
+      // never logged" from "nothing was logged at all".
+      expect(serialized).toContain("Passive agent session capture outcome");
       expect(serialized).not.toContain(SESSION_ID);
     });
   });

--- a/electron/services/pty/__tests__/TerminalProcess.passiveSessionCapture.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.passiveSessionCapture.test.ts
@@ -1,0 +1,443 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { IPty } from "node-pty";
+import { TerminalProcess } from "../TerminalProcess.js";
+import type { SpawnContext } from "../terminalSpawn.js";
+import type { ProcessTreeCache } from "../../ProcessTreeCache.js";
+import type { DetectionResult } from "../../ProcessDetector.js";
+import { makeAgentResult, makeNoAgentResult } from "../../ProcessDetector.js";
+import { events } from "../../events.js";
+import type { DaintreeEventMap } from "../../events.js";
+import { getAgentConfig } from "../../../../shared/config/agentRegistry.js";
+
+vi.mock("node-pty", () => {
+  return { spawn: vi.fn() };
+});
+
+vi.mock("../terminalSessionPersistence.js", async (importOriginal) => {
+  const orig = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...orig,
+    TERMINAL_SESSION_PERSISTENCE_ENABLED: false,
+    persistSessionSnapshotSync: vi.fn(),
+    persistSessionSnapshotAsync: vi.fn(),
+  };
+});
+
+// The capture stamps a best-effort branch by shelling out to git. Never let a
+// unit test spawn a real process — and pin the value so the record assertions
+// below can prove the stamp actually rides along.
+vi.mock("../../../utils/gitUtils.js", () => ({
+  getGitBranch: vi.fn(async () => "feature/passive-capture"),
+}));
+
+const SESSION_ID = "0199f8c1-2b4d-7e3a-9f10-5c6d7e8f9a0b";
+
+/** Codex's real hint line, so a pattern change upstream fails these tests. */
+function codexHint(id: string): string {
+  const resume = getAgentConfig("codex")?.resume;
+  if (resume?.kind !== "session-id" || !resume.sessionIdPattern) {
+    throw new Error("codex must declare a sessionIdPattern");
+  }
+  const line = `  To continue this session, run codex resume ${id}`;
+  if (!new RegExp(resume.sessionIdPattern).test(line)) {
+    throw new Error("fixture no longer matches codex's declared sessionIdPattern");
+  }
+  return line;
+}
+
+type MockPty = IPty & {
+  __emitData: (data: string) => void;
+  __emitExit: (exitCode?: number, signal?: number) => void;
+};
+
+function createMockPty(): MockPty {
+  const dataListeners = new Set<(data: string) => void>();
+  const exitListeners = new Set<(event: { exitCode: number; signal?: number }) => void>();
+
+  const pty: Partial<MockPty> = {
+    // 0, not a plausible pid: kill paths route through ProcessTreeKiller, which
+    // signals a real process for any pid > 0.
+    pid: 0,
+    cols: 80,
+    rows: 24,
+    write: () => {},
+    resize: () => {},
+    kill: vi.fn(),
+    pause: () => {},
+    resume: () => {},
+    onData: (callback: (data: string) => void) => {
+      dataListeners.add(callback);
+      return { dispose: () => dataListeners.delete(callback) };
+    },
+    onExit: (callback: (event: { exitCode: number; signal?: number }) => void) => {
+      exitListeners.add(callback);
+      return { dispose: () => exitListeners.delete(callback) };
+    },
+    __emitData: (data: string) => {
+      for (const listener of dataListeners) listener(data);
+    },
+    __emitExit: (exitCode = 0, signal = 0) => {
+      for (const listener of [...exitListeners]) listener({ exitCode, signal });
+    },
+  };
+  return pty as MockPty;
+}
+
+function createMockProcessTreeCache(): ProcessTreeCache {
+  return {
+    getDescendantPids: vi.fn().mockReturnValue([]),
+    getChildPids: vi.fn().mockReturnValue([]),
+    getChildren: vi.fn().mockReturnValue([]),
+    getProcess: vi.fn(),
+    hasChildren: vi.fn().mockReturnValue(false),
+    start: vi.fn(),
+    stop: vi.fn(),
+    onRefresh: vi.fn().mockReturnValue(() => {}),
+    refresh: vi.fn(),
+    getLastRefreshTime: vi.fn().mockReturnValue(0),
+    getLastError: vi.fn().mockReturnValue(null),
+    getCacheSize: vi.fn().mockReturnValue(0),
+  } as unknown as ProcessTreeCache;
+}
+
+type TerminalProcessOptions = ConstructorParameters<typeof TerminalProcess>[1];
+type TerminalProcessDeps = ConstructorParameters<typeof TerminalProcess>[3];
+
+function createTerminal(overrides: Partial<Record<string, unknown>> = {}): TerminalProcess {
+  const options = {
+    cwd: "/tmp/passive-capture",
+    cols: 80,
+    rows: 24,
+    kind: "terminal",
+    launchAgentId: "codex",
+    projectId: "proj-1",
+    worktreeId: "wt-1",
+    agentLaunchFlags: ["--yolo"],
+    agentModelId: "gpt-5",
+    launchGeneration: 7,
+    ...overrides,
+  } as TerminalProcessOptions;
+  const ctx: SpawnContext = { shell: "/bin/zsh", args: ["-l"], env: {} };
+  const terminal = new TerminalProcess(
+    "t-passive",
+    options,
+    { emitData: () => {}, onExit: () => {} },
+    {
+      agentStateService: {
+        handleActivityState: () => {},
+        updateAgentState: () => {},
+        emitAgentKilled: () => {},
+        emitAgentCompleted: () => {},
+      } as unknown as TerminalProcessDeps["agentStateService"],
+      ptyPool: null,
+      processTreeCache: createMockProcessTreeCache(),
+    } as TerminalProcessDeps,
+    ctx,
+    createMockPty()
+  );
+  // The production foreground probe is an async stale-while-revalidate cache
+  // whose pre-first-probe sentinel would hold the demotion gate closed here.
+  (
+    terminal as unknown as { readForegroundProcessGroupSnapshot: () => null }
+  ).readForegroundProcessGroupSnapshot = () => null;
+  return terminal;
+}
+
+function spawnedAt(terminal: TerminalProcess): number {
+  return (terminal as unknown as { terminalInfo: { spawnedAt: number } }).terminalInfo.spawnedAt;
+}
+
+function detect(
+  terminal: TerminalProcess,
+  result: DetectionResult,
+  at = spawnedAt(terminal)
+): void {
+  (
+    terminal as unknown as { handleAgentDetection: (r: DetectionResult, s: number) => void }
+  ).handleAgentDetection(result, at);
+}
+
+function mockPty(terminal: TerminalProcess): MockPty {
+  return terminal.getInfo().ptyProcess as MockPty;
+}
+
+/** Promote to a live Codex identity, the state both boundaries start from. */
+function promoteCodex(terminal: TerminalProcess): void {
+  detect(terminal, makeAgentResult({ agentType: "codex", processIconId: "codex" }));
+}
+
+/** Prompt-return is the evidence that clears a launch-anchored agent. */
+function demote(terminal: TerminalProcess): void {
+  detect(terminal, makeNoAgentResult({ evidenceSource: "shell_command" }));
+}
+
+describe("passive agent session capture", () => {
+  let captured: DaintreeEventMap["agent-session:captured"][];
+  let unsubscribe: () => void;
+  let terminals: TerminalProcess[];
+
+  beforeEach(() => {
+    captured = [];
+    terminals = [];
+    unsubscribe = events.on("agent-session:captured", (payload) => {
+      captured.push(payload);
+    });
+  });
+
+  afterEach(() => {
+    unsubscribe();
+    for (const terminal of terminals) {
+      try {
+        terminal.dispose();
+      } catch {
+        // Already torn down by the test.
+      }
+    }
+    vi.clearAllMocks();
+  });
+
+  function track(terminal: TerminalProcess): TerminalProcess {
+    terminals.push(terminal);
+    return terminal;
+  }
+
+  async function settle(): Promise<void> {
+    await vi.waitFor(() => expect(captured.length).toBeGreaterThan(0));
+  }
+
+  describe("natural PTY exit", () => {
+    it("captures the resume hint the agent printed on its way out", async () => {
+      const terminal = track(createTerminal());
+      promoteCodex(terminal);
+      mockPty(terminal).__emitData(`${codexHint(SESSION_ID)}\n`);
+      mockPty(terminal).__emitExit(0);
+
+      await settle();
+      expect(captured).toHaveLength(1);
+      expect(captured[0].terminalId).toBe("t-passive");
+      // A PTY exit is one close per incarnation, so it keeps the ledger gate.
+      expect(captured[0].launchGeneration).toBe(7);
+      expect(captured[0].record).toEqual({
+        sessionId: SESSION_ID,
+        agentId: "codex",
+        worktreeId: "wt-1",
+        title: expect.anything(),
+        projectId: "proj-1",
+        agentLaunchFlags: ["--yolo"],
+        agentModelId: "gpt-5",
+        cwd: "/tmp/passive-capture",
+        branch: "feature/passive-capture",
+      });
+    });
+
+    it("accepts a hint delivered with no trailing newline before exit", async () => {
+      const terminal = track(createTerminal());
+      promoteCodex(terminal);
+      mockPty(terminal).__emitData(codexHint(SESSION_ID));
+      mockPty(terminal).__emitExit(0);
+
+      await settle();
+      expect(captured[0].record.sessionId).toBe(SESSION_ID);
+    });
+
+    it("takes the last hint when the buffer holds more than one", async () => {
+      const terminal = track(createTerminal());
+      promoteCodex(terminal);
+      mockPty(terminal).__emitData(`${codexHint("stale-session-id")}\n`);
+      mockPty(terminal).__emitData(`${codexHint(SESSION_ID)}\n`);
+      mockPty(terminal).__emitExit(0);
+
+      await settle();
+      expect(captured[0].record.sessionId).toBe(SESSION_ID);
+    });
+
+    it("captures a hint wrapped in ANSI decoration", async () => {
+      const terminal = track(createTerminal());
+      promoteCodex(terminal);
+      mockPty(terminal).__emitData(`\x1b[2m${codexHint(SESSION_ID)}\x1b[0m\r\n`);
+      mockPty(terminal).__emitExit(0);
+
+      await settle();
+      expect(captured[0].record.sessionId).toBe(SESSION_ID);
+    });
+
+    it("stays silent when the terminal was killed — teardown already captured", async () => {
+      const terminal = track(createTerminal());
+      promoteCodex(terminal);
+      mockPty(terminal).__emitData(`${codexHint(SESSION_ID)}\n`);
+      terminal.kill("graceful-shutdown");
+      mockPty(terminal).__emitExit(0);
+
+      await vi.waitFor(() => expect(true).toBe(true));
+      expect(captured).toHaveLength(0);
+    });
+
+    it("stays silent when the agent printed no hint", async () => {
+      const terminal = track(createTerminal());
+      promoteCodex(terminal);
+      mockPty(terminal).__emitData("goodbye\n$ \n");
+      mockPty(terminal).__emitExit(0);
+
+      await vi.waitFor(() => expect(true).toBe(true));
+      expect(captured).toHaveLength(0);
+    });
+
+    it("stays silent for a terminal that never hosted an agent", async () => {
+      const terminal = track(createTerminal({ launchAgentId: undefined }));
+      mockPty(terminal).__emitData(`${codexHint(SESSION_ID)}\n`);
+      mockPty(terminal).__emitExit(0);
+
+      await vi.waitFor(() => expect(true).toBe(true));
+      expect(captured).toHaveLength(0);
+    });
+  });
+
+  describe("demotion to a surviving shell", () => {
+    it("captures the resume hint when the agent quits but the pane lives on", async () => {
+      const terminal = track(createTerminal());
+      promoteCodex(terminal);
+      mockPty(terminal).__emitData(`${codexHint(SESSION_ID)}\n\nuser@host project % `);
+      demote(terminal);
+
+      await settle();
+      expect(captured).toHaveLength(1);
+      expect(captured[0].record.sessionId).toBe(SESSION_ID);
+      // Deliberately ungated: a surviving shell can host several agent runs in
+      // one generation, and gating would let the first consume the only slot.
+      expect(captured[0].launchGeneration).toBeNull();
+    });
+
+    it("still clears the live identity and emits agent:exited", async () => {
+      const exited: unknown[] = [];
+      const off = events.on("agent:exited", (payload) => exited.push(payload));
+      try {
+        const terminal = track(createTerminal());
+        promoteCodex(terminal);
+        mockPty(terminal).__emitData(`${codexHint(SESSION_ID)}\n$ `);
+        demote(terminal);
+
+        await settle();
+        expect(terminal.getInfo().detectedAgentId).toBeUndefined();
+        expect(exited).toHaveLength(1);
+      } finally {
+        off();
+      }
+    });
+
+    it("rejects a mid-conversation mention pushed past the trailing-line window", async () => {
+      const terminal = track(createTerminal());
+      promoteCodex(terminal);
+      mockPty(terminal).__emitData(
+        [
+          `I resumed it earlier with codex resume ${SESSION_ID} and it worked`,
+          "$ npm test",
+          "  ok 1 - first",
+          "  ok 2 - second",
+          "  ok 3 - third",
+          "user@host project % ",
+        ].join("\n")
+      );
+      demote(terminal);
+
+      await vi.waitFor(() => expect(true).toBe(true));
+      expect(captured).toHaveLength(0);
+    });
+
+    it("holds a hint that is still mid-arrival on a live PTY", async () => {
+      const terminal = track(createTerminal());
+      promoteCodex(terminal);
+      // No trailing character yet — the id may still be arriving, and a
+      // truncated id would send restore to a session that does not exist.
+      mockPty(terminal).__emitData(codexHint(SESSION_ID.slice(0, 18)));
+      demote(terminal);
+
+      await vi.waitFor(() => expect(true).toBe(true));
+      expect(captured).toHaveLength(0);
+    });
+
+    it("captures each agent run in a shell that hosts several", async () => {
+      const terminal = track(createTerminal());
+      promoteCodex(terminal);
+      mockPty(terminal).__emitData(`${codexHint(SESSION_ID)}\n$ `);
+      demote(terminal);
+      await settle();
+
+      promoteCodex(terminal);
+      mockPty(terminal).__emitData(`${codexHint("second-run-session-id")}\n$ `);
+      demote(terminal);
+
+      await vi.waitFor(() => expect(captured).toHaveLength(2));
+      expect(captured.map((c) => c.record.sessionId)).toEqual([
+        SESSION_ID,
+        "second-run-session-id",
+      ]);
+      expect(captured.every((c) => c.launchGeneration === null)).toBe(true);
+    });
+
+    it("stays silent when a plain process icon clears with no agent behind it", async () => {
+      const terminal = track(createTerminal({ launchAgentId: undefined }));
+      detect(terminal, makeAgentResult({ processIconId: "npm", processName: "npm" }));
+      mockPty(terminal).__emitData(`${codexHint(SESSION_ID)}\n$ `);
+      demote(terminal);
+
+      await vi.waitFor(() => expect(true).toBe(true));
+      expect(captured).toHaveLength(0);
+    });
+
+    it("stays silent for a stale detection from a previous incarnation", async () => {
+      const terminal = track(createTerminal());
+      promoteCodex(terminal);
+      // Deliberately no prompt-shaped tail: IdentityWatcher's own prompt-return
+      // heuristic drives a genuine demotion through the same entry point, which
+      // would make the stale-guard assertion below vacuous. The identity check
+      // proves no real demotion slipped in.
+      mockPty(terminal).__emitData(`${codexHint(SESSION_ID)}\nthinking...\n`);
+      detect(terminal, makeNoAgentResult({ evidenceSource: "shell_command" }), 1);
+
+      await vi.waitFor(() => expect(true).toBe(true));
+      expect(terminal.getInfo().detectedAgentId).toBe("codex");
+      expect(captured).toHaveLength(0);
+    });
+  });
+
+  describe("record construction", () => {
+    it("omits launch flags and model for an agent Daintree did not launch", async () => {
+      const terminal = track(createTerminal({ launchAgentId: "claude" }));
+      // The user quit Claude and started Codex by hand in the same pane.
+      promoteCodex(terminal);
+      mockPty(terminal).__emitData(`${codexHint(SESSION_ID)}\n$ `);
+      demote(terminal);
+
+      await settle();
+      expect(captured[0].record.agentId).toBe("codex");
+      expect(captured[0].record.agentLaunchFlags).toBeUndefined();
+      expect(captured[0].record.agentModelId).toBeUndefined();
+    });
+
+    it("prefers the observed task title unless the user locked the title", async () => {
+      const terminal = track(createTerminal());
+      promoteCodex(terminal);
+      const info = terminal.getInfo();
+      info.lastObservedTitle = "Fixing the parser";
+      mockPty(terminal).__emitData(`${codexHint(SESSION_ID)}\n$ `);
+      demote(terminal);
+
+      await settle();
+      expect(captured[0].record.title).toBe("Fixing the parser");
+    });
+  });
+
+  describe("logging", () => {
+    it("never writes the captured session id into the log context", async () => {
+      const terminal = track(createTerminal());
+      promoteCodex(terminal);
+      mockPty(terminal).__emitData(`${codexHint(SESSION_ID)}\n$ `);
+      demote(terminal);
+
+      await settle();
+      const { logBuffer } = await import("../../LogBuffer.js");
+      const serialized = JSON.stringify(logBuffer.getAll());
+      expect(serialized).not.toContain(SESSION_ID);
+    });
+  });
+});

--- a/electron/services/pty/__tests__/sessionIdCapture.test.ts
+++ b/electron/services/pty/__tests__/sessionIdCapture.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+import { createSessionIdMatcher } from "../sessionIdCapture.js";
+import { getAgentConfig } from "../../../../shared/config/agentRegistry.js";
+
+/**
+ * Read Codex's real pattern rather than copying it: a matcher that only works
+ * against a hand-written regex would pass here and fail in production.
+ */
+function codexPattern(): string {
+  const resume = getAgentConfig("codex")?.resume;
+  if (resume?.kind !== "session-id" || !resume.sessionIdPattern) {
+    throw new Error("codex must declare a sessionIdPattern");
+  }
+  return resume.sessionIdPattern;
+}
+
+const PATTERN = codexPattern();
+const ID = "0199f8c1-2b4d-7e3a-9f10-5c6d7e8f9a0b";
+
+function match(
+  raw: string,
+  options: Parameters<NonNullable<ReturnType<typeof createSessionIdMatcher>>>[1]
+) {
+  const matcher = createSessionIdMatcher(PATTERN);
+  if (!matcher) throw new Error("matcher must compile");
+  return matcher(raw, options);
+}
+
+describe("createSessionIdMatcher", () => {
+  it("returns null when the agent declares no pattern", () => {
+    expect(createSessionIdMatcher(undefined)).toBeNull();
+    expect(createSessionIdMatcher("")).toBeNull();
+  });
+
+  it("matches through ANSI decoration", () => {
+    const raw = `\x1b[2m\x1b[38;5;245mTo resume, run codex resume ${ID}\x1b[0m\n`;
+    expect(match(raw, { occurrence: "last", boundary: "eof" })).toEqual({
+      kind: "match",
+      sessionId: ID,
+    });
+  });
+
+  it("takes the first occurrence in first mode and the last in last mode", () => {
+    const raw = `codex resume aaa-111\nsomething else\ncodex resume ${ID}\n`;
+    expect(match(raw, { occurrence: "first", boundary: "eof" })).toEqual({
+      kind: "match",
+      sessionId: "aaa-111",
+    });
+    expect(match(raw, { occurrence: "last", boundary: "eof" })).toEqual({
+      kind: "match",
+      sessionId: ID,
+    });
+  });
+
+  it("holds a stream match that ends at the tail until a boundary arrives", () => {
+    const truncated = `codex resume ${ID.slice(0, 15)}`;
+    expect(match(truncated, { occurrence: "first", boundary: "stream" })).toEqual({
+      kind: "needs-boundary",
+    });
+    expect(match(`${truncated}\n`, { occurrence: "first", boundary: "stream" })).toEqual({
+      kind: "match",
+      sessionId: ID.slice(0, 15),
+    });
+  });
+
+  it("accepts a match ending exactly at the tail in eof mode", () => {
+    expect(match(`codex resume ${ID}`, { occurrence: "last", boundary: "eof" })).toEqual({
+      kind: "match",
+      sessionId: ID,
+    });
+  });
+
+  it("never trades an unterminated newest match for an older complete one", () => {
+    const raw = `codex resume older-session-id\ncodex resume ${ID.slice(0, 20)}`;
+    expect(match(raw, { occurrence: "last", boundary: "stream" })).toEqual({
+      kind: "needs-boundary",
+    });
+  });
+
+  it("returns none when nothing matches", () => {
+    expect(match("$ ls -la\ntotal 0\n", { occurrence: "last", boundary: "eof" })).toEqual({
+      kind: "none",
+    });
+  });
+
+  describe("tailLines window", () => {
+    it("rejects a hint pushed beyond the window by later output", () => {
+      const raw = [
+        `I ran it with codex resume ${ID} and it worked`,
+        "$ npm test",
+        "  ok 1 - first",
+        "  ok 2 - second",
+        "  ok 3 - third",
+        "$ ",
+      ].join("\n");
+      expect(match(raw, { occurrence: "last", boundary: "eof", tailLines: 4 })).toEqual({
+        kind: "none",
+      });
+      // The same text with no window restriction still matches, proving the
+      // window — not the regex — is what rejected it.
+      expect(match(raw, { occurrence: "last", boundary: "eof" })).toEqual({
+        kind: "match",
+        sessionId: ID,
+      });
+    });
+
+    it("accepts a hint still inside the window, with the shell prompt after it", () => {
+      const raw = [
+        "some earlier conversation output",
+        "and more of it",
+        "",
+        `To continue this session, run codex resume ${ID}`,
+        "",
+        "user@host project % ",
+      ].join("\n");
+      expect(match(raw, { occurrence: "last", boundary: "stream", tailLines: 4 })).toEqual({
+        kind: "match",
+        sessionId: ID,
+      });
+    });
+
+    it("does not spend the window budget on blank lines", () => {
+      const raw = [`codex resume ${ID}`, "", "", "", "", "$ "].join("\n");
+      expect(match(raw, { occurrence: "last", boundary: "stream", tailLines: 4 })).toEqual({
+        kind: "match",
+        sessionId: ID,
+      });
+    });
+
+    it("treats CRLF output as line-separated", () => {
+      const raw = `noise\r\nmore noise\r\ncodex resume ${ID}\r\n$ \r\n`;
+      expect(match(raw, { occurrence: "last", boundary: "stream", tailLines: 2 })).toEqual({
+        kind: "match",
+        sessionId: ID,
+      });
+    });
+  });
+
+  it("does not leak regex lastIndex between calls", () => {
+    const matcher = createSessionIdMatcher(PATTERN);
+    if (!matcher) throw new Error("matcher must compile");
+    const raw = `codex resume ${ID}\n`;
+    const first = matcher(raw, { occurrence: "last", boundary: "eof" });
+    const second = matcher(raw, { occurrence: "last", boundary: "eof" });
+    expect(second).toEqual(first);
+    expect(second).toEqual({ kind: "match", sessionId: ID });
+  });
+});

--- a/electron/services/pty/__tests__/sessionIdCapture.test.ts
+++ b/electron/services/pty/__tests__/sessionIdCapture.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { createSessionIdMatcher } from "../sessionIdCapture.js";
 import { getAgentConfig } from "../../../../shared/config/agentRegistry.js";
+import { BUILT_IN_AGENT_IDS } from "../../../../shared/config/agentIds.js";
 
 /**
  * Read Codex's real pattern rather than copying it: a matcher that only works
@@ -133,6 +134,54 @@ describe("createSessionIdMatcher", () => {
         kind: "match",
         sessionId: ID,
       });
+    });
+  });
+
+  it("rejects a capture that is really a CLI flag", () => {
+    // `[\w-]+` matches `--last`, and Daintree echoes the launch command into the
+    // pane, so `codex resume --last` sits in the output of every resume-latest
+    // launch. No agent mints an id that opens with a dash.
+    expect(
+      match("$ codex resume --last\nerror: no sessions found\n", {
+        occurrence: "last",
+        boundary: "eof",
+      })
+    ).toEqual({ kind: "none" });
+  });
+
+  it("still finds a real id when a flag echo follows it", () => {
+    const raw = `codex resume ${ID}\n$ codex resume --last\n`;
+    expect(match(raw, { occurrence: "last", boundary: "eof" })).toEqual({
+      kind: "match",
+      sessionId: ID,
+    });
+  });
+
+  describe("every agent that declares a sessionIdPattern", () => {
+    const patterns = BUILT_IN_AGENT_IDS.flatMap((agentId) => {
+      const resume = getAgentConfig(agentId)?.resume;
+      return resume?.kind === "session-id" && resume.sessionIdPattern
+        ? [{ agentId, source: resume.sessionIdPattern }]
+        : [];
+    });
+
+    it("finds more than one, so the loop below is not vacuous", () => {
+      expect(patterns.length).toBeGreaterThan(1);
+    });
+
+    it.each(patterns)("$agentId captures its own id and holds a truncated one", ({ source }) => {
+      const matcher = createSessionIdMatcher(source);
+      if (!matcher) throw new Error("pattern must compile");
+      // Build a hint line from the pattern's own literal prefix so each agent is
+      // exercised against the text it actually prints, not a Codex-shaped one.
+      const line = source.replace(/\\s\*/g, " ").replace(/\(\[\\w-\]\+\)$/, ID);
+      expect(matcher(`${line}\n`, { occurrence: "last", boundary: "eof" })).toEqual({
+        kind: "match",
+        sessionId: ID,
+      });
+      expect(
+        matcher(line.replace(ID, ID.slice(0, 12)), { occurrence: "last", boundary: "stream" })
+      ).toEqual({ kind: "needs-boundary" });
     });
   });
 

--- a/electron/services/pty/__tests__/sessionIdCapture.test.ts
+++ b/electron/services/pty/__tests__/sessionIdCapture.test.ts
@@ -185,6 +185,43 @@ describe("createSessionIdMatcher", () => {
     });
   });
 
+  it("returns null rather than throwing on a pattern that will not compile", () => {
+    // Plugin- and user-registered agents can supply any string here, and both
+    // call sites are synchronous PTY lifecycle handlers.
+    expect(createSessionIdMatcher("codex resume ([\\w-]+")).toBeNull();
+    expect(createSessionIdMatcher("(?<=")).toBeNull();
+  });
+
+  describe("tailChars window", () => {
+    it("rejects a hint pushed beyond the character budget", () => {
+      const trailing = "x".repeat(120);
+      const raw = `codex resume ${ID}\n${trailing}\n${trailing}\n`;
+      expect(match(raw, { occurrence: "last", boundary: "eof", tailChars: 100 })).toEqual({
+        kind: "none",
+      });
+      expect(match(raw, { occurrence: "last", boundary: "eof", tailChars: 400 })).toEqual({
+        kind: "match",
+        sessionId: ID,
+      });
+    });
+
+    it("bounds a collapsed TUI frame that carries no line breaks at all", () => {
+      // What stripAnsiCodes leaves behind once CUP moves are deleted: one line.
+      const collapsed = `you can resume with codex resume ${ID}${"  and then more output".repeat(20)}`;
+      expect(
+        match(collapsed, { occurrence: "last", boundary: "eof", tailLines: 8, tailChars: 400 })
+      ).toEqual({ kind: "none" });
+    });
+
+    it("applies whichever of the two windows is more restrictive", () => {
+      const raw = `codex resume ${ID}\n${"y".repeat(500)}\n`;
+      // Only two lines, so the line budget admits it; the char budget does not.
+      expect(
+        match(raw, { occurrence: "last", boundary: "eof", tailLines: 8, tailChars: 400 })
+      ).toEqual({ kind: "none" });
+    });
+  });
+
   it("does not leak regex lastIndex between calls", () => {
     const matcher = createSessionIdMatcher(PATTERN);
     if (!matcher) throw new Error("matcher must compile");

--- a/electron/services/pty/agentEndCapture.ts
+++ b/electron/services/pty/agentEndCapture.ts
@@ -1,5 +1,6 @@
 import { getEffectiveAgentConfig } from "../../../shared/config/agentRegistry.js";
 import { supportsSessionIdAssignment } from "../../../shared/types/agentSettings.js";
+import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
 import { getGitBranch } from "../../utils/gitUtils.js";
 import { createLogger } from "../../utils/logger.js";
 import { events } from "../events.js";
@@ -9,17 +10,35 @@ import type { TerminalInfo } from "./types.js";
 const logger = createLogger("pty:AgentEndCapture");
 
 /**
- * Non-blank trailing lines of rolling output the passive scrape will trust.
+ * Non-blank trailing ROWS of rendered output the passive scrape will trust.
  *
- * The forensic buffer is a purpose-agnostic 4000-char tail that keeps filling
- * after the agent is gone, so the same `codex resume <id>` text can sit in it as
- * ordinary conversation. Taking the last match is not enough on its own: with no
- * real hint printed, the last match would still be that conversational mention.
- * Four lines is the same evidence horizon `IdentityWatcher` already trusts for
- * prompt-return detection (`SHELL_IDENTITY_FALLBACK_SCAN_LINES`), and it
- * comfortably spans an exit hint plus the shell prompt that follows it.
+ * Taking the last match is not enough on its own: with no real hint printed, the
+ * last match would be whatever `codex resume <id>` text the conversation
+ * happened to contain. The window is what makes the scrape mean "the agent's
+ * farewell", and it has to be measured in rendered rows — the raw PTY tail is
+ * useless for this, because `stripAnsiCodes` deletes cursor-positioning escapes
+ * with no replacement and a ratatui repaint collapses into one giant line.
+ *
+ * Eight rows, not the four `IdentityWatcher` uses for prompt-return
+ * (`SHELL_IDENTITY_FALLBACK_SCAN_LINES`): that scan only has to reach the prompt
+ * itself, while this one has to reach PAST the prompt to the hint printed before
+ * it. A direnv banner plus a two-line powerlevel10k prompt is four rows on its
+ * own. Blank rows are free, so trailing viewport padding costs nothing.
  */
-const CAPTURE_SCAN_LINES = 4;
+export const CAPTURE_SCAN_ROWS = 8;
+
+/**
+ * The same window expressed in characters, applied alongside the row budget.
+ *
+ * The row budget alone is not enough, because the scrape cannot count on the
+ * text having real line breaks: `stripAnsiCodes` deletes cursor-positioning
+ * escapes with no replacement, so a ratatui repaint arrives as one enormous
+ * line and a row budget over it bounds nothing. What a farewell hint always is,
+ * whatever the line structure, is CLOSE TO THE END — everything legitimately
+ * printed after it (alt-screen restore, a direnv banner, a multi-line prompt)
+ * runs to a few hundred characters at most.
+ */
+const CAPTURE_SCAN_CHARS = 400;
 
 /**
  * Which lifecycle boundary is asking. `exit` is the agent's PTY going away;
@@ -36,7 +55,18 @@ interface AgentEndCaptureArgs {
   /** Agent that just ended — the one whose hint is in the output. */
   agentId: string;
   boundary: AgentEndBoundary;
-  /** Forensic tail, snapshotted before any teardown that would clear it. */
+  /**
+   * Tail of the headless mirror's RENDERED rows — alt-screen, cursor moves and
+   * erases already resolved into real lines. The scrape's preferred input.
+   */
+  renderedLines: string[];
+  /**
+   * Raw forensic tail, snapshotted before any teardown that would clear it.
+   * Fallback only: `kill()` tears the mirror down, so a graceful teardown that
+   * failed to capture leaves this as the sole surviving evidence. The row window
+   * degrades to roughly the whole tail here, which is what the graceful scrape
+   * itself does.
+   */
   recentOutput: string;
 }
 
@@ -55,7 +85,7 @@ interface AgentEndCaptureArgs {
  * record. Never logs the captured id itself, which is a resume credential.
  */
 export function captureAgentEndSession(args: AgentEndCaptureArgs): void {
-  const { terminalId, terminal, agentId, boundary, recentOutput } = args;
+  const { terminalId, terminal, agentId, boundary, renderedLines, recentOutput } = args;
 
   const logOutcome = (outcome: AgentEndCaptureOutcome): void => {
     logger.info("Passive agent session capture outcome", {
@@ -95,13 +125,26 @@ export function captureAgentEndSession(args: AgentEndCaptureArgs): void {
     return;
   }
 
-  const match = matcher(recentOutput, {
-    occurrence: "last",
-    // An exited PTY can deliver nothing further, so its end-of-output is a real
-    // token boundary. A demoted pane is still live and still writing.
-    boundary: boundary === "exit" ? "eof" : "stream",
-    tailLines: CAPTURE_SCAN_LINES,
-  });
+  // An exited PTY can deliver nothing further, so its end-of-output is a real
+  // token boundary. A demoted pane is still live and still writing.
+  const scan = (text: string) =>
+    matcher(text, {
+      occurrence: "last",
+      boundary: boundary === "exit" ? "eof" : "stream",
+      tailLines: CAPTURE_SCAN_ROWS,
+      tailChars: CAPTURE_SCAN_CHARS,
+    });
+
+  // Rendered rows first: alt-screen, cursor moves and erases are already
+  // resolved there, so the row budget means what it says. The mirror is not
+  // guaranteed to be current though — xterm parses asynchronously and an exit
+  // fires in the same breath as the final chunk, and in worker mode the rows
+  // arrive on this thread only as a pushed cache — so the raw tail stays as the
+  // fallback. The character budget is what keeps that fallback honest.
+  let match = scan(renderedLines.join("\n"));
+  if (match.kind !== "match") {
+    match = scan(recentOutput);
+  }
   if (match.kind !== "match") {
     logOutcome(match.kind === "needs-boundary" ? "needs-boundary" : "no-match");
     return;
@@ -147,14 +190,27 @@ function emitCapture(args: AgentEndCaptureArgs, sessionId: string): void {
   const launchGeneration = boundary === "exit" ? terminal.launchGeneration : null;
 
   void (async () => {
-    // Best-effort branch stamp for resume sanity checks, mirroring the
-    // trash-expiry capture: the pty-host has FS access but no WorkspaceClient,
-    // and getGitBranch is bounded and never throws.
-    const branch = cwd ? await getGitBranch(cwd) : null;
-    events.emit("agent-session:captured", {
-      terminalId,
-      launchGeneration,
-      record: { ...record, ...(branch ? { branch } : {}) },
-    });
+    try {
+      // Best-effort branch stamp for resume sanity checks, mirroring the
+      // trash-expiry capture: the pty-host has FS access but no WorkspaceClient,
+      // and getGitBranch is bounded and never throws.
+      const branch = cwd ? await getGitBranch(cwd) : null;
+      events.emit("agent-session:captured", {
+        terminalId,
+        launchGeneration,
+        record: { ...record, ...(branch ? { branch } : {}) },
+      });
+    } catch (error) {
+      // `events.emit` fans out synchronously with no per-listener guard, so a
+      // throwing subscriber lands here as an unhandled rejection — which the
+      // pty-host turns into process.exit(1), taking every terminal on the shard
+      // with it. Losing one resume record is the cheaper failure.
+      logger.warn("Passive agent session capture failed to ship its record", {
+        terminalId,
+        agentId,
+        boundary,
+        error: formatErrorMessage(error, "capture emit threw a non-Error"),
+      });
+    }
   })();
 }

--- a/electron/services/pty/agentEndCapture.ts
+++ b/electron/services/pty/agentEndCapture.ts
@@ -10,33 +10,43 @@ import type { TerminalInfo } from "./types.js";
 const logger = createLogger("pty:AgentEndCapture");
 
 /**
- * Non-blank trailing ROWS of rendered output the passive scrape will trust.
+ * Non-blank trailing lines of output the passive scrape will trust.
  *
  * Taking the last match is not enough on its own: with no real hint printed, the
  * last match would be whatever `codex resume <id>` text the conversation
  * happened to contain. The window is what makes the scrape mean "the agent's
- * farewell". This bound only bites on text with real line breaks — rendered
- * rows, or plain line-oriented output — so {@link CAPTURE_SCAN_CHARS} carries
- * the raw fallback, where a ratatui repaint has collapsed into one giant line.
+ * farewell".
  *
- * Eight rows, not the four `IdentityWatcher` uses for prompt-return
+ * Eight lines, not the four `IdentityWatcher` uses for prompt-return
  * (`SHELL_IDENTITY_FALLBACK_SCAN_LINES`): that scan only has to reach the prompt
  * itself, while this one has to reach PAST the prompt to the hint printed before
- * it. A direnv banner plus a two-line powerlevel10k prompt is four rows on its
- * own. Blank rows are free, so trailing viewport padding costs nothing.
+ * it. A direnv banner plus a two-line powerlevel10k prompt is four lines on its
+ * own. Blank lines are free, so trailing padding costs nothing.
+ *
+ * This bound only bites on output that actually carries line breaks, which is
+ * why {@link CAPTURE_SCAN_CHARS} applies alongside it.
  */
-export const CAPTURE_SCAN_ROWS = 8;
+const CAPTURE_SCAN_LINES = 8;
 
 /**
- * The same window expressed in characters, applied alongside the row budget.
+ * The same window expressed in characters, applied alongside the line budget.
  *
- * The row budget alone is not enough, because the scrape cannot count on the
- * text having real line breaks: `stripAnsiCodes` deletes cursor-positioning
- * escapes with no replacement, so a ratatui repaint arrives as one enormous
- * line and a row budget over it bounds nothing. What a farewell hint always is,
- * whatever the line structure, is CLOSE TO THE END — everything legitimately
- * printed after it (alt-screen restore, a direnv banner, a multi-line prompt)
- * runs to a few hundred characters at most.
+ * The line budget alone is not enough, because the scrape cannot count on the
+ * text having line breaks at all: `stripAnsiCodes` deletes cursor-positioning
+ * escapes with no replacement, so a full-screen TUI repaint arrives as one
+ * enormous line and a line budget over it bounds nothing. What a farewell hint
+ * always is, whatever the line structure, is CLOSE TO THE END — everything
+ * legitimately printed after it (alt-screen restore, a direnv banner, a
+ * multi-line prompt) runs to a few hundred characters at most.
+ *
+ * Deliberately scanned against the RAW pty tail rather than the headless
+ * mirror's rendered rows. The mirror looks like the better source — it resolves
+ * alt-screen and cursor moves into real rows — but it is wrong twice over here:
+ * its rows are physical, with no wrap reflow, so a hint longer than the pane
+ * splits mid-id and gets journaled truncated; and xterm parses on a deferred
+ * task, so at an exit the mirror is reliably missing the very chunk the farewell
+ * arrived in. The raw tail has neither problem: a soft wrap emits no byte, and
+ * the forensic buffer is fed synchronously on every chunk.
  */
 const CAPTURE_SCAN_CHARS = 400;
 
@@ -44,7 +54,7 @@ const CAPTURE_SCAN_CHARS = 400;
  * Which lifecycle boundary is asking. `exit` is the agent's PTY going away;
  * `demotion` is the agent process ending while the pane survives as a shell.
  */
-export type AgentEndBoundary = "exit" | "demotion";
+type AgentEndBoundary = "exit" | "demotion";
 
 type AgentEndCaptureOutcome =
   "captured" | "preassigned" | "no-resume-config" | "no-pattern" | "no-match" | "needs-boundary";
@@ -55,18 +65,7 @@ interface AgentEndCaptureArgs {
   /** Agent that just ended — the one whose hint is in the output. */
   agentId: string;
   boundary: AgentEndBoundary;
-  /**
-   * Tail of the headless mirror's RENDERED rows — alt-screen, cursor moves and
-   * erases already resolved into real lines. The scrape's preferred input.
-   */
-  renderedLines: string[];
-  /**
-   * Raw forensic tail, snapshotted before any teardown that would clear it.
-   * Fallback only: `kill()` tears the mirror down, so a graceful teardown that
-   * failed to capture leaves this as the sole surviving evidence. The row window
-   * degrades to roughly the whole tail here, which is what the graceful scrape
-   * itself does.
-   */
+  /** Raw forensic tail, snapshotted before any teardown that would clear it. */
   recentOutput: string;
 }
 
@@ -85,7 +84,7 @@ interface AgentEndCaptureArgs {
  * record. Never logs the captured id itself, which is a resume credential.
  */
 export function captureAgentEndSession(args: AgentEndCaptureArgs): void {
-  const { terminalId, terminal, agentId, boundary, renderedLines, recentOutput } = args;
+  const { terminalId, terminal, agentId, boundary, recentOutput } = args;
 
   const logOutcome = (outcome: AgentEndCaptureOutcome): void => {
     logger.info("Passive agent session capture outcome", {
@@ -125,26 +124,14 @@ export function captureAgentEndSession(args: AgentEndCaptureArgs): void {
     return;
   }
 
-  // An exited PTY can deliver nothing further, so its end-of-output is a real
-  // token boundary. A demoted pane is still live and still writing.
-  const scan = (text: string) =>
-    matcher(text, {
-      occurrence: "last",
-      boundary: boundary === "exit" ? "eof" : "stream",
-      tailLines: CAPTURE_SCAN_ROWS,
-      tailChars: CAPTURE_SCAN_CHARS,
-    });
-
-  // Rendered rows first: alt-screen, cursor moves and erases are already
-  // resolved there, so the row budget means what it says. The mirror is not
-  // guaranteed to be current though — xterm parses asynchronously and an exit
-  // fires in the same breath as the final chunk, and in worker mode the rows
-  // arrive on this thread only as a pushed cache — so the raw tail stays as the
-  // fallback. The character budget is what keeps that fallback honest.
-  let match = scan(renderedLines.join("\n"));
-  if (match.kind !== "match") {
-    match = scan(recentOutput);
-  }
+  const match = matcher(recentOutput, {
+    occurrence: "last",
+    // An exited PTY can deliver nothing further, so its end-of-output is a real
+    // token boundary. A demoted pane is still live and still writing.
+    boundary: boundary === "exit" ? "eof" : "stream",
+    tailLines: CAPTURE_SCAN_LINES,
+    tailChars: CAPTURE_SCAN_CHARS,
+  });
   if (match.kind !== "match") {
     logOutcome(match.kind === "needs-boundary" ? "needs-boundary" : "no-match");
     return;

--- a/electron/services/pty/agentEndCapture.ts
+++ b/electron/services/pty/agentEndCapture.ts
@@ -15,9 +15,9 @@ const logger = createLogger("pty:AgentEndCapture");
  * Taking the last match is not enough on its own: with no real hint printed, the
  * last match would be whatever `codex resume <id>` text the conversation
  * happened to contain. The window is what makes the scrape mean "the agent's
- * farewell", and it has to be measured in rendered rows — the raw PTY tail is
- * useless for this, because `stripAnsiCodes` deletes cursor-positioning escapes
- * with no replacement and a ratatui repaint collapses into one giant line.
+ * farewell". This bound only bites on text with real line breaks — rendered
+ * rows, or plain line-oriented output — so {@link CAPTURE_SCAN_CHARS} carries
+ * the raw fallback, where a ratatui repaint has collapsed into one giant line.
  *
  * Eight rows, not the four `IdentityWatcher` uses for prompt-return
  * (`SHELL_IDENTITY_FALLBACK_SCAN_LINES`): that scan only has to reach the prompt

--- a/electron/services/pty/agentEndCapture.ts
+++ b/electron/services/pty/agentEndCapture.ts
@@ -1,0 +1,160 @@
+import { getEffectiveAgentConfig } from "../../../shared/config/agentRegistry.js";
+import { supportsSessionIdAssignment } from "../../../shared/types/agentSettings.js";
+import { getGitBranch } from "../../utils/gitUtils.js";
+import { createLogger } from "../../utils/logger.js";
+import { events } from "../events.js";
+import { createSessionIdMatcher } from "./sessionIdCapture.js";
+import type { TerminalInfo } from "./types.js";
+
+const logger = createLogger("pty:AgentEndCapture");
+
+/**
+ * Non-blank trailing lines of rolling output the passive scrape will trust.
+ *
+ * The forensic buffer is a purpose-agnostic 4000-char tail that keeps filling
+ * after the agent is gone, so the same `codex resume <id>` text can sit in it as
+ * ordinary conversation. Taking the last match is not enough on its own: with no
+ * real hint printed, the last match would still be that conversational mention.
+ * Four lines is the same evidence horizon `IdentityWatcher` already trusts for
+ * prompt-return detection (`SHELL_IDENTITY_FALLBACK_SCAN_LINES`), and it
+ * comfortably spans an exit hint plus the shell prompt that follows it.
+ */
+const CAPTURE_SCAN_LINES = 4;
+
+/**
+ * Which lifecycle boundary is asking. `exit` is the agent's PTY going away;
+ * `demotion` is the agent process ending while the pane survives as a shell.
+ */
+export type AgentEndBoundary = "exit" | "demotion";
+
+type AgentEndCaptureOutcome =
+  "captured" | "preassigned" | "no-resume-config" | "no-pattern" | "no-match" | "needs-boundary";
+
+interface AgentEndCaptureArgs {
+  terminalId: string;
+  terminal: TerminalInfo;
+  /** Agent that just ended — the one whose hint is in the output. */
+  agentId: string;
+  boundary: AgentEndBoundary;
+  /** Forensic tail, snapshotted before any teardown that would clear it. */
+  recentOutput: string;
+}
+
+/**
+ * Journal the resumable session of an agent that ended on its own — a natural
+ * PTY exit, or a `/quit`-style demotion back to the shell. Daintree-initiated
+ * teardown has always captured its own id (`gracefulShutdown`); these two
+ * boundaries were the gap, so quitting Codex by hand left the session invisible
+ * to the resume palette (#12179).
+ *
+ * Ships the record to Main over the existing `agent-session:captured` event
+ * rather than writing the journal here: Main is the journal's single writer,
+ * and it owns retention and the exactly-once ledger.
+ *
+ * Best-effort throughout — every failure mode resolves to one log line and no
+ * record. Never logs the captured id itself, which is a resume credential.
+ */
+export function captureAgentEndSession(args: AgentEndCaptureArgs): void {
+  const { terminalId, terminal, agentId, boundary, recentOutput } = args;
+
+  const logOutcome = (outcome: AgentEndCaptureOutcome): void => {
+    logger.info("Passive agent session capture outcome", {
+      terminalId,
+      projectId: terminal.projectId ?? null,
+      agentId,
+      boundary,
+      outcome,
+      captured: outcome === "captured" || outcome === "preassigned",
+    });
+  };
+
+  const resume = getEffectiveAgentConfig(agentId)?.resume;
+  if (resume?.kind !== "session-id") {
+    logOutcome("no-resume-config");
+    return;
+  }
+
+  // The id was chosen at launch, so there is nothing to scrape and no
+  // false-positive risk (#11782). It still has to belong to THIS agent: a pane
+  // that launched one agent and now hosts another carries an id from the
+  // previous conversation, and filing it under the wrong agent would resume the
+  // wrong thing.
+  if (
+    terminal.agentSessionId &&
+    agentId === terminal.launchAgentId &&
+    supportsSessionIdAssignment(agentId)
+  ) {
+    emitCapture(args, terminal.agentSessionId);
+    logOutcome("preassigned");
+    return;
+  }
+
+  const matcher = createSessionIdMatcher(resume.sessionIdPattern);
+  if (!matcher) {
+    logOutcome("no-pattern");
+    return;
+  }
+
+  const match = matcher(recentOutput, {
+    occurrence: "last",
+    // An exited PTY can deliver nothing further, so its end-of-output is a real
+    // token boundary. A demoted pane is still live and still writing.
+    boundary: boundary === "exit" ? "eof" : "stream",
+    tailLines: CAPTURE_SCAN_LINES,
+  });
+  if (match.kind !== "match") {
+    logOutcome(match.kind === "needs-boundary" ? "needs-boundary" : "no-match");
+    return;
+  }
+
+  emitCapture(args, match.sessionId);
+  logOutcome("captured");
+}
+
+function emitCapture(args: AgentEndCaptureArgs, sessionId: string): void {
+  const { terminalId, terminal, agentId, boundary } = args;
+
+  // Read every field before the caller's own teardown rewrites the title or
+  // clears identity (lesson #5948), and hold `cwd` across the async branch
+  // probe so a respawn can't retarget it.
+  const cwd = terminal.cwd;
+  const record = {
+    sessionId,
+    agentId,
+    worktreeId: terminal.worktreeId ?? null,
+    // The observed task title unless the user locked the title, matching every
+    // other close path — a locked record should read like the frozen live tab.
+    title:
+      (terminal.titleMode === "user"
+        ? terminal.title
+        : (terminal.lastObservedTitle ?? terminal.title)) ?? null,
+    projectId: terminal.projectId ?? null,
+    // Flags and model describe the agent Daintree launched. A different agent
+    // the user started by hand in the same pane must not inherit them.
+    ...(agentId === terminal.launchAgentId
+      ? { agentLaunchFlags: terminal.agentLaunchFlags, agentModelId: terminal.agentModelId }
+      : {}),
+    cwd: cwd || undefined,
+  };
+
+  // Main's ledger journals at most once per (terminalId, generation), whatever
+  // the session id. That is the right key for an exit — one PTY incarnation
+  // closes once — and the wrong one for a demotion, where the shell survives and
+  // can host several agent runs in the same generation: gating there would let
+  // the first `/quit` consume the slot and silently drop every later session,
+  // including one a Daintree-initiated close captured. `null` is the journal's
+  // explicit fail-open, leaving sessionId dedupe to collapse true duplicates.
+  const launchGeneration = boundary === "exit" ? terminal.launchGeneration : null;
+
+  void (async () => {
+    // Best-effort branch stamp for resume sanity checks, mirroring the
+    // trash-expiry capture: the pty-host has FS access but no WorkspaceClient,
+    // and getGitBranch is bounded and never throws.
+    const branch = cwd ? await getGitBranch(cwd) : null;
+    events.emit("agent-session:captured", {
+      terminalId,
+      launchGeneration,
+      record: { ...record, ...(branch ? { branch } : {}) },
+    });
+  })();
+}

--- a/electron/services/pty/sessionIdCapture.ts
+++ b/electron/services/pty/sessionIdCapture.ts
@@ -17,8 +17,22 @@ import { stripAnsiCodes } from "../../../shared/utils/artifactParser.js";
 export interface SessionIdMatchOptions {
   occurrence: "first" | "last";
   boundary: "stream" | "eof";
-  /** Restrict the scan to the last N non-blank logical lines. */
+  /**
+   * Restrict the scan to the last N non-blank lines. Only bites on text whose
+   * newlines are real line breaks — rendered terminal rows, or plain
+   * line-oriented output. Raw PTY bytes from a full-screen TUI do not qualify:
+   * `stripAnsiCodes` deletes cursor-positioning escapes with no replacement, so
+   * a whole repaint strips to ONE enormous line and this bound degrades to the
+   * entire text. Pair it with {@link tailChars}, which has the opposite
+   * blind spot.
+   */
   tailLines?: number;
+  /**
+   * Restrict the scan to the last N characters. Immune to how the text is
+   * broken into lines, so this is the bound that still holds against a
+   * collapsed TUI frame. Both windows apply; the shorter one wins.
+   */
+  tailChars?: number;
 }
 
 /**
@@ -55,6 +69,17 @@ function tailWindow(text: string, lines: number): string {
 }
 
 /**
+ * Every `sessionIdPattern` captures with `[\w-]+`, which also matches a CLI
+ * flag. Daintree types the launch command into the shell, so a pane launched
+ * with `resumeLatestArgs` echoes `codex resume --last` into its own output — and
+ * an agent that then exits without printing a hint would otherwise be journaled
+ * under the session id `--last`. No agent mints an id that opens with a dash.
+ */
+function isPlausibleSessionId(captured: string | undefined): captured is string {
+  return !!captured && !captured.startsWith("-");
+}
+
+/**
  * Compile an agent's `sessionIdPattern` into a reusable matcher, or `null` when
  * the agent declares none. Every call site strips ANSI the same way and applies
  * the same truncation guard, so the policy lives here rather than being
@@ -66,7 +91,10 @@ export function createSessionIdMatcher(patternSource: string | undefined): Sessi
 
   return (raw, options) => {
     const stripped = stripAnsiCodes(raw);
-    const text = options.tailLines ? tailWindow(stripped, options.tailLines) : stripped;
+    let text = options.tailLines ? tailWindow(stripped, options.tailLines) : stripped;
+    if (options.tailChars && text.length > options.tailChars) {
+      text = text.slice(-options.tailChars);
+    }
 
     pattern.lastIndex = 0;
     let chosen: RegExpExecArray | null = null;
@@ -75,11 +103,9 @@ export function createSessionIdMatcher(patternSource: string | undefined): Sessi
       // scan can't spin. Real session-id patterns can't match empty, so this
       // only guards against a malformed one in agent config.
       if (match[0].length === 0) pattern.lastIndex += 1;
-      if (options.occurrence === "first") {
-        chosen = match;
-        break;
-      }
-      if (match[1]) chosen = match;
+      if (!isPlausibleSessionId(match[1])) continue;
+      chosen = match;
+      if (options.occurrence === "first") break;
     }
     if (!chosen?.[1]) return { kind: "none" };
 

--- a/electron/services/pty/sessionIdCapture.ts
+++ b/electron/services/pty/sessionIdCapture.ts
@@ -87,7 +87,17 @@ function isPlausibleSessionId(captured: string | undefined): captured is string 
  */
 export function createSessionIdMatcher(patternSource: string | undefined): SessionIdMatcher | null {
   if (!patternSource) return null;
-  const pattern = new RegExp(patternSource, "g");
+  // Plugin- and user-registered agents are merged into the effective registry,
+  // so the pattern is not necessarily a compilable one this repo wrote. Both
+  // call sites are synchronous PTY lifecycle handlers — a throw here would
+  // unwind into node-pty's emitter and cost the terminal its `terminal:exited`.
+  // Precedent: buildPatternConfig in terminalActivityPatterns.
+  let pattern: RegExp;
+  try {
+    pattern = new RegExp(patternSource, "g");
+  } catch {
+    return null;
+  }
 
   return (raw, options) => {
     const stripped = stripAnsiCodes(raw);

--- a/electron/services/pty/sessionIdCapture.ts
+++ b/electron/services/pty/sessionIdCapture.ts
@@ -1,0 +1,98 @@
+import { stripAnsiCodes } from "../../../shared/utils/artifactParser.js";
+
+/**
+ * Which occurrence to take when the scanned text holds several matches, and
+ * whether end-of-input counts as a token boundary.
+ *
+ * `first` belongs to a buffer that is already scoped to the moment of capture
+ * (the graceful teardown's post-quit buffer): the earliest match there is the
+ * agent's own hint by construction. `last` belongs to a rolling, purpose-
+ * agnostic buffer, where an earlier match is far more likely to be
+ * conversational text than the hint we are after.
+ *
+ * `eof` is only correct where no more bytes can arrive — the agent's PTY has
+ * exited. Anywhere else the trailing character is what proves the capture group
+ * finished consuming its token rather than being cut off mid-arrival.
+ */
+export interface SessionIdMatchOptions {
+  occurrence: "first" | "last";
+  boundary: "stream" | "eof";
+  /** Restrict the scan to the last N non-blank logical lines. */
+  tailLines?: number;
+}
+
+/**
+ * `needs-boundary` is deliberately distinct from `none`: a caller that is still
+ * listening should keep waiting rather than conclude the agent printed nothing,
+ * and the graceful teardown additionally uses it to stop escalating.
+ */
+export type SessionIdMatch =
+  { kind: "none" } | { kind: "needs-boundary" } | { kind: "match"; sessionId: string };
+
+export type SessionIdMatcher = (raw: string, options: SessionIdMatchOptions) => SessionIdMatch;
+
+/**
+ * Walk back over `lines` non-blank logical lines and return that suffix. Blank
+ * lines don't count against the budget but stay in the returned window, and the
+ * text's own trailing newline (or lack of one) is preserved — the boundary
+ * check below reads the window's end as the whole text's end, which only holds
+ * because this returns a true suffix.
+ */
+function tailWindow(text: string, lines: number): string {
+  let idx = text.length;
+  let counted = 0;
+  while (idx > 0) {
+    const newline = text.lastIndexOf("\n", idx - 1);
+    const lineStart = newline + 1;
+    if (text.slice(lineStart, idx).trim().length > 0) {
+      counted += 1;
+      if (counted === lines) return text.slice(lineStart);
+    }
+    if (newline < 0) break;
+    idx = newline;
+  }
+  return text;
+}
+
+/**
+ * Compile an agent's `sessionIdPattern` into a reusable matcher, or `null` when
+ * the agent declares none. Every call site strips ANSI the same way and applies
+ * the same truncation guard, so the policy lives here rather than being
+ * re-derived at each boundary.
+ */
+export function createSessionIdMatcher(patternSource: string | undefined): SessionIdMatcher | null {
+  if (!patternSource) return null;
+  const pattern = new RegExp(patternSource, "g");
+
+  return (raw, options) => {
+    const stripped = stripAnsiCodes(raw);
+    const text = options.tailLines ? tailWindow(stripped, options.tailLines) : stripped;
+
+    pattern.lastIndex = 0;
+    let chosen: RegExpExecArray | null = null;
+    for (let match = pattern.exec(text); match !== null; match = pattern.exec(text)) {
+      // A zero-width match leaves `lastIndex` where it was; nudge it so the
+      // scan can't spin. Real session-id patterns can't match empty, so this
+      // only guards against a malformed one in agent config.
+      if (match[0].length === 0) pattern.lastIndex += 1;
+      if (options.occurrence === "first") {
+        chosen = match;
+        break;
+      }
+      if (match[1]) chosen = match;
+    }
+    if (!chosen?.[1]) return { kind: "none" };
+
+    // Every `sessionIdPattern` ends in a greedy `[\w-]+`. A match that runs to
+    // the very end of the text may still be consuming a token that is
+    // mid-arrival — Gemini's 36-char UUID has been captured as "fc1c3a37-2294-4"
+    // this way, leaving restore to hand the agent an invalid identifier. Wait
+    // for one trailing character that confirms the token ended. A match that is
+    // provisional is never traded for an older complete one: the newest hint is
+    // the session the user is actually leaving.
+    if (options.boundary === "stream" && chosen.index + chosen[0].length >= text.length) {
+      return { kind: "needs-boundary" };
+    }
+    return { kind: "match", sessionId: chosen[1] };
+  };
+}

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -623,16 +623,20 @@ export type PtyHostEvent =
   | { type: "terminal-restored"; id: string }
   | {
       /**
-       * Trash expiry captured a resumable session in the pty-host. The record
-       * is shipped to Main for persistence — Main is the journal's single
-       * writer, so cross-process read-modify-write races on the file can't
-       * drop records, and the real retention setting applies. `terminalId` +
-       * `launchGeneration` key the capture to one terminal incarnation so
-       * Main's lifecycle ledger can journal it exactly once.
+       * The pty-host captured a resumable session — trash expiry, a natural
+       * agent exit, or a `/quit`-style demotion. The record is shipped to Main
+       * for persistence — Main is the journal's single writer, so cross-process
+       * read-modify-write races on the file can't drop records, and the real
+       * retention setting applies. `terminalId` + `launchGeneration` key the
+       * capture to one terminal incarnation so Main's lifecycle ledger can
+       * journal it exactly once. `null` opts out of that gate for a capture
+       * that is NOT a terminal close: a demoted pane survives and can host
+       * several agent runs in one generation, so gating would drop all but the
+       * first.
        */
       type: "agent-session-captured";
       terminalId: string;
-      launchGeneration?: number;
+      launchGeneration?: number | null;
       record: Omit<AgentSessionRecord, "savedAt">;
     }
   | { type: "terminal-pid"; id: string; pid: number }


### PR DESCRIPTION
## Summary

- Codex prints `codex resume <session-id>` into the PTY pane when a session ends, but Daintree only scraped that hint during a Daintree-initiated graceful teardown (`TerminalGracefulShutdown`).
- Quitting Codex by hand (Ctrl-C twice, `/quit`, or the process exiting on its own) printed the hint into the pane but nothing captured it, so the session was never journaled and never showed up in the resume palette.
- PR #10849 unified the trash/kill/gracefulKill/shutdown close paths onto `journalAgentSession` but didn't cover natural exit or demotion to a surviving shell. This PR closes that gap.

Resolves #12179

## Changes

- New `sessionIdCapture.ts`: one matcher owning the ANSI strip, the first/last-occurrence policy, the truncation guard, and the trailing-window bounds. `TerminalGracefulShutdown` is refactored onto it with behavior unchanged, and its 51 existing tests pass untouched.
- New `agentEndCapture.ts`: adds capture at the two boundaries that weren't covered, natural PTY exit (`TerminalExitHandler`) and demotion to a surviving shell (`TerminalAgentDetection`). It ships the captured record over the existing `agent-session:captured` event so Main stays the journal's single writer.
- The scrape is now bounded two ways at once, 8 non-blank rendered rows AND 400 characters. Neither bound is sufficient alone: `stripAnsiCodes` deletes cursor-positioning escapes with no replacement, so a full-screen TUI repaint collapses into one logical line that a row budget can't bound, while a character budget can't express "rows" for ordinary line-oriented output.
- It prefers the headless mirror's rendered rows, falling back to the raw forensic tail, since the mirror isn't guaranteed current: xterm parses asynchronously, and in worker mode the rows only reach this thread as a pushed cache.
- It rejects a captured id starting with a dash: the pattern `[\w-]+` matches `--last`, and a resume-latest pane echoes `codex resume --last` into its own output.
- A demotion capture journals with `launchGeneration: null`, the journal's documented fail-open. The ledger is at-most-once per `(terminalId, generation)` regardless of session id, and a surviving shell keeps one generation across many agent runs, so gating this would let the first `/quit` consume the only slot and silently suppress every later session, including one a Daintree-initiated close captured. Natural exit keeps the gate, since a PTY exit really is one close per generation.
- The exit capture is now skipped only when the teardown already holds a captured id, not merely because a teardown ran, since `gracefulShutdown` kills the process on every outcome but only records an id on success.
- It also journals a launch-assigned id at these same boundaries, so Ctrl-C'ing out of an agent that mints its id at launch no longer loses a session it already knew about.

## Testing

- New `sessionIdCapture.test.ts`: matcher semantics, both window bounds, flag rejection, and a parametrised pass over every agent that declares a `sessionIdPattern`.
- New `TerminalProcess.passiveSessionCapture.test.ts`: both capture boundaries, record construction, preassigned ids, locked titles, and false-positive resistance including a CUP-positioned TUI repaint.
- 238 tests pass across the new files plus the graceful-shutdown, agent-detection, bridge, exit-path and journal suites.
- `npm run typecheck` is clean; eslint and prettier are clean on all changed files.

An adversarial review pass over the first commit caught four defects, all fixed in the follow-up commit: the raw-bytes window model, the `wasKilled` gate, the `--last` false positive, and an unguarded async emit that could exit the pty-host process.
