### PR TITLE
fix(terminal): keep the assistant's terminal out of generic pane paths

### DIFF
--- a/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
@@ -1222,6 +1222,54 @@ describe("terminal spawn handler - help session detection (#6524)", () => {
     expect(mockPreparePaneConfig).not.toHaveBeenCalled();
   });
 
+  it("stamps isAssistantTerminal on the spawn so teardown paths can recognise it", async () => {
+    // #12183: the spawn handler already knew this was the assistant (it is
+    // what gates MCP command mutation) but threw the answer away, so the
+    // session journal and hydration's orphan adoption treated the overlay's
+    // PTY as an ordinary agent pane. Sealing it onto the record is what lets
+    // those paths recognise it from a pre-kill snapshot.
+    mockValidateToken.mockImplementation((token) => (token === "help-token" ? "action" : false));
+
+    const deps = { ptyClient } as unknown as HandlerDependencies;
+    registerTerminalLifecycleHandlers(deps);
+
+    const handler = getSpawnHandler();
+    await handler(
+      {} as Electron.IpcMainInvokeEvent,
+      {
+        cols: 80,
+        rows: 24,
+        cwd: tmpDir,
+        command: "claude",
+        launchAgentId: "claude",
+        env: { DAINTREE_MCP_TOKEN: "help-token" },
+      } as unknown as Parameters<typeof handler>[1]
+    );
+
+    expect(ptyClient.spawn.mock.calls[0][1].isAssistantTerminal).toBe(true);
+  });
+
+  it("does not stamp isAssistantTerminal on an ordinary agent launch", async () => {
+    // The same agent binary, launched by the user into the grid, must stay
+    // journalable and adoptable — `launchAgentId` alone cannot tell them apart.
+    const deps = { ptyClient } as unknown as HandlerDependencies;
+    registerTerminalLifecycleHandlers(deps);
+
+    const handler = getSpawnHandler();
+    await handler(
+      {} as Electron.IpcMainInvokeEvent,
+      {
+        cols: 80,
+        rows: 24,
+        cwd: tmpDir,
+        command: "claude",
+        launchAgentId: "claude",
+      } as unknown as Parameters<typeof handler>[1]
+    );
+
+    expect(ptyClient.spawn.mock.calls[0][1].isAssistantTerminal).toBe(false);
+  });
+
   it("appends --dangerously-skip-permissions when help session bypassPermissions is true", async () => {
     mockValidateToken.mockImplementation((token) => (token === "bypass-token" ? "system" : false));
     mockGetBypassPermissions.mockImplementation((token) => token === "bypass-token");

--- a/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
@@ -224,6 +224,8 @@ const mockGetAssistantScratchEnv = vi.hoisted(() =>
   vi.fn<(token: string) => Record<string, string> | null>(() => null)
 );
 
+const mockIsHelpTerminal = vi.hoisted(() => vi.fn<(terminalId: string) => boolean>(() => false));
+
 vi.mock("../../../../services/HelpSessionService.js", () => ({
   helpSessionService: {
     validateToken: (token: string) => mockValidateToken(token),
@@ -235,7 +237,12 @@ vi.mock("../../../../services/HelpSessionService.js", () => ({
     markTerminalForToken: (token: string, terminalId: string) =>
       mockMarkTerminalForToken(token, terminalId),
     unbindTerminal: (terminalId: string) => mockUnbindTerminal(terminalId),
+    isHelpTerminal: (terminalId: string) => mockIsHelpTerminal(terminalId),
   },
+}));
+
+vi.mock("../../../../services/AgentAvailabilityStore.js", () => ({
+  getAgentAvailabilityStore: () => ({ isHelpTerminal: () => false }),
 }));
 
 vi.mock("../../../../services/McpServerService.js", () => ({
@@ -1189,6 +1196,8 @@ describe("terminal spawn handler - help session detection (#6524)", () => {
     mockGetBypassPermissions.mockReturnValue(false);
     mockMarkTerminalForToken.mockReset();
     mockMarkTerminalForToken.mockReturnValue(true);
+    mockIsHelpTerminal.mockReset();
+    mockIsHelpTerminal.mockReturnValue(false);
     mockUnbindTerminal.mockReset();
     mockGetAssistantScratchEnv.mockReset();
     mockGetAssistantScratchEnv.mockReturnValue(null);
@@ -1243,6 +1252,33 @@ describe("terminal spawn handler - help session detection (#6524)", () => {
         command: "claude",
         launchAgentId: "claude",
         env: { DAINTREE_MCP_TOKEN: "help-token" },
+      } as unknown as Parameters<typeof handler>[1]
+    );
+
+    expect(ptyClient.spawn.mock.calls[0][1].isAssistantTerminal).toBe(true);
+  });
+
+  it("keeps the assistant stamp across a restart, which respawns without the token", async () => {
+    // `buildRestartEnv` rebuilds the env from global + project + runtime vars
+    // only, so a restarted assistant arrives with no DAINTREE_MCP_TOKEN and
+    // `isHelpLaunch` is false. The live binding survives the restart's kill
+    // and is what keeps the record honest — without it, Restart All Terminals
+    // would silently strip the assistant's identity and reopen #12183.
+    mockIsHelpTerminal.mockImplementation((id) => id === "assistant-term");
+
+    const deps = { ptyClient } as unknown as HandlerDependencies;
+    registerTerminalLifecycleHandlers(deps);
+
+    const handler = getSpawnHandler();
+    await handler(
+      {} as Electron.IpcMainInvokeEvent,
+      {
+        id: "assistant-term",
+        cols: 80,
+        rows: 24,
+        cwd: tmpDir,
+        command: "claude",
+        launchAgentId: "claude",
       } as unknown as Parameters<typeof handler>[1]
     );
 
@@ -2570,6 +2606,31 @@ describe("terminal close handlers - resume journaling", () => {
     const deps = { ptyClient, worktreeService } as unknown as HandlerDependencies;
     registerTerminalLifecycleHandlers(deps);
   }
+
+  it("does not journal the assistant's overlay terminal on close", async () => {
+    // The path the assistant travels every time it closes: removePanel ->
+    // terminal:kill -> persistCloseRecord. Journaling here is what put the
+    // assistant's conversation in the resume picker (#12183).
+    ptyClient.getTerminalAsync.mockResolvedValue({ ...agentInfo, isAssistantTerminal: true });
+    ptyClient.gracefulKill.mockResolvedValue("sess-abc");
+    register();
+
+    await getKillHandler()({}, "term-1");
+
+    // Still torn down gracefully — only the resume record is suppressed.
+    expect(ptyClient.gracefulKill).toHaveBeenCalledWith("term-1");
+    expect(persistAgentSessionMock).not.toHaveBeenCalled();
+  });
+
+  it("does not journal the assistant on an explicit gracefulKill either", async () => {
+    ptyClient.getTerminalAsync.mockResolvedValue({ ...agentInfo, isAssistantTerminal: true });
+    ptyClient.gracefulKill.mockResolvedValue("sess-abc");
+    register();
+
+    await getGracefulKillHandler()({}, "term-1");
+
+    expect(persistAgentSessionMock).not.toHaveBeenCalled();
+  });
 
   it("routes an agent terminal kill through gracefulKill and journals a record", async () => {
     ptyClient.getTerminalAsync.mockResolvedValue(agentInfo);

--- a/electron/ipc/handlers/terminal/__tests__/snapshots.reconnectBulk.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/snapshots.reconnectBulk.test.ts
@@ -113,6 +113,9 @@ const TERMINALS = new Map<string, Record<string, unknown>>([
     "t-worktreed",
     { ...makeTerminal("t-worktreed", "project-a"), worktreeId: "/repo/.worktrees/backend" },
   ],
+  // The assistant's overlay PTY, recognised from its spawn-time record stamp
+  // rather than the renderer's mark (#12183).
+  ["t-assistant", { ...makeTerminal("t-assistant", "project-a"), isAssistantTerminal: true }],
 ]);
 
 /** An invoke event whose URL can be mutated mid-flight, to prove identity is snapshotted. */
@@ -172,6 +175,20 @@ beforeEach(() => {
   mockIsHelpTerminal.mockReturnValue(false);
   getProjectForWebContentsMock.mockImplementation((id) => VIEW_TO_PROJECT.get(id) ?? null);
   getWindowForWebContentsMock.mockReturnValue(null);
+});
+
+describe("terminal:reconnect — assistant overlay", () => {
+  it("refuses a stamped assistant terminal the renderer has not marked", async () => {
+    // Reconnect is hydration's fallback for panes `getForProject` missed, so
+    // reading only the renderer's mark let a cold-boot bulk restore adopt the
+    // assistant as a grid pane before that mark landed.
+    mockIsHelpTerminal.mockReturnValue(false);
+    register();
+
+    await expect(reconnect(senderEvent(SENDER_A), "t-assistant")).resolves.toMatchObject({
+      exists: false,
+    });
+  });
 });
 
 describe("terminal:reconnect — workspace ownership", () => {

--- a/electron/ipc/handlers/terminal/lifecycle.ts
+++ b/electron/ipc/handlers/terminal/lifecycle.ts
@@ -12,6 +12,7 @@ import { projectStore } from "../../../services/ProjectStore.js";
 import type * as McpServerServiceModule from "../../../services/McpServerService.js";
 import { mcpPaneConfigService } from "../../../services/McpPaneConfigService.js";
 import { helpSessionService } from "../../../services/HelpSessionService.js";
+import { isAssistantTerminalRecord } from "../../../services/assistantTerminal.js";
 import type { HandlerDependencies, IpcContext } from "../../types.js";
 import {
   TerminalSpawnOptionsSchema,
@@ -781,6 +782,12 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
         projectId,
         restore: validatedOptions.restore,
         isEphemeral: validatedOptions.isEphemeral,
+        // Seal the assistant's identity onto the record itself. Derived from
+        // the validated help token above, never from a renderer-supplied
+        // field: a pane that could assert this would opt itself out of the
+        // session journal. The generic terminal paths read it back through
+        // `isAssistantTerminalRecord`.
+        isAssistantTerminal: isHelpLaunch,
         agentLaunchFlags: validatedOptions.agentLaunchFlags,
         agentModelId: validatedOptions.agentModelId,
         agentSessionId: validatedOptions.agentSessionId,
@@ -849,6 +856,10 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
     generation?: number
   ): Promise<void> => {
     if (!sessionId || !info?.launchAgentId) return;
+    // The Daintree Assistant's overlay terminal must never surface in the
+    // resume picker as an ordinary agent pane (#12183). Both callers snapshot
+    // `info` before the kill, so the record still carries the stamp here.
+    if (isAssistantTerminalRecord(info)) return;
     try {
       const branch = await resolveBranchForMain(info.worktreeId, deps.worktreeService);
       // journalAgentSession is the exactly-once funnel: it gates on the

--- a/electron/ipc/handlers/terminal/lifecycle.ts
+++ b/electron/ipc/handlers/terminal/lifecycle.ts
@@ -782,12 +782,18 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
         projectId,
         restore: validatedOptions.restore,
         isEphemeral: validatedOptions.isEphemeral,
-        // Seal the assistant's identity onto the record itself. Derived from
-        // the validated help token above, never from a renderer-supplied
-        // field: a pane that could assert this would opt itself out of the
-        // session journal. The generic terminal paths read it back through
-        // `isAssistantTerminalRecord`.
-        isAssistantTerminal: isHelpLaunch,
+        // Seal the assistant's identity onto the record itself, for the
+        // generic terminal paths to read back through
+        // `isAssistantTerminalRecord`. Derived in main, never from a
+        // renderer-supplied field: a pane that could assert this would opt
+        // itself out of the session journal.
+        //
+        // The live binding is the second source because a restart respawns the
+        // same panel id with a rebuilt env that carries no help token
+        // (`buildRestartEnv`), so `isHelpLaunch` is false there — and nothing
+        // unbinds the session on a restart's kill. Without it, Restart All
+        // Terminals would quietly strip the assistant's identity.
+        isAssistantTerminal: isHelpLaunch || helpSessionService.isHelpTerminal(id),
         agentLaunchFlags: validatedOptions.agentLaunchFlags,
         agentModelId: validatedOptions.agentModelId,
         agentSessionId: validatedOptions.agentSessionId,

--- a/electron/ipc/handlers/terminal/snapshots.ts
+++ b/electron/ipc/handlers/terminal/snapshots.ts
@@ -7,7 +7,7 @@ import { CHANNELS } from "../../channels.js";
 import type { HandlerDependencies, IpcContext } from "../../types.js";
 import { TerminalReplayHistoryPayloadSchema } from "../../../schemas/index.js";
 import { logDebug, logInfo, logWarn } from "../../../utils/logger.js";
-import { getAgentAvailabilityStore } from "../../../services/AgentAvailabilityStore.js";
+import { isAssistantTerminalRecord } from "../../../services/assistantTerminal.js";
 import {
   buildTerminalInventory,
   consumeTerminalInventoryPrefetch,
@@ -410,8 +410,8 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
         return { exists: false, conflict: true };
       }
 
-      if (getAgentAvailabilityStore().isHelpTerminal(terminal.id)) {
-        logInfo(`terminal:reconnect: Skipping help terminal ${terminalId}`);
+      if (isAssistantTerminalRecord(terminal)) {
+        logInfo(`terminal:reconnect: Skipping assistant terminal ${terminalId}`);
         return { exists: false };
       }
 

--- a/electron/lifecycle/__tests__/shutdown.test.ts
+++ b/electron/lifecycle/__tests__/shutdown.test.ts
@@ -67,6 +67,7 @@ vi.mock("../../utils/quitWarning.js", () => quitWarningMock);
 
 const agentStoreMock = vi.hoisted(() => ({
   getAgentsByAvailability: vi.fn(() => []),
+  isHelpTerminal: vi.fn(() => false),
 }));
 
 vi.mock("../../services/AgentAvailabilityStore.js", () => ({
@@ -1195,6 +1196,31 @@ describe("registerShutdownHandler", () => {
       expect(record.agentId).toBe("claude");
       expect(record.cwd).toBe("/repo");
       expect(record.branch).toBe("feature/x");
+    });
+
+    it("skips the assistant's overlay terminal but journals the pane beside it", async () => {
+      // #12183: a quit journaled the assistant as an ordinary AgentSessionRecord,
+      // so it could surface in the resume picker and reopen the assistant's
+      // conversation as a grid pane running the underlying CLI.
+      projectStoreMock.getAllProjects.mockReturnValue([{ id: "proj-1" }] as never);
+      const ptyClient = makePtyClient({
+        getAllTerminalsAsync: vi.fn(async () => [
+          agentTerminal,
+          { ...agentTerminal, id: "assistant", isAssistantTerminal: true },
+        ]),
+        gracefulKillByProject: vi.fn(async () => [
+          { id: "t1", agentSessionId: "sess-1" },
+          { id: "assistant", agentSessionId: "sess-assistant" },
+        ]),
+      });
+      const { beforeQuitCb } = await setup({ getPtyClient: () => ptyClient });
+
+      await beforeQuitCb(makeEvent());
+      await vi.waitFor(() => expect(appMock.exit).toHaveBeenCalled());
+
+      expect(persistAgentSessionMock).toHaveBeenCalledTimes(1);
+      const record = persistAgentSessionMock.mock.calls[0][0] as Record<string, unknown>;
+      expect(record.sessionId).toBe("sess-1");
     });
 
     it("still captures and journals when the rate-limit drain import fails", async () => {

--- a/electron/lifecycle/__tests__/shutdown.test.ts
+++ b/electron/lifecycle/__tests__/shutdown.test.ts
@@ -34,7 +34,9 @@ const projectStoreMock = vi.hoisted(() => ({
   getAllProjects: vi.fn(() => []),
   getProjectState: vi.fn(),
   saveProjectState: vi.fn(),
-  enqueueProjectStateUpdate: vi.fn(async () => undefined),
+  enqueueProjectStateUpdate: vi.fn<
+    (id: string, updater: (state: unknown) => unknown) => Promise<void>
+  >(async () => undefined),
 }));
 
 vi.mock("../../services/ProjectStore.js", () => ({
@@ -1221,6 +1223,21 @@ describe("registerShutdownHandler", () => {
       expect(persistAgentSessionMock).toHaveBeenCalledTimes(1);
       const record = persistAgentSessionMock.mock.calls[0][0] as Record<string, unknown>;
       expect(record.sessionId).toBe("sess-1");
+
+      // The session-id writeback skips it too, matching the mirrored block in
+      // `gracefulTeardownAndJournalProject`.
+      const [, updater] = projectStoreMock.enqueueProjectStateUpdate.mock.calls[0]!;
+      const state = {
+        terminals: [
+          { id: "t1", agentSessionId: undefined },
+          { id: "assistant", agentSessionId: undefined },
+        ],
+      };
+      updater(state);
+      expect(state.terminals).toEqual([
+        { id: "t1", agentSessionId: "sess-1" },
+        { id: "assistant", agentSessionId: undefined },
+      ]);
     });
 
     it("still captures and journals when the rate-limit drain import fails", async () => {

--- a/electron/lifecycle/shutdown.ts
+++ b/electron/lifecycle/shutdown.ts
@@ -4,6 +4,7 @@ import type { PtyClient } from "../services/PtyClient.js";
 import type { WorkspaceClient } from "../services/WorkspaceClient.js";
 import { projectStore } from "../services/ProjectStore.js";
 import { journalAgentSession } from "../services/pty/agentSessionJournal.js";
+import { isAssistantTerminalRecord } from "../services/assistantTerminal.js";
 import { getLifecycleLedger } from "../services/pty/lifecycleLedger.js";
 import { getActiveAgentCount, showQuitWarning } from "../utils/quitWarning.js";
 import {
@@ -335,7 +336,11 @@ async function runShutdownChain(deps: ShutdownDeps): Promise<ShutdownOutcome> {
         .map((r) => ({ result: r, info: terminalInfoById.get(r.id) }))
         .filter((c): c is { result: typeof c.result; info: NonNullable<typeof c.info> } =>
           Boolean(c.info?.launchAgentId)
-        );
+        )
+        // The assistant's overlay terminal is not a resumable grid pane
+        // (#12183). Read off the pre-kill snapshot above, which is the only
+        // place its identity still survives once the PTY is gone.
+        .filter((c) => !isAssistantTerminalRecord(c.info));
 
       if (capturedAgents.length > 0) {
         const uniqueWorktreeIds = [

--- a/electron/lifecycle/shutdown.ts
+++ b/electron/lifecycle/shutdown.ts
@@ -303,7 +303,9 @@ async function runShutdownChain(deps: ShutdownDeps): Promise<ShutdownOutcome> {
         // Same assistant skip as the journal below, keeping this block a true
         // mirror of `gracefulTeardownAndJournalProject`'s writeback.
         const captured = results.filter(
-          (r) => r.agentSessionId && !isAssistantTerminalRecord(terminalInfoById.get(r.id) ?? { id: r.id })
+          (r) =>
+            r.agentSessionId &&
+            !isAssistantTerminalRecord(terminalInfoById.get(r.id) ?? { id: r.id })
         );
         if (captured.length === 0) continue;
 

--- a/electron/lifecycle/shutdown.ts
+++ b/electron/lifecycle/shutdown.ts
@@ -300,7 +300,11 @@ async function runShutdownChain(deps: ShutdownDeps): Promise<ShutdownOutcome> {
 
       for (let i = 0; i < projectIds.length; i++) {
         const results = allResults[i];
-        const captured = results.filter((r) => r.agentSessionId);
+        // Same assistant skip as the journal below, keeping this block a true
+        // mirror of `gracefulTeardownAndJournalProject`'s writeback.
+        const captured = results.filter(
+          (r) => r.agentSessionId && !isAssistantTerminalRecord(terminalInfoById.get(r.id))
+        );
         if (captured.length === 0) continue;
 
         try {

--- a/electron/lifecycle/shutdown.ts
+++ b/electron/lifecycle/shutdown.ts
@@ -303,7 +303,7 @@ async function runShutdownChain(deps: ShutdownDeps): Promise<ShutdownOutcome> {
         // Same assistant skip as the journal below, keeping this block a true
         // mirror of `gracefulTeardownAndJournalProject`'s writeback.
         const captured = results.filter(
-          (r) => r.agentSessionId && !isAssistantTerminalRecord(terminalInfoById.get(r.id))
+          (r) => r.agentSessionId && !isAssistantTerminalRecord(terminalInfoById.get(r.id) ?? { id: r.id })
         );
         if (captured.length === 0) continue;
 

--- a/electron/pty-host/handlers/__tests__/terminalInfo.test.ts
+++ b/electron/pty-host/handlers/__tests__/terminalInfo.test.ts
@@ -81,6 +81,17 @@ function makeTerminal(overrides: Record<string, unknown> = {}) {
 }
 
 describe("mapTerminalInfo", () => {
+  it("reports the assistant stamp back to main", () => {
+    // #10927: a spawn-time field present in four of five layers still vanishes
+    // silently. Main's teardown and hydration paths only ever see the record
+    // through this mapper, so dropping it here would quietly restore #12183.
+    const ctx = createCtx();
+    expect(mapTerminalInfo(makeTerminal({ isAssistantTerminal: true }), ctx)).toMatchObject({
+      isAssistantTerminal: true,
+    });
+    expect(mapTerminalInfo(makeTerminal(), ctx).isAssistantTerminal).toBeUndefined();
+  });
+
   it("derives isTrashed from ptyManager.isInTrash, not the raw record", () => {
     // Lesson #4753: the in-memory TerminalInfo object never carries a
     // populated `isTrashed` field; trash status lives in PtyManager's

--- a/electron/pty-host/handlers/terminalInfo.ts
+++ b/electron/pty-host/handlers/terminalInfo.ts
@@ -46,6 +46,7 @@ export function mapTerminalInfo(t: NonNullable<TerminalInfoLike>, ctx: HostConte
     ptyRows: ptyRows ?? undefined,
 
     launchAgentId: t.launchAgentId,
+    isAssistantTerminal: t.isAssistantTerminal,
     title: t.title,
     titleMode: t.titleMode,
     // Preferred over `title` for resume-record labels on the kill/shutdown

--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -125,6 +125,8 @@ interface TerminalInfoResponse {
   projectId?: string;
   kind?: PanelKind;
   launchAgentId?: AgentId;
+  /** This PTY backs the Daintree Assistant overlay, not a grid pane. */
+  isAssistantTerminal?: boolean;
   title?: string;
   /** Title ownership rung mirrored from the pty-host record. */
   titleMode?: PanelTitleMode;

--- a/electron/services/PtyManager.ts
+++ b/electron/services/PtyManager.ts
@@ -730,7 +730,11 @@ export class PtyManager extends EventEmitter {
       void (async () => {
         try {
           const { sessionId } = await this.gracefulKill(termId);
-          if (sessionId && info?.launchAgentId) {
+          // The assistant's overlay terminal must never produce a resume
+          // record (#12183). It cannot reach the trash today — the renderer
+          // routes `removeOnExit` panels straight to removal — but that
+          // invariant lives a process away from the record that states it.
+          if (sessionId && info?.launchAgentId && info.isAssistantTerminal !== true) {
             // Best-effort branch stamp for resume sanity checks. The pty-host
             // has FS access but no WorkspaceClient, so resolve directly from
             // git with a short timeout; never let it block or fail the close.

--- a/electron/services/__tests__/PtyManager.lifecycleLedger.test.ts
+++ b/electron/services/__tests__/PtyManager.lifecycleLedger.test.ts
@@ -119,7 +119,10 @@ class MockTerminalProcess {
     return false;
   }
 
+  gracefulShutdownCalled = false;
+
   gracefulShutdown(): Promise<string | null> {
+    this.gracefulShutdownCalled = true;
     return Promise.resolve(this.sessionId);
   }
 }
@@ -391,6 +394,30 @@ describe("PtyManager lifecycle ledger", () => {
 
     expect(shared.created[0]?.options.cols).toBe(100);
     expect(shared.created[0]?.options.rows).toBe(30);
+  });
+
+  it("captures no resume record when a trashed assistant terminal expires", async () => {
+    // The assistant cannot reach the trash today — the renderer routes
+    // `removeOnExit` panels straight to removal — but the record that says so
+    // lives here, a process away from that rule (#12183).
+    const manager = new PtyManager();
+
+    manager.spawn(
+      "t1",
+      spawnOptions({ launchAgentId: "claude", launchGeneration: 3, isAssistantTerminal: true })
+    );
+    shared.created[0]!.sessionId = "sess-1";
+
+    manager.trash("t1");
+    shared.trashCallbacks.get("t1")!("t1");
+    await vi.waitFor(() => {
+      expect(shared.created[0]!.gracefulShutdownCalled).toBe(true);
+    });
+
+    expect(shared.eventsEmit).not.toHaveBeenCalledWith(
+      "agent-session:captured",
+      expect.anything()
+    );
   });
 
   it("stamps terminalId and launchGeneration on trash-expiry session captures", async () => {

--- a/electron/services/__tests__/PtyManager.lifecycleLedger.test.ts
+++ b/electron/services/__tests__/PtyManager.lifecycleLedger.test.ts
@@ -414,10 +414,7 @@ describe("PtyManager lifecycle ledger", () => {
       expect(shared.created[0]!.gracefulShutdownCalled).toBe(true);
     });
 
-    expect(shared.eventsEmit).not.toHaveBeenCalledWith(
-      "agent-session:captured",
-      expect.anything()
-    );
+    expect(shared.eventsEmit).not.toHaveBeenCalledWith("agent-session:captured", expect.anything());
   });
 
   it("stamps terminalId and launchGeneration on trash-expiry session captures", async () => {

--- a/electron/services/__tests__/assistantTerminal.test.ts
+++ b/electron/services/__tests__/assistantTerminal.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("../AgentAvailabilityStore.js", () => ({
+  getAgentAvailabilityStore: () => ({ isHelpTerminal: (id: string) => id === "marked-help" }),
+}));
+
+import { isAssistantTerminalRecord } from "../assistantTerminal.js";
+
+describe("isAssistantTerminalRecord", () => {
+  it("recognises the spawn-time record stamp", () => {
+    expect(isAssistantTerminalRecord({ id: "t1", isAssistantTerminal: true })).toBe(true);
+  });
+
+  it("falls back to the renderer's availability-store mark", () => {
+    // Covers records with no stamp — one adopted across a pty-host restart,
+    // say — where the renderer's `help.markTerminal` is the only signal.
+    expect(isAssistantTerminalRecord({ id: "marked-help" })).toBe(true);
+  });
+
+  it("treats an ordinary agent pane as adoptable and journalable", () => {
+    expect(isAssistantTerminalRecord({ id: "t1" })).toBe(false);
+    expect(isAssistantTerminalRecord({ id: "t1", isAssistantTerminal: false })).toBe(false);
+  });
+
+  it("fails open when the availability store is unusable", async () => {
+    // This predicate runs inside the shutdown and project-teardown journal
+    // loops, which wrap their work in best-effort catches. A throw here would
+    // be swallowed as "journal nothing at all" and cost every terminal its
+    // resume record — so an unavailable store must degrade to one stray
+    // assistant record, never to a silent loss of all of them.
+    vi.resetModules();
+    vi.doMock("../AgentAvailabilityStore.js", () => ({
+      getAgentAvailabilityStore: () => {
+        throw new Error("store not initialised");
+      },
+    }));
+    const { isAssistantTerminalRecord: predicate } = await import("../assistantTerminal.js");
+
+    expect(predicate({ id: "t1" })).toBe(false);
+    // The record stamp is checked first, so it survives the store being gone.
+    expect(predicate({ id: "t1", isAssistantTerminal: true })).toBe(true);
+
+    vi.doUnmock("../AgentAvailabilityStore.js");
+    vi.resetModules();
+  });
+
+  it("answers false for a missing record rather than throwing", () => {
+    // The teardown paths look records up in a pre-kill snapshot that can miss.
+    expect(isAssistantTerminalRecord(undefined)).toBe(false);
+    expect(isAssistantTerminalRecord(null)).toBe(false);
+  });
+});

--- a/electron/services/__tests__/projectAgentCounts.test.ts
+++ b/electron/services/__tests__/projectAgentCounts.test.ts
@@ -45,6 +45,19 @@ describe("classifyRun", () => {
     expect(classifyRun(agent({ id: "help" }), isHelp)).toBe("help");
   });
 
+  it("reports a stamped assistant as help before the renderer's mark lands", () => {
+    // The mark arrives on a round trip that lands after the PTY exists, so
+    // until this read the assistant tallied as a working agent and showed up
+    // as a fleet queue row during that window (#12183).
+    expect(classifyRun(agent({ id: "unmarked", isAssistantTerminal: true }), isHelp)).toBe("help");
+  });
+
+  it("still checks trashed before the stamp", () => {
+    expect(
+      classifyRun(agent({ id: "unmarked", isAssistantTerminal: true, isTrashed: true }), isHelp)
+    ).toBe("trashed");
+  });
+
   it("reports help before the no-pty and non-agent guards", () => {
     // A dead or unidentified assistant must still classify as help rather than
     // falling through — the tally decision belongs to the caller, not here.

--- a/electron/services/__tests__/terminalInventoryPrefetch.test.ts
+++ b/electron/services/__tests__/terminalInventoryPrefetch.test.ts
@@ -13,8 +13,8 @@ import {
   prefetchTerminalInventory,
 } from "../terminalInventoryPrefetch.js";
 
-function terminal(id: string, kind = "terminal") {
-  return { id, projectId: "p1", kind, title: id, hasPty: true } as never;
+function terminal(id: string, kind = "terminal", extra: Record<string, unknown> = {}) {
+  return { id, projectId: "p1", kind, title: id, hasPty: true, ...extra } as never;
 }
 
 describe("buildTerminalInventory", () => {
@@ -28,6 +28,23 @@ describe("buildTerminalInventory", () => {
     const inventory = await buildTerminalInventory(ptyClient, "p1");
     expect(inventory.map((t) => t.id)).toEqual(["t1"]);
     expect(ptyClient.getTerminalAsync).toHaveBeenCalledTimes(4);
+  });
+
+  it("drops an assistant PTY the renderer has not marked yet", async () => {
+    // #12183: the availability-store mark arrives on a fire-and-forget renderer
+    // round trip that lands AFTER the spawn IPC returned, so between "PTY
+    // exists" and "help.markTerminal processed" this inventory used to report
+    // the assistant — and `restorePanelsPhase` appends anything here with no
+    // saved panel as a grid orphan. The spawn-time record stamp closes that
+    // window, since it is on the record before the PTY is reachable at all.
+    const ptyClient = {
+      getTerminalsForProjectAsync: vi.fn(async () => ["t1", "assistant"]),
+      getTerminalAsync: vi.fn(async (id: string) =>
+        terminal(id, "terminal", id === "assistant" ? { isAssistantTerminal: true } : {})
+      ),
+    };
+    const inventory = await buildTerminalInventory(ptyClient, "p1");
+    expect(inventory.map((t) => t.id)).toEqual(["t1"]);
   });
 });
 

--- a/electron/services/assistantTerminal.ts
+++ b/electron/services/assistantTerminal.ts
@@ -1,10 +1,5 @@
 import { getAgentAvailabilityStore } from "./AgentAvailabilityStore.js";
 
-/**
- * The subset of a backend terminal record this predicate needs. Every generic
- * path already holds something of this shape — the pty-host record, a
- * `getAllTerminalsAsync` snapshot, or a `get-terminal` response.
- */
 export interface AssistantTerminalCandidate {
   id: string;
   isAssistantTerminal?: boolean;
@@ -12,7 +7,8 @@ export interface AssistantTerminalCandidate {
 
 /**
  * Whether a terminal record belongs to the Daintree Assistant overlay rather
- * than the grid.
+ * than the grid. ("Assistant" here is what older main-process code calls
+ * "help".)
  *
  * The single predicate every generic terminal path consults, so the assistant
  * cannot fall into a filter's default "treat as an ordinary pane" bucket the
@@ -21,29 +17,24 @@ export interface AssistantTerminalCandidate {
  *
  * Two sources, deliberately OR'd:
  *
- * - `isAssistantTerminal` — sealed onto the record at spawn from the spawn
- *   handler's validated help token. Authoritative and durable: it is readable
- *   from a snapshot taken before a kill, which is the only thing the teardown
- *   paths have once the PTY is gone.
- * - `AgentAvailabilityStore.isHelpTerminal` — the pre-existing renderer mark
- *   (`help.markTerminal`). Kept as a fallback because it also covers records
- *   that predate the stamp, such as a terminal adopted across a pty-host
- *   restart. On its own it is race-prone: the renderer sends it only after the
- *   spawn IPC has returned, so there is a window where the PTY is live and the
- *   mark has not landed — which is what let hydration adopt the assistant.
+ * - `isAssistantTerminal` — sealed onto the record at spawn. Authoritative:
+ *   it is readable from a snapshot taken before a kill, which is all a
+ *   teardown path has once the PTY is gone.
+ * - `AgentAvailabilityStore.isHelpTerminal` — the renderer's
+ *   `help.markTerminal`, kept as a same-window fallback for unstamped
+ *   records. Not sufficient alone: it lands only after the spawn IPC returns,
+ *   and a second window re-initialises the store and drops it.
  *
- * Neither `HelpSessionService.isHelpTerminal` nor `launchAgentId` works here.
- * The former is a *live binding* that goes false on revoke/displace/unbind, so
- * it is already gone by the time a teardown path journals. The latter is just
- * a launch hint: the assistant can be backed by `claude`/`codex`/`copilot`, so
- * its `launchAgentId` is indistinguishable from a user-launched agent's.
+ * Neither `HelpSessionService.isHelpTerminal` nor `launchAgentId` can stand in
+ * here. The former is a live binding that goes false on revoke/displace, so it
+ * is already gone by the time a teardown path journals. The latter is a launch
+ * hint: the assistant can be backed by `claude`/`codex`/`copilot`, making it
+ * indistinguishable from a user-launched agent.
  *
- * Fails open, and never throws. This runs inside the shutdown and project-
- * teardown journal loops, whose surrounding best-effort catches would turn one
- * throw here into "no resume records for anything" — far worse than the single
- * stray assistant record a false answer costs. The record stamp is consulted
- * first, so a stamped assistant is still skipped even if the store is
- * unavailable.
+ * Fails open. This runs inside best-effort journal loops whose surrounding
+ * catches would turn a throw here into "no resume records for anything" — far
+ * worse than the one stray record a false answer costs. The stamp is checked
+ * first, so a stamped assistant is skipped regardless.
  */
 export function isAssistantTerminalRecord(
   terminal: AssistantTerminalCandidate | null | undefined

--- a/electron/services/assistantTerminal.ts
+++ b/electron/services/assistantTerminal.ts
@@ -1,0 +1,58 @@
+import { getAgentAvailabilityStore } from "./AgentAvailabilityStore.js";
+
+/**
+ * The subset of a backend terminal record this predicate needs. Every generic
+ * path already holds something of this shape — the pty-host record, a
+ * `getAllTerminalsAsync` snapshot, or a `get-terminal` response.
+ */
+export interface AssistantTerminalCandidate {
+  id: string;
+  isAssistantTerminal?: boolean;
+}
+
+/**
+ * Whether a terminal record belongs to the Daintree Assistant overlay rather
+ * than the grid.
+ *
+ * The single predicate every generic terminal path consults, so the assistant
+ * cannot fall into a filter's default "treat as an ordinary pane" bucket the
+ * way it did in #12183 — where a project sleep journaled it into the resume
+ * picker and hydration adopted its live PTY as a grid pane.
+ *
+ * Two sources, deliberately OR'd:
+ *
+ * - `isAssistantTerminal` — sealed onto the record at spawn from the spawn
+ *   handler's validated help token. Authoritative and durable: it is readable
+ *   from a snapshot taken before a kill, which is the only thing the teardown
+ *   paths have once the PTY is gone.
+ * - `AgentAvailabilityStore.isHelpTerminal` — the pre-existing renderer mark
+ *   (`help.markTerminal`). Kept as a fallback because it also covers records
+ *   that predate the stamp, such as a terminal adopted across a pty-host
+ *   restart. On its own it is race-prone: the renderer sends it only after the
+ *   spawn IPC has returned, so there is a window where the PTY is live and the
+ *   mark has not landed — which is what let hydration adopt the assistant.
+ *
+ * Neither `HelpSessionService.isHelpTerminal` nor `launchAgentId` works here.
+ * The former is a *live binding* that goes false on revoke/displace/unbind, so
+ * it is already gone by the time a teardown path journals. The latter is just
+ * a launch hint: the assistant can be backed by `claude`/`codex`/`copilot`, so
+ * its `launchAgentId` is indistinguishable from a user-launched agent's.
+ *
+ * Fails open, and never throws. This runs inside the shutdown and project-
+ * teardown journal loops, whose surrounding best-effort catches would turn one
+ * throw here into "no resume records for anything" — far worse than the single
+ * stray assistant record a false answer costs. The record stamp is consulted
+ * first, so a stamped assistant is still skipped even if the store is
+ * unavailable.
+ */
+export function isAssistantTerminalRecord(
+  terminal: AssistantTerminalCandidate | null | undefined
+): boolean {
+  if (!terminal) return false;
+  if (terminal.isAssistantTerminal === true) return true;
+  try {
+    return getAgentAvailabilityStore().isHelpTerminal(terminal.id) === true;
+  } catch {
+    return false;
+  }
+}

--- a/electron/services/projectAgentCounts.ts
+++ b/electron/services/projectAgentCounts.ts
@@ -98,6 +98,8 @@ export interface CountableTerminal {
   detectedAgentId?: string;
   launchAgentId?: string;
   everDetectedAgent?: boolean;
+  /** Sealed at spawn: this PTY backs the Daintree Assistant overlay (#12183). */
+  isAssistantTerminal?: boolean;
   /**
    * When this PTY was spawned. Read only to tell one assistant session from
    * another during a displacement — `AgentStateService` already treats it as
@@ -144,6 +146,13 @@ export function classifyRun(
   // counts as an agent. Named rather than silently dropped so callers can net
   // it out of a process count the host already included it in, and so its
   // state can be carried as presence instead of vanishing (#11806).
+  //
+  // The record stamp is checked first because the callback reads a mark the
+  // renderer sends only after the spawn IPC returns, leaving a window where a
+  // live assistant tallies as a working agent (#12183). Read inline rather
+  // than through `isAssistantTerminalRecord` so this stays importable from the
+  // pty-host, which has no availability store.
+  if (terminal.isAssistantTerminal === true) return "help";
   if (terminal.id !== undefined && isHelpTerminal(terminal.id)) return "help";
 
   if (terminal.kind === "dev-preview") return "dev-preview";

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -384,6 +384,7 @@ export class TerminalProcess {
       titleMode: options.titleMode ?? "default",
       command: options.command,
       launchAgentId,
+      isAssistantTerminal: options.isAssistantTerminal,
       spawnedAt,
       // If we launched an agent, seed its state as "idle" — the activity
       // monitor will update it as soon as the pty produces output. Plain

--- a/electron/services/pty/__tests__/projectSessionJournal.test.ts
+++ b/electron/services/pty/__tests__/projectSessionJournal.test.ts
@@ -21,6 +21,12 @@ const projectStoreMock = vi.hoisted(() => ({
 }));
 vi.mock("../../ProjectStore.js", () => ({ projectStore: projectStoreMock }));
 
+// The assistant-terminal predicate falls back to this store for records that
+// predate the spawn-time stamp; faked so both of its branches are exercised.
+vi.mock("../../AgentAvailabilityStore.js", () => ({
+  getAgentAvailabilityStore: () => ({ isHelpTerminal: (id: string) => id === "marked-help" }),
+}));
+
 import { gracefulTeardownAndJournalProject } from "../projectSessionJournal.js";
 import type { PtyClient } from "../../PtyClient.js";
 import type { WorkspaceClient } from "../../WorkspaceClient.js";
@@ -36,6 +42,7 @@ interface FakeTerminal {
   cwd: string;
   agentLaunchFlags?: string[];
   agentModelId?: string;
+  isAssistantTerminal?: boolean;
   spawnedAt: number;
 }
 
@@ -508,6 +515,98 @@ describe("gracefulTeardownAndJournalProject", () => {
 
       expect(result.confirmed).toBe(true);
       expect(journalMock.journalAgentSession).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("the assistant's overlay terminal", () => {
+    it("journals neither the record nor the session-id writeback for it", async () => {
+      // #12183: a sleep used to journal the assistant as an ordinary
+      // AgentSessionRecord, and after a sleep it is usually the newest one —
+      // so the empty-grid resume line offered to reopen the assistant's
+      // conversation as a grid pane running the underlying CLI.
+      const { client } = makePtyClient({
+        terminals: [
+          {
+            id: "assistant",
+            projectId: "proj",
+            launchAgentId: "claude",
+            isAssistantTerminal: true,
+            cwd: "/root",
+            spawnedAt: 1,
+          },
+          { id: "t1", projectId: "proj", launchAgentId: "claude", cwd: "/a", spawnedAt: 1 },
+        ],
+        outcome: {
+          confirmed: true,
+          sessions: [
+            { id: "assistant", agentSessionId: "assistant-session" },
+            { id: "t1", agentSessionId: "s1" },
+          ],
+        },
+      });
+
+      await gracefulTeardownAndJournalProject("proj", client, undefined, {
+        writeBackSessionIds: true,
+      });
+
+      // The ordinary pane beside it still journals — the skip is targeted, not
+      // a blanket bail-out of the teardown's journaling.
+      expect(journalMock.journalAgentSession).toHaveBeenCalledTimes(1);
+      const [record] = journalMock.journalAgentSession.mock.calls[0]!;
+      expect(record).toMatchObject({ sessionId: "s1" });
+
+      const [, updater] = projectStoreMock.enqueueProjectStateUpdate.mock.calls[0]!;
+      const state = {
+        terminals: [
+          { id: "assistant", agentSessionId: undefined },
+          { id: "t1", agentSessionId: undefined },
+        ],
+      };
+      updater(state);
+      expect(state.terminals).toEqual([
+        { id: "assistant", agentSessionId: undefined },
+        { id: "t1", agentSessionId: "s1" },
+      ]);
+    });
+
+    it("skips the writeback entirely when the assistant is the only capture", async () => {
+      const { client } = makePtyClient({
+        terminals: [
+          {
+            id: "assistant",
+            projectId: "proj",
+            launchAgentId: "claude",
+            isAssistantTerminal: true,
+            cwd: "/root",
+            spawnedAt: 1,
+          },
+        ],
+        outcome: { confirmed: true, sessions: [{ id: "assistant", agentSessionId: "a1" }] },
+      });
+
+      const result = await gracefulTeardownAndJournalProject("proj", client, undefined, {
+        writeBackSessionIds: true,
+      });
+
+      expect(result.confirmed).toBe(true);
+      expect(projectStoreMock.enqueueProjectStateUpdate).not.toHaveBeenCalled();
+      expect(journalMock.journalAgentSession).not.toHaveBeenCalled();
+    });
+
+    it("still recognises a record marked only through the availability store", async () => {
+      // Covers a terminal that predates the spawn-time stamp — adopted across
+      // a pty-host restart, say — where the renderer's `help.markTerminal` is
+      // the only signal there is.
+      const { client } = makePtyClient({
+        terminals: [
+          { id: "marked-help", projectId: "proj", launchAgentId: "claude", cwd: "/r", spawnedAt: 1 },
+        ],
+        outcome: { confirmed: true, sessions: [{ id: "marked-help", agentSessionId: "s1" }] },
+      });
+
+      await gracefulTeardownAndJournalProject("proj", client);
+
+      expect(journalMock.journalAgentSession).not.toHaveBeenCalled();
     });
   });
 });

--- a/electron/services/pty/__tests__/projectSessionJournal.test.ts
+++ b/electron/services/pty/__tests__/projectSessionJournal.test.ts
@@ -599,7 +599,13 @@ describe("gracefulTeardownAndJournalProject", () => {
       // the only signal there is.
       const { client } = makePtyClient({
         terminals: [
-          { id: "marked-help", projectId: "proj", launchAgentId: "claude", cwd: "/r", spawnedAt: 1 },
+          {
+            id: "marked-help",
+            projectId: "proj",
+            launchAgentId: "claude",
+            cwd: "/r",
+            spawnedAt: 1,
+          },
         ],
         outcome: { confirmed: true, sessions: [{ id: "marked-help", agentSessionId: "s1" }] },
       });

--- a/electron/services/pty/projectSessionJournal.ts
+++ b/electron/services/pty/projectSessionJournal.ts
@@ -2,6 +2,7 @@ import type { PtyClient } from "../PtyClient.js";
 import type { WorkspaceClient } from "../WorkspaceClient.js";
 import { getLifecycleLedger } from "./lifecycleLedger.js";
 import { journalAgentSession } from "./agentSessionJournal.js";
+import { isAssistantTerminalRecord } from "../assistantTerminal.js";
 import { projectStore } from "../ProjectStore.js";
 import { createLogger } from "../../utils/logger.js";
 
@@ -96,6 +97,15 @@ export async function gracefulTeardownAndJournalProject(
     [...infoById.keys()].map((id) => [id, ledger.currentGeneration(id)])
   );
 
+  // The Daintree Assistant's overlay terminal is not a grid pane, so it must
+  // reach neither the resume picker nor a saved terminal snapshot (#12183).
+  // Resolved against the pre-kill info snapshot for the same reason the
+  // generation is frozen above: by the time the writeback and journal loop run
+  // the PTY is dead and its live help-session binding has been torn down, so
+  // asking a session service after the fact would answer "not the assistant".
+  const isAssistant = (id: string): boolean =>
+    isAssistantTerminalRecord(infoById.get(id) ?? { id });
+
   const outcome = await ptyClient.gracefulKillByProjectConfirmed(
     scopeId,
     options.preserveSession !== undefined ? { preserveSession: options.preserveSession } : undefined
@@ -106,7 +116,7 @@ export async function gracefulTeardownAndJournalProject(
   // resume each agent in place, the journal is what the session picker reads.
   // Only callers that keep the restoration state ask for this.
   if (options.writeBackSessionIds) {
-    const capturedIds = outcome.sessions.filter((r) => r.agentSessionId);
+    const capturedIds = outcome.sessions.filter((r) => r.agentSessionId && !isAssistant(r.id));
     if (capturedIds.length > 0) {
       try {
         await projectStore.enqueueProjectStateUpdate(scopeId, (state) => {
@@ -129,7 +139,7 @@ export async function gracefulTeardownAndJournalProject(
   }
 
   const captured = outcome.sessions
-    .filter((r) => r.agentSessionId)
+    .filter((r) => r.agentSessionId && !isAssistant(r.id))
     .map((r) => ({ result: r, info: infoById.get(r.id) }))
     .filter((c): c is { result: (typeof c)["result"]; info: NonNullable<(typeof c)["info"]> } =>
       Boolean(c.info?.launchAgentId)

--- a/electron/services/pty/types.ts
+++ b/electron/services/pty/types.ts
@@ -37,6 +37,13 @@ export interface TerminalPublicState {
    * restored agent terminals branded until explicit exit.
    */
   launchAgentId?: AgentId;
+  /**
+   * This PTY backs the Daintree Assistant overlay rather than a grid pane.
+   * Sealed at spawn and never cleared, so a generic path can recognise the
+   * assistant from a record snapshot taken before the kill — the live
+   * help-session binding is gone by then. See `isAssistantTerminalRecord`.
+   */
+  isAssistantTerminal?: boolean;
   title?: string;
   titleMode?: PanelTitleMode;
   /** Command submitted immediately after shell spawn, if any. */

--- a/electron/services/pty/types.ts
+++ b/electron/services/pty/types.ts
@@ -38,10 +38,9 @@ export interface TerminalPublicState {
    */
   launchAgentId?: AgentId;
   /**
-   * This PTY backs the Daintree Assistant overlay rather than a grid pane.
-   * Sealed at spawn and never cleared, so a generic path can recognise the
-   * assistant from a record snapshot taken before the kill — the live
-   * help-session binding is gone by then. See `isAssistantTerminalRecord`.
+   * This PTY backs the Daintree Assistant overlay, not a grid pane. Sealed at
+   * spawn so a teardown path can still recognise it from a pre-kill snapshot.
+   * See `isAssistantTerminalRecord`.
    */
   isAssistantTerminal?: boolean;
   title?: string;

--- a/electron/services/terminalInventoryPrefetch.ts
+++ b/electron/services/terminalInventoryPrefetch.ts
@@ -1,6 +1,6 @@
 import type { BackendTerminalInfo } from "../../shared/types/ipc.js";
 import type { PtyClient } from "./PtyClient.js";
-import { getAgentAvailabilityStore } from "./AgentAvailabilityStore.js";
+import { isAssistantTerminalRecord } from "./assistantTerminal.js";
 import { logInfo } from "../utils/logger.js";
 
 /**
@@ -39,13 +39,13 @@ export async function buildTerminalInventory(
 
   const terminals: BackendTerminalInfo[] = [];
   for (const terminal of infos) {
-    // Dev preview and help PTYs should not be rehydrated as generic terminal
-    // panels during project switching/hydration.
-    if (
-      terminal &&
-      terminal.kind !== "dev-preview" &&
-      !getAgentAvailabilityStore().isHelpTerminal(terminal.id)
-    ) {
+    // Dev preview and assistant PTYs should not be rehydrated as generic
+    // terminal panels during project switching/hydration. The assistant's
+    // terminal never has a saved panel, so anything left in this inventory is
+    // appended by `restorePanelsPhase` as a grid orphan (#12183) — which is
+    // how a renderer crash could surface the assistant's conversation as a
+    // pane in the main area.
+    if (terminal && terminal.kind !== "dev-preview" && !isAssistantTerminalRecord(terminal)) {
       terminals.push({
         id: terminal.id,
         projectId: terminal.projectId,

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -65,12 +65,8 @@ export interface PtyHostSpawnOptions {
   isEphemeral?: boolean;
   /**
    * This PTY backs the Daintree Assistant overlay rather than a grid pane.
-   *
-   * Stamped by Main from the spawn handler's already-validated `isHelpLaunch`
-   * — never from a renderer-supplied field, which would let any pane claim
-   * assistant status and opt itself out of journaling. Durable on the record
-   * so the generic terminal paths can still recognise it from a pre-kill
-   * snapshot, long after the live help-session binding has been torn down.
+   * Stamped by Main from a validated help token — never from a renderer field,
+   * which would let any pane opt itself out of journaling.
    */
   isAssistantTerminal?: boolean;
   /** Process-level flags captured at launch time (e.g. --dangerously-skip-permissions) */

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -63,6 +63,16 @@ export interface PtyHostSpawnOptions {
   restore?: boolean;
   /** Whether to kill the PTY when the frontend disconnects (no terminal registry entry) */
   isEphemeral?: boolean;
+  /**
+   * This PTY backs the Daintree Assistant overlay rather than a grid pane.
+   *
+   * Stamped by Main from the spawn handler's already-validated `isHelpLaunch`
+   * — never from a renderer-supplied field, which would let any pane claim
+   * assistant status and opt itself out of journaling. Durable on the record
+   * so the generic terminal paths can still recognise it from a pre-kill
+   * snapshot, long after the live help-session binding has been torn down.
+   */
+  isAssistantTerminal?: boolean;
   /** Process-level flags captured at launch time (e.g. --dangerously-skip-permissions) */
   agentLaunchFlags?: string[];
   /** Model ID selected at launch time for per-panel model selection */
@@ -856,6 +866,8 @@ export interface PtyHostTerminalInfo {
   id: string;
   projectId?: string;
   kind?: PanelKind;
+  /** This PTY backs the Daintree Assistant overlay, not a grid pane. */
+  isAssistantTerminal?: boolean;
   /** Launch hint — agent this terminal was launched to run. Not identity. */
   launchAgentId?: AgentId;
   title?: string;

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -65,7 +65,8 @@ export interface PtyHostSpawnOptions {
   isEphemeral?: boolean;
   /**
    * This PTY backs the Daintree Assistant overlay rather than a grid pane.
-   * Stamped by Main from a validated help token — never from a renderer field,
+   * Stamped by Main from a validated help token, or from the live help-session
+   * binding when a restart respawns without one — never from a renderer field,
    * which would let any pane opt itself out of journaling.
    */
   isAssistantTerminal?: boolean;


### PR DESCRIPTION
## Summary

- Nothing on the PTY host's terminal record indicated a terminal belonged to the Daintree Assistant overlay. The renderer knew (`location: "overlay"`, `excludeFromPersistence`, `removeOnExit`), but none of it reached the backend, so every main-side path that treats terminals generically treated the assistant's the same as an ordinary agent pane.
- A project sleep or close journaled it as a normal `AgentSessionRecord`, usually the newest for the project, so the empty-grid resume line offered to reopen the assistant's conversation as a pane running the underlying CLI. Hydration's `restorePanelsPhase` also appended its live PTY as a grid orphan, since the assistant never has a saved panel by design (a renderer crash is the easiest way to trigger it).
- The fix stamps the record at spawn with a single `isAssistantTerminal` field, and every generic backend path now checks it through one shared predicate.

Resolves #12183

## Problem

A user reported the assistant's conversation opening as a pane in the main area after reopening a project. Both routes above produce exactly that, and neither the journal nor `buildResumeSessionItems` nor the orphan-adoption filter had any way to tell the assistant's terminal apart from a real one.

## Approach

The spawn handler already computed `isHelpLaunch` from a validated help token, to gate MCP command mutation, then discarded it. It's now preserved as `isAssistantTerminal` and threaded through to main's readback of the terminal record, so generic paths can recognize the assistant from a record snapshot taken *before* the process is killed.

That timing matters. By the time journaling runs, the two live signals that could otherwise identify the assistant's terminal are both gone: `HelpSessionService`'s binding is dropped on revoke or displacement, and the renderer's `help.markTerminal` mark lands only after the spawn IPC call returns, too late to stop the orphan-adoption race.

The field is derived only in the main process, never supplied by the renderer. A renderer-supplied flag would let any pane assert its way out of journaling.

One shared predicate, `isAssistantTerminalRecord`, is what every generic path now consults, so the assistant can't fall into a filter's default "ordinary pane" bucket again. That covers the journal write and session-id writeback on project sleep and close, the identical block at app shutdown, the kill and graceful-kill close path, trash-expiry capture, `buildTerminalInventory` (hydration's orphan-adoption source), `terminal:reconnect` (hydration's fallback), and `classifyRun`, shared by the per-project agent tallies and the fleet snapshot.

One more wrinkle worth flagging: the stamp survives a restart. `buildRestartEnv` rebuilds the environment without the help token, so `isHelpLaunch` comes back false on a respawn, and "Restart All Terminals" would have silently stripped the assistant's identity. The fix reads a second source, the live session binding, which does survive a restart's kill step, to cover that case.

## Testing

- 859 tests across 30 files pass locally.
- Typecheck is clean.
- Prettier and eslint are clean on the changed files, zero errors.
- New coverage pins the spawn stamp, the restart respawn, the close path the assistant travels on every close, the sleep and quit journal skips plus both writebacks, the reconnect guard, the inventory race, the trash-expiry guard, the `classifyRun` stamp, and the `mapTerminalInfo` readback.

## Follow-ups (out of scope)

- Related to #12181: with journaling suppressed, the assistant's hibernation entry becomes the surviving copy of the conversation after a sleep, which is exactly what #12181 fixes. The two are complementary regardless of which teardown path #12181 lands on.
- `initializeAgentAvailabilityStore()` runs per `createWindow` and disposes the singleton, so opening a second window clears `helpTerminalIds`. Pre-existing, affects availability counts and quit warnings beyond this issue.
- `bulkRestartAll` includes the assistant's overlay pane, and the respawn carries no `DAINTREE_MCP_TOKEN` while `HelpSessionService` keeps its old binding, i.e. a silently MCP-dead assistant after a bulk restart. Pre-existing and separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AcsbXSFEyjQNp3tbKmnF6k