### PR TITLE
fix(notifications): sound and flash still default on, and flash eligibility goes stale across windows

### DIFF
--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -1241,7 +1241,7 @@ function buildElectronApi(): ElectronAPI {
       onFallbackTriggered: (callback: (data: AgentFallbackTriggeredPayload) => void) =>
         _eventBusOn("agent:fallback-triggered", callback),
 
-      onAllAgentsClear: (callback: (data: { timestamp: number }) => void) =>
+      onAllAgentsClear: (callback: (data: { timestamp: number; shouldFlash: boolean }) => void) =>
         _eventBusOn("agent:all-clear", callback),
 
       onActivity: (callback: (data: TerminalActivityPayload) => void) =>

--- a/electron/services/AgentNotificationService.ts
+++ b/electron/services/AgentNotificationService.ts
@@ -252,14 +252,17 @@ class AgentNotificationService {
         this.agentSpawnTimestamps.set(agentKey, Date.now());
       }
       const settings = projectStore.getEffectiveNotificationSettings();
+      // isInformationalAudioSuppressed covers quiet hours, session mute, and
+      // OS DND — the same chain the sound and the all-clear flash use.
+      // Boot grace is a separate, spawn-specific condition (avoids a flood
+      // of sounds when many terminals restore at once) that chain doesn't
+      // cover, so it stays a standalone check.
       if (
         shouldPlayUiFeedbackSound(settings) &&
         !this.isWithinBootGrace() &&
-        !this.isSessionMuted()
+        !this.isInformationalAudioSuppressed(settings)
       ) {
-        if (!isScheduledQuietNow(settings)) {
-          soundService.play("agent-spawned");
-        }
+        soundService.play("agent-spawned");
       }
     });
 
