### PR TITLE
fix(notifications): disable sound and all-clear flash by default

### DIFF
--- a/electron/ipc/handlers/__tests__/notifications.adversarial.test.ts
+++ b/electron/ipc/handlers/__tests__/notifications.adversarial.test.ts
@@ -213,6 +213,28 @@ describe("notifications IPC adversarial", () => {
     expect(soundServiceMock.play).not.toHaveBeenCalled();
   });
 
+  it("playUiEvent is gated on soundEnabled=false even when uiFeedbackSoundEnabled=true (#12185)", async () => {
+    storeMock.get.mockReturnValue({
+      ...defaultSettings,
+      soundEnabled: false,
+      uiFeedbackSoundEnabled: true,
+    });
+
+    await getHandler(CHANNELS.SOUND_PLAY_UI_EVENT)(fakeEvent(), "click");
+    expect(soundServiceMock.play).not.toHaveBeenCalled();
+  });
+
+  it("playUiEvent plays when both soundEnabled and uiFeedbackSoundEnabled are true", async () => {
+    storeMock.get.mockReturnValue({
+      ...defaultSettings,
+      soundEnabled: true,
+      uiFeedbackSoundEnabled: true,
+    });
+
+    await getHandler(CHANNELS.SOUND_PLAY_UI_EVENT)(fakeEvent(), "click");
+    expect(soundServiceMock.play).toHaveBeenCalledWith("click");
+  });
+
   it("syncWatched filters non-string entries from the id array", async () => {
     getListener(CHANNELS.NOTIFICATION_SYNC_WATCHED)(
       fakeEvent(createSender(7)) as Electron.IpcMainEvent,

--- a/electron/ipc/handlers/__tests__/worktree.adversarial.test.ts
+++ b/electron/ipc/handlers/__tests__/worktree.adversarial.test.ts
@@ -279,7 +279,9 @@ describe("worktree IPC adversarial", () => {
       throw new Error("fs cache unreachable");
     });
     storeMock.get.mockImplementation(
-      baseStoreGetImpl({ notificationSettings: { uiFeedbackSoundEnabled: true } })
+      baseStoreGetImpl({
+        notificationSettings: { soundEnabled: true, uiFeedbackSoundEnabled: true },
+      })
     );
     worktreeService.createWorktree.mockResolvedValue("wt-1");
 

--- a/electron/ipc/handlers/git-write.ts
+++ b/electron/ipc/handlers/git-write.ts
@@ -42,10 +42,12 @@ import {
   STAGED_FILE_SIZE_CAP,
   scanStagedFilesForConflictMarkers,
 } from "../../services/git/conflictMarkerScan.js";
+import { shouldPlayUiFeedbackSound } from "../../utils/uiFeedbackSound.js";
 
 type SoundId = keyof typeof SoundServiceModule.SOUND_FILES;
 
 function playSoundFireAndForget(id: SoundId): void {
+  if (!shouldPlayUiFeedbackSound(store.get("notificationSettings"))) return;
   void getSoundService()
     .then((svc) => svc.play(id))
     .catch((err) => console.error("[git-write] sound play failed:", err));

--- a/electron/ipc/handlers/notifications.ts
+++ b/electron/ipc/handlers/notifications.ts
@@ -19,6 +19,7 @@ import type { HandlerDependencies } from "../types.js";
 import type { NotificationSettings } from "../../../shared/types/ipc/api.js";
 import { typedHandle } from "../utils.js";
 import { sanitizeNotificationSettingsPatch } from "../../utils/notificationSettingsPatch.js";
+import { shouldPlayUiFeedbackSound } from "../../utils/uiFeedbackSound.js";
 
 type SoundId = keyof typeof SoundServiceModule.SOUND_FILES;
 type AgentNotificationSingleton = typeof AgentNotificationServiceModule.agentNotificationService;
@@ -136,7 +137,7 @@ export function registerNotificationHandlers(deps: HandlerDependencies): () => v
     if (typeof soundId !== "string") return;
     const SOUNDS = await soundFiles();
     if (!(soundId in SOUNDS)) return;
-    if (!store.get("notificationSettings").uiFeedbackSoundEnabled) return;
+    if (!shouldPlayUiFeedbackSound(store.get("notificationSettings"))) return;
     const sound = await getSoundService();
     sound.play(soundId as SoundId);
   };

--- a/electron/ipc/handlers/worktree/lifecycle.ts
+++ b/electron/ipc/handlers/worktree/lifecycle.ts
@@ -28,12 +28,14 @@ import {
   WORKTREE_RATE_LIMIT_INTERVAL_MS,
   WORKTREE_RATE_LIMIT_BURST,
 } from "./constants.js";
+import { shouldPlayUiFeedbackSound } from "../../../utils/uiFeedbackSound.js";
 
 type SoundId = keyof typeof SoundServiceModule.SOUND_FILES;
 
 const inFlightWorktreeCreateRequests = new Map<string, Promise<WorktreeCreateResult>>();
 
 function playSoundFireAndForget(id: SoundId): void {
+  if (!shouldPlayUiFeedbackSound(store.get("notificationSettings"))) return;
   void getSoundService()
     .then((svc) => svc.play(id))
     .catch((err) => console.error("[worktree.lifecycle] sound play failed:", err));

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -2496,6 +2496,7 @@ function buildElectronApi(): ElectronAPI {
         workingPulseEnabled: boolean;
         workingPulseSoundFile: string;
         uiFeedbackSoundEnabled: boolean;
+        flashEnabled: boolean;
         quietHoursEnabled: boolean;
         quietHoursStartMin: number;
         quietHoursEndMin: number;
@@ -2515,6 +2516,7 @@ function buildElectronApi(): ElectronAPI {
           workingPulseEnabled: boolean;
           workingPulseSoundFile: string;
           uiFeedbackSoundEnabled: boolean;
+          flashEnabled: boolean;
           quietHoursEnabled: boolean;
           quietHoursStartMin: number;
           quietHoursEndMin: number;

--- a/electron/services/AgentNotificationService.ts
+++ b/electron/services/AgentNotificationService.ts
@@ -11,6 +11,7 @@ import { soundService } from "./SoundService.js";
 import { CHANNELS } from "../ipc/channels.js";
 import { isScheduledQuietNow } from "../../shared/utils/quietHours.js";
 import { getOsDndService } from "./OsDndService.js";
+import { shouldPlayUiFeedbackSound } from "../utils/uiFeedbackSound.js";
 import { coerceWaitingReason, type WaitingReason } from "../../shared/types/agent.js";
 import {
   actionableWaitingReason,
@@ -251,7 +252,11 @@ class AgentNotificationService {
         this.agentSpawnTimestamps.set(agentKey, Date.now());
       }
       const settings = projectStore.getEffectiveNotificationSettings();
-      if (settings.uiFeedbackSoundEnabled && !this.isWithinBootGrace() && !this.isSessionMuted()) {
+      if (
+        shouldPlayUiFeedbackSound(settings) &&
+        !this.isWithinBootGrace() &&
+        !this.isSessionMuted()
+      ) {
         if (!isScheduledQuietNow(settings)) {
           soundService.play("agent-spawned");
         }

--- a/electron/services/ProjectSettingsManager.ts
+++ b/electron/services/ProjectSettingsManager.ts
@@ -48,6 +48,7 @@ export class ProjectSettingsManager {
       workingPulseEnabled: overrides.workingPulseEnabled ?? global.workingPulseEnabled,
       workingPulseSoundFile: overrides.workingPulseSoundFile ?? global.workingPulseSoundFile,
       uiFeedbackSoundEnabled: global.uiFeedbackSoundEnabled,
+      flashEnabled: global.flashEnabled,
       quietHoursEnabled: global.quietHoursEnabled,
       quietHoursStartMin: global.quietHoursStartMin,
       quietHoursEndMin: global.quietHoursEndMin,

--- a/electron/services/StoreMigrations.ts
+++ b/electron/services/StoreMigrations.ts
@@ -7,7 +7,7 @@ import { z } from "zod";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 import { getCurrentDiskSpaceStatus } from "./DiskSpaceMonitor.js";
 
-export const LATEST_SCHEMA_VERSION = 27;
+export const LATEST_SCHEMA_VERSION = 28;
 
 export interface Migration {
   version: number;

--- a/electron/services/__tests__/AgentNotificationService.allClear.test.ts
+++ b/electron/services/__tests__/AgentNotificationService.allClear.test.ts
@@ -69,6 +69,7 @@ const DEFAULT_SETTINGS = {
   workingPulseEnabled: false,
   workingPulseSoundFile: "pulse.wav",
   uiFeedbackSoundEnabled: false,
+  flashEnabled: false,
   quietHoursEnabled: false,
   quietHoursStartMin: 22 * 60,
   quietHoursEndMin: 6 * 60,

--- a/electron/services/__tests__/AgentNotificationService.test.ts
+++ b/electron/services/__tests__/AgentNotificationService.test.ts
@@ -1205,7 +1205,7 @@ describe("AgentNotificationService", () => {
 
   describe("agent:spawned UI feedback sound", () => {
     it("plays agent-spawned sound when uiFeedbackSoundEnabled is true", () => {
-      mockStore({ uiFeedbackSoundEnabled: true });
+      mockStore({ soundEnabled: true, uiFeedbackSoundEnabled: true });
 
       // Advance past boot grace period so the sound is not suppressed
       vi.advanceTimersByTime(10_000);
@@ -1221,7 +1221,22 @@ describe("AgentNotificationService", () => {
     });
 
     it("does not play agent-spawned sound when uiFeedbackSoundEnabled is false", () => {
-      mockStore({ uiFeedbackSoundEnabled: false });
+      mockStore({ soundEnabled: true, uiFeedbackSoundEnabled: false });
+
+      vi.advanceTimersByTime(10_000);
+
+      events.emit("agent:spawned", {
+        terminalId: "term-1",
+        agentId: "claude",
+        worktreeId: "wt-1",
+        timestamp: Date.now(),
+      });
+
+      expect(soundServiceMock.play).not.toHaveBeenCalled();
+    });
+
+    it("does not play agent-spawned sound when soundEnabled is false, even if uiFeedbackSoundEnabled is true (#12185)", () => {
+      mockStore({ soundEnabled: false, uiFeedbackSoundEnabled: true });
 
       vi.advanceTimersByTime(10_000);
 
@@ -1236,7 +1251,7 @@ describe("AgentNotificationService", () => {
     });
 
     it("suppresses agent-spawned sound during boot grace period", () => {
-      mockStore({ uiFeedbackSoundEnabled: true });
+      mockStore({ soundEnabled: true, uiFeedbackSoundEnabled: true });
 
       // Emit immediately after initialization (within boot grace)
       events.emit("agent:spawned", {
@@ -1252,6 +1267,7 @@ describe("AgentNotificationService", () => {
     it("suppresses agent-spawned sound during quiet hours", () => {
       // Set quiet hours 22:00–06:00, fix time at midnight so it falls within the window
       mockStore({
+        soundEnabled: true,
         uiFeedbackSoundEnabled: true,
         quietHoursEnabled: true,
         quietHoursStartMin: 22 * 60,
@@ -1274,7 +1290,7 @@ describe("AgentNotificationService", () => {
     });
 
     it("suppresses agent-spawned sound during session mute", () => {
-      mockStore({ uiFeedbackSoundEnabled: true });
+      mockStore({ soundEnabled: true, uiFeedbackSoundEnabled: true });
 
       // Mute for 60 seconds from now
       agentNotificationService.setSessionMuteUntil(Date.now() + 60_000);

--- a/electron/services/migrations/028-quiet-sound-and-flash-defaults.ts
+++ b/electron/services/migrations/028-quiet-sound-and-flash-defaults.ts
@@ -1,0 +1,41 @@
+import type { Migration } from "../StoreMigrations.js";
+
+export const migration028: Migration = {
+  version: 28,
+  description: "Default sound and the all-clear flash off for existing installs (#12185)",
+  up: (store) => {
+    const settings = store.get("notificationSettings") as Record<string, unknown> | undefined;
+
+    if (!settings) {
+      console.log("[Migration 028] No notificationSettings found, skipping");
+      return;
+    }
+
+    const changes: Record<string, unknown> = {};
+
+    // soundEnabled was the last non-quiet default left in the soundscape
+    // (#12185) — force it off like migration011 did for the others,
+    // regardless of whether a persisted `true` is a deliberate choice or
+    // just the old default. There is no way to tell the two apart, and
+    // re-enabling costs one click in Settings.
+    if (settings.soundEnabled !== false) {
+      changes.soundEnabled = false;
+    }
+
+    // flashEnabled is a brand-new field. electron-store's defaults merge is
+    // shallow, so every existing install is missing it from its persisted
+    // notificationSettings blob and would otherwise read back `undefined`
+    // forever — backfill it off, matching the sound default it is paired
+    // with.
+    if (typeof settings.flashEnabled !== "boolean") {
+      changes.flashEnabled = false;
+    }
+
+    if (Object.keys(changes).length > 0) {
+      console.log("[Migration 028] Applying quiet sound/flash defaults:", Object.keys(changes));
+      store.set("notificationSettings", { ...settings, ...changes });
+    } else {
+      console.log("[Migration 028] Settings already quiet, skipping");
+    }
+  },
+};

--- a/electron/services/migrations/__tests__/028-quiet-sound-and-flash-defaults.test.ts
+++ b/electron/services/migrations/__tests__/028-quiet-sound-and-flash-defaults.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from "vitest";
+import { migration028 } from "../028-quiet-sound-and-flash-defaults.js";
+
+function makeStoreMock(data: Record<string, unknown>) {
+  return {
+    get: vi.fn((key: string) => data[key]),
+    set: vi.fn((key: string, value: unknown) => {
+      data[key] = value;
+    }),
+  } as unknown as Parameters<typeof migration028.up>[0];
+}
+
+describe("migration028 — quiet sound and flash defaults", () => {
+  it("has version 28", () => {
+    expect(migration028.version).toBe(28);
+  });
+
+  it("flips a persisted soundEnabled:true to false and backfills flashEnabled:false", () => {
+    const data: Record<string, unknown> = {
+      notificationSettings: { enabled: true, soundEnabled: true },
+    };
+    const store = makeStoreMock(data);
+    migration028.up(store);
+
+    const after = data.notificationSettings as Record<string, unknown>;
+    expect(after.soundEnabled).toBe(false);
+    expect(after.flashEnabled).toBe(false);
+  });
+
+  it("forces a corrupted, non-boolean soundEnabled to false too", () => {
+    const data: Record<string, unknown> = {
+      notificationSettings: { soundEnabled: "true" },
+    };
+    const store = makeStoreMock(data);
+    migration028.up(store);
+
+    expect((data.notificationSettings as Record<string, unknown>).soundEnabled).toBe(false);
+  });
+
+  it("leaves an already-false soundEnabled alone", () => {
+    const data: Record<string, unknown> = {
+      notificationSettings: { soundEnabled: false, flashEnabled: false },
+    };
+    const store = makeStoreMock(data);
+    migration028.up(store);
+
+    expect(store.set).not.toHaveBeenCalled();
+  });
+
+  it("is idempotent — running twice does not re-apply", () => {
+    const data: Record<string, unknown> = {
+      notificationSettings: { soundEnabled: true },
+    };
+    const store = makeStoreMock(data);
+    migration028.up(store);
+    const firstCallCount = (store.set as ReturnType<typeof vi.fn>).mock.calls.length;
+
+    migration028.up(store);
+    const secondCallCount = (store.set as ReturnType<typeof vi.fn>).mock.calls.length;
+
+    expect(secondCallCount).toBe(firstCallCount);
+  });
+
+  it("no-op when notificationSettings is missing", () => {
+    const store = makeStoreMock({});
+    migration028.up(store);
+    expect(store.set).not.toHaveBeenCalled();
+  });
+
+  it("preserves unrelated fields, including a user's other customized settings", () => {
+    const data: Record<string, unknown> = {
+      notificationSettings: {
+        soundEnabled: true,
+        completedEnabled: true,
+        completedSoundFile: "user-completed.wav",
+      },
+    };
+    const store = makeStoreMock(data);
+    migration028.up(store);
+
+    const after = data.notificationSettings as Record<string, unknown>;
+    expect(after.completedEnabled).toBe(true);
+    expect(after.completedSoundFile).toBe("user-completed.wav");
+  });
+});

--- a/electron/services/migrations/index.ts
+++ b/electron/services/migrations/index.ts
@@ -24,6 +24,7 @@ import { migration024 } from "./024-backfill-github-forge-credential.js";
 import { migration025 } from "./025-upgrade-voice-correction-model.js";
 import { migration026 } from "./026-remove-full-tool-surface.js";
 import { migration027 } from "./027-upgrade-voice-transcription-model.js";
+import { migration028 } from "./028-quiet-sound-and-flash-defaults.js";
 
 export const migrations: Migration[] = [
   migration002,
@@ -52,4 +53,5 @@ export const migrations: Migration[] = [
   migration025,
   migration026,
   migration027,
+  migration028,
 ];

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -224,6 +224,7 @@ export interface StoreSchema {
     workingPulseEnabled: boolean;
     workingPulseSoundFile: string;
     uiFeedbackSoundEnabled: boolean;
+    flashEnabled: boolean;
     quietHoursEnabled: boolean;
     quietHoursStartMin: number;
     quietHoursEndMin: number;
@@ -631,6 +632,7 @@ const storeOptions = {
       workingPulseEnabled: false,
       workingPulseSoundFile: "pulse.wav",
       uiFeedbackSoundEnabled: false,
+      flashEnabled: false,
       quietHoursEnabled: false,
       quietHoursStartMin: 22 * 60,
       quietHoursEndMin: 8 * 60,

--- a/electron/utils/__tests__/notificationSettingsPatch.test.ts
+++ b/electron/utils/__tests__/notificationSettingsPatch.test.ts
@@ -18,6 +18,15 @@ describe("sanitizeNotificationSettingsPatch", () => {
     expect(result).not.toHaveProperty("enabled");
   });
 
+  it("accepts flashEnabled and drops a non-boolean value for it", () => {
+    expect(sanitizeNotificationSettingsPatch({ flashEnabled: true }, ALLOWED)).toEqual({
+      flashEnabled: true,
+    });
+    expect(sanitizeNotificationSettingsPatch({ flashEnabled: "true" }, ALLOWED)).not.toHaveProperty(
+      "flashEnabled"
+    );
+  });
+
   it("drops a sound file that isn't available and keeps one that is", () => {
     const result = sanitizeNotificationSettingsPatch(
       { completedSoundFile: "missing.wav", waitingSoundFile: "ping.wav" },

--- a/electron/utils/__tests__/uiFeedbackSound.test.ts
+++ b/electron/utils/__tests__/uiFeedbackSound.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { shouldPlayUiFeedbackSound } from "../uiFeedbackSound.js";
+
+describe("shouldPlayUiFeedbackSound", () => {
+  it("plays when both soundEnabled and uiFeedbackSoundEnabled are true", () => {
+    expect(shouldPlayUiFeedbackSound({ soundEnabled: true, uiFeedbackSoundEnabled: true })).toBe(
+      true
+    );
+  });
+
+  it("stays silent when soundEnabled is off, even with uiFeedbackSoundEnabled on (#12185)", () => {
+    expect(shouldPlayUiFeedbackSound({ soundEnabled: false, uiFeedbackSoundEnabled: true })).toBe(
+      false
+    );
+  });
+
+  it("stays silent when uiFeedbackSoundEnabled is off, even with soundEnabled on", () => {
+    expect(shouldPlayUiFeedbackSound({ soundEnabled: true, uiFeedbackSoundEnabled: false })).toBe(
+      false
+    );
+  });
+
+  it("stays silent when both are off", () => {
+    expect(shouldPlayUiFeedbackSound({ soundEnabled: false, uiFeedbackSoundEnabled: false })).toBe(
+      false
+    );
+  });
+});

--- a/electron/utils/notificationSettingsPatch.ts
+++ b/electron/utils/notificationSettingsPatch.ts
@@ -63,6 +63,9 @@ export function sanitizeNotificationSettingsPatch(
   if (typeof s.uiFeedbackSoundEnabled === "boolean") {
     allowed.uiFeedbackSoundEnabled = s.uiFeedbackSoundEnabled;
   }
+  if (typeof s.flashEnabled === "boolean") {
+    allowed.flashEnabled = s.flashEnabled;
+  }
   if (typeof s.quietHoursEnabled === "boolean") {
     allowed.quietHoursEnabled = s.quietHoursEnabled;
   }

--- a/electron/utils/uiFeedbackSound.ts
+++ b/electron/utils/uiFeedbackSound.ts
@@ -1,0 +1,17 @@
+import type { NotificationSettings } from "../../shared/types/ipc/api.js";
+
+/**
+ * Whether a UI-feedback sound (git operations, worktree lifecycle, agent
+ * spawning, context injection) should play right now.
+ *
+ * The master `soundEnabled` toggle must actually mute everything, not just
+ * agent-notification sounds — call sites used to check `uiFeedbackSoundEnabled`
+ * alone, so turning sound off left git/worktree sounds playing (#12185).
+ * Extracted so every call site enforces both flags identically rather than
+ * risking drift across duplicated inline checks.
+ */
+export function shouldPlayUiFeedbackSound(
+  settings: Pick<NotificationSettings, "soundEnabled" | "uiFeedbackSoundEnabled">
+): boolean {
+  return settings.soundEnabled && settings.uiFeedbackSoundEnabled;
+}

--- a/scripts/perf/__tests__/migrations.test.ts
+++ b/scripts/perf/__tests__/migrations.test.ts
@@ -67,7 +67,7 @@ describe("PERF-080 drives the real migration chain", () => {
       expect(metrics[name], name).toBe(0);
     }
 
-    expect(metrics.schemaVersion).toBe(27);
+    expect(metrics.schemaVersion).toBe(28);
     expect(metrics.terminalCount).toBe(HEAVY_FIXTURE_COUNTS.terminals);
     expect(metrics.recipeCount).toBe(HEAVY_FIXTURE_COUNTS.recipes);
     expect(metrics.agentCount).toBe(HEAVY_FIXTURE_COUNTS.survivingAgents);
@@ -82,6 +82,6 @@ describe("PERF-080 drives the real migration chain", () => {
     const sample = await scenario.run(context);
     const metrics = sample.metrics as Record<string, number>;
     expect(metrics.migrationMisses).toBe(0);
-    expect(metrics.schemaVersion).toBe(27);
+    expect(metrics.schemaVersion).toBe(28);
   }, 120_000);
 });

--- a/scripts/perf/lib/migrationFixture.ts
+++ b/scripts/perf/lib/migrationFixture.ts
@@ -5,7 +5,7 @@
  * scenario file. That benchmark could not regress when the product did: it
  * measured a hand-written copy of the chain, so the only thing its oracle
  * proved was that the copy still ran. This fixture drives the shipped
- * `MigrationRunner` over the shipped `migrations` barrel (v0→v27), against a
+ * `MigrationRunner` over the shipped `migrations` barrel (v0→v28), against a
  * real `config.json` on disk opened through the product's own
  * `initializeStore()` — the same call `globalServicesInit` makes at boot.
  *
@@ -113,6 +113,7 @@ type LegacyStoreV0 = Omit<
     | "workingPulseEnabled"
     | "workingPulseSoundFile"
     | "uiFeedbackSoundEnabled"
+    | "flashEnabled"
     | "quietHoursEnabled"
     | "quietHoursStartMin"
     | "quietHoursEndMin"
@@ -865,7 +866,7 @@ async function buildHarness(): Promise<MigrationHarness> {
         if (recipe.projectId !== FIXTURE_PROJECT_ID) recipeMigrationMisses += 1;
       }
 
-      // --- 008 / 010 / 011 / 017
+      // --- 008 / 010 / 011 / 017 / 028
       let notificationMisses = 0;
       const expectNotification: Array<[string, unknown]> = [
         ["soundFile", undefined],
@@ -879,6 +880,9 @@ async function buildHarness(): Promise<MigrationHarness> {
         ["quietHoursEnabled", false],
         ["quietHoursStartMin", 22 * 60],
         ["quietHoursEndMin", 8 * 60],
+        // 028 flips the v0 fixture's soundEnabled:true and backfills flashEnabled.
+        ["soundEnabled", false],
+        ["flashEnabled", false],
       ];
       for (const [key, expected] of expectNotification) {
         if (notifications?.[key] !== expected) notificationMisses += 1;

--- a/scripts/perf/lib/notificationFixture.ts
+++ b/scripts/perf/lib/notificationFixture.ts
@@ -171,6 +171,7 @@ export function defaultNotificationSettings(): NotificationSettings {
     workingPulseEnabled: false,
     workingPulseSoundFile: "pulse.wav",
     uiFeedbackSoundEnabled: false,
+    flashEnabled: false,
     quietHoursEnabled: false,
     quietHoursStartMin: 22 * 60,
     quietHoursEndMin: 8 * 60,

--- a/scripts/perf/scenarios/migrations.ts
+++ b/scripts/perf/scenarios/migrations.ts
@@ -6,7 +6,7 @@ import {
 } from "../lib/migrationFixture";
 
 /**
- * The real electron-store migration chain, v0 → v27.
+ * The real electron-store migration chain, v0 → v28.
  *
  * This scenario used to reimplement all sixteen migrations inside this file and
  * time the copy. The copy could not regress when the product did — a migration
@@ -54,7 +54,7 @@ const FIXTURE_BYTES = JSON.stringify(createHeavyMigrationFixture()).length;
 export const migrationScenarios: PerfScenario[] = [
   {
     id: "PERF-080",
-    name: "Migration Chain v0→v27 (real MigrationRunner)",
+    name: "Migration Chain v0→v28 (real MigrationRunner)",
     description:
       "Run the shipped MigrationRunner over the shipped migrations barrel, v0 to head, against a " +
       "worst-case on-disk store (10k terminals, 500 recipes, 200 agents, six audit rings) opened " +

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -191,6 +191,8 @@ export interface NotificationSettings {
   workingPulseEnabled: boolean;
   workingPulseSoundFile: string;
   uiFeedbackSoundEnabled: boolean;
+  /** When true, the screen flashes once every agent goes idle (the "all-clear"). */
+  flashEnabled: boolean;
   /** When true, non-urgent notifications are suppressed during the scheduled window. */
   quietHoursEnabled: boolean;
   /** Start of the quiet window, minutes since local midnight (0-1439). */

--- a/src/components/AllClearOverlay/AllClearOverlay.tsx
+++ b/src/components/AllClearOverlay/AllClearOverlay.tsx
@@ -1,12 +1,54 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
+import { useShallow } from "zustand/react/shallow";
+import { isScheduledQuietNow } from "@shared/utils/quietHours";
+import { useNotificationSettingsStore } from "@/store/notificationSettingsStore";
 
 export function AllClearOverlay() {
   const [visible, setVisible] = useState(false);
   const safetyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  const {
+    notificationsEnabled,
+    flashEnabled,
+    quietUntil,
+    quietHoursEnabled,
+    quietHoursStartMin,
+    quietHoursEndMin,
+    quietHoursWeekdays,
+    osDndActive,
+  } = useNotificationSettingsStore(
+    useShallow((s) => ({
+      notificationsEnabled: s.enabled,
+      flashEnabled: s.flashEnabled,
+      quietUntil: s.quietUntil,
+      quietHoursEnabled: s.quietHoursEnabled,
+      quietHoursStartMin: s.quietHoursStartMin,
+      quietHoursEndMin: s.quietHoursEndMin,
+      quietHoursWeekdays: s.quietHoursWeekdays,
+      osDndActive: s.osDndActive,
+    }))
+  );
+
   useEffect(() => {
     const cleanup = window.electron.terminal.onAllAgentsClear(() => {
+      // The flash is the visual half of the same paired all-clear moment as
+      // the sound (#12185) — it must obey the same gate and suppression
+      // chain as AgentNotificationService.isInformationalAudioSuppressed.
+      if (!notificationsEnabled || !flashEnabled) return;
+      if (quietUntil > Date.now()) return;
+      if (
+        isScheduledQuietNow({
+          quietHoursEnabled,
+          quietHoursStartMin,
+          quietHoursEndMin,
+          quietHoursWeekdays,
+        })
+      ) {
+        return;
+      }
+      if (osDndActive === true) return;
+
       if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
       if (document.body.getAttribute("data-reduce-animations") === "true") return;
       if (document.body.getAttribute("data-performance-mode") === "true") return;
@@ -14,7 +56,16 @@ export function AllClearOverlay() {
       setVisible(true);
     });
     return cleanup;
-  }, []);
+  }, [
+    notificationsEnabled,
+    flashEnabled,
+    quietUntil,
+    quietHoursEnabled,
+    quietHoursStartMin,
+    quietHoursEndMin,
+    quietHoursWeekdays,
+    osDndActive,
+  ]);
 
   const handleAnimationEnd = useCallback((event: React.AnimationEvent) => {
     if (event.animationName === "all-clear-flash") {

--- a/src/components/AllClearOverlay/__tests__/AllClearOverlay.test.tsx
+++ b/src/components/AllClearOverlay/__tests__/AllClearOverlay.test.tsx
@@ -2,6 +2,7 @@
 import { render, act } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { AllClearOverlay } from "../AllClearOverlay";
+import { useNotificationSettingsStore } from "@/store/notificationSettingsStore";
 
 const OVERLAY_SELECTOR = "[aria-hidden='true']";
 
@@ -10,6 +11,19 @@ let onAllAgentsClearCb: ((data: { timestamp: number }) => void) | null = null;
 beforeEach(() => {
   vi.useFakeTimers();
   onAllAgentsClearCb = null;
+
+  // Suppressed-by-default is the point of #12185 — every test that expects
+  // the overlay to actually fire must opt in explicitly.
+  useNotificationSettingsStore.setState({
+    enabled: true,
+    flashEnabled: true,
+    quietUntil: 0,
+    quietHoursEnabled: false,
+    quietHoursStartMin: 22 * 60,
+    quietHoursEndMin: 8 * 60,
+    quietHoursWeekdays: [],
+    osDndActive: undefined,
+  });
 
   Object.defineProperty(window, "electron", {
     configurable: true,
@@ -130,5 +144,84 @@ describe("AllClearOverlay", () => {
     const { unmount } = render(<AllClearOverlay />);
     unmount();
     expect(onAllAgentsClearCb).toBeNull();
+  });
+
+  it("suppresses the overlay when flashEnabled is off (the new default)", () => {
+    useNotificationSettingsStore.setState({ flashEnabled: false });
+    render(<AllClearOverlay />);
+
+    act(() => {
+      onAllAgentsClearCb?.({ timestamp: Date.now() });
+    });
+
+    expect(document.body.querySelector(OVERLAY_SELECTOR)).toBeNull();
+  });
+
+  it("suppresses the overlay when notifications are disabled entirely", () => {
+    useNotificationSettingsStore.setState({ enabled: false });
+    render(<AllClearOverlay />);
+
+    act(() => {
+      onAllAgentsClearCb?.({ timestamp: Date.now() });
+    });
+
+    expect(document.body.querySelector(OVERLAY_SELECTOR)).toBeNull();
+  });
+
+  it("suppresses the overlay while session-muted", () => {
+    useNotificationSettingsStore.setState({ quietUntil: Date.now() + 60_000 });
+    render(<AllClearOverlay />);
+
+    act(() => {
+      onAllAgentsClearCb?.({ timestamp: Date.now() });
+    });
+
+    expect(document.body.querySelector(OVERLAY_SELECTOR)).toBeNull();
+  });
+
+  it("suppresses the overlay during scheduled quiet hours", () => {
+    const now = new Date();
+    const nowMin = now.getHours() * 60 + now.getMinutes();
+    useNotificationSettingsStore.setState({
+      quietHoursEnabled: true,
+      quietHoursStartMin: 0,
+      quietHoursEndMin: 0,
+      quietHoursWeekdays: [],
+    });
+    // startMin === endMin disables the window in isScheduledQuietNow — cover
+    // the "currently inside the window" branch explicitly instead.
+    useNotificationSettingsStore.setState({
+      quietHoursStartMin: nowMin,
+      quietHoursEndMin: (nowMin + 60) % 1440,
+    });
+    render(<AllClearOverlay />);
+
+    act(() => {
+      onAllAgentsClearCb?.({ timestamp: Date.now() });
+    });
+
+    expect(document.body.querySelector(OVERLAY_SELECTOR)).toBeNull();
+  });
+
+  it("suppresses the overlay when OS DND is active", () => {
+    useNotificationSettingsStore.setState({ osDndActive: true });
+    render(<AllClearOverlay />);
+
+    act(() => {
+      onAllAgentsClearCb?.({ timestamp: Date.now() });
+    });
+
+    expect(document.body.querySelector(OVERLAY_SELECTOR)).toBeNull();
+  });
+
+  it("still renders when OS DND state is unknown (undefined means do-not-gate)", () => {
+    useNotificationSettingsStore.setState({ osDndActive: undefined });
+    render(<AllClearOverlay />);
+
+    act(() => {
+      onAllAgentsClearCb?.({ timestamp: Date.now() });
+    });
+
+    expect(document.body.querySelector(OVERLAY_SELECTOR)).toBeTruthy();
   });
 });

--- a/src/components/Settings/NotificationSettingsTab.tsx
+++ b/src/components/Settings/NotificationSettingsTab.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useId } from "react";
-import { Play, Bell, BellOff, Volume2, AudioLines, Moon } from "lucide-react";
+import { Play, Bell, BellOff, Volume2, AudioLines, Moon, Zap } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useDeferredLoading } from "@/hooks/useDeferredLoading";
 import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
@@ -38,6 +38,7 @@ const DEFAULT_SETTINGS: NotificationSettings = {
   workingPulseEnabled: false,
   workingPulseSoundFile: "pulse.wav",
   uiFeedbackSoundEnabled: false,
+  flashEnabled: false,
   quietHoursEnabled: false,
   quietHoursStartMin: 22 * 60,
   quietHoursEndMin: 8 * 60,
@@ -163,6 +164,7 @@ export function NotificationSettingsTab() {
           waitingEnabled: boolean;
           workingPulseEnabled: boolean;
           uiFeedbackSoundEnabled: boolean;
+          flashEnabled: boolean;
           quietHoursEnabled: boolean;
           quietHoursStartMin: number;
           quietHoursEndMin: number;
@@ -176,6 +178,7 @@ export function NotificationSettingsTab() {
           revert.workingPulseEnabled = prevStore.workingPulseEnabled;
         if (patch.uiFeedbackSoundEnabled !== undefined)
           revert.uiFeedbackSoundEnabled = prevStore.uiFeedbackSoundEnabled;
+        if (patch.flashEnabled !== undefined) revert.flashEnabled = prevStore.flashEnabled;
         if (patch.quietHoursEnabled !== undefined)
           revert.quietHoursEnabled = prevStore.quietHoursEnabled;
         if (patch.quietHoursStartMin !== undefined)
@@ -196,6 +199,7 @@ export function NotificationSettingsTab() {
       waitingEnabled: boolean;
       workingPulseEnabled: boolean;
       uiFeedbackSoundEnabled: boolean;
+      flashEnabled: boolean;
       quietHoursEnabled: boolean;
       quietHoursStartMin: number;
       quietHoursEndMin: number;
@@ -208,6 +212,7 @@ export function NotificationSettingsTab() {
       storePatch.workingPulseEnabled = patch.workingPulseEnabled;
     if (patch.uiFeedbackSoundEnabled !== undefined)
       storePatch.uiFeedbackSoundEnabled = patch.uiFeedbackSoundEnabled;
+    if (patch.flashEnabled !== undefined) storePatch.flashEnabled = patch.flashEnabled;
     if (patch.quietHoursEnabled !== undefined)
       storePatch.quietHoursEnabled = patch.quietHoursEnabled;
     if (patch.quietHoursStartMin !== undefined)
@@ -359,6 +364,21 @@ export function NotificationSettingsTab() {
               </div>
             )}
           </div>
+        </SettingsSection>
+
+        <SettingsSection
+          icon={Zap}
+          title="Screen flash"
+          description="Flash the screen once every agent has finished and gone idle."
+        >
+          <SettingsSwitchCard
+            variant="compact"
+            title="Flash on all-clear"
+            subtitle="Briefly flash the screen when a working fleet goes fully idle"
+            isEnabled={settings.flashEnabled}
+            onChange={() => update({ flashEnabled: !settings.flashEnabled })}
+            ariaLabel="Flash screen on all-clear"
+          />
         </SettingsSection>
 
         <SettingsSection

--- a/src/components/Settings/NotificationSettingsTab.tsx
+++ b/src/components/Settings/NotificationSettingsTab.tsx
@@ -329,7 +329,7 @@ export function NotificationSettingsTab() {
             <SettingsSwitchCard
               variant="compact"
               title="Play sound"
-              subtitle="Enable audio alerts for agent notifications"
+              subtitle="Master switch for every sound, including UI feedback sounds"
               isEnabled={settings.soundEnabled}
               onChange={() => update({ soundEnabled: !settings.soundEnabled })}
               ariaLabel="Play sound for notifications"
@@ -463,7 +463,7 @@ export function NotificationSettingsTab() {
         <SettingsSection
           icon={AudioLines}
           title="UI feedback sounds"
-          description="Play subtle audio cues for git operations, worktree lifecycle, agent spawning, and context injection. These sounds are independent of agent notification sounds above."
+          description="Play subtle audio cues for git operations, worktree lifecycle, agent spawning, and context injection. They only play while Play sound is on."
         >
           <SettingsSwitchCard
             variant="compact"

--- a/src/components/Settings/NotificationSettingsTab.tsx
+++ b/src/components/Settings/NotificationSettingsTab.tsx
@@ -369,7 +369,7 @@ export function NotificationSettingsTab() {
         <SettingsSection
           icon={Zap}
           title="Screen flash"
-          description="Flash the screen once every agent has finished and gone idle."
+          description="Flash the screen once a working fleet of agents goes fully idle."
         >
           <SettingsSwitchCard
             variant="compact"

--- a/src/store/__tests__/notificationSettingsStore.test.ts
+++ b/src/store/__tests__/notificationSettingsStore.test.ts
@@ -15,6 +15,7 @@ beforeEach(() => {
     waitingEnabled: true,
     workingPulseEnabled: false,
     uiFeedbackSoundEnabled: false,
+    flashEnabled: false,
     osDndActive: undefined,
   });
   (globalThis as { window?: unknown }).window = {
@@ -37,6 +38,7 @@ describe("notificationSettingsStore hydrate — per-kind toggles", () => {
       waitingEnabled: true,
       workingPulseEnabled: true,
       uiFeedbackSoundEnabled: true,
+      flashEnabled: true,
     });
 
     await useNotificationSettingsStore.getState().hydrate();
@@ -46,6 +48,7 @@ describe("notificationSettingsStore hydrate — per-kind toggles", () => {
     expect(s.waitingEnabled).toBe(true);
     expect(s.workingPulseEnabled).toBe(true);
     expect(s.uiFeedbackSoundEnabled).toBe(true);
+    expect(s.flashEnabled).toBe(true);
     expect(s.hydrated).toBe(true);
   });
 
@@ -60,6 +63,7 @@ describe("notificationSettingsStore hydrate — per-kind toggles", () => {
     expect(s.waitingEnabled).toBe(true);
     expect(s.workingPulseEnabled).toBe(false);
     expect(s.uiFeedbackSoundEnabled).toBe(false);
+    expect(s.flashEnabled).toBe(false);
   });
 
   it("marks hydrated and preserves defaults when getSettings rejects", async () => {

--- a/src/store/notificationSettingsStore.ts
+++ b/src/store/notificationSettingsStore.ts
@@ -5,12 +5,15 @@ interface NotificationSettingsState {
   hydrated: boolean;
   // Per-kind toggles, mirrored from IPC settings so the notification center can
   // compute a "what will fire right now" summary without a per-open IPC round
-  // trip. These gate the main-process completion/waiting notifications and the
-  // working-pulse / UI-feedback sounds — they are display-only here.
+  // trip. `completedEnabled`/`waitingEnabled`/`workingPulseEnabled`/
+  // `uiFeedbackSoundEnabled` gate main-process notifications and sounds and
+  // are display-only here; `flashEnabled` is read directly by
+  // AllClearOverlay to gate the all-clear screen flash (#12185).
   completedEnabled: boolean;
   waitingEnabled: boolean;
   workingPulseEnabled: boolean;
   uiFeedbackSoundEnabled: boolean;
+  flashEnabled: boolean;
   quietHoursEnabled: boolean;
   quietHoursStartMin: number;
   quietHoursEndMin: number;
@@ -52,6 +55,7 @@ export const useNotificationSettingsStore = create<NotificationSettingsState>((s
   waitingEnabled: true,
   workingPulseEnabled: false,
   uiFeedbackSoundEnabled: false,
+  flashEnabled: false,
   quietHoursEnabled: false,
   quietHoursStartMin: 22 * 60,
   quietHoursEndMin: 8 * 60,
@@ -76,6 +80,7 @@ export const useNotificationSettingsStore = create<NotificationSettingsState>((s
           waitingEnabled: settings.waitingEnabled !== false,
           workingPulseEnabled: settings.workingPulseEnabled === true,
           uiFeedbackSoundEnabled: settings.uiFeedbackSoundEnabled === true,
+          flashEnabled: settings.flashEnabled === true,
           quietHoursEnabled: settings.quietHoursEnabled === true,
           quietHoursStartMin:
             typeof settings.quietHoursStartMin === "number" ? settings.quietHoursStartMin : 22 * 60,


### PR DESCRIPTION
## Summary
- `soundEnabled` and a new `flashEnabled` setting now default to off, matching the existing defaults for `completedEnabled`, `uiFeedbackSoundEnabled`, `workingPulseEnabled`, and `waitingEscalationEnabled`
- The all-clear screen flash (`AllClearOverlay.tsx`) previously had no setting at all and ignored every notification setting; it now has its own toggle in Settings, separate from sound, and obeys the same suppression chain (quiet hours, session mute, OS do-not-disturb)
- Fixed the master `soundEnabled` toggle not actually muting everything: git-write, worktree-lifecycle, and UI-feedback sounds only checked `uiFeedbackSoundEnabled`, bypassing the master toggle entirely

Resolves #12185

## Changes
- `soundEnabled` and `flashEnabled` default to `false` in `electron/store.ts` and `NotificationSettingsTab.tsx`
- New `electron/services/migrations/028-quiet-sound-and-flash-defaults.ts` backfills `flashEnabled` and flips existing installs' persisted `soundEnabled: true` to `false`. electron-store's defaults merge is shallow, so a code-level default change alone wouldn't reach existing installs
- `AllClearOverlay.tsx` gets its own `flashEnabled` setting, independent of sound, so sound-off/flash-on and the reverse both work
- Extracted a shared `shouldPlayUiFeedbackSound()` predicate so `soundEnabled` and `uiFeedbackSoundEnabled` are always enforced together across git-write, worktree-lifecycle, and UI-feedback sounds

## Testing
- Added/updated unit tests covering migration028, the `AllClearOverlay` flash and its suppression chain, `shouldPlayUiFeedbackSound()`, and the notification settings store/patch defaults
- `npm test` on the branch