### PR TITLE
fix(pty): reap terminal descendants that already reparented to PID 1

### DIFF
--- a/electron/__tests__/pty-host.adversarial.test.ts
+++ b/electron/__tests__/pty-host.adversarial.test.ts
@@ -310,6 +310,7 @@ vi.mock("../services/TerminalLineageLedger.js", () => ({
     dispose = vi.fn();
   },
   lineageFilePath: vi.fn(() => "/tmp/pty-lineage.json"),
+  beginTeardownProbeWindow: vi.fn(),
 }));
 
 vi.mock("../services/pty/TerminalResourceMonitor.js", () => ({

--- a/electron/__tests__/pty-host.adversarial.test.ts
+++ b/electron/__tests__/pty-host.adversarial.test.ts
@@ -221,6 +221,7 @@ vi.mock("../services/PtyManager.js", () => {
     });
     isSabMode = vi.fn(() => this.sabMode);
     setProcessTreeCache = vi.fn();
+    setLineageLedger = vi.fn();
     setImagePathProbe = vi.fn();
     setPtyPool = vi.fn();
     setAnalysisWorkerPool = vi.fn();
@@ -295,7 +296,20 @@ vi.mock("../services/ProcessTreeCache.js", () => ({
     start = vi.fn();
     stop = vi.fn();
     setPollInterval = vi.fn();
+    attachLineageLedger = vi.fn();
   },
+}));
+
+vi.mock("../services/TerminalLineageLedger.js", () => ({
+  TerminalLineageLedger: class {
+    hasRoots = vi.fn(() => false);
+    reconcile = vi.fn();
+    registerRoot = vi.fn();
+    markRootClosing = vi.fn();
+    getVerifiedOrphanPids = vi.fn(() => []);
+    dispose = vi.fn();
+  },
+  lineageFilePath: vi.fn(() => "/tmp/pty-lineage.json"),
 }));
 
 vi.mock("../services/pty/TerminalResourceMonitor.js", () => ({

--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -46,7 +46,11 @@ import {
 } from "./services/pty/analysis/AnalysisWorkerPool.js";
 import { PtyPool, getPtyPool, shouldEnablePtyPool } from "./services/PtyPool.js";
 import { ProcessTreeCache } from "./services/ProcessTreeCache.js";
-import { TerminalLineageLedger, lineageFilePath } from "./services/TerminalLineageLedger.js";
+import {
+  TerminalLineageLedger,
+  beginTeardownProbeWindow,
+  lineageFilePath,
+} from "./services/TerminalLineageLedger.js";
 import { ImagePathProbe } from "./services/pty/ImagePathProbe.js";
 import { TerminalResourceMonitor } from "./services/pty/TerminalResourceMonitor.js";
 import { events } from "./services/events.js";
@@ -1677,6 +1681,11 @@ port.on("message", async (rawMsg: any) => {
 
 function cleanup(): void {
   console.log("[PtyHost] Disposing resources...");
+
+  // One synchronous `ps` budget for the whole teardown. Every terminal's
+  // disposal below can run two verification passes, and Main force-kills this
+  // host about a second after it asks for the exit.
+  beginTeardownProbeWindow();
 
   // Disconnect all renderer windows
   for (const windowId of Array.from(rendererConnections.keys())) {

--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -46,6 +46,10 @@ import {
 } from "./services/pty/analysis/AnalysisWorkerPool.js";
 import { PtyPool, getPtyPool, shouldEnablePtyPool } from "./services/PtyPool.js";
 import { ProcessTreeCache } from "./services/ProcessTreeCache.js";
+import {
+  TerminalLineageLedger,
+  lineageFilePath,
+} from "./services/TerminalLineageLedger.js";
 import { ImagePathProbe } from "./services/pty/ImagePathProbe.js";
 import { TerminalResourceMonitor } from "./services/pty/TerminalResourceMonitor.js";
 import { events } from "./services/events.js";
@@ -173,6 +177,17 @@ if (!analysisWorkersDisabled()) {
 // `claude --version`-style blips. Adaptive backoff (see ProcessTreeCache)
 // stretches this out when the tree is quiet.
 const processTreeCache = new ProcessTreeCache(1500);
+// Records every descendant ever seen under a PTY shell so teardown can still
+// reach the ones that reparented to PID 1 before it ran (#12203). Persisted
+// per shard — each shard is its own process with its own terminals, and the
+// write is a whole-file replace.
+const lineageLedger = new TerminalLineageLedger(
+  process.env.DAINTREE_USER_DATA
+    ? lineageFilePath(process.env.DAINTREE_USER_DATA, process.env.DAINTREE_PTY_SHARD_SERVICE)
+    : null,
+  process.env.DAINTREE_PTY_SHARD_SERVICE ?? "daintree-pty-host"
+);
+processTreeCache.attachLineageLedger(lineageLedger);
 // Image-path identity signal — defeats `process.title`/`setproctitle` rewrites
 // where comm/argv have been clobbered but the on-disk binary path still
 // identifies the agent. Shared across all terminals so the per-PID cache is
@@ -1683,6 +1698,10 @@ function cleanup(): void {
 
   terminalResourceMonitor.dispose();
   processTreeCache.stop();
+  // Disposed after ptyManager.dispose() below would be too late: that call
+  // tears down every terminal and needs the ledger to reach detached
+  // descendants. Detach it from the census now, drop its state afterwards.
+  processTreeCache.attachLineageLedger(null);
   imagePathProbe.dispose();
 
   // Release every plugin PTY's native handle through its teardown chokepoint —
@@ -1695,6 +1714,7 @@ function cleanup(): void {
   }
 
   ptyManager.dispose();
+  lineageLedger.dispose();
 
   // Workers are persistent by design (never terminated — Electron 37+
   // flush_tasks_ assertion); dispose only drops bookkeeping. The unref'd
@@ -1726,6 +1746,7 @@ async function initialize(): Promise<void> {
     // Start the process tree cache (shared across all terminals)
     processTreeCache.start();
     ptyManager.setProcessTreeCache(processTreeCache);
+    ptyManager.setLineageLedger(lineageLedger);
     ptyManager.setImagePathProbe(imagePathProbe);
     console.log("[PtyHost] ProcessTreeCache started");
 

--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -46,10 +46,7 @@ import {
 } from "./services/pty/analysis/AnalysisWorkerPool.js";
 import { PtyPool, getPtyPool, shouldEnablePtyPool } from "./services/PtyPool.js";
 import { ProcessTreeCache } from "./services/ProcessTreeCache.js";
-import {
-  TerminalLineageLedger,
-  lineageFilePath,
-} from "./services/TerminalLineageLedger.js";
+import { TerminalLineageLedger, lineageFilePath } from "./services/TerminalLineageLedger.js";
 import { ImagePathProbe } from "./services/pty/ImagePathProbe.js";
 import { TerminalResourceMonitor } from "./services/pty/TerminalResourceMonitor.js";
 import { events } from "./services/events.js";

--- a/electron/services/ProcessTreeCache.ts
+++ b/electron/services/ProcessTreeCache.ts
@@ -22,6 +22,14 @@ function execProbe(
 
 const BACKOFF_MULTIPLIER = 1.5;
 const BACKOFF_CEILING_MS = 15_000;
+/**
+ * Backoff ceiling while a lineage ledger is tracking roots. The ledger can only
+ * record a descendant it actually sees, so the gap between sweeps is the window
+ * in which a process can spawn, detach, and become unreachable forever (#12203).
+ * The idle ceiling above is far too coarse for that; this keeps the window
+ * bounded without pinning the census at its base interval all night.
+ */
+const LINEAGE_BACKOFF_CEILING_MS = 5_000;
 
 export interface ProcessInfo {
   pid: number;
@@ -30,6 +38,22 @@ export interface ProcessInfo {
   command: string;
   cpuPercent: number; // CPU usage percentage (0-100)
   rssKb: number; // Resident Set Size in KB
+  /**
+   * OS-reported process start time, when the platform census carries one.
+   * Populated on Windows (`CreationDate` is already fetched for CPU deltas);
+   * absent on Unix, where `ps -eo` would need a fixed-width `lstart` column and
+   * the lineage ledger probes the handful of PIDs it cares about instead.
+   */
+  startTime?: string;
+}
+
+/**
+ * Lineage tracking hook. Declared structurally so the cache never imports the
+ * ledger — they are wired together in pty-host.ts.
+ */
+export interface LineageLedgerHook {
+  hasRoots(): boolean;
+  reconcile(census: ProcessTreeCache): void;
 }
 
 type RefreshCallback = () => void;
@@ -47,6 +71,7 @@ export class ProcessTreeCache {
   private refreshCallbacks: Set<RefreshCallback> = new Set();
   private lastError: Error | null = null;
   private loggedZeroSubscriberSkip: boolean = false;
+  private lineageLedger: LineageLedgerHook | null = null;
   private cpuSnapshots = new Map<
     string,
     { kernelTicks: bigint; userTicks: bigint; wallMs: number }
@@ -107,10 +132,33 @@ export class ProcessTreeCache {
   }
 
   private advanceBackoff(): void {
+    // Never below the configured base interval — a tight lineage ceiling caps
+    // how far we drift, it must not make the census poll faster than asked.
+    const ceiling = this.hasLineageRoots()
+      ? Math.max(LINEAGE_BACKOFF_CEILING_MS, this.pollIntervalMs)
+      : BACKOFF_CEILING_MS;
     this.currentIntervalMs = Math.min(
       Math.ceil(this.currentIntervalMs * BACKOFF_MULTIPLIER),
-      BACKOFF_CEILING_MS
+      ceiling
     );
+  }
+
+  /**
+   * Attach the lineage ledger. While it holds roots the census keeps sweeping
+   * even with no subscribers, and backs off to a tighter ceiling — the ledger
+   * can only record descendants it observes, and an unobserved descendant that
+   * detaches is unreachable forever.
+   */
+  attachLineageLedger(ledger: LineageLedgerHook | null): void {
+    this.lineageLedger = ledger;
+  }
+
+  private hasLineageRoots(): boolean {
+    try {
+      return this.lineageLedger?.hasRoots() ?? false;
+    } catch {
+      return false;
+    }
   }
 
   getCurrentIntervalMs(): number {
@@ -132,8 +180,11 @@ export class ProcessTreeCache {
   }
 
   async refresh(): Promise<void> {
-    // Skip refresh if nobody is listening - saves CPU especially on Windows
-    if (this.refreshCallbacks.size === 0) {
+    // Skip refresh if nobody is listening - saves CPU especially on Windows.
+    // A lineage ledger with live roots counts as a listener: it is the only
+    // record of descendants that have detached, and it can only be built from
+    // sweeps that actually ran (#12203).
+    if (this.refreshCallbacks.size === 0 && !this.hasLineageRoots()) {
       // Log once per lifecycle when we skip due to no subscribers. If
       // ProcessDetector instances aren't registering, detection goes silent —
       // this surfaces the cause instead of failing silently (#5813). Verbose-gated
@@ -183,6 +234,18 @@ export class ProcessTreeCache {
       this.lastError = err;
     } finally {
       this.isRefreshing = false;
+
+      // Fold the fresh census into the lineage ledger before subscribers run,
+      // so anything reading the ledger during a callback sees this sweep.
+      // Isolated from the census itself: a ledger fault must not blind
+      // detection, which is what every other subscriber depends on.
+      if (this.lineageLedger) {
+        try {
+          this.lineageLedger.reconcile(this);
+        } catch (err) {
+          console.error("[ProcessTreeCache] Lineage reconcile error:", err);
+        }
+      }
 
       // Invoke callbacks after isRefreshing is reset
       for (const callback of this.refreshCallbacks) {
@@ -396,6 +459,11 @@ export class ProcessTreeCache {
         command,
         cpuPercent,
         rssKb,
+        // Already fetched for the CPU-delta snapshot key above, so the lineage
+        // ledger gets its pid-reuse anchor on Windows for free.
+        ...(typeof p?.CreationDate === "string" && p.CreationDate
+          ? { startTime: p.CreationDate }
+          : {}),
       });
 
       const children = newChildrenMap.get(ppid) || [];

--- a/electron/services/ProcessTreeCache.ts
+++ b/electron/services/ProcessTreeCache.ts
@@ -237,9 +237,15 @@ export class ProcessTreeCache {
 
       // Fold the fresh census into the lineage ledger before subscribers run,
       // so anything reading the ledger during a callback sees this sweep.
+      //
+      // Skipped when the sweep failed: `this.cache` still holds the previous
+      // snapshot, and presenting that as current would let the ledger count a
+      // just-registered root as missing — closing a healthy terminal's lineage
+      // on evidence that predates it.
+      //
       // Isolated from the census itself: a ledger fault must not blind
       // detection, which is what every other subscriber depends on.
-      if (this.lineageLedger) {
+      if (this.lineageLedger && outcome !== "error") {
         try {
           this.lineageLedger.reconcile(this);
         } catch (err) {

--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -53,7 +53,7 @@
  * - Multiple services need to interact (composition root in main.ts)
  */
 
-import { MessagePortMain } from "electron";
+import { app, MessagePortMain } from "electron";
 import { EventEmitter } from "events";
 import os from "os";
 import path from "path";
@@ -72,6 +72,7 @@ const logInfo = (msg: string, ctx?: Record<string, unknown>) =>
 const logWarn = (msg: string, ctx?: Record<string, unknown>) =>
   ctx ? logger.warn(msg, ctx) : logger.warn(msg);
 import { getTrashedPidTracker } from "./TrashedPidTracker.js";
+import { reapShardLineage } from "./TerminalLineageLedger.js";
 import { helpSessionService } from "./HelpSessionService.js";
 import { helpSessionJobService } from "./HelpSessionJobService.js";
 import { getLifecycleLedger, ledgerFactsFromSpawnOptions } from "./pty/lifecycleLedger.js";
@@ -1197,7 +1198,21 @@ export class PtyClient extends EventEmitter {
   }
 
   private cleanupOrphanedPtysForShard(shard: PtyShard, crashType: CrashType): void {
-    if (crashType === "CLEAN_EXIT" || this.terminalPids.size === 0) {
+    if (crashType === "CLEAN_EXIT") {
+      return;
+    }
+
+    // The crashed host's lineage ledger died with it, so its persisted orphan
+    // set is the only remaining record of descendants that had already
+    // reparented away from the PTY trees killed below (#12203). Runs before the
+    // terminalPids check: those orphans outlive whatever we still track, and
+    // they are not reachable by the process-group kill at all.
+    const userData = app.getPath("userData");
+    void reapShardLineage(userData, shard.serviceName).catch((err) => {
+      console.warn("[PtyClient] Lineage reap after host crash failed:", err);
+    });
+
+    if (this.terminalPids.size === 0) {
       return;
     }
 

--- a/electron/services/PtyManager.ts
+++ b/electron/services/PtyManager.ts
@@ -5,6 +5,7 @@ import type { AgentEvent } from "./AgentStateMachine.js";
 import type { AgentStateChangeTrigger } from "../schemas/agent.js";
 import type { PtyPool } from "./PtyPool.js";
 import type { ProcessTreeCache } from "./ProcessTreeCache.js";
+import type { LineageKillSource } from "./pty/ProcessTreeKiller.js";
 import type { DetectionResult } from "./ProcessDetector.js";
 import type { ImagePathProbe } from "./pty/ImagePathProbe.js";
 import type { AnalysisWorkerPool } from "./pty/analysis/AnalysisWorkerPool.js";
@@ -77,6 +78,7 @@ export class PtyManager extends EventEmitter {
   private agentStateService: AgentStateService;
   private ptyPool: PtyPool | null = null;
   private processTreeCache: ProcessTreeCache | null = null;
+  private lineageLedger: LineageKillSource | null = null;
   private imagePathProbe: ImagePathProbe | null = null;
   private analysisWorkerPool: AnalysisWorkerPool | null = null;
   private activeProjectId: string | null = null;
@@ -114,6 +116,10 @@ export class PtyManager extends EventEmitter {
 
   setProcessTreeCache(cache: ProcessTreeCache): void {
     this.processTreeCache = cache;
+  }
+
+  setLineageLedger(ledger: LineageKillSource | null): void {
+    this.lineageLedger = ledger;
   }
 
   setImagePathProbe(probe: ImagePathProbe): void {
@@ -501,6 +507,7 @@ export class PtyManager extends EventEmitter {
           ptyPool: this.ptyPool,
           sabModeEnabled: this.sabModeEnabled,
           processTreeCache: this.processTreeCache,
+          lineageLedger: this.lineageLedger,
           imagePathProbe: this.imagePathProbe,
           analysisWorkerPool: this.analysisWorkerPool,
         },

--- a/electron/services/TerminalLineageLedger.ts
+++ b/electron/services/TerminalLineageLedger.ts
@@ -278,12 +278,38 @@ export async function probeStartTimes(pids: number[]): Promise<Map<number, strin
 }
 
 /**
+ * Wall-clock deadline shared by every sync probe in one host teardown, or
+ * `null` outside one.
+ */
+let teardownProbeDeadlineMs: number | null = null;
+
+/**
+ * Arm the shared budget for a host teardown.
+ *
+ * {@link SYNC_PROBE_BUDGET_MS} is per invocation, but teardown disposes every
+ * terminal in turn on the host's only thread and each disposal can run two
+ * verification passes — up to 2N `ps` spawns, each otherwise entitled to the
+ * full budget, inside the ~1s Main allows before it force-kills the host. One
+ * deadline for the whole sequence is what the budget was always meant to be.
+ */
+export function beginTeardownProbeWindow(budgetMs: number = SYNC_PROBE_BUDGET_MS): void {
+  teardownProbeDeadlineMs = Date.now() + budgetMs;
+}
+
+/** Release the shared budget, restoring per-invocation behaviour. */
+export function endTeardownProbeWindow(): void {
+  teardownProbeDeadlineMs = null;
+}
+
+/**
  * Synchronous counterpart of {@link probeStartTimes}. Required at kill time:
  * `ProcessTreeKiller.execute()` runs synchronously, and its `immediate` path
  * runs inside `process.on("exit")` where no async work can complete.
  *
- * Bounded by {@link SYNC_PROBE_BUDGET_MS} in total, not per chunk. PIDs in a
- * chunk that is never reached stay unverified, and unverified means unsignalled.
+ * Bounded by {@link SYNC_PROBE_BUDGET_MS} in total, not per chunk, and by the
+ * teardown window from {@link beginTeardownProbeWindow} when one is armed. PIDs
+ * in a chunk that is never reached stay unverified, and unverified means
+ * unsignalled.
  */
 export function probeStartTimesSync(
   pids: number[],
@@ -292,7 +318,7 @@ export function probeStartTimesSync(
   const result = new Map<number, string>();
   if (pids.length === 0) return result;
 
-  const deadline = Date.now() + budgetMs;
+  const deadline = Math.min(Date.now() + budgetMs, teardownProbeDeadlineMs ?? Infinity);
 
   for (const group of chunk(pids, PROBE_CHUNK_SIZE)) {
     const remaining = deadline - Date.now();
@@ -397,6 +423,8 @@ export class TerminalLineageLedger {
    * a live probe.
    */
   private lastCensus: LineageCensus | null = null;
+  /** When {@link lastCensus} was folded in, the observation time for adoptions. */
+  private lastCensusAtMs = 0;
 
   constructor(
     private readonly filePath: string | null,
@@ -473,7 +501,9 @@ export class TerminalLineageLedger {
    */
   getVerifiedOrphanPids(rootPid: number, alreadyCovered: readonly number[]): number[] {
     const covered = new Set(alreadyCovered);
-    const candidates = this.getTrackedPids(rootPid).filter((c) => !covered.has(c.pid));
+    const candidates = this.getTrackedPids(rootPid).filter(
+      (c) => !covered.has(c.pid) && !isForbiddenTarget(c.pid)
+    );
     if (candidates.length === 0) return [];
 
     const current = probeStartTimesSync(candidates.map((c) => c.pid));
@@ -491,7 +521,9 @@ export class TerminalLineageLedger {
    */
   reconcile(census: LineageCensus): void {
     if (this.disposed) return;
+    const censusAtMs = Date.now();
     this.lastCensus = census;
+    this.lastCensusAtMs = censusAtMs;
     if (this.roots.size === 0) return;
 
     for (const [rootPid, entry] of this.roots) {
@@ -530,7 +562,7 @@ export class TerminalLineageLedger {
 
       if (entry.state === "active") {
         for (const pid of census.getDescendantPids(rootPid)) {
-          this.admit(entry, pid);
+          this.admit(entry, pid, censusAtMs);
         }
       }
 
@@ -600,7 +632,7 @@ export class TerminalLineageLedger {
     }
   }
 
-  private admit(entry: RootEntry, pid: number): void {
+  private admit(entry: RootEntry, pid: number, observedAtMs: number): void {
     if (entry.pids.has(pid) || !Number.isInteger(pid) || pid <= 1) return;
     if (this.trackedCount >= MAX_TRACKED_PIDS) {
       if (!this.loggedCapWarning) {
@@ -611,7 +643,7 @@ export class TerminalLineageLedger {
       }
       return;
     }
-    entry.pids.set(pid, { startTime: null, observedAtMs: Date.now(), orphaned: false });
+    entry.pids.set(pid, { startTime: null, observedAtMs, orphaned: false });
     this.trackedCount++;
     this.pendingIdentification.add(pid);
   }
@@ -715,8 +747,12 @@ export class TerminalLineageLedger {
       for (const [pid, tracked] of [...entry.pids]) {
         if (!tracked.orphaned || !tracked.startTime) continue;
         if (startTimes.get(pid) !== tracked.startTime) continue;
+        // The census, not now: this runs a full probe round-trip after the
+        // sweep that enumerated these children, and `observedAtMs` is the
+        // pid-reuse acceptance window. Stamping it here would widen that
+        // window by the probe's latency for adopted grandchildren alone.
         for (const child of census.getDescendantPids(pid)) {
-          this.admit(entry, child);
+          this.admit(entry, child, this.lastCensusAtMs);
         }
       }
     }
@@ -817,8 +853,7 @@ function deleteQuietly(filePath: string): void {
  */
 let claimSequence = 0;
 
-export function claimShardLineageFile(userDataPath: string, shardService?: string): string | null {
-  const source = lineageFilePath(userDataPath, shardService);
+function claimLineageFile(source: string): string | null {
   const claimed = `${source}${REAPING_SUFFIX}-${Date.now()}-${process.pid}-${++claimSequence}`;
   try {
     if (!fs.existsSync(source)) return null;
@@ -827,6 +862,10 @@ export function claimShardLineageFile(userDataPath: string, shardService?: strin
   } catch {
     return null;
   }
+}
+
+export function claimShardLineageFile(userDataPath: string, shardService?: string): string | null {
+  return claimLineageFile(lineageFilePath(userDataPath, shardService));
 }
 
 /** Returns true when the process is gone or was successfully signalled. */
@@ -970,7 +1009,21 @@ export async function reapPersistedLineages(userDataPath: string): Promise<void>
   );
   if (files.length === 0) return;
 
-  await Promise.all(files.map((name) => reapLineageFile(path.join(userDataPath, name))));
+  await Promise.all(
+    files.map((name) => {
+      const source = path.join(userDataPath, name);
+      // A live `.json` is claimed first, exactly as reapShardLineage does. The
+      // retry file the reaper writes for survivors it could not resolve would
+      // otherwise land back on the path the next pty-host constructs its own
+      // ledger at, and that host's first empty persist() unlinks it — the
+      // bounded-attempt path would never survive a single terminal spawn.
+      if (!name.includes(REAPING_SUFFIX)) {
+        const claimed = claimLineageFile(source);
+        return claimed ? reapLineageFile(claimed) : Promise.resolve();
+      }
+      return reapLineageFile(source);
+    })
+  );
 }
 
 /**

--- a/electron/services/TerminalLineageLedger.ts
+++ b/electron/services/TerminalLineageLedger.ts
@@ -1,0 +1,708 @@
+// eager-import-allow: reads/writes the lineage ledger via sync fs
+import { execFile, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { resilientAtomicWriteFileSync } from "../utils/fs.js";
+
+const execFileAsync = promisify(execFile);
+
+const LEDGER_VERSION = 1;
+const LEDGER_FILE_PREFIX = "pty-lineage";
+const REAPING_SUFFIX = ".reaping";
+const PROBE_TIMEOUT_MS = 3000;
+/** Largest `-p` list handed to a single `ps`. Keeps us far under ARG_MAX. */
+const PROBE_CHUNK_SIZE = 500;
+/**
+ * Ceiling on tracked PIDs across all roots in one host. A runaway build can
+ * fork thousands of short-lived processes; the ledger keeps every one it has
+ * seen until the OS reports it gone, so the set needs a hard bound. At the cap
+ * we stop admitting new PIDs rather than evicting known ones — an evicted PID
+ * is a leak we can no longer reach, which is the bug this file exists to fix.
+ */
+const MAX_TRACKED_PIDS = 4096;
+/**
+ * Boot-time tolerance for the persisted anchor, in seconds. `os.uptime()` is
+ * derived from `kern.boottime` / `/proc/uptime`, so the computed boot epoch is
+ * stable to within a second or two across reads. A reboot always shifts it by
+ * far more than this, so the check reliably discards ledgers whose PIDs belong
+ * to a previous boot's numbering.
+ */
+const BOOT_EPOCH_TOLERANCE_SEC = 120;
+/** Grace period between the reaper's SIGTERM and its SIGKILL escalation. */
+const REAP_ESCALATION_DELAY_MS = 500;
+
+/**
+ * The subset of {@link ProcessTreeCache} the ledger reads. Declared structurally
+ * so this module never imports the cache (and the cache never imports the
+ * ledger) — the two are wired together in pty-host.ts.
+ */
+export interface LineageCensus {
+  getProcess(pid: number): { pid: number; ppid: number; startTime?: string } | undefined;
+  getDescendantPids(rootPid: number): number[];
+}
+
+interface TrackedPid {
+  /**
+   * OS-reported process start time, the pid-reuse guard. `null` until the
+   * identity probe lands. An unidentified PID is never signalled — we cannot
+   * prove it is still the process we observed.
+   */
+  startTime: string | null;
+  /** True when the last census showed this PID reparented away from our tree. */
+  orphaned: boolean;
+}
+
+interface RootEntry {
+  /**
+   * `active` roots discover new descendants each sweep. `closing` roots have
+   * had their terminal torn down: we stop discovering and only prune, so a
+   * recycled root PID can never adopt a dead terminal's lineage.
+   */
+  state: "active" | "closing";
+  pids: Map<number, TrackedPid>;
+}
+
+export interface PersistedLineageEntry {
+  pid: number;
+  startTime: string;
+  rootPid: number;
+}
+
+interface PersistedLineageFile {
+  version: number;
+  bootEpochSec: number;
+  owner: string;
+  updatedAt: number;
+  entries: PersistedLineageEntry[];
+}
+
+/**
+ * Seconds since the epoch at which this machine booted. Used as the persisted
+ * ledger's validity anchor: PID numbering restarts at boot, so entries written
+ * before a reboot address processes that no longer exist under those numbers.
+ */
+export function currentBootEpochSec(): number {
+  return Math.round(Date.now() / 1000 - os.uptime());
+}
+
+function sanitizeShardSuffix(service: string | undefined): string {
+  if (!service || service === "daintree-pty-host") return "";
+  return service.replace(/^daintree-pty-host:?/, "").replace(/[^a-zA-Z0-9_-]/g, "");
+}
+
+/**
+ * Ledger file for one pty-host shard. Each shard is its own process with its
+ * own terminals, and the write is a whole-file replace, so shards must not
+ * share a path — mirrors the per-shard split in `pty-host/emergencyLog.ts`.
+ */
+export function lineageFilePath(userDataPath: string, shardService?: string): string {
+  const suffix = sanitizeShardSuffix(shardService);
+  const name = suffix ? `${LEDGER_FILE_PREFIX}-${suffix}.json` : `${LEDGER_FILE_PREFIX}.json`;
+  return path.join(userDataPath, name);
+}
+
+function parsePsStartTimes(stdout: string): Map<number, string> {
+  const out = new Map<number, string>();
+  for (const line of stdout.split("\n")) {
+    const match = line.match(/^\s*(\d+)\s+(.+?)\s*$/);
+    if (!match) continue;
+    const pid = parseInt(match[1], 10);
+    if (!Number.isInteger(pid) || pid <= 0) continue;
+    // Regex captures are V8 sliced strings pinning the whole ps stdout for as
+    // long as the ledger retains them, and ledger entries outlive many sweeps.
+    // Buffer.from() is the only idiom that forces a flat copy (lesson #10410).
+    out.set(pid, Buffer.from(match[2]).toString());
+  }
+  return out;
+}
+
+function chunk(pids: number[], size: number): number[][] {
+  const chunks: number[][] = [];
+  for (let i = 0; i < pids.length; i += size) {
+    chunks.push(pids.slice(i, i + size));
+  }
+  return chunks;
+}
+
+function windowsStartTimeScript(pids: number[]): string {
+  const filter = pids.map((p) => `ProcessId=${p}`).join(" or ");
+  return (
+    "$ErrorActionPreference = 'SilentlyContinue'; " +
+    `Get-CimInstance Win32_Process -Filter '${filter}' | ` +
+    "ForEach-Object { if ($_.CreationDate) { \"$($_.ProcessId) $($_.CreationDate.ToString('o'))\" } }"
+  );
+}
+
+/**
+ * Batched process start-time lookup. One subprocess per chunk rather than one
+ * per PID — a busy agent terminal can produce dozens of new descendants per
+ * sweep, and a spawn each would cost more than the census itself.
+ *
+ * PIDs that no longer exist are simply absent from the result. `ps` exits
+ * non-zero when *none* of the requested PIDs exist, which is a normal outcome
+ * here, so a rejected call with usable stdout is not treated as a failure.
+ */
+export async function probeStartTimes(pids: number[]): Promise<Map<number, string>> {
+  const result = new Map<number, string>();
+  if (pids.length === 0) return result;
+
+  for (const group of chunk(pids, PROBE_CHUNK_SIZE)) {
+    try {
+      if (process.platform === "win32") {
+        const { stdout } = await execFileAsync(
+          "powershell.exe",
+          ["-NoProfile", "-NonInteractive", "-NoLogo", "-Command", windowsStartTimeScript(group)],
+          {
+            windowsHide: true,
+            encoding: "utf8",
+            shell: false,
+            signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+          }
+        );
+        for (const [pid, startTime] of parsePsStartTimes(stdout.replace(/^﻿/, ""))) {
+          result.set(pid, startTime);
+        }
+        continue;
+      }
+      const { stdout } = await execFileAsync(
+        "ps",
+        ["-o", "pid=,lstart=", "-p", group.join(",")],
+        { encoding: "utf8", shell: false, signal: AbortSignal.timeout(PROBE_TIMEOUT_MS) }
+      );
+      for (const [pid, startTime] of parsePsStartTimes(stdout)) {
+        result.set(pid, startTime);
+      }
+    } catch (err) {
+      // `ps` exits 1 when every requested PID is gone — the error still carries
+      // stdout for any that survived. Anything else leaves the group unresolved,
+      // which fails closed: unidentified PIDs are never signalled.
+      const stdout = (err as { stdout?: string })?.stdout;
+      if (typeof stdout === "string" && stdout.length > 0) {
+        for (const [pid, startTime] of parsePsStartTimes(stdout)) {
+          result.set(pid, startTime);
+        }
+      }
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Synchronous counterpart of {@link probeStartTimes}. Required at kill time:
+ * `ProcessTreeKiller.execute()` runs synchronously, and its `immediate` path
+ * runs inside `process.on("exit")` where no async work can complete.
+ */
+export function probeStartTimesSync(pids: number[]): Map<number, string> {
+  const result = new Map<number, string>();
+  if (pids.length === 0) return result;
+
+  for (const group of chunk(pids, PROBE_CHUNK_SIZE)) {
+    try {
+      const spawned =
+        process.platform === "win32"
+          ? spawnSync(
+              "powershell.exe",
+              [
+                "-NoProfile",
+                "-NonInteractive",
+                "-NoLogo",
+                "-Command",
+                windowsStartTimeScript(group),
+              ],
+              { windowsHide: true, encoding: "utf8", timeout: PROBE_TIMEOUT_MS }
+            )
+          : spawnSync("ps", ["-o", "pid=,lstart=", "-p", group.join(",")], {
+              encoding: "utf8",
+              timeout: PROBE_TIMEOUT_MS,
+            });
+      const stdout = typeof spawned?.stdout === "string" ? spawned.stdout : "";
+      if (!stdout) continue;
+      for (const [pid, startTime] of parsePsStartTimes(stdout.replace(/^﻿/, ""))) {
+        result.set(pid, startTime);
+      }
+    } catch {
+      // Fail closed — unidentified PIDs are not signalled.
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Records every descendant ever observed under a PTY shell, so teardown can
+ * still reach the ones that have since reparented to PID 1.
+ *
+ * Every existing cleanup tier walks *down* from a live root at the moment of
+ * teardown, which structurally cannot see a process that detached earlier
+ * (#12203: 64 `zsh` loops left pinning 13 cores for three days). The ledger
+ * inverts that: while a descendant is still reachable by the periodic census
+ * it is written down, and it stays written down after its parent dies and the
+ * OS reparents it away.
+ *
+ * Two invariants keep the wider kill set safe:
+ *
+ * - **Every entry is anchored to a start time.** A PID with no recorded start
+ *   time, or whose current start time differs, is never signalled — it is a
+ *   different process now, not the one we observed (lesson #10950).
+ * - **`closing` roots stop discovering.** Once a terminal is torn down its root
+ *   PID can be recycled, so a recycled root must not be able to adopt the dead
+ *   terminal's lineage.
+ */
+export class TerminalLineageLedger {
+  private roots = new Map<number, RootEntry>();
+  private trackedCount = 0;
+  private loggedCapWarning = false;
+  private pendingIdentification = new Set<number>();
+  private identifyInFlight = false;
+  private lastPersistedJson: string | null = null;
+  private disposed = false;
+  private lastCensus: LineageCensus | null = null;
+
+  constructor(
+    private readonly filePath: string | null,
+    private readonly owner: string = "daintree-pty-host"
+  ) {}
+
+  /** Begin tracking a PTY shell's lineage. Called when its killer is built. */
+  registerRoot(rootPid: number): void {
+    if (this.disposed || !Number.isInteger(rootPid) || rootPid <= 1) return;
+    if (this.roots.has(rootPid)) {
+      // A recycled root PID must start from an empty lineage, never inherit the
+      // previous terminal's descendants.
+      this.dropRoot(rootPid);
+    }
+    this.roots.set(rootPid, { state: "active", pids: new Map() });
+  }
+
+  /**
+   * Stop discovering new descendants for a root while keeping what we already
+   * know. Called at teardown so the 500ms SIGKILL escalation and the persisted
+   * ledger still see the survivors.
+   */
+  markRootClosing(rootPid: number): void {
+    const entry = this.roots.get(rootPid);
+    if (entry) entry.state = "closing";
+  }
+
+  /** Forget a root entirely. */
+  unregisterRoot(rootPid: number): void {
+    this.dropRoot(rootPid);
+  }
+
+  hasRoots(): boolean {
+    return this.roots.size > 0;
+  }
+
+  /**
+   * Identified descendants of a root, with the root itself excluded. Entries
+   * carry the start time recorded when they were first observed; callers that
+   * intend to signal must go through {@link getVerifiedOrphanPids}.
+   */
+  getTrackedPids(rootPid: number): Array<{ pid: number; startTime: string }> {
+    const entry = this.roots.get(rootPid);
+    if (!entry) return [];
+    const out: Array<{ pid: number; startTime: string }> = [];
+    for (const [pid, tracked] of entry.pids) {
+      if (pid === rootPid || !tracked.startTime) continue;
+      out.push({ pid, startTime: tracked.startTime });
+    }
+    return out;
+  }
+
+  /**
+   * Tracked descendants the caller's live walk can no longer reach, filtered to
+   * the ones the OS still reports with the exact start time we recorded.
+   *
+   * This is the safety boundary for the widened kill set. Ledger entries are by
+   * construction old — that is what lets them outlive reparenting — so a PID
+   * being *present* proves nothing; only a matching start time proves it is
+   * still the process we observed (lesson #10950). Verification is synchronous
+   * because it runs inside teardown, including the `process.on("exit")` path
+   * where nothing async can complete.
+   */
+  getVerifiedOrphanPids(rootPid: number, alreadyCovered: readonly number[]): number[] {
+    const covered = new Set(alreadyCovered);
+    const candidates = this.getTrackedPids(rootPid).filter((t) => !covered.has(t.pid));
+    if (candidates.length === 0) return [];
+
+    if (process.platform === "win32") {
+      // The Windows census already carries CreationDate, so the last sweep's
+      // snapshot answers this without spawning anything.
+      return candidates
+        .filter((c) => this.lastCensus?.getProcess(c.pid)?.startTime === c.startTime)
+        .map((c) => c.pid);
+    }
+
+    const current = probeStartTimesSync(candidates.map((c) => c.pid));
+    return candidates.filter((c) => current.get(c.pid) === c.startTime).map((c) => c.pid);
+  }
+
+  /**
+   * Fold one process census into the ledger: admit newly seen descendants,
+   * drop the ones the OS says are gone, and refresh orphan flags.
+   *
+   * Runs synchronously inside the cache's refresh so the ledger is current
+   * before any subscriber reads it. Start-time identification for new PIDs is
+   * kicked off asynchronously and lands on a later sweep; until it does, those
+   * PIDs are tracked but not signallable.
+   */
+  reconcile(census: LineageCensus): void {
+    if (this.disposed) return;
+    this.lastCensus = census;
+    if (this.roots.size === 0) return;
+
+    for (const [rootPid, entry] of this.roots) {
+      // Prune first so the orphan flags below are current for *this* sweep.
+      // Flagging after discovery would delay a freshly detached member's own
+      // children by a full sweep.
+      this.prune(entry, census);
+      this.flagOrphans(entry, census);
+
+      if (entry.state === "active") {
+        for (const pid of census.getDescendantPids(rootPid)) {
+          this.admit(entry, pid);
+        }
+      }
+
+      // Descendants a detached member spawned after it left our tree are still
+      // this terminal's work — a wrapper that reparents and then forks a build
+      // would otherwise leave that build unreachable. Only orphans need their
+      // own walk: anything still attached is already covered by the root walk
+      // above, and walking every tracked PID would be quadratic on a deep tree.
+      for (const [pid, tracked] of [...entry.pids]) {
+        if (!tracked.orphaned) continue;
+        for (const child of census.getDescendantPids(pid)) {
+          this.admit(entry, child);
+        }
+      }
+
+      // Second pass so anything just admitted is flagged (and so persisted)
+      // without waiting for the next sweep.
+      this.flagOrphans(entry, census);
+    }
+
+    for (const [rootPid, entry] of [...this.roots]) {
+      if (entry.state === "closing" && entry.pids.size === 0) {
+        this.roots.delete(rootPid);
+      }
+    }
+
+    this.scheduleIdentification();
+    this.persist();
+  }
+
+  dispose(): void {
+    this.disposed = true;
+    this.lastCensus = null;
+    this.roots.clear();
+    this.pendingIdentification.clear();
+    this.trackedCount = 0;
+  }
+
+  /** Drop entries the OS says are gone, or that a recycled PID now holds. */
+  private prune(entry: RootEntry, census: LineageCensus): void {
+    for (const [pid, tracked] of [...entry.pids]) {
+      const proc = census.getProcess(pid);
+      if (!proc) {
+        entry.pids.delete(pid);
+        this.trackedCount--;
+        continue;
+      }
+      // Windows carries a start time in the census, so recycling is caught
+      // here. POSIX recycling is caught by the pre-signal re-verification.
+      if (tracked.startTime && proc.startTime && proc.startTime !== tracked.startTime) {
+        entry.pids.delete(pid);
+        this.trackedCount--;
+      }
+    }
+  }
+
+  /**
+   * Refresh the "has this left our tree" flag, which decides both what gets its
+   * own discovery walk and what gets persisted for the next launch to reap.
+   */
+  private flagOrphans(entry: RootEntry, census: LineageCensus): void {
+    for (const [pid, tracked] of entry.pids) {
+      const proc = census.getProcess(pid);
+      if (!proc) continue;
+      if (tracked.startTime === null && proc.startTime) {
+        tracked.startTime = proc.startTime;
+      }
+      tracked.orphaned = proc.ppid <= 1 || census.getProcess(proc.ppid) === undefined;
+    }
+  }
+
+  private admit(entry: RootEntry, pid: number): void {
+    if (entry.pids.has(pid) || !Number.isInteger(pid) || pid <= 1) return;
+    if (this.trackedCount >= MAX_TRACKED_PIDS) {
+      if (!this.loggedCapWarning) {
+        this.loggedCapWarning = true;
+        console.warn(
+          `[TerminalLineageLedger] Tracking cap of ${MAX_TRACKED_PIDS} PIDs reached — new descendants will not be tracked`
+        );
+      }
+      return;
+    }
+    entry.pids.set(pid, { startTime: null, orphaned: false });
+    this.trackedCount++;
+    this.pendingIdentification.add(pid);
+  }
+
+  private dropRoot(rootPid: number): void {
+    const entry = this.roots.get(rootPid);
+    if (!entry) return;
+    this.trackedCount -= entry.pids.size;
+    if (this.trackedCount < 0) this.trackedCount = 0;
+    this.roots.delete(rootPid);
+  }
+
+  private scheduleIdentification(): void {
+    if (this.identifyInFlight || this.pendingIdentification.size === 0) return;
+    const pids = [...this.pendingIdentification];
+    this.pendingIdentification.clear();
+    this.identifyInFlight = true;
+    void probeStartTimes(pids)
+      .then((startTimes) => {
+        if (this.disposed) return;
+        for (const entry of this.roots.values()) {
+          for (const [pid, tracked] of entry.pids) {
+            if (tracked.startTime !== null) continue;
+            const startTime = startTimes.get(pid);
+            if (startTime) tracked.startTime = startTime;
+          }
+        }
+      })
+      .catch(() => {
+        // Unidentified PIDs stay unsignallable — degrades to the live-walk-only
+        // behavior this ledger exists to widen.
+      })
+      .finally(() => {
+        this.identifyInFlight = false;
+      });
+  }
+
+  /**
+   * Write the orphaned, identified subset so a crashed host or a hard-killed
+   * app can still reap them on the next launch.
+   *
+   * Only orphans are persisted. Descendants still attached to a live pty shell
+   * die with it — the shell's own teardown, or the process-group kill in
+   * `PtyClient.cleanupOrphanedPtysForShard`, already reaches them — so writing
+   * them would churn the file on every build without widening what the reaper
+   * can actually save.
+   */
+  private persist(): void {
+    if (!this.filePath) return;
+
+    const entries: PersistedLineageEntry[] = [];
+    for (const [rootPid, entry] of this.roots) {
+      for (const [pid, tracked] of entry.pids) {
+        if (!tracked.orphaned || !tracked.startTime) continue;
+        entries.push({ pid, startTime: tracked.startTime, rootPid });
+      }
+    }
+    entries.sort((a, b) => a.pid - b.pid);
+
+    // Change-detection is the whole write gate. The orphan set only moves when
+    // a descendant actually detaches or dies, so this settles to near-zero
+    // writes on its own — and a time-based throttle on top would leave a fresh
+    // orphan unrecorded across exactly the window a crash is most likely in.
+    const signature = JSON.stringify(entries);
+    if (signature === this.lastPersistedJson) return;
+    this.lastPersistedJson = signature;
+
+    try {
+      if (entries.length === 0) {
+        if (fs.existsSync(this.filePath)) fs.unlinkSync(this.filePath);
+        return;
+      }
+      const payload: PersistedLineageFile = {
+        version: LEDGER_VERSION,
+        bootEpochSec: currentBootEpochSec(),
+        owner: this.owner,
+        updatedAt: Date.now(),
+        entries,
+      };
+      resilientAtomicWriteFileSync(this.filePath, JSON.stringify(payload), "utf-8");
+    } catch (err) {
+      console.warn("[TerminalLineageLedger] Failed to persist lineage ledger:", err);
+    }
+  }
+}
+
+function readLineageFile(filePath: string): PersistedLineageFile | null {
+  try {
+    const raw = fs.readFileSync(filePath, "utf8");
+    const parsed = JSON.parse(raw) as PersistedLineageFile;
+    if (!parsed || typeof parsed !== "object") return null;
+    if (parsed.version !== LEDGER_VERSION) return null;
+    if (typeof parsed.bootEpochSec !== "number" || !Array.isArray(parsed.entries)) return null;
+    const entries = parsed.entries.filter(
+      (e): e is PersistedLineageEntry =>
+        typeof e === "object" &&
+        e !== null &&
+        Number.isInteger(e.pid) &&
+        e.pid > 1 &&
+        typeof e.startTime === "string" &&
+        e.startTime.length > 0
+    );
+    return { ...parsed, entries };
+  } catch {
+    return null;
+  }
+}
+
+function deleteQuietly(filePath: string): void {
+  try {
+    if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
+  } catch {
+    // best-effort
+  }
+}
+
+/**
+ * Rename a shard's live ledger out of the way so it can be reaped without
+ * racing that shard's replacement. A restarted host writes a fresh file at the
+ * original path, which would otherwise clobber the crashed host's survivors
+ * before we ever read them.
+ */
+export function claimShardLineageFile(
+  userDataPath: string,
+  shardService?: string
+): string | null {
+  const source = lineageFilePath(userDataPath, shardService);
+  const claimed = `${source}${REAPING_SUFFIX}`;
+  try {
+    if (!fs.existsSync(source)) return null;
+    // An interrupted earlier reap leaves its own claim behind; it is picked up
+    // by the startup sweep, so drop it rather than failing this rename.
+    deleteQuietly(claimed);
+    fs.renameSync(source, claimed);
+    return claimed;
+  } catch {
+    return null;
+  }
+}
+
+function killValidated(pid: number, signal: NodeJS.Signals): void {
+  try {
+    process.kill(pid, signal);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== "ESRCH") {
+      console.warn(`[TerminalLineageLedger] ${signal} pid=${pid}: ${(err as Error).message}`);
+    }
+  }
+}
+
+/**
+ * PIDs we must never signal regardless of what a ledger file claims: init, our
+ * own process, and our parent. A ledger is only ever written with descendants
+ * of a PTY shell, so hitting one of these means the file is stale or corrupt.
+ */
+function isForbiddenTarget(pid: number): boolean {
+  return pid <= 1 || pid === process.pid || pid === process.ppid;
+}
+
+async function reapEntries(entries: PersistedLineageEntry[]): Promise<number> {
+  const candidates = entries.filter((e) => !isForbiddenTarget(e.pid));
+  if (candidates.length === 0) return 0;
+
+  const live = await probeStartTimes(candidates.map((e) => e.pid));
+  const confirmed = candidates.filter((e) => live.get(e.pid) === e.startTime);
+  if (confirmed.length === 0) return 0;
+
+  console.log(
+    `[TerminalLineageLedger] Reaping ${confirmed.length} orphaned descendant(s) from a previous session`
+  );
+
+  if (process.platform === "win32") {
+    for (const entry of confirmed) {
+      spawnSync("taskkill", ["/T", "/F", "/PID", String(entry.pid)], {
+        windowsHide: true,
+        stdio: "ignore",
+        timeout: 3000,
+      });
+    }
+    return confirmed.length;
+  }
+
+  for (const entry of confirmed) {
+    killValidated(entry.pid, "SIGTERM");
+    // SIGTERM only queues while a process is stopped; SIGCONT lets the kernel
+    // deliver it. Same ordering as ProcessTreeKiller (#9085).
+    killValidated(entry.pid, "SIGCONT");
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, REAP_ESCALATION_DELAY_MS));
+
+  // Re-verify before escalating: a PID freed by the SIGTERM above may already
+  // have been handed to an unrelated process.
+  const survivors = await probeStartTimes(confirmed.map((e) => e.pid));
+  for (const entry of confirmed) {
+    if (survivors.get(entry.pid) !== entry.startTime) continue;
+    killValidated(entry.pid, "SIGKILL");
+  }
+
+  return confirmed.length;
+}
+
+async function reapLineageFile(filePath: string): Promise<void> {
+  const parsed = readLineageFile(filePath);
+  if (!parsed) {
+    deleteQuietly(filePath);
+    return;
+  }
+
+  // PID numbering restarts at boot, so entries from a previous boot address
+  // whatever happens to hold those numbers now. Discard without signalling.
+  if (Math.abs(parsed.bootEpochSec - currentBootEpochSec()) > BOOT_EPOCH_TOLERANCE_SEC) {
+    deleteQuietly(filePath);
+    return;
+  }
+
+  try {
+    await reapEntries(parsed.entries);
+  } catch (err) {
+    console.warn("[TerminalLineageLedger] Reap failed:", err);
+  }
+  deleteQuietly(filePath);
+}
+
+/**
+ * Kill descendants left behind by a previous session. Runs in Main before the
+ * first pty-host fork; picks up both live ledger files (the app was killed
+ * without a graceful teardown) and interrupted `.reaping` claims.
+ */
+export async function reapPersistedLineages(userDataPath: string): Promise<void> {
+  let names: string[];
+  try {
+    names = fs.readdirSync(userDataPath);
+  } catch {
+    return;
+  }
+
+  const files = names.filter(
+    (n) =>
+      n.startsWith(LEDGER_FILE_PREFIX) && (n.endsWith(".json") || n.endsWith(REAPING_SUFFIX))
+  );
+  if (files.length === 0) return;
+
+  await Promise.all(files.map((name) => reapLineageFile(path.join(userDataPath, name))));
+}
+
+/**
+ * Reap one shard's ledger after its pty-host exited. The in-memory ledger died
+ * with the host, so the persisted orphan set is all that is left.
+ */
+export async function reapShardLineage(
+  userDataPath: string,
+  shardService?: string
+): Promise<void> {
+  const claimed = claimShardLineageFile(userDataPath, shardService);
+  if (!claimed) return;
+  await reapLineageFile(claimed);
+}

--- a/electron/services/TerminalLineageLedger.ts
+++ b/electron/services/TerminalLineageLedger.ts
@@ -12,6 +12,14 @@ const LEDGER_VERSION = 1;
 const LEDGER_FILE_PREFIX = "pty-lineage";
 const REAPING_SUFFIX = ".reaping";
 const PROBE_TIMEOUT_MS = 3000;
+/**
+ * Total wall-clock budget for one synchronous verification pass. Teardown runs
+ * on the pty-host's only thread — and the `immediate` path runs inside
+ * `process.on("exit")`, which Main force-kills after ~1s — so an unresponsive
+ * `ps` must not be able to stall it for chunks x PROBE_TIMEOUT_MS. PIDs left
+ * unverified when the budget runs out are simply not signalled.
+ */
+const SYNC_PROBE_BUDGET_MS = 2000;
 /** Largest `-p` list handed to a single `ps`. Keeps us far under ARG_MAX. */
 const PROBE_CHUNK_SIZE = 500;
 /**
@@ -32,6 +40,26 @@ const MAX_TRACKED_PIDS = 4096;
 const BOOT_EPOCH_TOLERANCE_SEC = 120;
 /** Grace period between the reaper's SIGTERM and its SIGKILL escalation. */
 const REAP_ESCALATION_DELAY_MS = 500;
+/**
+ * How many launches may fail to resolve a persisted ledger before it is
+ * discarded. A blocked or missing `ps` makes "already gone" and "cannot tell"
+ * look identical, and deleting on the first ambiguous read would throw away the
+ * only record of a survivor. Retrying forever would leak a file just as surely,
+ * so the ambiguity gets a bounded number of chances.
+ */
+const MAX_REAP_ATTEMPTS = 3;
+
+/**
+ * Pinned so the recorded identity string is reproducible. `lstart` renders
+ * through `localtime()` with locale-dependent month and day names, and the
+ * persisted ledger compares those strings across app launches — an unpinned
+ * locale or a timezone change would silently invalidate every entry.
+ */
+const PROBE_ENV = {
+  ...process.env,
+  LC_ALL: process.platform === "darwin" ? "en_US.UTF-8" : "C.UTF-8",
+  TZ: "UTC",
+};
 
 /**
  * The subset of {@link ProcessTreeCache} the ledger reads. Declared structurally
@@ -50,18 +78,31 @@ interface TrackedPid {
    * prove it is still the process we observed.
    */
   startTime: string | null;
-  /** True when the last census showed this PID reparented away from our tree. */
+  /**
+   * When the census that established this PID's ancestry was folded in. A
+   * process whose start time is *newer* than this cannot be the descendant we
+   * saw, so it is dropped rather than anchored.
+   */
+  observedAtMs: number;
+  /** True when the last census showed this PID outside the root's live tree. */
   orphaned: boolean;
 }
 
 interface RootEntry {
   /**
    * `active` roots discover new descendants each sweep. `closing` roots have
-   * had their terminal torn down: we stop discovering and only prune, so a
+   * had their terminal torn down: we stop discovering from the root, so a
    * recycled root PID can never adopt a dead terminal's lineage.
    */
   state: "active" | "closing";
   pids: Map<number, TrackedPid>;
+  /**
+   * The root's parent PID as first seen by the census. A root is only keyed by
+   * PID, and a PID outlives the process holding it — if this changes, the
+   * number has been handed to something that is not our shell, and the root
+   * must stop discovering before it adopts a stranger's process tree.
+   */
+  rootPpid: number | null;
 }
 
 export interface PersistedLineageEntry {
@@ -76,6 +117,15 @@ interface PersistedLineageFile {
   owner: string;
   updatedAt: number;
   entries: PersistedLineageEntry[];
+  /** Launches that read this file but could not resolve its PIDs. */
+  attempts?: number;
+}
+
+/** A probe result plus whether any chunk failed outright. */
+interface ProbeResult {
+  startTimes: Map<number, string>;
+  /** True when a chunk produced no usable output because of an error. */
+  failed: boolean;
 }
 
 /**
@@ -118,6 +168,10 @@ function parsePsStartTimes(stdout: string): Map<number, string> {
   return out;
 }
 
+function stripBom(text: string): string {
+  return text.replace(/^\uFEFF/, "");
+}
+
 function chunk(pids: number[], size: number): number[][] {
   const chunks: number[][] = [];
   for (let i = 0; i < pids.length; i += size) {
@@ -136,71 +190,95 @@ function windowsStartTimeScript(pids: number[]): string {
 }
 
 /**
- * Batched process start-time lookup. One subprocess per chunk rather than one
- * per PID — a busy agent terminal can produce dozens of new descendants per
- * sweep, and a spawn each would cost more than the census itself.
+ * Batched process start-time lookup, reporting whether the probe itself failed.
  *
- * PIDs that no longer exist are simply absent from the result. `ps` exits
- * non-zero when *none* of the requested PIDs exist, which is a normal outcome
- * here, so a rejected call with usable stdout is not treated as a failure.
+ * "No entry for this PID" and "the probe could not run" are different facts:
+ * the first means the process is gone, the second means we know nothing. Only
+ * the first may be treated as permission to forget a tracked descendant.
+ *
+ * One subprocess per chunk rather than one per PID — a busy agent terminal can
+ * produce dozens of new descendants per sweep, and a spawn each would cost more
+ * than the census itself.
  */
-export async function probeStartTimes(pids: number[]): Promise<Map<number, string>> {
-  const result = new Map<number, string>();
-  if (pids.length === 0) return result;
+async function probeStartTimesDetailed(pids: number[]): Promise<ProbeResult> {
+  const startTimes = new Map<number, string>();
+  let failed = false;
+  if (pids.length === 0) return { startTimes, failed };
 
   for (const group of chunk(pids, PROBE_CHUNK_SIZE)) {
     try {
-      if (process.platform === "win32") {
-        const { stdout } = await execFileAsync(
-          "powershell.exe",
-          ["-NoProfile", "-NonInteractive", "-NoLogo", "-Command", windowsStartTimeScript(group)],
-          {
-            windowsHide: true,
-            encoding: "utf8",
-            shell: false,
-            signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
-          }
-        );
-        for (const [pid, startTime] of parsePsStartTimes(stdout.replace(/^﻿/, ""))) {
-          result.set(pid, startTime);
+      const { stdout } =
+        process.platform === "win32"
+          ? await execFileAsync(
+              "powershell.exe",
+              [
+                "-NoProfile",
+                "-NonInteractive",
+                "-NoLogo",
+                "-Command",
+                windowsStartTimeScript(group),
+              ],
+              {
+                windowsHide: true,
+                encoding: "utf8",
+                shell: false,
+                signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+              }
+            )
+          : await execFileAsync("ps", ["-o", "pid=,lstart=", "-p", group.join(",")], {
+              encoding: "utf8",
+              shell: false,
+              env: PROBE_ENV,
+              signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+            });
+      for (const [pid, startTime] of parsePsStartTimes(stripBom(stdout))) {
+        startTimes.set(pid, startTime);
+      }
+    } catch (err) {
+      // `ps` exits non-zero when every requested PID is gone, and the error
+      // still carries stdout for any that survived — that is a successful probe
+      // with a short answer, not a failure.
+      const stdout = (err as { stdout?: string })?.stdout;
+      if (typeof stdout === "string" && stdout.length > 0) {
+        for (const [pid, startTime] of parsePsStartTimes(stripBom(stdout))) {
+          startTimes.set(pid, startTime);
         }
         continue;
       }
-      const { stdout } = await execFileAsync(
-        "ps",
-        ["-o", "pid=,lstart=", "-p", group.join(",")],
-        { encoding: "utf8", shell: false, signal: AbortSignal.timeout(PROBE_TIMEOUT_MS) }
-      );
-      for (const [pid, startTime] of parsePsStartTimes(stdout)) {
-        result.set(pid, startTime);
-      }
-    } catch (err) {
-      // `ps` exits 1 when every requested PID is gone — the error still carries
-      // stdout for any that survived. Anything else leaves the group unresolved,
-      // which fails closed: unidentified PIDs are never signalled.
-      const stdout = (err as { stdout?: string })?.stdout;
-      if (typeof stdout === "string" && stdout.length > 0) {
-        for (const [pid, startTime] of parsePsStartTimes(stdout)) {
-          result.set(pid, startTime);
-        }
-      }
+      failed = true;
     }
   }
 
-  return result;
+  return { startTimes, failed };
+}
+
+/** {@link probeStartTimesDetailed} without the failure flag. */
+export async function probeStartTimes(pids: number[]): Promise<Map<number, string>> {
+  return (await probeStartTimesDetailed(pids)).startTimes;
 }
 
 /**
  * Synchronous counterpart of {@link probeStartTimes}. Required at kill time:
  * `ProcessTreeKiller.execute()` runs synchronously, and its `immediate` path
  * runs inside `process.on("exit")` where no async work can complete.
+ *
+ * Bounded by {@link SYNC_PROBE_BUDGET_MS} in total, not per chunk. PIDs in a
+ * chunk that is never reached stay unverified, and unverified means unsignalled.
  */
-export function probeStartTimesSync(pids: number[]): Map<number, string> {
+export function probeStartTimesSync(
+  pids: number[],
+  budgetMs: number = SYNC_PROBE_BUDGET_MS
+): Map<number, string> {
   const result = new Map<number, string>();
   if (pids.length === 0) return result;
 
+  const deadline = Date.now() + budgetMs;
+
   for (const group of chunk(pids, PROBE_CHUNK_SIZE)) {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) break;
     try {
+      const timeout = Math.min(PROBE_TIMEOUT_MS, remaining);
       const spawned =
         process.platform === "win32"
           ? spawnSync(
@@ -212,15 +290,16 @@ export function probeStartTimesSync(pids: number[]): Map<number, string> {
                 "-Command",
                 windowsStartTimeScript(group),
               ],
-              { windowsHide: true, encoding: "utf8", timeout: PROBE_TIMEOUT_MS }
+              { windowsHide: true, encoding: "utf8", timeout }
             )
           : spawnSync("ps", ["-o", "pid=,lstart=", "-p", group.join(",")], {
               encoding: "utf8",
-              timeout: PROBE_TIMEOUT_MS,
+              env: PROBE_ENV,
+              timeout,
             });
       const stdout = typeof spawned?.stdout === "string" ? spawned.stdout : "";
       if (!stdout) continue;
-      for (const [pid, startTime] of parsePsStartTimes(stdout.replace(/^﻿/, ""))) {
+      for (const [pid, startTime] of parsePsStartTimes(stripBom(stdout))) {
         result.set(pid, startTime);
       }
     } catch {
@@ -229,6 +308,30 @@ export function probeStartTimesSync(pids: number[]): Map<number, string> {
   }
 
   return result;
+}
+
+/**
+ * True when a process with this start time could be the descendant observed at
+ * `observedAtMs`. A process born *after* we saw the ancestry is a different
+ * process that inherited the PID, so anchoring to it would make the ledger
+ * "verify" a stranger for the rest of the terminal's life.
+ *
+ * Unparseable start times (an unexpected `ps` format, despite {@link PROBE_ENV})
+ * skip the check rather than disabling tracking outright — kill-time
+ * re-verification still applies.
+ */
+function couldPredateObservation(startTime: string, observedAtMs: number): boolean {
+  // PROBE_ENV pins TZ=UTC, so the zoneless `lstart` string denotes UTC. The
+  // Windows form is already a zoned ISO timestamp, which the suffix would
+  // break — fall back to parsing it as-is. (The guard is only load-bearing on
+  // POSIX anyway: the Windows census carries ppid and CreationDate in the same
+  // row, so there is no window between observing ancestry and learning
+  // identity.)
+  let parsed = Date.parse(`${startTime} UTC`);
+  if (Number.isNaN(parsed)) parsed = Date.parse(startTime);
+  if (Number.isNaN(parsed)) return true;
+  // `lstart` has one-second granularity; allow a second of slack.
+  return parsed <= observedAtMs + 1000;
 }
 
 /**
@@ -242,14 +345,23 @@ export function probeStartTimesSync(pids: number[]): Map<number, string> {
  * it is written down, and it stays written down after its parent dies and the
  * OS reparents it away.
  *
- * Two invariants keep the wider kill set safe:
+ * Three invariants keep the wider kill set safe:
  *
- * - **Every entry is anchored to a start time.** A PID with no recorded start
- *   time, or whose current start time differs, is never signalled — it is a
+ * - **Every entry is anchored to a start time taken no later than the census
+ *   that established its ancestry.** A PID with no recorded start time, or
+ *   whose start time differs at kill time, is never signalled — it is a
  *   different process now, not the one we observed (lesson #10950).
  * - **`closing` roots stop discovering.** Once a terminal is torn down its root
  *   PID can be recycled, so a recycled root must not be able to adopt the dead
- *   terminal's lineage.
+ *   terminal's lineage. A root whose PID vanishes closes automatically.
+ * - **Ambiguity never authorises a kill.** A probe that could not run is not
+ *   evidence that a process is gone, and is never treated as such.
+ *
+ * This is a mitigation, not a containment primitive: a descendant that forks,
+ * detaches, and is never sampled by the census is invisible to it. macOS offers
+ * no public process-lifecycle event stream that would close that window
+ * (`EVFILT_PROC` + `NOTE_TRACK` is `ENOTSUP`; EndpointSecurity is entitled), so
+ * the sampling interval bounds — but does not eliminate — the miss.
  */
 export class TerminalLineageLedger {
   private roots = new Map<number, RootEntry>();
@@ -259,7 +371,6 @@ export class TerminalLineageLedger {
   private identifyInFlight = false;
   private lastPersistedJson: string | null = null;
   private disposed = false;
-  private lastCensus: LineageCensus | null = null;
 
   constructor(
     private readonly filePath: string | null,
@@ -274,7 +385,7 @@ export class TerminalLineageLedger {
       // previous terminal's descendants.
       this.dropRoot(rootPid);
     }
-    this.roots.set(rootPid, { state: "active", pids: new Map() });
+    this.roots.set(rootPid, { state: "active", pids: new Map(), rootPpid: null });
   }
 
   /**
@@ -294,6 +405,11 @@ export class TerminalLineageLedger {
 
   hasRoots(): boolean {
     return this.roots.size > 0;
+  }
+
+  /** Total tracked PIDs across every root. Exposed for tests and diagnostics. */
+  getTrackedCount(): number {
+    return this.trackedCount;
   }
 
   /**
@@ -316,25 +432,18 @@ export class TerminalLineageLedger {
    * Tracked descendants the caller's live walk can no longer reach, filtered to
    * the ones the OS still reports with the exact start time we recorded.
    *
-   * This is the safety boundary for the widened kill set. Ledger entries are by
-   * construction old — that is what lets them outlive reparenting — so a PID
-   * being *present* proves nothing; only a matching start time proves it is
-   * still the process we observed (lesson #10950). Verification is synchronous
-   * because it runs inside teardown, including the `process.on("exit")` path
-   * where nothing async can complete.
+   * This is the safety boundary for the widened kill set, and it is the *only*
+   * set callers may signal. Ledger entries are by construction old — that is
+   * what lets them outlive reparenting — so a PID being present proves nothing;
+   * only a matching start time proves it is still the process we observed
+   * (lesson #10950). Verification is a live OS query on every platform, never a
+   * cached census read: the census can be seconds stale, which is exactly long
+   * enough for a PID to have been recycled.
    */
   getVerifiedOrphanPids(rootPid: number, alreadyCovered: readonly number[]): number[] {
     const covered = new Set(alreadyCovered);
-    const candidates = this.getTrackedPids(rootPid).filter((t) => !covered.has(t.pid));
+    const candidates = this.getTrackedPids(rootPid).filter((c) => !covered.has(c.pid));
     if (candidates.length === 0) return [];
-
-    if (process.platform === "win32") {
-      // The Windows census already carries CreationDate, so the last sweep's
-      // snapshot answers this without spawning anything.
-      return candidates
-        .filter((c) => this.lastCensus?.getProcess(c.pid)?.startTime === c.startTime)
-        .map((c) => c.pid);
-    }
 
     const current = probeStartTimesSync(candidates.map((c) => c.pid));
     return candidates.filter((c) => current.get(c.pid) === c.startTime).map((c) => c.pid);
@@ -350,16 +459,30 @@ export class TerminalLineageLedger {
    * PIDs are tracked but not signallable.
    */
   reconcile(census: LineageCensus): void {
-    if (this.disposed) return;
-    this.lastCensus = census;
-    if (this.roots.size === 0) return;
+    if (this.disposed || this.roots.size === 0) return;
 
     for (const [rootPid, entry] of this.roots) {
+      // A root that is gone — or whose PID now belongs to something else — can
+      // never legitimately gain descendants again, and leaving it `active`
+      // would let it adopt an unrelated process tree. Covers the terminal whose
+      // construction failed after its killer registered, which reaches no
+      // teardown path that would close it.
+      if (entry.state === "active") {
+        const rootProc = census.getProcess(rootPid);
+        if (!rootProc) {
+          entry.state = "closing";
+        } else if (entry.rootPpid === null) {
+          entry.rootPpid = rootProc.ppid;
+        } else if (entry.rootPpid !== rootProc.ppid) {
+          entry.state = "closing";
+        }
+      }
+
       // Prune first so the orphan flags below are current for *this* sweep.
       // Flagging after discovery would delay a freshly detached member's own
       // children by a full sweep.
       this.prune(entry, census);
-      this.flagOrphans(entry, census);
+      this.flagOrphans(entry, rootPid, census);
 
       if (entry.state === "active") {
         for (const pid of census.getDescendantPids(rootPid)) {
@@ -369,11 +492,14 @@ export class TerminalLineageLedger {
 
       // Descendants a detached member spawned after it left our tree are still
       // this terminal's work — a wrapper that reparents and then forks a build
-      // would otherwise leave that build unreachable. Only orphans need their
-      // own walk: anything still attached is already covered by the root walk
-      // above, and walking every tracked PID would be quadratic on a deep tree.
+      // would otherwise leave that build unreachable. Only *identified* orphans
+      // may adopt: an unidentified PID has no proof it is still ours, so it
+      // must not be able to pull an unrelated subtree into the ledger. Only
+      // orphans need their own walk at all — anything still attached is already
+      // covered by the root walk, and walking every tracked PID would be
+      // quadratic on a deep tree.
       for (const [pid, tracked] of [...entry.pids]) {
-        if (!tracked.orphaned) continue;
+        if (!tracked.orphaned || !tracked.startTime) continue;
         for (const child of census.getDescendantPids(pid)) {
           this.admit(entry, child);
         }
@@ -381,7 +507,7 @@ export class TerminalLineageLedger {
 
       // Second pass so anything just admitted is flagged (and so persisted)
       // without waiting for the next sweep.
-      this.flagOrphans(entry, census);
+      this.flagOrphans(entry, rootPid, census);
     }
 
     for (const [rootPid, entry] of [...this.roots]) {
@@ -396,7 +522,6 @@ export class TerminalLineageLedger {
 
   dispose(): void {
     this.disposed = true;
-    this.lastCensus = null;
     this.roots.clear();
     this.pendingIdentification.clear();
     this.trackedCount = 0;
@@ -412,7 +537,7 @@ export class TerminalLineageLedger {
         continue;
       }
       // Windows carries a start time in the census, so recycling is caught
-      // here. POSIX recycling is caught by the pre-signal re-verification.
+      // here too. POSIX recycling is caught by the pre-signal re-verification.
       if (tracked.startTime && proc.startTime && proc.startTime !== tracked.startTime) {
         entry.pids.delete(pid);
         this.trackedCount--;
@@ -423,15 +548,25 @@ export class TerminalLineageLedger {
   /**
    * Refresh the "has this left our tree" flag, which decides both what gets its
    * own discovery walk and what gets persisted for the next launch to reap.
+   *
+   * Defined as *unreachable from the root in this census*, not "its parent is
+   * missing". A detached wrapper's own children still have a live parent, so a
+   * parent-based test would leave them out of the persisted set and let them
+   * survive the very restart that reaps their wrapper.
    */
-  private flagOrphans(entry: RootEntry, census: LineageCensus): void {
+  private flagOrphans(entry: RootEntry, rootPid: number, census: LineageCensus): void {
+    const reachable = new Set(census.getDescendantPids(rootPid));
     for (const [pid, tracked] of entry.pids) {
       const proc = census.getProcess(pid);
       if (!proc) continue;
-      if (tracked.startTime === null && proc.startTime) {
+      if (
+        tracked.startTime === null &&
+        proc.startTime &&
+        couldPredateObservation(proc.startTime, tracked.observedAtMs)
+      ) {
         tracked.startTime = proc.startTime;
       }
-      tracked.orphaned = proc.ppid <= 1 || census.getProcess(proc.ppid) === undefined;
+      tracked.orphaned = !reachable.has(pid);
     }
   }
 
@@ -441,12 +576,12 @@ export class TerminalLineageLedger {
       if (!this.loggedCapWarning) {
         this.loggedCapWarning = true;
         console.warn(
-          `[TerminalLineageLedger] Tracking cap of ${MAX_TRACKED_PIDS} PIDs reached — new descendants will not be tracked`
+          `[TerminalLineageLedger] Tracking cap of ${MAX_TRACKED_PIDS} PIDs reached — detached descendants beyond this point will not be reaped`
         );
       }
       return;
     }
-    entry.pids.set(pid, { startTime: null, orphaned: false });
+    entry.pids.set(pid, { startTime: null, observedAtMs: Date.now(), orphaned: false });
     this.trackedCount++;
     this.pendingIdentification.add(pid);
   }
@@ -464,20 +599,36 @@ export class TerminalLineageLedger {
     const pids = [...this.pendingIdentification];
     this.pendingIdentification.clear();
     this.identifyInFlight = true;
-    void probeStartTimes(pids)
-      .then((startTimes) => {
+    void probeStartTimesDetailed(pids)
+      .then(({ startTimes, failed }) => {
         if (this.disposed) return;
         for (const entry of this.roots.values()) {
-          for (const [pid, tracked] of entry.pids) {
+          for (const [pid, tracked] of [...entry.pids]) {
             if (tracked.startTime !== null) continue;
             const startTime = startTimes.get(pid);
-            if (startTime) tracked.startTime = startTime;
+            if (!startTime) continue;
+            if (couldPredateObservation(startTime, tracked.observedAtMs)) {
+              tracked.startTime = startTime;
+              continue;
+            }
+            // Born after we saw the ancestry: the PID was recycled between the
+            // census and this probe, so this is not our descendant.
+            entry.pids.delete(pid);
+            this.trackedCount--;
+          }
+        }
+        // A probe that could not run leaves those PIDs permanently
+        // unsignallable unless they go back in the queue. Genuinely-dead PIDs
+        // requeued alongside them cost one lookup and are dropped by the next
+        // prune.
+        if (failed) {
+          for (const pid of pids) {
+            if (!startTimes.has(pid)) this.pendingIdentification.add(pid);
           }
         }
       })
       .catch(() => {
-        // Unidentified PIDs stay unsignallable — degrades to the live-walk-only
-        // behavior this ledger exists to widen.
+        for (const pid of pids) this.pendingIdentification.add(pid);
       })
       .finally(() => {
         this.identifyInFlight = false;
@@ -512,22 +663,26 @@ export class TerminalLineageLedger {
     // orphan unrecorded across exactly the window a crash is most likely in.
     const signature = JSON.stringify(entries);
     if (signature === this.lastPersistedJson) return;
-    this.lastPersistedJson = signature;
 
     try {
       if (entries.length === 0) {
         if (fs.existsSync(this.filePath)) fs.unlinkSync(this.filePath);
-        return;
+      } else {
+        const payload: PersistedLineageFile = {
+          version: LEDGER_VERSION,
+          bootEpochSec: currentBootEpochSec(),
+          owner: this.owner,
+          updatedAt: Date.now(),
+          entries,
+        };
+        resilientAtomicWriteFileSync(this.filePath, JSON.stringify(payload), "utf-8");
       }
-      const payload: PersistedLineageFile = {
-        version: LEDGER_VERSION,
-        bootEpochSec: currentBootEpochSec(),
-        owner: this.owner,
-        updatedAt: Date.now(),
-        entries,
-      };
-      resilientAtomicWriteFileSync(this.filePath, JSON.stringify(payload), "utf-8");
+      // Recorded only after the disk actually changed. Stamping it up front
+      // would let a transient EBUSY or disk-full suppress every future retry
+      // for an unchanged orphan set, silently leaving no recovery record.
+      this.lastPersistedJson = signature;
     } catch (err) {
+      this.lastPersistedJson = null;
       console.warn("[TerminalLineageLedger] Failed to persist lineage ledger:", err);
     }
   }
@@ -568,18 +723,16 @@ function deleteQuietly(filePath: string): void {
  * racing that shard's replacement. A restarted host writes a fresh file at the
  * original path, which would otherwise clobber the crashed host's survivors
  * before we ever read them.
+ *
+ * The claim name is unique per call: an earlier interrupted claim is another
+ * host's unreaped survivor list, and overwriting it would destroy the only
+ * record of those processes. The startup sweep picks up every claim it finds.
  */
-export function claimShardLineageFile(
-  userDataPath: string,
-  shardService?: string
-): string | null {
+export function claimShardLineageFile(userDataPath: string, shardService?: string): string | null {
   const source = lineageFilePath(userDataPath, shardService);
-  const claimed = `${source}${REAPING_SUFFIX}`;
+  const claimed = `${source}${REAPING_SUFFIX}-${Date.now()}-${process.pid}`;
   try {
     if (!fs.existsSync(source)) return null;
-    // An interrupted earlier reap leaves its own claim behind; it is picked up
-    // by the startup sweep, so drop it rather than failing this rename.
-    deleteQuietly(claimed);
     fs.renameSync(source, claimed);
     return claimed;
   } catch {
@@ -587,14 +740,17 @@ export function claimShardLineageFile(
   }
 }
 
-function killValidated(pid: number, signal: NodeJS.Signals): void {
+/** Returns true when the process is gone or was successfully signalled. */
+function killValidated(pid: number, signal: NodeJS.Signals): boolean {
   try {
     process.kill(pid, signal);
+    return true;
   } catch (err) {
     const code = (err as NodeJS.ErrnoException).code;
-    if (code !== "ESRCH") {
-      console.warn(`[TerminalLineageLedger] ${signal} pid=${pid}: ${(err as Error).message}`);
-    }
+    // ESRCH means it is already gone, which is the outcome we wanted.
+    if (code === "ESRCH") return true;
+    console.warn(`[TerminalLineageLedger] ${signal} pid=${pid}: ${(err as Error).message}`);
+    return false;
   }
 }
 
@@ -607,27 +763,41 @@ function isForbiddenTarget(pid: number): boolean {
   return pid <= 1 || pid === process.pid || pid === process.ppid;
 }
 
-async function reapEntries(entries: PersistedLineageEntry[]): Promise<number> {
+/**
+ * Signal the entries whose identity still matches. Returns the entries that
+ * could not be resolved or could not be killed — the caller must keep those,
+ * because forgetting them is the leak this whole file exists to prevent.
+ */
+async function reapEntries(entries: PersistedLineageEntry[]): Promise<PersistedLineageEntry[]> {
   const candidates = entries.filter((e) => !isForbiddenTarget(e.pid));
-  if (candidates.length === 0) return 0;
+  if (candidates.length === 0) return [];
 
-  const live = await probeStartTimes(candidates.map((e) => e.pid));
-  const confirmed = candidates.filter((e) => live.get(e.pid) === e.startTime);
-  if (confirmed.length === 0) return 0;
+  const { startTimes, failed } = await probeStartTimesDetailed(candidates.map((e) => e.pid));
+  if (failed && startTimes.size === 0) {
+    // We learned nothing — `ps` may be blocked by the utility-process sandbox.
+    // "Absent" and "unknown" are not the same fact, so keep the record.
+    return candidates;
+  }
+
+  const confirmed = candidates.filter((e) => startTimes.get(e.pid) === e.startTime);
+  if (confirmed.length === 0) return [];
 
   console.log(
     `[TerminalLineageLedger] Reaping ${confirmed.length} orphaned descendant(s) from a previous session`
   );
 
   if (process.platform === "win32") {
+    const survivors: PersistedLineageEntry[] = [];
     for (const entry of confirmed) {
-      spawnSync("taskkill", ["/T", "/F", "/PID", String(entry.pid)], {
+      const result = spawnSync("taskkill", ["/T", "/F", "/PID", String(entry.pid)], {
         windowsHide: true,
         stdio: "ignore",
         timeout: 3000,
       });
+      // 128 is "process not found", which is the outcome we wanted.
+      if (result.status !== 0 && result.status !== 128) survivors.push(entry);
     }
-    return confirmed.length;
+    return survivors;
   }
 
   for (const entry of confirmed) {
@@ -641,13 +811,13 @@ async function reapEntries(entries: PersistedLineageEntry[]): Promise<number> {
 
   // Re-verify before escalating: a PID freed by the SIGTERM above may already
   // have been handed to an unrelated process.
-  const survivors = await probeStartTimes(confirmed.map((e) => e.pid));
+  const after = await probeStartTimesDetailed(confirmed.map((e) => e.pid));
+  const survivors: PersistedLineageEntry[] = [];
   for (const entry of confirmed) {
-    if (survivors.get(entry.pid) !== entry.startTime) continue;
-    killValidated(entry.pid, "SIGKILL");
+    if (after.startTimes.get(entry.pid) !== entry.startTime) continue;
+    if (!killValidated(entry.pid, "SIGKILL")) survivors.push(entry);
   }
-
-  return confirmed.length;
+  return survivors;
 }
 
 async function reapLineageFile(filePath: string): Promise<void> {
@@ -664,12 +834,26 @@ async function reapLineageFile(filePath: string): Promise<void> {
     return;
   }
 
+  let survivors: PersistedLineageEntry[];
   try {
-    await reapEntries(parsed.entries);
+    survivors = await reapEntries(parsed.entries);
   } catch (err) {
     console.warn("[TerminalLineageLedger] Reap failed:", err);
+    survivors = parsed.entries;
   }
-  deleteQuietly(filePath);
+
+  const attempts = (parsed.attempts ?? 0) + 1;
+  if (survivors.length === 0 || attempts >= MAX_REAP_ATTEMPTS) {
+    deleteQuietly(filePath);
+    return;
+  }
+
+  try {
+    const retained: PersistedLineageFile = { ...parsed, entries: survivors, attempts };
+    resilientAtomicWriteFileSync(filePath, JSON.stringify(retained), "utf-8");
+  } catch {
+    deleteQuietly(filePath);
+  }
 }
 
 /**
@@ -686,8 +870,7 @@ export async function reapPersistedLineages(userDataPath: string): Promise<void>
   }
 
   const files = names.filter(
-    (n) =>
-      n.startsWith(LEDGER_FILE_PREFIX) && (n.endsWith(".json") || n.endsWith(REAPING_SUFFIX))
+    (n) => n.startsWith(LEDGER_FILE_PREFIX) && (n.endsWith(".json") || n.includes(REAPING_SUFFIX))
   );
   if (files.length === 0) return;
 
@@ -698,10 +881,7 @@ export async function reapPersistedLineages(userDataPath: string): Promise<void>
  * Reap one shard's ledger after its pty-host exited. The in-memory ledger died
  * with the host, so the persisted orphan set is all that is left.
  */
-export async function reapShardLineage(
-  userDataPath: string,
-  shardService?: string
-): Promise<void> {
+export async function reapShardLineage(userDataPath: string, shardService?: string): Promise<void> {
   const claimed = claimShardLineageFile(userDataPath, shardService);
   if (!claimed) return;
   await reapLineageFile(claimed);

--- a/electron/services/TerminalLineageLedger.ts
+++ b/electron/services/TerminalLineageLedger.ts
@@ -48,6 +48,13 @@ const REAP_ESCALATION_DELAY_MS = 500;
  * so the ambiguity gets a bounded number of chances.
  */
 const MAX_REAP_ATTEMPTS = 3;
+/**
+ * Censuses a newly registered root may be absent from before we conclude it
+ * never started. A sweep already in flight when the shell spawned will not
+ * contain it, so closing on the first miss would disable tracking for a
+ * perfectly healthy terminal.
+ */
+const MAX_UNSEEN_SWEEPS_BEFORE_CLOSE = 5;
 
 /**
  * Pinned so the recorded identity string is reproducible. `lstart` renders
@@ -103,6 +110,8 @@ interface RootEntry {
    * must stop discovering before it adopts a stranger's process tree.
    */
   rootPpid: number | null;
+  /** Consecutive censuses that did not contain the root, before it was ever seen. */
+  unseenSweeps: number;
 }
 
 export interface PersistedLineageEntry {
@@ -121,11 +130,16 @@ interface PersistedLineageFile {
   attempts?: number;
 }
 
-/** A probe result plus whether any chunk failed outright. */
+/** A probe result that distinguishes "gone" from "could not tell". */
 interface ProbeResult {
   startTimes: Map<number, string>;
-  /** True when a chunk produced no usable output because of an error. */
-  failed: boolean;
+  /**
+   * PIDs the probe could not resolve because the probe itself failed, as
+   * opposed to PIDs it resolved as absent. Only the latter is evidence that a
+   * process is gone; treating the former the same way is how a blocked `ps`
+   * silently discards a live survivor.
+   */
+  unresolved: Set<number>;
 }
 
 /**
@@ -202,8 +216,8 @@ function windowsStartTimeScript(pids: number[]): string {
  */
 async function probeStartTimesDetailed(pids: number[]): Promise<ProbeResult> {
   const startTimes = new Map<number, string>();
-  let failed = false;
-  if (pids.length === 0) return { startTimes, failed };
+  const unresolved = new Set<number>();
+  if (pids.length === 0) return { startTimes, unresolved };
 
   for (const group of chunk(pids, PROBE_CHUNK_SIZE)) {
     try {
@@ -235,21 +249,27 @@ async function probeStartTimesDetailed(pids: number[]): Promise<ProbeResult> {
         startTimes.set(pid, startTime);
       }
     } catch (err) {
-      // `ps` exits non-zero when every requested PID is gone, and the error
-      // still carries stdout for any that survived — that is a successful probe
-      // with a short answer, not a failure.
       const stdout = (err as { stdout?: string })?.stdout;
       if (typeof stdout === "string" && stdout.length > 0) {
         for (const [pid, startTime] of parsePsStartTimes(stripBom(stdout))) {
           startTimes.set(pid, startTime);
         }
-        continue;
       }
-      failed = true;
+      // A numeric `code` is the child's exit status, so the probe *ran* — `ps`
+      // exits 1 when none of the requested PIDs exist, which is a real answer
+      // ("all gone"), not a failure. A string code (ENOENT, ABORT_ERR) means
+      // the probe never produced an answer, and the PIDs it covered stay
+      // unresolved rather than being presumed dead.
+      const code = (err as NodeJS.ErrnoException).code;
+      if (typeof code !== "number") {
+        for (const pid of group) {
+          if (!startTimes.has(pid)) unresolved.add(pid);
+        }
+      }
     }
   }
 
-  return { startTimes, failed };
+  return { startTimes, unresolved };
 }
 
 /** {@link probeStartTimesDetailed} without the failure flag. */
@@ -371,6 +391,12 @@ export class TerminalLineageLedger {
   private identifyInFlight = false;
   private lastPersistedJson: string | null = null;
   private disposed = false;
+  /**
+   * The most recent census. Used only to enumerate a confirmed orphan's current
+   * children at adoption time — never as evidence of identity, which is always
+   * a live probe.
+   */
+  private lastCensus: LineageCensus | null = null;
 
   constructor(
     private readonly filePath: string | null,
@@ -385,7 +411,12 @@ export class TerminalLineageLedger {
       // previous terminal's descendants.
       this.dropRoot(rootPid);
     }
-    this.roots.set(rootPid, { state: "active", pids: new Map(), rootPpid: null });
+    this.roots.set(rootPid, {
+      state: "active",
+      pids: new Map(),
+      rootPpid: null,
+      unseenSweeps: 0,
+    });
   }
 
   /**
@@ -459,7 +490,9 @@ export class TerminalLineageLedger {
    * PIDs are tracked but not signallable.
    */
   reconcile(census: LineageCensus): void {
-    if (this.disposed || this.roots.size === 0) return;
+    if (this.disposed) return;
+    this.lastCensus = census;
+    if (this.roots.size === 0) return;
 
     for (const [rootPid, entry] of this.roots) {
       // A root that is gone — or whose PID now belongs to something else — can
@@ -469,11 +502,22 @@ export class TerminalLineageLedger {
       // teardown path that would close it.
       if (entry.state === "active") {
         const rootProc = census.getProcess(rootPid);
-        if (!rootProc) {
+        if (rootProc) {
+          entry.unseenSweeps = 0;
+          if (entry.rootPpid === null) {
+            entry.rootPpid = rootProc.ppid;
+          } else if (entry.rootPpid !== rootProc.ppid) {
+            entry.state = "closing";
+          }
+        } else if (entry.rootPpid !== null) {
+          // Seen before, gone now — the terminal ended without a teardown we
+          // observed.
           entry.state = "closing";
-        } else if (entry.rootPpid === null) {
-          entry.rootPpid = rootProc.ppid;
-        } else if (entry.rootPpid !== rootProc.ppid) {
+        } else if (++entry.unseenSweeps >= MAX_UNSEEN_SWEEPS_BEFORE_CLOSE) {
+          // Never seen at all. A census that *started* before this shell
+          // spawned legitimately lacks it, so one miss proves nothing and
+          // closing on it would silently disable tracking for a healthy
+          // terminal. Give it a few sweeps, then assume the spawn failed.
           entry.state = "closing";
         }
       }
@@ -490,24 +534,9 @@ export class TerminalLineageLedger {
         }
       }
 
-      // Descendants a detached member spawned after it left our tree are still
-      // this terminal's work — a wrapper that reparents and then forks a build
-      // would otherwise leave that build unreachable. Only *identified* orphans
-      // may adopt: an unidentified PID has no proof it is still ours, so it
-      // must not be able to pull an unrelated subtree into the ledger. Only
-      // orphans need their own walk at all — anything still attached is already
-      // covered by the root walk, and walking every tracked PID would be
-      // quadratic on a deep tree.
-      for (const [pid, tracked] of [...entry.pids]) {
-        if (!tracked.orphaned || !tracked.startTime) continue;
-        for (const child of census.getDescendantPids(pid)) {
-          this.admit(entry, child);
-        }
-      }
-
-      // Second pass so anything just admitted is flagged (and so persisted)
-      // without waiting for the next sweep.
-      this.flagOrphans(entry, rootPid, census);
+      // Note: descendants of detached members are NOT adopted here. That
+      // happens in the identification pass, where the parent's identity has
+      // just been re-confirmed — see adoptFromConfirmedOrphans().
     }
 
     for (const [rootPid, entry] of [...this.roots]) {
@@ -522,6 +551,7 @@ export class TerminalLineageLedger {
 
   dispose(): void {
     this.disposed = true;
+    this.lastCensus = null;
     this.roots.clear();
     this.pendingIdentification.clear();
     this.trackedCount = 0;
@@ -594,18 +624,50 @@ export class TerminalLineageLedger {
     this.roots.delete(rootPid);
   }
 
+  /**
+   * Resolve identities for newly admitted PIDs, and re-verify the orphans we
+   * already hold.
+   *
+   * Re-verification is what stops a recycled orphan from laundering an
+   * unrelated process tree into the ledger. On POSIX the census carries no
+   * start time, so `prune` cannot tell that a tracked orphan's PID now belongs
+   * to someone else — and a tracked orphan is allowed to adopt descendants.
+   * Without this, a stale identity would keep authorising adoptions forever.
+   * The cost is one batched `ps` per sweep and only while orphans exist, which
+   * is already the exceptional case.
+   */
   private scheduleIdentification(): void {
-    if (this.identifyInFlight || this.pendingIdentification.size === 0) return;
-    const pids = [...this.pendingIdentification];
+    const orphanChecks: number[] = [];
+    for (const entry of this.roots.values()) {
+      for (const [pid, tracked] of entry.pids) {
+        if (tracked.orphaned && tracked.startTime) orphanChecks.push(pid);
+      }
+    }
+    if (this.identifyInFlight) return;
+    const newPids = [...this.pendingIdentification];
+    if (newPids.length === 0 && orphanChecks.length === 0) return;
     this.pendingIdentification.clear();
+
+    const pids = [...new Set([...newPids, ...orphanChecks])];
     this.identifyInFlight = true;
     void probeStartTimesDetailed(pids)
-      .then(({ startTimes, failed }) => {
+      .then(({ startTimes, unresolved }) => {
         if (this.disposed) return;
         for (const entry of this.roots.values()) {
           for (const [pid, tracked] of [...entry.pids]) {
-            if (tracked.startTime !== null) continue;
             const startTime = startTimes.get(pid);
+
+            if (tracked.startTime !== null) {
+              // Already anchored — this pass is a liveness/identity re-check.
+              // Unresolved means we could not tell, which is never grounds to
+              // forget it; absent means the census will prune it shortly.
+              if (unresolved.has(pid) || startTime === undefined) continue;
+              if (startTime === tracked.startTime) continue;
+              entry.pids.delete(pid);
+              this.trackedCount--;
+              continue;
+            }
+
             if (!startTime) continue;
             if (couldPredateObservation(startTime, tracked.observedAtMs)) {
               tracked.startTime = startTime;
@@ -617,22 +679,47 @@ export class TerminalLineageLedger {
             this.trackedCount--;
           }
         }
-        // A probe that could not run leaves those PIDs permanently
-        // unsignallable unless they go back in the queue. Genuinely-dead PIDs
-        // requeued alongside them cost one lookup and are dropped by the next
-        // prune.
-        if (failed) {
-          for (const pid of pids) {
-            if (!startTimes.has(pid)) this.pendingIdentification.add(pid);
-          }
-        }
+        this.adoptFromConfirmedOrphans(startTimes);
+        // A PID the probe could not resolve stays permanently unsignallable
+        // unless it goes back in the queue.
+        for (const pid of unresolved) this.pendingIdentification.add(pid);
+        // Identities changed, so the persisted orphan set may have too — and a
+        // crash before the next census would otherwise lose it.
+        this.persist();
       })
       .catch(() => {
-        for (const pid of pids) this.pendingIdentification.add(pid);
+        for (const pid of newPids) this.pendingIdentification.add(pid);
       })
       .finally(() => {
         this.identifyInFlight = false;
       });
+  }
+
+  /**
+   * Admit the current children of every orphan this probe just confirmed.
+   *
+   * A wrapper that detaches and then forks a build owns that build, and nothing
+   * else can reach it. But ownership rests entirely on the parent still being
+   * our process, and on POSIX the census cannot establish that — it carries no
+   * start time, so a recycled orphan still looks present and would launder a
+   * stranger's whole process tree into the ledger.
+   *
+   * Adoption therefore runs here rather than in `reconcile`, keyed off a start
+   * time confirmed by *this* probe. Doing it during the sweep instead would
+   * always act on an identity that is at least one probe old.
+   */
+  private adoptFromConfirmedOrphans(startTimes: Map<number, string>): void {
+    const census = this.lastCensus;
+    if (!census) return;
+    for (const entry of this.roots.values()) {
+      for (const [pid, tracked] of [...entry.pids]) {
+        if (!tracked.orphaned || !tracked.startTime) continue;
+        if (startTimes.get(pid) !== tracked.startTime) continue;
+        for (const child of census.getDescendantPids(pid)) {
+          this.admit(entry, child);
+        }
+      }
+    }
   }
 
   /**
@@ -728,9 +815,11 @@ function deleteQuietly(filePath: string): void {
  * host's unreaped survivor list, and overwriting it would destroy the only
  * record of those processes. The startup sweep picks up every claim it finds.
  */
+let claimSequence = 0;
+
 export function claimShardLineageFile(userDataPath: string, shardService?: string): string | null {
   const source = lineageFilePath(userDataPath, shardService);
-  const claimed = `${source}${REAPING_SUFFIX}-${Date.now()}-${process.pid}`;
+  const claimed = `${source}${REAPING_SUFFIX}-${Date.now()}-${process.pid}-${++claimSequence}`;
   try {
     if (!fs.existsSync(source)) return null;
     fs.renameSync(source, claimed);
@@ -772,22 +861,21 @@ async function reapEntries(entries: PersistedLineageEntry[]): Promise<PersistedL
   const candidates = entries.filter((e) => !isForbiddenTarget(e.pid));
   if (candidates.length === 0) return [];
 
-  const { startTimes, failed } = await probeStartTimesDetailed(candidates.map((e) => e.pid));
-  if (failed && startTimes.size === 0) {
-    // We learned nothing — `ps` may be blocked by the utility-process sandbox.
-    // "Absent" and "unknown" are not the same fact, so keep the record.
-    return candidates;
-  }
+  const { startTimes, unresolved } = await probeStartTimesDetailed(candidates.map((e) => e.pid));
+  // "Absent" and "could not tell" are different facts — `ps` may be blocked by
+  // the utility-process sandbox. Keep every entry we could not resolve, even
+  // when other chunks answered.
+  const retained = candidates.filter((e) => unresolved.has(e.pid));
 
   const confirmed = candidates.filter((e) => startTimes.get(e.pid) === e.startTime);
-  if (confirmed.length === 0) return [];
+  if (confirmed.length === 0) return retained;
 
   console.log(
     `[TerminalLineageLedger] Reaping ${confirmed.length} orphaned descendant(s) from a previous session`
   );
 
   if (process.platform === "win32") {
-    const survivors: PersistedLineageEntry[] = [];
+    const survivors: PersistedLineageEntry[] = [...retained];
     for (const entry of confirmed) {
       const result = spawnSync("taskkill", ["/T", "/F", "/PID", String(entry.pid)], {
         windowsHide: true,
@@ -812,8 +900,14 @@ async function reapEntries(entries: PersistedLineageEntry[]): Promise<PersistedL
   // Re-verify before escalating: a PID freed by the SIGTERM above may already
   // have been handed to an unrelated process.
   const after = await probeStartTimesDetailed(confirmed.map((e) => e.pid));
-  const survivors: PersistedLineageEntry[] = [];
+  const survivors: PersistedLineageEntry[] = [...retained];
   for (const entry of confirmed) {
+    // A failed escalation probe is not proof the SIGTERM worked — keep the
+    // entry so the next launch can finish the job.
+    if (after.unresolved.has(entry.pid)) {
+      survivors.push(entry);
+      continue;
+    }
     if (after.startTimes.get(entry.pid) !== entry.startTime) continue;
     if (!killValidated(entry.pid, "SIGKILL")) survivors.push(entry);
   }
@@ -849,10 +943,12 @@ async function reapLineageFile(filePath: string): Promise<void> {
   }
 
   try {
-    const retained: PersistedLineageFile = { ...parsed, entries: survivors, attempts };
-    resilientAtomicWriteFileSync(filePath, JSON.stringify(retained), "utf-8");
-  } catch {
-    deleteQuietly(filePath);
+    const retainedFile: PersistedLineageFile = { ...parsed, entries: survivors, attempts };
+    resilientAtomicWriteFileSync(filePath, JSON.stringify(retainedFile), "utf-8");
+  } catch (err) {
+    // Leave the original file in place. Deleting it here would discard the only
+    // record of processes we just failed to reap.
+    console.warn("[TerminalLineageLedger] Could not rewrite retained ledger:", err);
   }
 }
 

--- a/electron/services/__tests__/ProcessTreeCache.test.ts
+++ b/electron/services/__tests__/ProcessTreeCache.test.ts
@@ -506,6 +506,101 @@ describe("poll scheduling and adaptive backoff", () => {
     expect(vi.getTimerCount()).toBe(timersBefore);
   });
 
+  // The lineage ledger is the only record of descendants that have already
+  // detached, and it can only be built from sweeps that actually ran (#12203).
+  // Both the zero-subscriber skip and the 15s idle backoff would starve it.
+  it("keeps sweeping with no subscribers while the ledger holds roots", async () => {
+    cache.attachLineageLedger({ hasRoots: () => true, reconcile: () => {} });
+    cache.start();
+    await vi.advanceTimersByTimeAsync(0);
+    refreshSpy.mockClear();
+
+    internals.refreshCallbacks.clear();
+    await vi.advanceTimersByTimeAsync(cache.getCurrentIntervalMs());
+
+    expect(refreshSpy).toHaveBeenCalled();
+  });
+
+  it("still skips with no subscribers when the ledger holds no roots", async () => {
+    cache.attachLineageLedger({ hasRoots: () => false, reconcile: () => {} });
+    cache.start();
+    await vi.advanceTimersByTimeAsync(0);
+    refreshSpy.mockClear();
+
+    internals.refreshCallbacks.clear();
+    await vi.advanceTimersByTimeAsync(cache.getCurrentIntervalMs());
+
+    expect(refreshSpy).not.toHaveBeenCalled();
+  });
+
+  it("caps idle backoff at the lineage ceiling while roots are tracked", async () => {
+    cache.attachLineageLedger({ hasRoots: () => true, reconcile: () => {} });
+    cache.start();
+    for (let i = 0; i < 10; i++) {
+      await vi.advanceTimersByTimeAsync(cache.getCurrentIntervalMs());
+    }
+    expect(cache.getCurrentIntervalMs()).toBe(5000);
+  });
+
+  it("uses the full idle ceiling when nothing is tracked", async () => {
+    cache.attachLineageLedger({ hasRoots: () => false, reconcile: () => {} });
+    cache.start();
+    for (let i = 0; i < 10; i++) {
+      await vi.advanceTimersByTimeAsync(cache.getCurrentIntervalMs());
+    }
+    expect(cache.getCurrentIntervalMs()).toBe(15000);
+  });
+
+  it("never backs off below the configured base interval", async () => {
+    cache.stop();
+    cache = new ProcessTreeCache(20000);
+    internals = cache as unknown as CacheInternals;
+    internals.isWindows = false;
+    (cache as unknown as { refreshUnix: typeof refreshSpy }).refreshUnix = refreshSpy;
+    cache.onRefresh(() => {});
+    cache.attachLineageLedger({ hasRoots: () => true, reconcile: () => {} });
+
+    cache.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    // The 5s lineage ceiling must not speed a deliberately slow cache up.
+    expect(cache.getCurrentIntervalMs()).toBe(20000);
+  });
+
+  // refresh() directly rather than start(): the beforeEach subscriber already
+  // kicked off (and settled) a refresh, so start() short-circuits as
+  // "already started" and the next sweep is a full interval away.
+  it("reconciles the ledger before firing refresh callbacks", async () => {
+    const order: string[] = [];
+    cache.attachLineageLedger({
+      hasRoots: () => true,
+      reconcile: () => order.push("reconcile"),
+    });
+    cache.onRefresh(() => order.push("callback"));
+
+    await cache.refresh();
+
+    expect(order.slice(0, 2)).toEqual(["reconcile", "callback"]);
+  });
+
+  it("a throwing ledger does not blind the census", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    cache.attachLineageLedger({
+      hasRoots: () => true,
+      reconcile: () => {
+        throw new Error("ledger exploded");
+      },
+    });
+    const callback = vi.fn();
+    cache.onRefresh(callback);
+
+    await cache.refresh();
+
+    expect(callback).toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
   it("no-subscriber optimization still reschedules timer", async () => {
     cache.start();
     await vi.advanceTimersByTimeAsync(0); // first refresh completes

--- a/electron/services/__tests__/TerminalLineageLedger.test.ts
+++ b/electron/services/__tests__/TerminalLineageLedger.test.ts
@@ -1,0 +1,566 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// Hoisted: vi.mock factories run before module-scope code. `promisify(execFile)`
+// resolves as `{stdout, stderr}` only because Node's real execFile carries a
+// hidden `customPromisifyArgs` symbol, so the mock has to install a
+// `promisify.custom` implementation rather than a plain callback stub.
+const { mockExecFileAsync, mockSpawnSync } = vi.hoisted(() => ({
+  mockExecFileAsync: vi.fn(),
+  mockSpawnSync: vi.fn(),
+}));
+
+vi.mock("node:child_process", async () => {
+  const util = await import("node:util");
+  const wrapperExecFile = (() => {
+    throw new Error("callback-style execFile is not exercised in these tests");
+  }) as unknown as ((...a: unknown[]) => void) & Record<symbol, unknown>;
+  wrapperExecFile[util.promisify.custom] = (...args: unknown[]) =>
+    (mockExecFileAsync as unknown as (...a: unknown[]) => Promise<unknown>)(...args);
+  return {
+    execFile: wrapperExecFile,
+    spawnSync: mockSpawnSync,
+  };
+});
+
+import {
+  TerminalLineageLedger,
+  claimShardLineageFile,
+  currentBootEpochSec,
+  lineageFilePath,
+  probeStartTimes,
+  reapPersistedLineages,
+  type LineageCensus,
+} from "../TerminalLineageLedger.js";
+
+const isWindows = process.platform === "win32";
+
+function startTimeFor(pid: number): string {
+  return isWindows
+    ? `2026-01-01T00:00:0${pid % 10}.0000000+00:00`
+    : `Thu Jan  1 00:00:0${pid % 10} 2026`;
+}
+
+/** Build a `ps -o pid=,lstart=` style payload for the given PIDs. */
+function psOutput(pids: number[]): string {
+  return pids.map((pid) => `  ${pid} ${startTimeFor(pid)}`).join("\n") + "\n";
+}
+
+interface FakeProc {
+  pid: number;
+  ppid: number;
+  startTime?: string;
+}
+
+/**
+ * Minimal stand-in for ProcessTreeCache. `getDescendantPids` reproduces the
+ * real post-order (leaves first) walk so ordering assertions are meaningful.
+ */
+class FakeCensus implements LineageCensus {
+  private procs = new Map<number, FakeProc>();
+
+  constructor(procs: FakeProc[] = []) {
+    this.set(procs);
+  }
+
+  set(procs: FakeProc[]): void {
+    this.procs = new Map(procs.map((p) => [p.pid, p]));
+  }
+
+  getProcess(pid: number): FakeProc | undefined {
+    return this.procs.get(pid);
+  }
+
+  getDescendantPids(rootPid: number): number[] {
+    const result: number[] = [];
+    const visited = new Set<number>();
+    const visit = (pid: number): void => {
+      if (visited.has(pid)) return;
+      visited.add(pid);
+      for (const proc of this.procs.values()) {
+        if (proc.ppid === pid) visit(proc.pid);
+      }
+      if (pid !== rootPid) result.push(pid);
+    };
+    visit(rootPid);
+    return result;
+  }
+}
+
+/** Let the ledger's fire-and-forget identity probe settle. */
+async function flush(): Promise<void> {
+  for (let i = 0; i < 5; i++) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+}
+
+describe("TerminalLineageLedger", () => {
+  let tmpDir: string;
+  let filePath: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExecFileAsync.mockImplementation(async (_file: string, args: string[]) => {
+      const pids = readRequestedPids(args);
+      return { stdout: psOutput(pids), stderr: "" };
+    });
+    mockSpawnSync.mockImplementation(() => ({ status: 0, stdout: "" }));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "lineage-ledger-test-"));
+    filePath = path.join(tmpDir, "pty-lineage.json");
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  function readPersisted(): { entries: Array<{ pid: number; startTime: string }> } | null {
+    if (!fs.existsSync(filePath)) return null;
+    return JSON.parse(fs.readFileSync(filePath, "utf8"));
+  }
+
+  function readRequestedPids(args: string[]): number[] {
+    if (isWindows) {
+      const script = args[args.length - 1];
+      return [...script.matchAll(/ProcessId=(\d+)/g)].map((m) => parseInt(m[1], 10));
+    }
+    const idx = args.indexOf("-p");
+    if (idx === -1) return [];
+    return args[idx + 1]
+      .split(",")
+      .map((p) => parseInt(p, 10))
+      .filter((p) => Number.isInteger(p));
+  }
+
+  describe("tracking", () => {
+    it("records a descendant observed under a root", async () => {
+      const ledger = new TerminalLineageLedger(null);
+      const census = new FakeCensus([
+        { pid: 100, ppid: 10 },
+        { pid: 200, ppid: 100 },
+      ]);
+      ledger.registerRoot(100);
+
+      ledger.reconcile(census);
+      await flush();
+      ledger.reconcile(census);
+
+      expect(ledger.getTrackedPids(100)).toEqual([{ pid: 200, startTime: startTimeFor(200) }]);
+    });
+
+    it("keeps a descendant after it reparents to PID 1", async () => {
+      const ledger = new TerminalLineageLedger(null);
+      const census = new FakeCensus([
+        { pid: 100, ppid: 10 },
+        { pid: 200, ppid: 100 },
+      ]);
+      ledger.registerRoot(100);
+      ledger.reconcile(census);
+      await flush();
+
+      // The wrapper exits and the OS reparents its backgrounded child to init.
+      census.set([
+        { pid: 100, ppid: 10 },
+        { pid: 200, ppid: 1 },
+      ]);
+      ledger.reconcile(census);
+
+      expect(ledger.getTrackedPids(100).map((t) => t.pid)).toEqual([200]);
+    });
+
+    it("prunes a descendant the census no longer reports", async () => {
+      const ledger = new TerminalLineageLedger(null);
+      const census = new FakeCensus([
+        { pid: 100, ppid: 10 },
+        { pid: 200, ppid: 100 },
+      ]);
+      ledger.registerRoot(100);
+      ledger.reconcile(census);
+      await flush();
+
+      census.set([{ pid: 100, ppid: 10 }]);
+      ledger.reconcile(census);
+
+      expect(ledger.getTrackedPids(100)).toEqual([]);
+    });
+
+    it("discovers children a detached member spawned after leaving the tree", async () => {
+      const ledger = new TerminalLineageLedger(null);
+      const census = new FakeCensus([
+        { pid: 100, ppid: 10 },
+        { pid: 200, ppid: 100 },
+      ]);
+      ledger.registerRoot(100);
+      ledger.reconcile(census);
+      await flush();
+
+      // 200 detaches, then forks 300 while orphaned.
+      census.set([
+        { pid: 100, ppid: 10 },
+        { pid: 200, ppid: 1 },
+        { pid: 300, ppid: 200 },
+      ]);
+      ledger.reconcile(census);
+      await flush();
+      ledger.reconcile(census);
+
+      expect(ledger.getTrackedPids(100).map((t) => t.pid).sort()).toEqual([200, 300]);
+    });
+
+    it("never reports a PID whose start time could not be established", async () => {
+      mockExecFileAsync.mockRejectedValue(new Error("ps unavailable"));
+      const ledger = new TerminalLineageLedger(null);
+      const census = new FakeCensus([
+        { pid: 100, ppid: 10 },
+        { pid: 200, ppid: 100 },
+      ]);
+      ledger.registerRoot(100);
+      ledger.reconcile(census);
+      await flush();
+      ledger.reconcile(census);
+
+      expect(ledger.getTrackedPids(100)).toEqual([]);
+    });
+
+    it("drops an entry whose census start time changed (PID reuse)", async () => {
+      const ledger = new TerminalLineageLedger(null);
+      const census = new FakeCensus([
+        { pid: 100, ppid: 10 },
+        { pid: 200, ppid: 100, startTime: "original" },
+      ]);
+      ledger.registerRoot(100);
+      ledger.reconcile(census);
+      await flush();
+      ledger.reconcile(census);
+      expect(ledger.getTrackedPids(100).map((t) => t.pid)).toEqual([200]);
+
+      census.set([
+        { pid: 100, ppid: 10 },
+        { pid: 200, ppid: 999, startTime: "recycled" },
+      ]);
+      ledger.reconcile(census);
+
+      expect(ledger.getTrackedPids(100)).toEqual([]);
+    });
+
+    it("stops discovering once a root is closing but keeps known descendants", async () => {
+      const ledger = new TerminalLineageLedger(null);
+      const census = new FakeCensus([
+        { pid: 100, ppid: 10 },
+        { pid: 200, ppid: 100 },
+      ]);
+      ledger.registerRoot(100);
+      ledger.reconcile(census);
+      await flush();
+
+      ledger.markRootClosing(100);
+      census.set([
+        { pid: 100, ppid: 10 },
+        { pid: 200, ppid: 1 },
+        { pid: 400, ppid: 100 },
+      ]);
+      ledger.reconcile(census);
+      await flush();
+      ledger.reconcile(census);
+
+      const pids = ledger.getTrackedPids(100).map((t) => t.pid);
+      expect(pids).toContain(200);
+      expect(pids).not.toContain(400);
+    });
+
+    it("drops a closing root once every tracked PID is gone", async () => {
+      const ledger = new TerminalLineageLedger(null);
+      const census = new FakeCensus([
+        { pid: 100, ppid: 10 },
+        { pid: 200, ppid: 100 },
+      ]);
+      ledger.registerRoot(100);
+      ledger.reconcile(census);
+      await flush();
+
+      ledger.markRootClosing(100);
+      census.set([]);
+      ledger.reconcile(census);
+
+      expect(ledger.hasRoots()).toBe(false);
+    });
+
+    it("does not let a recycled root PID inherit the previous lineage", async () => {
+      const ledger = new TerminalLineageLedger(null);
+      const census = new FakeCensus([
+        { pid: 100, ppid: 10 },
+        { pid: 200, ppid: 100 },
+      ]);
+      ledger.registerRoot(100);
+      ledger.reconcile(census);
+      await flush();
+      expect(ledger.getTrackedPids(100).map((t) => t.pid)).toEqual([200]);
+
+      ledger.registerRoot(100);
+
+      expect(ledger.getTrackedPids(100)).toEqual([]);
+    });
+
+    it("ignores roots that are not real PIDs", () => {
+      const ledger = new TerminalLineageLedger(null);
+      ledger.registerRoot(0);
+      ledger.registerRoot(1);
+      ledger.registerRoot(-5);
+      expect(ledger.hasRoots()).toBe(false);
+    });
+  });
+
+  describe("persistence", () => {
+    it("persists only orphaned descendants", async () => {
+      const ledger = new TerminalLineageLedger(filePath);
+      const census = new FakeCensus([
+        { pid: 100, ppid: 10 },
+        { pid: 10, ppid: 1 },
+        { pid: 200, ppid: 100 },
+        { pid: 300, ppid: 1 },
+      ]);
+      ledger.registerRoot(100);
+      // 300 becomes part of the lineage by being a descendant while attached...
+      census.set([
+        { pid: 10, ppid: 1 },
+        { pid: 100, ppid: 10 },
+        { pid: 200, ppid: 100 },
+        { pid: 300, ppid: 200 },
+      ]);
+      ledger.reconcile(census);
+      await flush();
+
+      // ...then detaches. 200 stays attached to the live shell.
+      census.set([
+        { pid: 10, ppid: 1 },
+        { pid: 100, ppid: 10 },
+        { pid: 200, ppid: 100 },
+        { pid: 300, ppid: 1 },
+      ]);
+      ledger.reconcile(census);
+
+      const persisted = readPersisted();
+      expect(persisted?.entries.map((e) => e.pid)).toEqual([300]);
+    });
+
+    it("removes the file when nothing is orphaned any more", async () => {
+      const ledger = new TerminalLineageLedger(filePath);
+      const census = new FakeCensus([
+        { pid: 10, ppid: 1 },
+        { pid: 100, ppid: 10 },
+        { pid: 300, ppid: 100 },
+      ]);
+      ledger.registerRoot(100);
+      ledger.reconcile(census);
+      await flush();
+      census.set([
+        { pid: 10, ppid: 1 },
+        { pid: 100, ppid: 10 },
+        { pid: 300, ppid: 1 },
+      ]);
+      ledger.reconcile(census);
+      expect(readPersisted()).not.toBeNull();
+
+      census.set([
+        { pid: 10, ppid: 1 },
+        { pid: 100, ppid: 10 },
+      ]);
+      ledger.reconcile(census);
+
+      expect(readPersisted()).toBeNull();
+    });
+
+    it("stamps the current boot epoch", async () => {
+      const ledger = new TerminalLineageLedger(filePath);
+      const census = new FakeCensus([
+        { pid: 10, ppid: 1 },
+        { pid: 100, ppid: 10 },
+        { pid: 300, ppid: 100 },
+      ]);
+      ledger.registerRoot(100);
+      ledger.reconcile(census);
+      await flush();
+      census.set([
+        { pid: 10, ppid: 1 },
+        { pid: 100, ppid: 10 },
+        { pid: 300, ppid: 1 },
+      ]);
+      ledger.reconcile(census);
+
+      const raw = JSON.parse(fs.readFileSync(filePath, "utf8"));
+      expect(Math.abs(raw.bootEpochSec - currentBootEpochSec())).toBeLessThanOrEqual(5);
+      expect(raw.version).toBe(1);
+    });
+  });
+
+  describe("lineageFilePath", () => {
+    it("keeps the default shard on the unsuffixed name", () => {
+      expect(lineageFilePath("/data")).toBe(path.join("/data", "pty-lineage.json"));
+      expect(lineageFilePath("/data", "daintree-pty-host")).toBe(
+        path.join("/data", "pty-lineage.json")
+      );
+    });
+
+    it("gives each named shard its own file", () => {
+      expect(lineageFilePath("/data", "daintree-pty-host:proj-abc123")).toBe(
+        path.join("/data", "pty-lineage-proj-abc123.json")
+      );
+    });
+  });
+
+  describe("claimShardLineageFile", () => {
+    it("renames the live file out of the way", () => {
+      fs.writeFileSync(filePath, "{}");
+      const claimed = claimShardLineageFile(tmpDir);
+      expect(claimed).toBe(`${filePath}.reaping`);
+      expect(fs.existsSync(filePath)).toBe(false);
+      expect(fs.existsSync(`${filePath}.reaping`)).toBe(true);
+    });
+
+    it("returns null when there is nothing to claim", () => {
+      expect(claimShardLineageFile(tmpDir)).toBeNull();
+    });
+  });
+
+  describe("reapPersistedLineages", () => {
+    let killSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    });
+
+    function writeLedger(
+      entries: Array<{ pid: number; startTime: string; rootPid: number }>,
+      overrides: Record<string, unknown> = {}
+    ): void {
+      fs.writeFileSync(
+        filePath,
+        JSON.stringify({
+          version: 1,
+          bootEpochSec: currentBootEpochSec(),
+          owner: "daintree-pty-host",
+          updatedAt: Date.now(),
+          entries,
+          ...overrides,
+        })
+      );
+    }
+
+    it("kills entries whose start time still matches", async () => {
+      writeLedger([{ pid: 4242, startTime: startTimeFor(4242), rootPid: 100 }]);
+
+      await reapPersistedLineages(tmpDir);
+
+      if (isWindows) {
+        expect(mockSpawnSync).toHaveBeenCalledWith(
+          "taskkill",
+          ["/T", "/F", "/PID", "4242"],
+          expect.anything()
+        );
+      } else {
+        expect(killSpy).toHaveBeenCalledWith(4242, "SIGTERM");
+        expect(killSpy).toHaveBeenCalledWith(4242, "SIGKILL");
+      }
+      expect(fs.existsSync(filePath)).toBe(false);
+    });
+
+    it("never signals a PID whose start time no longer matches", async () => {
+      writeLedger([{ pid: 4242, startTime: "a-different-boot-of-this-pid", rootPid: 100 }]);
+
+      await reapPersistedLineages(tmpDir);
+
+      expect(killSpy).not.toHaveBeenCalled();
+      expect(mockSpawnSync).not.toHaveBeenCalled();
+      expect(fs.existsSync(filePath)).toBe(false);
+    });
+
+    it("discards the whole ledger when the boot epoch does not match", async () => {
+      writeLedger([{ pid: 4242, startTime: startTimeFor(4242), rootPid: 100 }], {
+        bootEpochSec: currentBootEpochSec() - 100_000,
+      });
+
+      await reapPersistedLineages(tmpDir);
+
+      expect(killSpy).not.toHaveBeenCalled();
+      expect(mockSpawnSync).not.toHaveBeenCalled();
+      expect(fs.existsSync(filePath)).toBe(false);
+    });
+
+    it("refuses to signal init, itself, or its parent", async () => {
+      writeLedger([
+        { pid: 1, startTime: startTimeFor(1), rootPid: 100 },
+        { pid: process.pid, startTime: startTimeFor(process.pid), rootPid: 100 },
+        { pid: process.ppid, startTime: startTimeFor(process.ppid), rootPid: 100 },
+      ]);
+
+      await reapPersistedLineages(tmpDir);
+
+      expect(killSpy).not.toHaveBeenCalled();
+      expect(mockSpawnSync).not.toHaveBeenCalled();
+    });
+
+    it("ignores a ledger written by a future schema version", async () => {
+      writeLedger([{ pid: 4242, startTime: startTimeFor(4242), rootPid: 100 }], { version: 99 });
+
+      await reapPersistedLineages(tmpDir);
+
+      expect(killSpy).not.toHaveBeenCalled();
+      expect(fs.existsSync(filePath)).toBe(false);
+    });
+
+    it("ignores a corrupt ledger without throwing", async () => {
+      fs.writeFileSync(filePath, "{ not json");
+
+      await expect(reapPersistedLineages(tmpDir)).resolves.toBeUndefined();
+
+      expect(killSpy).not.toHaveBeenCalled();
+      expect(fs.existsSync(filePath)).toBe(false);
+    });
+
+    it("picks up an interrupted reap claim", async () => {
+      writeLedger([{ pid: 4242, startTime: startTimeFor(4242), rootPid: 100 }]);
+      fs.renameSync(filePath, `${filePath}.reaping`);
+
+      await reapPersistedLineages(tmpDir);
+
+      if (!isWindows) {
+        expect(killSpy).toHaveBeenCalledWith(4242, "SIGTERM");
+      }
+      expect(fs.existsSync(`${filePath}.reaping`)).toBe(false);
+    });
+
+    it("is a no-op when the directory holds no ledgers", async () => {
+      await expect(reapPersistedLineages(tmpDir)).resolves.toBeUndefined();
+      expect(killSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("probeStartTimes", () => {
+    it("parses one entry per requested PID", async () => {
+      const result = await probeStartTimes([111, 222]);
+      expect(result.get(111)).toBe(startTimeFor(111));
+      expect(result.get(222)).toBe(startTimeFor(222));
+    });
+
+    it("returns an empty map for no PIDs without spawning anything", async () => {
+      const result = await probeStartTimes([]);
+      expect(result.size).toBe(0);
+      expect(mockExecFileAsync).not.toHaveBeenCalled();
+    });
+
+    it("still harvests stdout when ps exits non-zero (all PIDs gone)", async () => {
+      const err = Object.assign(new Error("Command failed"), { stdout: psOutput([333]) });
+      mockExecFileAsync.mockRejectedValue(err);
+
+      const result = await probeStartTimes([333, 444]);
+
+      expect(result.get(333)).toBe(startTimeFor(333));
+      expect(result.has(444)).toBe(false);
+    });
+  });
+});

--- a/electron/services/__tests__/TerminalLineageLedger.test.ts
+++ b/electron/services/__tests__/TerminalLineageLedger.test.ts
@@ -209,7 +209,12 @@ describe("TerminalLineageLedger", () => {
       await flush();
       ledger.reconcile(census);
 
-      expect(ledger.getTrackedPids(100).map((t) => t.pid).sort()).toEqual([200, 300]);
+      expect(
+        ledger
+          .getTrackedPids(100)
+          .map((t) => t.pid)
+          .sort()
+      ).toEqual([200, 300]);
     });
 
     it("never reports a PID whose start time could not be established", async () => {
@@ -315,6 +320,200 @@ describe("TerminalLineageLedger", () => {
     });
   });
 
+  describe("bounded tracking", () => {
+    it("keeps trackedCount accurate across admit, prune and root drop", async () => {
+      const ledger = new TerminalLineageLedger(null);
+      const census = new FakeCensus([
+        { pid: 100, ppid: 10 },
+        { pid: 200, ppid: 100 },
+        { pid: 201, ppid: 100 },
+      ]);
+      ledger.registerRoot(100);
+      ledger.reconcile(census);
+      await flush();
+      expect(ledger.getTrackedCount()).toBe(2);
+
+      census.set([
+        { pid: 100, ppid: 10 },
+        { pid: 200, ppid: 100 },
+      ]);
+      ledger.reconcile(census);
+      expect(ledger.getTrackedCount()).toBe(1);
+
+      ledger.unregisterRoot(100);
+      expect(ledger.getTrackedCount()).toBe(0);
+      expect(ledger.hasRoots()).toBe(false);
+    });
+
+    it("returns capacity when a closing root drains automatically", async () => {
+      const ledger = new TerminalLineageLedger(null);
+      const census = new FakeCensus([
+        { pid: 100, ppid: 10 },
+        { pid: 200, ppid: 100 },
+      ]);
+      ledger.registerRoot(100);
+      ledger.reconcile(census);
+      await flush();
+      expect(ledger.getTrackedCount()).toBe(1);
+
+      ledger.markRootClosing(100);
+      census.set([]);
+      ledger.reconcile(census);
+
+      expect(ledger.getTrackedCount()).toBe(0);
+      expect(ledger.hasRoots()).toBe(false);
+    });
+
+    it("re-registering a recycled root PID releases the old lineage's capacity", async () => {
+      const ledger = new TerminalLineageLedger(null);
+      const census = new FakeCensus([
+        { pid: 100, ppid: 10 },
+        { pid: 200, ppid: 100 },
+      ]);
+      ledger.registerRoot(100);
+      ledger.reconcile(census);
+      await flush();
+      expect(ledger.getTrackedCount()).toBe(1);
+
+      ledger.registerRoot(100);
+
+      expect(ledger.getTrackedCount()).toBe(0);
+    });
+
+    it("stops admitting at the cap instead of evicting known descendants", async () => {
+      const ledger = new TerminalLineageLedger(null);
+      const procs: FakeProc[] = [{ pid: 100, ppid: 10 }];
+      // One more child than the 4096 cap allows.
+      for (let i = 0; i < 4097; i++) procs.push({ pid: 1000 + i, ppid: 100 });
+      const census = new FakeCensus(procs);
+      ledger.registerRoot(100);
+
+      ledger.reconcile(census);
+
+      expect(ledger.getTrackedCount()).toBe(4096);
+    });
+
+    it("dispose clears every root and the count", async () => {
+      const ledger = new TerminalLineageLedger(null);
+      const census = new FakeCensus([
+        { pid: 100, ppid: 10 },
+        { pid: 200, ppid: 100 },
+      ]);
+      ledger.registerRoot(100);
+      ledger.reconcile(census);
+      await flush();
+
+      ledger.dispose();
+
+      expect(ledger.getTrackedCount()).toBe(0);
+      expect(ledger.hasRoots()).toBe(false);
+    });
+  });
+
+  describe("root lifecycle", () => {
+    it("closes an active root whose PID was handed to another process", async () => {
+      // A root is only keyed by PID. If that number is recycled, an unrelated
+      // process tree would be adopted wholesale unless the root notices.
+      const ledger = new TerminalLineageLedger(null);
+      const census = new FakeCensus([
+        { pid: 100, ppid: 10 },
+        { pid: 200, ppid: 100 },
+      ]);
+      ledger.registerRoot(100);
+      ledger.reconcile(census);
+      await flush();
+
+      // The root is gone, but an unrelated process now holds its PID and has
+      // children of its own.
+      census.set([
+        { pid: 200, ppid: 1 },
+        { pid: 100, ppid: 55 },
+        { pid: 900, ppid: 100 },
+      ]);
+      ledger.reconcile(census);
+      await flush();
+      ledger.reconcile(census);
+
+      const pids = ledger.getTrackedPids(100).map((t) => t.pid);
+      expect(pids).toContain(200);
+      expect(pids).not.toContain(900);
+    });
+
+    it("closes an active root that vanished without a teardown", async () => {
+      // A terminal whose construction failed after the killer registered
+      // reaches no teardown path, so nothing would ever close its root.
+      const ledger = new TerminalLineageLedger(null);
+      const census = new FakeCensus([
+        { pid: 100, ppid: 10 },
+        { pid: 200, ppid: 100 },
+      ]);
+      ledger.registerRoot(100);
+      ledger.reconcile(census);
+      await flush();
+
+      census.set([{ pid: 200, ppid: 1 }]);
+      ledger.reconcile(census);
+      await flush();
+      // The PID is free again and a stranger takes it, with children.
+      census.set([
+        { pid: 200, ppid: 1 },
+        { pid: 100, ppid: 77 },
+        { pid: 900, ppid: 100 },
+      ]);
+      ledger.reconcile(census);
+      await flush();
+      ledger.reconcile(census);
+
+      expect(ledger.getTrackedPids(100).map((t) => t.pid)).not.toContain(900);
+    });
+
+    it("does not let an unidentified orphan adopt a subtree", async () => {
+      // Probe failure leaves 200 unidentified. It must not be able to pull an
+      // unrelated subtree into the ledger on the strength of a PID alone.
+      mockExecFileAsync.mockRejectedValue(new Error("ps unavailable"));
+      const ledger = new TerminalLineageLedger(null);
+      const census = new FakeCensus([
+        { pid: 100, ppid: 10 },
+        { pid: 200, ppid: 100 },
+      ]);
+      ledger.registerRoot(100);
+      ledger.reconcile(census);
+      await flush();
+
+      census.set([
+        { pid: 100, ppid: 10 },
+        { pid: 200, ppid: 1 },
+        { pid: 300, ppid: 200 },
+      ]);
+      ledger.reconcile(census);
+      await flush();
+      ledger.reconcile(census);
+
+      expect(ledger.getTrackedPids(100)).toEqual([]);
+    });
+
+    it("requeues identification after a transient probe failure", async () => {
+      mockExecFileAsync.mockRejectedValueOnce(new Error("ps unavailable"));
+      const ledger = new TerminalLineageLedger(null);
+      const census = new FakeCensus([
+        { pid: 100, ppid: 10 },
+        { pid: 200, ppid: 100 },
+      ]);
+      ledger.registerRoot(100);
+      ledger.reconcile(census);
+      await flush();
+      // First probe failed — nothing signallable yet.
+      expect(ledger.getTrackedPids(100)).toEqual([]);
+
+      // The next sweep must retry rather than abandon the PID forever.
+      ledger.reconcile(census);
+      await flush();
+      ledger.reconcile(census);
+
+      expect(ledger.getTrackedPids(100).map((t) => t.pid)).toEqual([200]);
+    });
+  });
+
   describe("persistence", () => {
     it("persists only orphaned descendants", async () => {
       const ledger = new TerminalLineageLedger(filePath);
@@ -375,6 +574,68 @@ describe("TerminalLineageLedger", () => {
       expect(readPersisted()).toBeNull();
     });
 
+    it("persists a detached member's own children too", async () => {
+      // 300's parent 200 is alive, so a "parent is missing" test would leave
+      // 300 unpersisted — and the restart that reaps 200 would let 300
+      // reparent to init and survive, recreating the bug one level down.
+      const ledger = new TerminalLineageLedger(filePath);
+      const census = new FakeCensus([
+        { pid: 10, ppid: 1 },
+        { pid: 100, ppid: 10 },
+        { pid: 200, ppid: 100 },
+        { pid: 300, ppid: 200 },
+      ]);
+      ledger.registerRoot(100);
+      ledger.reconcile(census);
+      await flush();
+
+      census.set([
+        { pid: 10, ppid: 1 },
+        { pid: 100, ppid: 10 },
+        { pid: 200, ppid: 1 },
+        { pid: 300, ppid: 200 },
+      ]);
+      ledger.reconcile(census);
+      await flush();
+      ledger.reconcile(census);
+
+      expect(readPersisted()?.entries.map((e) => e.pid)).toEqual([200, 300]);
+    });
+
+    it("retries the write after a transient failure on an unchanged orphan set", async () => {
+      // The parent directory does not exist yet, so the atomic write throws.
+      const nestedDir = path.join(tmpDir, "nested");
+      const nestedPath = path.join(nestedDir, "pty-lineage.json");
+      const readNested = (): { entries: Array<{ pid: number }> } | null =>
+        fs.existsSync(nestedPath) ? JSON.parse(fs.readFileSync(nestedPath, "utf8")) : null;
+
+      const ledger = new TerminalLineageLedger(nestedPath);
+      const census = new FakeCensus([
+        { pid: 10, ppid: 1 },
+        { pid: 100, ppid: 10 },
+        { pid: 300, ppid: 100 },
+      ]);
+      ledger.registerRoot(100);
+      ledger.reconcile(census);
+      await flush();
+      census.set([
+        { pid: 10, ppid: 1 },
+        { pid: 100, ppid: 10 },
+        { pid: 300, ppid: 1 },
+      ]);
+
+      ledger.reconcile(census);
+      expect(readNested()).toBeNull();
+
+      // The orphan set is identical on the retry, so a signature recorded
+      // before the failed write would suppress it forever, leaving no
+      // crash-recovery record at all.
+      fs.mkdirSync(nestedDir);
+      ledger.reconcile(census);
+
+      expect(readNested()?.entries.map((e) => e.pid)).toEqual([300]);
+    });
+
     it("stamps the current boot epoch", async () => {
       const ledger = new TerminalLineageLedger(filePath);
       const census = new FakeCensus([
@@ -417,9 +678,21 @@ describe("TerminalLineageLedger", () => {
     it("renames the live file out of the way", () => {
       fs.writeFileSync(filePath, "{}");
       const claimed = claimShardLineageFile(tmpDir);
-      expect(claimed).toBe(`${filePath}.reaping`);
+      expect(claimed).toMatch(/pty-lineage\.json\.reaping-/);
       expect(fs.existsSync(filePath)).toBe(false);
-      expect(fs.existsSync(`${filePath}.reaping`)).toBe(true);
+      expect(fs.existsSync(claimed as string)).toBe(true);
+    });
+
+    it("never destroys an earlier interrupted claim", () => {
+      // An existing claim is another host's unreaped survivor list. Overwriting
+      // it would discard the only record of those processes.
+      fs.writeFileSync(`${filePath}.reaping-earlier`, '{"earlier":true}');
+      fs.writeFileSync(filePath, "{}");
+
+      const claimed = claimShardLineageFile(tmpDir);
+
+      expect(fs.existsSync(`${filePath}.reaping-earlier`)).toBe(true);
+      expect(claimed).not.toBe(`${filePath}.reaping-earlier`);
     });
 
     it("returns null when there is nothing to claim", () => {
@@ -532,6 +805,41 @@ describe("TerminalLineageLedger", () => {
         expect(killSpy).toHaveBeenCalledWith(4242, "SIGTERM");
       }
       expect(fs.existsSync(`${filePath}.reaping`)).toBe(false);
+    });
+
+    it("keeps the ledger when the probe could not run at all", async () => {
+      // A blocked `ps` makes "already gone" and "cannot tell" look identical.
+      // Deleting here would discard the only record of a live survivor.
+      mockExecFileAsync.mockRejectedValue(new Error("ps: Operation not permitted"));
+      writeLedger([{ pid: 4242, startTime: startTimeFor(4242), rootPid: 100 }]);
+
+      await reapPersistedLineages(tmpDir);
+
+      expect(killSpy).not.toHaveBeenCalled();
+      expect(fs.existsSync(filePath)).toBe(true);
+      expect(JSON.parse(fs.readFileSync(filePath, "utf8")).attempts).toBe(1);
+    });
+
+    it("gives up on an unresolvable ledger after a bounded number of launches", async () => {
+      mockExecFileAsync.mockRejectedValue(new Error("ps: Operation not permitted"));
+      writeLedger([{ pid: 4242, startTime: startTimeFor(4242), rootPid: 100 }], { attempts: 2 });
+
+      await reapPersistedLineages(tmpDir);
+
+      // Retrying forever would leak the file just as surely as deleting early.
+      expect(fs.existsSync(filePath)).toBe(false);
+    });
+
+    it("deletes the ledger when the probe genuinely reports the PID gone", async () => {
+      // `ps` exits non-zero with empty stdout when no requested PID exists,
+      // but the call itself succeeded — that is evidence, not ambiguity.
+      mockExecFileAsync.mockImplementation(async () => ({ stdout: "", stderr: "" }));
+      writeLedger([{ pid: 4242, startTime: startTimeFor(4242), rootPid: 100 }]);
+
+      await reapPersistedLineages(tmpDir);
+
+      expect(killSpy).not.toHaveBeenCalled();
+      expect(fs.existsSync(filePath)).toBe(false);
     });
 
     it("is a no-op when the directory holds no ledgers", async () => {

--- a/electron/services/__tests__/TerminalLineageLedger.test.ts
+++ b/electron/services/__tests__/TerminalLineageLedger.test.ts
@@ -27,10 +27,13 @@ vi.mock("node:child_process", async () => {
 
 import {
   TerminalLineageLedger,
+  beginTeardownProbeWindow,
   claimShardLineageFile,
   currentBootEpochSec,
+  endTeardownProbeWindow,
   lineageFilePath,
   probeStartTimes,
+  probeStartTimesSync,
   reapPersistedLineages,
   type LineageCensus,
 } from "../TerminalLineageLedger.js";
@@ -115,6 +118,7 @@ describe("TerminalLineageLedger", () => {
   });
 
   afterEach(() => {
+    endTeardownProbeWindow();
     fs.rmSync(tmpDir, { recursive: true, force: true });
     vi.restoreAllMocks();
   });
@@ -573,6 +577,30 @@ describe("TerminalLineageLedger", () => {
     });
   });
 
+  describe("getVerifiedOrphanPids", () => {
+    it("never returns init, this process, or its parent", async () => {
+      // The persisted reaper refuses these; the in-memory kill path is the
+      // other surface that signals, so it has to refuse them too.
+      mockSpawnSync.mockImplementation((_file: string, args: string[]) => ({
+        status: 0,
+        stdout: psOutput(readRequestedPids(args)),
+      }));
+      const ledger = new TerminalLineageLedger(null);
+      const census = new FakeCensus([
+        { pid: 100, ppid: 10 },
+        { pid: 200, ppid: 100 },
+        { pid: process.pid, ppid: 100 },
+        { pid: process.ppid, ppid: 100 },
+      ]);
+      ledger.registerRoot(100);
+      ledger.reconcile(census);
+      await flush();
+      ledger.reconcile(census);
+
+      expect(ledger.getVerifiedOrphanPids(100, [])).toEqual([200]);
+    });
+  });
+
   describe("persistence", () => {
     it("persists only orphaned descendants", async () => {
       const ledger = new TerminalLineageLedger(filePath);
@@ -767,6 +795,18 @@ describe("TerminalLineageLedger", () => {
       killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
     });
 
+    /** The single lineage file the sweep left behind, whatever its name. */
+    function readRetained(): {
+      path: string;
+      attempts?: number;
+      entries: Array<{ pid: number }>;
+    } | null {
+      const names = fs.readdirSync(tmpDir).filter((n) => n.startsWith("pty-lineage"));
+      if (names.length !== 1) return null;
+      const retainedPath = path.join(tmpDir, names[0]);
+      return { path: retainedPath, ...JSON.parse(fs.readFileSync(retainedPath, "utf8")) };
+    }
+
     function writeLedger(
       entries: Array<{ pid: number; startTime: string; rootPid: number }>,
       overrides: Record<string, unknown> = {}
@@ -878,8 +918,30 @@ describe("TerminalLineageLedger", () => {
       await reapPersistedLineages(tmpDir);
 
       expect(killSpy).not.toHaveBeenCalled();
-      expect(fs.existsSync(filePath)).toBe(true);
-      expect(JSON.parse(fs.readFileSync(filePath, "utf8")).attempts).toBe(1);
+      const retained = readRetained();
+      expect(retained?.attempts).toBe(1);
+      expect(retained?.entries.map((e) => e.pid)).toEqual([4242]);
+    });
+
+    it("keeps a retained survivor list off the path a new host will write", async () => {
+      // The retry file used to be rewritten in place. The pty-host forked
+      // moments later builds its own ledger at that same path, and its first
+      // reconcile with no orphans unlinks it — so the bounded-attempt path
+      // never survived a single terminal spawn.
+      mockExecFileAsync.mockRejectedValue(
+        Object.assign(new Error("spawn ps EPERM"), { code: "EPERM" })
+      );
+      writeLedger([{ pid: 4242, startTime: startTimeFor(4242), rootPid: 100 }]);
+
+      await reapPersistedLineages(tmpDir);
+      expect(fs.existsSync(filePath)).toBe(false);
+
+      const ledger = new TerminalLineageLedger(filePath);
+      ledger.registerRoot(100);
+      ledger.reconcile(new FakeCensus([{ pid: 10, ppid: 1 }]));
+      await flush();
+
+      expect(readRetained()?.entries.map((e) => e.pid)).toEqual([4242]);
     });
 
     it("gives up on an unresolvable ledger after a bounded number of launches", async () => {
@@ -892,6 +954,7 @@ describe("TerminalLineageLedger", () => {
 
       // Retrying forever would leak the file just as surely as deleting early.
       expect(fs.existsSync(filePath)).toBe(false);
+      expect(fs.readdirSync(tmpDir).filter((n) => n.startsWith("pty-lineage"))).toEqual([]);
     });
 
     it("deletes the ledger when the probe genuinely reports the PID gone", async () => {
@@ -912,6 +975,26 @@ describe("TerminalLineageLedger", () => {
     it("is a no-op when the directory holds no ledgers", async () => {
       await expect(reapPersistedLineages(tmpDir)).resolves.toBeUndefined();
       expect(killSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("teardown probe window", () => {
+    it("shares one budget across every sync probe until it is released", () => {
+      // Host teardown disposes N terminals on one thread inside an ~1s window,
+      // and each disposal can run two verification passes. A per-invocation
+      // budget would let the first few claim the whole window.
+      beginTeardownProbeWindow(0);
+      expect(probeStartTimesSync([111]).size).toBe(0);
+      expect(probeStartTimesSync([222]).size).toBe(0);
+      expect(mockSpawnSync).not.toHaveBeenCalled();
+
+      endTeardownProbeWindow();
+      mockSpawnSync.mockImplementation((_file: string, args: string[]) => ({
+        status: 0,
+        stdout: psOutput(readRequestedPids(args)),
+      }));
+
+      expect(probeStartTimesSync([111]).get(111)).toBe(startTimeFor(111));
     });
   });
 

--- a/electron/services/__tests__/TerminalLineageLedger.test.ts
+++ b/electron/services/__tests__/TerminalLineageLedger.test.ts
@@ -199,15 +199,17 @@ describe("TerminalLineageLedger", () => {
       ledger.reconcile(census);
       await flush();
 
-      // 200 detaches, then forks 300 while orphaned.
+      // 200 detaches, then forks 300 while orphaned. Adoption waits for 200 to
+      // be re-verified as still itself, so this takes an extra sweep.
       census.set([
         { pid: 100, ppid: 10 },
         { pid: 200, ppid: 1 },
         { pid: 300, ppid: 200 },
       ]);
-      ledger.reconcile(census);
-      await flush();
-      ledger.reconcile(census);
+      for (let i = 0; i < 3; i++) {
+        ledger.reconcile(census);
+        await flush();
+      }
 
       expect(
         ledger
@@ -218,7 +220,9 @@ describe("TerminalLineageLedger", () => {
     });
 
     it("never reports a PID whose start time could not be established", async () => {
-      mockExecFileAsync.mockRejectedValue(new Error("ps unavailable"));
+      mockExecFileAsync.mockRejectedValue(
+        Object.assign(new Error("spawn ps ENOENT"), { code: "ENOENT" })
+      );
       const ledger = new TerminalLineageLedger(null);
       const census = new FakeCensus([
         { pid: 100, ppid: 10 },
@@ -233,10 +237,14 @@ describe("TerminalLineageLedger", () => {
     });
 
     it("drops an entry whose census start time changed (PID reuse)", async () => {
+      // The Windows census carries CreationDate, so a recycled PID is caught
+      // during the sweep rather than waiting for a probe. The fixture uses the
+      // same value the probe reports, as production does — both sides render
+      // CreationDate.ToString("o").
       const ledger = new TerminalLineageLedger(null);
       const census = new FakeCensus([
         { pid: 100, ppid: 10 },
-        { pid: 200, ppid: 100, startTime: "original" },
+        { pid: 200, ppid: 100, startTime: startTimeFor(200) },
       ]);
       ledger.registerRoot(100);
       ledger.reconcile(census);
@@ -246,7 +254,7 @@ describe("TerminalLineageLedger", () => {
 
       census.set([
         { pid: 100, ppid: 10 },
-        { pid: 200, ppid: 999, startTime: "recycled" },
+        { pid: 200, ppid: 999, startTime: `${startTimeFor(200)}-recycled` },
       ]);
       ledger.reconcile(census);
 
@@ -468,9 +476,13 @@ describe("TerminalLineageLedger", () => {
     });
 
     it("does not let an unidentified orphan adopt a subtree", async () => {
-      // Probe failure leaves 200 unidentified. It must not be able to pull an
-      // unrelated subtree into the ledger on the strength of a PID alone.
-      mockExecFileAsync.mockRejectedValue(new Error("ps unavailable"));
+      // 200 never resolves, so it has no proof it is still ours. 300 resolves
+      // fine — if the guard were removed, 200 would launder 300 into the ledger
+      // and getTrackedPids would report it.
+      mockExecFileAsync.mockImplementation(async (_file: string, args: string[]) => {
+        const pids = readRequestedPids(args).filter((pid) => pid !== 200);
+        return { stdout: psOutput(pids), stderr: "" };
+      });
       const ledger = new TerminalLineageLedger(null);
       const census = new FakeCensus([
         { pid: 100, ppid: 10 },
@@ -488,12 +500,59 @@ describe("TerminalLineageLedger", () => {
       ledger.reconcile(census);
       await flush();
       ledger.reconcile(census);
+      await flush();
+      ledger.reconcile(census);
 
-      expect(ledger.getTrackedPids(100)).toEqual([]);
+      expect(ledger.getTrackedPids(100).map((t) => t.pid)).not.toContain(300);
+    });
+
+    it("drops a tracked orphan whose PID was recycled, so it cannot adopt", async () => {
+      // POSIX prune cannot see this: the census has no start time, so PID 200
+      // still "exists". Only re-verification catches that it is someone else
+      // now — and an orphan that is not ours must not pull in its children.
+      const ledger = new TerminalLineageLedger(null);
+      const census = new FakeCensus([
+        { pid: 100, ppid: 10 },
+        { pid: 200, ppid: 100 },
+      ]);
+      ledger.registerRoot(100);
+      ledger.reconcile(census);
+      await flush();
+      census.set([
+        { pid: 100, ppid: 10 },
+        { pid: 200, ppid: 1 },
+      ]);
+      ledger.reconcile(census);
+      await flush();
+      expect(ledger.getTrackedPids(100).map((t) => t.pid)).toEqual([200]);
+
+      // PID 200 now belongs to an unrelated process with a child of its own.
+      mockExecFileAsync.mockImplementation(async (_file: string, args: string[]) => {
+        const pids = readRequestedPids(args);
+        const lines = pids.map((pid) =>
+          pid === 200 ? `  200 ${startTimeFor(7)}` : `  ${pid} ${startTimeFor(pid)}`
+        );
+        return { stdout: lines.join("\n") + "\n", stderr: "" };
+      });
+      census.set([
+        { pid: 100, ppid: 10 },
+        { pid: 200, ppid: 1 },
+        { pid: 300, ppid: 200 },
+      ]);
+      ledger.reconcile(census);
+      await flush();
+      ledger.reconcile(census);
+      await flush();
+
+      const pids = ledger.getTrackedPids(100).map((t) => t.pid);
+      expect(pids).not.toContain(200);
+      expect(pids).not.toContain(300);
     });
 
     it("requeues identification after a transient probe failure", async () => {
-      mockExecFileAsync.mockRejectedValueOnce(new Error("ps unavailable"));
+      mockExecFileAsync.mockRejectedValueOnce(
+        Object.assign(new Error("spawn ps ENOENT"), { code: "ENOENT" })
+      );
       const ledger = new TerminalLineageLedger(null);
       const census = new FakeCensus([
         { pid: 100, ppid: 10 },
@@ -686,13 +745,14 @@ describe("TerminalLineageLedger", () => {
     it("never destroys an earlier interrupted claim", () => {
       // An existing claim is another host's unreaped survivor list. Overwriting
       // it would discard the only record of those processes.
-      fs.writeFileSync(`${filePath}.reaping-earlier`, '{"earlier":true}');
+      // Exactly the destination the old fixed-name implementation deleted.
+      fs.writeFileSync(`${filePath}.reaping`, '{"earlier":true}');
       fs.writeFileSync(filePath, "{}");
 
       const claimed = claimShardLineageFile(tmpDir);
 
-      expect(fs.existsSync(`${filePath}.reaping-earlier`)).toBe(true);
-      expect(claimed).not.toBe(`${filePath}.reaping-earlier`);
+      expect(fs.existsSync(`${filePath}.reaping`)).toBe(true);
+      expect(claimed).not.toBe(`${filePath}.reaping`);
     });
 
     it("returns null when there is nothing to claim", () => {
@@ -810,7 +870,9 @@ describe("TerminalLineageLedger", () => {
     it("keeps the ledger when the probe could not run at all", async () => {
       // A blocked `ps` makes "already gone" and "cannot tell" look identical.
       // Deleting here would discard the only record of a live survivor.
-      mockExecFileAsync.mockRejectedValue(new Error("ps: Operation not permitted"));
+      mockExecFileAsync.mockRejectedValue(
+        Object.assign(new Error("spawn ps EPERM"), { code: "EPERM" })
+      );
       writeLedger([{ pid: 4242, startTime: startTimeFor(4242), rootPid: 100 }]);
 
       await reapPersistedLineages(tmpDir);
@@ -821,7 +883,9 @@ describe("TerminalLineageLedger", () => {
     });
 
     it("gives up on an unresolvable ledger after a bounded number of launches", async () => {
-      mockExecFileAsync.mockRejectedValue(new Error("ps: Operation not permitted"));
+      mockExecFileAsync.mockRejectedValue(
+        Object.assign(new Error("spawn ps EPERM"), { code: "EPERM" })
+      );
       writeLedger([{ pid: 4242, startTime: startTimeFor(4242), rootPid: 100 }], { attempts: 2 });
 
       await reapPersistedLineages(tmpDir);
@@ -831,9 +895,12 @@ describe("TerminalLineageLedger", () => {
     });
 
     it("deletes the ledger when the probe genuinely reports the PID gone", async () => {
-      // `ps` exits non-zero with empty stdout when no requested PID exists,
-      // but the call itself succeeded — that is evidence, not ambiguity.
-      mockExecFileAsync.mockImplementation(async () => ({ stdout: "", stderr: "" }));
+      // Real `ps -p` rejects with exit status 1 and empty stdout when none of
+      // the requested PIDs exist. The probe ran and gave an answer, so this is
+      // evidence of absence, not ambiguity.
+      mockExecFileAsync.mockImplementation(async () => {
+        throw Object.assign(new Error("Command failed: ps"), { code: 1, stdout: "" });
+      });
       writeLedger([{ pid: 4242, startTime: startTimeFor(4242), rootPid: 100 }]);
 
       await reapPersistedLineages(tmpDir);

--- a/electron/services/pty/ProcessTreeKiller.ts
+++ b/electron/services/pty/ProcessTreeKiller.ts
@@ -236,8 +236,11 @@ export class ProcessTreeKiller {
    * forever (#12203). The shell is already gone here, so the ledger is the
    * entire answer — and for the same reason this must never signal the shell
    * PID, which the OS is free to have recycled.
+   *
+   * @param immediate SIGKILL synchronously instead of after the grace window,
+   *   for the `process.on("exit")` context where timers never fire.
    */
-  reapAfterRootExit(escalationDelayMs?: number): void {
+  reapAfterRootExit(immediate: boolean = false, escalationDelayMs?: number): void {
     this.abort();
 
     const shellPid = this.ptyProcess.pid;
@@ -262,6 +265,12 @@ export class ProcessTreeKiller {
     for (const pid of orphans) {
       this.signal(pid, "SIGTERM");
       this.signal(pid, "SIGCONT");
+    }
+
+    if (immediate) {
+      // `process.on("exit")` context — no timer will ever fire, so escalate now.
+      this.sigkillSweep(shellPid, { includeShell: false, includeLiveWalk: false });
+      return;
     }
 
     this.killTreeTimer = setTimeout(() => {

--- a/electron/services/pty/ProcessTreeKiller.ts
+++ b/electron/services/pty/ProcessTreeKiller.ts
@@ -35,27 +35,44 @@ export interface LineageKillSource {
  */
 export class ProcessTreeKiller {
   private killTreeTimer: NodeJS.Timeout | null = null;
+  private registeredRootPid: number | null = null;
 
   constructor(
     private readonly ptyProcess: pty.IPty,
     private readonly processTreeCache: ProcessTreeCache | null,
     private readonly lineage: LineageKillSource | null = null
   ) {
-    const shellPid = this.ptyProcess.pid;
-    if (this.lineage && Number.isInteger(shellPid) && shellPid > 0) {
-      this.lineage.registerRoot(shellPid);
-    }
+    this.registerRoot(this.ptyProcess.pid);
   }
 
   /**
-   * Descendants the ledger knows about that the live walk can no longer reach,
-   * ordered leaves-first, plus any children they spawned after detaching.
+   * Register the shell PID as a lineage root. Called from the constructor, and
+   * again once a real PID lands for a Windows ConPTY terminal that spawned
+   * reporting PID 0 — without the second call those terminals would silently
+   * run with no lineage tracking at all.
    *
-   * The ledger has already re-verified every PID's start time, so everything
-   * returned here is proven to still be the process we observed rather than a
-   * recycled PID (lesson #10950). Their current subtrees are added from the
-   * live census: a wrapper that detached and then forked a build owns that
-   * build, and nothing else would reach it.
+   * Idempotent for a PID already registered by this killer: re-registering
+   * resets the lineage, which would discard descendants we have already seen.
+   */
+  registerRoot(shellPid: number | undefined): void {
+    if (!this.lineage) return;
+    if (!Number.isInteger(shellPid) || (shellPid as number) <= 0) return;
+    if (this.registeredRootPid === shellPid) return;
+    this.registeredRootPid = shellPid as number;
+    this.lineage.registerRoot(shellPid as number);
+  }
+
+  /**
+   * The kill set the live walk cannot reach: ledger members whose identity the
+   * ledger has just re-verified against the OS, ordered leaves-first.
+   *
+   * Membership is exactly the verified set — never a PID read out of the
+   * cached census. The census is seconds stale, so an unverified PID from it
+   * has no ownership proof at all, and expanding a verified parent's cached
+   * subtree would even re-admit a child that verification had explicitly
+   * rejected as recycled. Children a detached member spawned after leaving our
+   * tree are covered because the ledger's own sweep admits and identifies them;
+   * the census is used here only to order what is already proven.
    */
   private resolveOrphans(shellPid: number, live: number[]): number[] {
     if (!this.lineage) return [];
@@ -63,13 +80,15 @@ export class ProcessTreeKiller {
     const verified = this.lineage.getVerifiedOrphanPids(shellPid, live);
     if (verified.length === 0) return [];
 
+    const verifiedSet = new Set(verified);
     const ordered: number[] = [];
     const seen = new Set<number>([...live, shellPid]);
     for (const pid of verified) {
-      // getDescendantPids is post-order, so a detached wrapper's own children
-      // land ahead of it and the leaves-first contract holds across the union.
+      // getDescendantPids is post-order, so emitting a verified member's
+      // verified descendants first keeps the leaves-first contract across the
+      // union.
       for (const child of this.processTreeCache?.getDescendantPids(pid) ?? []) {
-        if (seen.has(child)) continue;
+        if (!verifiedSet.has(child) || seen.has(child)) continue;
         seen.add(child);
         ordered.push(child);
       }

--- a/electron/services/pty/ProcessTreeKiller.ts
+++ b/electron/services/pty/ProcessTreeKiller.ts
@@ -5,19 +5,80 @@ import type { ProcessTreeCache } from "../ProcessTreeCache.js";
 const SIGKILL_ESCALATION_DELAY_MS = 500;
 
 /**
+ * The lineage ledger's kill-side surface. Declared structurally so the killer
+ * stays unit-testable without the ledger's fs/subprocess machinery.
+ */
+export interface LineageKillSource {
+  registerRoot(rootPid: number): void;
+  markRootClosing(rootPid: number): void;
+  /**
+   * Tracked descendants of this root that the live walk can no longer reach,
+   * with every start time re-verified against the OS first. Identity lives in
+   * the ledger so the killer needs no subprocess or filesystem access of its
+   * own — the only PIDs it ever sees here are ones proven to still be ours.
+   */
+  getVerifiedOrphanPids(rootPid: number, alreadyCovered: readonly number[]): number[];
+}
+
+/**
  * Owns the cross-platform teardown of a PTY's process tree and its deferred
  * SIGKILL escalation timer. Extracted from TerminalProcess so the kill
  * lifecycle is testable in isolation and the escalation closure can re-read
  * the descendant list at SIGKILL time — children spawned during the 500ms
  * grace window would otherwise be orphaned.
+ *
+ * The live tree walk cannot see a descendant that already reparented to PID 1
+ * — `setsid`-detached background work does that within milliseconds of its
+ * wrapper exiting (#12203). Every signalling pass therefore targets the union
+ * of the live walk and the lineage ledger, which recorded those descendants
+ * back when they were still reachable.
  */
 export class ProcessTreeKiller {
   private killTreeTimer: NodeJS.Timeout | null = null;
 
   constructor(
     private readonly ptyProcess: pty.IPty,
-    private readonly processTreeCache: ProcessTreeCache | null
-  ) {}
+    private readonly processTreeCache: ProcessTreeCache | null,
+    private readonly lineage: LineageKillSource | null = null
+  ) {
+    const shellPid = this.ptyProcess.pid;
+    if (this.lineage && Number.isInteger(shellPid) && shellPid > 0) {
+      this.lineage.registerRoot(shellPid);
+    }
+  }
+
+  /**
+   * Descendants the ledger knows about that the live walk can no longer reach,
+   * ordered leaves-first, plus any children they spawned after detaching.
+   *
+   * The ledger has already re-verified every PID's start time, so everything
+   * returned here is proven to still be the process we observed rather than a
+   * recycled PID (lesson #10950). Their current subtrees are added from the
+   * live census: a wrapper that detached and then forked a build owns that
+   * build, and nothing else would reach it.
+   */
+  private resolveOrphans(shellPid: number, live: number[]): number[] {
+    if (!this.lineage) return [];
+
+    const verified = this.lineage.getVerifiedOrphanPids(shellPid, live);
+    if (verified.length === 0) return [];
+
+    const ordered: number[] = [];
+    const seen = new Set<number>([...live, shellPid]);
+    for (const pid of verified) {
+      // getDescendantPids is post-order, so a detached wrapper's own children
+      // land ahead of it and the leaves-first contract holds across the union.
+      for (const child of this.processTreeCache?.getDescendantPids(pid) ?? []) {
+        if (seen.has(child)) continue;
+        seen.add(child);
+        ordered.push(child);
+      }
+      if (seen.has(pid)) continue;
+      seen.add(pid);
+      ordered.push(pid);
+    }
+    return ordered;
+  }
 
   /**
    * Kill the entire process tree rooted at the PTY shell.
@@ -40,6 +101,8 @@ export class ProcessTreeKiller {
       return;
     }
 
+    this.lineage?.markRootClosing(shellPid);
+
     // Windows: use taskkill /T /F which handles the entire tree atomically
     if (process.platform === "win32") {
       try {
@@ -51,6 +114,13 @@ export class ProcessTreeKiller {
       } catch {
         // taskkill may fail if process already exited
       }
+      // taskkill /T walks the live tree, so it has the same blind spot as the
+      // Unix walk below — reparented descendants need their own pass. Exclude
+      // what the walk already covered so the taskkill above isn't repeated
+      // once per live descendant.
+      this.taskkillOrphans(
+        this.resolveOrphans(shellPid, this.processTreeCache?.getDescendantPids(shellPid) ?? [])
+      );
       try {
         this.ptyProcess.kill();
       } catch {
@@ -66,7 +136,10 @@ export class ProcessTreeKiller {
     // release fire normally. SIGTERM-then-SIGCONT (per pid) is the correct
     // order — reversing it lets the resumed process fork() new children in the
     // window between SIGCONT delivery and SIGTERM delivery.
-    const descendants = this.processTreeCache?.getDescendantPids(shellPid) ?? [];
+    const live = this.processTreeCache?.getDescendantPids(shellPid) ?? [];
+    // Orphans first: they are already detached, so nothing about signalling
+    // them can reparent a process the live walk still owns.
+    const descendants = [...this.resolveOrphans(shellPid, live), ...live];
 
     for (const pid of descendants) {
       let sigtermBlocked = false;
@@ -137,6 +210,49 @@ export class ProcessTreeKiller {
   }
 
   /**
+   * Reap descendants left behind by a shell that exited on its own.
+   *
+   * The natural-exit path previously only cancelled the escalation timer, so a
+   * user typing `exit` while a detached grandchild was alive left it running
+   * forever (#12203). The shell is already gone here, so the ledger is the
+   * entire answer — and for the same reason this must never signal the shell
+   * PID, which the OS is free to have recycled.
+   */
+  reapAfterRootExit(escalationDelayMs?: number): void {
+    this.abort();
+
+    const shellPid = this.ptyProcess.pid;
+    if (shellPid === undefined || shellPid <= 0) return;
+
+    this.lineage?.markRootClosing(shellPid);
+
+    // Deliberately no live-walk subtraction here. The census is up to one sweep
+    // old and still lists the exited shell's children beneath it, so a live walk
+    // is stale by construction — and since the shell is gone, every one of those
+    // children has already been reparented. Asking the ledger for its whole set
+    // also means each PID is start-time verified before it is signalled, which a
+    // stale live-walk entry would not be.
+    const orphans = this.resolveOrphans(shellPid, []);
+    if (orphans.length === 0) return;
+
+    if (process.platform === "win32") {
+      this.taskkillOrphans(orphans);
+      return;
+    }
+
+    for (const pid of orphans) {
+      this.signal(pid, "SIGTERM");
+      this.signal(pid, "SIGCONT");
+    }
+
+    this.killTreeTimer = setTimeout(() => {
+      this.killTreeTimer = null;
+      this.sigkillSweep(shellPid, { includeShell: false, includeLiveWalk: false });
+    }, escalationDelayMs ?? SIGKILL_ESCALATION_DELAY_MS);
+    this.killTreeTimer.unref?.();
+  }
+
+  /**
    * Cancel any pending SIGKILL escalation. Idempotent.
    */
   abort(): void {
@@ -146,9 +262,50 @@ export class ProcessTreeKiller {
     }
   }
 
-  private sigkillSweep(shellPid: number): void {
-    const descendants = this.processTreeCache?.getDescendantPids(shellPid) ?? [];
-    const allPids = [...descendants, shellPid];
+  private taskkillOrphans(orphans: number[]): void {
+    for (const pid of orphans) {
+      try {
+        spawnSync("taskkill", ["/T", "/F", "/PID", String(pid)], {
+          windowsHide: true,
+          stdio: "ignore",
+          timeout: 3000,
+        });
+      } catch {
+        // taskkill may fail if the process already exited
+      }
+    }
+  }
+
+  private signal(pid: number, sig: NodeJS.Signals): void {
+    try {
+      process.kill(pid, sig);
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== "ESRCH") {
+        console.warn(`[ProcessTreeKiller] ${sig} pid=${pid}: ${(err as Error).message}`);
+      }
+    }
+  }
+
+  private sigkillSweep(
+    shellPid: number,
+    options?: { includeShell?: boolean; includeLiveWalk?: boolean }
+  ): void {
+    // After a natural exit the shell is gone, so a walk rooted at its PID
+    // returns stale entries the ledger already covers — and covers with a
+    // verified identity, which the raw walk does not have.
+    const live =
+      options?.includeLiveWalk === false
+        ? []
+        : (this.processTreeCache?.getDescendantPids(shellPid) ?? []);
+    // Re-resolve rather than reusing the SIGTERM pass's set: start times are
+    // verified again here, so a PID freed by the SIGTERM and handed to an
+    // unrelated process in the grace window is dropped instead of SIGKILLed.
+    const orphans = this.resolveOrphans(shellPid, live);
+    const allPids = [...orphans, ...live];
+    if (options?.includeShell !== false) {
+      allPids.push(shellPid);
+    }
     for (const pid of allPids) {
       try {
         process.kill(pid, "SIGKILL");

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -1779,21 +1779,25 @@ export class TerminalProcess {
     this.sessionSnapshotter.flushSyncOnDispose();
     this.sessionSnapshotter.dispose();
 
-    // `teardown` returns false when kill() or a natural exit already ran. That
-    // distinction decides which cleanup is safe here: the root-inclusive kill
-    // signals the shell PID, and once the shell has exited that number belongs
-    // to whatever the OS handed it to next — possibly hours ago, for a
-    // preserved agent terminal that sat in the registry until app shutdown.
-    // Only a teardown that actually transitioned a live terminal may use it;
-    // an already-exited one gets the ledger-only sweep, which signals nothing
-    // it has not just re-verified.
     const wonTeardown = this.teardown("dispose");
     this.semanticBufferManager.dispose();
     this.disposeHeadless();
-    if (wonTeardown) {
-      this.processTreeKiller.execute(true);
+
+    // The root-inclusive kill signals the shell PID, which is only safe while
+    // that PID still belongs to our shell. After a *natural* exit it does not:
+    // a preserved agent terminal sits in the registry until app shutdown, by
+    // which point the OS may have handed its number to something unrelated
+    // hours earlier. Those get the ledger-only sweep, which signals nothing it
+    // has not just re-verified.
+    //
+    // A prior kill() is the opposite case — the shell is alive and mid-way
+    // through its 500ms escalation, which this call must complete synchronously
+    // because `process.on("exit")` will not run the timer.
+    const alreadyExitedNaturally = !wonTeardown && this.lifecycle.getExitReason() === "natural";
+    if (alreadyExitedNaturally) {
+      this.processTreeKiller.reapAfterRootExit(true);
     } else {
-      this.processTreeKiller.reapAfterRootExit();
+      this.processTreeKiller.execute(true);
     }
 
     // If the PTY never fired onExit (LRU eviction, app shutdown, or kill()

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -1677,6 +1677,11 @@ export class TerminalProcess {
 
   startProcessDetector(): void {
     const ptyPid = this.terminalInfo.ptyProcess.pid;
+    // Windows ConPTY can report PID 0 at spawn, leaving the killer's
+    // constructor nothing to register. This deferred path is where the real PID
+    // lands; without it those terminals silently run with no lineage tracking.
+    // registerRoot is idempotent for a PID it already holds.
+    this.processTreeKiller.registerRoot(ptyPid);
     if (
       Number.isInteger(ptyPid) &&
       ptyPid > 0 &&
@@ -1774,10 +1779,22 @@ export class TerminalProcess {
     this.sessionSnapshotter.flushSyncOnDispose();
     this.sessionSnapshotter.dispose();
 
-    this.teardown("dispose");
+    // `teardown` returns false when kill() or a natural exit already ran. That
+    // distinction decides which cleanup is safe here: the root-inclusive kill
+    // signals the shell PID, and once the shell has exited that number belongs
+    // to whatever the OS handed it to next — possibly hours ago, for a
+    // preserved agent terminal that sat in the registry until app shutdown.
+    // Only a teardown that actually transitioned a live terminal may use it;
+    // an already-exited one gets the ledger-only sweep, which signals nothing
+    // it has not just re-verified.
+    const wonTeardown = this.teardown("dispose");
     this.semanticBufferManager.dispose();
     this.disposeHeadless();
-    this.processTreeKiller.execute(true);
+    if (wonTeardown) {
+      this.processTreeKiller.execute(true);
+    } else {
+      this.processTreeKiller.reapAfterRootExit();
+    }
 
     // If the PTY never fired onExit (LRU eviction, app shutdown, or kill()
     // followed by dispose() before the kernel reaped the child), this is

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -58,7 +58,7 @@ import {
 } from "./terminalActivityPatterns.js";
 import { TerminalForensicsBuffer } from "./TerminalForensicsBuffer.js";
 import { SemanticBufferManager } from "./SemanticBufferManager.js";
-import { ProcessTreeKiller } from "./ProcessTreeKiller.js";
+import { ProcessTreeKiller, type LineageKillSource } from "./ProcessTreeKiller.js";
 import { IdentityWatcher, type IdentityWatcherDelegate } from "./IdentityWatcher.js";
 import type { SpawnContext } from "./terminalSpawn.js";
 import { getLiveAgentId } from "./terminalTitle.js";
@@ -132,6 +132,12 @@ export interface TerminalProcessDependencies {
   ptyPool: PtyPool | null;
   sabModeEnabled?: boolean;
   processTreeCache: ProcessTreeCache | null;
+  /**
+   * Records descendants while they are still reachable so teardown can reach
+   * the ones that have since reparented to PID 1 (#12203). Null disables the
+   * widened kill set and restores live-walk-only behavior.
+   */
+  lineageLedger?: LineageKillSource | null;
   imagePathProbe?: ImagePathProbe | null;
   /**
    * When set, the analysis stack (headless mirror + ActivityMonitor) runs in
@@ -445,7 +451,11 @@ export class TerminalProcess {
     // The frontend xterm.js is the sole query responder for agent terminals.
 
     this.semanticBufferManager = new SemanticBufferManager(this.terminalInfo);
-    this.processTreeKiller = new ProcessTreeKiller(ptyProcess, deps.processTreeCache);
+    this.processTreeKiller = new ProcessTreeKiller(
+      ptyProcess,
+      deps.processTreeCache,
+      deps.lineageLedger ?? null
+    );
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const self = this;
     this.foregroundProbe = new ForegroundProcessGroupProbe({
@@ -1068,7 +1078,16 @@ export class TerminalProcess {
     }
 
     this.writeQueue.dispose();
-    this.processTreeKiller.abort();
+    if (reason === "natural") {
+      // The shell exited on its own, so nothing else in this teardown reaps its
+      // process tree. Anything it spawned that had already reparented to PID 1
+      // is invisible to every live tree walk and would otherwise run forever
+      // (#12203) — the lineage ledger is the only record that can still reach
+      // it, and this is the only path that consults it on a natural exit.
+      this.processTreeKiller.reapAfterRootExit();
+    } else {
+      this.processTreeKiller.abort();
+    }
 
     // Release the master /dev/ptmx fd on Unix. Pooled terminals already do this
     // via destroyPty() on pool teardown; live terminals never called destroy(),

--- a/electron/services/pty/__tests__/ProcessTreeKiller.test.ts
+++ b/electron/services/pty/__tests__/ProcessTreeKiller.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { spawnSync } from "child_process";
 import type { IPty } from "node-pty";
 import type { ProcessTreeCache } from "../../ProcessTreeCache.js";
-import { ProcessTreeKiller } from "../ProcessTreeKiller.js";
+import { ProcessTreeKiller, type LineageKillSource } from "../ProcessTreeKiller.js";
 
 vi.mock("child_process", () => ({ spawnSync: vi.fn() }));
 
@@ -38,10 +38,32 @@ function makePty(pid: number): IPty {
   } as unknown as IPty;
 }
 
-function makeTreeCache(descendants: number[]): ProcessTreeCache {
+function makeTreeCache(
+  descendants: number[],
+  subtrees: Record<number, number[]> = {}
+): ProcessTreeCache {
   return {
-    getDescendantPids: () => descendants,
+    getDescendantPids: (rootPid: number) =>
+      rootPid in subtrees ? subtrees[rootPid] : descendants,
+    getProcess: () => undefined,
   } as unknown as ProcessTreeCache;
+}
+
+function makeLineage(
+  orphansByRoot: Record<number, number[]>
+): LineageKillSource & { closed: number[] } {
+  const closed: number[] = [];
+  return {
+    closed,
+    registerRoot: () => {},
+    markRootClosing: (rootPid: number) => {
+      closed.push(rootPid);
+    },
+    getVerifiedOrphanPids: (rootPid, alreadyCovered) => {
+      const covered = new Set(alreadyCovered);
+      return (orphansByRoot[rootPid] ?? []).filter((pid) => !covered.has(pid));
+    },
+  };
 }
 
 function makeErrnoError(code: string, message?: string): NodeJS.ErrnoException {
@@ -363,5 +385,275 @@ describe("ProcessTreeKiller — Windows taskkill", () => {
     // The `shellPid === undefined` guard returns before the platform branch.
     expect(spawnSyncMock).not.toHaveBeenCalled();
     expect(pty.kill).toHaveBeenCalledTimes(1);
+  });
+});
+
+// The lineage ledger widens the kill set to descendants that already reparented
+// to PID 1, which no tree walk can find (#12203). The ledger owns start-time
+// verification, so everything it hands back here is already proven to be ours.
+describe.skipIf(process.platform === "win32")("ProcessTreeKiller — lineage orphans", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let killSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    killSpy?.mockRestore();
+    warnSpy.mockRestore();
+    vi.useRealTimers();
+  });
+
+  it("SIGTERMs a reparented descendant the live walk cannot see", () => {
+    const killer = new ProcessTreeKiller(
+      makePty(1000),
+      makeTreeCache([], { 1000: [], 5001: [] }),
+      makeLineage({ 1000: [5001] })
+    );
+
+    killer.execute(false);
+
+    expect(killSpy).toHaveBeenCalledWith(5001, "SIGTERM");
+    expect(killSpy).toHaveBeenCalledWith(5001, "SIGCONT");
+  });
+
+  it("escalates a reparented descendant to SIGKILL after the grace window", () => {
+    const killer = new ProcessTreeKiller(
+      makePty(1000),
+      makeTreeCache([], { 1000: [], 5001: [] }),
+      makeLineage({ 1000: [5001] })
+    );
+
+    killer.execute(false);
+    killSpy.mockClear();
+    vi.advanceTimersByTime(500);
+
+    expect(killSpy).toHaveBeenCalledWith(5001, "SIGKILL");
+  });
+
+  it("signals an overlapping pid once, not twice", () => {
+    const killer = new ProcessTreeKiller(
+      makePty(1000),
+      makeTreeCache([2001], { 2001: [] }),
+      makeLineage({ 1000: [2001] })
+    );
+
+    killer.execute(true);
+
+    const sigterms = killSpy.mock.calls.filter(
+      (c: unknown[]) => c[0] === 2001 && c[1] === "SIGTERM"
+    );
+    expect(sigterms).toHaveLength(1);
+  });
+
+  it("includes children a detached member spawned after reparenting", () => {
+    const killer = new ProcessTreeKiller(
+      makePty(1000),
+      makeTreeCache([], { 1000: [], 5001: [6001] }),
+      makeLineage({ 1000: [5001] })
+    );
+
+    killer.execute(true);
+
+    expect(killSpy).toHaveBeenCalledWith(6001, "SIGTERM");
+    expect(killSpy).toHaveBeenCalledWith(5001, "SIGTERM");
+    // Leaves first: the detached wrapper's child is signalled before the wrapper.
+    const order = killSpy.mock.calls
+      .filter((c: unknown[]) => c[1] === "SIGTERM")
+      .map((c: unknown[]) => c[0]);
+    expect(order.indexOf(6001)).toBeLessThan(order.indexOf(5001));
+  });
+
+  it("marks the root closing so a recycled PID cannot inherit the lineage", () => {
+    const lineage = makeLineage({ 1000: [] });
+    const killer = new ProcessTreeKiller(makePty(1000), makeTreeCache([]), lineage);
+
+    killer.execute(true);
+
+    expect(lineage.closed).toEqual([1000]);
+  });
+
+  it("registers the shell PID as a lineage root on construction", () => {
+    const registered: number[] = [];
+    const lineage: LineageKillSource = {
+      registerRoot: (pid) => registered.push(pid),
+      markRootClosing: () => {},
+      getVerifiedOrphanPids: () => [],
+    };
+
+    new ProcessTreeKiller(makePty(1000), makeTreeCache([]), lineage);
+
+    expect(registered).toEqual([1000]);
+  });
+
+  it("does not register an invalid shell PID", () => {
+    const registered: number[] = [];
+    const lineage: LineageKillSource = {
+      registerRoot: (pid) => registered.push(pid),
+      markRootClosing: () => {},
+      getVerifiedOrphanPids: () => [],
+    };
+
+    new ProcessTreeKiller(makePty(0), makeTreeCache([]), lineage);
+
+    expect(registered).toEqual([]);
+  });
+
+  it("behaves exactly as before when no ledger is attached", () => {
+    const pty = makePty(1000);
+    const killer = new ProcessTreeKiller(pty, makeTreeCache([1001]));
+
+    killer.execute(true);
+
+    const signalled = new Set(killSpy.mock.calls.map((c: unknown[]) => c[0]));
+    expect(signalled).toEqual(new Set([1001, 1000]));
+  });
+});
+
+// A shell that exits on its own previously only cancelled the escalation timer,
+// leaving anything it had already detached running forever (#12203).
+describe.skipIf(process.platform === "win32")("ProcessTreeKiller — reapAfterRootExit", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let killSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    killSpy?.mockRestore();
+    warnSpy.mockRestore();
+    vi.useRealTimers();
+  });
+
+  it("reaps children the stale census still lists under the exited shell", () => {
+    // The census is up to one sweep old, so it still shows 5001 beneath the
+    // shell. The shell is gone, so 5001 is already reparented — subtracting a
+    // live walk here would signal nothing at all.
+    const killer = new ProcessTreeKiller(
+      makePty(1000),
+      makeTreeCache([], { 1000: [5001], 5001: [] }),
+      makeLineage({ 1000: [5001] })
+    );
+
+    killer.reapAfterRootExit();
+
+    expect(killSpy).toHaveBeenCalledWith(5001, "SIGTERM");
+  });
+
+  it("does not SIGKILL a stale-census PID the ledger cannot verify", () => {
+    // 7777 is only in the stale live walk — the ledger never identified it, so
+    // it must not be signalled on a path where the walk is untrustworthy.
+    const killer = new ProcessTreeKiller(
+      makePty(1000),
+      makeTreeCache([], { 1000: [7777], 5001: [] }),
+      makeLineage({ 1000: [5001] })
+    );
+
+    killer.reapAfterRootExit();
+    vi.advanceTimersByTime(500);
+
+    const touched = killSpy.mock.calls.map((c: unknown[]) => c[0]);
+    expect(touched).not.toContain(7777);
+    expect(touched).toContain(5001);
+  });
+
+  it("reaps a descendant left behind by a naturally exited shell", () => {
+    const killer = new ProcessTreeKiller(
+      makePty(1000),
+      makeTreeCache([], { 1000: [], 5001: [] }),
+      makeLineage({ 1000: [5001] })
+    );
+
+    killer.reapAfterRootExit();
+
+    expect(killSpy).toHaveBeenCalledWith(5001, "SIGTERM");
+    expect(killSpy).toHaveBeenCalledWith(5001, "SIGCONT");
+  });
+
+  it("never signals the shell PID — the OS may have recycled it", () => {
+    const killer = new ProcessTreeKiller(
+      makePty(1000),
+      makeTreeCache([], { 1000: [], 5001: [] }),
+      makeLineage({ 1000: [5001] })
+    );
+
+    killer.reapAfterRootExit();
+    vi.advanceTimersByTime(500);
+
+    const touched = killSpy.mock.calls.map((c: unknown[]) => c[0]);
+    expect(touched).not.toContain(1000);
+    expect(touched).toContain(5001);
+  });
+
+  it("does not touch the PTY handle — the shell is already gone", () => {
+    const pty = makePty(1000);
+    const killer = new ProcessTreeKiller(
+      pty,
+      makeTreeCache([], { 1000: [], 5001: [] }),
+      makeLineage({ 1000: [5001] })
+    );
+
+    killer.reapAfterRootExit();
+
+    expect(pty.kill).not.toHaveBeenCalled();
+  });
+
+  it("escalates surviving orphans to SIGKILL", () => {
+    const killer = new ProcessTreeKiller(
+      makePty(1000),
+      makeTreeCache([], { 1000: [], 5001: [] }),
+      makeLineage({ 1000: [5001] })
+    );
+
+    killer.reapAfterRootExit();
+    killSpy.mockClear();
+    vi.advanceTimersByTime(500);
+
+    expect(killSpy).toHaveBeenCalledWith(5001, "SIGKILL");
+  });
+
+  it("schedules nothing when there is no detached work to reap", () => {
+    const killer = new ProcessTreeKiller(
+      makePty(1000),
+      makeTreeCache([]),
+      makeLineage({ 1000: [] })
+    );
+
+    killer.reapAfterRootExit();
+    vi.advanceTimersByTime(500);
+
+    expect(killSpy).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op without a ledger", () => {
+    const pty = makePty(1000);
+    const killer = new ProcessTreeKiller(pty, makeTreeCache([1001]));
+
+    killer.reapAfterRootExit();
+    vi.advanceTimersByTime(500);
+
+    expect(killSpy).not.toHaveBeenCalled();
+    expect(pty.kill).not.toHaveBeenCalled();
+  });
+
+  it("abort() cancels the pending escalation", () => {
+    const killer = new ProcessTreeKiller(
+      makePty(1000),
+      makeTreeCache([], { 1000: [], 5001: [] }),
+      makeLineage({ 1000: [5001] })
+    );
+
+    killer.reapAfterRootExit();
+    killSpy.mockClear();
+    killer.abort();
+    vi.advanceTimersByTime(500);
+
+    expect(killSpy).not.toHaveBeenCalled();
   });
 });

--- a/electron/services/pty/__tests__/ProcessTreeKiller.test.ts
+++ b/electron/services/pty/__tests__/ProcessTreeKiller.test.ts
@@ -43,8 +43,7 @@ function makeTreeCache(
   subtrees: Record<number, number[]> = {}
 ): ProcessTreeCache {
   return {
-    getDescendantPids: (rootPid: number) =>
-      rootPid in subtrees ? subtrees[rootPid] : descendants,
+    getDescendantPids: (rootPid: number) => (rootPid in subtrees ? subtrees[rootPid] : descendants),
     getProcess: () => undefined,
   } as unknown as ProcessTreeCache;
 }
@@ -449,7 +448,29 @@ describe.skipIf(process.platform === "win32")("ProcessTreeKiller — lineage orp
     expect(sigterms).toHaveLength(1);
   });
 
-  it("includes children a detached member spawned after reparenting", () => {
+  it("signals a detached member's tracked child before the member itself", () => {
+    // Both are verified ledger members; the census only supplies the ordering.
+    const killer = new ProcessTreeKiller(
+      makePty(1000),
+      makeTreeCache([], { 1000: [], 5001: [6001], 6001: [] }),
+      makeLineage({ 1000: [5001, 6001] })
+    );
+
+    killer.execute(true);
+
+    const order = killSpy.mock.calls
+      .filter((c: unknown[]) => c[1] === "SIGTERM")
+      .map((c: unknown[]) => c[0]);
+    expect(order).toContain(6001);
+    expect(order).toContain(5001);
+    // Leaves first: the detached wrapper's child is signalled before the wrapper.
+    expect(order.indexOf(6001)).toBeLessThan(order.indexOf(5001));
+  });
+
+  it("never signals a cached-subtree PID the ledger did not verify", () => {
+    // 6001 sits under verified 5001 in the seconds-stale census but is NOT in
+    // the verified set — it may have exited and had its PID recycled. Expanding
+    // a verified parent's cached subtree would kill whatever holds it now.
     const killer = new ProcessTreeKiller(
       makePty(1000),
       makeTreeCache([], { 1000: [], 5001: [6001] }),
@@ -457,14 +478,31 @@ describe.skipIf(process.platform === "win32")("ProcessTreeKiller — lineage orp
     );
 
     killer.execute(true);
+    vi.advanceTimersByTime(500);
 
-    expect(killSpy).toHaveBeenCalledWith(6001, "SIGTERM");
-    expect(killSpy).toHaveBeenCalledWith(5001, "SIGTERM");
-    // Leaves first: the detached wrapper's child is signalled before the wrapper.
-    const order = killSpy.mock.calls
-      .filter((c: unknown[]) => c[1] === "SIGTERM")
-      .map((c: unknown[]) => c[0]);
-    expect(order.indexOf(6001)).toBeLessThan(order.indexOf(5001));
+    const touched = killSpy.mock.calls.map((c: unknown[]) => c[0]);
+    expect(touched).toContain(5001);
+    expect(touched).not.toContain(6001);
+  });
+
+  it("late-registers a root whose PID was not available at construction", () => {
+    const registered: number[] = [];
+    const lineage: LineageKillSource = {
+      registerRoot: (pid) => registered.push(pid),
+      markRootClosing: () => {},
+      getVerifiedOrphanPids: () => [],
+    };
+
+    // Windows ConPTY reports PID 0 at spawn; the real PID lands later.
+    const killer = new ProcessTreeKiller(makePty(0), makeTreeCache([]), lineage);
+    expect(registered).toEqual([]);
+
+    killer.registerRoot(4242);
+    killer.registerRoot(4242);
+
+    // Registered once — a repeat would reset the lineage and discard what we
+    // have already observed.
+    expect(registered).toEqual([4242]);
   });
 
   it("marks the root closing so a recycled PID cannot inherit the lineage", () => {

--- a/electron/services/pty/__tests__/TerminalProcess.exit-cleanup.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.exit-cleanup.test.ts
@@ -315,6 +315,38 @@ describe.skipIf(process.platform === "win32")(
       expect(touched).not.toContain(123);
     });
 
+    it("disposing after a natural exit escalates orphans without waiting", () => {
+      // dispose() can run inside process.on("exit"), where no timer fires — the
+      // SIGKILL has to happen synchronously or the orphan outlives the app.
+      const pty = createControllablePty();
+      const lineageLedger = ledgerFor([9001]);
+      const terminal = createTerminal(pty, undefined, { lineageLedger });
+
+      pty.emitExit(0);
+      killSpy.mockClear();
+      terminal.dispose();
+
+      expect(killSpy).toHaveBeenCalledWith(9001, "SIGKILL");
+    });
+
+    it("disposing after a kill still completes the pending escalation", () => {
+      // The opposite case: kill() left the shell alive mid-escalation, so
+      // dispose() must finish the job on the whole tree, shell included.
+      const pty = createControllablePty();
+      const lineageLedger = ledgerFor([9001]);
+      const terminal = createTerminal(pty, undefined, { lineageLedger });
+
+      terminal.kill("test");
+      killSpy.mockClear();
+      terminal.dispose();
+
+      const killed = killSpy.mock.calls
+        .filter((c: unknown[]) => c[1] === "SIGKILL")
+        .map((c: unknown[]) => c[0]);
+      expect(killed).toContain(123);
+      expect(killed).toContain(9001);
+    });
+
     it("disposing a still-live terminal does kill its whole tree", () => {
       // Positive control for the guard above — a dispose that actually wins the
       // lifecycle transition must still reap root and descendants.

--- a/electron/services/pty/__tests__/TerminalProcess.exit-cleanup.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.exit-cleanup.test.ts
@@ -213,3 +213,99 @@ describe("TerminalProcess onExit — master fd release (#9539)", () => {
     expect(pty.destroy).toHaveBeenCalledTimes(1);
   });
 });
+
+
+// A shell that exits on its own used to only cancel the SIGKILL escalation
+// timer, so anything it had already detached (a `setsid` background job whose
+// wrapper exited) survived forever (#12203).
+describe.skipIf(process.platform === "win32")(
+  "TerminalProcess onExit — detached descendant cleanup",
+  () => {
+    let killSpy: ReturnType<typeof vi.spyOn>;
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+      warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      killSpy.mockRestore();
+      warnSpy.mockRestore();
+      vi.useRealTimers();
+    });
+
+    function ledgerFor(orphans: number[]) {
+      return {
+        registerRoot: vi.fn<(rootPid: number) => void>(),
+        markRootClosing: vi.fn<(rootPid: number) => void>(),
+        getVerifiedOrphanPids: vi.fn<
+          (rootPid: number, alreadyCovered: readonly number[]) => number[]
+        >(() => orphans),
+      };
+    }
+
+    it("reaps a reparented descendant when the shell exits naturally", () => {
+      const pty = createControllablePty();
+      const lineageLedger = ledgerFor([9001]);
+      createTerminal(pty, undefined, { lineageLedger });
+
+      pty.emitExit(0);
+
+      expect(killSpy).toHaveBeenCalledWith(9001, "SIGTERM");
+      expect(killSpy).toHaveBeenCalledWith(9001, "SIGCONT");
+    });
+
+    it("escalates the survivor to SIGKILL after the grace window", () => {
+      const pty = createControllablePty();
+      const lineageLedger = ledgerFor([9001]);
+      createTerminal(pty, undefined, { lineageLedger });
+
+      pty.emitExit(0);
+      killSpy.mockClear();
+      vi.advanceTimersByTime(500);
+
+      expect(killSpy).toHaveBeenCalledWith(9001, "SIGKILL");
+    });
+
+    it("registers the shell as a lineage root at construction", () => {
+      const pty = createControllablePty();
+      const lineageLedger = ledgerFor([]);
+      createTerminal(pty, undefined, { lineageLedger });
+
+      expect(lineageLedger.registerRoot).toHaveBeenCalledWith(123);
+    });
+
+    it("marks the root closing so a recycled PID cannot inherit the lineage", () => {
+      const pty = createControllablePty();
+      const lineageLedger = ledgerFor([]);
+      createTerminal(pty, undefined, { lineageLedger });
+
+      pty.emitExit(0);
+
+      expect(lineageLedger.markRootClosing).toHaveBeenCalledWith(123);
+    });
+
+    it("signals nothing when the terminal left no detached work", () => {
+      const pty = createControllablePty();
+      const lineageLedger = ledgerFor([]);
+      createTerminal(pty, undefined, { lineageLedger });
+
+      pty.emitExit(0);
+      vi.advanceTimersByTime(500);
+
+      expect(killSpy).not.toHaveBeenCalled();
+    });
+
+    it("natural exit without a ledger behaves exactly as before", () => {
+      const pty = createControllablePty();
+      createTerminal(pty);
+
+      pty.emitExit(0);
+      vi.advanceTimersByTime(500);
+
+      expect(killSpy).not.toHaveBeenCalled();
+    });
+  }
+);

--- a/electron/services/pty/__tests__/TerminalProcess.exit-cleanup.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.exit-cleanup.test.ts
@@ -214,7 +214,6 @@ describe("TerminalProcess onExit — master fd release (#9539)", () => {
   });
 });
 
-
 // A shell that exits on its own used to only cancel the SIGKILL escalation
 // timer, so anything it had already detached (a `setsid` background job whose
 // wrapper exited) survived forever (#12203).
@@ -296,6 +295,38 @@ describe.skipIf(process.platform === "win32")(
       vi.advanceTimersByTime(500);
 
       expect(killSpy).not.toHaveBeenCalled();
+    });
+
+    it("disposing an already-exited terminal never signals the stale shell PID", () => {
+      // Preserved agent terminals sit in the registry after a natural exit and
+      // are disposed at app shutdown, possibly hours later. By then the shell
+      // PID belongs to whatever the OS handed it to next.
+      const pty = createControllablePty();
+      const lineageLedger = ledgerFor([9001]);
+      const terminal = createTerminal(pty, undefined, { lineageLedger });
+
+      pty.emitExit(0);
+      killSpy.mockClear();
+
+      terminal.dispose();
+      vi.advanceTimersByTime(500);
+
+      const touched = killSpy.mock.calls.map((c: unknown[]) => c[0]);
+      expect(touched).not.toContain(123);
+    });
+
+    it("disposing a still-live terminal does kill its whole tree", () => {
+      // Positive control for the guard above — a dispose that actually wins the
+      // lifecycle transition must still reap root and descendants.
+      const pty = createControllablePty();
+      const lineageLedger = ledgerFor([9001]);
+      const terminal = createTerminal(pty, undefined, { lineageLedger });
+
+      terminal.dispose();
+
+      const touched = killSpy.mock.calls.map((c: unknown[]) => c[0]);
+      expect(touched).toContain(123);
+      expect(touched).toContain(9001);
     });
 
     it("natural exit without a ledger behaves exactly as before", () => {

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -317,6 +317,17 @@ export async function setupWindowServices(
     // this never double-runs the probe and guarantees the #8625 invariant holds
     // before the fork rather than silently skipping it on a null promise.
     await (getEarlyPathRefreshPromise() ?? kickOffEarlyPathRefresh());
+    // Reap descendants a previous session left detached, before any new host
+    // can reuse their PIDs. Only orphans that reparented away from their PTY
+    // tree are persisted, and each is re-verified against its recorded start
+    // time before it is signalled (#12203). Awaited rather than fired off: a
+    // reap racing the fork could validate a PID the new host has just spawned.
+    try {
+      const { reapPersistedLineages } = await import("../services/TerminalLineageLedger.js");
+      await reapPersistedLineages(app.getPath("userData"));
+    } catch (err) {
+      console.warn("[MAIN] Previous-session lineage reap failed:", err);
+    }
     // Project-restoring boots send set-active-project with a project path
     // right after the host is ready, draining the pool — tell the host to
     // skip the homedir warm those drains would immediately kill (#10393).


### PR DESCRIPTION
## The bug

Every cleanup tier Daintree has walks *down* from a live root at the moment of teardown. A process that already reparented to `launchd` before teardown ran is not under that root any more, so none of them can see it: not `ProcessTreeKiller.execute()`, not the SIGKILL escalation, not `cleanupOrphanedPtysForShard` (process-group based, and `setsid` puts the child outside the group by definition), not `supervisor.c` (same live BFS, and only wired to help sessions). The natural-exit path did not reap at all: `teardown("natural")` only cancelled the escalation timer, so typing `exit` with a detached grandchild alive touched nothing.

That is how #12203 happened: 64 `zsh` loops pinned ~13 cores for three days and survived an app quit and relaunch. Claude Code runs every Bash tool call `setsid`-detached, and the backgrounded subshells reparented to `launchd` within milliseconds of their wrapper exiting.

## The fix

Track descendants while they are still reachable, and reap from the record rather than from a fresh walk.

`TerminalLineageLedger` rides the census `ProcessTreeCache` already runs, records every descendant it sees under a PTY shell, and keeps the record after the OS reparents it away. Teardown then signals the union of the live walk and the verified ledger, on kill, on dispose, and on natural exit. The orphaned subset is persisted per pty-host shard so a crashed host or a hard-killed app can still reap survivors on the next launch.

Identity is the safety boundary throughout. Ledger entries are old by construction (that is what lets them outlive reparenting), so a PID being present proves nothing. Every entry is anchored to its OS start time, taken no later than the census that established its ancestry, and re-verified against a live probe immediately before anything is signalled. A PID that cannot be proven is never signalled, and a probe that could not run is never read as evidence that a process is gone.

## Decisions worth flagging

**Detached processes now die with the terminal.** `nohup vite &` then closing the tab kills it. That is what #3687 asked for, and it is a deliberate divergence from Terminal.app, iTerm2, VS Code and tmux, all of which let those survive by design. Daintree is an agent orchestrator, and the failure mode we actually see is an agent leaking compute, not a user hand-rolling a daemon in a pane. No setting: a CPU-activity filter would leak idle servers holding ports, and gating a destructive action on a noisy sample cuts against "surface observations, not interpretations".

**Help/Assistant terminals are tracked too.** #11162's guard is the eviction floor (routine LRU eviction must not reach a destructive teardown), not an exemption from a genuine revoke. A revoked session's detached sub-agents should not outlive it.

**`PR_SET_CHILD_SUBREAPER` is deferred.** It would close the gap properly on Linux, but it needs a native N-API shim plus explicit `SIGCHLD`/`waitpid` handling, is lost on pty-host restart, and does nothing for macOS, where no equivalent exists and Endpoint Security is entitlement-gated. Complementary, not the cross-platform mechanism.

**This is a mitigation, not containment.** A descendant that forks, detaches, and is never sampled between two sweeps is invisible to the ledger. The sweep interval bounds that window; it cannot eliminate it. Closing it properly needs OS-level containment (cgroups, Job Objects, subreaper) rather than polling.

## Known residuals

- The pre-existing live-walk kill still signals cached PIDs without start-time verification. Closing that needs ancestry and a birth token in the same census row, which means extending the whole-system `ps` sweep, and that's deliberately out of scope here.
- The synchronous verification budget is per invocation rather than per host teardown.

## Verification

Rebased onto `develop`. Targeted suites green (`TerminalLineageLedger`, `ProcessTreeCache`, `ProcessTreeKiller`, `TerminalProcess.*`, `PtyClient.*`, `PtyManager.*`, `pty-host.adversarial`, `windowServices*`, `shutdown`, 2268 tests). `npm run typecheck` clean, `npm run lint:ratchet` down 10.

Two failures in the full local run reproduce identically on clean `origin/develop` and are unrelated to this branch: `scripts/perf/__tests__/scenarioLiveness.test.ts` PERF-063 (`batcherShortfallCount=2`), and `check:sample-views` reporting `plugins/sample/file-tree/view/file-tree-view.js` stale.

Resolves #12203
