### PR TITLE
fix(file-browser): give HTML files a source view

### DIFF
--- a/src/components/Html/HtmlViewer.tsx
+++ b/src/components/Html/HtmlViewer.tsx
@@ -11,10 +11,11 @@ export interface HtmlViewerProps {
    */
   previewUrl: string | null;
   /**
-   * Bumped by FilePane on every (re)load so a rewritten file re-renders. The
-   * cross-origin sandboxed frame can't be `location.reload()`-ed from here, so a
-   * changing cache-buster query is the only way to force a fresh navigation; the
-   * daintree-html:// handler ignores the query when mapping to disk.
+   * Bumped by the host surface on every (re)load so a rewritten file
+   * re-renders. The cross-origin sandboxed frame can't be `location.reload()`-ed
+   * from here, so a changing cache-buster query is the only way to force a fresh
+   * navigation; the daintree-html:// handler ignores the query when mapping to
+   * disk.
    */
   reloadNonce: number;
   /** Accessible name for the frame (the file name). */

--- a/src/components/Html/HtmlViewer.tsx
+++ b/src/components/Html/HtmlViewer.tsx
@@ -28,8 +28,9 @@ export interface HtmlViewerProps {
  * token-scoped CSP; `sandbox="allow-scripts"` WITHOUT `allow-same-origin` gives
  * it an opaque origin, so its scripts run but it cannot reach the app, the
  * bridge, storage, or the network. Source mode stays on CodeViewer (owned by
- * FilePane), so this component is rendered-only — a thin, non-lazy iframe
- * wrapper with no heavy deps.
+ * whichever surface hosts this — FilePane, the file browser's viewer), so this
+ * component is rendered-only — a thin, non-lazy iframe wrapper with no heavy
+ * deps.
  */
 export function HtmlViewer({ previewUrl, reloadNonce, title, className }: HtmlViewerProps) {
   const src = useMemo(() => {

--- a/src/panels/file-browser/FileBrowserPane.tsx
+++ b/src/panels/file-browser/FileBrowserPane.tsx
@@ -1307,6 +1307,7 @@ export function FileBrowserPane({
             className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden"
           >
             <FileBrowserViewer
+              panelId={id}
               filePath={selectedFilePath}
               rootPath={basePath}
               fileName={selectedFileName}

--- a/src/panels/file-browser/FileBrowserViewer.tsx
+++ b/src/panels/file-browser/FileBrowserViewer.tsx
@@ -189,10 +189,10 @@ type ViewerState =
   | { status: "pdf" }
   | { status: "error"; message: string };
 
-// Markdown gets a Source/Rendered switch mirroring FilePane's toggle. Typed at
-// the constant so the option values stay `FileRenderMode` rather than widening
-// to `string`; a two-entry list only — the browser preview has no diff mode.
-const MARKDOWN_MODE_OPTIONS: Array<{ value: FileRenderMode; label: string }> = [
+// Markdown and HTML both get a Source/Rendered switch mirroring FilePane's
+// toggle. Typed at the constant so the option values stay `FileRenderMode`
+// rather than widening to `string`; a two-entry list only — no diff mode here.
+const FILE_RENDER_MODE_OPTIONS: Array<{ value: FileRenderMode; label: string }> = [
   { value: "source", label: "Source" },
   { value: "rendered", label: "Rendered" },
 ];
@@ -240,12 +240,20 @@ export function FileBrowserViewer({
   hiddenCounts,
 }: FileBrowserViewerProps) {
   const [state, setState] = useState<ViewerState>({ status: "idle" });
-  // Sticky Source/Rendered choice for markdown, defaulting to the rendered view
-  // this pane has always shown. Deliberately not reset on file change: a reader
-  // paging through docs in source keeps source, mirroring FilePane (whose
-  // per-panel mode also survives a file swap). Non-markdown files simply hide
-  // the toggle, so a stale "source" never applies where it can't be honoured.
-  const [markdownMode, setMarkdownMode] = useState<FileRenderMode>("rendered");
+  // The reader's explicit Source/Rendered choice, `null` until they touch the
+  // toggle. Untouched, each renderable type opens on the default that suits it:
+  // markdown is a document you read rendered, while HTML in a repo is code you
+  // opened to read, and a page that renders near-blank otherwise looks like a
+  // broken file (#12205). Once chosen the mode is sticky and shared across both
+  // types, deliberately not reset on file change: a reader paging through docs
+  // in source keeps source, mirroring FilePane (whose per-panel mode also
+  // survives a file swap). Files that are neither simply hide the toggle, so a
+  // stale mode never applies where it can't be honoured.
+  const [explicitRenderMode, setExplicitRenderMode] = useState<FileRenderMode | null>(null);
+  const isMarkdown = filePath !== null && isMarkdownFilePath(filePath);
+  const isHtml = filePath !== null && isHtmlFilePath(filePath);
+  const isRenderable = isMarkdown || isHtml;
+  const renderMode: FileRenderMode = explicitRenderMode ?? (isHtml ? "source" : "rendered");
   // The same app-level reading size the file panel shows, so a document is the
   // size the reader last chose in whichever surface they opened it (#12134).
   const markdownFontSize = usePreferencesStore((state) => state.markdownFontSize);
@@ -479,11 +487,11 @@ export function FileBrowserViewer({
         </FileViewerToolbar.IconButton>
         {filePath && (
           <>
-            {isMarkdownFilePath(filePath) && (
+            {isRenderable && (
               <SegmentedToggle<FileRenderMode>
-                options={MARKDOWN_MODE_OPTIONS}
-                value={markdownMode}
-                onChange={setMarkdownMode}
+                options={FILE_RENDER_MODE_OPTIONS}
+                value={renderMode}
+                onChange={setExplicitRenderMode}
               />
             )}
             <FileViewerToolbar.Path
@@ -530,7 +538,7 @@ export function FileBrowserViewer({
               does not reach, and every other preview kind has no prose to
               tune. Sits ahead of the file actions so the controls that change
               what you are looking at stay left of the ones that leave. */}
-          {filePath !== null && isMarkdownFilePath(filePath) && markdownMode === "rendered" && (
+          {isMarkdown && renderMode === "rendered" && (
             <MarkdownTextSizeControl
               value={markdownFontSize}
               onValueChange={setMarkdownFontSize}
@@ -874,12 +882,20 @@ export function FileBrowserViewer({
         );
 
       case "html":
+        // Source is the same CodeViewer the non-markdown text branch uses, off
+        // content the preview read already returned — switching modes never
+        // costs a second read. A null previewUrl still renders HtmlViewer in
+        // rendered mode rather than silently showing source: its empty state
+        // says why and points at the Source segment, which now exists here.
+        if (renderMode === "source") {
+          return <CodeViewer content={state.content} filePath={filePath} className="h-full" />;
+        }
         return (
           <HtmlViewer previewUrl={state.previewUrl} reloadNonce={reloadNonce} title={fileName} />
         );
 
       case "text":
-        if (!isMarkdownFilePath(filePath)) {
+        if (!isMarkdown) {
           return <CodeViewer content={state.content} filePath={filePath} className="h-full" />;
         }
         // Source mode was never part of #11441: CodeViewer's root is already a
@@ -890,13 +906,13 @@ export function FileBrowserViewer({
         // lines here don't wrap (CodeViewer defaults `wrapLines` to false).
         // `min-h-0` only replaces MarkdownViewer's min-h-[300px] floor, which
         // used to overflow a preview shorter than 300px.
-        if (markdownMode === "source") {
+        if (renderMode === "source") {
           return (
             <MarkdownViewer
               content={state.content}
               filePath={filePath}
               rootPath={rootPath}
-              viewMode={markdownMode}
+              viewMode={renderMode}
               className="h-full min-h-0"
             />
           );
@@ -919,7 +935,7 @@ export function FileBrowserViewer({
               content={state.content}
               filePath={filePath}
               rootPath={rootPath}
-              viewMode={markdownMode}
+              viewMode={renderMode}
               fontSize={markdownFontSize}
               cacheBust={revision}
               className="min-h-full"

--- a/src/panels/file-browser/FileBrowserViewer.tsx
+++ b/src/panels/file-browser/FileBrowserViewer.tsx
@@ -63,6 +63,8 @@ import type { WorkingTreeFileChange } from "@/lib/workingTreeDiff";
 import { FileBrowserChangeSummary } from "./FileBrowserChangeSummary";
 
 export interface FileBrowserViewerProps {
+  /** Owning panel's id, so a mode chosen in one panel stays in that panel. */
+  panelId: string;
   /** Absolute path of the selected file; null when nothing is selected. */
   filePath: string | null;
   /** Absolute worktree root — the containment root for reads and asset loads. */
@@ -207,6 +209,7 @@ const FILE_RENDER_MODE_OPTIONS: Array<{ value: FileRenderMode; label: string }> 
  * copy, so a file looks identical in either surface.
  */
 export function FileBrowserViewer({
+  panelId,
   filePath,
   rootPath,
   fileName,
@@ -254,6 +257,20 @@ export function FileBrowserViewer({
   const isHtml = filePath !== null && isHtmlFilePath(filePath);
   const isRenderable = isMarkdown || isHtml;
   const renderMode: FileRenderMode = explicitRenderMode ?? (isHtml ? "source" : "rendered");
+  // The panel id rides a sentinel because this component is not remounted per
+  // panel: a tab group renders one unkeyed GridPanel for whichever tab is
+  // active, so switching between two file browsers reuses this instance —
+  // `FileBrowserPane` guards its cursor the same way, and for the same reason.
+  // Adjusting state during render is React's documented alternative to an
+  // effect here: it re-renders before paint, so the new panel's first file is
+  // never briefly shown in the old panel's mode. Without it a Rendered choice
+  // made in one panel would decide how the next panel's first file opens, and
+  // an HTML file there would land on the very preview it is meant not to.
+  const [modeOwnerPanelId, setModeOwnerPanelId] = useState(panelId);
+  if (modeOwnerPanelId !== panelId) {
+    setModeOwnerPanelId(panelId);
+    setExplicitRenderMode(null);
+  }
   // The same app-level reading size the file panel shows, so a document is the
   // size the reader last chose in whichever surface they opened it (#12134).
   const markdownFontSize = usePreferencesStore((state) => state.markdownFontSize);

--- a/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
@@ -59,11 +59,22 @@ vi.mock("@/components/Markdown/MarkdownTextSizeControl", () => ({
     />
   ),
 }));
+// Both leaves surface the props the branch hands them: which mock renders only
+// proves the routing, and an HTML source branch wired to empty content or the
+// wrong path would satisfy that while showing the reader nothing (#12205).
 vi.mock("@/components/FileViewer/CodeViewer", () => ({
-  CodeViewer: () => <div data-testid="code-viewer-mock" />,
+  CodeViewer: (props: { content: string; filePath: string }) => (
+    <div
+      data-testid="code-viewer-mock"
+      data-content={props.content}
+      data-file-path={props.filePath}
+    />
+  ),
 }));
 vi.mock("@/components/Html/HtmlViewer", () => ({
-  HtmlViewer: () => <div data-testid="html-viewer-mock" />,
+  HtmlViewer: (props: { previewUrl: string | null }) => (
+    <div data-testid="html-viewer-mock" data-preview-url={props.previewUrl ?? ""} />
+  ),
 }));
 
 // Surfaces the `active` prop instead of letting the real component apply its
@@ -192,6 +203,7 @@ import type {
 import type { FolderListingStatus } from "../useFileBrowserTree";
 
 interface ViewerOpts {
+  panelId?: string;
   sidebarCollapsed?: boolean;
   onToggleSidebar?: () => void;
   revision?: string;
@@ -249,6 +261,7 @@ function viewerJsx(filePath: string | null, opts: ViewerOpts = {}) {
   return (
     <TooltipProvider>
       <FileBrowserViewer
+        panelId={opts.panelId ?? "panel-1"}
         filePath={filePath}
         rootPath="/repo"
         fileName={fileName}
@@ -301,6 +314,19 @@ async function clickMode(label: "Source" | "Rendered") {
 // An HTML read as the pane really gets it: raw markup plus the sandboxed
 // preview URL main minted for it.
 const HTML_READ = { content: "<h1>hi</h1>\n", htmlPreviewUrl: "daintree-html://preview/1" };
+
+// Answers each path with its own bytes. Handing every read the same content
+// would let a viewer that never re-read on a file change pass the navigation
+// tests on the first file's stale state.
+function readByPath() {
+  readMock.mockImplementation(({ path }: { path: string }) =>
+    Promise.resolve(isHtmlPath(path) ? HTML_READ : { content: `# ${path}` })
+  );
+}
+
+function isHtmlPath(path: string): boolean {
+  return path.endsWith(".html");
+}
 
 function currentViewMode(): string | null {
   return screen.getByTestId("markdown-viewer-mock").getAttribute("data-view-mode");
@@ -390,26 +416,36 @@ describe("FileBrowserViewer Source/Rendered toggle (#11319, #12205)", () => {
   });
 
   it("shows the toggle and defaults an HTML file to source (#12205)", async () => {
-    readMock.mockResolvedValue(HTML_READ);
+    readByPath();
     renderViewer("/repo/page.html");
 
     // The markup, not the sandboxed page: HTML in a repo is code you opened to
-    // read, and a page that renders near-blank reads as a broken file.
-    await screen.findByTestId("code-viewer-mock");
+    // read, and a page that renders near-blank reads as a broken file. Assert
+    // the bytes, not just the branch — a CodeViewer handed nothing would show
+    // the reader an empty pane while still satisfying the routing.
+    const source = await screen.findByTestId("code-viewer-mock");
+    expect(source.getAttribute("data-content")).toBe(HTML_READ.content);
+    expect(source.getAttribute("data-file-path")).toBe("/repo/page.html");
     expect(screen.queryByTestId("html-viewer-mock")).toBeNull();
-    expect(screen.getByRole("button", { name: "Source" })).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Rendered" })).toBeTruthy();
+    // The segment the reader sees selected has to agree with what is on screen.
+    expect(screen.getByRole("button", { name: "Source" }).getAttribute("aria-pressed")).toBe(
+      "true"
+    );
+    expect(screen.getByRole("button", { name: "Rendered" }).getAttribute("aria-pressed")).toBe(
+      "false"
+    );
   });
 
   it("switches HTML between source and rendered without a second read", async () => {
-    // No htmlPreviewUrl: mode routing is driven by the toggle alone, never by
-    // whether main produced a preview. HtmlViewer owns the missing-URL copy.
-    readMock.mockResolvedValue({ content: "<h1>hi</h1>\n" });
+    readMock.mockResolvedValue(HTML_READ);
     renderViewer("/repo/page.html");
     await screen.findByTestId("code-viewer-mock");
 
     await clickMode("Rendered");
-    await screen.findByTestId("html-viewer-mock");
+    const rendered = await screen.findByTestId("html-viewer-mock");
+    // The preview URL main minted, not a null that would strand HtmlViewer on
+    // its "can't render this file" fallback.
+    expect(rendered.getAttribute("data-preview-url")).toBe(HTML_READ.htmlPreviewUrl);
     expect(screen.queryByTestId("code-viewer-mock")).toBeNull();
 
     await clickMode("Source");
@@ -421,14 +457,17 @@ describe("FileBrowserViewer Source/Rendered toggle (#11319, #12205)", () => {
   });
 
   it("applies each file type's own default until a mode is explicitly chosen", async () => {
-    readMock.mockResolvedValue(HTML_READ);
+    readByPath();
     const { rerender } = renderViewer("/repo/docs/spec.md");
     await waitFor(() => expect(currentViewMode()).toBe("rendered"));
 
     // Untouched, the toggle is not carrying a choice around: each type opens on
     // what suits it, so an HTML file lands on source even after rendered markdown.
     rerender(viewerJsx("/repo/page.html"));
-    await screen.findByTestId("code-viewer-mock");
+    const source = await screen.findByTestId("code-viewer-mock");
+    // The HTML file's own bytes: a viewer that never re-read would still be
+    // holding the markdown text, and that renders through CodeViewer too.
+    expect(source.getAttribute("data-content")).toBe(HTML_READ.content);
     expect(screen.queryByTestId("html-viewer-mock")).toBeNull();
 
     rerender(viewerJsx("/repo/docs/spec.md"));
@@ -436,7 +475,7 @@ describe("FileBrowserViewer Source/Rendered toggle (#11319, #12205)", () => {
   });
 
   it("shares the last explicit mode between markdown and HTML", async () => {
-    readMock.mockResolvedValue(HTML_READ);
+    readByPath();
     const { rerender } = renderViewer("/repo/docs/spec.md");
     await waitFor(() => expect(currentViewMode()).toBe("rendered"));
     await clickMode("Source");
@@ -453,6 +492,41 @@ describe("FileBrowserViewer Source/Rendered toggle (#11319, #12205)", () => {
     // Rendered on the HTML file is what markdown shows on the way back.
     rerender(viewerJsx("/repo/docs/spec.md"));
     await waitFor(() => expect(currentViewMode()).toBe("rendered"));
+  });
+
+  it("keeps the explicit mode across a file with no rendered form", async () => {
+    readByPath();
+    const { rerender } = renderViewer("/repo/page.html");
+    await screen.findByTestId("code-viewer-mock");
+    await clickMode("Rendered");
+    await screen.findByTestId("html-viewer-mock");
+
+    // The toggle is hidden where it can't be honoured, but the choice behind it
+    // is only suspended, not discarded — the reader picked it once.
+    rerender(viewerJsx("/repo/src/notes.txt"));
+    await screen.findByTestId("code-viewer-mock");
+    expect(screen.queryByRole("button", { name: "Rendered" })).toBeNull();
+
+    rerender(viewerJsx(null));
+    await waitFor(() => expect(screen.queryByRole("button", { name: "Rendered" })).toBeNull());
+
+    rerender(viewerJsx("/repo/page.html"));
+    await screen.findByTestId("html-viewer-mock");
+  });
+
+  it("does not carry one panel's mode into the next panel's first file", async () => {
+    // A tab group renders one unkeyed viewer for whichever file browser is
+    // active, so a panel switch is a prop change, not a remount. Without the
+    // panel-id guard the choice made here would decide how panel two's HTML
+    // opens — landing it on the rendered page this issue is about.
+    readByPath();
+    const { rerender } = renderViewer("/repo/docs/spec.md", { panelId: "panel-1" });
+    await waitFor(() => expect(currentViewMode()).toBe("rendered"));
+    await clickMode("Rendered");
+
+    rerender(viewerJsx("/repo/page.html", { panelId: "panel-2" }));
+    await screen.findByTestId("code-viewer-mock");
+    expect(screen.queryByTestId("html-viewer-mock")).toBeNull();
   });
 });
 
@@ -1223,6 +1297,12 @@ describe("FileBrowserViewer copy file contents (#12136)", () => {
       htmlPreviewUrl: "daintree-html://preview/1",
     });
     renderViewer("/repo/page.html");
+
+    // HTML opens on source now (#12205), so switch to the preview first —
+    // copying while the iframe is showing is what this case is here to prove.
+    await screen.findByTestId("code-viewer-mock");
+    await clickMode("Rendered");
+    await screen.findByTestId("html-viewer-mock");
 
     fireEvent.click(await screen.findByRole("button", { name: "Copy file contents" }));
 

--- a/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserViewer.test.tsx
@@ -6,10 +6,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // module in ahead of its own mock.
 import type { MarkdownViewerProps } from "@/components/Markdown/MarkdownViewer";
 
-// FileBrowserViewer is the read-only preview beside the tree. #11319 adds a
-// Source/Rendered toggle for markdown, mirroring FilePane. Mock the heavy leaf
-// viewers so only FileBrowserViewer's own toolbar + mode wiring renders, and
-// capture the viewMode handed to MarkdownViewer — the seam the toggle drives.
+// FileBrowserViewer is the read-only preview beside the tree. #11319 added a
+// Source/Rendered toggle for markdown and #12205 extended it to HTML, mirroring
+// FilePane. Mock the heavy leaf viewers so only FileBrowserViewer's own toolbar
+// + mode wiring renders, and capture the viewMode handed to MarkdownViewer —
+// the seam the toggle drives for markdown. HTML has no such prop (HtmlViewer is
+// rendered-only), so there the mode shows up as which mock is on screen.
 const { readMock } = vi.hoisted(() => ({ readMock: vi.fn() }));
 vi.mock("@/clients/filesClient", () => ({
   filesClient: { read: readMock },
@@ -296,6 +298,10 @@ async function clickMode(label: "Source" | "Rendered") {
   });
 }
 
+// An HTML read as the pane really gets it: raw markup plus the sandboxed
+// preview URL main minted for it.
+const HTML_READ = { content: "<h1>hi</h1>\n", htmlPreviewUrl: "daintree-html://preview/1" };
+
 function currentViewMode(): string | null {
   return screen.getByTestId("markdown-viewer-mock").getAttribute("data-view-mode");
 }
@@ -334,7 +340,7 @@ beforeEach(() => {
   }
 });
 
-describe("FileBrowserViewer markdown Source/Rendered toggle (#11319)", () => {
+describe("FileBrowserViewer Source/Rendered toggle (#11319, #12205)", () => {
   it("shows the toggle and defaults to the rendered view for a markdown file", async () => {
     renderViewer("/repo/docs/spec.md");
     // Default preserves the pane's long-standing rendered-first behaviour.
@@ -366,10 +372,11 @@ describe("FileBrowserViewer markdown Source/Rendered toggle (#11319)", () => {
     await waitFor(() => expect(currentViewMode()).toBe("source"));
   });
 
-  it("drops the toggle and its stale source choice when switching to a non-markdown file", async () => {
+  it("drops the toggle and its stale source choice when switching to a non-renderable file", async () => {
     // Start on markdown in Source, then navigate to a .txt in the same viewer —
-    // the tree's real usage. Proves the markdown-only toggle disappears and the
-    // sticky "source" choice can't leak into the CodeViewer (non-markdown) branch.
+    // the tree's real usage. Proves the toggle disappears for a file with no
+    // rendered form, and the sticky "source" choice can't leak into the
+    // CodeViewer (non-renderable) branch.
     const { rerender } = renderViewer("/repo/docs/a.md");
     await waitFor(() => expect(currentViewMode()).toBe("rendered"));
     await clickMode("Source");
@@ -380,6 +387,72 @@ describe("FileBrowserViewer markdown Source/Rendered toggle (#11319)", () => {
     expect(screen.queryByRole("button", { name: "Source" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Rendered" })).toBeNull();
     expect(screen.queryByTestId("markdown-viewer-mock")).toBeNull();
+  });
+
+  it("shows the toggle and defaults an HTML file to source (#12205)", async () => {
+    readMock.mockResolvedValue(HTML_READ);
+    renderViewer("/repo/page.html");
+
+    // The markup, not the sandboxed page: HTML in a repo is code you opened to
+    // read, and a page that renders near-blank reads as a broken file.
+    await screen.findByTestId("code-viewer-mock");
+    expect(screen.queryByTestId("html-viewer-mock")).toBeNull();
+    expect(screen.getByRole("button", { name: "Source" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Rendered" })).toBeTruthy();
+  });
+
+  it("switches HTML between source and rendered without a second read", async () => {
+    // No htmlPreviewUrl: mode routing is driven by the toggle alone, never by
+    // whether main produced a preview. HtmlViewer owns the missing-URL copy.
+    readMock.mockResolvedValue({ content: "<h1>hi</h1>\n" });
+    renderViewer("/repo/page.html");
+    await screen.findByTestId("code-viewer-mock");
+
+    await clickMode("Rendered");
+    await screen.findByTestId("html-viewer-mock");
+    expect(screen.queryByTestId("code-viewer-mock")).toBeNull();
+
+    await clickMode("Source");
+    await screen.findByTestId("code-viewer-mock");
+
+    // Both surfaces come off the one read — the preview call already returned
+    // the raw markup, so toggling must never go back to the main process.
+    expect(readMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies each file type's own default until a mode is explicitly chosen", async () => {
+    readMock.mockResolvedValue(HTML_READ);
+    const { rerender } = renderViewer("/repo/docs/spec.md");
+    await waitFor(() => expect(currentViewMode()).toBe("rendered"));
+
+    // Untouched, the toggle is not carrying a choice around: each type opens on
+    // what suits it, so an HTML file lands on source even after rendered markdown.
+    rerender(viewerJsx("/repo/page.html"));
+    await screen.findByTestId("code-viewer-mock");
+    expect(screen.queryByTestId("html-viewer-mock")).toBeNull();
+
+    rerender(viewerJsx("/repo/docs/spec.md"));
+    await waitFor(() => expect(currentViewMode()).toBe("rendered"));
+  });
+
+  it("shares the last explicit mode between markdown and HTML", async () => {
+    readMock.mockResolvedValue(HTML_READ);
+    const { rerender } = renderViewer("/repo/docs/spec.md");
+    await waitFor(() => expect(currentViewMode()).toBe("rendered"));
+    await clickMode("Source");
+    await waitFor(() => expect(currentViewMode()).toBe("source"));
+
+    // The explicit choice overrides HTML's source default only in the sense
+    // that it is the same value here; the load-bearing half is the return trip.
+    rerender(viewerJsx("/repo/page.html"));
+    await screen.findByTestId("code-viewer-mock");
+    await clickMode("Rendered");
+    await screen.findByTestId("html-viewer-mock");
+
+    // One toggle position for the viewer, not one per file type: choosing
+    // Rendered on the HTML file is what markdown shows on the way back.
+    rerender(viewerJsx("/repo/docs/spec.md"));
+    await waitFor(() => expect(currentViewMode()).toBe("rendered"));
   });
 });
 


### PR DESCRIPTION
## Summary

- Opening an HTML file in the file browser panel always showed the rendered page in a sandboxed iframe, with no way to see source. The Source/Rendered toggle existed but was gated on `isMarkdownFilePath`, so HTML never got it, even though the file panel (`FilePane`) already treats HTML as renderable.
- The toggle is now gated on `isRenderable` (markdown or HTML). The `html` render branch splits on mode: source renders `CodeViewer` off the content the preview read already returned, rendered keeps the existing `HtmlViewer`. Switching modes costs no second read.
- HTML defaults to source, markdown keeps defaulting to rendered, and the choice is scoped to the owning panel so a Rendered pick in one file browser can't decide how the next panel's first HTML file opens.

Resolves #12205

## Changes

1. Toggle gating moved from markdown-only to `isRenderable`, and the render branch for `html` now checks mode instead of always mounting `HtmlViewer`.
2. The single `markdownMode` state became a nullable explicit choice: `explicitRenderMode ?? (isHtml ? "source" : "rendered")`. Each file type opens on its own suited default; once a reader picks a mode it's sticky and shared across both types, same as the markdown-only toggle behaved before.
3. The mode is now scoped to the owning panel. A tab group renders one unkeyed viewer, so switching between two file browsers was reusing the instance, letting one panel's Rendered choice decide how the next panel's first file opened. Guarded with the same render-time panel-id sentinel `FileBrowserPane` already uses for its cursor.
4. `HtmlViewer`'s null-`previewUrl` empty state said "Switch to Source to view the markup." On this surface that instruction now points at a control that actually exists.

## Testing

- 6 new cases in `FileBrowserViewer.test.tsx`: HTML defaults to source with the right bytes and the right segment pressed; source/rendered switching with a single read; per-type defaults until a mode is chosen; the choice shared between markdown and HTML; the choice surviving a non-renderable file and a null selection; one panel's mode not carrying into the next panel.
- The `CodeViewer`/`HtmlViewer` test mocks now surface `content`, `filePath`, and `previewUrl` so the branches prove what they hand the leaf component, not just which one they route to. Navigation tests answer each read by path so a stale body can't masquerade as a fresh one.
- The three pre-existing markdown toggle tests are unchanged and pass. The existing HTML copy test now clicks Rendered first, restoring its original intent of copying while the preview is showing.
- 377 tests pass across `FileBrowserViewer`, `FileBrowserPane`, `FileBrowserViewOptions`, `HtmlViewer`, and `FilePane` suites. Prettier and eslint clean on the changed files (the one remaining warning is a pre-existing `setTimeout` magic number outside the change). `tsc --noEmit` clean.
- Reviewed twice by Codex: the panel-scoping issue came out of the first pass, the second confirmed the fix held with no React Compiler diagnostic or budget regression.