### PR TITLE
feat(terminal): find and reopen a lost Codex session from the banner

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -508,6 +508,7 @@ export const CHANNELS = {
   CODEX_LIST_SUBAGENTS: "codex:list-subagents",
   CODEX_READ_SUBAGENT_TRANSCRIPT: "codex:read-subagent-transcript",
   CODEX_RESOLVE_RESUME_LATEST_SESSION: "codex:resolve-resume-latest-session",
+  CODEX_FIND_SESSIONS: "codex:find-sessions",
 
   CLAUDE_LIST_SUBAGENTS: "claude:list-subagents",
   CLAUDE_READ_SUBAGENT_TRANSCRIPT: "claude:read-subagent-transcript",

--- a/electron/ipc/handlers/__tests__/codex.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/codex.handlers.test.ts
@@ -10,6 +10,7 @@ const serviceMock = vi.hoisted(() => ({
   listCodexSubagents: vi.fn(),
   readCodexSubagentTranscript: vi.fn(),
   resolveCodexResumeLatestSession: vi.fn(),
+  listCodexSessionsForCwd: vi.fn(),
 }));
 
 vi.mock("electron", () => ({ ipcMain: ipcMainMock }));
@@ -31,6 +32,7 @@ function fakeEvent(): Electron.IpcMainInvokeEvent {
 }
 
 const resolveChannel = CHANNELS.CODEX_RESOLVE_RESUME_LATEST_SESSION;
+const findSessionsChannel = CHANNELS.CODEX_FIND_SESSIONS;
 
 describe("codex IPC handlers", () => {
   let cleanup: () => void;
@@ -90,9 +92,55 @@ describe("codex IPC handlers", () => {
     });
   });
 
+  // issue #12182 — "Find session" on the lost-session banner.
+  describe("findSessions", () => {
+    it("passes cwd and an optional codexHome through to the service", async () => {
+      serviceMock.listCodexSessionsForCwd.mockResolvedValue({ status: "ok", sessions: [] });
+
+      const result = await getHandler(findSessionsChannel)(fakeEvent(), {
+        cwd: "/repo/worktree",
+        codexHome: "/repo/.codex-home",
+      });
+
+      expect(result).toEqual({ status: "ok", sessions: [] });
+      expect(serviceMock.listCodexSessionsForCwd).toHaveBeenCalledWith(
+        "/repo/worktree",
+        "/repo/.codex-home"
+      );
+    });
+
+    it("omits codexHome when the caller doesn't supply one", async () => {
+      serviceMock.listCodexSessionsForCwd.mockResolvedValue({ status: "ok", sessions: [] });
+
+      await getHandler(findSessionsChannel)(fakeEvent(), { cwd: "/repo" });
+
+      expect(serviceMock.listCodexSessionsForCwd).toHaveBeenCalledWith("/repo", undefined);
+    });
+
+    it.each([
+      ["a relative cwd", { cwd: "relative/path" }],
+      ["a relative codexHome", { cwd: "/repo", codexHome: "relative" }],
+      ["a NUL byte in cwd", { cwd: "/repo\0" }],
+      ["a non-string codexHome", { cwd: "/repo", codexHome: 42 }],
+    ])("rejects %s before reaching the service", async (_label, payload) => {
+      await expect(getHandler(findSessionsChannel)(fakeEvent(), payload)).rejects.toThrow();
+
+      expect(serviceMock.listCodexSessionsForCwd).not.toHaveBeenCalled();
+    });
+
+    it("propagates a service failure", async () => {
+      serviceMock.listCodexSessionsForCwd.mockRejectedValue(new Error("app-server down"));
+
+      await expect(getHandler(findSessionsChannel)(fakeEvent(), { cwd: "/repo" })).rejects.toThrow(
+        "app-server down"
+      );
+    });
+  });
+
   it("removes every codex handler on cleanup", () => {
     expect(ipcHandlers.has(resolveChannel)).toBe(true);
     expect(ipcHandlers.has(CHANNELS.CODEX_LIST_SUBAGENTS)).toBe(true);
+    expect(ipcHandlers.has(findSessionsChannel)).toBe(true);
 
     cleanup();
 

--- a/electron/ipc/handlers/codex.preload.ts
+++ b/electron/ipc/handlers/codex.preload.ts
@@ -4,6 +4,7 @@ export const CODEX_METHOD_CHANNELS = {
   listSubagents: "codex:list-subagents",
   readSubagentTranscript: "codex:read-subagent-transcript",
   resolveResumeLatestSession: "codex:resolve-resume-latest-session",
+  findSessions: "codex:find-sessions",
 } as const satisfies Record<string, keyof IpcInvokeMap>;
 
 type Methods = typeof CODEX_METHOD_CHANNELS;

--- a/electron/ipc/handlers/codex.ts
+++ b/electron/ipc/handlers/codex.ts
@@ -4,6 +4,7 @@ import { CODEX_METHOD_CHANNELS } from "./codex.preload.js";
 import type {
   AgentSubagentsResult,
   AgentSubagentTranscriptResult,
+  CodexFolderSessionsResult,
 } from "../../../shared/types/ipc/agentSubagents.js";
 
 // The renderer names a terminal, never a folder or a bare thread id. Main
@@ -18,6 +19,22 @@ const id = z.string().trim().min(1).max(ID_MAX);
 const listSchema = z.object({ terminalId: id });
 const readSchema = z.object({ terminalId: id, subagentId: id });
 
+// Bound to a plausible absolute path so a malformed payload is refused at the
+// boundary instead of being carried into a protocol query. Shared by every op
+// below that takes a directory rather than a terminal id.
+const PATH_MAX = 4096;
+function absolutePath(label: string) {
+  return z
+    .string()
+    .min(1)
+    .max(PATH_MAX)
+    .refine((value) => !value.includes("\0"), `${label} must not contain a NUL byte`)
+    .refine(
+      (value) => value.startsWith("/") || /^[A-Za-z]:[\\/]/.test(value) || value.startsWith("\\\\"),
+      `${label} must be an absolute path`
+    );
+}
+
 /**
  * Restore is the one caller that cannot name a terminal: it runs before the PTY
  * exists, so the folder is all it has (#12178). The cwd it sends comes from the
@@ -25,21 +42,20 @@ const readSchema = z.object({ terminalId: id, subagentId: id });
  * is a single session id — never a cwd, a preview, a timestamp or a thread list
  * — so a caller that pointed this at someone else's folder would learn only
  * whether a Codex session id exists there, not what is in it.
- *
- * Bound it to a plausible absolute path anyway, so a malformed payload is
- * refused at the boundary instead of being carried into a protocol query.
  */
-const CWD_MAX = 4096;
-const resolveResumeLatestSchema = z.object({
-  cwd: z
-    .string()
-    .min(1)
-    .max(CWD_MAX)
-    .refine((value) => !value.includes("\0"), "cwd must not contain a NUL byte")
-    .refine(
-      (value) => value.startsWith("/") || /^[A-Za-z]:[\\/]/.test(value) || value.startsWith("\\\\"),
-      "cwd must be an absolute path"
-    ),
+const resolveResumeLatestSchema = z.object({ cwd: absolutePath("cwd") });
+
+/**
+ * "Find session" (#12182) also cannot name a terminal — it runs off a flagged
+ * pane's restart banner, after restore already gave up on that terminal.
+ * Unlike the resume-latest lookup above, the reply here does carry a thread
+ * list (ids, previews, timestamps), so this is a user-triggered action, not
+ * something restore calls silently. `codexHome` is optional: absent, the
+ * query runs against main's own profile.
+ */
+const findSessionsSchema = z.object({
+  cwd: absolutePath("cwd"),
+  codexHome: absolutePath("codexHome").optional(),
 });
 
 export const codexNamespace = defineIpcNamespace({
@@ -71,6 +87,15 @@ export const codexNamespace = defineIpcNamespace({
         const { resolveCodexResumeLatestSession } =
           await import("../../services/codex/CodexSubagentService.js");
         return resolveCodexResumeLatestSession(cwd);
+      }
+    ),
+    findSessions: opValidated(
+      CODEX_METHOD_CHANNELS.findSessions,
+      findSessionsSchema,
+      async ({ cwd, codexHome }): Promise<CodexFolderSessionsResult> => {
+        const { listCodexSessionsForCwd } =
+          await import("../../services/codex/CodexSubagentService.js");
+        return listCodexSessionsForCwd(cwd, codexHome);
       }
     ),
   },

--- a/electron/services/codex/CodexAppServerClient.ts
+++ b/electron/services/codex/CodexAppServerClient.ts
@@ -125,6 +125,13 @@ export interface CodexAppServerSessionOptions {
   command?: string;
   timeoutMs?: number;
   requestTimeoutMs?: number;
+  /**
+   * Overrides main's own `CODEX_HOME` for this session. A caller asking on
+   * behalf of a specific pane must pass the pane's own launch env here when it
+   * carries one (#12182) — without it, this client silently queries the
+   * default profile even though the pane itself ran against a redirected one.
+   */
+  codexHome?: string;
 }
 
 function classifySpawnError(error: NodeJS.ErrnoException): CodexAppServerError {
@@ -142,17 +149,17 @@ function classifySpawnError(error: NodeJS.ErrnoException): CodexAppServerError {
  * than a credential, and omitting it would silently point the query at the
  * default profile while the terminal itself runs against a relocated one.
  *
- * This inherits main's `CODEX_HOME`, not the terminal's own spawn env, so a
- * per-project override is invisible here. Usually that fails quiet — the
- * default profile holds no thread for that cwd, so the lookup reports
- * `no-session` and the UI stays hidden — but if the default profile also has
- * threads for the same folder, spawn-time correlation runs against the wrong
- * profile. Carrying the terminal's effective profile through pty-host metadata
- * is the real fix and is not wired yet.
+ * Falls back to inheriting main's own `CODEX_HOME` when no override is given.
+ * A caller that knows which pane it's asking on behalf of should pass
+ * `options.codexHome` — main's own env has no relation to a pane's redirected
+ * profile, so without it a query can silently run against the wrong index
+ * (#12182). Callers with no specific pane in mind (e.g. resume-latest
+ * resolution, which only ever asks against main's own profile today) are
+ * unaffected either way.
  */
-function buildAppServerEnv(): NodeJS.ProcessEnv {
+function buildAppServerEnv(codexHomeOverride?: string): NodeJS.ProcessEnv {
   const env = buildProbeEnv();
-  const codexHome = process.env.CODEX_HOME;
+  const codexHome = codexHomeOverride ?? process.env.CODEX_HOME;
   if (codexHome) env.CODEX_HOME = codexHome;
   return env;
 }
@@ -196,7 +203,7 @@ async function spawnCodexAppServerSession<T>(
     child = spawn(command, ["app-server", "--listen", "stdio://"], {
       shell: false,
       windowsHide: true,
-      env: buildAppServerEnv(),
+      env: buildAppServerEnv(options.codexHome),
       detached: useGroup,
       stdio: ["pipe", "pipe", "pipe"],
     });

--- a/electron/services/codex/CodexSubagentService.ts
+++ b/electron/services/codex/CodexSubagentService.ts
@@ -590,7 +590,11 @@ function toFolderSession(thread: RawThread): CodexFolderSession | null {
   // `selectResumeLatestThread`, which resolves the same value for the same
   // reason).
   const id = asString(thread.sessionId) ?? asString(thread.id);
-  if (!id) return null;
+  // This id reaches `buildResumeCommand` and is interpolated into a shell
+  // command the instant the user picks it — same shape check
+  // `selectResumeLatestThread` applies before trusting a session id from the
+  // wire.
+  if (!id || !CODEX_SESSION_ID_PATTERN.test(id)) return null;
   return {
     id,
     // The session's own first message — conversation text. Crosses IPC as-is

--- a/electron/services/codex/CodexSubagentService.ts
+++ b/electron/services/codex/CodexSubagentService.ts
@@ -43,6 +43,8 @@ import {
   type AgentSubagentUnavailableReason,
   type AgentSubagentsResult,
   type AgentSubagentTranscriptResult,
+  type CodexFolderSession,
+  type CodexFolderSessionsResult,
 } from "../../../shared/types/ipc/agentSubagents.js";
 
 /**
@@ -579,5 +581,58 @@ export async function resolveCodexResumeLatestSession(cwd: string): Promise<stri
     // Degrading to `--last` loses the id capture; failing the restore would lose
     // the pane. The pane is worth more.
     return null;
+  }
+}
+
+function toFolderSession(thread: RawThread): CodexFolderSession | null {
+  // `codex resume` takes `sessionId`; for a root thread it equals `id`, and an
+  // older server that omits the field falls back to that (matches
+  // `selectResumeLatestThread`, which resolves the same value for the same
+  // reason).
+  const id = asString(thread.sessionId) ?? asString(thread.id);
+  if (!id) return null;
+  return {
+    id,
+    // The session's own first message — conversation text. Crosses IPC as-is
+    // (see the type's doc comment) but must never be logged.
+    preview: typeof thread.preview === "string" ? thread.preview : "",
+    updatedAt: secondsToMs(activityOf(thread)),
+  };
+}
+
+/**
+ * List the Codex sessions recorded for a folder, for the "Find session"
+ * action on the lost-session banner (#12182) — the user picks one to reopen
+ * when restore couldn't reattach to it automatically.
+ *
+ * Root threads only: a picker offering to reopen a delegated subagent thread
+ * would be reopening something that was never its own conversation.
+ *
+ * `codexHome` should be the pane's own launch env when it carries one
+ * (renderer resolves this from `PtyPanelData.env`, matching the lookup
+ * `resolveNamedResumeLatestSession` already does for the same reason) — this
+ * client has no way to learn a pane's redirected profile on its own, and
+ * querying main's default one would silently show the wrong folder's history
+ * or nothing at all.
+ */
+export async function listCodexSessionsForCwd(
+  cwd: string,
+  codexHome?: string
+): Promise<CodexFolderSessionsResult> {
+  try {
+    return await runCodexAppServerSession(
+      async (call) => {
+        const threads = await listThreadsInCwd(call, await resolveCwdSpellings(cwd));
+        const sessions = threads
+          .filter((thread) => asString(thread.parentThreadId) === null)
+          .map(toFolderSession)
+          .filter((session): session is CodexFolderSession => session !== null)
+          .sort((a, b) => b.updatedAt - a.updatedAt);
+        return { status: "ok" as const, sessions };
+      },
+      { codexHome }
+    );
+  } catch (error) {
+    return toUnavailable(error);
   }
 }

--- a/electron/services/codex/__tests__/CodexAppServerClient.test.ts
+++ b/electron/services/codex/__tests__/CodexAppServerClient.test.ts
@@ -392,6 +392,54 @@ describe("runCodexAppServerSession", () => {
   });
 });
 
+// issue #12182 — "Find session" asks on behalf of a specific pane, which may
+// have launched under a redirected CODEX_HOME. This client has no other way
+// to learn that, so the caller must be able to hand it over per session.
+describe("CODEX_HOME override (#12182)", () => {
+  const originalCodexHome = process.env.CODEX_HOME;
+
+  afterEach(() => {
+    if (originalCodexHome === undefined) {
+      delete process.env.CODEX_HOME;
+    } else {
+      process.env.CODEX_HOME = originalCodexHome;
+    }
+  });
+
+  it("spawns with the caller-supplied codexHome, not main's own", async () => {
+    process.env.CODEX_HOME = "/main/.codex";
+
+    const promise = runCodexAppServerSession(async () => "done", {
+      command: "codex-test",
+      codexHome: "/pane/.codex",
+    });
+    await flush();
+    child.respondTo("initialize", { userAgent: "codex" });
+    await promise;
+
+    const spawnEnv = spawnMock.mock.calls[0]?.[2]?.env as NodeJS.ProcessEnv | undefined;
+    expect(spawnEnv?.CODEX_HOME).toBe("/pane/.codex");
+  });
+
+  it("falls back to main's own CODEX_HOME when no override is given", async () => {
+    process.env.CODEX_HOME = "/main/.codex";
+
+    await startSession(async () => "done");
+
+    const spawnEnv = spawnMock.mock.calls[0]?.[2]?.env as NodeJS.ProcessEnv | undefined;
+    expect(spawnEnv?.CODEX_HOME).toBe("/main/.codex");
+  });
+
+  it("omits CODEX_HOME entirely when neither the caller nor main's env has one", async () => {
+    delete process.env.CODEX_HOME;
+
+    await startSession(async () => "done");
+
+    const spawnEnv = spawnMock.mock.calls[0]?.[2]?.env as NodeJS.ProcessEnv | undefined;
+    expect(spawnEnv?.CODEX_HOME).toBeUndefined();
+  });
+});
+
 describe("session slot queue", () => {
   it("counts the wait for a slot against the caller's own budget", async () => {
     // Two sessions hold the gate. A third must not sit here unbounded: at

--- a/electron/services/codex/__tests__/CodexSubagentService.test.ts
+++ b/electron/services/codex/__tests__/CodexSubagentService.test.ts
@@ -713,6 +713,29 @@ describe("listCodexSessionsForCwd", () => {
     await expect(listCodexSessionsForCwd("/repo")).resolves.toEqual({ status: "ok", sessions: [] });
   });
 
+  it("drops a thread whose id doesn't match the session-id shape", async () => {
+    // The id reaches buildResumeCommand and is interpolated into a shell
+    // command the instant it's picked — never trust it unvalidated off the wire.
+    scriptSession((method) => {
+      if (method === "thread/list") {
+        return {
+          data: [
+            { id: "ok-thread", sessionId: "ok-thread", recencyAt: 5 },
+            { id: "bad; rm -rf /", sessionId: "bad; rm -rf /", recencyAt: 6 },
+          ],
+        };
+      }
+      return {};
+    });
+
+    const result = await listCodexSessionsForCwd("/repo");
+
+    expect(result).toEqual({
+      status: "ok",
+      sessions: [{ id: "ok-thread", preview: "", updatedAt: 5_000 }],
+    });
+  });
+
   it("asks under both spellings of a symlinked path, since the cwd filter is exact", async () => {
     let listParams: QueryParams = {};
     scriptSession((method, params) => {

--- a/electron/services/codex/__tests__/CodexSubagentService.test.ts
+++ b/electron/services/codex/__tests__/CodexSubagentService.test.ts
@@ -23,6 +23,7 @@ vi.mock("fs/promises", () => ({
 import { CodexAppServerError } from "../CodexAppServerClient.js";
 import {
   listCodexSubagents,
+  listCodexSessionsForCwd,
   readCodexSubagentTranscript,
   resolveCodexResumeLatestSession,
   selectParentThread,
@@ -619,5 +620,129 @@ describe("resolveCodexResumeLatestSession budget", () => {
 
     const options = runSession.mock.calls[0]?.[1] as { timeoutMs?: number } | undefined;
     expect(options?.timeoutMs).toBe(2_000);
+  });
+});
+
+// issue #12182 — "Find session" on the lost-session banner.
+describe("listCodexSessionsForCwd", () => {
+  it("queries the folder's root threads and maps them for the picker", async () => {
+    let listParams: QueryParams = {};
+    scriptSession((method, params) => {
+      if (method === "thread/list") {
+        listParams = params;
+        return {
+          data: [
+            { id: "root-1", sessionId: "root-1", preview: "fix the flaky test", recencyAt: 20 },
+            { id: "root-2", preview: "add the banner", updatedAt: 10 },
+          ],
+        };
+      }
+      return {};
+    });
+
+    const result = await listCodexSessionsForCwd("/repo");
+
+    expect(result).toEqual({
+      status: "ok",
+      sessions: [
+        { id: "root-1", preview: "fix the flaky test", updatedAt: 20_000 },
+        { id: "root-2", preview: "add the banner", updatedAt: 10_000 },
+      ],
+    });
+    expect(listParams.cwd).toEqual(["/repo"]);
+    expect(listParams.sortKey).toBe("recency_at");
+    expect(listParams.sortDirection).toBe("desc");
+    expect(listParams.useStateDbOnly).toBe(true);
+    // Same non-archived, interactive-only default the resume-latest lookup
+    // and picker share — naming either would broaden the filter, not restate it.
+    expect(listParams).not.toHaveProperty("sourceKinds");
+    expect(listParams).not.toHaveProperty("archived");
+  });
+
+  it("excludes subagent threads — a picker only offers root conversations", async () => {
+    scriptSession((method) => {
+      if (method === "thread/list") {
+        return {
+          data: [
+            { id: "root", sessionId: "root", recencyAt: 5 },
+            { id: "child", parentThreadId: "root", recencyAt: 6 },
+          ],
+        };
+      }
+      return {};
+    });
+
+    const result = await listCodexSessionsForCwd("/repo");
+
+    expect(result).toEqual({
+      status: "ok",
+      sessions: [{ id: "root", preview: "", updatedAt: 5_000 }],
+    });
+  });
+
+  it("orders sessions most-recently-active first", async () => {
+    scriptSession((method) => {
+      if (method === "thread/list") {
+        return {
+          data: [
+            { id: "older", sessionId: "older", recencyAt: 1 },
+            { id: "newer", sessionId: "newer", recencyAt: 99 },
+          ],
+        };
+      }
+      return {};
+    });
+
+    const result = await listCodexSessionsForCwd("/repo");
+
+    expect(result.status).toBe("ok");
+    expect(result.status === "ok" ? result.sessions.map((s) => s.id) : []).toEqual([
+      "newer",
+      "older",
+    ]);
+  });
+
+  it("drops a thread with no usable id rather than throwing", async () => {
+    scriptSession((method) => {
+      if (method === "thread/list") {
+        return { data: [{ preview: "no id at all", recencyAt: 1 }] };
+      }
+      return {};
+    });
+
+    await expect(listCodexSessionsForCwd("/repo")).resolves.toEqual({ status: "ok", sessions: [] });
+  });
+
+  it("asks under both spellings of a symlinked path, since the cwd filter is exact", async () => {
+    let listParams: QueryParams = {};
+    scriptSession((method, params) => {
+      if (method === "thread/list") {
+        listParams = params;
+        return { data: [] };
+      }
+      return {};
+    });
+
+    await listCodexSessionsForCwd("/tmp/repo");
+
+    expect(listParams.cwd).toEqual(["/tmp/repo", "/private/tmp/repo"]);
+  });
+
+  it("forwards codexHome to the session so the query runs against the pane's own profile", async () => {
+    scriptSession(() => ({ data: [] }));
+
+    await listCodexSessionsForCwd("/repo", "/pane/.codex");
+
+    const options = runSession.mock.calls[0]?.[1] as { codexHome?: string } | undefined;
+    expect(options?.codexHome).toBe("/pane/.codex");
+  });
+
+  it("reports unavailable rather than throwing when Codex cannot be reached", async () => {
+    runSession.mockRejectedValue(new CodexAppServerError("cli-missing", "no codex"));
+
+    await expect(listCodexSessionsForCwd("/repo")).resolves.toMatchObject({
+      status: "unavailable",
+      reason: "cli-missing",
+    });
   });
 });

--- a/scripts/perf/__tests__/hydrationSwitch.test.ts
+++ b/scripts/perf/__tests__/hydrationSwitch.test.ts
@@ -212,7 +212,7 @@ describe("hydration fixture drives the real statePatcher", () => {
         expect(command).toContain(planned.plantedSessionId!);
       } else if (planned.route === "respawnWithheld") {
         expect(command).not.toContain(planned.plantedSessionId!);
-        expect(observed.built[i].sessionLostOnRestore).toBe(true);
+        expect(observed.built[i].sessionLostOnRestore).toBe("sibling-owns-session-id");
       }
     }
   }, 30_000);

--- a/scripts/perf/lib/hydrationFixture.ts
+++ b/scripts/perf/lib/hydrationFixture.ts
@@ -2,6 +2,8 @@ import { performance } from "node:perf_hooks";
 import { dirname, join, resolve as pathResolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
+import type { SessionLostReason } from "../../../shared/types/panel";
+
 import { createPerfTempRoot } from "./tempRoots";
 
 /**
@@ -104,7 +106,7 @@ interface BuiltArgs {
   waitingReason?: string;
   agentSessionId?: string;
   agentLaunchFlags?: string[];
-  sessionLostOnRestore?: boolean;
+  sessionLostOnRestore?: SessionLostReason;
   browserUrl?: string;
   filePath?: string;
   fileViewMode?: string;
@@ -787,7 +789,7 @@ export function hydrationPassMisses(
         // saved conversation, and the id must ride onto the respawned panel.
         if (!args.command || !args.command.includes(sessionId)) misses.respawnResumeMisses += 1;
         if (args.agentSessionId !== sessionId) misses.respawnResumeMisses += 1;
-        if (args.sessionLostOnRestore === true) misses.respawnResumeMisses += 1;
+        if (args.sessionLostOnRestore !== undefined) misses.respawnResumeMisses += 1;
         // `mintFreshTerminalId: false`, so the pane keeps its persisted id.
         if (args.requestedId !== saved.id) misses.respawnResumeMisses += 1;
         if (args.launchAgentId !== saved.launchAgentId) misses.respawnResumeMisses += 1;
@@ -809,8 +811,11 @@ export function hydrationPassMisses(
         // above only if the id changed shape.
         if (args.command === saved.command) misses.resumeSuppressionMisses += 1;
         // The resume-latest back door does not set this; every branch that
-        // genuinely abandons the conversation does.
-        if (args.sessionLostOnRestore !== true) misses.resumeSuppressionMisses += 1;
+        // genuinely abandons the conversation names why (#12182), and here the
+        // only true cause is the sibling holding this exact session.
+        if (args.sessionLostOnRestore !== "sibling-owns-session-id") {
+          misses.resumeSuppressionMisses += 1;
+        }
         // `mintFreshTerminalId: true`, so the saved id must NOT be reused.
         if (args.requestedId !== undefined) misses.resumeSuppressionMisses += 1;
         break;

--- a/shared/types/addPanelOptions.ts
+++ b/shared/types/addPanelOptions.ts
@@ -9,6 +9,7 @@ import type {
   FileBrowserSortDirection,
   FileBrowserSortKey,
   FileBrowserTreeSnapshot,
+  SessionLostReason,
 } from "./panel.js";
 import type { GitStatus, DiffChangeSetEntry } from "./git.js";
 import type { BrowserHistory } from "./browser.js";
@@ -166,17 +167,18 @@ export interface AddPanelOptionsBase {
   /** Chain index consumed so far from the primary preset's fallback list. */
   fallbackChainIndex?: number;
   /**
-   * PTY-only, transient. True when session restore fell through to a fresh
+   * PTY-only, transient. Set when session restore fell through to a fresh
    * agent launch because no resume command was usable — either none was
    * available (neither exact-session nor resume-latest), or resume-latest was
    * suppressed because a sibling pane owns this agent+cwd's single slot
-   * (#11461) — so the prior conversation is unreachable for this pane.
+   * (#11461) — so the prior conversation is unreachable for this pane. The
+   * value names which of those it was (#12182).
    * Drives the "Session no longer reachable" restart banner, and doubles as the
    * "not yet acknowledged" gate: dismissing the banner consumes this flag
    * (#11589), as does the next restart. Never persisted — see
    * `serializePtyPanel` (intentionally omitted).
    */
-  sessionLostOnRestore?: boolean;
+  sessionLostOnRestore?: SessionLostReason;
   /**
    * User-initiated focus timestamp from the saved snapshot, propagated
    * from the hydration boundary (`statePatcher.ts:buildArgsFor*` →

--- a/shared/types/ipc/agentSubagents.ts
+++ b/shared/types/ipc/agentSubagents.ts
@@ -131,6 +131,28 @@ export interface AgentSubagentTranscriptOk {
 export type AgentSubagentTranscriptResult = AgentSubagentTranscriptOk | AgentSubagentsUnavailable;
 
 /**
+ * One root Codex session recorded for a folder — what "Find session"
+ * (issue #12182) offers to reopen after a restore couldn't reattach to the
+ * prior conversation.
+ *
+ * Deliberately minimal: `preview` is the session's own first message, which
+ * is conversation text and must stay local — never logged, sent anywhere but
+ * the renderer that asked for it, or persisted.
+ */
+export interface CodexFolderSession {
+  id: string;
+  preview: string;
+  updatedAt: number;
+}
+
+export interface CodexFolderSessionsOk {
+  status: "ok";
+  sessions: CodexFolderSession[];
+}
+
+export type CodexFolderSessionsResult = CodexFolderSessionsOk | AgentSubagentsUnavailable;
+
+/**
  * Messages returned per transcript read. Bounded so one long-running child
  * can't flood IPC. When it bites, the delegated task is kept and the oldest
  * replies are dropped — the task is the one message that explains the rest.

--- a/shared/types/ipc/generated-api.ts
+++ b/shared/types/ipc/generated-api.ts
@@ -75,6 +75,9 @@ export interface GeneratedElectronAPI {
     ): Promise<IpcInvokeMap["clipboard:write-text"]["result"]>;
   };
   codex: {
+    findSessions(
+      ...args: IpcInvokeMap["codex:find-sessions"]["args"]
+    ): Promise<IpcInvokeMap["codex:find-sessions"]["result"]>;
     listSubagents(
       ...args: IpcInvokeMap["codex:list-subagents"]["args"]
     ): Promise<IpcInvokeMap["codex:list-subagents"]["result"]>;

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -154,6 +154,10 @@ export interface GeneratedIpcInvokeMap {
     args: [text: string];
     result: void;
   };
+  "codex:find-sessions": {
+    args: [__0: { cwd: string; codexHome?: string | undefined }];
+    result: import("./agentSubagents.js").CodexFolderSessionsResult;
+  };
   "codex:list-subagents": {
     args: [__0: { terminalId: string }];
     result: import("./agentSubagents.js").AgentSubagentsResult;

--- a/shared/types/panel.ts
+++ b/shared/types/panel.ts
@@ -361,6 +361,24 @@ export interface PanelWorktreeMoveNotice {
   deliveryFailed?: boolean;
 }
 
+/**
+ * Why a restored pane's prior agent session could not be resumed (#12182).
+ *
+ * Distinguished because the banner's copy and its "Find session" affordance
+ * both depend on which one fired — "a sibling pane already has it" is a
+ * fundamentally different message (and a different recovery) than "there was
+ * never anything to resume".
+ */
+export type SessionLostReason =
+  /** Had the exact session id and permission to use it, but no resume command could be built. */
+  | "no-resume-command"
+  /** A sibling pane already holds the exact conversation this pane carried. */
+  | "sibling-owns-session-id"
+  /** A sibling pane already claimed this agent+folder's resume-latest slot. */
+  | "sibling-owns-resume-latest-slot"
+  /** No session id was ever captured and no resume-latest fallback exists for this agent. */
+  | "no-resume-path";
+
 export interface PtyPanelData extends BasePanelData {
   kind: "terminal";
   /**
@@ -574,17 +592,17 @@ export interface PtyPanelData extends BasePanelData {
   /** How many fallback hops have been consumed from the primary's chain (0-based index into fallbacks[]). */
   fallbackChainIndex?: number;
   /**
-   * Live-only restore signal. True on first mount when the saved agent session
+   * Live-only restore signal. Set on first mount when the saved agent session
    * could not be safely resumed — unreachable, or resume-latest suppressed
    * because a sibling pane owns the slot (#11461) — and a fresh session was
-   * launched instead. Drives the
+   * launched instead. The value names which cause it was (#12182). Drives the
    * "Session no longer reachable" restart banner. Cleared on restart, and when
    * the user dismisses the banner (#11589) — dismissal consumes this signal
    * rather than shadowing it with a second flag, so the acknowledgement
    * survives the unmount a worktree switch causes. Never serialized — see
    * `serializePtyPanel`.
    */
-  sessionLostOnRestore?: boolean;
+  sessionLostOnRestore?: SessionLostReason;
 }
 
 export interface BrowserPanelData extends BasePanelData {

--- a/src/clients/codexClient.ts
+++ b/src/clients/codexClient.ts
@@ -1,6 +1,7 @@
 import type {
   AgentSubagentsResult,
   AgentSubagentTranscriptResult,
+  CodexFolderSessionsResult,
 } from "@shared/types/ipc/agentSubagents";
 
 /**
@@ -27,5 +28,19 @@ export const codexClient = {
    */
   resolveResumeLatestSession: (payload: { cwd: string }): Promise<string | null> => {
     return window.electron.codex.resolveResumeLatestSession(payload);
+  },
+
+  /**
+   * Codex sessions recorded for a folder, for the "Find session" action on
+   * the lost-session banner (#12182). Pass `codexHome` when the pane carries
+   * its own launch env (`panel.env.CODEX_HOME`) — this asks main's own
+   * profile otherwise, which is wrong for a pane that ran under a redirected
+   * one.
+   */
+  findSessions: (payload: {
+    cwd: string;
+    codexHome?: string;
+  }): Promise<CodexFolderSessionsResult> => {
+    return window.electron.codex.findSessions(payload);
   },
 } as const;

--- a/src/components/Terminal/FindCodexSessionAction.tsx
+++ b/src/components/Terminal/FindCodexSessionAction.tsx
@@ -1,0 +1,201 @@
+import { useCallback, useState } from "react";
+import { useShallow } from "zustand/react/shallow";
+import { Search, RefreshCw } from "lucide-react";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Spinner } from "@/components/ui/Spinner";
+import { useDohertyGate } from "@/hooks/useDeferredLoading";
+import { cn } from "@/lib/utils";
+import { usePanelStore } from "@/store/panelStore";
+import { isPtyPanel } from "@shared/types/panel";
+import { buildResumeCommand } from "@shared/types";
+import { formatTimeAgo } from "@/utils/timeAgo";
+import { logWarn, logError } from "@/utils/logger";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
+import { codexClient } from "@/clients/codexClient";
+import type {
+  AgentSubagentUnavailableReason,
+  CodexFolderSession,
+  CodexFolderSessionsResult,
+} from "@shared/types/ipc/agentSubagents";
+
+// Only the reasons `listCodexSessionsForCwd` can actually surface: it queries
+// the app-server directly rather than resolving a terminal, so the
+// terminal/session-attribution reasons in the shared taxonomy never reach here.
+function findSessionsErrorMessage(reason: AgentSubagentUnavailableReason): string {
+  switch (reason) {
+    case "cli-missing":
+      return "Codex CLI isn't available";
+    case "timeout":
+      return "Codex took too long to respond";
+    default:
+      return "Couldn't check for Codex sessions";
+  }
+}
+
+function firstLine(value: string): string {
+  return value.trim().split("\n")[0]?.trim() ?? "";
+}
+
+/**
+ * "Find session" action on the lost-session banner (#12182): lists this
+ * pane's folder's Codex sessions and reopens the chosen one in a new pane.
+ *
+ * Codex-only — the other agents have no equivalent read-only index to ask,
+ * so this renders nothing for them. Read-only throughout: picking a session
+ * opens it in a NEW pane via the ordinary `codex resume <id>` launch path,
+ * the same one restore itself uses. Nothing here writes to Codex's own
+ * config, and a session's `preview` (conversation text) never leaves this
+ * component — it is rendered, not logged.
+ */
+export function FindCodexSessionAction({ panelId }: { panelId: string }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [result, setResult] = useState<CodexFolderSessionsResult | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const showSpinner = useDohertyGate(isLoading);
+  const addPanel = usePanelStore((state) => state.addPanel);
+
+  const { agentId, cwd, codexHome, agentLaunchFlags } = usePanelStore(
+    useShallow((state) => {
+      const panel = state.panelsById[panelId];
+      const pty = panel && isPtyPanel(panel) ? panel : undefined;
+      const env = pty?.env;
+      const codexHomeKey = env
+        ? Object.keys(env).find((key) => key.toUpperCase() === "CODEX_HOME")
+        : undefined;
+      return {
+        // Live detection wins, launch affinity as the fallback — matches
+        // `SubagentChip`, so a pane relaunched onto another agent stops
+        // offering this the same way it stops answering for the old one.
+        agentId: pty?.runtimeIdentity?.agentId ?? pty?.launchAgentId,
+        cwd: pty?.cwd,
+        codexHome: codexHomeKey ? env?.[codexHomeKey] : undefined,
+        agentLaunchFlags: pty?.agentLaunchFlags,
+      };
+    })
+  );
+
+  const load = useCallback(() => {
+    if (!cwd || isLoading) return;
+    setIsLoading(true);
+    void codexClient
+      .findSessions({ cwd, codexHome })
+      .then(setResult)
+      .catch((error: unknown) => {
+        logWarn(
+          `[FindCodexSessionAction] query failed: ${formatErrorMessage(error, "unknown error")}`
+        );
+        setResult({ status: "unavailable", reason: "protocol-error" });
+      })
+      .finally(() => setIsLoading(false));
+  }, [cwd, codexHome, isLoading]);
+
+  if (agentId !== "codex") return null;
+
+  // A sibling pane already holding one of these conversations isn't worth
+  // offering back — reopening it would put two writers on one transcript,
+  // exactly the collision restore's own suppression exists to prevent
+  // (#11461). Read fresh off the store rather than a subscription: this list
+  // only matters while the popover is open, so it doesn't need to track
+  // panes that open or close in the background.
+  const heldElsewhere = new Set<string>();
+  if (result?.status === "ok") {
+    for (const panel of Object.values(usePanelStore.getState().panelsById)) {
+      if (panel.id === panelId || !isPtyPanel(panel)) continue;
+      const heldAgentId = panel.runtimeIdentity?.agentId ?? panel.launchAgentId;
+      if (heldAgentId === "codex" && panel.agentSessionId) heldElsewhere.add(panel.agentSessionId);
+    }
+  }
+  const sessions: CodexFolderSession[] =
+    result?.status === "ok"
+      ? result.sessions.filter((session) => !heldElsewhere.has(session.id))
+      : [];
+
+  const openSession = async (session: CodexFolderSession) => {
+    if (!cwd) return;
+    const command = buildResumeCommand("codex", session.id, agentLaunchFlags);
+    if (!command) return;
+    setIsOpen(false);
+    try {
+      await addPanel({
+        kind: "terminal",
+        cwd,
+        launchAgentId: "codex",
+        agentSessionId: session.id,
+        command,
+      });
+    } catch (error) {
+      logError("[FindCodexSessionAction] failed to open session", error);
+    }
+  };
+
+  return (
+    <Popover
+      open={isOpen}
+      onOpenChange={(open) => {
+        setIsOpen(open);
+        if (open && result === null) load();
+      }}
+    >
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className="flex items-center gap-1.5 px-2 py-1 text-xs font-medium text-text-secondary hover:text-text-primary hover:bg-daintree-border/50 transition-colors outline-hidden focus-visible:outline-solid focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-primary"
+        >
+          <Search className="w-3 h-3" aria-hidden="true" />
+          Find session
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-80 p-0">
+        <div className="flex items-center justify-between px-3 py-2 border-b border-divider">
+          <span className="text-xs font-medium text-text-primary">
+            Codex sessions in this folder
+          </span>
+          <button
+            type="button"
+            onClick={load}
+            disabled={isLoading}
+            className="text-daintree-text/40 hover:text-text-primary transition-colors disabled:opacity-50 disabled:pointer-events-none"
+            aria-label="Refresh sessions"
+          >
+            <RefreshCw className={cn("w-3 h-3", isLoading && "animate-spin")} aria-hidden="true" />
+          </button>
+        </div>
+        {result === null ? (
+          showSpinner ? (
+            <div className="flex items-center gap-2 px-3 py-3 text-xs text-text-secondary">
+              <Spinner size="sm" />
+              Looking for sessions
+            </div>
+          ) : null
+        ) : result.status === "unavailable" ? (
+          <p className="px-3 py-3 text-xs text-text-secondary">
+            {findSessionsErrorMessage(result.reason)}
+          </p>
+        ) : sessions.length === 0 ? (
+          <p className="px-3 py-3 text-xs text-text-secondary">No other sessions found here</p>
+        ) : (
+          <ul className="max-h-80 overflow-y-auto">
+            {sessions.map((session) => (
+              <li key={session.id} className="border-b border-divider last:border-b-0">
+                <button
+                  type="button"
+                  onClick={() => void openSession(session)}
+                  className="w-full flex flex-col items-start gap-0.5 px-3 py-2 text-left hover:bg-overlay-subtle transition-colors"
+                >
+                  <span className="text-xs text-text-primary truncate w-full">
+                    {firstLine(session.preview).slice(0, 80) || session.id.slice(0, 8)}
+                  </span>
+                  {session.updatedAt > 0 && (
+                    <span className="text-3xs text-text-placeholder tabular-nums">
+                      {formatTimeAgo(session.updatedAt)}
+                    </span>
+                  )}
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/components/Terminal/FindCodexSessionAction.tsx
+++ b/src/components/Terminal/FindCodexSessionAction.tsx
@@ -58,7 +58,17 @@ export function FindCodexSessionAction({ panelId }: { panelId: string }) {
   const showSpinner = useDohertyGate(isLoading);
   const addPanel = usePanelStore((state) => state.addPanel);
 
-  const { agentId, cwd, codexHome, agentLaunchFlags } = usePanelStore(
+  const {
+    agentId,
+    cwd,
+    codexHome,
+    worktreeId,
+    env,
+    agentLaunchFlags,
+    agentModelId,
+    agentPresetId,
+    agentPresetColor,
+  } = usePanelStore(
     useShallow((state) => {
       const panel = state.panelsById[panelId];
       const pty = panel && isPtyPanel(panel) ? panel : undefined;
@@ -73,7 +83,17 @@ export function FindCodexSessionAction({ panelId }: { panelId: string }) {
         agentId: pty?.runtimeIdentity?.agentId ?? pty?.launchAgentId,
         cwd: pty?.cwd,
         codexHome: codexHomeKey ? env?.[codexHomeKey] : undefined,
+        // The reopened pane inherits this pane's launch shape: `worktreeId`
+        // because the grid only renders the active worktree's bucket, so a
+        // worktree-less pane is invisible whenever one is active (#11290),
+        // and `env` because the sessions were listed under this pane's
+        // CODEX_HOME — resuming under main's default profile wouldn't find them.
+        worktreeId: pty?.worktreeId,
+        env,
         agentLaunchFlags: pty?.agentLaunchFlags,
+        agentModelId: pty?.agentModelId,
+        agentPresetId: pty?.agentPresetId,
+        agentPresetColor: pty?.agentPresetColor,
       };
     })
   );
@@ -127,9 +147,15 @@ export function FindCodexSessionAction({ panelId }: { panelId: string }) {
       await addPanel({
         kind: "terminal",
         cwd,
+        worktreeId,
         launchAgentId: "codex",
         agentSessionId: session.id,
         command,
+        agentLaunchFlags,
+        agentModelId,
+        agentPresetId,
+        agentPresetColor,
+        env,
       });
     } catch (error) {
       logError("[FindCodexSessionAction] failed to open session", error);

--- a/src/components/Terminal/FindCodexSessionAction.tsx
+++ b/src/components/Terminal/FindCodexSessionAction.tsx
@@ -6,7 +6,7 @@ import { Spinner } from "@/components/ui/Spinner";
 import { useDohertyGate } from "@/hooks/useDeferredLoading";
 import { cn } from "@/lib/utils";
 import { usePanelStore } from "@/store/panelStore";
-import { isPtyPanel } from "@shared/types/panel";
+import { isPtyPanel, type PanelInstance } from "@shared/types/panel";
 import { buildResumeCommand } from "@shared/types";
 import { formatTimeAgo } from "@/utils/timeAgo";
 import { logWarn, logError } from "@/utils/logger";
@@ -34,6 +34,26 @@ function findSessionsErrorMessage(reason: AgentSubagentUnavailableReason): strin
 
 function firstLine(value: string): string {
   return value.trim().split("\n")[0]?.trim() ?? "";
+}
+
+/**
+ * Codex session ids already held by a sibling pane, excluding `panelId`
+ * itself. Shared by the initial fetch filter and by `openSession`'s
+ * just-before-opening recheck (#11461) — a sibling can claim one of these
+ * conversations in the gap between listing and picking, and reopening it
+ * anyway would put two writers on the same transcript.
+ */
+function siblingHeldSessionIds(
+  panelsById: Record<string, PanelInstance>,
+  panelId: string
+): Set<string> {
+  const held = new Set<string>();
+  for (const panel of Object.values(panelsById)) {
+    if (panel.id === panelId || !isPtyPanel(panel)) continue;
+    const heldAgentId = panel.runtimeIdentity?.agentId ?? panel.launchAgentId;
+    if (heldAgentId === "codex" && panel.agentSessionId) held.add(panel.agentSessionId);
+  }
+  return held;
 }
 
 /**
@@ -68,6 +88,9 @@ export function FindCodexSessionAction({ panelId }: { panelId: string }) {
     agentModelId,
     agentPresetId,
     agentPresetColor,
+    originalPresetId,
+    isUsingFallback,
+    fallbackChainIndex,
   } = usePanelStore(
     useShallow((state) => {
       const panel = state.panelsById[panelId];
@@ -94,6 +117,12 @@ export function FindCodexSessionAction({ panelId }: { panelId: string }) {
         agentModelId: pty?.agentModelId,
         agentPresetId: pty?.agentPresetId,
         agentPresetColor: pty?.agentPresetColor,
+        // Carried too, or a lost pane already running on a fallback preset
+        // would present the fallback as though it were the original choice,
+        // losing the "was X → now Y" state the fallback chain tracks.
+        originalPresetId: pty?.originalPresetId,
+        isUsingFallback: pty?.isUsingFallback,
+        fallbackChainIndex: pty?.fallbackChainIndex,
       };
     })
   );
@@ -113,14 +142,10 @@ export function FindCodexSessionAction({ panelId }: { panelId: string }) {
         // its subscribed selector is impure and the React Compiler bails out
         // on it, and this list only matters while the popover is open anyway
         // — it doesn't need to track panes that open or close in the
-        // background.
-        const held = new Set<string>();
-        for (const panel of Object.values(usePanelStore.getState().panelsById)) {
-          if (panel.id === panelId || !isPtyPanel(panel)) continue;
-          const heldAgentId = panel.runtimeIdentity?.agentId ?? panel.launchAgentId;
-          if (heldAgentId === "codex" && panel.agentSessionId) held.add(panel.agentSessionId);
-        }
-        setHeldElsewhere(held);
+        // background. `openSession` below re-checks right before opening, so
+        // this snapshot going stale only ever costs a still-listed row, never
+        // a duplicate resume.
+        setHeldElsewhere(siblingHeldSessionIds(usePanelStore.getState().panelsById, panelId));
       })
       .catch((error: unknown) => {
         logWarn(
@@ -140,6 +165,14 @@ export function FindCodexSessionAction({ panelId }: { panelId: string }) {
 
   const openSession = async (session: CodexFolderSession) => {
     if (!cwd) return;
+    // A sibling can claim this exact conversation in the gap between the list
+    // loading and the user picking a row — the popover can sit open for a
+    // while. Re-check right before opening rather than trusting the snapshot
+    // the list was filtered against (#11461).
+    if (siblingHeldSessionIds(usePanelStore.getState().panelsById, panelId).has(session.id)) {
+      setHeldElsewhere((prev) => new Set(prev).add(session.id));
+      return;
+    }
     const command = buildResumeCommand("codex", session.id, agentLaunchFlags);
     if (!command) return;
     setIsOpen(false);
@@ -155,6 +188,9 @@ export function FindCodexSessionAction({ panelId }: { panelId: string }) {
         agentModelId,
         agentPresetId,
         agentPresetColor,
+        originalPresetId,
+        isUsingFallback,
+        fallbackChainIndex,
         env,
       });
     } catch (error) {

--- a/src/components/Terminal/FindCodexSessionAction.tsx
+++ b/src/components/Terminal/FindCodexSessionAction.tsx
@@ -51,6 +51,10 @@ export function FindCodexSessionAction({ panelId }: { panelId: string }) {
   const [isOpen, setIsOpen] = useState(false);
   const [result, setResult] = useState<CodexFolderSessionsResult | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  // Sibling-held session ids at the moment sessions were last fetched — see
+  // the load() callback below for why this is computed there rather than
+  // read here at render time.
+  const [heldElsewhere, setHeldElsewhere] = useState<ReadonlySet<string>>(new Set());
   const showSpinner = useDohertyGate(isLoading);
   const addPanel = usePanelStore((state) => state.addPanel);
 
@@ -79,7 +83,25 @@ export function FindCodexSessionAction({ panelId }: { panelId: string }) {
     setIsLoading(true);
     void codexClient
       .findSessions({ cwd, codexHome })
-      .then(setResult)
+      .then((response) => {
+        setResult(response);
+        // A sibling pane already holding one of these conversations isn't
+        // worth offering back — reopening it would put two writers on one
+        // transcript, exactly the collision restore's own suppression exists
+        // to prevent (#11461). Snapshotted here, at fetch time, rather than
+        // read live during render: a render body reading the store outside
+        // its subscribed selector is impure and the React Compiler bails out
+        // on it, and this list only matters while the popover is open anyway
+        // — it doesn't need to track panes that open or close in the
+        // background.
+        const held = new Set<string>();
+        for (const panel of Object.values(usePanelStore.getState().panelsById)) {
+          if (panel.id === panelId || !isPtyPanel(panel)) continue;
+          const heldAgentId = panel.runtimeIdentity?.agentId ?? panel.launchAgentId;
+          if (heldAgentId === "codex" && panel.agentSessionId) held.add(panel.agentSessionId);
+        }
+        setHeldElsewhere(held);
+      })
       .catch((error: unknown) => {
         logWarn(
           `[FindCodexSessionAction] query failed: ${formatErrorMessage(error, "unknown error")}`
@@ -87,24 +109,10 @@ export function FindCodexSessionAction({ panelId }: { panelId: string }) {
         setResult({ status: "unavailable", reason: "protocol-error" });
       })
       .finally(() => setIsLoading(false));
-  }, [cwd, codexHome, isLoading]);
+  }, [cwd, codexHome, isLoading, panelId]);
 
   if (agentId !== "codex") return null;
 
-  // A sibling pane already holding one of these conversations isn't worth
-  // offering back — reopening it would put two writers on one transcript,
-  // exactly the collision restore's own suppression exists to prevent
-  // (#11461). Read fresh off the store rather than a subscription: this list
-  // only matters while the popover is open, so it doesn't need to track
-  // panes that open or close in the background.
-  const heldElsewhere = new Set<string>();
-  if (result?.status === "ok") {
-    for (const panel of Object.values(usePanelStore.getState().panelsById)) {
-      if (panel.id === panelId || !isPtyPanel(panel)) continue;
-      const heldAgentId = panel.runtimeIdentity?.agentId ?? panel.launchAgentId;
-      if (heldAgentId === "codex" && panel.agentSessionId) heldElsewhere.add(panel.agentSessionId);
-    }
-  }
   const sessions: CodexFolderSession[] =
     result?.status === "ok"
       ? result.sessions.filter((session) => !heldElsewhere.has(session.id))
@@ -139,7 +147,7 @@ export function FindCodexSessionAction({ panelId }: { panelId: string }) {
       <PopoverTrigger asChild>
         <button
           type="button"
-          className="flex items-center gap-1.5 px-2 py-1 text-xs font-medium text-text-secondary hover:text-text-primary hover:bg-daintree-border/50 transition-colors outline-hidden focus-visible:outline-solid focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-primary"
+          className="flex items-center gap-1.5 px-2 py-1 text-xs font-medium text-text-secondary hover:text-text-primary hover:bg-border-default/50 transition-colors outline-hidden focus-visible:outline-solid focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-primary"
         >
           <Search className="w-3 h-3" aria-hidden="true" />
           Find session
@@ -154,7 +162,7 @@ export function FindCodexSessionAction({ panelId }: { panelId: string }) {
             type="button"
             onClick={load}
             disabled={isLoading}
-            className="text-daintree-text/40 hover:text-text-primary transition-colors disabled:opacity-50 disabled:pointer-events-none"
+            className="text-text-secondary hover:text-text-primary transition-colors disabled:opacity-50 disabled:pointer-events-none"
             aria-label="Refresh sessions"
           >
             <RefreshCw className={cn("w-3 h-3", isLoading && "animate-spin")} aria-hidden="true" />

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -32,6 +32,7 @@ import { useUnmountVisibilityCleanup } from "./useUnmountVisibilityCleanup";
 import { useTerminalVisibilityObserver } from "./useTerminalVisibilityObserver";
 import { FleetDraftingPill } from "@/components/Fleet/FleetDraftingPill";
 import { TerminalRestartStatusBanner } from "./TerminalRestartStatusBanner";
+import { FindCodexSessionAction } from "./FindCodexSessionAction";
 import { InlineStatusBanner } from "./InlineStatusBanner";
 import { useForceResumeCycleWatchdog } from "@/hooks/terminal/useForceResumeCycleWatchdog";
 import { useContextInjection } from "@/hooks/useContextInjection";
@@ -1429,6 +1430,12 @@ function TerminalPaneComponent({
             restartBannerVariant.type === "session-resume-unavailable"
               ? sessionLostBanner.dismissAll
               : undefined
+          }
+          findSessionSlot={
+            restartBannerVariant.type === "session-resume-unavailable" &&
+            effectiveAgentId === "codex" ? (
+              <FindCodexSessionAction panelId={id} />
+            ) : undefined
           }
         />
       </BannerSlot>

--- a/src/components/Terminal/TerminalRestartStatusBanner.tsx
+++ b/src/components/Terminal/TerminalRestartStatusBanner.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties } from "react";
+import type { CSSProperties, ReactNode } from "react";
 import { XCircle, Loader2, RotateCcw, AlertTriangle } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { InlineStatusBanner } from "./InlineStatusBanner";
@@ -16,6 +16,12 @@ export interface TerminalRestartStatusBannerProps {
    * undefined keeps the banner at exactly one control.
    */
   onDismissAll?: () => void;
+  /**
+   * "Find session" (issue #12182), pre-built by the caller — which already
+   * knows whether this pane's agent has one to offer — or `undefined` when it
+   * doesn't. Only meaningful for the `session-resume-unavailable` variant.
+   */
+  findSessionSlot?: ReactNode;
 }
 
 function SpinnerIcon({ className, style }: { className?: string; style?: CSSProperties }) {
@@ -33,6 +39,7 @@ export function TerminalRestartStatusBanner({
   onRestart,
   onDismiss,
   onDismissAll,
+  findSessionSlot,
 }: TerminalRestartStatusBannerProps) {
   switch (variant.type) {
     case "none":
@@ -64,7 +71,7 @@ export function TerminalRestartStatusBanner({
         />
       );
 
-    case "session-resume-unavailable":
+    case "session-resume-unavailable": {
       // Toned down per issue #10823: the terminal already relaunched into a
       // fresh, usable session, so this is a dismissable acknowledgement, not an
       // assertive error. Warning severity + polite status role + a dismiss
@@ -72,39 +79,46 @@ export function TerminalRestartStatusBanner({
       // session). The banner still surfaces the lost session so it isn't
       // dropped silently (issue #9802).
       //
+      // Copy is reason-specific (issue #12182): a sibling pane already holding
+      // the conversation reads very differently from there being nothing to
+      // resume, and the banner should say which one happened.
+      const copy = RESTART_BANNER_COPY["session-resume-unavailable"]({ reason: variant.reason });
       // A restart can strand this banner on a dozen panes at once, so when more
       // than one is flagged the caller supplies `onDismissAll` and we offer a
       // second, neutral control (issue #11589). Warning severity is not bound by
       // the single-action rule, so `actions` is legal here — and with a
       // description present `InlineStatusBanner` keeps the close X in the title
       // row and drops actions into their own controls row, which reads as the
-      // per-pane vs. project-wide split it is.
+      // per-pane vs. project-wide split it is. "Find session" (#12182) rides
+      // `trailingSlot` instead of `actions`, exactly what that prop documents
+      // itself for — a Popover trigger, not a plain button.
       return (
         <InlineStatusBanner
           icon={AlertTriangle}
-          title={RESTART_BANNER_COPY["session-resume-unavailable"].title}
-          description={RESTART_BANNER_COPY["session-resume-unavailable"].description}
+          title={copy.title}
+          description={copy.description}
           severity="warning"
           animated={false}
           role="status"
           ariaLive="polite"
           onClose={onDismiss}
+          trailingSlot={findSessionSlot}
           actions={
             onDismissAll
               ? [
                   {
                     id: "dismiss-all-session-lost",
-                    label: RESTART_BANNER_COPY["session-resume-unavailable"].dismissAllLabel,
+                    label: copy.dismissAllLabel,
                     variant: "dismiss",
                     onClick: onDismissAll,
-                    ariaLabel:
-                      RESTART_BANNER_COPY["session-resume-unavailable"].dismissAllAriaLabel,
+                    ariaLabel: copy.dismissAllAriaLabel,
                   },
                 ]
               : undefined
           }
         />
       );
+    }
 
     case "exit-error":
       return (

--- a/src/components/Terminal/__tests__/FindCodexSessionAction.test.tsx
+++ b/src/components/Terminal/__tests__/FindCodexSessionAction.test.tsx
@@ -1,0 +1,212 @@
+// @vitest-environment jsdom
+/**
+ * "Find session" action on the lost-session banner (issue #12182). Uses the
+ * real store (matching `useSessionLostBanner.test.tsx`'s harness) with
+ * `addPanel` swapped for a spy — everything else about panel state stays
+ * real, only the heavy IPC-backed action is replaced. Radix renders
+ * synchronously via `vitest.setup.ts`'s global priming, so no popover mock
+ * is needed.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { PanelInstance, PtyPanelData } from "@shared/types/panel";
+import type { CodexFolderSession } from "@shared/types/ipc/agentSubagents";
+
+const findSessions = vi.hoisted(() => vi.fn());
+
+vi.mock("@/clients/codexClient", () => ({
+  codexClient: { findSessions },
+}));
+
+// Deterministic in place of the real agent-config lookup, matching the
+// pattern `statePatcher.test.ts` uses for the same function.
+vi.mock("@shared/types", async () => {
+  const actual = await vi.importActual<typeof import("@shared/types")>("@shared/types");
+  return {
+    ...actual,
+    buildResumeCommand: (agentId: string, sessionId: string) => `${agentId} resume ${sessionId}`,
+  };
+});
+
+vi.mock("@/clients", () => ({
+  terminalClient: {
+    spawn: vi.fn(),
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn().mockResolvedValue(undefined),
+    trash: vi.fn().mockResolvedValue(undefined),
+    restore: vi.fn().mockResolvedValue(undefined),
+    onData: vi.fn(),
+    onExit: vi.fn(),
+    onAgentStateChanged: vi.fn(),
+  },
+  appClient: { setState: vi.fn().mockResolvedValue(undefined) },
+  projectClient: {
+    getTerminals: vi.fn().mockResolvedValue([]),
+    setTerminals: vi.fn().mockResolvedValue(undefined),
+    setTabGroups: vi.fn().mockResolvedValue(undefined),
+    getSettings: vi.fn().mockResolvedValue({}),
+  },
+  agentSettingsClient: { get: vi.fn().mockResolvedValue({}) },
+  systemClient: { getAppMetrics: vi.fn().mockResolvedValue({ totalMemoryMB: 512 }) },
+}));
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: {
+    cleanup: vi.fn(),
+    applyRendererPolicy: vi.fn(),
+    onPanelBackgrounded: vi.fn(),
+    destroy: vi.fn(),
+  },
+}));
+
+vi.mock("../../../store/slices/panelRegistry/persistence", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../../store/slices/panelRegistry/persistence")
+  >("../../../store/slices/panelRegistry/persistence");
+  return { ...actual, saveNormalized: vi.fn() };
+});
+
+const { usePanelStore } = await import("@/store/panelStore");
+const { FindCodexSessionAction } = await import("../FindCodexSessionAction");
+const { _resetSelectorCacheForTests } = await import("@/store/slices/panelRegistry/selectors");
+
+const addPanel = vi.fn().mockResolvedValue("new-pane-id");
+
+function panel(id: string, overrides: Partial<PtyPanelData> = {}): PanelInstance {
+  return {
+    id,
+    kind: "terminal",
+    title: id,
+    cwd: "/repo",
+    cols: 80,
+    rows: 24,
+    location: "grid",
+    launchAgentId: "codex",
+    ...overrides,
+  } as PanelInstance;
+}
+
+function seed(...panels: PanelInstance[]) {
+  usePanelStore.setState({
+    panelsById: Object.fromEntries(panels.map((p) => [p.id, p])),
+    panelIds: panels.map((p) => p.id),
+    addPanel,
+  });
+}
+
+function ok(sessions: CodexFolderSession[]) {
+  return { status: "ok" as const, sessions };
+}
+
+beforeEach(() => {
+  _resetSelectorCacheForTests();
+  findSessions.mockReset();
+  addPanel.mockClear();
+  usePanelStore.setState({ panelsById: {}, panelIds: [] });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("FindCodexSessionAction", () => {
+  it("renders nothing for a pane not running Codex", () => {
+    seed(panel("t-1", { launchAgentId: "gemini" }));
+    render(<FindCodexSessionAction panelId="t-1" />);
+    expect(screen.queryByRole("button", { name: "Find session" })).toBeNull();
+  });
+
+  it("renders nothing for an unknown panel id", () => {
+    render(<FindCodexSessionAction panelId="missing" />);
+    expect(screen.queryByRole("button", { name: "Find session" })).toBeNull();
+  });
+
+  it("renders the trigger for a Codex pane and fetches on open", async () => {
+    findSessions.mockResolvedValue(
+      ok([{ id: "sess-1", preview: "fix the flaky test", updatedAt: 1_700_000_000_000 }])
+    );
+    seed(panel("t-1"));
+
+    render(<FindCodexSessionAction panelId="t-1" />);
+    fireEvent.click(screen.getByRole("button", { name: "Find session" }));
+
+    expect(await screen.findByText("fix the flaky test")).toBeTruthy();
+    expect(findSessions).toHaveBeenCalledWith({ cwd: "/repo", codexHome: undefined });
+  });
+
+  it("passes the pane's own CODEX_HOME, not main's default profile", async () => {
+    findSessions.mockResolvedValue(ok([]));
+    seed(panel("t-1", { env: { CODEX_HOME: "/pane/.codex" } }));
+
+    render(<FindCodexSessionAction panelId="t-1" />);
+    fireEvent.click(screen.getByRole("button", { name: "Find session" }));
+
+    await waitFor(() =>
+      expect(findSessions).toHaveBeenCalledWith({ cwd: "/repo", codexHome: "/pane/.codex" })
+    );
+  });
+
+  it("shows an empty state when the folder has no sessions", async () => {
+    findSessions.mockResolvedValue(ok([]));
+    seed(panel("t-1"));
+
+    render(<FindCodexSessionAction panelId="t-1" />);
+    fireEvent.click(screen.getByRole("button", { name: "Find session" }));
+
+    expect(await screen.findByText("No other sessions found here")).toBeTruthy();
+  });
+
+  it("shows an error state when Codex can't be reached", async () => {
+    findSessions.mockResolvedValue({ status: "unavailable", reason: "cli-missing" });
+    seed(panel("t-1"));
+
+    render(<FindCodexSessionAction panelId="t-1" />);
+    fireEvent.click(screen.getByRole("button", { name: "Find session" }));
+
+    expect(await screen.findByText("Codex CLI isn't available")).toBeTruthy();
+  });
+
+  it("excludes a session a sibling pane already has open (#11461)", async () => {
+    findSessions.mockResolvedValue(
+      ok([
+        { id: "held-by-sibling", preview: "already open elsewhere", updatedAt: 2 },
+        { id: "still-findable", preview: "not open anywhere", updatedAt: 1 },
+      ])
+    );
+    seed(
+      panel("t-1"),
+      panel("t-2", { agentSessionId: "held-by-sibling" }),
+      panel("t-3", { agentSessionId: "unrelated", launchAgentId: "claude" })
+    );
+
+    render(<FindCodexSessionAction panelId="t-1" />);
+    fireEvent.click(screen.getByRole("button", { name: "Find session" }));
+
+    expect(await screen.findByText("not open anywhere")).toBeTruthy();
+    expect(screen.queryByText("already open elsewhere")).toBeNull();
+  });
+
+  it("opens the chosen session in a new pane and closes the picker", async () => {
+    findSessions.mockResolvedValue(ok([{ id: "sess-1", preview: "pick me", updatedAt: 1 }]));
+    seed(panel("t-1", { agentLaunchFlags: ["--yolo"] }));
+
+    render(<FindCodexSessionAction panelId="t-1" />);
+    fireEvent.click(screen.getByRole("button", { name: "Find session" }));
+    fireEvent.click(await screen.findByText("pick me"));
+
+    await waitFor(() => expect(addPanel).toHaveBeenCalledOnce());
+    const call = addPanel.mock.calls[0]?.[0];
+    expect(call).toMatchObject({
+      kind: "terminal",
+      cwd: "/repo",
+      launchAgentId: "codex",
+      agentSessionId: "sess-1",
+    });
+    expect(typeof call.command).toBe("string");
+    expect(call.command).toContain("sess-1");
+    // Picking a session closes the popover — its content leaves the document.
+    await waitFor(() => expect(screen.queryByText("pick me")).toBeNull());
+  });
+});

--- a/src/components/Terminal/__tests__/FindCodexSessionAction.test.tsx
+++ b/src/components/Terminal/__tests__/FindCodexSessionAction.test.tsx
@@ -209,4 +209,34 @@ describe("FindCodexSessionAction", () => {
     // Picking a session closes the popover — its content leaves the document.
     await waitFor(() => expect(screen.queryByText("pick me")).toBeNull());
   });
+
+  it("reopens the session in the pane's own worktree and env", async () => {
+    findSessions.mockResolvedValue(ok([{ id: "sess-1", preview: "pick me", updatedAt: 1 }]));
+    seed(
+      panel("t-1", {
+        worktreeId: "wt-1",
+        env: { CODEX_HOME: "/pane/.codex" },
+        agentPresetId: "preset-1",
+        agentPresetColor: "#123456",
+        agentModelId: "o3",
+      })
+    );
+
+    render(<FindCodexSessionAction panelId="t-1" />);
+    fireEvent.click(screen.getByRole("button", { name: "Find session" }));
+    fireEvent.click(await screen.findByText("pick me"));
+
+    await waitFor(() => expect(addPanel).toHaveBeenCalledOnce());
+    // Without `worktreeId` the new pane lands in the "__none__" bucket and is
+    // never rendered while a worktree is active; without `env` Codex resumes
+    // under main's default profile and can't find a session listed under the
+    // pane's own CODEX_HOME.
+    expect(addPanel.mock.calls[0]?.[0]).toMatchObject({
+      worktreeId: "wt-1",
+      env: { CODEX_HOME: "/pane/.codex" },
+      agentPresetId: "preset-1",
+      agentPresetColor: "#123456",
+      agentModelId: "o3",
+    });
+  });
 });

--- a/src/components/Terminal/__tests__/FindCodexSessionAction.test.tsx
+++ b/src/components/Terminal/__tests__/FindCodexSessionAction.test.tsx
@@ -9,7 +9,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { PanelInstance, PtyPanelData } from "@shared/types/panel";
 import type { CodexFolderSession } from "@shared/types/ipc/agentSubagents";
 
@@ -238,5 +238,55 @@ describe("FindCodexSessionAction", () => {
       agentPresetColor: "#123456",
       agentModelId: "o3",
     });
+  });
+
+  it("carries the fallback-chain state, so a fallback preset isn't presented as the original", async () => {
+    findSessions.mockResolvedValue(ok([{ id: "sess-1", preview: "pick me", updatedAt: 1 }]));
+    seed(
+      panel("t-1", {
+        originalPresetId: "preset-original",
+        isUsingFallback: true,
+        fallbackChainIndex: 2,
+      })
+    );
+
+    render(<FindCodexSessionAction panelId="t-1" />);
+    fireEvent.click(screen.getByRole("button", { name: "Find session" }));
+    fireEvent.click(await screen.findByText("pick me"));
+
+    await waitFor(() => expect(addPanel).toHaveBeenCalledOnce());
+    expect(addPanel.mock.calls[0]?.[0]).toMatchObject({
+      originalPresetId: "preset-original",
+      isUsingFallback: true,
+      fallbackChainIndex: 2,
+    });
+  });
+
+  it("re-checks for a sibling claim right before opening, even if the list is stale (#11461)", async () => {
+    findSessions.mockResolvedValue(ok([{ id: "sess-1", preview: "pick me", updatedAt: 1 }]));
+    seed(panel("t-1"));
+
+    render(<FindCodexSessionAction panelId="t-1" />);
+    fireEvent.click(screen.getByRole("button", { name: "Find session" }));
+    await screen.findByText("pick me");
+
+    // A sibling claims this exact conversation after the list loaded but
+    // before the user clicks it — the popover can sit open for a while.
+    act(() => {
+      usePanelStore.setState((state) => ({
+        panelsById: {
+          ...state.panelsById,
+          "t-2": panel("t-2", { agentSessionId: "sess-1" }),
+        },
+        panelIds: [...state.panelIds, "t-2"],
+      }));
+    });
+
+    fireEvent.click(screen.getByText("pick me"));
+
+    // Never opened — the recheck caught the just-claimed session instead of
+    // trusting the now-stale list.
+    await waitFor(() => expect(screen.queryByText("pick me")).toBeNull());
+    expect(addPanel).not.toHaveBeenCalled();
   });
 });

--- a/src/components/Terminal/__tests__/TerminalRestartStatusBanner.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalRestartStatusBanner.test.tsx
@@ -120,7 +120,7 @@ describe("TerminalRestartStatusBanner", () => {
     it("renders neutral title and a non-accusatory description", () => {
       render(
         <TerminalRestartStatusBanner
-          variant={{ type: "session-resume-unavailable" }}
+          variant={{ type: "session-resume-unavailable", reason: "no-resume-command" }}
           onRestart={vi.fn()}
           onDismiss={vi.fn()}
         />
@@ -134,7 +134,7 @@ describe("TerminalRestartStatusBanner", () => {
     it("uses role=status with a polite live region (toned down per #10823)", () => {
       render(
         <TerminalRestartStatusBanner
-          variant={{ type: "session-resume-unavailable" }}
+          variant={{ type: "session-resume-unavailable", reason: "no-resume-command" }}
           onRestart={vi.fn()}
           onDismiss={vi.fn()}
         />
@@ -149,7 +149,7 @@ describe("TerminalRestartStatusBanner", () => {
     it("has no restart action — the terminal already relaunched fresh (#10823)", () => {
       render(
         <TerminalRestartStatusBanner
-          variant={{ type: "session-resume-unavailable" }}
+          variant={{ type: "session-resume-unavailable", reason: "no-resume-command" }}
           onRestart={vi.fn()}
           onDismiss={vi.fn()}
         />
@@ -164,7 +164,7 @@ describe("TerminalRestartStatusBanner", () => {
       const onDismiss = vi.fn();
       render(
         <TerminalRestartStatusBanner
-          variant={{ type: "session-resume-unavailable" }}
+          variant={{ type: "session-resume-unavailable", reason: "no-resume-command" }}
           onRestart={vi.fn()}
           onDismiss={onDismiss}
         />
@@ -181,7 +181,7 @@ describe("TerminalRestartStatusBanner", () => {
       it("offers a second control when onDismissAll is supplied", () => {
         render(
           <TerminalRestartStatusBanner
-            variant={{ type: "session-resume-unavailable" }}
+            variant={{ type: "session-resume-unavailable", reason: "no-resume-command" }}
             onRestart={vi.fn()}
             onDismiss={vi.fn()}
             onDismissAll={vi.fn()}
@@ -197,7 +197,7 @@ describe("TerminalRestartStatusBanner", () => {
       it("names the bulk control with its visible label plus the missing scope", () => {
         render(
           <TerminalRestartStatusBanner
-            variant={{ type: "session-resume-unavailable" }}
+            variant={{ type: "session-resume-unavailable", reason: "no-resume-command" }}
             onRestart={vi.fn()}
             onDismiss={vi.fn()}
             onDismissAll={vi.fn()}
@@ -218,7 +218,7 @@ describe("TerminalRestartStatusBanner", () => {
         const onDismissAll = vi.fn();
         render(
           <TerminalRestartStatusBanner
-            variant={{ type: "session-resume-unavailable" }}
+            variant={{ type: "session-resume-unavailable", reason: "no-resume-command" }}
             onRestart={vi.fn()}
             onDismiss={onDismiss}
             onDismissAll={onDismissAll}
@@ -237,7 +237,7 @@ describe("TerminalRestartStatusBanner", () => {
       it("still offers no restart action alongside the bulk control", () => {
         render(
           <TerminalRestartStatusBanner
-            variant={{ type: "session-resume-unavailable" }}
+            variant={{ type: "session-resume-unavailable", reason: "no-resume-command" }}
             onRestart={vi.fn()}
             onDismiss={vi.fn()}
             onDismissAll={vi.fn()}
@@ -263,6 +263,85 @@ describe("TerminalRestartStatusBanner", () => {
           expect(screen.queryByRole("button", { name: /dismiss all/i })).toBeNull();
           unmount();
         }
+      });
+    });
+
+    // Reason-specific copy (issue #12182) — a sibling pane already holding the
+    // conversation must read differently from there being nothing to resume.
+    describe("reason-specific copy (issue #12182)", () => {
+      it("names a sibling holding the exact conversation", () => {
+        render(
+          <TerminalRestartStatusBanner
+            variant={{ type: "session-resume-unavailable", reason: "sibling-owns-session-id" }}
+            onRestart={vi.fn()}
+            onDismiss={vi.fn()}
+          />
+        );
+        expect(screen.getByText("Session already open elsewhere")).toBeTruthy();
+        expect(screen.queryByText("Session no longer reachable")).toBeNull();
+      });
+
+      it("names a sibling holding the folder's most-recent slot", () => {
+        render(
+          <TerminalRestartStatusBanner
+            variant={{
+              type: "session-resume-unavailable",
+              reason: "sibling-owns-resume-latest-slot",
+            }}
+            onRestart={vi.fn()}
+            onDismiss={vi.fn()}
+          />
+        );
+        expect(screen.getByText("Most recent session claimed elsewhere")).toBeTruthy();
+      });
+
+      it("uses the same 'nothing to resume' copy for no-resume-command and no-resume-path", () => {
+        const { unmount } = render(
+          <TerminalRestartStatusBanner
+            variant={{ type: "session-resume-unavailable", reason: "no-resume-command" }}
+            onRestart={vi.fn()}
+            onDismiss={vi.fn()}
+          />
+        );
+        expect(screen.getByText("Session no longer reachable")).toBeTruthy();
+        unmount();
+
+        render(
+          <TerminalRestartStatusBanner
+            variant={{ type: "session-resume-unavailable", reason: "no-resume-path" }}
+            onRestart={vi.fn()}
+            onDismiss={vi.fn()}
+          />
+        );
+        expect(screen.getByText("Session no longer reachable")).toBeTruthy();
+      });
+    });
+
+    // "Find session" (issue #12182) — a pre-built slot the caller supplies,
+    // since only it knows whether this pane's agent has one to offer.
+    describe("findSessionSlot (issue #12182)", () => {
+      it("renders nothing extra when the caller supplies no slot", () => {
+        render(
+          <TerminalRestartStatusBanner
+            variant={{ type: "session-resume-unavailable", reason: "no-resume-command" }}
+            onRestart={vi.fn()}
+            onDismiss={vi.fn()}
+          />
+        );
+        expect(screen.getAllByRole("button")).toHaveLength(1);
+      });
+
+      it("renders the caller-supplied slot alongside dismiss", () => {
+        render(
+          <TerminalRestartStatusBanner
+            variant={{ type: "session-resume-unavailable", reason: "no-resume-command" }}
+            onRestart={vi.fn()}
+            onDismiss={vi.fn()}
+            findSessionSlot={<button type="button">Find session</button>}
+          />
+        );
+        expect(screen.getByRole("button", { name: "Find session" })).toBeTruthy();
+        expect(screen.getByRole("button", { name: "Dismiss" })).toBeTruthy();
       });
     });
   });

--- a/src/components/Terminal/__tests__/restartBannerCopy.test.ts
+++ b/src/components/Terminal/__tests__/restartBannerCopy.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { RESTART_BANNER_COPY } from "../restartBannerCopy";
+import type { SessionLostReason } from "@shared/types/panel";
 
 describe("RESTART_BANNER_COPY", () => {
   it("renders the auto-restarting title with a Unicode ellipsis", () => {
@@ -19,37 +20,82 @@ describe("RESTART_BANNER_COPY", () => {
     );
   });
 
-  // issue #9802 — the session-lost copy must satisfy the CLAUDE.md microcopy
-  // constraints (neutral, non-accusatory; title is a period-free noun phrase).
+  // issue #9802 / #12182 — the session-lost copy must satisfy the CLAUDE.md
+  // microcopy constraints (neutral, non-accusatory; title is a period-free
+  // noun phrase) for every reason the signal can carry.
   describe("session-resume-unavailable copy", () => {
-    const copy = RESTART_BANNER_COPY["session-resume-unavailable"];
+    const REASONS: SessionLostReason[] = [
+      "no-resume-command",
+      "no-resume-path",
+      "sibling-owns-session-id",
+      "sibling-owns-resume-latest-slot",
+    ];
 
-    it("provides a non-empty title and description", () => {
+    it.each(REASONS)("provides a non-empty title and description for %s", (reason) => {
+      const copy = RESTART_BANNER_COPY["session-resume-unavailable"]({ reason });
       expect(copy.title.length).toBeGreaterThan(0);
       expect(copy.description.length).toBeGreaterThan(0);
     });
 
-    it("keeps the title a period-free noun phrase", () => {
+    it.each(REASONS)("keeps the title a period-free noun phrase for %s", (reason) => {
+      const copy = RESTART_BANNER_COPY["session-resume-unavailable"]({ reason });
       expect(copy.title.endsWith(".")).toBe(false);
     });
 
-    it("avoids accusatory or blame-assigning phrasing", () => {
+    it.each(REASONS)("avoids accusatory or blame-assigning phrasing for %s", (reason) => {
+      const copy = RESTART_BANNER_COPY["session-resume-unavailable"]({ reason });
       const text = `${copy.title} ${copy.description}`.toLowerCase();
       expect(text).not.toMatch(/expired|you lost|your fault|agent closed|killed/);
     });
 
     // issue #11589 — the bulk control keeps a short visible label and carries
-    // the full scope in its accessible name.
+    // the full scope in its accessible name. Reason-independent, so one
+    // representative reason is enough.
     it("keeps the bulk label period-free and shorter than its accessible name", () => {
+      const copy = RESTART_BANNER_COPY["session-resume-unavailable"]({
+        reason: "no-resume-command",
+      });
       expect(copy.dismissAllLabel.endsWith(".")).toBe(false);
       expect(copy.dismissAllAriaLabel.endsWith(".")).toBe(false);
       expect(copy.dismissAllAriaLabel.length).toBeGreaterThan(copy.dismissAllLabel.length);
     });
 
     it("keeps the bulk label in sentence case", () => {
+      const copy = RESTART_BANNER_COPY["session-resume-unavailable"]({
+        reason: "no-resume-command",
+      });
       const [firstWord = "", ...restWords] = copy.dismissAllLabel.split(" ");
       expect(firstWord).toMatch(/^[A-Z]/);
       expect(restWords.every((word) => /^[a-z]/.test(word))).toBe(true);
+    });
+
+    // issue #12182 — the reasons don't all collapse to identical copy: a
+    // sibling pane already holding the conversation must read differently
+    // from there being nothing to resume, and the two sibling causes must
+    // read differently from each other.
+    it("gives sibling-attributed reasons distinct copy from the others", () => {
+      const nothingToResume = RESTART_BANNER_COPY["session-resume-unavailable"]({
+        reason: "no-resume-command",
+      });
+      const siblingId = RESTART_BANNER_COPY["session-resume-unavailable"]({
+        reason: "sibling-owns-session-id",
+      });
+      const siblingSlot = RESTART_BANNER_COPY["session-resume-unavailable"]({
+        reason: "sibling-owns-resume-latest-slot",
+      });
+      expect(siblingId.title).not.toBe(nothingToResume.title);
+      expect(siblingSlot.title).not.toBe(nothingToResume.title);
+      expect(siblingId.title).not.toBe(siblingSlot.title);
+    });
+
+    it("shares copy between the two 'nothing to resume' reasons", () => {
+      const commandFailed = RESTART_BANNER_COPY["session-resume-unavailable"]({
+        reason: "no-resume-command",
+      });
+      const noPath = RESTART_BANNER_COPY["session-resume-unavailable"]({
+        reason: "no-resume-path",
+      });
+      expect(commandFailed).toEqual(noPath);
     });
   });
 });

--- a/src/components/Terminal/__tests__/restartStatus.test.ts
+++ b/src/components/Terminal/__tests__/restartStatus.test.ts
@@ -257,15 +257,25 @@ describe("getRestartBannerVariant — session-resume-unavailable (issue #9802)",
   };
 
   it("returns session-resume-unavailable when restore fell through to a fresh launch", () => {
-    const result = getRestartBannerVariant({ ...restored, sessionLostOnRestore: true });
-    expect(result).toEqual({ type: "session-resume-unavailable" });
+    const result = getRestartBannerVariant({
+      ...restored,
+      sessionLostOnRestore: "no-resume-command",
+    });
+    expect(result).toEqual({ type: "session-resume-unavailable", reason: "no-resume-command" });
   });
 
-  it("returns none when sessionLostOnRestore is absent (resumed normally)", () => {
-    // Both falsey shapes: never set, and consumed by a dismissal (#11589).
-    expect(getRestartBannerVariant({ ...restored, sessionLostOnRestore: false })).toEqual({
-      type: "none",
+  it("passes the reason through verbatim, whichever of the four fired (#12182)", () => {
+    const result = getRestartBannerVariant({
+      ...restored,
+      sessionLostOnRestore: "sibling-owns-session-id",
     });
+    expect(result).toEqual({
+      type: "session-resume-unavailable",
+      reason: "sibling-owns-session-id",
+    });
+  });
+
+  it("returns none when sessionLostOnRestore is absent (resumed normally, or consumed by a dismissal — #11589)", () => {
     expect(getRestartBannerVariant({ ...restored, sessionLostOnRestore: undefined })).toEqual({
       type: "none",
     });
@@ -275,10 +285,10 @@ describe("getRestartBannerVariant — session-resume-unavailable (issue #9802)",
     // Dismissing an exit-error prompt must not hide a lost-session acknowledgement.
     const result = getRestartBannerVariant({
       ...restored,
-      sessionLostOnRestore: true,
+      sessionLostOnRestore: "no-resume-command",
       dismissedRestartPrompt: true,
     });
-    expect(result).toEqual({ type: "session-resume-unavailable" });
+    expect(result).toEqual({ type: "session-resume-unavailable", reason: "no-resume-command" });
   });
 
   it("hands off to exit-error when the lost-session banner is dismissed (#10823)", () => {
@@ -290,8 +300,11 @@ describe("getRestartBannerVariant — session-resume-unavailable (issue #9802)",
     const crashedAfterLostSession = { ...restored, isExited: true, exitCode: 1 };
 
     expect(
-      getRestartBannerVariant({ ...crashedAfterLostSession, sessionLostOnRestore: true })
-    ).toEqual({ type: "session-resume-unavailable" });
+      getRestartBannerVariant({
+        ...crashedAfterLostSession,
+        sessionLostOnRestore: "no-resume-command",
+      })
+    ).toEqual({ type: "session-resume-unavailable", reason: "no-resume-command" });
 
     expect(
       getRestartBannerVariant({ ...crashedAfterLostSession, sessionLostOnRestore: undefined })
@@ -301,16 +314,16 @@ describe("getRestartBannerVariant — session-resume-unavailable (issue #9802)",
   it("ignores backendStatus — the lost session is independent of host connectivity", () => {
     const result = getRestartBannerVariant({
       ...restored,
-      sessionLostOnRestore: true,
+      sessionLostOnRestore: "no-resume-command",
       backendStatus: "disconnected",
     });
-    expect(result).toEqual({ type: "session-resume-unavailable" });
+    expect(result).toEqual({ type: "session-resume-unavailable", reason: "no-resume-command" });
   });
 
   it("yields to an in-flight restart (isRestarting wins)", () => {
     const result = getRestartBannerVariant({
       ...restored,
-      sessionLostOnRestore: true,
+      sessionLostOnRestore: "no-resume-command",
       isRestarting: true,
     });
     expect(result).toEqual({ type: "restarting" });
@@ -319,7 +332,7 @@ describe("getRestartBannerVariant — session-resume-unavailable (issue #9802)",
   it("yields to auto-restart (isAutoRestarting wins)", () => {
     const result = getRestartBannerVariant({
       ...restored,
-      sessionLostOnRestore: true,
+      sessionLostOnRestore: "no-resume-command",
       isAutoRestarting: true,
     });
     expect(result).toEqual({ type: "auto-restarting" });
@@ -328,7 +341,7 @@ describe("getRestartBannerVariant — session-resume-unavailable (issue #9802)",
   it("suppresses while a restartError is present", () => {
     const result = getRestartBannerVariant({
       ...restored,
-      sessionLostOnRestore: true,
+      sessionLostOnRestore: "no-resume-command",
       restartError: {
         message: "failed",
         code: "RESTART_FAILED",
@@ -342,7 +355,7 @@ describe("getRestartBannerVariant — session-resume-unavailable (issue #9802)",
   it("suppresses while a reconnectError is present", () => {
     const result = getRestartBannerVariant({
       ...restored,
-      sessionLostOnRestore: true,
+      sessionLostOnRestore: "no-resume-command",
       reconnectError: {
         message: "lost connection",
         code: "RECONNECT_FAILED",
@@ -355,7 +368,7 @@ describe("getRestartBannerVariant — session-resume-unavailable (issue #9802)",
   it("suppresses while a spawnError is present", () => {
     const result = getRestartBannerVariant({
       ...restored,
-      sessionLostOnRestore: true,
+      sessionLostOnRestore: "no-resume-command",
       spawnError: {
         message: "spawn failed",
         code: "SPAWN_FAILED",
@@ -370,8 +383,8 @@ describe("getRestartBannerVariant — session-resume-unavailable (issue #9802)",
       ...restored,
       isExited: true,
       exitCode: 1,
-      sessionLostOnRestore: true,
+      sessionLostOnRestore: "no-resume-command",
     });
-    expect(result).toEqual({ type: "session-resume-unavailable" });
+    expect(result).toEqual({ type: "session-resume-unavailable", reason: "no-resume-command" });
   });
 });

--- a/src/components/Terminal/__tests__/useSessionLostBanner.test.tsx
+++ b/src/components/Terminal/__tests__/useSessionLostBanner.test.tsx
@@ -9,7 +9,12 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { act, renderHook } from "@testing-library/react";
-import { isPtyPanel, type PanelInstance, type PtyPanelData } from "@shared/types/panel";
+import {
+  isPtyPanel,
+  type PanelInstance,
+  type PtyPanelData,
+  type SessionLostReason,
+} from "@shared/types/panel";
 
 vi.mock("@/clients", () => ({
   terminalClient: {
@@ -74,7 +79,7 @@ function seed(...panels: PanelInstance[]) {
   });
 }
 
-function flagOf(id: string): boolean | undefined {
+function flagOf(id: string): SessionLostReason | undefined {
   const panel = usePanelStore.getState().panelsById[id];
   return panel && isPtyPanel(panel) ? panel.sessionLostOnRestore : undefined;
 }
@@ -86,15 +91,15 @@ beforeEach(() => {
 
 describe("useSessionLostBanner", () => {
   it("reports the pane's unacknowledged signal", () => {
-    seed(panel("t-1", { sessionLostOnRestore: true }));
+    seed(panel("t-1", { sessionLostOnRestore: "no-resume-command" }));
     const { result } = renderHook(() => useSessionLostBanner("t-1"));
-    expect(result.current.sessionLostOnRestore).toBe(true);
+    expect(result.current.sessionLostOnRestore).toBe("no-resume-command");
   });
 
   it("reports no signal for a pane that resumed cleanly", () => {
     seed(panel("t-1"));
     const { result } = renderHook(() => useSessionLostBanner("t-1"));
-    expect(result.current.sessionLostOnRestore).toBe(false);
+    expect(result.current.sessionLostOnRestore).toBeUndefined();
   });
 
   it("reports no signal for an unknown or non-PTY pane", () => {
@@ -107,53 +112,53 @@ describe("useSessionLostBanner", () => {
     seed(browserPanel);
     const { result: unknown } = renderHook(() => useSessionLostBanner("missing"));
     const { result: browser } = renderHook(() => useSessionLostBanner("b-1"));
-    expect(unknown.current.sessionLostOnRestore).toBe(false);
-    expect(browser.current.sessionLostOnRestore).toBe(false);
+    expect(unknown.current.sessionLostOnRestore).toBeUndefined();
+    expect(browser.current.sessionLostOnRestore).toBeUndefined();
   });
 
   // The bug: this sequence is exactly what a worktree switch does to a pane.
   it("keeps the acknowledgement across an unmount and remount (#11589)", () => {
-    seed(panel("t-1", { sessionLostOnRestore: true }));
+    seed(panel("t-1", { sessionLostOnRestore: "no-resume-command" }));
 
     const first = renderHook(() => useSessionLostBanner("t-1"));
-    expect(first.result.current.sessionLostOnRestore).toBe(true);
+    expect(first.result.current.sessionLostOnRestore).toBe("no-resume-command");
     act(() => first.result.current.dismiss());
-    expect(first.result.current.sessionLostOnRestore).toBe(false);
+    expect(first.result.current.sessionLostOnRestore).toBeUndefined();
 
     // Switch away: the pane leaves the grid entirely.
     first.unmount();
 
     // Switch back: a brand-new hook instance with no memory of the dismissal.
     const second = renderHook(() => useSessionLostBanner("t-1"));
-    expect(second.result.current.sessionLostOnRestore).toBe(false);
+    expect(second.result.current.sessionLostOnRestore).toBeUndefined();
   });
 
   it("still reports the signal on remount when it was never acknowledged", () => {
-    seed(panel("t-1", { sessionLostOnRestore: true }));
+    seed(panel("t-1", { sessionLostOnRestore: "no-resume-command" }));
 
     const first = renderHook(() => useSessionLostBanner("t-1"));
     first.unmount();
 
     const second = renderHook(() => useSessionLostBanner("t-1"));
-    expect(second.result.current.sessionLostOnRestore).toBe(true);
+    expect(second.result.current.sessionLostOnRestore).toBe("no-resume-command");
   });
 
   it("acknowledges only its own pane", () => {
     seed(
-      panel("t-1", { sessionLostOnRestore: true }),
-      panel("t-2", { sessionLostOnRestore: true })
+      panel("t-1", { sessionLostOnRestore: "no-resume-command" }),
+      panel("t-2", { sessionLostOnRestore: "no-resume-command" })
     );
 
     const { result } = renderHook(() => useSessionLostBanner("t-1"));
     act(() => result.current.dismiss());
 
     expect(flagOf("t-1")).toBeUndefined();
-    expect(flagOf("t-2")).toBe(true);
+    expect(flagOf("t-2")).toBe("no-resume-command");
   });
 
   describe("bulk dismissal gate", () => {
     it("withholds the bulk action when this is the only flagged pane", () => {
-      seed(panel("t-1", { sessionLostOnRestore: true }), panel("t-2"));
+      seed(panel("t-1", { sessionLostOnRestore: "no-resume-command" }), panel("t-2"));
       const { result } = renderHook(() => useSessionLostBanner("t-1"));
       expect(result.current.dismissAll).toBeUndefined();
     });
@@ -161,8 +166,8 @@ describe("useSessionLostBanner", () => {
     it("withholds the bulk action from an unflagged pane even when others are flagged", () => {
       seed(
         panel("t-1"),
-        panel("t-2", { sessionLostOnRestore: true }),
-        panel("t-3", { sessionLostOnRestore: true })
+        panel("t-2", { sessionLostOnRestore: "no-resume-command" }),
+        panel("t-3", { sessionLostOnRestore: "no-resume-command" })
       );
       const { result } = renderHook(() => useSessionLostBanner("t-1"));
       expect(result.current.dismissAll).toBeUndefined();
@@ -170,8 +175,8 @@ describe("useSessionLostBanner", () => {
 
     it("offers the bulk action once a second pane is flagged", () => {
       seed(
-        panel("t-1", { sessionLostOnRestore: true }),
-        panel("t-2", { sessionLostOnRestore: true })
+        panel("t-1", { sessionLostOnRestore: "no-resume-command" }),
+        panel("t-2", { sessionLostOnRestore: "no-resume-command" })
       );
       const { result } = renderHook(() => useSessionLostBanner("t-1"));
       expect(result.current.dismissAll).toBeInstanceOf(Function);
@@ -181,8 +186,8 @@ describe("useSessionLostBanner", () => {
     // dismissal would leave banners waiting behind a switch — the bug itself.
     it("counts flagged panes in other worktrees", () => {
       seed(
-        panel("t-1", { sessionLostOnRestore: true, worktreeId: "wt-a" }),
-        panel("t-2", { sessionLostOnRestore: true, worktreeId: "wt-b" })
+        panel("t-1", { sessionLostOnRestore: "no-resume-command", worktreeId: "wt-a" }),
+        panel("t-2", { sessionLostOnRestore: "no-resume-command", worktreeId: "wt-b" })
       );
       const { result } = renderHook(() => useSessionLostBanner("t-1"));
       expect(result.current.dismissAll).toBeInstanceOf(Function);
@@ -190,8 +195,8 @@ describe("useSessionLostBanner", () => {
 
     it("clears every flagged pane and then withdraws the bulk action", () => {
       seed(
-        panel("t-1", { sessionLostOnRestore: true, worktreeId: "wt-a" }),
-        panel("t-2", { sessionLostOnRestore: true, worktreeId: "wt-b" }),
+        panel("t-1", { sessionLostOnRestore: "no-resume-command", worktreeId: "wt-a" }),
+        panel("t-2", { sessionLostOnRestore: "no-resume-command", worktreeId: "wt-b" }),
         panel("t-3")
       );
 
@@ -200,14 +205,14 @@ describe("useSessionLostBanner", () => {
 
       expect(flagOf("t-1")).toBeUndefined();
       expect(flagOf("t-2")).toBeUndefined();
-      expect(result.current.sessionLostOnRestore).toBe(false);
+      expect(result.current.sessionLostOnRestore).toBeUndefined();
       expect(result.current.dismissAll).toBeUndefined();
     });
 
     it("withdraws the bulk action when the other flagged pane is dismissed elsewhere", () => {
       seed(
-        panel("t-1", { sessionLostOnRestore: true }),
-        panel("t-2", { sessionLostOnRestore: true })
+        panel("t-1", { sessionLostOnRestore: "no-resume-command" }),
+        panel("t-2", { sessionLostOnRestore: "no-resume-command" })
       );
 
       const { result } = renderHook(() => useSessionLostBanner("t-1"));
@@ -215,7 +220,7 @@ describe("useSessionLostBanner", () => {
 
       act(() => usePanelStore.getState().dismissSessionLost("t-2"));
 
-      expect(result.current.sessionLostOnRestore).toBe(true);
+      expect(result.current.sessionLostOnRestore).toBe("no-resume-command");
       expect(result.current.dismissAll).toBeUndefined();
     });
   });
@@ -223,14 +228,14 @@ describe("useSessionLostBanner", () => {
   it("re-renders when the signal arrives after mount", () => {
     seed(panel("t-1"));
     const { result } = renderHook(() => useSessionLostBanner("t-1"));
-    expect(result.current.sessionLostOnRestore).toBe(false);
+    expect(result.current.sessionLostOnRestore).toBeUndefined();
 
     act(() => {
       usePanelStore.setState({
-        panelsById: { "t-1": panel("t-1", { sessionLostOnRestore: true }) },
+        panelsById: { "t-1": panel("t-1", { sessionLostOnRestore: "no-resume-command" }) },
       });
     });
 
-    expect(result.current.sessionLostOnRestore).toBe(true);
+    expect(result.current.sessionLostOnRestore).toBe("no-resume-command");
   });
 });

--- a/src/components/Terminal/restartBannerCopy.ts
+++ b/src/components/Terminal/restartBannerCopy.ts
@@ -1,30 +1,59 @@
+import type { SessionLostReason } from "@shared/types/panel";
+
+interface SessionLostCopy {
+  title: string;
+  description: string;
+  dismissAllLabel: string;
+  dismissAllAriaLabel: string;
+}
+
 export interface RestartBannerCopyMap {
   "auto-restarting": { title: string };
   restarting: { title: string };
-  "session-resume-unavailable": {
-    title: string;
-    description: string;
-    dismissAllLabel: string;
-    dismissAllAriaLabel: string;
-  };
+  "session-resume-unavailable": (args: { reason: SessionLostReason }) => SessionLostCopy;
   "exit-error": (args: { exitCode: number }) => { title: string };
 }
+
+// Bulk control copy is reason-independent — it's about how many panes are
+// flagged, not why any one of them is (issue #11589).
+const DISMISS_ALL: Pick<SessionLostCopy, "dismissAllLabel" | "dismissAllAriaLabel"> = {
+  dismissAllLabel: "Dismiss all",
+  dismissAllAriaLabel: "Dismiss all session-lost warnings",
+};
+
+// Neutral, non-accusatory copy per issue #9802 and the CLAUDE.md microcopy
+// rule. Titles are period-free noun phrases. Descriptions reassure rather
+// than prompt an action (issue #10823) — the terminal already relaunched into
+// a fresh, usable session, so the banner is a dismissable acknowledgement.
+// Reason-specific per issue #12182: a sibling pane already holding the
+// conversation is a materially different situation from there being nothing
+// to resume, and the two shouldn't read as the same "it's gone" message.
+const SESSION_LOST_COPY: Record<
+  SessionLostReason,
+  Omit<SessionLostCopy, keyof typeof DISMISS_ALL>
+> = {
+  "no-resume-command": {
+    title: "Session no longer reachable",
+    description: "The previous session couldn't be restored. A fresh session was started.",
+  },
+  "no-resume-path": {
+    title: "Session no longer reachable",
+    description: "The previous session couldn't be restored. A fresh session was started.",
+  },
+  "sibling-owns-session-id": {
+    title: "Session already open elsewhere",
+    description: "Another pane already holds this conversation. A fresh session was started here.",
+  },
+  "sibling-owns-resume-latest-slot": {
+    title: "Most recent session claimed elsewhere",
+    description:
+      "Another pane in this folder already reopened the most recent session. A fresh session was started here.",
+  },
+};
 
 export const RESTART_BANNER_COPY: RestartBannerCopyMap = {
   "auto-restarting": { title: "Auto-restarting…" },
   restarting: { title: "Restarting…" },
-  // Neutral, non-accusatory copy per issue #9802 and the CLAUDE.md microcopy
-  // rule. Title is a period-free noun phrase. The description reassures rather
-  // than prompts an action (issue #10823) — the terminal already relaunched
-  // into a fresh, usable session, so the banner is a dismissable acknowledgement.
-  // The bulk control keeps a short visible label — it sits inline next to the
-  // per-pane close X, where the banner's own title supplies the context — and
-  // carries the full scope in its accessible name (issue #11589).
-  "session-resume-unavailable": {
-    title: "Session no longer reachable",
-    description: "The previous session couldn't be restored. A fresh session was started.",
-    dismissAllLabel: "Dismiss all",
-    dismissAllAriaLabel: "Dismiss all session-lost warnings",
-  },
+  "session-resume-unavailable": ({ reason }) => ({ ...SESSION_LOST_COPY[reason], ...DISMISS_ALL }),
   "exit-error": ({ exitCode }) => ({ title: `Session exited with code ${exitCode}` }),
 };

--- a/src/components/Terminal/restartStatus.ts
+++ b/src/components/Terminal/restartStatus.ts
@@ -1,11 +1,11 @@
-import type { PanelExitBehavior } from "@shared/types/panel";
+import type { PanelExitBehavior, SessionLostReason } from "@shared/types/panel";
 import type { TerminalRestartError, SpawnError, TerminalReconnectError } from "@/types";
 import type { BackendStatus } from "@/store/panelStore";
 
 export type RestartBannerVariant =
   | { type: "auto-restarting" }
   | { type: "restarting" }
-  | { type: "session-resume-unavailable" }
+  | { type: "session-resume-unavailable"; reason: SessionLostReason }
   | { type: "exit-error"; exitCode: number }
   | { type: "none" };
 
@@ -29,7 +29,7 @@ export interface RestartBannerInput {
    * lost session never suppresses a later exit-error banner for a crash of the
    * fresh session (issue #10823).
    */
-  sessionLostOnRestore?: boolean;
+  sessionLostOnRestore?: SessionLostReason;
 }
 
 export function getRestartBannerVariant(input: RestartBannerInput): RestartBannerVariant {
@@ -65,7 +65,7 @@ export function getRestartBannerVariant(input: RestartBannerInput): RestartBanne
     !input.reconnectError &&
     !input.spawnError
   ) {
-    return { type: "session-resume-unavailable" };
+    return { type: "session-resume-unavailable", reason: input.sessionLostOnRestore };
   }
 
   if (

--- a/src/components/Terminal/useSessionLostBanner.ts
+++ b/src/components/Terminal/useSessionLostBanner.ts
@@ -1,16 +1,16 @@
 import { useCallback } from "react";
 import { useShallow } from "zustand/react/shallow";
-import { isPtyPanel } from "@shared/types/panel";
+import { isPtyPanel, type SessionLostReason } from "@shared/types/panel";
 import { usePanelStore } from "@/store/panelStore";
 import { selectHasMultipleSessionLost } from "@/store/slices/panelRegistry/selectors";
 
 export interface SessionLostBanner {
   /**
-   * True while this pane has an unacknowledged lost-session signal. Feeds
-   * `getRestartBannerVariant`, which gates the banner below the in-flight
-   * restart states.
+   * Set while this pane has an unacknowledged lost-session signal, naming why
+   * (#12182). Feeds `getRestartBannerVariant`, which gates the banner below
+   * the in-flight restart states.
    */
-  sessionLostOnRestore: boolean;
+  sessionLostOnRestore: SessionLostReason | undefined;
   /** Acknowledge this pane's signal. */
   dismiss: () => void;
   /**
@@ -41,7 +41,7 @@ export function useSessionLostBanner(panelId: string): SessionLostBanner {
     useShallow((state) => {
       const panel = state.panelsById[panelId];
       const pty = panel && isPtyPanel(panel) ? panel : undefined;
-      const flagged = pty?.sessionLostOnRestore ?? false;
+      const flagged = pty?.sessionLostOnRestore;
       return {
         sessionLostOnRestore: flagged,
         // Gate the cross-panel scan on this pane's own flag: with no banner to

--- a/src/panels/terminal/__tests__/serializer.test.ts
+++ b/src/panels/terminal/__tests__/serializer.test.ts
@@ -196,7 +196,7 @@ describe("serializePtyPanel — detectedAgentId is never persisted", () => {
 // restart, so the serializer must never write it into project JSON.
 describe("serializePtyPanel — sessionLostOnRestore is never persisted", () => {
   it("omits sessionLostOnRestore even when the panel currently carries it", () => {
-    const panel = makePanel({ sessionLostOnRestore: true });
+    const panel = makePanel({ sessionLostOnRestore: "no-resume-command" });
     const snapshot = serializePtyPanel(panel) as Record<string, unknown>;
     expect("sessionLostOnRestore" in snapshot).toBe(false);
   });

--- a/src/store/slices/panelRegistry/__tests__/dismissSessionLost.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/dismissSessionLost.test.ts
@@ -8,7 +8,12 @@
  */
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { isPtyPanel, type PanelInstance, type PtyPanelData } from "@shared/types/panel";
+import {
+  isPtyPanel,
+  type PanelInstance,
+  type PtyPanelData,
+  type SessionLostReason,
+} from "@shared/types/panel";
 
 vi.mock("@/clients", () => ({
   terminalClient: {
@@ -94,7 +99,7 @@ function seed(panels: PanelInstance[], panelIds?: string[]) {
   });
 }
 
-function signalOf(id: string): boolean | undefined {
+function signalOf(id: string): SessionLostReason | undefined {
   const panel = usePanelStore.getState().panelsById[id];
   return panel && isPtyPanel(panel) ? panel.sessionLostOnRestore : undefined;
 }
@@ -106,7 +111,7 @@ beforeEach(() => {
 
 describe("dismissSessionLost", () => {
   it("consumes the signal so a remount can't resurface the banner", () => {
-    seed([ptyPanel("t-1", { sessionLostOnRestore: true })]);
+    seed([ptyPanel("t-1", { sessionLostOnRestore: "no-resume-command" })]);
 
     usePanelStore.getState().dismissSessionLost("t-1");
 
@@ -115,21 +120,21 @@ describe("dismissSessionLost", () => {
 
   it("leaves other flagged panels alone", () => {
     seed([
-      ptyPanel("t-1", { sessionLostOnRestore: true }),
-      ptyPanel("t-2", { sessionLostOnRestore: true }),
+      ptyPanel("t-1", { sessionLostOnRestore: "no-resume-command" }),
+      ptyPanel("t-2", { sessionLostOnRestore: "no-resume-command" }),
     ]);
 
     usePanelStore.getState().dismissSessionLost("t-1");
 
     expect(signalOf("t-1")).toBeUndefined();
-    expect(signalOf("t-2")).toBe(true);
+    expect(signalOf("t-2")).toBe("no-resume-command");
   });
 
   // Whole-object equality, not a sampled field list: an implementation that
   // rebuilt the panel and dropped unrelated fields would pass a spot check.
   it("changes nothing on the panel but the consumed signal", () => {
     const before = ptyPanel("t-1", {
-      sessionLostOnRestore: true,
+      sessionLostOnRestore: "no-resume-command",
       agentState: "working",
       exitCode: 3,
       isRestarting: true,
@@ -149,7 +154,7 @@ describe("dismissSessionLost", () => {
   // against the previous state, so an in-place mutation would leave every value
   // assertion above green while the banner stayed on screen.
   it("writes immutably so subscribers are notified", () => {
-    const before = ptyPanel("t-1", { sessionLostOnRestore: true });
+    const before = ptyPanel("t-1", { sessionLostOnRestore: "no-resume-command" });
     seed([before]);
     const carrierBefore = usePanelStore.getState().panelsById;
 
@@ -161,11 +166,11 @@ describe("dismissSessionLost", () => {
     expect(notified).toHaveBeenCalledTimes(1);
     expect(usePanelStore.getState().panelsById).not.toBe(carrierBefore);
     expect(usePanelStore.getState().panelsById["t-1"]).not.toBe(before);
-    expect(before.sessionLostOnRestore).toBe(true);
+    expect(before.sessionLostOnRestore).toBe("no-resume-command");
   });
 
   it("is a no-op for an unknown id", () => {
-    seed([ptyPanel("t-1", { sessionLostOnRestore: true })]);
+    seed([ptyPanel("t-1", { sessionLostOnRestore: "no-resume-command" })]);
     const before = usePanelStore.getState().panelsById;
 
     usePanelStore.getState().dismissSessionLost("nope");
@@ -183,7 +188,7 @@ describe("dismissSessionLost", () => {
   });
 
   it("keeps the same carrier identity on a repeat dismissal", () => {
-    seed([ptyPanel("t-1", { sessionLostOnRestore: true })]);
+    seed([ptyPanel("t-1", { sessionLostOnRestore: "no-resume-command" })]);
     usePanelStore.getState().dismissSessionLost("t-1");
     const afterFirst = usePanelStore.getState().panelsById;
 
@@ -193,7 +198,7 @@ describe("dismissSessionLost", () => {
   });
 
   it("ignores a non-PTY panel", () => {
-    seed([browserPanel("b-1", { sessionLostOnRestore: true })]);
+    seed([browserPanel("b-1", { sessionLostOnRestore: "no-resume-command" })]);
     const before = usePanelStore.getState().panelsById;
 
     usePanelStore.getState().dismissSessionLost("b-1");
@@ -204,7 +209,7 @@ describe("dismissSessionLost", () => {
   // The signal is deliberately excluded from the persisted snapshot, so
   // consuming it must not schedule a write.
   it("does not persist", () => {
-    seed([ptyPanel("t-1", { sessionLostOnRestore: true })]);
+    seed([ptyPanel("t-1", { sessionLostOnRestore: "no-resume-command" })]);
 
     usePanelStore.getState().dismissSessionLost("t-1");
 
@@ -215,9 +220,9 @@ describe("dismissSessionLost", () => {
 describe("dismissAllSessionLost", () => {
   it("clears every flagged panel regardless of worktree, keeping them all", () => {
     seed([
-      ptyPanel("t-1", { sessionLostOnRestore: true, worktreeId: "wt-a" }),
-      ptyPanel("t-2", { sessionLostOnRestore: true, worktreeId: "wt-b" }),
-      ptyPanel("t-3", { sessionLostOnRestore: true, worktreeId: undefined }),
+      ptyPanel("t-1", { sessionLostOnRestore: "no-resume-command", worktreeId: "wt-a" }),
+      ptyPanel("t-2", { sessionLostOnRestore: "no-resume-command", worktreeId: "wt-b" }),
+      ptyPanel("t-3", { sessionLostOnRestore: "no-resume-command", worktreeId: undefined }),
     ]);
 
     usePanelStore.getState().dismissAllSessionLost();
@@ -236,9 +241,9 @@ describe("dismissAllSessionLost", () => {
   // fresh carrier, which React memo boundaries reading a panel would miss.
   it("notifies once and replaces each flagged panel object", () => {
     const before = [
-      ptyPanel("t-1", { sessionLostOnRestore: true }),
-      ptyPanel("t-2", { sessionLostOnRestore: true }),
-      ptyPanel("t-3", { sessionLostOnRestore: true }),
+      ptyPanel("t-1", { sessionLostOnRestore: "no-resume-command" }),
+      ptyPanel("t-2", { sessionLostOnRestore: "no-resume-command" }),
+      ptyPanel("t-3", { sessionLostOnRestore: "no-resume-command" }),
     ];
     seed(before);
 
@@ -250,7 +255,7 @@ describe("dismissAllSessionLost", () => {
     expect(notified).toHaveBeenCalledTimes(1);
     for (const panel of before) {
       expect(usePanelStore.getState().panelsById[panel.id]).not.toBe(panel);
-      expect(panel.sessionLostOnRestore).toBe(true);
+      expect(panel.sessionLostOnRestore).toBe("no-resume-command");
     }
   });
 
@@ -260,8 +265,8 @@ describe("dismissAllSessionLost", () => {
   it("clears a panel that is not in panelIds yet", () => {
     seed(
       [
-        ptyPanel("t-1", { sessionLostOnRestore: true }),
-        ptyPanel("t-batched", { sessionLostOnRestore: true }),
+        ptyPanel("t-1", { sessionLostOnRestore: "no-resume-command" }),
+        ptyPanel("t-batched", { sessionLostOnRestore: "no-resume-command" }),
       ],
       ["t-1"]
     );
@@ -273,8 +278,8 @@ describe("dismissAllSessionLost", () => {
 
   it("clears panels parked outside the grid", () => {
     seed([
-      ptyPanel("t-dock", { sessionLostOnRestore: true, location: "dock" }),
-      ptyPanel("t-trash", { sessionLostOnRestore: true, location: "trash" }),
+      ptyPanel("t-dock", { sessionLostOnRestore: "no-resume-command", location: "dock" }),
+      ptyPanel("t-trash", { sessionLostOnRestore: "no-resume-command", location: "trash" }),
     ]);
 
     usePanelStore.getState().dismissAllSessionLost();
@@ -285,7 +290,7 @@ describe("dismissAllSessionLost", () => {
 
   it("leaves unflagged panels untouched by identity", () => {
     const untouched = ptyPanel("t-2");
-    seed([ptyPanel("t-1", { sessionLostOnRestore: true }), untouched]);
+    seed([ptyPanel("t-1", { sessionLostOnRestore: "no-resume-command" }), untouched]);
 
     usePanelStore.getState().dismissAllSessionLost();
 
@@ -307,8 +312,8 @@ describe("dismissAllSessionLost", () => {
 
   it("is idempotent", () => {
     seed([
-      ptyPanel("t-1", { sessionLostOnRestore: true }),
-      ptyPanel("t-2", { sessionLostOnRestore: true }),
+      ptyPanel("t-1", { sessionLostOnRestore: "no-resume-command" }),
+      ptyPanel("t-2", { sessionLostOnRestore: "no-resume-command" }),
     ]);
     usePanelStore.getState().dismissAllSessionLost();
     const afterFirst = usePanelStore.getState().panelsById;
@@ -319,8 +324,8 @@ describe("dismissAllSessionLost", () => {
   });
 
   it("skips non-PTY panels", () => {
-    const browser = browserPanel("b-1", { sessionLostOnRestore: true });
-    seed([ptyPanel("t-1", { sessionLostOnRestore: true }), browser]);
+    const browser = browserPanel("b-1", { sessionLostOnRestore: "no-resume-command" });
+    seed([ptyPanel("t-1", { sessionLostOnRestore: "no-resume-command" }), browser]);
 
     usePanelStore.getState().dismissAllSessionLost();
 
@@ -329,7 +334,7 @@ describe("dismissAllSessionLost", () => {
   });
 
   it("does not persist", () => {
-    seed([ptyPanel("t-1", { sessionLostOnRestore: true })]);
+    seed([ptyPanel("t-1", { sessionLostOnRestore: "no-resume-command" })]);
 
     usePanelStore.getState().dismissAllSessionLost();
 

--- a/src/store/slices/panelRegistry/__tests__/restartTerminal.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/restartTerminal.test.ts
@@ -947,7 +947,7 @@ describe("restartTerminal stale flow state cleared (#9899)", () => {
   it("consumes the session-lost signal on restart (#9802)", async () => {
     const lost = {
       ...agentPanelBase,
-      sessionLostOnRestore: true,
+      sessionLostOnRestore: "no-resume-command" as const,
     };
     usePanelStore.setState({
       panelsById: { [lost.id]: lost },

--- a/src/utils/stateHydration/__tests__/statePatcher.test.ts
+++ b/src/utils/stateHydration/__tests__/statePatcher.test.ts
@@ -648,7 +648,7 @@ describe("buildArgsForRespawn", () => {
         "/tmp"
       );
       expect(result.command).toBe("claude --generated");
-      expect(result.sessionLostOnRestore).toBe(true);
+      expect(result.sessionLostOnRestore).toBe("no-resume-command");
     });
 
     it("is set when no session was captured and resume-latest is unavailable (branch 3)", () => {
@@ -666,7 +666,7 @@ describe("buildArgsForRespawn", () => {
       // that flags the session lost without trying to recover it first.
       expect(buildResumeLatestCommandMock).toHaveBeenCalledWith("claude", undefined);
       expect(result.command).toBe("claude --generated");
-      expect(result.sessionLostOnRestore).toBe(true);
+      expect(result.sessionLostOnRestore).toBe("no-resume-path");
     });
 
     it("is left unset when agent settings are unavailable (no fresh launch produced)", () => {
@@ -718,9 +718,15 @@ describe("buildArgsForRespawn", () => {
         undefined,
         { allowResumeLatest: false }
       );
-      expect(buildResumeLatestCommandMock).not.toHaveBeenCalled();
+      // The bare single-arg call is the reason-classification probe (#12182) —
+      // it never builds a usable command, only names why the pane fell
+      // through. The fallback must still never be genuinely ATTEMPTED: no
+      // call carries flags/baseCommand, and its return value never reaches
+      // `result.command` below — that's the suppression #11461 exists for.
+      expect(buildResumeLatestCommandMock).toHaveBeenCalledTimes(1);
+      expect(buildResumeLatestCommandMock).toHaveBeenCalledWith("claude");
       expect(result.command).toBe("claude --generated");
-      expect(result.sessionLostOnRestore).toBe(true);
+      expect(result.sessionLostOnRestore).toBe("sibling-owns-resume-latest-slot");
     });
 
     it("does not inherit a persisted resume-latest command when suppressed (#11461)", () => {
@@ -746,7 +752,7 @@ describe("buildArgsForRespawn", () => {
         { allowResumeLatest: false }
       );
       expect(result.command).toBe("claude");
-      expect(result.sessionLostOnRestore).toBe(true);
+      expect(result.sessionLostOnRestore).toBe("sibling-owns-resume-latest-slot");
     });
 
     it("still resumes an exact session id when resume-latest is suppressed (#11461)", () => {
@@ -793,7 +799,7 @@ describe("buildArgsForRespawn", () => {
         { allowResumeLatest: false }
       );
       expect(result.command).toBe("claude --flagged");
-      expect(result.sessionLostOnRestore).toBe(true);
+      expect(result.sessionLostOnRestore).toBe("sibling-owns-resume-latest-slot");
     });
 
     it("leaves an agent with no resume-latest fallback untouched when suppressed (#11461)", () => {
@@ -847,7 +853,7 @@ describe("buildArgsForRespawn", () => {
         { allowSessionIdResume: false, allowResumeLatest: false }
       );
       expect(result.command).toBe("claude --generated");
-      expect(result.sessionLostOnRestore).toBe(true);
+      expect(result.sessionLostOnRestore).toBe("sibling-owns-session-id");
     });
 
     it("does not inherit a persisted --resume command when the id is withheld (#11461)", () => {
@@ -877,7 +883,7 @@ describe("buildArgsForRespawn", () => {
         { allowSessionIdResume: false, allowResumeLatest: false }
       );
       expect(result.command).toBe("claude");
-      expect(result.sessionLostOnRestore).toBe(true);
+      expect(result.sessionLostOnRestore).toBe("sibling-owns-session-id");
     });
 
     it("does not fall back to resume-latest when the session id is withheld (#11461)", () => {
@@ -904,7 +910,7 @@ describe("buildArgsForRespawn", () => {
         { allowSessionIdResume: false }
       );
       expect(result.command).toBe("claude --generated");
-      expect(result.sessionLostOnRestore).toBe(true);
+      expect(result.sessionLostOnRestore).toBe("sibling-owns-session-id");
     });
 
     it("resumes its own session id by default when no allowance is passed (#11461)", () => {
@@ -2447,7 +2453,7 @@ describe("buildArgsForRespawn — persisted launch env (#10922)", () => {
       false,
       "/tmp"
     );
-    expect(result.sessionLostOnRestore).toBe(true);
+    expect(result.sessionLostOnRestore).toBe("no-resume-command");
     expect(result.env).toEqual({ ANTHROPIC_BASE_URL: "https://api.z.ai/api/anthropic" });
   });
 });
@@ -3326,7 +3332,7 @@ describe("buildArgsForRespawn — assigned session id", () => {
       "/tmp"
     );
 
-    expect(result.sessionLostOnRestore).toBe(true);
+    expect(result.sessionLostOnRestore).toBe("no-resume-command");
     expect(result.agentSessionId).not.toBe("sess-expired");
     // Must be a real UUID — the CLI rejects anything else — and, crucially, the
     // SAME id the rebuilt command was given. A record holding an id the command
@@ -3494,7 +3500,7 @@ describe("buildArgsForRespawn — a named resume-latest session (#12178)", () =>
 
     expect(result.command).toBe("codex --generated");
     expect(result.agentSessionId).not.toBe("sess-9");
-    expect(result.sessionLostOnRestore).toBe(true);
+    expect(result.sessionLostOnRestore).toBe("sibling-owns-resume-latest-slot");
   });
 
   it("never displaces the exact id a snapshot already carries", () => {

--- a/src/utils/stateHydration/index.ts
+++ b/src/utils/stateHydration/index.ts
@@ -17,6 +17,7 @@ import type {
   TabGroup,
 } from "@/types";
 import type { WaitingReason } from "@shared/types/agent";
+import type { SessionLostReason } from "@shared/types/panel";
 import type { BackendTerminalInfo, TerminalReconnectResult } from "@shared/types/ipc/terminal";
 import { panelKindHasPty } from "@shared/config/panelKindRegistry";
 import { isGitBackedProject } from "@shared/types";
@@ -109,7 +110,7 @@ export interface HydrationOptions {
     originalPresetId?: string;
     isUsingFallback?: boolean;
     fallbackChainIndex?: number;
-    sessionLostOnRestore?: boolean;
+    sessionLostOnRestore?: SessionLostReason;
     env?: Record<string, string>;
     extensionState?: Record<string, unknown>;
     pluginId?: string;

--- a/src/utils/stateHydration/statePatcher.ts
+++ b/src/utils/stateHydration/statePatcher.ts
@@ -9,6 +9,7 @@ import type {
   FileBrowserTreeSnapshot,
   PanelExitBehavior,
   PanelTitleMode,
+  SessionLostReason,
 } from "@shared/types/panel";
 import type { GitStatus } from "@shared/types/git";
 import type { AddPanelOptionsBase } from "@shared/types/addPanelOptions";
@@ -505,10 +506,12 @@ export function buildArgsForRespawn(
   const isAgentPanel = Boolean(effectiveAgentId);
   const agentId = effectiveAgentId;
   let command = saved.command?.trim() || undefined;
-  // True when we fall through to a fresh agent launch because no resume command
+  // Set when we fall through to a fresh agent launch because no resume command
   // was available — the user's prior conversation is unreachable and we must
   // surface it rather than silently respawning a clean session (issue #9802).
-  let sessionLostOnRestore = false;
+  // The value names which of the causes below it was (#12182), so the banner
+  // can say something more specific than "gone".
+  let sessionLostOnRestore: SessionLostReason | undefined;
   // Session id this respawn will run under (#11782): the saved one when the
   // pane genuinely reattaches, a freshly minted one on every branch that gives
   // up and starts over, and undefined for agents that don't take an id at
@@ -609,7 +612,9 @@ export function buildArgsForRespawn(
         respawnSessionId = saved.agentSessionId;
       } else if (hasPersistedFlags) {
         command = buildFromPersistedFlags();
-        sessionLostOnRestore = true;
+        // Had the id and permission to resume it, but the agent couldn't turn
+        // that into a command — a config/build issue, not a collision.
+        sessionLostOnRestore = "no-resume-command";
       } else if (agentSettings) {
         command = generateAgentCommand(baseCommand, effectiveEntry, agentId, {
           clipboardDirectory,
@@ -619,7 +624,7 @@ export function buildArgsForRespawn(
           globalUseAltScreen,
           sessionId: mintFreshSessionId(),
         });
-        sessionLostOnRestore = true;
+        sessionLostOnRestore = "no-resume-command";
       }
     } else {
       // Either no session id was captured (graceful-shutdown pattern match missed
@@ -654,11 +659,28 @@ export function buildArgsForRespawn(
           ? buildResumeLatestCommand(agentId, resumeFlags, baseCommand)
           : buildResumeLatestCommand(agentId, resumeFlags);
       }
+      // Why resume-latest didn't run, or didn't help — lazy and memoized so the
+      // capability probe below runs at most once, and never at all when
+      // `resumeLatestCmd` already succeeded. Reused across whichever
+      // fresh-launch path ends up building `command`, since that choice is
+      // orthogonal to what suppressed (or never offered) the resume this pane
+      // would otherwise have used (#12182).
+      let elseReasonCache: SessionLostReason | undefined;
+      const getElseReason = (): SessionLostReason =>
+        (elseReasonCache ??= resumeWithheld
+          ? "sibling-owns-session-id"
+          : // Config-only, so flag-independent and in agreement with the
+            // restore election's own probe — keeps resume-latest suppression
+            // from being mislabeled a slot collision for an agent that has no
+            // such fallback to collide over.
+            !allowResumeLatest && buildResumeLatestCommand(agentId) !== undefined
+            ? "sibling-owns-resume-latest-slot"
+            : "no-resume-path");
       if (resumeLatestCmd) {
         command = resumeLatestCmd;
       } else if (hasPersistedFlags) {
         command = buildFromPersistedFlags();
-        sessionLostOnRestore = true;
+        sessionLostOnRestore = getElseReason();
       } else if (agentSettings) {
         command = generateAgentCommand(baseCommand, effectiveEntry, agentId, {
           clipboardDirectory,
@@ -668,24 +690,17 @@ export function buildArgsForRespawn(
           globalUseAltScreen,
           sessionId: mintFreshSessionId(),
         });
-        sessionLostOnRestore = true;
-      } else if (
-        resumeWithheld ||
-        (!allowResumeLatest && buildResumeLatestCommand(agentId) !== undefined)
-      ) {
+        sessionLostOnRestore = getElseReason();
+      } else if (getElseReason() !== "no-resume-path") {
         // Nothing above rebuilt the command, so `command` still holds
         // `saved.command` — which is itself a persisted resume command whenever an
         // earlier restore built one. Inheriting it would reinstate the very
-        // collision this suppression exists to prevent, so launch clean. The bare
-        // capability probe (config-only, so flag-independent and in agreement with
-        // the restore election's) keeps resume-latest suppression from touching an
-        // agent that has no such fallback; a withheld session id needs no probe,
-        // since the id in hand is proof the snapshot can carry a resume command.
+        // collision this suppression exists to prevent, so launch clean.
         command = buildLaunchCommandFromFlags(baseCommand, agentId, injectedFromEmpty, {
           clipboardDirectory,
           shareClipboardDirectory,
         });
-        sessionLostOnRestore = true;
+        sessionLostOnRestore = getElseReason();
       }
     }
   }
@@ -746,7 +761,7 @@ export function buildArgsForRespawn(
     originalPresetId: respawnOriginalPresetId,
     isUsingFallback: presetWasStale ? undefined : saved.isUsingFallback,
     fallbackChainIndex: presetWasStale ? undefined : saved.fallbackChainIndex,
-    sessionLostOnRestore: sessionLostOnRestore || undefined,
+    sessionLostOnRestore,
     // Prefer the launch env captured in the snapshot (#10922) so the restored
     // session replays the same provider environment (e.g. a Z.AI/GLM preset or a
     // recipe's inline env) even when that preset/recipe no longer resolves in the


### PR DESCRIPTION
## Summary

- When a Codex pane can't reattach to its conversation on restore, the banner used to just say the session is no longer reachable, with no way to actually find it, even though Codex still has it on disk and `codex resume <id>` reopens it fine.
- `sessionLostOnRestore` is now a 4-value `SessionLostReason` instead of a bare boolean, so the banner can tell the difference between resume-latest being suppressed, a sibling pane already owning the session id, no resume command being buildable, and no resume path existing at all.
- The banner gets a read-only "Find session" action (Codex-only) that lists sessions for the pane's folder and reopens the chosen one in a new pane, so a scraped-and-lost session id is no longer the end of the road.

Resolves #12182

## Changes

- `SessionLostReason` derived once per restore branch in `statePatcher.ts`, replacing the boolean flag
- Reason-specific copy in `restartBannerCopy.ts`: a sibling pane holding the conversation now reads differently ("intact, may be open right next door") from there being genuinely nothing to resume
- New "Find session" action (`FindCodexSessionAction.tsx`) that queries the app-server's `thread/list` for the pane's folder, sorted newest first, and opens the chosen session in a new pane rather than replacing the running one
- Optional `CODEX_HOME` override threaded through `CodexAppServerClient` so the query runs against the pane's own profile, not main's default one
- New `codex:find-sessions` IPC op across `codex.ts`, `codex.preload.ts`, and `codexClient.ts`, with regenerated IPC type maps

## Testing

- `npm test` (full suite), including new unit tests for the reason-derivation logic, the banner copy variants, the `FindCodexSessionAction` component, and the `CodexAppServerClient` `CODEX_HOME` override

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXEddDS8sWFTmM1jQLbVr1