@@ -576,18 +579,20 @@ class AgentNotificationService {
       const currentActive = this.countActiveAgents(store.get("appState").terminals);
       if (currentActive > 0) return;
 
-      // Fire the all-clear. The sound obeys the same suppression chain as every
-      // other informational audio cue; the event does not — it drives renderer
-      // state (the all-clear overlay), which must still settle while silent.
+      // Fire the all-clear. The event itself is unconditional — it drives
+      // renderer state (the all-clear overlay), which must still settle even
+      // when silent — but it carries a `shouldFlash` verdict computed here,
+      // from the single freshest copy of settings, rather than leaving each
+      // renderer to recompute it from its own (possibly stale, per-view)
+      // settings mirror: a second project view left open across a settings
+      // change would otherwise flash on stale eligibility.
       const settings = projectStore.getEffectiveNotificationSettings();
-      if (
-        settings.enabled !== false &&
-        settings.soundEnabled &&
-        !this.isInformationalAudioSuppressed(settings)
-      ) {
+      const isSuppressed = this.isInformationalAudioSuppressed(settings);
+      if (settings.enabled !== false && settings.soundEnabled && !isSuppressed) {
         soundService.play("all-clear");
       }
-      events.emit("agent:all-clear", { timestamp: Date.now() });
+      const shouldFlash = settings.enabled !== false && settings.flashEnabled && !isSuppressed;
+      events.emit("agent:all-clear", { timestamp: Date.now(), shouldFlash });
 
       // Reset for next multi-agent session
       this.peakConcurrentWorking = 0;

--- a/electron/services/__tests__/AgentNotificationService.allClear.test.ts
+++ b/electron/services/__tests__/AgentNotificationService.allClear.test.ts
@@ -69,7 +69,7 @@ const DEFAULT_SETTINGS = {
   workingPulseEnabled: false,
   workingPulseSoundFile: "pulse.wav",
   uiFeedbackSoundEnabled: false,
-  flashEnabled: false,
+  flashEnabled: true,
   quietHoursEnabled: false,
   quietHoursStartMin: 22 * 60,
   quietHoursEndMin: 6 * 60,
@@ -149,6 +149,7 @@ describe("AgentNotificationService – all-clear", () => {
     expect(soundServiceMock.play).toHaveBeenCalledWith("all-clear");
     expect(emitSpy).toHaveBeenCalledWith("agent:all-clear", {
       timestamp: expect.any(Number),
+      shouldFlash: true,
     });
 
     emitSpy.mockRestore();
@@ -209,7 +210,8 @@ describe("AgentNotificationService – all-clear", () => {
     expect(soundServiceMock.play).not.toHaveBeenCalledWith("all-clear");
   });
 
-  it("does not play sound when soundEnabled is false", () => {
+  it("does not play sound when soundEnabled is false, but still flashes (#12185: independent toggles)", () => {
+    const emitSpy = vi.spyOn(events, "emit");
     projectStoreMock.getEffectiveNotificationSettings.mockReturnValue({
       ...DEFAULT_SETTINGS,
       soundEnabled: false,
@@ -231,6 +233,41 @@ describe("AgentNotificationService – all-clear", () => {
 
     vi.advanceTimersByTime(600);
     expect(soundServiceMock.play).not.toHaveBeenCalledWith("all-clear");
+    expect(emitSpy).toHaveBeenCalledWith("agent:all-clear", {
+      timestamp: expect.any(Number),
+      shouldFlash: true,
+    });
+    emitSpy.mockRestore();
+  });
+
+  it("does not flash when flashEnabled is false, but still plays the sound (#12185: independent toggles)", () => {
+    const emitSpy = vi.spyOn(events, "emit");
+    projectStoreMock.getEffectiveNotificationSettings.mockReturnValue({
+      ...DEFAULT_SETTINGS,
+      flashEnabled: false,
+    });
+
+    mockTerminals([
+      { id: "term-1", agentState: "working" },
+      { id: "term-2", agentState: "working" },
+    ]);
+    emitStateChange("working", "idle", "term-1");
+    emitStateChange("working", "idle", "term-2");
+
+    mockTerminals([
+      { id: "term-1", agentState: "completed" },
+      { id: "term-2", agentState: "completed" },
+    ]);
+    emitStateChange("completed", "working", "term-1");
+    emitStateChange("completed", "working", "term-2");
+
+    vi.advanceTimersByTime(600);
+    expect(soundServiceMock.play).toHaveBeenCalledWith("all-clear");
+    expect(emitSpy).toHaveBeenCalledWith("agent:all-clear", {
+      timestamp: expect.any(Number),
+      shouldFlash: false,
+    });
+    emitSpy.mockRestore();
   });
 
   it("resets after firing so next multi-agent session can fire again", () => {
@@ -344,11 +381,13 @@ describe("AgentNotificationService – all-clear", () => {
     expect(soundServiceMock.play).toHaveBeenCalledWith("all-clear");
   });
 
-  it("does not play sound when master enabled toggle is false", () => {
+  it("does not play sound or flash when master enabled toggle is false", () => {
+    const emitSpy = vi.spyOn(events, "emit");
     projectStoreMock.getEffectiveNotificationSettings.mockReturnValue({
       ...DEFAULT_SETTINGS,
       enabled: false,
       soundEnabled: true,
+      flashEnabled: true,
     });
 
     mockTerminals([
@@ -367,6 +406,11 @@ describe("AgentNotificationService – all-clear", () => {
 
     vi.advanceTimersByTime(600);
     expect(soundServiceMock.play).not.toHaveBeenCalledWith("all-clear");
+    expect(emitSpy).toHaveBeenCalledWith("agent:all-clear", {
+      timestamp: expect.any(Number),
+      shouldFlash: false,
+    });
+    emitSpy.mockRestore();
   });
 
   it("does not fire when no working transition ever occurs (empty session)", () => {
@@ -459,6 +503,12 @@ describe("AgentNotificationService – all-clear", () => {
       return calls.filter((call) => call[0] === "agent:all-clear").length;
     }
 
+    /** The `shouldFlash` verdict carried on the (first) emitted all-clear event. */
+    function allClearShouldFlash(calls: readonly unknown[][]): boolean | undefined {
+      const call = calls.find((c) => c[0] === "agent:all-clear");
+      return (call?.[1] as { shouldFlash?: boolean } | undefined)?.shouldFlash;
+    }
+
     it("suppresses the sound during scheduled quiet hours but still emits the event", () => {
       // Monday 23:00 falls inside the 22:00 -> 06:00 window
       vi.setSystemTime(new Date(2024, 0, 1, 23, 0));
@@ -473,6 +523,7 @@ describe("AgentNotificationService – all-clear", () => {
 
       expect(soundServiceMock.play).not.toHaveBeenCalled();
       expect(countAllClearEvents(emitSpy.mock.calls)).toBe(1);
+      expect(allClearShouldFlash(emitSpy.mock.calls)).toBe(false);
       emitSpy.mockRestore();
     });
 
@@ -482,12 +533,15 @@ describe("AgentNotificationService – all-clear", () => {
         ...DEFAULT_SETTINGS,
         quietHoursEnabled: true,
       });
+      const emitSpy = vi.spyOn(events, "emit");
 
       runTwoAgentSession();
       vi.advanceTimersByTime(600);
 
       expect(soundServiceMock.play).toHaveBeenCalledTimes(1);
       expect(soundServiceMock.play).toHaveBeenCalledWith("all-clear");
+      expect(allClearShouldFlash(emitSpy.mock.calls)).toBe(true);
+      emitSpy.mockRestore();
     });
 
     it("suppresses the sound during a session mute but still emits the event", () => {
@@ -500,6 +554,7 @@ describe("AgentNotificationService – all-clear", () => {
 
       expect(soundServiceMock.play).not.toHaveBeenCalled();
       expect(countAllClearEvents(emitSpy.mock.calls)).toBe(1);
+      expect(allClearShouldFlash(emitSpy.mock.calls)).toBe(false);
       emitSpy.mockRestore();
     });
 
@@ -508,12 +563,15 @@ describe("AgentNotificationService – all-clear", () => {
       // active when the timer is armed and lapses during the 500ms window.
       vi.setSystemTime(new Date(2024, 0, 1, 12, 0));
       agentNotificationService.setSessionMuteUntil(Date.now() + 250);
+      const emitSpy = vi.spyOn(events, "emit");
 
       runTwoAgentSession();
       vi.advanceTimersByTime(600);
 
       expect(soundServiceMock.play).toHaveBeenCalledTimes(1);
       expect(soundServiceMock.play).toHaveBeenCalledWith("all-clear");
+      expect(allClearShouldFlash(emitSpy.mock.calls)).toBe(true);
+      emitSpy.mockRestore();
     });
 
     it("suppresses the sound when OS Do-Not-Disturb turns on during the debounce", () => {
@@ -529,6 +587,7 @@ describe("AgentNotificationService – all-clear", () => {
 
       expect(soundServiceMock.play).not.toHaveBeenCalled();
       expect(countAllClearEvents(emitSpy.mock.calls)).toBe(1);
+      expect(allClearShouldFlash(emitSpy.mock.calls)).toBe(false);
       emitSpy.mockRestore();
     });
 
@@ -541,29 +600,36 @@ describe("AgentNotificationService – all-clear", () => {
 
       expect(soundServiceMock.play).not.toHaveBeenCalled();
       expect(countAllClearEvents(emitSpy.mock.calls)).toBe(1);
+      expect(allClearShouldFlash(emitSpy.mock.calls)).toBe(false);
       emitSpy.mockRestore();
     });
 
     it("plays the sound when OS Do-Not-Disturb is explicitly inactive", () => {
       osDndServiceMock.getState.mockReturnValue(false);
+      const emitSpy = vi.spyOn(events, "emit");
 
       runTwoAgentSession();
       vi.advanceTimersByTime(600);
 
       expect(soundServiceMock.play).toHaveBeenCalledTimes(1);
       expect(soundServiceMock.play).toHaveBeenCalledWith("all-clear");
+      expect(allClearShouldFlash(emitSpy.mock.calls)).toBe(true);
+      emitSpy.mockRestore();
     });
 
     it("plays the sound when the OS Do-Not-Disturb state is unknown", () => {
       // Windows and Linux have no detection at all and always report
       // `undefined` — fail open, never gate.
       osDndServiceMock.getState.mockReturnValue(undefined);
+      const emitSpy = vi.spyOn(events, "emit");
 
       runTwoAgentSession();
       vi.advanceTimersByTime(600);
 
       expect(soundServiceMock.play).toHaveBeenCalledTimes(1);
       expect(soundServiceMock.play).toHaveBeenCalledWith("all-clear");
+      expect(allClearShouldFlash(emitSpy.mock.calls)).toBe(true);
+      emitSpy.mockRestore();
     });
 
     it("never raises an OS notification for the all-clear, suppressed or not", () => {

--- a/electron/services/__tests__/AgentNotificationService.test.ts
+++ b/electron/services/__tests__/AgentNotificationService.test.ts
@@ -1307,6 +1307,23 @@ describe("AgentNotificationService", () => {
 
       expect(soundServiceMock.play).not.toHaveBeenCalled();
     });
+
+    it("suppresses agent-spawned sound while OS Do-Not-Disturb is active (#12185)", () => {
+      mockStore({ soundEnabled: true, uiFeedbackSoundEnabled: true });
+      osDndServiceMock.getState.mockReturnValue(true);
+
+      // Advance past boot grace period
+      vi.advanceTimersByTime(10_000);
+
+      events.emit("agent:spawned", {
+        terminalId: "term-1",
+        agentId: "claude",
+        worktreeId: "wt-1",
+        timestamp: Date.now(),
+      });
+
+      expect(soundServiceMock.play).not.toHaveBeenCalled();
+    });
   });
 
   // #5139 follow-up: backend-emitted events no longer carry worktreeId.

--- a/electron/services/events.ts
+++ b/electron/services/events.ts
@@ -662,6 +662,8 @@ export type DaintreeEventMap = {
    */
   "agent:all-clear": {
     timestamp: number;
+    /** Computed main-process-side from the freshest settings; see AgentNotificationService.checkAllClear. */
+    shouldFlash: boolean;
   };
 
   /**

--- a/electron/services/migrations/028-quiet-sound-and-flash-defaults.ts
+++ b/electron/services/migrations/028-quiet-sound-and-flash-defaults.ts
@@ -1,15 +1,20 @@
 import type { Migration } from "../StoreMigrations.js";
 
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 export const migration028: Migration = {
   version: 28,
   description: "Default sound and the all-clear flash off for existing installs (#12185)",
   up: (store) => {
-    const settings = store.get("notificationSettings") as Record<string, unknown> | undefined;
+    const raw = store.get("notificationSettings");
 
-    if (!settings) {
+    if (!isPlainObject(raw)) {
       console.log("[Migration 028] No notificationSettings found, skipping");
       return;
     }
+    const settings = raw;
 
     const changes: Record<string, unknown> = {};
 

--- a/electron/services/migrations/__tests__/028-quiet-sound-and-flash-defaults.test.ts
+++ b/electron/services/migrations/__tests__/028-quiet-sound-and-flash-defaults.test.ts
@@ -67,6 +67,14 @@ describe("migration028 — quiet sound and flash defaults", () => {
     expect(store.set).not.toHaveBeenCalled();
   });
 
+  it("no-op when notificationSettings is malformed (string, array, or number)", () => {
+    for (const malformed of ["corrupted", ["not", "an", "object"], 42]) {
+      const store = makeStoreMock({ notificationSettings: malformed });
+      migration028.up(store);
+      expect(store.set).not.toHaveBeenCalled();
+    }
+  });
+
   it("preserves unrelated fields, including a user's other customized settings", () => {
     const data: Record<string, unknown> = {
       notificationSettings: {

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -623,7 +623,7 @@ const storeOptions = {
       enabled: true,
       completedEnabled: false,
       waitingEnabled: true,
-      soundEnabled: true,
+      soundEnabled: false,
       completedSoundFile: "complete.wav",
       waitingSoundFile: "waiting.wav",
       escalationSoundFile: "ping.wav",

--- a/scripts/perf/lib/notificationFixture.ts
+++ b/scripts/perf/lib/notificationFixture.ts
@@ -162,7 +162,7 @@ export function defaultNotificationSettings(): NotificationSettings {
     enabled: true,
     completedEnabled: false,
     waitingEnabled: true,
-    soundEnabled: true,
+    soundEnabled: false,
     completedSoundFile: "complete.wav",
     waitingSoundFile: "waiting.wav",
     escalationSoundFile: "ping.wav",

--- a/scripts/perf/scenarios/notifications.ts
+++ b/scripts/perf/scenarios/notifications.ts
@@ -227,7 +227,13 @@ async function resetAgentService(
 ): Promise<void> {
   const bus = notificationBus();
   harness.modules.agentNotificationService.dispose();
-  bus.settings = { ...defaultNotificationSettings(), ...settings };
+  // The gate battery (PERF-322) represents a user who has sound turned on,
+  // so each row can grade its own named gate — master toggle, per-type,
+  // watch, spawn/boot grace, mute, quiet hours, escalation, all-clear —
+  // without every "must not fire" row being confounded by soundEnabled's
+  // product default (off, #12185). No case below overrides soundEnabled, so
+  // this is the effective baseline for the whole battery.
+  bus.settings = { ...defaultNotificationSettings(), soundEnabled: true, ...settings };
   bus.osDnd = undefined;
   harness.modules.store.set("appState", appStateForFleet(harness.fleet, "idle"));
   harness.modules.agentNotificationService.initialize();

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -315,7 +315,9 @@ export interface ElectronAPI extends GeneratedElectronAPI {
     onAgentDetected(callback: (data: AgentDetectedPayload) => void): () => void;
     onAgentExited(callback: (data: AgentExitedPayload) => void): () => void;
     onFallbackTriggered(callback: (data: AgentFallbackTriggeredPayload) => void): () => void;
-    onAllAgentsClear(callback: (data: { timestamp: number }) => void): () => void;
+    onAllAgentsClear(
+      callback: (data: { timestamp: number; shouldFlash: boolean }) => void
+    ): () => void;
     onActivity(callback: (data: TerminalActivityPayload) => void): () => void;
     onTrashed(callback: (data: { id: string; expiresAt: number }) => void): () => void;
     onRestored(callback: (data: { id: string }) => void): () => void;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1447,7 +1447,7 @@ export interface IpcEventMap {
   // Agent events
   "agent:state-changed": AgentStateChangePayload;
   "agent:state-transition-dropped": AgentStateTransitionDroppedPayload;
-  "agent:all-clear": { timestamp: number };
+  "agent:all-clear": { timestamp: number; shouldFlash: boolean };
   "agent:detected": AgentDetectedPayload;
   "agent:exited": AgentExitedPayload;
   "agent:fallback-triggered": AgentFallbackTriggeredPayload;

--- a/src/components/AllClearOverlay/AllClearOverlay.tsx
+++ b/src/components/AllClearOverlay/AllClearOverlay.tsx
@@ -1,54 +1,22 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { useShallow } from "zustand/react/shallow";
-import { isScheduledQuietNow } from "@shared/utils/quietHours";
-import { useNotificationSettingsStore } from "@/store/notificationSettingsStore";
 
 export function AllClearOverlay() {
   const [visible, setVisible] = useState(false);
   const safetyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const {
-    notificationsEnabled,
-    flashEnabled,
-    quietUntil,
-    quietHoursEnabled,
-    quietHoursStartMin,
-    quietHoursEndMin,
-    quietHoursWeekdays,
-    osDndActive,
-  } = useNotificationSettingsStore(
-    useShallow((s) => ({
-      notificationsEnabled: s.enabled,
-      flashEnabled: s.flashEnabled,
-      quietUntil: s.quietUntil,
-      quietHoursEnabled: s.quietHoursEnabled,
-      quietHoursStartMin: s.quietHoursStartMin,
-      quietHoursEndMin: s.quietHoursEndMin,
-      quietHoursWeekdays: s.quietHoursWeekdays,
-      osDndActive: s.osDndActive,
-    }))
-  );
-
   useEffect(() => {
-    const cleanup = window.electron.terminal.onAllAgentsClear(() => {
-      // The flash is the visual half of the same paired all-clear moment as
-      // the sound (#12185) — it must obey the same gate and suppression
-      // chain as AgentNotificationService.isInformationalAudioSuppressed.
-      if (!notificationsEnabled || !flashEnabled) return;
-      if (quietUntil > Date.now()) return;
-      if (
-        isScheduledQuietNow({
-          quietHoursEnabled,
-          quietHoursStartMin,
-          quietHoursEndMin,
-          quietHoursWeekdays,
-        })
-      ) {
-        return;
-      }
-      if (osDndActive === true) return;
+    const cleanup = window.electron.terminal.onAllAgentsClear((data) => {
+      // `shouldFlash` is computed main-process-side, from the single
+      // freshest copy of settings (flashEnabled, the master enabled toggle,
+      // and the same suppression chain as the sound — quiet hours, session
+      // mute, OS DND). See AgentNotificationService.checkAllClear (#12185).
+      // Recomputing this from a per-project-view renderer store would go
+      // stale the moment a second open view's settings changed elsewhere.
+      if (!data.shouldFlash) return;
 
+      // These three remain renderer-only concerns — CSS media queries and
+      // DOM attributes the main process has no way to observe.
       if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
       if (document.body.getAttribute("data-reduce-animations") === "true") return;
       if (document.body.getAttribute("data-performance-mode") === "true") return;
@@ -56,16 +24,7 @@ export function AllClearOverlay() {
       setVisible(true);
     });
     return cleanup;
-  }, [
-    notificationsEnabled,
-    flashEnabled,
-    quietUntil,
-    quietHoursEnabled,
-    quietHoursStartMin,
-    quietHoursEndMin,
-    quietHoursWeekdays,
-    osDndActive,
-  ]);
+  }, []);
 
   const handleAnimationEnd = useCallback((event: React.AnimationEvent) => {
     if (event.animationName === "all-clear-flash") {

--- a/src/components/AllClearOverlay/__tests__/AllClearOverlay.test.tsx
+++ b/src/components/AllClearOverlay/__tests__/AllClearOverlay.test.tsx
@@ -2,35 +2,27 @@
 import { render, act } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { AllClearOverlay } from "../AllClearOverlay";
-import { useNotificationSettingsStore } from "@/store/notificationSettingsStore";
 
 const OVERLAY_SELECTOR = "[aria-hidden='true']";
 
-let onAllAgentsClearCb: ((data: { timestamp: number }) => void) | null = null;
+type AllClearPayload = { timestamp: number; shouldFlash: boolean };
+
+let onAllAgentsClearCb: ((data: AllClearPayload) => void) | null = null;
+
+function fireAllClear(shouldFlash = true) {
+  onAllAgentsClearCb?.({ timestamp: Date.now(), shouldFlash });
+}
 
 beforeEach(() => {
   vi.useFakeTimers();
   onAllAgentsClearCb = null;
-
-  // Suppressed-by-default is the point of #12185 — every test that expects
-  // the overlay to actually fire must opt in explicitly.
-  useNotificationSettingsStore.setState({
-    enabled: true,
-    flashEnabled: true,
-    quietUntil: 0,
-    quietHoursEnabled: false,
-    quietHoursStartMin: 22 * 60,
-    quietHoursEndMin: 8 * 60,
-    quietHoursWeekdays: [],
-    osDndActive: undefined,
-  });
 
   Object.defineProperty(window, "electron", {
     configurable: true,
     writable: true,
     value: {
       terminal: {
-        onAllAgentsClear: vi.fn((callback: (data: { timestamp: number }) => void) => {
+        onAllAgentsClear: vi.fn((callback: (data: AllClearPayload) => void) => {
           onAllAgentsClearCb = callback;
           return () => {
             onAllAgentsClearCb = null;
@@ -52,11 +44,11 @@ afterEach(() => {
 });
 
 describe("AllClearOverlay", () => {
-  it("renders the overlay when onAllAgentsClear fires", () => {
+  it("renders the overlay when the event carries shouldFlash: true", () => {
     render(<AllClearOverlay />);
 
     act(() => {
-      onAllAgentsClearCb?.({ timestamp: Date.now() });
+      fireAllClear(true);
     });
 
     expect(document.body.querySelector(OVERLAY_SELECTOR)).toBeTruthy();
@@ -67,12 +59,26 @@ describe("AllClearOverlay", () => {
     expect(document.body.querySelector(OVERLAY_SELECTOR)).toBeNull();
   });
 
+  it("suppresses the overlay when the event carries shouldFlash: false", () => {
+    // shouldFlash is computed main-process-side (flashEnabled, the master
+    // enabled toggle, and the audio suppression chain) — see
+    // AgentNotificationService.checkAllClear (#12185). The overlay trusts it
+    // rather than recomputing suppression from its own settings mirror.
+    render(<AllClearOverlay />);
+
+    act(() => {
+      fireAllClear(false);
+    });
+
+    expect(document.body.querySelector(OVERLAY_SELECTOR)).toBeNull();
+  });
+
   it("suppresses the overlay when prefers-reduced-motion is set", () => {
     (window.matchMedia as ReturnType<typeof vi.fn>).mockReturnValue({ matches: true });
     render(<AllClearOverlay />);
 
     act(() => {
-      onAllAgentsClearCb?.({ timestamp: Date.now() });
+      fireAllClear(true);
     });
 
     expect(document.body.querySelector(OVERLAY_SELECTOR)).toBeNull();
@@ -84,7 +90,7 @@ describe("AllClearOverlay", () => {
       render(<AllClearOverlay />);
 
       act(() => {
-        onAllAgentsClearCb?.({ timestamp: Date.now() });
+        fireAllClear(true);
       });
 
       expect(document.body.querySelector(OVERLAY_SELECTOR)).toBeNull();
@@ -99,7 +105,7 @@ describe("AllClearOverlay", () => {
       render(<AllClearOverlay />);
 
       act(() => {
-        onAllAgentsClearCb?.({ timestamp: Date.now() });
+        fireAllClear(true);
       });
 
       expect(document.body.querySelector(OVERLAY_SELECTOR)).toBeNull();
@@ -112,7 +118,7 @@ describe("AllClearOverlay", () => {
     render(<AllClearOverlay />);
 
     act(() => {
-      onAllAgentsClearCb?.({ timestamp: Date.now() });
+      fireAllClear(true);
     });
 
     expect(document.body.querySelector(OVERLAY_SELECTOR)).toBeTruthy();
@@ -128,7 +134,7 @@ describe("AllClearOverlay", () => {
     const { unmount } = render(<AllClearOverlay />);
 
     act(() => {
-      onAllAgentsClearCb?.({ timestamp: Date.now() });
+      fireAllClear(true);
     });
 
     unmount();
@@ -144,84 +150,5 @@ describe("AllClearOverlay", () => {
     const { unmount } = render(<AllClearOverlay />);
     unmount();
     expect(onAllAgentsClearCb).toBeNull();
-  });
-
-  it("suppresses the overlay when flashEnabled is off (the new default)", () => {
-    useNotificationSettingsStore.setState({ flashEnabled: false });
-    render(<AllClearOverlay />);
-
-    act(() => {
-      onAllAgentsClearCb?.({ timestamp: Date.now() });
-    });
-
-    expect(document.body.querySelector(OVERLAY_SELECTOR)).toBeNull();
-  });
-
-  it("suppresses the overlay when notifications are disabled entirely", () => {
-    useNotificationSettingsStore.setState({ enabled: false });
-    render(<AllClearOverlay />);
-
-    act(() => {
-      onAllAgentsClearCb?.({ timestamp: Date.now() });
-    });
-
-    expect(document.body.querySelector(OVERLAY_SELECTOR)).toBeNull();
-  });
-
-  it("suppresses the overlay while session-muted", () => {
-    useNotificationSettingsStore.setState({ quietUntil: Date.now() + 60_000 });
-    render(<AllClearOverlay />);
-
-    act(() => {
-      onAllAgentsClearCb?.({ timestamp: Date.now() });
-    });
-
-    expect(document.body.querySelector(OVERLAY_SELECTOR)).toBeNull();
-  });
-
-  it("suppresses the overlay during scheduled quiet hours", () => {
-    const now = new Date();
-    const nowMin = now.getHours() * 60 + now.getMinutes();
-    useNotificationSettingsStore.setState({
-      quietHoursEnabled: true,
-      quietHoursStartMin: 0,
-      quietHoursEndMin: 0,
-      quietHoursWeekdays: [],
-    });
-    // startMin === endMin disables the window in isScheduledQuietNow — cover
-    // the "currently inside the window" branch explicitly instead.
-    useNotificationSettingsStore.setState({
-      quietHoursStartMin: nowMin,
-      quietHoursEndMin: (nowMin + 60) % 1440,
-    });
-    render(<AllClearOverlay />);
-
-    act(() => {
-      onAllAgentsClearCb?.({ timestamp: Date.now() });
-    });
-
-    expect(document.body.querySelector(OVERLAY_SELECTOR)).toBeNull();
-  });
-
-  it("suppresses the overlay when OS DND is active", () => {
-    useNotificationSettingsStore.setState({ osDndActive: true });
-    render(<AllClearOverlay />);
-
-    act(() => {
-      onAllAgentsClearCb?.({ timestamp: Date.now() });
-    });
-
-    expect(document.body.querySelector(OVERLAY_SELECTOR)).toBeNull();
-  });
-
-  it("still renders when OS DND state is unknown (undefined means do-not-gate)", () => {
-    useNotificationSettingsStore.setState({ osDndActive: undefined });
-    render(<AllClearOverlay />);
-
-    act(() => {
-      onAllAgentsClearCb?.({ timestamp: Date.now() });
-    });
-
-    expect(document.body.querySelector(OVERLAY_SELECTOR)).toBeTruthy();
   });
 });

--- a/src/components/Settings/NotificationSettingsTab.tsx
+++ b/src/components/Settings/NotificationSettingsTab.tsx
@@ -29,7 +29,7 @@ const DEFAULT_SETTINGS: NotificationSettings = {
   enabled: true,
   completedEnabled: false,
   waitingEnabled: true,
-  soundEnabled: true,
+  soundEnabled: false,
   completedSoundFile: "complete.wav",
   waitingSoundFile: "waiting.wav",
   escalationSoundFile: "ping.wav",

--- a/src/store/notificationSettingsStore.ts
+++ b/src/store/notificationSettingsStore.ts
@@ -5,10 +5,12 @@ interface NotificationSettingsState {
   hydrated: boolean;
   // Per-kind toggles, mirrored from IPC settings so the notification center can
   // compute a "what will fire right now" summary without a per-open IPC round
-  // trip. `completedEnabled`/`waitingEnabled`/`workingPulseEnabled`/
-  // `uiFeedbackSoundEnabled` gate main-process notifications and sounds and
-  // are display-only here; `flashEnabled` is read directly by
-  // AllClearOverlay to gate the all-clear screen flash (#12185).
+  // trip. These gate main-process notifications, sounds, and (for
+  // `flashEnabled`) the all-clear screen flash — all display-only here. The
+  // flash's actual eligibility is decided main-process-side and carried on
+  // the `agent:all-clear` event payload, not read from this mirror — a
+  // per-project-view store can go stale the moment another view changes
+  // settings (#12185).
   completedEnabled: boolean;
   waitingEnabled: boolean;
   workingPulseEnabled: boolean;


### PR DESCRIPTION
## Summary

Follow-up to #12199, which merged before a deeper Codex review pass surfaced four real issues in it. This PR fixes all four; details of what shipped and what was still broken are in the review trail on #12199. `develop` currently ships with sound on by default despite #12199 — this closes that gap.

## What was still broken after #12199 merged

- **`soundEnabled` still defaulted to `true`** in `electron/store.ts` (plus the settings-tab and perf-fixture duplicates). Fresh installs skip the migration chain entirely (`globalServicesInit.ts`'s fast path just stamps the schema version when there's no pre-existing store), so migration028 never ran for them — every fresh install still shipped with sound on, which was the entire point of the original issue.
- **The all-clear flash's eligibility was decided in the renderer**, from a per-project-view Zustand mirror of notification settings. Each project view has its own V8 context and its own store instance with no cross-view sync, so a second already-open project view could flash after the user disabled/muted it elsewhere (or fail to flash after enabling it) until that view happened to reload.
- **The agent-spawned UI-feedback sound's suppression check omitted OS Do-Not-Disturb** — it observed quiet hours and session mute but not DND, unlike every other informational sound.
- **migration028 trusted `notificationSettings`'s shape** without a guard against a malformed (non-object) persisted value, unlike migrations 013/014's established `isPlainObject` pattern.

## Fixes

- `soundEnabled` now defaults to `false` everywhere it's declared.
- `AgentNotificationService.checkAllClear` now computes a `shouldFlash` verdict main-process-side, from the single freshest copy of settings (mirroring the sound's exact gate), and carries it on the `agent:all-clear` event payload. `AllClearOverlay` now just reads `shouldFlash` from the event instead of recomputing suppression from its own store — it no longer depends on `notificationSettingsStore` at all, which also simplifies the component.
- The agent-spawned sound now reuses the existing `isInformationalAudioSuppressed` predicate (quiet hours + session mute + OS DND) instead of a partial ad-hoc check, while keeping its separate boot-grace gate.
- migration028 adds the `isPlainObject` guard already established elsewhere in the migrations barrel.

## Testing

- Extended `AgentNotificationService.allClear.test.ts`'s suppression-chain tests to also verify the `shouldFlash` payload value (not just that the sound is silenced), and added tests proving sound and flash toggle independently.
- Extended `AgentNotificationService.test.ts` with an OS-DND agent-spawned-sound test.
- Rewrote `AllClearOverlay.test.tsx` for the simplified, store-free component.
- Extended migration028's tests with a malformed-shape case.
- Two Codex adversarial review passes (max reasoning effort) on this diff — the first found the four issues above, the second confirmed all four resolved with no new issues introduced.
- 1413 targeted tests pass locally against current `develop`; eslint/prettier clean on every touched file.