### PR TITLE
feat(file-menu): nest file row copies and plugin items into submenus

### DIFF
--- a/src/components/FileViewer/__tests__/DiffFileSidebar.test.tsx
+++ b/src/components/FileViewer/__tests__/DiffFileSidebar.test.tsx
@@ -75,6 +75,16 @@ function renderSidebar(overrides: Partial<React.ComponentProps<typeof DiffFileSi
   return { onSelect, ...utils };
 }
 
+/**
+ * Opens a nested submenu and hands back its content. `SubContent` is
+ * Presence-gated, so its items are not in the DOM until the trigger fires;
+ * clicked rather than hovered because Radix opens synchronously on click.
+ */
+async function openSubmenu(menu: HTMLElement, name: string): Promise<HTMLElement> {
+  fireEvent.click(within(menu).getByRole("menuitem", { name }));
+  return screen.findByRole("menu", { name });
+}
+
 beforeAll(async () => {
   await primeRadix();
 });
@@ -95,7 +105,8 @@ describe("DiffFileSidebar — file row menu", () => {
 
     const menu = await screen.findByRole("menu");
     expect(within(menu).getByRole("menuitem", { name: /Open file/ })).toBeTruthy();
-    expect(within(menu).getByRole("menuitem", { name: /Copy path/ })).toBeTruthy();
+    const copy = await openSubmenu(menu, "Copy");
+    expect(within(copy).getByRole("menuitem", { name: "Copy path" })).toBeTruthy();
     expect(screen.queryByText(OUTER_SENTINEL)).toBeNull();
   });
 
