### PR TITLE
fix(file-menu): say why Insert file reference is disabled

### DIFF
--- a/src/components/FileViewer/__tests__/DiffFileSidebar.test.tsx
+++ b/src/components/FileViewer/__tests__/DiffFileSidebar.test.tsx
@@ -17,7 +17,11 @@ vi.mock("@/services/ActionService", () => ({
 }));
 
 vi.mock("@/hooks/useInsertFileReference", () => ({
-  useInsertFileReference: () => ({ canInsert: false, insert: () => false }),
+  useInsertFileReference: () => ({
+    canInsert: false,
+    refusalReason: "no-eligible-agent",
+    insert: () => false,
+  }),
 }));
 
 const { itemsRef } = vi.hoisted(() => ({

--- a/src/components/Worktree/__tests__/FileChangeList.pluginMenu.test.tsx
+++ b/src/components/Worktree/__tests__/FileChangeList.pluginMenu.test.tsx
@@ -27,7 +27,11 @@ vi.mock("@/hooks/usePluginContextMenuItems", () => ({
 // stand up; the menu item's enabled/disabled branch is covered in the hook's
 // own suite.
 vi.mock("@/hooks/useInsertFileReference", () => ({
-  useInsertFileReference: () => ({ canInsert: false, insert: () => false }),
+  useInsertFileReference: () => ({
+    canInsert: false,
+    refusalReason: "no-eligible-agent",
+    insert: () => false,
+  }),
 }));
 
 import {

--- a/src/hooks/__tests__/useFileRowMenuItems.test.tsx
+++ b/src/hooks/__tests__/useFileRowMenuItems.test.tsx
@@ -4,7 +4,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach, beforeAll } from "vitest";
 import { render, screen, cleanup, fireEvent, within, waitFor } from "@testing-library/react";
 import type { PluginContextMenuItemEntry } from "@/hooks/usePluginContextMenuItems";
-import type { InsertFileReferenceRefusalReason } from "@/hooks/useInsertFileReference";
+import type {
+  InsertFileReference,
+  InsertFileReferenceRefusalReason,
+} from "@/hooks/useInsertFileReference";
 
 // Typed rather than bare `vi.fn()`: the destructuring below reads positional
 // args off `mock.calls`, and an untyped double makes those `unknown[]` — which
@@ -54,11 +57,11 @@ vi.mock("@/hooks/useWorktreeActions", () => ({
 const { itemsRef, insertRef } = vi.hoisted(() => ({
   itemsRef: { current: [] as PluginContextMenuItemEntry[] },
   insertRef: {
-    current: { canInsert: true, refusalReason: null, insert: vi.fn(() => true) } as {
-      canInsert: boolean;
-      refusalReason: InsertFileReferenceRefusalReason | null;
-      insert: () => boolean;
-    },
+    current: {
+      canInsert: true,
+      refusalReason: null,
+      insert: vi.fn(() => true),
+    } as InsertFileReference,
   },
 }));
 vi.mock("@/hooks/usePluginContextMenuItems", () => ({
@@ -412,15 +415,15 @@ describe("useFileRowMenuItems — Insert file reference refusal reasons", () => 
     ],
     [
       "backend-unavailable",
-      "Terminal service down",
-      "Insert file reference, the terminal service is down",
+      "No terminal service",
+      "Insert file reference, the terminal service is unavailable",
     ],
     [
       "recorded-target-unavailable",
       "Agent unavailable",
       "Insert file reference, that agent can't take input",
     ],
-    ["no-eligible-agent", "No agent in the grid", "Insert file reference, no agent is in the grid"],
+    ["no-eligible-agent", "No agent available", "Insert file reference, no agent is available"],
     [
       "multiple-eligible-agents",
       "Type to an agent",
@@ -440,16 +443,14 @@ describe("useFileRowMenuItems — Insert file reference refusal reasons", () => 
 
       expect(item.getAttribute("data-disabled")).not.toBeNull();
       expect(item.getAttribute("aria-label")).toBe(ariaLabel);
-      expect(item.textContent).toContain(meta);
+      // The element, not just the text: the reason has to be in the trailing
+      // meta slot, and it has to stay hidden from assistive tech because the
+      // accessible name above already carries it. A second announced copy is
+      // the failure `ContextMenuMeta` is `aria-hidden` to prevent.
+      const metaEl = within(item).getByText(meta);
+      expect(metaEl.getAttribute("aria-hidden")).toBe("true");
     });
   }
-
-  it("hides the reason from assistive tech, since the accessible name already carries it", async () => {
-    const item = await openDisabled("multiple-eligible-agents");
-
-    const meta = within(item).getByText("Type to an agent");
-    expect(meta.getAttribute("aria-hidden")).toBe("true");
-  });
 
   it("drops the shortcut hint while disabled — the keybinding would be a lie", async () => {
     const item = await openDisabled("no-eligible-agent");
@@ -470,16 +471,6 @@ describe("useFileRowMenuItems — Insert file reference refusal reasons", () => 
     for (const [, meta] of CASES) {
       expect(item.textContent).not.toContain(meta);
     }
-  });
-
-  it("degrades to a bare disabled row when a caller reports no reason at all", async () => {
-    insertRef.current = { canInsert: false, refusalReason: null, insert: vi.fn(() => false) };
-    const menu = await openMenu();
-    const item = within(menu).getByRole("menuitem", { name: /Insert file reference/ });
-
-    expect(item.getAttribute("data-disabled")).not.toBeNull();
-    expect(item.hasAttribute("aria-label")).toBe(false);
-    expect(item.textContent).not.toContain("⌘I");
   });
 });
 

--- a/src/hooks/__tests__/useFileRowMenuItems.test.tsx
+++ b/src/hooks/__tests__/useFileRowMenuItems.test.tsx
@@ -4,6 +4,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach, beforeAll } from "vitest";
 import { render, screen, cleanup, fireEvent, within, waitFor } from "@testing-library/react";
 import type { PluginContextMenuItemEntry } from "@/hooks/usePluginContextMenuItems";
+import type { InsertFileReferenceRefusalReason } from "@/hooks/useInsertFileReference";
 
 // Typed rather than bare `vi.fn()`: the destructuring below reads positional
 // args off `mock.calls`, and an untyped double makes those `unknown[]` — which
@@ -52,7 +53,13 @@ vi.mock("@/hooks/useWorktreeActions", () => ({
 
 const { itemsRef, insertRef } = vi.hoisted(() => ({
   itemsRef: { current: [] as PluginContextMenuItemEntry[] },
-  insertRef: { current: { canInsert: true, insert: vi.fn(() => true) } },
+  insertRef: {
+    current: { canInsert: true, refusalReason: null, insert: vi.fn(() => true) } as {
+      canInsert: boolean;
+      refusalReason: InsertFileReferenceRefusalReason | null;
+      insert: () => boolean;
+    },
+  },
 }));
 vi.mock("@/hooks/usePluginContextMenuItems", () => ({
   usePluginContextMenuItems: () => itemsRef.current,
@@ -184,7 +191,7 @@ beforeEach(() => {
   notifyMock.mockClear();
   copyContextMock.mockClear();
   itemsRef.current = [];
-  insertRef.current = { canInsert: true, insert: vi.fn(() => true) };
+  insertRef.current = { canInsert: true, refusalReason: null, insert: vi.fn(() => true) };
   writeTextMock.mockReset();
   writeTextMock.mockResolvedValue(undefined);
   Object.assign(navigator, { clipboard: { writeText: writeTextMock } });
@@ -376,11 +383,103 @@ describe("useFileRowMenuItems — conditional items", () => {
   });
 
   it("disables Insert file reference when no agent resolves", async () => {
-    insertRef.current = { canInsert: false, insert: vi.fn(() => false) };
+    insertRef.current = {
+      canInsert: false,
+      refusalReason: "no-eligible-agent",
+      insert: vi.fn(() => false),
+    };
     const menu = await openMenu();
 
     const item = within(menu).getByRole("menuitem", { name: /Insert file reference/ });
     expect(item.getAttribute("data-disabled")).not.toBeNull();
+  });
+});
+
+/**
+ * #12207: seven different gates used to share one grey item with nothing on the
+ * row to tell them apart. Each reason has to reach BOTH registers — the visible
+ * meta slot and the accessible name — because `ContextMenuMeta` is `aria-hidden`
+ * and a screen reader would otherwise hear the same bare label every time.
+ */
+describe("useFileRowMenuItems — Insert file reference refusal reasons", () => {
+  const CASES: Array<[InsertFileReferenceRefusalReason, string, string]> = [
+    ["workspace-unavailable", "No workspace", "Insert file reference, no workspace"],
+    ["fleet-broadcast-armed", "Fleet armed", "Insert file reference, the fleet is armed"],
+    [
+      "hybrid-input-disabled",
+      "Input bar off",
+      "Insert file reference, the hybrid input bar is off",
+    ],
+    [
+      "backend-unavailable",
+      "Terminal service down",
+      "Insert file reference, the terminal service is down",
+    ],
+    [
+      "recorded-target-unavailable",
+      "Agent unavailable",
+      "Insert file reference, that agent can't take input",
+    ],
+    ["no-eligible-agent", "No agent in the grid", "Insert file reference, no agent is in the grid"],
+    [
+      "multiple-eligible-agents",
+      "Type to an agent",
+      "Insert file reference, type to an agent first",
+    ],
+  ];
+
+  async function openDisabled(reason: InsertFileReferenceRefusalReason): Promise<HTMLElement> {
+    insertRef.current = { canInsert: false, refusalReason: reason, insert: vi.fn(() => false) };
+    const menu = await openMenu();
+    return within(menu).getByRole("menuitem", { name: /^Insert file reference/ });
+  }
+
+  for (const [reason, meta, ariaLabel] of CASES) {
+    it(`says "${meta}" when the refusal is ${reason}`, async () => {
+      const item = await openDisabled(reason);
+
+      expect(item.getAttribute("data-disabled")).not.toBeNull();
+      expect(item.getAttribute("aria-label")).toBe(ariaLabel);
+      expect(item.textContent).toContain(meta);
+    });
+  }
+
+  it("hides the reason from assistive tech, since the accessible name already carries it", async () => {
+    const item = await openDisabled("multiple-eligible-agents");
+
+    const meta = within(item).getByText("Type to an agent");
+    expect(meta.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("drops the shortcut hint while disabled — the keybinding would be a lie", async () => {
+    const item = await openDisabled("no-eligible-agent");
+
+    expect(item.textContent).not.toContain("⌘I");
+    expect(item.hasAttribute("aria-keyshortcuts")).toBe(false);
+  });
+
+  it("shows the shortcut and no reason once a target resolves", async () => {
+    const menu = await openMenu();
+    const item = within(menu).getByRole("menuitem", { name: /Insert file reference/ });
+
+    expect(item.getAttribute("data-disabled")).toBeNull();
+    expect(item.textContent).toContain("⌘I");
+    expect(item.getAttribute("aria-keyshortcuts")).toBeTruthy();
+    // No `aria-label` override: the label plus the shortcut is the whole name.
+    expect(item.hasAttribute("aria-label")).toBe(false);
+    for (const [, meta] of CASES) {
+      expect(item.textContent).not.toContain(meta);
+    }
+  });
+
+  it("degrades to a bare disabled row when a caller reports no reason at all", async () => {
+    insertRef.current = { canInsert: false, refusalReason: null, insert: vi.fn(() => false) };
+    const menu = await openMenu();
+    const item = within(menu).getByRole("menuitem", { name: /Insert file reference/ });
+
+    expect(item.getAttribute("data-disabled")).not.toBeNull();
+    expect(item.hasAttribute("aria-label")).toBe(false);
+    expect(item.textContent).not.toContain("⌘I");
   });
 });
 

--- a/src/hooks/__tests__/useInsertFileReference.test.tsx
+++ b/src/hooks/__tests__/useInsertFileReference.test.tsx
@@ -55,7 +55,8 @@ vi.mock("@/store/accessibilityAnnouncerStore", () => ({
 }));
 
 import type { PtyPanelData } from "@shared/types/panel";
-import { useInsertFileReference } from "../useInsertFileReference";
+import { shallow } from "zustand/shallow";
+import { resolveInsertTarget, useInsertFileReference } from "../useInsertFileReference";
 
 /**
  * Mirrors the fixture `typeAnywhere.test.ts` uses: PTY panels are
@@ -195,6 +196,144 @@ describe("useInsertFileReference — target resolution", () => {
     getViewWorkspaceIdMock.mockReturnValue(null);
     const { result } = renderHook(() => useInsertFileReference());
     expect(result.current.canInsert).toBe(false);
+  });
+});
+
+/**
+ * #12207: the menu could say "no" but never why, so one grey item stood in for
+ * seven unrelated situations. Each gate has to be distinguishable, and the
+ * order matters — the first gate reached is the one the user is told about.
+ */
+describe("useInsertFileReference — refusal reasons", () => {
+  it.each([
+    [
+      "no workspace identity",
+      () => getViewWorkspaceIdMock.mockReturnValue(null),
+      "workspace-unavailable",
+    ],
+    [
+      "a live fleet broadcast",
+      () => (fleetState.armedIds = new Set(["t-1", "t-2"])),
+      "fleet-broadcast-armed",
+    ],
+    [
+      "hybrid input switched off",
+      () => (inputState.hybridInputEnabled = false),
+      "hybrid-input-disabled",
+    ],
+    [
+      "a disconnected backend",
+      () => (panelState.backendStatus = "disconnected"),
+      "backend-unavailable",
+    ],
+    [
+      "a recovering backend",
+      () => (panelState.backendStatus = "recovering"),
+      "backend-unavailable",
+    ],
+    ["no agent at all", () => seedPanels(), "no-eligible-agent"],
+    [
+      "only a docked agent",
+      () => seedPanels(agentPanel("t-1", { location: "dock" })),
+      "no-eligible-agent",
+    ],
+    [
+      "two agents and no typing history",
+      () => seedPanels(agentPanel("t-1"), agentPanel("t-2")),
+      "multiple-eligible-agents",
+    ],
+  ])("names %s", (_label, seed, reason) => {
+    seed();
+    const { result } = renderHook(() => useInsertFileReference());
+    expect(result.current.canInsert).toBe(false);
+    expect(result.current.refusalReason).toBe(reason);
+  });
+
+  it.each([
+    ["locked", { isInputLocked: true }],
+    ["restarting", { isRestarting: true }],
+    ["exited", { runtimeStatus: "exited" as const }],
+  ])("blames the recorded agent, not the room, when it is %s", (_label, overrides) => {
+    seedPanels(agentPanel("t-1"), agentPanel("t-2", overrides));
+    inputState.lastTypedAgentTarget = { workspaceId: WORKSPACE_ID, terminalId: "t-2" };
+
+    const { result } = renderHook(() => useInsertFileReference());
+    expect(result.current.refusalReason).toBe("recorded-target-unavailable");
+  });
+
+  it("blames the recorded agent while it is mid-voice-submit", () => {
+    seedPanels(agentPanel("t-1"), agentPanel("t-2"));
+    inputState.lastTypedAgentTarget = { workspaceId: WORKSPACE_ID, terminalId: "t-2" };
+    inputState.voiceSubmittingPanels = new Set(["t-2"]);
+
+    const { result } = renderHook(() => useInsertFileReference());
+    expect(result.current.refusalReason).toBe("recorded-target-unavailable");
+  });
+
+  it("treats a sibling view's record as no record, so the refusal is the ambiguity", () => {
+    seedPanels(agentPanel("t-1"), agentPanel("t-2"));
+    inputState.lastTypedAgentTarget = { workspaceId: "ws-other", terminalId: "t-2" };
+
+    const { result } = renderHook(() => useInsertFileReference());
+    expect(result.current.refusalReason).toBe("multiple-eligible-agents");
+  });
+
+  it("reports the first gate reached when several are shut at once", () => {
+    // Armed fleet, hybrid off and a dead backend together: the order is the
+    // contract, so the user is told the one nearest the front.
+    fleetState.armedIds = new Set(["t-1", "t-2"]);
+    inputState.hybridInputEnabled = false;
+    panelState.backendStatus = "disconnected";
+    seedPanels();
+
+    const { result } = renderHook(() => useInsertFileReference());
+    expect(result.current.refusalReason).toBe("fleet-broadcast-armed");
+  });
+
+  it.each([
+    [
+      "the recorded agent",
+      () => {
+        seedPanels(agentPanel("t-1"), agentPanel("t-2"));
+        inputState.lastTypedAgentTarget = { workspaceId: WORKSPACE_ID, terminalId: "t-2" };
+      },
+    ],
+    ["the sole open agent", () => seedPanels(agentPanel("t-1"))],
+  ])("carries no reason once %s resolves", (_label, seed) => {
+    seed();
+    const { result } = renderHook(() => useInsertFileReference());
+    expect(result.current.canInsert).toBe(true);
+    expect(result.current.refusalReason).toBeNull();
+  });
+
+  /**
+   * The pane subscribes to this verdict through `useShallow`, which only bails
+   * if both halves compare equal. A verdict that churned on unrelated panel
+   * traffic would re-render the file browser on every agent-state flip — the
+   * exact cost the single-string selector was written to avoid.
+   */
+  it("stays shallow-equal across unrelated panel churn, so the pane does not re-render", () => {
+    // Built here rather than read back off the store double: the resolver is
+    // pure, and this keeps the panels the assertion talks about in one place.
+    const inputs = (...panels: PtyPanelData[]) => ({
+      panelsById: Object.fromEntries(panels.map((p) => [p.id, p])),
+      panelIds: panels.map((p) => p.id),
+      backendStatus: "connected" as const,
+      hybridInputEnabled: true,
+      voiceSubmittingIds: new Set<string>(),
+      lastTypedAgentTarget: null,
+      armedCount: 0,
+    });
+
+    const before = resolveInsertTarget(inputs(agentPanel("t-1"), agentPanel("t-2")));
+
+    const churned = resolveInsertTarget(
+      inputs(agentPanel("t-1", { agentState: "working" }), agentPanel("t-2"))
+    );
+    expect(shallow(before, churned)).toBe(true);
+
+    // A verdict that genuinely changed must NOT compare equal.
+    expect(shallow(before, resolveInsertTarget(inputs(agentPanel("t-1"))))).toBe(false);
   });
 });
 

--- a/src/hooks/__tests__/useInsertFileReference.test.tsx
+++ b/src/hooks/__tests__/useInsertFileReference.test.tsx
@@ -11,34 +11,49 @@ vi.mock("@/store/viewWorkspaceId", () => ({ getViewWorkspaceId: getViewWorkspace
 
 // The real store graph pulls the whole app in; these four are all the hook
 // reads, and driving them directly is what makes the refusal matrix legible.
-const { asStore, panelState, inputState, fleetState, projectState } = vi.hoisted(() => ({
-  // Stands in for a Zustand hook: callable with a selector and carrying
-  // `getState`, which is the only shape this hook uses.
-  asStore: <S,>(state: S) => {
-    const hook = (selector: (s: S) => unknown) => selector(state);
-    hook.getState = () => state;
-    return hook;
-  },
-  panelState: {
-    panelsById: {} as Record<string, unknown>,
-    panelIds: [] as string[],
-    backendStatus: "connected" as string,
-    pingTerminal: vi.fn<(id: string) => void>(),
-  },
-  inputState: {
-    hybridInputEnabled: true,
-    voiceSubmittingPanels: new Set<string>(),
-    lastTypedAgentTarget: null as { workspaceId: string; terminalId: string } | null,
-    getDraftInput: vi.fn<(id: string, projectId?: string) => string>(() => ""),
-    setDraftInput: vi.fn<(id: string, value: string, projectId?: string) => void>(),
-    bumpExternalDraftRevision: vi.fn(),
-    recordLastTypedAgentTarget: vi.fn(),
-  },
-  fleetState: { armedIds: new Set<string>() },
-  projectState: { currentProject: { id: "proj-1" } as { id: string } | undefined },
-}));
+const { asStore, panelState, inputState, fleetState, projectState, panelSelectorRef } = vi.hoisted(
+  () => ({
+    // Stands in for a Zustand hook: callable with a selector and carrying
+    // `getState`, which is the only shape this hook uses.
+    asStore: <S,>(state: S) => {
+      const hook = (selector: (s: S) => unknown) => selector(state);
+      hook.getState = () => state;
+      return hook;
+    },
+    panelState: {
+      panelsById: {} as Record<string, unknown>,
+      panelIds: [] as string[],
+      backendStatus: "connected" as string,
+      pingTerminal: vi.fn<(id: string) => void>(),
+    },
+    inputState: {
+      hybridInputEnabled: true,
+      voiceSubmittingPanels: new Set<string>(),
+      lastTypedAgentTarget: null as { workspaceId: string; terminalId: string } | null,
+      getDraftInput: vi.fn<(id: string, projectId?: string) => string>(() => ""),
+      setDraftInput: vi.fn<(id: string, value: string, projectId?: string) => void>(),
+      bumpExternalDraftRevision: vi.fn(),
+      recordLastTypedAgentTarget: vi.fn(),
+    },
+    fleetState: { armedIds: new Set<string>() },
+    projectState: { currentProject: { id: "proj-1" } as { id: string } | undefined },
+    // Holds the hook's selector already bound to the live panel state, so a
+    // test can re-read the verdict without restating the store's shape.
+    panelSelectorRef: { current: null as (() => unknown) | null },
+  })
+);
 
-vi.mock("@/store", () => ({ usePanelStore: asStore(panelState) }));
+// Records the selector the hook hands over, which is the only handle a test has
+// on the `useShallow` wrapper the pane's re-render behaviour depends on.
+vi.mock("@/store", () => {
+  const store = asStore(panelState);
+  const usePanelStore = (selector: (s: typeof panelState) => unknown) => {
+    panelSelectorRef.current = () => selector(panelState);
+    return store(selector);
+  };
+  usePanelStore.getState = store.getState;
+  return { usePanelStore };
+});
 vi.mock("@/store/terminalInputStore", () => ({ useTerminalInputStore: asStore(inputState) }));
 vi.mock("@/store/fleetArmingStore", () => ({ useFleetArmingStore: asStore(fleetState) }));
 vi.mock("@/store/projectStore", () => ({ useProjectStore: asStore(projectState) }));
@@ -278,16 +293,66 @@ describe("useInsertFileReference — refusal reasons", () => {
     expect(result.current.refusalReason).toBe("multiple-eligible-agents");
   });
 
-  it("reports the first gate reached when several are shut at once", () => {
-    // Armed fleet, hybrid off and a dead backend together: the order is the
-    // contract, so the user is told the one nearest the front.
-    fleetState.armedIds = new Set(["t-1", "t-2"]);
-    inputState.hybridInputEnabled = false;
-    panelState.backendStatus = "disconnected";
-    seedPanels();
-
+  /**
+   * The gate ORDER is the contract, not an accident of how the branches fell
+   * out: with several shut at once the user is told about the one nearest the
+   * front. Pinned as adjacent pairs so an inversion anywhere in the chain
+   * fails a test that names both sides of it.
+   */
+  it.each([
+    [
+      "workspace over fleet",
+      () => {
+        getViewWorkspaceIdMock.mockReturnValue(null);
+        fleetState.armedIds = new Set(["t-1", "t-2"]);
+      },
+      "workspace-unavailable",
+    ],
+    [
+      "fleet over hybrid-off",
+      () => {
+        fleetState.armedIds = new Set(["t-1", "t-2"]);
+        inputState.hybridInputEnabled = false;
+      },
+      "fleet-broadcast-armed",
+    ],
+    [
+      "hybrid-off over backend",
+      () => {
+        inputState.hybridInputEnabled = false;
+        panelState.backendStatus = "disconnected";
+      },
+      "hybrid-input-disabled",
+    ],
+    [
+      "backend over an unroutable recorded target",
+      () => {
+        panelState.backendStatus = "disconnected";
+        seedPanels(agentPanel("t-1", { isInputLocked: true }));
+        inputState.lastTypedAgentTarget = { workspaceId: WORKSPACE_ID, terminalId: "t-1" };
+      },
+      "backend-unavailable",
+    ],
+    [
+      "an unroutable recorded target over the ambiguity behind it",
+      () => {
+        seedPanels(agentPanel("t-1"), agentPanel("t-2", { isRestarting: true }));
+        inputState.lastTypedAgentTarget = { workspaceId: WORKSPACE_ID, terminalId: "t-2" };
+      },
+      "recorded-target-unavailable",
+    ],
+    [
+      "fleet over the ambiguity behind it",
+      () => {
+        fleetState.armedIds = new Set(["t-1", "t-2"]);
+        seedPanels(agentPanel("t-1"), agentPanel("t-2"));
+      },
+      "fleet-broadcast-armed",
+    ],
+  ])("reports %s", (_label, seed, reason) => {
+    seed();
     const { result } = renderHook(() => useInsertFileReference());
-    expect(result.current.refusalReason).toBe("fleet-broadcast-armed");
+    expect(result.current.refusalReason).toBe(reason);
   });
 
   it.each([
@@ -307,12 +372,39 @@ describe("useInsertFileReference — refusal reasons", () => {
   });
 
   /**
-   * The pane subscribes to this verdict through `useShallow`, which only bails
-   * if both halves compare equal. A verdict that churned on unrelated panel
-   * traffic would re-render the file browser on every agent-state flip — the
-   * exact cost the single-string selector was written to avoid.
+   * The verdict reaches the pane through `useShallow`, which hands back the
+   * PREVIOUS object whenever both halves still compare equal. Identity is the
+   * whole mechanism: a fresh object on every panel-store update would re-render
+   * the file browser on every agent-state flip and status flush, which is the
+   * cost the original one-string selector was written to avoid.
+   *
+   * Asserted through the selector the hook actually registered, so removing
+   * `useShallow` from the hook fails this test — comparing two resolver results
+   * by value would not.
    */
-  it("stays shallow-equal across unrelated panel churn, so the pane does not re-render", () => {
+  it("hands the panel store a selector that keeps its verdict's identity across unrelated churn", () => {
+    seedPanels(agentPanel("t-1"), agentPanel("t-2"));
+    renderHook(() => useInsertFileReference());
+    const readVerdict = panelSelectorRef.current;
+    expect(readVerdict).not.toBeNull();
+    if (readVerdict === null) return;
+
+    const first = readVerdict();
+
+    // An agent-state flip on a panel that changes no part of the verdict.
+    seedPanels(agentPanel("t-1", { agentState: "working" }), agentPanel("t-2"));
+    expect(readVerdict()).toBe(first);
+
+    // A change that DOES move the verdict must not be memoised away.
+    seedPanels(agentPanel("t-1"));
+    expect(readVerdict()).not.toBe(first);
+  });
+
+  /**
+   * The other half of the same mechanism: `useShallow` can only bail if the
+   * resolver is itself stable under churn it does not care about.
+   */
+  it("resolves the same verdict either side of unrelated panel churn", () => {
     // Built here rather than read back off the store double: the resolver is
     // pure, and this keeps the panels the assertion talks about in one place.
     const inputs = (...panels: PtyPanelData[]) => ({

--- a/src/hooks/useFileRowMenuItems.tsx
+++ b/src/hooks/useFileRowMenuItems.tsx
@@ -50,12 +50,22 @@ const INSERT_REFUSAL_COPY = {
   "workspace-unavailable": { meta: "No workspace", detail: "no workspace" },
   "fleet-broadcast-armed": { meta: "Fleet armed", detail: "the fleet is armed" },
   "hybrid-input-disabled": { meta: "Input bar off", detail: "the hybrid input bar is off" },
-  "backend-unavailable": { meta: "Terminal service down", detail: "the terminal service is down" },
+  // One string for `disconnected` and `recovering` alike. The distinction that
+  // matters — wait, or act — is already on screen: `HostCrashBanner` renders
+  // for every non-connected status and says which, so a menu row repeating it
+  // in four words could only get it wrong.
+  "backend-unavailable": {
+    meta: "No terminal service",
+    detail: "the terminal service is unavailable",
+  },
   "recorded-target-unavailable": {
     meta: "Agent unavailable",
     detail: "that agent can't take input",
   },
-  "no-eligible-agent": { meta: "No agent in the grid", detail: "no agent is in the grid" },
+  // Deliberately not "no agent in the grid": this also fires when agents are
+  // there but none can take input — locked, restarting, mid-voice-submit — and
+  // naming the grid would then be false.
+  "no-eligible-agent": { meta: "No agent available", detail: "no agent is available" },
   "multiple-eligible-agents": { meta: "Type to an agent", detail: "type to an agent first" },
 } as const satisfies Record<InsertFileReferenceRefusalReason, { meta: string; detail: string }>;
 
@@ -232,6 +242,14 @@ export function useFileRowMenuItems(surface: FileRowMenuSurface): FileRowMenuCon
   const { worktreePath, worktreeId, copyTreeRunSource } = surface;
   const filePluginItems = usePluginContextMenuItems("file");
   const { canInsert, refusalReason, insert } = useInsertFileReference();
+  // Narrowed here, where the discriminated pair still correlates, and reduced
+  // to two primitives so `renderItems` keeps a stable dependency list.
+  // `undefined` rather than `null` for the absent case: that is what a DOM
+  // attribute prop takes to mean "don't render me".
+  const insertRefusalMeta = canInsert ? undefined : INSERT_REFUSAL_COPY[refusalReason].meta;
+  const insertRefusalLabel = canInsert
+    ? undefined
+    : `${INSERT_LABEL}, ${INSERT_REFUSAL_COPY[refusalReason].detail}`;
 
   // Bucketed here rather than in `renderItems`: that runs once per row, and a
   // Review Hub listing thousands of changed files would rebuild the same map
@@ -331,11 +349,6 @@ export function useFileRowMenuItems(surface: FileRowMenuSurface): FileRowMenuCon
       // nothing here has read the file — so an unfamiliar binary still shows
       // the item and fails at the read with a reason.
       const showCopyFileContents = showOpenCurrent && isFileContentsCopyCandidate(absolutePath);
-      // Null only if a caller hands back `canInsert: false` with no reason —
-      // the hook always pairs them, and the item degrades to a bare disabled
-      // row rather than an empty slot.
-      const insertRefusal =
-        canInsert || refusalReason === null ? null : INSERT_REFUSAL_COPY[refusalReason];
 
       return (
         <>
@@ -388,16 +401,14 @@ export function useFileRowMenuItems(surface: FileRowMenuSurface): FileRowMenuCon
             disabled={!canInsert}
             {...(canInsert
               ? { "aria-keyshortcuts": insertAriaKeyshortcuts }
-              : insertRefusal !== null
-                ? { "aria-label": `${INSERT_LABEL}, ${insertRefusal.detail}` }
-                : {})}
+              : { "aria-label": insertRefusalLabel })}
           >
             <AtSign className={ICON_CLASS} />
             {INSERT_LABEL}
-            {insertRefusal === null ? (
-              canInsert && <ContextMenuShortcut>{insertShortcutHint}</ContextMenuShortcut>
+            {canInsert ? (
+              <ContextMenuShortcut>{insertShortcutHint}</ContextMenuShortcut>
             ) : (
-              <ContextMenuMeta>{insertRefusal.meta}</ContextMenuMeta>
+              <ContextMenuMeta>{insertRefusalMeta}</ContextMenuMeta>
             )}
           </ContextMenuItem>
           {/* Reveal and Insert render unconditionally, so the direct-action
@@ -499,7 +510,8 @@ export function useFileRowMenuItems(surface: FileRowMenuSurface): FileRowMenuCon
       worktreeId,
       pluginGroups,
       canInsert,
-      refusalReason,
+      insertRefusalMeta,
+      insertRefusalLabel,
       insert,
       insertAriaKeyshortcuts,
       insertShortcutHint,

--- a/src/hooks/useFileRowMenuItems.tsx
+++ b/src/hooks/useFileRowMenuItems.tsx
@@ -6,6 +6,7 @@ import {
   ContextMenuActionItem,
   ContextMenuItem,
   ContextMenuLabel,
+  ContextMenuMeta,
   ContextMenuSeparator,
   ContextMenuShortcut,
   ContextMenuSub,
@@ -17,7 +18,10 @@ import {
   usePluginContextMenuItems,
   type PluginContextMenuItemEntry,
 } from "@/hooks/usePluginContextMenuItems";
-import { useInsertFileReference } from "@/hooks/useInsertFileReference";
+import {
+  useInsertFileReference,
+  type InsertFileReferenceRefusalReason,
+} from "@/hooks/useInsertFileReference";
 import { copyContextWithFeedback } from "@/hooks/useWorktreeActions";
 import { revealCopy } from "@/components/FileViewer/revealCopy";
 import { isFileContentsCopyCandidate } from "@/components/FileViewer/filePreviewKinds";
@@ -30,6 +34,30 @@ import type { BuiltInRuntimeActionId } from "@shared/config/actionIds";
 import type { CopyTreeRunSource, GitStatus } from "@shared/types";
 
 const ICON_CLASS = "w-3.5 h-3.5 mr-2";
+
+const INSERT_LABEL = "Insert file reference";
+
+/**
+ * Why the row can't insert a reference, in the two registers the menu needs.
+ *
+ * `meta` is the trailing muted slot a sighted user reads; `detail` is folded
+ * into the item's accessible name because `ContextMenuMeta` is `aria-hidden`,
+ * so the visible reason would otherwise be silent to a screen reader. One
+ * entry per gate: a single "nothing resolved" is what made the item read as
+ * broken rather than conditional (#12207).
+ */
+const INSERT_REFUSAL_COPY = {
+  "workspace-unavailable": { meta: "No workspace", detail: "no workspace" },
+  "fleet-broadcast-armed": { meta: "Fleet armed", detail: "the fleet is armed" },
+  "hybrid-input-disabled": { meta: "Input bar off", detail: "the hybrid input bar is off" },
+  "backend-unavailable": { meta: "Terminal service down", detail: "the terminal service is down" },
+  "recorded-target-unavailable": {
+    meta: "Agent unavailable",
+    detail: "that agent can't take input",
+  },
+  "no-eligible-agent": { meta: "No agent in the grid", detail: "no agent is in the grid" },
+  "multiple-eligible-agents": { meta: "Type to an agent", detail: "type to an agent first" },
+} as const satisfies Record<InsertFileReferenceRefusalReason, { meta: string; detail: string }>;
 
 /**
  * Dispatch an action for the clicked row and, if it fails, say so with a Retry
@@ -203,7 +231,7 @@ export function isFileRowMenuKey(event: {
 export function useFileRowMenuItems(surface: FileRowMenuSurface): FileRowMenuController {
   const { worktreePath, worktreeId, copyTreeRunSource } = surface;
   const filePluginItems = usePluginContextMenuItems("file");
-  const { canInsert, insert } = useInsertFileReference();
+  const { canInsert, refusalReason, insert } = useInsertFileReference();
 
   // Bucketed here rather than in `renderItems`: that runs once per row, and a
   // Review Hub listing thousands of changed files would rebuild the same map
@@ -303,6 +331,11 @@ export function useFileRowMenuItems(surface: FileRowMenuSurface): FileRowMenuCon
       // nothing here has read the file — so an unfamiliar binary still shows
       // the item and fails at the read with a reason.
       const showCopyFileContents = showOpenCurrent && isFileContentsCopyCandidate(absolutePath);
+      // Null only if a caller hands back `canInsert: false` with no reason —
+      // the hook always pairs them, and the item degrades to a bare disabled
+      // row rather than an empty slot.
+      const insertRefusal =
+        canInsert || refusalReason === null ? null : INSERT_REFUSAL_COPY[refusalReason];
 
       return (
         <>
@@ -343,16 +376,29 @@ export function useFileRowMenuItems(surface: FileRowMenuSurface): FileRowMenuCon
           </ContextMenuItem>
           {/* Disabled rather than hidden when nothing resolves: the gesture is
               the point of the menu entry, and a row that silently drops it
-              would read as broken. The agent is resolved from typing history,
-              so this is off until the user has actually talked to one. */}
+              would read as broken. The reason rides along so the row accounts
+              for itself — seven different gates used to share one grey item
+              (#12207). It takes the trailing slot from the shortcut hint
+              rather than sitting beside it: two `ml-auto` siblings split the
+              free space into two ragged columns, and advertising a keybinding
+              on an item that cannot run is the same lie `aria-keyshortcuts`
+              already declines to tell. */}
           <ContextMenuItem
             onSelect={() => insert(absolutePath)}
             disabled={!canInsert}
-            {...(canInsert ? { "aria-keyshortcuts": insertAriaKeyshortcuts } : {})}
+            {...(canInsert
+              ? { "aria-keyshortcuts": insertAriaKeyshortcuts }
+              : insertRefusal !== null
+                ? { "aria-label": `${INSERT_LABEL}, ${insertRefusal.detail}` }
+                : {})}
           >
             <AtSign className={ICON_CLASS} />
-            Insert file reference
-            <ContextMenuShortcut>{insertShortcutHint}</ContextMenuShortcut>
+            {INSERT_LABEL}
+            {insertRefusal === null ? (
+              canInsert && <ContextMenuShortcut>{insertShortcutHint}</ContextMenuShortcut>
+            ) : (
+              <ContextMenuMeta>{insertRefusal.meta}</ContextMenuMeta>
+            )}
           </ContextMenuItem>
           {/* Reveal and Insert render unconditionally, so the direct-action
               block above is never empty and this separator never leads. */}
@@ -453,6 +499,7 @@ export function useFileRowMenuItems(surface: FileRowMenuSurface): FileRowMenuCon
       worktreeId,
       pluginGroups,
       canInsert,
+      refusalReason,
       insert,
       insertAriaKeyshortcuts,
       insertShortcutHint,

--- a/src/hooks/useInsertFileReference.ts
+++ b/src/hooks/useInsertFileReference.ts
@@ -1,7 +1,8 @@
 import { useCallback } from "react";
+import { useShallow } from "zustand/react/shallow";
 import { isPtyPanel, type PanelInstance } from "@shared/types/panel";
 import { usePanelStore } from "@/store";
-import type { BackendStatus } from "@/store/panelStore";
+import type { BackendStatus, PanelGridState } from "@/store/panelStore";
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
 import { useProjectStore } from "@/store/projectStore";
 import { useTerminalInputStore, type LastTypedAgentTarget } from "@/store/terminalInputStore";
@@ -9,7 +10,7 @@ import { useTypingLocatorStore } from "@/store/typingLocatorStore";
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import { getViewWorkspaceId } from "@/store/viewWorkspaceId";
 import { getTerminalDisplayTitle } from "@/utils/terminalTitleDisplay";
-import { resolveRescueTarget } from "@/lib/typeAnywhere";
+import { isRescueTargetRoutable } from "@/lib/typeAnywhere";
 import { appendFileReference } from "@/panels/file-browser/fileReference";
 
 interface TargetInputs {
@@ -23,43 +24,87 @@ interface TargetInputs {
 }
 
 /**
- * The agent this view may insert a reference into, or `null` to refuse.
+ * Why this view cannot insert a reference right now.
  *
- * Reuses `resolveRescueTarget` verbatim rather than deriving a second, weaker
- * heuristic: the "recorded target wins, otherwise the sole eligible agent,
- * otherwise refuse" contract (#11147) is exactly right here, and its
- * hybrid-only gate is a feature — this feature writes a hybrid draft and
- * nothing else, so a disabled hybrid bar genuinely has nowhere to put the
- * token.
+ * One code per gate rather than a single "refused": the same greyed item used
+ * to mean "you haven't typed to an agent yet", "your fleet is armed" and "your
+ * agent is docked", and the menu could say none of it (#12207). Codes, not
+ * copy — the wording belongs to the surface that renders it.
+ */
+export type InsertFileReferenceRefusalReason =
+  | "workspace-unavailable"
+  | "fleet-broadcast-armed"
+  | "hybrid-input-disabled"
+  | "backend-unavailable"
+  | "recorded-target-unavailable"
+  | "no-eligible-agent"
+  | "multiple-eligible-agents";
+
+/** A resolved agent, or the reason there isn't one. Never both, never neither. */
+export type InsertTargetResolution =
+  { targetId: string; reason: null } | { targetId: null; reason: InsertFileReferenceRefusalReason };
+
+function refuse(reason: InsertFileReferenceRefusalReason): InsertTargetResolution {
+  return { targetId: null, reason };
+}
+
+/**
+ * The agent this view may insert a reference into, or the reason it may not.
+ *
+ * Applies `resolveRescueTarget`'s contract rather than deriving a second,
+ * weaker heuristic: "recorded target wins, otherwise the sole eligible agent,
+ * otherwise refuse" (#11147) is exactly right here, and its hybrid-only gate is
+ * a feature — this feature writes a hybrid draft and nothing else, so a
+ * disabled hybrid bar genuinely has nowhere to put the token. The per-panel
+ * half is literally shared, via `isRescueTargetRoutable`, so the two paths
+ * cannot drift on what counts as an available agent.
+ *
+ * It walks the gates itself rather than calling `resolveRescueTarget` and
+ * classifying its `null` afterwards: one walk cannot disagree with itself,
+ * whereas a second pass looking for a reason could name a gate the first pass
+ * never reached.
  *
  * The two guards `useTypeAnywhere` keeps outside the resolver are repeated for
  * the same reasons: a target recorded by a sibling view belongs to that view,
  * and a live fleet broadcast would fan one reference out to every armed agent.
  */
-export function resolveInsertTargetId(inputs: TargetInputs): string | null {
+export function resolveInsertTarget(inputs: TargetInputs): InsertTargetResolution {
   const workspaceId = getViewWorkspaceId();
-  if (workspaceId === null) return null;
+  if (workspaceId === null) return refuse("workspace-unavailable");
 
   // Two armed ids means a real broadcast rather than a preview — the same
   // threshold `tryFleetBroadcastFromEditor` uses.
-  if (inputs.armedCount >= 2) return null;
+  if (inputs.armedCount >= 2) return refuse("fleet-broadcast-armed");
+
+  // Both of these disable every agent's editor at once, so there is no target
+  // worth resolving — the same pair, in the same order, `resolveRescueTarget`
+  // opens with.
+  if (!inputs.hybridInputEnabled) return refuse("hybrid-input-disabled");
+  if (inputs.backendStatus !== "connected") return refuse("backend-unavailable");
 
   const recorded = inputs.lastTypedAgentTarget;
   const lastTypedTerminalId =
     recorded !== null && recorded.workspaceId === workspaceId ? recorded.terminalId : null;
 
-  const targetId = resolveRescueTarget({
-    panelsById: inputs.panelsById,
-    panelIds: inputs.panelIds,
-    lastTypedTerminalId,
-    voiceSubmittingIds: inputs.voiceSubmittingIds,
-    hybridInputEnabled: inputs.hybridInputEnabled,
-    isBackendReady: inputs.backendStatus === "connected",
-  });
-  if (targetId === null) return null;
+  if (lastTypedTerminalId !== null) {
+    // Refuse rather than fall through: routing to a different agent would send
+    // the reference somewhere the user never chose.
+    return isRescueTargetRoutable(inputs, lastTypedTerminalId)
+      ? { targetId: lastTypedTerminalId, reason: null }
+      : refuse("recorded-target-unavailable");
+  }
 
-  const target = inputs.panelsById[targetId];
-  return target !== undefined && isPtyPanel(target) ? targetId : null;
+  // Stops at the second candidate — by then the answer is "ambiguous"
+  // regardless of what follows.
+  let sole: string | null = null;
+  for (const id of inputs.panelIds) {
+    if (!isRescueTargetRoutable(inputs, id)) continue;
+    if (sole !== null) return refuse("multiple-eligible-agents");
+    sole = id;
+  }
+  // `isRescueTargetRoutable` already requires a live agent PTY panel in the
+  // grid, so a docked-only workspace lands here too.
+  return sole === null ? refuse("no-eligible-agent") : { targetId: sole, reason: null };
 }
 
 /**
@@ -78,6 +123,12 @@ function reportRefused(): void {
 export interface InsertFileReference {
   /** False when nothing resolves — the menu item disables and the shortcut no-ops. */
   canInsert: boolean;
+  /**
+   * Why `canInsert` is false, for a surface that can say so; `null` while it is
+   * true. Paired with `canInsert` rather than replacing it: every consumer but
+   * the context menu only ever needed the boolean.
+   */
+  refusalReason: InsertFileReferenceRefusalReason | null;
   /** Returns whether the reference was actually written. */
   insert: (absolutePath: string) => boolean;
 }
@@ -103,24 +154,25 @@ export function useInsertFileReference(): InsertFileReference {
   const lastTypedAgentTarget = useTerminalInputStore((s) => s.lastTypedAgentTarget);
   const armedCount = useFleetArmingStore((s) => s.armedIds.size);
 
-  // Derived inside the selector so the pane subscribes to one string, not the
+  // Derived inside the selector so the pane subscribes to the verdict, not the
   // whole panel map: a live `panelsById` selector here would re-render the file
-  // browser on every agent-state flip and status flush.
-  const targetId = usePanelStore(
-    useCallback(
-      (state) =>
-        resolveInsertTargetId({
-          panelsById: state.panelsById,
-          panelIds: state.panelIds,
-          backendStatus: state.backendStatus,
-          hybridInputEnabled,
-          voiceSubmittingIds: voiceSubmittingPanels,
-          lastTypedAgentTarget,
-          armedCount,
-        }),
-      [hybridInputEnabled, voiceSubmittingPanels, lastTypedAgentTarget, armedCount]
-    )
+  // browser on every agent-state flip and status flush. `useShallow` is what
+  // keeps that true now the verdict is a pair — both halves are primitives, so
+  // an unchanged verdict keeps its object identity and re-renders nothing.
+  const selectResolution = useCallback(
+    (state: PanelGridState): InsertTargetResolution =>
+      resolveInsertTarget({
+        panelsById: state.panelsById,
+        panelIds: state.panelIds,
+        backendStatus: state.backendStatus,
+        hybridInputEnabled,
+        voiceSubmittingIds: voiceSubmittingPanels,
+        lastTypedAgentTarget,
+        armedCount,
+      }),
+    [hybridInputEnabled, voiceSubmittingPanels, lastTypedAgentTarget, armedCount]
   );
+  const resolution = usePanelStore(useShallow(selectResolution));
 
   const insert = useCallback((absolutePath: string): boolean => {
     if (absolutePath === "") return false;
@@ -129,7 +181,7 @@ export function useInsertFileReference(): InsertFileReference {
     // the menu can sit open while the agent it named exits or locks.
     const panelState = usePanelStore.getState();
     const inputStore = useTerminalInputStore.getState();
-    const resolvedId = resolveInsertTargetId({
+    const { targetId: resolvedId } = resolveInsertTarget({
       panelsById: panelState.panelsById,
       panelIds: panelState.panelIds,
       backendStatus: panelState.backendStatus,
@@ -154,7 +206,7 @@ export function useInsertFileReference(): InsertFileReference {
     const draft = inputStore.getDraftInput(resolvedId, projectId);
     // The token is relativized against the TARGET's cwd, not the browser's
     // base path: that is what a drop into this agent would produce, and it is
-    // what makes a reference to another worktree stay absolute. `resolveInsertTargetId`
+    // what makes a reference to another worktree stay absolute. `resolveInsertTarget`
     // already guarantees a pty panel; the narrow is for the type, not a case.
     const targetCwd = isPtyPanel(target) ? (target.cwd ?? "") : "";
     inputStore.setDraftInput(
@@ -172,5 +224,5 @@ export function useInsertFileReference(): InsertFileReference {
     return true;
   }, []);
 
-  return { canInsert: targetId !== null, insert };
+  return { canInsert: resolution.targetId !== null, refusalReason: resolution.reason, insert };
 }

--- a/src/hooks/useInsertFileReference.ts
+++ b/src/hooks/useInsertFileReference.ts
@@ -120,18 +120,21 @@ function reportRefused(): void {
   report("No agent is available for a file reference");
 }
 
-export interface InsertFileReference {
-  /** False when nothing resolves — the menu item disables and the shortcut no-ops. */
-  canInsert: boolean;
-  /**
-   * Why `canInsert` is false, for a surface that can say so; `null` while it is
-   * true. Paired with `canInsert` rather than replacing it: every consumer but
-   * the context menu only ever needed the boolean.
-   */
-  refusalReason: InsertFileReferenceRefusalReason | null;
+/**
+ * Discriminated on `canInsert` so "disabled with no reason" — the very state
+ * #12207 is about — cannot be constructed. Consumers that only ever wanted the
+ * boolean (`FileTreeView`'s Cmd+I gate) keep destructuring it and ignoring the
+ * rest.
+ */
+export type InsertFileReference = {
   /** Returns whether the reference was actually written. */
   insert: (absolutePath: string) => boolean;
-}
+} & (
+  | { canInsert: true; refusalReason: null }
+  /** Nothing resolves: the menu item disables, the shortcut no-ops, and the
+   * reason is what the row shows instead. */
+  | { canInsert: false; refusalReason: InsertFileReferenceRefusalReason }
+);
 
 /**
  * Send an `@file` reference to the agent the user was last talking to (#11577).
@@ -224,5 +227,10 @@ export function useInsertFileReference(): InsertFileReference {
     return true;
   }, []);
 
-  return { canInsert: resolution.targetId !== null, refusalReason: resolution.reason, insert };
+  // Rebuilt as the discriminated pair rather than spread: `targetId !== null`
+  // and `reason === null` are the same fact, and TypeScript will not infer that
+  // from the resolution object alone.
+  return resolution.reason === null
+    ? { canInsert: true, refusalReason: null, insert }
+    : { canInsert: false, refusalReason: resolution.reason, insert };
 }

--- a/src/lib/__tests__/typeAnywhere.test.ts
+++ b/src/lib/__tests__/typeAnywhere.test.ts
@@ -374,6 +374,18 @@ describe("isRescueTargetRoutable", () => {
     expect(routable(agentPanel("t-1"), ["t-1"])).toBe(false);
   });
 
+  /**
+   * `isAgentFleetActionEligible` resolves a BUILT-IN runtime agent id, so a
+   * plugin- or user-contributed agent is not routable here even when it is
+   * live and in the grid. Pinned rather than left implicit: the module's own
+   * `isAgentTerminalFleetEligible` exists for the broader case (#11637), and
+   * whether routing should widen to match it is a decision about the rescue
+   * contract, not something to change by accident from the file menu.
+   */
+  it("refuses an agent with no built-in runtime id, such as a plugin agent", () => {
+    expect(routable(agentPanel("t-1", { launchAgentId: "some-plugin-agent" }))).toBe(false);
+  });
+
   it("refuses an id with no panel behind it", () => {
     expect(isRescueTargetRoutable({ panelsById: {}, voiceSubmittingIds: new Set() }, "gone")).toBe(
       false

--- a/src/lib/__tests__/typeAnywhere.test.ts
+++ b/src/lib/__tests__/typeAnywhere.test.ts
@@ -7,6 +7,7 @@ import {
   hasBlockingOverlay,
   hasUsefulFocus,
   isRescuableKeystroke,
+  isRescueTargetRoutable,
   resolveRescueTarget,
   type RescueContext,
 } from "../typeAnywhere";
@@ -337,5 +338,45 @@ describe("resolveRescueTarget", () => {
   it("refuses when a stale target id is no longer present", () => {
     const ctx = makeContext([agentPanel("a1")], { lastTypedTerminalId: "gone" });
     expect(resolveRescueTarget(ctx)).toBeNull();
+  });
+});
+
+/**
+ * The per-panel half of the contract, now shared verbatim with the file-row
+ * menu's insert gate (#12207). Tested directly as well as through
+ * `resolveRescueTarget` so the two callers cannot drift on what "available"
+ * means without a test saying so.
+ */
+describe("isRescueTargetRoutable", () => {
+  const routable = (panel: PtyPanelData, voiceSubmitting: string[] = []): boolean =>
+    isRescueTargetRoutable(
+      { panelsById: { [panel.id]: panel }, voiceSubmittingIds: new Set(voiceSubmitting) },
+      panel.id
+    );
+
+  it("accepts a live agent in the grid", () => {
+    expect(routable(agentPanel("t-1"))).toBe(true);
+  });
+
+  it.each([
+    ["a locked editor", { isInputLocked: true }],
+    ["a restarting agent", { isRestarting: true }],
+    ["an exited agent", { runtimeStatus: "exited" as const }],
+    ["an errored agent", { runtimeStatus: "error" as const }],
+    ["a docked agent", { location: "dock" as const }],
+    ["a pty-less agent", { hasPty: false }],
+    ["a raw shell", { launchAgentId: undefined }],
+  ])("refuses %s", (_label, overrides) => {
+    expect(routable(agentPanel("t-1", overrides))).toBe(false);
+  });
+
+  it("refuses a panel mid-voice-submit", () => {
+    expect(routable(agentPanel("t-1"), ["t-1"])).toBe(false);
+  });
+
+  it("refuses an id with no panel behind it", () => {
+    expect(isRescueTargetRoutable({ panelsById: {}, voiceSubmittingIds: new Set() }, "gone")).toBe(
+      false
+    );
   });
 });

--- a/src/lib/typeAnywhere.ts
+++ b/src/lib/typeAnywhere.ts
@@ -135,13 +135,42 @@ export function findPanelIdForElement(el: Element | null): string | null {
   return host?.getAttribute("data-panel-id") ?? null;
 }
 
-export interface RescueContext {
+/**
+ * The per-panel half of the routing contract, split out so callers that need
+ * the same "may this agent take a draft right now?" test can share it rather
+ * than re-deriving it. `useInsertFileReference` classifies its own refusals and
+ * must apply exactly these rules to reach the same verdict.
+ */
+export interface RescueRoutability {
   panelsById: Record<string, PanelInstance>;
+  /** Panels mid-voice-submit: the editor is read-only and submits asynchronously. */
+  voiceSubmittingIds: ReadonlySet<string>;
+}
+
+/**
+ * May a draft be routed into this panel right now?
+ *
+ * Deliberately reason-free: the rescue path has nowhere to show one, and every
+ * clause here is a hard refusal rather than a ranking.
+ */
+export function isRescueTargetRoutable(ctx: RescueRoutability, id: string): boolean {
+  if (ctx.voiceSubmittingIds.has(id)) return false;
+  const panel = ctx.panelsById[id];
+  // Agent identity + live PTY + grid location. Excludes raw shells (no agent
+  // identity — routing a draft there would execute on Enter against a shell),
+  // exited panels, and dock/background panels.
+  if (!isAgentFleetActionEligible(panel)) return false;
+  // Mirrors `isHybridInputDisabled` in TerminalPane: a locked or restarting
+  // editor is read-only, and focus would fall back to the raw xterm.
+  if (panel.isInputLocked === true) return false;
+  if (panel.isRestarting === true) return false;
+  return true;
+}
+
+export interface RescueContext extends RescueRoutability {
   panelIds: string[];
   /** `terminalId` of the last agent the user actually typed into, if any. */
   lastTypedTerminalId: string | null;
-  /** Panels mid-voice-submit: the editor is read-only and submits asynchronously. */
-  voiceSubmittingIds: ReadonlySet<string>;
   /**
    * The global hybrid-input setting. With it off, `shouldShowHybridInputBar`
    * renders no draft bar for ANY panel — routing a character into a draft
@@ -180,19 +209,7 @@ export function resolveRescueTarget(ctx: RescueContext): string | null {
   if (!ctx.hybridInputEnabled) return null;
   if (!ctx.isBackendReady) return null;
 
-  const isRoutable = (id: string): boolean => {
-    if (ctx.voiceSubmittingIds.has(id)) return false;
-    const panel = ctx.panelsById[id];
-    // Agent identity + live PTY + grid location. Excludes raw shells (no agent
-    // identity — routing a draft there would execute on Enter against a shell),
-    // exited panels, and dock/background panels.
-    if (!isAgentFleetActionEligible(panel)) return false;
-    // Mirrors `isHybridInputDisabled` in TerminalPane: a locked or restarting
-    // editor is read-only, and focus would fall back to the raw xterm.
-    if (panel.isInputLocked === true) return false;
-    if (panel.isRestarting === true) return false;
-    return true;
-  };
+  const isRoutable = (id: string): boolean => isRescueTargetRoutable(ctx, id);
 
   if (ctx.lastTypedTerminalId !== null) {
     return isRoutable(ctx.lastTypedTerminalId) ? ctx.lastTypedTerminalId : null;

--- a/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
@@ -364,6 +364,9 @@ const { insertFileReferenceMock, canInsertRef } = vi.hoisted(() => ({
 vi.mock("@/hooks/useInsertFileReference", () => ({
   useInsertFileReference: () => ({
     canInsert: canInsertRef.current,
+    // The pane only reads the boolean; the reason is here so the shared menu
+    // item renders the same shape it does in production.
+    refusalReason: canInsertRef.current ? null : "multiple-eligible-agents",
     insert: insertFileReferenceMock,
   }),
 }));


### PR DESCRIPTION
## Summary

`Insert file reference` in the file row context menu was greyed out with no reason given. Seven distinct gates all collapsed to one `null`, so the same grey item meant "you haven't typed to an agent yet," "your fleet is armed," and "your agent is docked." It read as broken rather than conditional.

The issue offered two ways out: explain the reason, or resolve a target in more cases. This PR takes the first. The second was already ruled out twice on purpose. `lastTypedAgentTarget` is deliberately not derived from panel selection or focus (`terminalInputStore.ts`, and #11147's refuse-rather-than-guess contract), and `useInsertFileReference`'s own docstring says reusing that contract "is exactly right here." A tooltip is also structurally impossible: `ContextMenuItem` carries `data-[disabled]:pointer-events-none`, so hover never lands, and Radix drops disabled items from the roving tabindex.

So the fix follows the pattern already live in `WorktreeMenuItems.tsx` ("Pull and rebase" / "No upstream"): a `ContextMenuMeta` slot for the visible reason, folded into the item's `aria-label` since `ContextMenuMeta` is `aria-hidden`. The reason takes the trailing slot from the Cmd+I hint rather than sitting beside it. Two `ml-auto` siblings would split the free space into two ragged columns, and advertising a keybinding on an item that can't run is the same lie `aria-keyshortcuts` already declines to tell.

Resolves #12207

## Changes

- `resolveInsertTargetId` becomes `resolveInsertTarget`, returning a discriminated `{ targetId, reason }`. One walk decides both halves, so the enabled state and the displayed reason can't disagree.
- `resolveRescueTarget`'s per-panel `isRoutable` closure is extracted as the exported `isRescueTargetRoutable`, shared verbatim by both paths so they can't drift on what counts as an available agent. `resolveRescueTarget` keeps its signature and behaviour.
- `InsertFileReference` is discriminated on `canInsert`, so "disabled with no reason," the state the issue is about, can't be constructed.
- The subscription moves to `useShallow` to keep the single-value selector's re-render behaviour now that the verdict is a pair.

Seven reasons a user can now see: No workspace, Fleet armed, Input bar off, No terminal service, Agent unavailable, No agent available, Type to an agent.

## Testing

381 tests pass across the 8 affected specs. `npm run typecheck` is clean. Prettier and eslint are clean on the changed files with no new warnings. The `useShallow` usage was mutation checked: removing it from the hook fails that one test and nothing else.

One thing worth flagging honestly: Radix excludes disabled items from arrow-key focus, so the reason reaches sighted users and the accessible name but not in-menu arrow navigation. That's inherent to the shared `ContextMenuItem` primitive and identical to the existing `WorktreeMenuItems` precedent, so changing it is a design-system decision for every menu, not something in scope here.