@@ -139,8 +150,9 @@ describe("DiffFileSidebar — file row menu", () => {
     fireEvent.contextMenu(screen.getByTestId("diff-sidebar-file").parentElement!);
     const menu = await screen.findByRole("menu");
 
-    expect(within(menu).queryByRole("menuitem", { name: "Copy context" })).toBeNull();
-    expect(within(menu).getByRole("menuitem", { name: /Copy path/ })).toBeTruthy();
+    const copy = await openSubmenu(menu, "Copy");
+    expect(within(copy).queryByRole("menuitem", { name: "Copy context" })).toBeNull();
+    expect(within(copy).getByRole("menuitem", { name: "Copy path" })).toBeTruthy();
   });
 
   it("offers no row menu at all when the worktree root has not resolved", async () => {
@@ -154,7 +166,9 @@ describe("DiffFileSidebar — file row menu", () => {
     fireEvent.contextMenu(screen.getByTestId("diff-sidebar-file").parentElement!);
 
     expect(await screen.findByText(OUTER_SENTINEL)).toBeTruthy();
-    expect(screen.queryByRole("menuitem", { name: /Copy path/ })).toBeNull();
+    // The row menu's own root row, not one of its nested copies — a closed
+    // submenu is absent from the DOM either way and would prove nothing.
+    expect(screen.queryByRole("menuitem", { name: "Copy" })).toBeNull();
   });
 
   it("stands the global menu key down only while rows have a menu to open", () => {
@@ -180,7 +194,8 @@ describe("DiffFileSidebar — file row menu", () => {
 
     fireEvent.contextMenu(screen.getByTestId("diff-sidebar-file").parentElement!);
     const menu = await screen.findByRole("menu");
-    fireEvent.click(within(menu).getByRole("menuitem", { name: "Acme thing" }));
+    const extensions = await openSubmenu(menu, "Extensions");
+    fireEvent.click(within(extensions).getByRole("menuitem", { name: "Acme thing" }));
 
     const call = dispatchMock.mock.calls.find(([id]) => id === "acme.do");
     expect(call).toBeDefined();

--- a/src/components/Plugin/PluginContextMenuSection.tsx
+++ b/src/components/Plugin/PluginContextMenuSection.tsx
@@ -23,9 +23,11 @@ interface PluginContextMenuSectionProps {
   dispatchArgs?: Record<string, unknown>;
   /**
    * Whether to render a leading separator above the items. Defaults to `true`
-   * (the section trails native menu items on every surface). Pass `false` only
-   * when plugin items are a menu's entire content — since #11757 the `file`
-   * surface has a built-in core above them and keeps the separator.
+   * (the section trails native menu items on the surfaces that render it
+   * inline). Pass `false` when the parent owns the boundary instead: plugin
+   * items are a menu's entire content, or the section sits inside a submenu
+   * whose shell already separates the groups — which is what the `file` surface
+   * does since #12206.
    */
   leadingSeparator?: boolean;
 }

--- a/src/components/Worktree/__tests__/FileChangeList.pluginMenu.test.tsx
+++ b/src/components/Worktree/__tests__/FileChangeList.pluginMenu.test.tsx
@@ -76,6 +76,16 @@ function renderInWorktreeCard(props: Partial<React.ComponentProps<typeof FileCha
   );
 }
 
+/**
+ * Opens a nested submenu and hands back its content. `SubContent` is
+ * Presence-gated, so its items are not in the DOM until the trigger fires;
+ * clicked rather than hovered because Radix opens synchronously on click.
+ */
+async function openSubmenu(menu: HTMLElement, name: string): Promise<HTMLElement> {
+  fireEvent.click(within(menu).getByRole("menuitem", { name }));
+  return screen.findByRole("menu", { name });
+}
+
 // Radix is behind a dynamic import; priming it once up front means the very
 // first right-click in each test has real primitives to open.
 beforeAll(async () => {
@@ -100,7 +110,8 @@ describe("FileChangeList — the file row owns its menu", () => {
 
     const menu = await screen.findByRole("menu");
     expect(within(menu).getByRole("menuitem", { name: /Open file/ })).toBeTruthy();
-    expect(within(menu).getByRole("menuitem", { name: /Copy path/ })).toBeTruthy();
+    const copy = await openSubmenu(menu, "Copy");
+    expect(within(copy).getByRole("menuitem", { name: "Copy path" })).toBeTruthy();
     expect(screen.queryByRole("menuitem", { name: WORKTREE_SENTINEL })).toBeNull();
   });
 
@@ -172,21 +183,24 @@ describe("FileChangeList — the file row owns its menu", () => {
 });
 
 describe("FileChangeList — plugin items", () => {
-  it("appends plugin items after the built-in core rather than replacing it", async () => {
+  it("nests plugin items under Extensions rather than replacing the core", async () => {
     itemsRef.current = [fileItem("acme.open")];
     renderInWorktreeCard();
 
     fireEvent.contextMenu(screen.getByRole("button", { name: "Open src/index.ts" }));
     const menu = await screen.findByRole("menu");
 
-    const items = within(menu).getAllByRole("menuitem");
-    const revealIndex = items.findIndex((item) => /Reveal|Show in/.test(item.textContent ?? ""));
-    const pluginIndex = items.findIndex((item) => item.textContent === "Open with Acme");
+    const rootLabels = within(menu)
+      .getAllByRole("menuitem")
+      .map((item) => item.textContent ?? "");
+    expect(rootLabels.some((label) => /Reveal|Show in/.test(label))).toBe(true);
+    // Document order, not a count: the trigger trails the core wherever the
+    // core's own length lands, and the plugin's own row never reaches the root.
+    expect(rootLabels).not.toContain("Open with Acme");
+    expect(rootLabels.at(-1)).toBe("Extensions");
 
-    expect(revealIndex).toBeGreaterThanOrEqual(0);
-    // Document order, not a count: the section trails the core wherever the
-    // core's own length lands.
-    expect(pluginIndex).toBeGreaterThan(revealIndex);
+    const extensions = await openSubmenu(menu, "Extensions");
+    expect(within(extensions).getByRole("menuitem", { name: "Open with Acme" })).toBeTruthy();
   });
 
   it("dispatches the clicked file's real absolute path, not undefined", async () => {
@@ -195,7 +209,8 @@ describe("FileChangeList — plugin items", () => {
 
     fireEvent.contextMenu(screen.getByRole("button", { name: "Open src/index.ts" }));
     const menu = await screen.findByRole("menu");
-    fireEvent.click(within(menu).getByRole("menuitem", { name: "Open with Acme" }));
+    const extensions = await openSubmenu(menu, "Extensions");
+    fireEvent.click(within(extensions).getByRole("menuitem", { name: "Open with Acme" }));
 
     const call = dispatchMock.mock.calls.find(([actionId]) => actionId === "acme.open");
     expect(call).toBeDefined();
@@ -212,7 +227,8 @@ describe("FileChangeList — plugin items", () => {
 
     fireEvent.contextMenu(screen.getByRole("button", { name: "Open src/abs.ts" }));
     const menu = await screen.findByRole("menu");
-    fireEvent.click(within(menu).getByRole("menuitem", { name: "Open with Acme" }));
+    const extensions = await openSubmenu(menu, "Extensions");
+    fireEvent.click(within(extensions).getByRole("menuitem", { name: "Open with Acme" }));
 
     const call = dispatchMock.mock.calls.find(([actionId]) => actionId === "acme.open");
     expect(call![1]).toMatchObject({ path: "/repo/src/abs.ts", status: "added" });

--- a/src/hooks/__tests__/useFileRowMenuItems.test.tsx
+++ b/src/hooks/__tests__/useFileRowMenuItems.test.tsx
@@ -136,6 +136,25 @@ function labels(menu: HTMLElement): string[] {
     .map((item) => item.textContent ?? "");
 }
 
+function separatorCount(menu: HTMLElement): number {
+  return within(menu).queryAllByRole("separator").length;
+}
+
+/**
+ * Opens a nested submenu and hands back its content.
+ *
+ * `SubContent` is Presence-gated: its items are not in the DOM at all until the
+ * trigger fires, so an assertion that skipped this step would look for nothing,
+ * find nothing, and pass for the wrong reason. Clicked rather than hovered —
+ * Radix opens synchronously on click, while the pointer path arms a 100ms timer
+ * this suite would then have to fake. The content is found by name because
+ * `SubContent` is labelled by its trigger and lands in a portal outside `menu`.
+ */
+async function openSubmenu(menu: HTMLElement, name: string): Promise<HTMLElement> {
+  fireEvent.click(within(menu).getByRole("menuitem", { name }));
+  return screen.findByRole("menu", { name });
+}
+
 beforeAll(async () => {
   await primeRadix();
 });
@@ -158,32 +177,80 @@ beforeEach(() => {
 afterEach(() => cleanup());
 
 describe("useFileRowMenuItems — canonical order", () => {
-  it("renders the core in the documented order for a changed file", async () => {
+  it("keeps only the direct actions at the root and nests the copies", async () => {
     const menu = await openMenu();
 
     expect(labels(menu)).toEqual([
       "Open diff",
       "Open file",
       "Open in editor",
+      "Reveal in Finder",
       expect.stringContaining("Insert file reference"),
+      "Copy",
+    ]);
+    // One rule, between the direct actions and Copy. Counted rather than
+    // eyeballed: the separators are the only thing here that can end up
+    // leading, trailing or doubled as items drop out.
+    expect(separatorCount(menu)).toBe(1);
+  });
+
+  it("renders the copies in the documented order inside the Copy submenu", async () => {
+    const menu = await openMenu();
+    const copy = await openSubmenu(menu, "Copy");
+
+    expect(labels(copy)).toEqual([
       "Copy context",
       "Copy path",
       "Copy relative path",
       "Copy file name",
       "Copy file contents",
-      "Reveal in Finder",
     ]);
+    // CopyTree is set apart from the three clipboard strings.
+    expect(separatorCount(copy)).toBe(1);
   });
 
-  it("appends plugin items after the core rather than replacing it", async () => {
+  it("nests plugin items under Extensions rather than trailing the root", async () => {
     itemsRef.current = [
       { pluginId: "acme", item: { label: "Acme thing", actionId: "acme.do", location: "file" } },
     ];
     const menu = await openMenu();
     const rendered = labels(menu);
 
-    expect(rendered.indexOf("Acme thing")).toBe(rendered.length - 1);
-    expect(rendered.indexOf("Acme thing")).toBeGreaterThan(rendered.indexOf("Reveal in Finder"));
+    // The whole point of the nesting: the root is the same height whatever is
+    // installed, and a third party can no longer render past the core.
+    expect(rendered).not.toContain("Acme thing");
+    expect(rendered.at(-1)).toBe("Extensions");
+    expect(separatorCount(menu)).toBe(2);
+
+    const extensions = await openSubmenu(menu, "Extensions");
+    expect(labels(extensions)).toEqual(["Acme thing"]);
+    // A lone contributor needs no provenance label above its own items.
+    expect(within(extensions).queryByText("acme")).toBeNull();
+    expect(separatorCount(extensions)).toBe(0);
+  });
+
+  it("groups the submenu by contributor when more than one plugin adds items", async () => {
+    itemsRef.current = [
+      { pluginId: "acme", item: { label: "Acme thing", actionId: "acme.do", location: "file" } },
+      { pluginId: "beta", item: { label: "Beta thing", actionId: "beta.do", location: "file" } },
+      { pluginId: "acme", item: { label: "Acme other", actionId: "acme.other", location: "file" } },
+    ];
+    const menu = await openMenu();
+    const extensions = await openSubmenu(menu, "Extensions");
+
+    // Grouped by contributor in first-seen order — acme's second item joins its
+    // first rather than staying where it happened to be contributed.
+    expect(labels(extensions)).toEqual(["Acme thing", "Acme other", "Beta thing"]);
+    expect(within(extensions).getByText("acme")).toBeTruthy();
+    expect(within(extensions).getByText("beta")).toBeTruthy();
+    expect(separatorCount(extensions)).toBe(1);
+  });
+
+  it("renders no Extensions trigger, and no rule for one, with nothing installed", async () => {
+    const menu = await openMenu();
+
+    expect(labels(menu)).not.toContain("Extensions");
+    expect(separatorCount(menu)).toBe(1);
   });
 });
 
@@ -208,9 +275,14 @@ describe("useFileRowMenuItems — conditional items", () => {
     expect(rendered).not.toContain("Open diff");
     expect(rendered).not.toContain("Open file");
     expect(rendered).not.toContain("Open in editor");
-    expect(rendered).toContain("Copy path");
-    expect(rendered).toContain("Copy context");
     expect(rendered).toContain("Reveal in Finder");
+    // With every open item gone the direct-action block is Reveal and Insert,
+    // so the rule below them still has something above it.
+    expect(separatorCount(menu)).toBe(1);
+
+    const copy = await openSubmenu(menu, "Copy");
+    expect(labels(copy)).toContain("Copy path");
+    expect(labels(copy)).toContain("Copy context");
   });
 
   it("drops the current-content items for a deleted file but keeps its diff", async () => {
@@ -222,15 +294,21 @@ describe("useFileRowMenuItems — conditional items", () => {
     expect(rendered).toContain("Open diff");
     expect(rendered).not.toContain("Open file");
     expect(rendered).not.toContain("Open in editor");
-    expect(rendered).toContain("Copy path");
+
+    const copy = await openSubmenu(menu, "Copy");
+    expect(labels(copy)).toContain("Copy path");
   });
 
   it("drops Copy context on a surface with no worktree behind it", async () => {
     const menu = await openMenu({ surface: { worktreeId: null } });
-    expect(labels(menu)).not.toContain("Copy context");
+    const copy = await openSubmenu(menu, "Copy");
+
+    expect(labels(copy)).not.toContain("Copy context");
     // The rest of the core is unaffected — a file must not lose Copy path by
-    // which panel lists it.
-    expect(labels(menu)).toContain("Copy path");
+    // which panel lists it — and the rule that set CopyTree apart goes with it
+    // rather than leading the submenu.
+    expect(labels(copy)).toContain("Copy path");
+    expect(separatorCount(copy)).toBe(0);
   });
 
   it("disables Insert file reference when no agent resolves", async () => {
@@ -282,7 +360,8 @@ describe("useFileRowMenuItems — path semantics", () => {
       ["Copy file name", "index.ts"],
     ] as const) {
       const menu = await openMenu();
-      fireEvent.click(within(menu).getByRole("menuitem", { name: label }));
+      const copy = await openSubmenu(menu, "Copy");
+      fireEvent.click(within(copy).getByRole("menuitem", { name: label }));
       await waitFor(() => expect(writeText).toHaveBeenCalledWith(expected));
       writeText.mockClear();
       cleanup();
@@ -296,8 +375,9 @@ describe("useFileRowMenuItems — path semantics", () => {
     const menu = await openMenu({
       row: { absolutePath: "/elsewhere/pkg/a.ts", relativePath: "pkg/a.ts" },
     });
+    const copy = await openSubmenu(menu, "Copy");
 
-    fireEvent.click(within(menu).getByRole("menuitem", { name: "Copy relative path" }));
+    fireEvent.click(within(copy).getByRole("menuitem", { name: "Copy relative path" }));
     await waitFor(() => expect(writeText).toHaveBeenCalledWith("pkg/a.ts"));
   });
 
@@ -305,8 +385,9 @@ describe("useFileRowMenuItems — path semantics", () => {
     const writeText = navigator.clipboard.writeText as ReturnType<typeof vi.fn>;
     writeText.mockRejectedValueOnce(new Error("nope"));
     const menu = await openMenu();
+    const copy = await openSubmenu(menu, "Copy");
 
-    fireEvent.click(within(menu).getByRole("menuitem", { name: "Copy path" }));
+    fireEvent.click(within(copy).getByRole("menuitem", { name: "Copy path" }));
 
     await waitFor(() => expect(notifyMock).toHaveBeenCalledTimes(1));
     const [payload] = notifyMock.mock.calls[0]!;
@@ -329,8 +410,9 @@ describe("useFileRowMenuItems — Copy file contents", () => {
         : Promise.resolve({ ok: true, result: undefined })
     );
     const menu = await openMenu();
+    const copy = await openSubmenu(menu, "Copy");
 
-    fireEvent.click(within(menu).getByRole("menuitem", { name: "Copy file contents" }));
+    fireEvent.click(within(copy).getByRole("menuitem", { name: "Copy file contents" }));
 
     await waitFor(() => {
       const call = dispatchMock.mock.calls.find(([id]) => id === "file.read");
@@ -351,8 +433,9 @@ describe("useFileRowMenuItems — Copy file contents", () => {
         : Promise.resolve({ ok: true, result: undefined })
     );
     const menu = await openMenu();
+    const copy = await openSubmenu(menu, "Copy");
 
-    fireEvent.click(within(menu).getByRole("menuitem", { name: "Copy file contents" }));
+    fireEvent.click(within(copy).getByRole("menuitem", { name: "Copy file contents" }));
 
     await waitFor(() => expect(notifyMock).toHaveBeenCalledTimes(1));
     const [payload] = notifyMock.mock.calls[0]!;
@@ -378,8 +461,9 @@ describe("useFileRowMenuItems — Copy file contents", () => {
         : Promise.resolve({ ok: true, result: undefined })
     );
     const menu = await openMenu();
+    const copy = await openSubmenu(menu, "Copy");
 
-    fireEvent.click(within(menu).getByRole("menuitem", { name: "Copy file contents" }));
+    fireEvent.click(within(copy).getByRole("menuitem", { name: "Copy file contents" }));
 
     await waitFor(() => expect(notifyMock).toHaveBeenCalledTimes(1));
     const [payload] = notifyMock.mock.calls[0]!;
@@ -405,7 +489,11 @@ describe("useFileRowMenuItems — Copy file contents", () => {
     ["a PDF", { absolutePath: "/repo/spec.pdf", name: "spec.pdf" }],
   ])("hides the item for %s", async (_case, row) => {
     const menu = await openMenu({ row });
-    expect(labels(menu)).not.toContain("Copy file contents");
+    // The submenu has to be opened first: its content is Presence-gated, so a
+    // check against the closed root would pass whether the item was dropped or
+    // not.
+    const copy = await openSubmenu(menu, "Copy");
+    expect(labels(copy)).not.toContain("Copy file contents");
   });
 
   it("copies an empty file as the empty string", async () => {
@@ -415,8 +503,9 @@ describe("useFileRowMenuItems — Copy file contents", () => {
         : Promise.resolve({ ok: true, result: undefined })
     );
     const menu = await openMenu();
+    const copy = await openSubmenu(menu, "Copy");
 
-    fireEvent.click(within(menu).getByRole("menuitem", { name: "Copy file contents" }));
+    fireEvent.click(within(copy).getByRole("menuitem", { name: "Copy file contents" }));
 
     // A truthiness gate on the read result would silently write nothing here.
     await waitFor(() => expect(writeTextMock).toHaveBeenCalledWith(""));
@@ -427,15 +516,17 @@ describe("useFileRowMenuItems — Copy file contents", () => {
     // Optimistic by design: the read is the real gate, and hiding everything
     // unfamiliar would drop the item for perfectly ordinary text files.
     const menu = await openMenu({ row: { absolutePath: "/repo/Makefile", name: "Makefile" } });
-    expect(labels(menu)).toContain("Copy file contents");
+    const copy = await openSubmenu(menu, "Copy");
+    expect(labels(copy)).toContain("Copy file contents");
   });
 });
 
 describe("useFileRowMenuItems — Copy context", () => {
   it("scopes CopyTree to the row's relative path and names the scope kind", async () => {
     const menu = await openMenu();
+    const copy = await openSubmenu(menu, "Copy");
 
-    fireEvent.click(within(menu).getByRole("menuitem", { name: "Copy context" }));
+    fireEvent.click(within(copy).getByRole("menuitem", { name: "Copy context" }));
 
     await waitFor(() => expect(copyContextMock).toHaveBeenCalledTimes(1));
     const [worktreeId, source, options, runSource] = copyContextMock.mock.calls[0]!;
@@ -449,8 +540,9 @@ describe("useFileRowMenuItems — Copy context", () => {
     const menu = await openMenu({
       row: { isDirectory: true, relativePath: "src", name: "src", status: null },
     });
+    const copy = await openSubmenu(menu, "Copy");
 
-    fireEvent.click(within(menu).getByRole("menuitem", { name: "Copy context" }));
+    fireEvent.click(within(copy).getByRole("menuitem", { name: "Copy context" }));
 
     await waitFor(() => expect(copyContextMock).toHaveBeenCalledTimes(1));
     const [, , options] = copyContextMock.mock.calls[0]!;

--- a/src/hooks/__tests__/useFileRowMenuItems.test.tsx
+++ b/src/hooks/__tests__/useFileRowMenuItems.test.tsx
@@ -230,13 +230,22 @@ describe("useFileRowMenuItems — canonical order", () => {
       { pluginId: "acme", item: { label: "Acme thing", actionId: "acme.do", location: "file" } },
     ];
     const menu = await openMenu();
-    const rendered = labels(menu);
 
     // The whole point of the nesting: the root is the same height whatever is
-    // installed, and a third party can no longer render past the core.
-    expect(rendered).not.toContain("Acme thing");
-    expect(rendered.at(-1)).toBe("Extensions");
-    expect(separatorCount(menu)).toBe(2);
+    // installed, and a third party can no longer render past the core. Pinned
+    // as a sequence so the second rule has to sit between Copy and Extensions
+    // rather than merely exist.
+    expect(structure(menu)).toEqual([
+      "Open diff",
+      "Open file",
+      "Open in editor",
+      "Reveal in Finder",
+      expect.stringContaining("Insert file reference"),
+      "---",
+      "Copy",
+      "---",
+      "Extensions",
+    ]);
 
     const extensions = await openSubmenu(menu, "Extensions");
     // A lone contributor needs no provenance label above its own items, and no

--- a/src/hooks/__tests__/useFileRowMenuItems.test.tsx
+++ b/src/hooks/__tests__/useFileRowMenuItems.test.tsx
@@ -141,6 +141,22 @@ function separatorCount(menu: HTMLElement): number {
 }
 
 /**
+ * A menu's rows in DOM order — items, group labels and rules alike, with rules
+ * written as `---`.
+ *
+ * `labels()` sees only menuitems and `separatorCount()` only counts, so between
+ * them a rule moved to the top of a menu, or a group label rendered away from
+ * the group it names, reads as correct. Placement is the whole claim in a
+ * regrouped menu, so it gets an assertion that can see it. The content's own
+ * scroll-shadow overlays are `aria-hidden` and drop out.
+ */
+function structure(menu: HTMLElement): string[] {
+  return [...menu.children]
+    .filter((node) => node.getAttribute("aria-hidden") !== "true")
+    .map((node) => (node.getAttribute("role") === "separator" ? "---" : (node.textContent ?? "")));
+}
+
+/**
  * Opens a nested submenu and hands back its content.
  *
  * `SubContent` is Presence-gated: its items are not in the DOM at all until the
@@ -180,33 +196,33 @@ describe("useFileRowMenuItems — canonical order", () => {
   it("keeps only the direct actions at the root and nests the copies", async () => {
     const menu = await openMenu();
 
-    expect(labels(menu)).toEqual([
+    // The rule is asserted in place, not counted: it is the one thing here that
+    // can end up leading, trailing or doubled as items drop out.
+    expect(structure(menu)).toEqual([
       "Open diff",
       "Open file",
       "Open in editor",
       "Reveal in Finder",
       expect.stringContaining("Insert file reference"),
+      "---",
       "Copy",
     ]);
-    // One rule, between the direct actions and Copy. Counted rather than
-    // eyeballed: the separators are the only thing here that can end up
-    // leading, trailing or doubled as items drop out.
-    expect(separatorCount(menu)).toBe(1);
   });
 
   it("renders the copies in the documented order inside the Copy submenu", async () => {
     const menu = await openMenu();
     const copy = await openSubmenu(menu, "Copy");
 
-    expect(labels(copy)).toEqual([
+    // CopyTree is set apart from the clipboard strings, and the rule sits
+    // between them rather than merely existing somewhere in the submenu.
+    expect(structure(copy)).toEqual([
       "Copy context",
+      "---",
       "Copy path",
       "Copy relative path",
       "Copy file name",
       "Copy file contents",
     ]);
-    // CopyTree is set apart from the three clipboard strings.
-    expect(separatorCount(copy)).toBe(1);
   });
 
   it("nests plugin items under Extensions rather than trailing the root", async () => {
@@ -223,10 +239,9 @@ describe("useFileRowMenuItems — canonical order", () => {
     expect(separatorCount(menu)).toBe(2);
 
     const extensions = await openSubmenu(menu, "Extensions");
-    expect(labels(extensions)).toEqual(["Acme thing"]);
-    // A lone contributor needs no provenance label above its own items.
-    expect(within(extensions).queryByText("acme")).toBeNull();
-    expect(separatorCount(extensions)).toBe(0);
+    // A lone contributor needs no provenance label above its own items, and no
+    // rule to divide it from a group that isn't there.
+    expect(structure(extensions)).toEqual(["Acme thing"]);
   });
 
   it("groups the submenu by contributor when more than one plugin adds items", async () => {
@@ -239,11 +254,39 @@ describe("useFileRowMenuItems — canonical order", () => {
     const extensions = await openSubmenu(menu, "Extensions");
 
     // Grouped by contributor in first-seen order — acme's second item joins its
-    // first rather than staying where it happened to be contributed.
-    expect(labels(extensions)).toEqual(["Acme thing", "Acme other", "Beta thing"]);
-    expect(within(extensions).getByText("acme")).toBeTruthy();
-    expect(within(extensions).getByText("beta")).toBeTruthy();
-    expect(separatorCount(extensions)).toBe(1);
+    // first rather than staying where it happened to be contributed. Asserted
+    // as one sequence because a label that doesn't sit above its own group is
+    // worse than no label: it credits the wrong extension.
+    expect(structure(extensions)).toEqual([
+      "acme",
+      "Acme thing",
+      "Acme other",
+      "---",
+      "beta",
+      "Beta thing",
+    ]);
+  });
+
+  it("opens and closes the Copy submenu from the keyboard", async () => {
+    // Nesting is only honest if it is reachable without a mouse. Every other
+    // submenu test here opens by click, so a regression that kept the click
+    // path and broke ArrowRight — or lost the trigger on the way back out —
+    // would leave the whole suite green with the copies unreachable.
+    const menu = await openMenu();
+    const trigger = within(menu).getByRole("menuitem", { name: "Copy" });
+
+    trigger.focus();
+    fireEvent.keyDown(trigger, { key: "ArrowRight" });
+
+    const copy = await screen.findByRole("menu", { name: "Copy" });
+    await waitFor(() => expect(copy.contains(document.activeElement)).toBe(true));
+
+    fireEvent.keyDown(copy, { key: "ArrowLeft" });
+
+    await waitFor(() => expect(screen.queryByRole("menu", { name: "Copy" })).toBeNull());
+    // Back on the trigger, not stranded on the document — the root menu is
+    // still open and still navigable.
+    expect(document.activeElement).toBe(trigger);
   });
 
   it("renders no Extensions trigger, and no rule for one, with nothing installed", async () => {
@@ -275,10 +318,14 @@ describe("useFileRowMenuItems — conditional items", () => {
     expect(rendered).not.toContain("Open diff");
     expect(rendered).not.toContain("Open file");
     expect(rendered).not.toContain("Open in editor");
-    expect(rendered).toContain("Reveal in Finder");
     // With every open item gone the direct-action block is Reveal and Insert,
-    // so the rule below them still has something above it.
-    expect(separatorCount(menu)).toBe(1);
+    // so the rule below them still has something above it and never leads.
+    expect(structure(menu)).toEqual([
+      "Reveal in Finder",
+      expect.stringContaining("Insert file reference"),
+      "---",
+      "Copy",
+    ]);
 
     const copy = await openSubmenu(menu, "Copy");
     expect(labels(copy)).toContain("Copy path");
@@ -294,6 +341,14 @@ describe("useFileRowMenuItems — conditional items", () => {
     expect(rendered).toContain("Open diff");
     expect(rendered).not.toContain("Open file");
     expect(rendered).not.toContain("Open in editor");
+    // Two of the three opens gone still leaves the rule with items above it.
+    expect(structure(menu)).toEqual([
+      "Open diff",
+      "Reveal in Finder",
+      expect.stringContaining("Insert file reference"),
+      "---",
+      "Copy",
+    ]);
 
     const copy = await openSubmenu(menu, "Copy");
     expect(labels(copy)).toContain("Copy path");

--- a/src/hooks/useFileRowMenuItems.tsx
+++ b/src/hooks/useFileRowMenuItems.tsx
@@ -1,15 +1,22 @@
-import { useCallback, useMemo } from "react";
+import { Fragment, useCallback, useMemo } from "react";
 import type React from "react";
 import { Copy, ExternalLink, FileDiff } from "lucide-react";
-import { AtSign, FileText, FolderOpen, Folders } from "@/components/icons";
+import { AtSign, FileText, FolderOpen, Folders, Package } from "@/components/icons";
 import {
   ContextMenuActionItem,
   ContextMenuItem,
+  ContextMenuLabel,
   ContextMenuSeparator,
   ContextMenuShortcut,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
 } from "@/components/ui/context-menu";
 import { PluginContextMenuSection } from "@/components/Plugin/PluginContextMenuSection";
-import { usePluginContextMenuItems } from "@/hooks/usePluginContextMenuItems";
+import {
+  usePluginContextMenuItems,
+  type PluginContextMenuItemEntry,
+} from "@/hooks/usePluginContextMenuItems";
 import { useInsertFileReference } from "@/hooks/useInsertFileReference";
 import { copyContextWithFeedback } from "@/hooks/useWorktreeActions";
 import { revealCopy } from "@/components/FileViewer/revealCopy";
@@ -186,11 +193,31 @@ export function isFileRowMenuKey(event: {
  * browser's `Show contents` / `Set as root` for a folder); the core itself is
  * identical everywhere, so a file never gains or loses `Copy path` by which
  * panel it happens to be listed in.
+ *
+ * The root is the direct actions only — the opens, reveal, insert — with the
+ * copies and the plugin contributions nested (#12206). That keeps it the same
+ * height on every row and with any number of plugins installed, so the folder
+ * prefix reads as the first group of one menu rather than as a lid on a
+ * ten-item column.
  */
 export function useFileRowMenuItems(surface: FileRowMenuSurface): FileRowMenuController {
   const { worktreePath, worktreeId, copyTreeRunSource } = surface;
   const filePluginItems = usePluginContextMenuItems("file");
   const { canInsert, insert } = useInsertFileReference();
+
+  // Bucketed here rather than in `renderItems`: that runs once per row, and a
+  // Review Hub listing thousands of changed files would rebuild the same map
+  // for every one of them. Insertion order is the plugins' contribution order,
+  // so the submenu doesn't reshuffle between renders.
+  const pluginGroups = useMemo(() => {
+    const byPluginId = new Map<string, PluginContextMenuItemEntry[]>();
+    for (const entry of filePluginItems) {
+      const bucket = byPluginId.get(entry.pluginId);
+      if (bucket) bucket.push(entry);
+      else byPluginId.set(entry.pluginId, [entry]);
+    }
+    return [...byPluginId.entries()];
+  }, [filePluginItems]);
 
   const reveal = useMemo(() => revealCopy(), []);
   const insertShortcutHint = isMac() ? "⌘I" : "Ctrl+I";
@@ -310,7 +337,10 @@ export function useFileRowMenuItems(surface: FileRowMenuSurface): FileRowMenuCon
               </ContextMenuActionItem>
             </>
           )}
-          {(showOpenDiff || showOpenCurrent) && <ContextMenuSeparator />}
+          <ContextMenuItem onSelect={() => handleReveal(absolutePath)}>
+            <FolderOpen className={ICON_CLASS} />
+            {reveal.label}
+          </ContextMenuItem>
           {/* Disabled rather than hidden when nothing resolves: the gesture is
               the point of the menu entry, and a row that silently drops it
               would read as broken. The agent is resolved from typing history,
@@ -324,60 +354,104 @@ export function useFileRowMenuItems(surface: FileRowMenuSurface): FileRowMenuCon
             Insert file reference
             <ContextMenuShortcut>{insertShortcutHint}</ContextMenuShortcut>
           </ContextMenuItem>
-          {/* Always enabled for a worktree: the row's ignore status isn't known
-              here, and CopyTree still applies its own .gitignore-aware
-              discovery (reporting when nothing was eligible), so this stays
-              safe for an ignored path. Absent for a workspace root — CopyTree
-              is worktree-scoped, so leaving it on would be a dead item
-              (#11482). */}
-          {worktreeId !== null && (
-            <ContextMenuItem onSelect={() => handleCopyContext(target)}>
-              <Folders className={ICON_CLASS} />
-              Copy context
-            </ContextMenuItem>
-          )}
+          {/* Reveal and Insert render unconditionally, so the direct-action
+              block above is never empty and this separator never leads. */}
           <ContextMenuSeparator />
-          <ContextMenuItem onSelect={() => copyToClipboard(absolutePath, "Couldn't copy path")}>
-            <Copy className={ICON_CLASS} />
-            Copy path
-          </ContextMenuItem>
-          <ContextMenuItem onSelect={() => copyToClipboard(relativePath, "Couldn't copy path")}>
-            <Copy className={ICON_CLASS} />
-            Copy relative path
-          </ContextMenuItem>
-          <ContextMenuItem onSelect={() => copyToClipboard(name, "Couldn't copy file name")}>
-            <Copy className={ICON_CLASS} />
-            Copy file name
-          </ContextMenuItem>
-          {showCopyFileContents && (
-            <ContextMenuItem onSelect={() => handleCopyFileContents(absolutePath)}>
+          {/* Nested for the same reason the worktree card nests its own Copy:
+              four near-identical rows read as one choice, not four, and the
+              root stays the length of the things the menu is actually opened
+              for. Always present — the three path copies never gate. */}
+          <ContextMenuSub>
+            <ContextMenuSubTrigger>
               <Copy className={ICON_CLASS} />
-              Copy file contents
-            </ContextMenuItem>
+              Copy
+            </ContextMenuSubTrigger>
+            <ContextMenuSubContent>
+              {/* First and set apart, mirroring the worktree card: this runs
+                  CopyTree over the row, it does not put a string on the
+                  clipboard. Always enabled for a worktree — the row's ignore
+                  status isn't known here, and CopyTree still applies its own
+                  .gitignore-aware discovery (reporting when nothing was
+                  eligible), so this stays safe for an ignored path. Absent for
+                  a workspace root, where CopyTree is worktree-scoped and it
+                  would be a dead item (#11482). */}
+              {worktreeId !== null && (
+                <>
+                  <ContextMenuItem onSelect={() => handleCopyContext(target)}>
+                    <Folders className={ICON_CLASS} />
+                    Copy context
+                  </ContextMenuItem>
+                  <ContextMenuSeparator />
+                </>
+              )}
+              <ContextMenuItem onSelect={() => copyToClipboard(absolutePath, "Couldn't copy path")}>
+                <Copy className={ICON_CLASS} />
+                Copy path
+              </ContextMenuItem>
+              <ContextMenuItem onSelect={() => copyToClipboard(relativePath, "Couldn't copy path")}>
+                <Copy className={ICON_CLASS} />
+                Copy relative path
+              </ContextMenuItem>
+              <ContextMenuItem onSelect={() => copyToClipboard(name, "Couldn't copy file name")}>
+                <Copy className={ICON_CLASS} />
+                Copy file name
+              </ContextMenuItem>
+              {showCopyFileContents && (
+                <ContextMenuItem onSelect={() => handleCopyFileContents(absolutePath)}>
+                  <Copy className={ICON_CLASS} />
+                  Copy file contents
+                </ContextMenuItem>
+              )}
+            </ContextMenuSubContent>
+          </ContextMenuSub>
+          {/* Plugins reach every file surface through this one submenu, or none
+              of them (#11757). Nested so the root is the same height whatever
+              is installed, and grouped by plugin so two extensions offering
+              similarly named items stay tellable apart — the same shape the
+              worktree card's Extensions uses. Rendered only when something
+              contributes: an empty submenu is a dead end. */}
+          {pluginGroups.length > 0 && (
+            <>
+              <ContextMenuSeparator />
+              <ContextMenuSub>
+                <ContextMenuSubTrigger>
+                  <Package className={ICON_CLASS} />
+                  Extensions
+                </ContextMenuSubTrigger>
+                <ContextMenuSubContent>
+                  {pluginGroups.map(([pluginId, entries], groupIndex) => (
+                    <Fragment key={pluginId}>
+                      {pluginGroups.length > 1 && groupIndex > 0 && <ContextMenuSeparator />}
+                      {pluginGroups.length > 1 && <ContextMenuLabel>{pluginId}</ContextMenuLabel>}
+                      {/* Still the shared section, one call per group: it owns
+                          the action source, the namespaced keys and the
+                          dispatch, and a second copy of that here is how the
+                          two drift. The separators are the shell's now, so it
+                          renders none. The dispatched args name the clicked
+                          file so a plugin item receives its subject rather than
+                          `undefined`. */}
+                      <PluginContextMenuSection
+                        items={entries}
+                        leadingSeparator={false}
+                        dispatchArgs={{
+                          path: absolutePath,
+                          ...(worktreePath && { worktreePath }),
+                          ...(status && { status }),
+                        }}
+                      />
+                    </Fragment>
+                  ))}
+                </ContextMenuSubContent>
+              </ContextMenuSub>
+            </>
           )}
-          <ContextMenuSeparator />
-          <ContextMenuItem onSelect={() => handleReveal(absolutePath)}>
-            <FolderOpen className={ICON_CLASS} />
-            {reveal.label}
-          </ContextMenuItem>
-          {/* Plugins reach every file surface through this one section, or
-              none of them (#11757). The dispatched args name the clicked file
-              so a plugin item receives its subject rather than `undefined`. */}
-          <PluginContextMenuSection
-            items={filePluginItems}
-            dispatchArgs={{
-              path: absolutePath,
-              ...(worktreePath && { worktreePath }),
-              ...(status && { status }),
-            }}
-          />
         </>
       );
     },
     [
       worktreePath,
       worktreeId,
-      filePluginItems,
+      pluginGroups,
       canInsert,
       insert,
       insertAriaKeyshortcuts,

--- a/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
@@ -411,6 +411,23 @@ vi.mock("@/components/ui/context-menu", async (importOriginal) => ({
   ),
   ContextMenuShortcut: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
   ContextMenuSeparator: () => null,
+  // Flat, always-rendered stand-ins for the submenu primitives (#12206). The
+  // real ones need a Radix menu root this harness never mounts, and gate their
+  // content behind an open state — so every nested "Copy path" assertion here
+  // would look for something that is not in the DOM and pass for the wrong
+  // reason. What this suite owns is which path each item names, not Radix's
+  // nesting; the hook's own suite drives the real submenus.
+  ContextMenuSub: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  ContextMenuSubTrigger: ({ children }: { children: React.ReactNode }) => (
+    <button type="button">{children}</button>
+  ),
+  // Marked rather than bare so a test can still tell a root row from a nested
+  // one — flattening is what makes the items reachable here, and it is also
+  // what would otherwise hide a regression that moved something up to the root.
+  ContextMenuSubContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-submenu-content="">{children}</div>
+  ),
+  ContextMenuLabel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
 }));
 
 // The view's own workspace root, behind a worktree-less browser (#11482). The
@@ -498,6 +515,7 @@ import {
   FILE_BROWSER_SIDEBAR_RESIZE_STEP_COARSE as COARSE_W,
 } from "../sidebarWidth";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { revealCopy } from "@/components/FileViewer/revealCopy";
 import {
   getFileBrowserRowGitStatus,
   type FileBrowserGitStatusIndex,
@@ -3009,6 +3027,28 @@ describe("FileBrowserPane tree navigation vs the viewer", () => {
     });
 
     expect(viewerWrites()).toEqual([FOLDER_ROW.path]);
+  });
+
+  it("reads as one menu: the folder prefix, then the shared direct actions", () => {
+    // The prefix lives here and the core lives in the shared hook, so nothing
+    // else asserts that they compose. Order only — this suite's menu stub
+    // renders no separators, and the hook's own suite counts those.
+    renderPane();
+
+    const menu = screen.getByTestId("file-tree-view");
+    expect(
+      within(menu)
+        .getAllByRole("button")
+        .filter((item) => item.closest("[data-submenu-content]") === null)
+        .map((item) => item.textContent ?? "")
+    ).toEqual([
+      "Show contents",
+      "Set as root",
+      "Refresh",
+      revealCopy().label,
+      expect.stringContaining("Insert file reference"),
+      "Copy",
+    ]);
   });
 
   it("reveals a collapsed viewer for both explicit folder routes", () => {


### PR DESCRIPTION
## Summary
- The shared file row context menu (`src/hooks/useFileRowMenuItems.tsx`) had grown to ten flat items plus whatever a plugin contributes, across five surfaces: the file browser tree, the file browser folder listing, the worktree card's changed files, the Review Hub staging rows, and the diff file sidebar.
- Reorganizes it to match the shape the worktree card menu already uses: direct actions stay at the root, copies move into a `Copy` submenu, and plugin items move into an `Extensions` submenu.

Resolves #12206

## Changes
- Root keeps only the direct actions: Open diff / Open file / Open in editor, Reveal in Finder, Insert file reference.
- `Copy path`, `Copy relative path`, `Copy file name`, and `Copy file contents` move under a new `Copy` submenu. `Copy context` is placed first and set apart by a separator, since it runs CopyTree rather than writing a clipboard string.
- Plugin items move under a new `Extensions` submenu, grouped per plugin (a per-plugin label only shows when more than one plugin contributes), and the submenu is omitted entirely when nothing contributes, so the root menu is the same height whatever's installed.
- No call site changes: all five surfaces still render the returned fragment into their own `ContextMenuContent`, and the file browser's folder-specific prefix (`Show contents`, `Set as root`, `Refresh`) still composes as the first group.
- Plugin grouping is memoized once per surface, not rebuilt per row, since `renderItems` runs once per row and the Review Hub can list thousands.
- Updated the doc comment on `PluginContextMenuSection`'s `leadingSeparator` prop: `false` now also means the parent owns the boundary, for the submenu case. Its other consumer, `TerminalContextMenu`, keeps the default and is unaffected.

Item labels were deliberately not shortened to match the worktree card's style (`Path`, `Full context`). `Copy context` is a product term shared with the CopyTree panel, its toolbar button, and its keyboard shortcut, so renaming it here would desync the one name that needs to stay stable. Easy follow-up if wanted.

`Insert file reference`'s greyed-out state is out of scope, tracked separately as #12207.

## Testing
- Targeted vitest sweep over every suite touching the changed modules and all five surfaces: 228 test files, 4472 tests, all passing. Includes `useFileRowMenuItems.test.tsx`, `PluginContextMenuSection.test.tsx`, `DiffFileSidebar.test.tsx`, and the full `file-browser`, `Worktree`, `ReviewHub`, `Terminal`, and `ui` test directories.
- `prettier --check` and `eslint` on the 6 changed files: 0 errors, 11 pre-existing warnings, ratchet counts unchanged from origin/develop.
- Two adversarial Codex review passes plus a confirmation pass. The correctness pass found nothing and confirmed no new React Compiler bailout on the changed files. The test pass found no high-severity issues; its minor findings were addressed except one deliberately left as-is.
- Didn't run the full test suite, a build, or E2E locally. Relying on GitHub CI for those.