### PR TITLE
fix(plugins): stop project plugins leaking raw instance keys

### DIFF
--- a/electron/plugin-dev-worker.ts
+++ b/electron/plugin-dev-worker.ts
@@ -7,7 +7,7 @@
 
 import { PluginDevWorkerHostProxy } from "./services/plugin/pluginDevWorkerHostProxy.js";
 import { formatErrorMessage } from "../shared/utils/errorMessage.js";
-import type { PluginActivate } from "../shared/types/plugin.js";
+import type { PluginActivate, PluginIdentity } from "../shared/types/plugin.js";
 import type {
   PluginHostToWorkerMessage,
   PluginWorkerToHostMessage,
@@ -43,11 +43,11 @@ let proxy: PluginDevWorkerHostProxy | null = null;
 let cleanup: (() => void) | null = null;
 let started = false;
 
-async function start(bundleUrl: string, pluginId: string): Promise<void> {
+async function start(bundleUrl: string, pluginId: string, identity: PluginIdentity): Promise<void> {
   if (started) return;
   started = true;
 
-  proxy = new PluginDevWorkerHostProxy(pluginId, post);
+  proxy = new PluginDevWorkerHostProxy(pluginId, post, identity);
 
   let mod: { activate?: unknown };
   try {
@@ -111,7 +111,7 @@ port.on("message", (rawMsg: unknown) => {
 
   switch (msg.type) {
     case "start":
-      void start(msg.bundleUrl, msg.pluginId);
+      void start(msg.bundleUrl, msg.pluginId, msg.identity);
       return;
     case "dispose":
       disposeAndExit();

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -104,6 +104,8 @@ import { store } from "../store.js";
 import {
   makeProjectPluginInstanceKey,
   parseProjectPluginInstanceKey,
+  pluginManifestIdFromInstanceKey,
+  projectIdFromPluginInstanceKey,
 } from "../../shared/types/plugin.js";
 import {
   PluginPanelLifecycleBroker,
@@ -2724,16 +2726,13 @@ export class PluginService {
     // buffers and audit records are themselves keyed by the registry key, the
     // one class of plugin whose author is reading these diagnostics (#12214).
     //
-    // Indexed by manifest identity: each load parses and freezes its own
-    // manifest object, so two projects holding the same id still index apart.
-    const keyByManifest = new Map<Readonly<PluginManifest>, string>();
-    for (const [key, plugin] of this.plugins) keyByManifest.set(plugin.manifest, key);
-
+    // `info.instanceId` IS that registry key — `listPlugins` carries it through
+    // (#12211) — so this filters and indexes on the key itself rather than
+    // reconstructing it from manifest object identity.
     const plugins = this.listPlugins()
-      .filter((info) => keyByManifest.has(info.manifest))
+      .filter((info) => this.plugins.has(info.instanceId))
       .map((info) => {
-        // Non-null: the filter above admitted only manifests present in the index.
-        const pluginId = keyByManifest.get(info.manifest) as string;
+        const pluginId = info.instanceId;
         const buffer = this.logBuffers.get(pluginId);
         return {
           pluginId,
@@ -2787,6 +2786,7 @@ export class PluginService {
       recordPluginLog: (boundPlugin, pluginId, level, message, fields) =>
         this.recordPluginLog(boundPlugin, pluginId, level, message, fields),
       serializePluginBadges: (pluginId) => this.serializePluginBadges(pluginId),
+      pluginDisplayName: (pluginId) => this.getPluginDisplayName(pluginId),
       pluginDataDir: (pluginId) => this.pluginDataDir(pluginId),
       isPathUnder: (root, candidate) => this.isPathUnder(root, candidate),
       expandAllowedPathEntries: (pluginId, options) =>
@@ -4559,6 +4559,21 @@ export class PluginService {
   }
 
   /**
+   * The user-facing name of a loaded plugin — what any surface that names a
+   * plugin to a person should print instead of its id.
+   *
+   * The id is an instance key for a project-owned plugin, so printing it raw
+   * leaks `project__{projectId}__{manifestId}` into the UI (#12211). An
+   * unloaded plugin falls back to its manifest id rather than the instance key,
+   * which keeps even the miss path free of the machine-local project id.
+   */
+  getPluginDisplayName(pluginId: string): string {
+    const manifest = this.plugins.get(pluginId)?.manifest;
+    if (!manifest) return pluginManifestIdFromInstanceKey(pluginId);
+    return manifest.displayName ?? manifest.name;
+  }
+
+  /**
    * Resolve a `${settings:<id>}` template by reading the named user-scope
    * setting and stringifying the value. Booleans and numbers become their
    * JSON representation; objects/arrays become JSON-encoded strings. An
@@ -4582,6 +4597,10 @@ export class PluginService {
     const desiredDisabled = this.records.getDisabledIds();
     const installed = this.records.getInstalledRecords();
 
+    // `instanceId` is the MAP KEY, not `manifest.name`: for a project-owned
+    // plugin those differ, and the key is what every contribution carries as
+    // its `pluginId`/`extensionId`. Dropping it here is what left the renderer
+    // unable to match a contribution to its plugin (#12211).
     const toInfo = (
       instanceId: string,
       p: { manifest: PluginManifest; dir: string; isBuiltin: boolean },
@@ -4589,7 +4608,21 @@ export class PluginService {
       isRunning: boolean,
       blocklistReason?: string
     ): LoadedPluginInfo => {
-      const disabled = desiredDisabled.has(p.manifest.name);
+      const projectId = projectIdFromPluginInstanceKey(instanceId);
+      const isProject = projectId !== null;
+      const identity = {
+        instanceId,
+        origin: isProject ? ("project" as const) : ("global" as const),
+        projectId,
+      };
+      // Both of these are keyed by manifest id, and a project plugin is allowed
+      // to share its manifest id with an installed one — so consulting either
+      // for a project row hands it the *other* plugin's state. The disable list
+      // is explicitly about installed and builtin plugins (a project plugin's
+      // gate is its project's trust decision, see the load path), and the
+      // install record belongs to the global copy. A project instance only ever
+      // reaches this projection from the running map, so it is never disabled.
+      const disabled = isProject ? false : desiredDisabled.has(p.manifest.name);
       // pendingRestart: desired state diverges from running state.
       // Running + now-disabled → unload pending; skipped + now-enabled → load pending.
       // Blocklisted plugins are host-refused, not user-toggled — no pending cue.
@@ -4598,8 +4631,8 @@ export class PluginService {
       const pluginDanger = computePluginDanger(p.manifest);
       if (p.isBuiltin) {
         return {
+          ...identity,
           manifest: p.manifest,
-          instanceId,
           dir: p.dir,
           loadedAt,
           isBuiltin: true,
@@ -4617,10 +4650,10 @@ export class PluginService {
           blocklistReason,
         };
       }
-      const record = installed[p.manifest.name];
+      const record = isProject ? undefined : installed[p.manifest.name];
       return {
+        ...identity,
         manifest: p.manifest,
-        instanceId,
         dir: p.dir,
         loadedAt,
         isBuiltin: false,

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -2270,6 +2270,9 @@ export class PluginService {
     const { host, revoke } = this.createHost(pluginId);
     const workerHost = new PluginDevWorkerHost({
       pluginId,
+      // The host's own identity, so the worker-side proxy reports the real
+      // binding instead of reconstructing one from the instance key.
+      identity: host.pluginInfo,
       pluginDir: plugin.dir,
       bundlePath: plugin.resolvedMain,
       mode: plugin.devMode ? "dev" : "prod",

--- a/electron/services/__tests__/PluginService.core.test.ts
+++ b/electron/services/__tests__/PluginService.core.test.ts
@@ -446,6 +446,53 @@ describe("PluginService", () => {
     expect(plugins[0].manifest.main).toBe("../evil.js");
   });
 
+  it("carries the host-side instance key and origin on every listPlugins entry", async () => {
+    // #12211: the entries were built from `this.plugins.values()`, so the map
+    // key — the id every contribution carries — never reached the renderer.
+    await writePlugin("origin-test", {
+      name: "acme.origin-test",
+      version: "1.0.0",
+      displayName: "Origin Test",
+    });
+
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const plugins = service.listPlugins();
+    expect(plugins).toHaveLength(1);
+    // An installed plugin's instance key IS its manifest id — this path must
+    // stay byte-identical to the pre-fix behaviour.
+    expect(plugins[0].instanceId).toBe("acme.origin-test");
+    expect(plugins[0].origin).toBe("global");
+    expect(plugins[0].projectId).toBeNull();
+  });
+
+  it("reports a project-owned instance under its instance key, not its manifest name", async () => {
+    await writePlugin("proj-test", {
+      name: "acme.proj-test",
+      version: "1.0.0",
+      displayName: "Project Test",
+    });
+
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    // Re-key the loaded entry the way the project loader does. Going through
+    // the map directly keeps this a test of listPlugins' projection rather than
+    // of the project-plugin loader, which has its own coverage.
+    const maps = service as unknown as { plugins: Map<string, unknown> };
+    const loaded = maps.plugins.get("acme.proj-test");
+    expect(loaded).toBeDefined();
+    maps.plugins.delete("acme.proj-test");
+    maps.plugins.set("project__b6700c7a__acme.proj-test", loaded);
+
+    const entry = service.listPlugins().find((p) => p.manifest.name === "acme.proj-test");
+    expect(entry).toBeDefined();
+    expect(entry!.instanceId).toBe("project__b6700c7a__acme.proj-test");
+    expect(entry!.origin).toBe("project");
+    expect(entry!.projectId).toBe("b6700c7a");
+  });
+
   it("does not include resolvedMain in listPlugins output", async () => {
     await writePlugin("main-test", {
       name: "acme.main-test",

--- a/electron/services/__tests__/PluginService.createHostCore.test.ts
+++ b/electron/services/__tests__/PluginService.createHostCore.test.ts
@@ -1031,6 +1031,35 @@ describe("createHost — showToast", () => {
     });
   });
 
+  it("prefixes with the manifest displayName rather than the raw plugin id", async () => {
+    // A project plugin's id is an instance key, so the raw prefix read
+    // `project__b67…: Synced 12 videos` in the UI (#12211). The prefix stays —
+    // it is unspoofable provenance — but it names the plugin, not the key.
+    await writePlugin("toast-named", {
+      name: "acme.toast-named",
+      version: "1.0.0",
+      displayName: "Video Manager",
+    });
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const { host } = (service as unknown as { createHost: ToastHostShape }).createHost(
+      "acme.toast-named"
+    );
+
+    broadcastToRendererMock.mockClear();
+    await host.showToast({ message: "Synced 12 videos", type: "success" });
+
+    expect(broadcastToRendererMock).toHaveBeenCalledWith(CHANNELS.NOTIFICATION_SHOW_TOAST, {
+      type: "success",
+      message: "Video Manager: Synced 12 videos",
+      duration: undefined,
+      // The bucket key stays the raw id: never rendered, and two plugins may
+      // share a display name.
+      rateLimitKey: "plugin:acme.toast-named:success",
+    });
+  });
+
   it("defaults type to info when omitted", async () => {
     await writePlugin("toast-default", { name: "acme.toast-default", version: "1.0.0" });
     const service = new PluginService(tmpDir);

--- a/electron/services/plugin/PluginDevWorkerHost.ts
+++ b/electron/services/plugin/PluginDevWorkerHost.ts
@@ -12,6 +12,7 @@ import {
   PLUGIN_DEV_WORKER_KIND,
   PLUGIN_PROD_WORKER_KIND,
 } from "../../../shared/types/pluginDevWorker.js";
+import type { PluginIdentity } from "../../../shared/types/plugin.js";
 import type {
   PluginHostToWorkerMessage,
   PluginWorkerToHostMessage,
@@ -45,6 +46,13 @@ export const CRASH_WINDOW_MS = 30 * 60 * 1000;
 
 export interface PluginDevWorkerHostOptions {
   pluginId: string;
+  /**
+   * The plugin's identity as the host knows it, relayed to the worker so the
+   * proxy's `host.pluginInfo` answers with the real binding rather than a
+   * reconstruction. `projectRoot` in particular cannot be derived from the
+   * instance key.
+   */
+  identity: PluginIdentity;
   /** Plugin directory root (the symlink target). Used as the worker `cwd`. */
   pluginDir: string;
   /** Absolute path to the built bundle (`dist/index.js`) the worker imports. */
@@ -85,6 +93,7 @@ export class PluginDevWorkerHost extends EventEmitter {
   private isDisposed = false;
   private isReloading = false;
   readonly pluginId: string;
+  private readonly identity: PluginIdentity;
   private readonly pluginDir: string;
   private readonly bundlePath: string;
   private readonly serviceName: string;
@@ -117,6 +126,7 @@ export class PluginDevWorkerHost extends EventEmitter {
   constructor(options: PluginDevWorkerHostOptions) {
     super();
     this.pluginId = options.pluginId;
+    this.identity = options.identity;
     this.pluginDir = options.pluginDir;
     this.bundlePath = options.bundlePath;
     this.mode = options.mode ?? "dev";
@@ -473,6 +483,7 @@ export class PluginDevWorkerHost extends EventEmitter {
         type: "start",
         bundleUrl: pathToBundleUrl(this.bundlePath),
         pluginId: this.pluginId,
+        identity: this.identity,
       });
       if (this.readyResolve) {
         this.readyResolve();

--- a/electron/services/plugin/PluginHostFactory.ts
+++ b/electron/services/plugin/PluginHostFactory.ts
@@ -9,6 +9,11 @@ import { assertExtensionAllowed } from "../../utils/executablePathGuard.js";
 import { getPluginCapabilityConsentService } from "../plugin-capability/instances.js";
 import { resolveContainedPath, PluginPathNotAllowedError } from "./pluginFsContainment.js";
 import { PluginHostGit, type HostGitFactory } from "./pluginHostGit.js";
+import {
+  pluginManifestIdFromInstanceKey,
+  projectIdFromPluginInstanceKey,
+} from "./projectPluginIdentity.js";
+import { toRuntimePanelKindId } from "../../../shared/config/panelKindRegistry.js";
 import type { PluginProcessManager } from "./PluginProcessManager.js";
 import { PLUGIN_PTY_DEFAULT_COLS, PLUGIN_PTY_DEFAULT_ROWS } from "./PluginProcessManager.js";
 import type { PluginContributionBroadcaster } from "./PluginContributionBroadcaster.js";
@@ -51,6 +56,7 @@ import type { PluginDiagnosticsLogLine } from "../../../shared/types/ipc/pluginD
 import type {
   PluginIpcHandler,
   PluginHostApi,
+  PluginIdentity,
   PluginWorktreesResult,
   PluginWorktreesUnavailableReason,
   PluginActionContribution,
@@ -304,6 +310,8 @@ export interface PluginHostFactoryDeps {
     fields?: Record<string, unknown>
   ) => void;
   serializePluginBadges: (pluginId: string) => Record<string, PluginPanelBadge>;
+  /** User-facing name for a plugin id, for surfaces that name a plugin to a person. */
+  pluginDisplayName: (pluginId: string) => string;
   pluginDataDir: (pluginId: string) => string;
   isPathUnder: (root: string, candidate: string) => boolean;
   expandAllowedPathEntries: (
@@ -531,9 +539,51 @@ export function createHost(
     }
   };
 
+  // Identity is derived once, here, from the id and binding this host was built
+  // with. Deriving it host-side — through the canonical parser that owns the key
+  // format — is the whole point: it is what lets a plugin stop splitting its own
+  // id apart to find its manifest id or its project (#12211).
+  const manifestId = pluginManifestIdFromInstanceKey(pluginId);
+  // Origin comes from the KEY, not the binding. The key states what the plugin
+  // *is*; the binding states which project this host acts for, and the two
+  // disagreeing is a malformed binding, not a global plugin. Reading origin off
+  // the binding would silently downgrade such a host to "global" and hand back
+  // a dotted id that aliases a project kind onto a global one — the exact
+  // collision `toRuntimePanelKindId` refuses to mint.
+  const pluginInfo: PluginIdentity = Object.freeze({
+    instanceId: pluginId,
+    manifestId,
+    origin:
+      projectIdFromPluginInstanceKey(pluginId) === null
+        ? ("global" as const)
+        : ("project" as const),
+    projectId: boundProjectId,
+    projectRoot: boundProjectRoot,
+  });
+
   const host: PluginHostApi = {
     get pluginId() {
       return pluginId;
+    },
+    pluginInfo,
+    panelKindId: (bareId: string) => {
+      if (typeof bareId !== "string" || bareId.length === 0) {
+        throw new Error(`Plugin "${pluginId}" panelKindId: bareId must be a non-empty string`);
+      }
+      const qualified = toRuntimePanelKindId(
+        { origin: pluginInfo.origin, pluginId: manifestId, kindId: bareId },
+        boundProjectId
+      );
+      // Only reachable for a project-owned host with no project in its binding,
+      // or an id carrying the `/` the qualified form delimits on. Both would
+      // otherwise mint an id that resolves to no registered kind, so say so
+      // rather than hand back something that silently opens nothing.
+      if (qualified === null) {
+        throw new Error(
+          `Plugin "${pluginId}" panelKindId: cannot qualify panel kind "${bareId}" for this plugin`
+        );
+      }
+      return qualified;
     },
     registerAction: (descriptor, handler) => {
       if (revoked) {
@@ -1200,16 +1250,21 @@ export function createHost(
             .join("; ")}`
         );
       }
-      // Provenance: prefix the message with the plugin id so users can see
-      // which plugin raised the toast. pluginId is bound to the host closure
-      // at activation and cannot be spoofed.
+      // Provenance: prefix the message with the plugin's name so users can see
+      // which plugin raised the toast. Resolved host-side from the pluginId
+      // bound to this closure at activation, so it still cannot be spoofed —
+      // but it prints the manifest's display name rather than the raw id,
+      // which for a project-owned plugin is an instance key no user should be
+      // shown (#12211).
       //
-      // rateLimitKey scopes the rate-limit bucket per plugin+type. Without it
-      // plugin toasts fall into the global type-keyed bucket and a burst of
-      // unrelated system toasts could silently suppress a plugin's toast.
+      // rateLimitKey keeps the raw id: it is a bucket key, never rendered, and
+      // two plugins may legitimately share a display name. It scopes the
+      // rate-limit bucket per plugin+type — without it plugin toasts fall into
+      // the global type-keyed bucket and a burst of unrelated system toasts
+      // could silently suppress a plugin's toast.
       pushToRenderers(CHANNELS.NOTIFICATION_SHOW_TOAST, {
         type: parsed.data.type,
-        message: `${pluginId}: ${parsed.data.message}`,
+        message: `${deps.pluginDisplayName(pluginId)}: ${parsed.data.message}`,
         duration: parsed.data.durationMs,
         rateLimitKey: `plugin:${pluginId}:${parsed.data.type}`,
       });

--- a/electron/services/plugin/__tests__/PluginDevWorkerHost.test.ts
+++ b/electron/services/plugin/__tests__/PluginDevWorkerHost.test.ts
@@ -64,6 +64,13 @@ async function loadModule(): Promise<typeof import("../PluginDevWorkerHost.js")>
 
 const OPTS = {
   pluginId: "acme.demo",
+  identity: {
+    instanceId: "acme.demo",
+    manifestId: "acme.demo",
+    origin: "global" as const,
+    projectId: null,
+    projectRoot: null,
+  },
   pluginDir: "/plugins/acme.demo",
   bundlePath: "/plugins/acme.demo/dist/index.js",
 };

--- a/electron/services/plugin/__tests__/PluginHostFactory.binding.test.ts
+++ b/electron/services/plugin/__tests__/PluginHostFactory.binding.test.ts
@@ -144,6 +144,7 @@ function makeHarness(): Harness {
     fetchWorktreeSnapshotsForProjectResult: projectFetch,
     recordPluginLog,
     serializePluginBadges: () => ({}),
+    pluginDisplayName: (id: string) => id,
     pluginDataDir: () => path.join(path.sep, "tmp", "data"),
     isPathUnder: () => false,
     expandAllowedPathEntries: async () => [],
@@ -853,5 +854,77 @@ describe("createHost onDidWake (#12175)", () => {
     revoke();
 
     expect(() => host.onDidWake(vi.fn())).toThrow(/onDidWake/);
+  });
+});
+
+describe("host identity (#12211)", () => {
+  const PROJECT_INSTANCE = `project__${PROJECT_A}__acme.video-manager`;
+
+  it("reports a project plugin's identity without the plugin parsing its own id", () => {
+    const { deps } = makeHarness();
+    const { host } = createHost(deps, PROJECT_INSTANCE, BOUND);
+
+    // pluginId keeps its documented meaning — the instance key — because
+    // transport routing and settings/storage paths are keyed on it.
+    expect(host.pluginId).toBe(PROJECT_INSTANCE);
+    expect(host.pluginInfo).toEqual({
+      instanceId: PROJECT_INSTANCE,
+      manifestId: "acme.video-manager",
+      origin: "project",
+      projectId: PROJECT_A,
+      projectRoot: ROOT_A,
+    });
+  });
+
+  it("reports an app-global plugin as unbound with the id as its manifest id", () => {
+    const { deps } = makeHarness();
+    const { host } = createHost(deps, PLUGIN_ID, UNBOUND_PLUGIN_HOST_BINDING);
+
+    expect(host.pluginInfo).toEqual({
+      instanceId: PLUGIN_ID,
+      manifestId: PLUGIN_ID,
+      origin: "global",
+      projectId: null,
+      projectRoot: null,
+    });
+  });
+
+  it("qualifies a bare panel id into the project-scoped runtime kind id", () => {
+    const { deps } = makeHarness();
+    const { host } = createHost(deps, PROJECT_INSTANCE, BOUND);
+
+    expect(host.panelKindId("overview")).toBe(`project:${PROJECT_A}/acme.video-manager/overview`);
+  });
+
+  it("qualifies a bare panel id into the dotted global form for an unbound plugin", () => {
+    const { deps } = makeHarness();
+    const { host } = createHost(deps, PLUGIN_ID, UNBOUND_PLUGIN_HOST_BINDING);
+
+    expect(host.panelKindId("overview")).toBe("acme.overview");
+  });
+
+  it("stays readable after the host is revoked — identity is static, not a registration", () => {
+    const { deps } = makeHarness();
+    const { host, revoke } = createHost(deps, PROJECT_INSTANCE, BOUND);
+    revoke();
+
+    expect(host.pluginInfo.manifestId).toBe("acme.video-manager");
+    expect(host.panelKindId("overview")).toBe(`project:${PROJECT_A}/acme.video-manager/overview`);
+  });
+
+  it("throws on an empty bare id rather than minting an unresolvable kind", () => {
+    const { deps } = makeHarness();
+    const { host } = createHost(deps, PROJECT_INSTANCE, BOUND);
+
+    expect(() => host.panelKindId("")).toThrow(/bareId must be a non-empty string/);
+  });
+
+  it("throws when a project-owned plugin's binding names no project", () => {
+    const { deps } = makeHarness();
+    // A malformed binding cannot name a project kind — refuse rather than
+    // aliasing the project kind onto the global one.
+    const { host } = createHost(deps, PROJECT_INSTANCE, UNBOUND_PLUGIN_HOST_BINDING);
+
+    expect(() => host.panelKindId("overview")).toThrow(/cannot qualify panel kind/);
   });
 });

--- a/electron/services/plugin/__tests__/confusedDeputy.test.ts
+++ b/electron/services/plugin/__tests__/confusedDeputy.test.ts
@@ -238,6 +238,7 @@ function makeHostDeps(): PluginHostFactoryDeps {
     fetchWorktreeSnapshotsForProjectResult: projectWorktreeFetch,
     recordPluginLog: vi.fn(),
     serializePluginBadges: () => ({}),
+    pluginDisplayName: (id: string) => id,
     pluginDataDir: () => path.join(tmpDir, "plugin-data"),
     isPathUnder: () => false,
     expandAllowedPathEntries: async () => [],

--- a/electron/services/plugin/__tests__/pluginDevWorkerHostProxy.test.ts
+++ b/electron/services/plugin/__tests__/pluginDevWorkerHostProxy.test.ts
@@ -4,12 +4,20 @@ import { PluginDevWorkerHostProxy } from "../pluginDevWorkerHostProxy.js";
 
 const flush = () => new Promise((r) => setImmediate(r));
 
+const GLOBAL_IDENTITY = {
+  instanceId: "acme.demo",
+  manifestId: "acme.demo",
+  origin: "global" as const,
+  projectId: null,
+  projectRoot: null,
+};
+
 function makeProxy() {
   const sent: any[] = [];
   const post = vi.fn((msg: any) => {
     sent.push(msg);
   });
-  const proxy = new PluginDevWorkerHostProxy("acme.demo", post);
+  const proxy = new PluginDevWorkerHostProxy("acme.demo", post, GLOBAL_IDENTITY);
   return { proxy, post, sent };
 }
 
@@ -603,7 +611,7 @@ describe("PluginDevWorkerHostProxy host-call post failure (#10526)", () => {
     const post = vi.fn(() => {
       throw new Error("DataCloneError: value could not be cloned");
     });
-    const proxy = new PluginDevWorkerHostProxy("acme.demo", post);
+    const proxy = new PluginDevWorkerHostProxy("acme.demo", post, GLOBAL_IDENTITY);
     await expect(proxy.host.getWorktrees()).rejects.toThrow(/could not be cloned/);
     // The proxy isn't wedged — the failed call posted exactly once and rejected.
     expect(post).toHaveBeenCalledTimes(1);

--- a/electron/services/plugin/pluginDevWorkerHostProxy.ts
+++ b/electron/services/plugin/pluginDevWorkerHostProxy.ts
@@ -18,6 +18,7 @@ import type {
   ActionHandler,
   PluginChannelSchema,
   PluginHostApi,
+  PluginIdentity,
   PluginIpcContext,
   PluginIpcHandler,
   PluginSettingsScope,
@@ -42,6 +43,11 @@ import type {
   PluginProcessDataChunk,
   PluginProcessMode,
 } from "../../../shared/types/plugin.js";
+import {
+  pluginManifestIdFromInstanceKey,
+  projectIdFromPluginInstanceKey,
+} from "./projectPluginIdentity.js";
+import { toRuntimePanelKindId } from "../../../shared/config/panelKindRegistry.js";
 import type {
   FileDecorationProviderDescriptor,
   FileDecorationProviderImpl,
@@ -314,9 +320,37 @@ export class PluginDevWorkerHostProxy {
     // object literal, not this class instance. Every other member is an arrow
     // function that closes over the class `this` lexically.
     const pluginId = this.pluginId;
+    // Mirrors the real host's identity, derived from the same canonical parser.
+    // A dev-attached plugin is app-global, so it has no project root to report;
+    // a project instance key still resolves its manifest id and project id.
+    const manifestId = pluginManifestIdFromInstanceKey(pluginId);
+    const projectId = projectIdFromPluginInstanceKey(pluginId);
+    const pluginInfo: PluginIdentity = Object.freeze({
+      instanceId: pluginId,
+      manifestId,
+      origin: projectId === null ? ("global" as const) : ("project" as const),
+      projectId,
+      projectRoot: null,
+    });
     const host: PluginHostApi = {
       get pluginId() {
         return pluginId;
+      },
+      pluginInfo,
+      panelKindId: (bareId: string) => {
+        if (typeof bareId !== "string" || bareId.length === 0) {
+          throw new Error(`Plugin "${pluginId}" panelKindId: bareId must be a non-empty string`);
+        }
+        const qualified = toRuntimePanelKindId(
+          { origin: pluginInfo.origin, pluginId: manifestId, kindId: bareId },
+          projectId
+        );
+        if (qualified === null) {
+          throw new Error(
+            `Plugin "${pluginId}" panelKindId: cannot qualify panel kind "${bareId}" for this plugin`
+          );
+        }
+        return qualified;
       },
       registerAction: (descriptor, handler) => {
         this.assertActivationOpen("registerAction");

--- a/electron/services/plugin/pluginDevWorkerHostProxy.ts
+++ b/electron/services/plugin/pluginDevWorkerHostProxy.ts
@@ -43,10 +43,6 @@ import type {
   PluginProcessDataChunk,
   PluginProcessMode,
 } from "../../../shared/types/plugin.js";
-import {
-  pluginManifestIdFromInstanceKey,
-  projectIdFromPluginInstanceKey,
-} from "./projectPluginIdentity.js";
 import { toRuntimePanelKindId } from "../../../shared/config/panelKindRegistry.js";
 import type {
   FileDecorationProviderDescriptor,
@@ -92,6 +88,7 @@ export class PluginDevWorkerHostProxy {
   readonly host: PluginHostApi;
   private readonly post: Post;
   private readonly pluginId: string;
+  private readonly identity: PluginIdentity;
 
   private nextId = 1;
   private revoked = false;
@@ -103,9 +100,10 @@ export class PluginDevWorkerHostProxy {
   private readonly subscriptions = new Map<string, (payload: unknown) => void>();
   private readonly fileDecorationProviders = new Map<string, FileDecorationProviderImpl>();
 
-  constructor(pluginId: string, post: Post) {
+  constructor(pluginId: string, post: Post, identity: PluginIdentity) {
     this.pluginId = pluginId;
     this.post = post;
+    this.identity = identity;
     this.host = this.buildHost();
   }
 
@@ -320,18 +318,14 @@ export class PluginDevWorkerHostProxy {
     // object literal, not this class instance. Every other member is an arrow
     // function that closes over the class `this` lexically.
     const pluginId = this.pluginId;
-    // Mirrors the real host's identity, derived from the same canonical parser.
-    // A dev-attached plugin is app-global, so it has no project root to report;
-    // a project instance key still resolves its manifest id and project id.
-    const manifestId = pluginManifestIdFromInstanceKey(pluginId);
-    const projectId = projectIdFromPluginInstanceKey(pluginId);
-    const pluginInfo: PluginIdentity = Object.freeze({
-      instanceId: pluginId,
-      manifestId,
-      origin: projectId === null ? ("global" as const) : ("project" as const),
-      projectId,
-      projectRoot: null,
-    });
+    // The identity the main-process host computed, relayed verbatim in the
+    // `start` message. Not reconstructed from `pluginId`: `projectRoot` lives on
+    // the host's binding and cannot be recovered from an instance key, and a
+    // project plugin — which reaches this worker like any other plugin with a
+    // `main` — would otherwise report a project with no root.
+    const pluginInfo = this.identity;
+    const manifestId = pluginInfo.manifestId;
+    const projectId = pluginInfo.projectId;
     const host: PluginHostApi = {
       get pluginId() {
         return pluginId;

--- a/packages/plugin-sdk/api-report/index.d.ts
+++ b/packages/plugin-sdk/api-report/index.d.ts
@@ -3616,8 +3616,61 @@ interface PluginHostActionsApi {
      */
     canDispatch(actionId: ActionId): Promise<PluginCanDispatchResult>;
 }
+/**
+ * Who this plugin is, as the host knows it — the facts a plugin previously had
+ * to recover by string-splitting its own {@link PluginHostApi.pluginId}
+ * (#12211). Every field is fixed for the life of the host: the binding is
+ * captured once when the host is built, never resolved per call.
+ */
+interface PluginIdentity {
+    /**
+     * The key this instance is indexed under host-side, byte-identical to
+     * {@link PluginHostApi.pluginId}. Present so a plugin passing identity around
+     * as one object never has to reach back for the bare id.
+     */
+    readonly instanceId: string;
+    /**
+     * The manifest id (`publisher.name`) — what belongs in anything the
+     * *repository* sees, since a project id is machine-local.
+     */
+    readonly manifestId: string;
+    /** `"project"` for a `.daintree/plugins` contribution, `"global"` otherwise. */
+    readonly origin: "global" | "project";
+    /** Owning project, or `null` for an app-global (installed/builtin) plugin. */
+    readonly projectId: string | null;
+    /** Absolute project root. Null iff `projectId` is null. */
+    readonly projectRoot: string | null;
+}
 interface PluginHostApi extends PluginActivationApi {
     readonly pluginId: string;
+    /**
+     * This plugin's own identity, frozen at activation. Read `manifestId` rather
+     * than parsing {@link pluginId}: for a project-owned plugin the id is an
+     * instance key, and splitting it by hand is exactly the coupling to the
+     * host's internal key format that this exists to remove (#12211).
+     *
+     * Always readable — it is static closure data, not a live registration, so
+     * unlike the registration surface it neither throws after `activate()`
+     * resolves nor goes quiet once the plugin unloads.
+     */
+    readonly pluginInfo: PluginIdentity;
+    /**
+     * Qualify one of this plugin's own `contributes.panels[].id` values into the
+     * runtime panel kind id that {@link PluginHostApi.dispatch}'s
+     * `panel.openPluginPanel` expects — `{manifestId}.{bareId}` for a global
+     * plugin, `project:{projectId}/{manifestId}/{bareId}` for a project-owned one.
+     *
+     * Resolution is scoped to this host's own binding, never inferred from the
+     * shape of the string, so a plugin can hand over a bare id and get back the
+     * qualified form without knowing which of the two it lives under.
+     *
+     * Throws on an empty `bareId`, and on a project-owned plugin whose binding
+     * carries no project (a malformed binding cannot name a project kind) — an
+     * authoring or host error either way, surfaced loudly rather than returning
+     * an id that resolves to nothing. Synchronous: pure closure data, no
+     * round-trip. Always callable, for the same reason as {@link pluginInfo}.
+     */
+    panelKindId(bareId: string): string;
     /**
      * Push a fire-and-forget payload to every renderer subscribed to
      * `(pluginId, channel)` via `window.electron.plugin.on(...)`. This is the
@@ -4062,4 +4115,4 @@ type PluginProcessStreamEvent = {
     signal: string | null;
 };
 
-export { type ActionDanger, type ActionDispatchError, type ActionDispatchResult, type ActionDispatchSuccess, type ActionError, type ActionErrorCode, type ActionExample, type ActionHandler, type ActionId, type ActionKind, type AgentState, type AuthValidation, type BuiltInActionId, type BuiltInPluginCapability, type CIStatus, type CheckRun, type CheckRunConclusion, type CheckRunStatus, type ChecksCapability, type ContextMenuContribution, type ContextMenuLocation, type CreateIssueInput, type Credentials, type FetchOptions, type FileDecoration, type FileDecorationContribution, type FileDecorationProviderDescriptor, type FileDecorationProviderImpl, type ForgeLabel, type ForgeProviderContribution, type ForgeProviderDescriptor, type ForgeProviderImpl, type ForgeProviderKind, type ForgeUser, type Issue, type KeybindingContribution, type ListOptions, type McpServerContribution, type MenuItemContribution, type MenuItemLocation, type NormalizedIssueState, type NormalizedPRState, PLUGIN_PROCESS_STREAM_CHANNEL, PLUGIN_STYLE_ROOT_ATTRIBUTE, type PR, type Page, type PanelContribution, type PanelViewProps, type PluginActionContribution, type PluginActionManifestEntry, type PluginActivate, type PluginActivationApi, type PluginAgentSnapshot, type PluginAuthor, type PluginCanDispatchResult, type PluginCapability, type PluginChannelSchema, type PluginClipboardApi, type PluginConfirmOptions, type PluginDuplexProcessHandle, type PluginDuplexProcessSpawnOptions, type PluginFsApi, type PluginFsDirEntry, type PluginFsScope, type PluginFsStat, type PluginGitApi, type PluginGitCommitOptions, type PluginGitCommitResult, type PluginGitStatus, type PluginGitStatusFile, type PluginHostActionsApi, type PluginHostApi, type PluginHostCallOptions, type PluginHostSubscriptionOptions, type PluginInputBoxOptions, type PluginIpcContext, type PluginIpcHandler, type PluginLocalSocketScope, type PluginLogger, type PluginManifest, type PluginManifestScopes, type PluginNetworkScope, type PluginPanelBadge, type PluginPanelBadgeColor, type PluginPanelLifecycleEvent, type PluginPanelLifecyclePhase, type PluginProcessApi, type PluginProcessDataChunk, type PluginProcessHandle, type PluginProcessMode, type PluginProcessSpawnOptions, type PluginProcessStreamEvent, type PluginPtyProcessHandle, type PluginPtyProcessSpawnOptions, type PluginQuickPickItem, type PluginQuickPickOptions, type PluginSettingsScope, type PluginStorageScope, type PluginSystemApi, type PluginSystemWakeEvent, type PluginToastOptions, type PluginTypedIpcHandler, type PluginWorktreeFileState, type PluginWorktreeLinked, type PluginWorktreeLinkedIssue, type PluginWorktreeLinkedPR, type PluginWorktreeSnapshot, type PluginWorktreeStatus, type PluginWorktreeStatusFile, type PluginWorktreesResult, type PluginWorktreesUnavailableReason, type RateLimitInfo, type RepoMetadata, type RepoRef, type ResourceRef, type SettingDefinition, type SettingFieldType, type SettingsApi, type StorageApi, type ToolbarButtonContribution, type ViewContribution, type ViewLocation, type WaitingReason, localAuthStubs };
+export { type ActionDanger, type ActionDispatchError, type ActionDispatchResult, type ActionDispatchSuccess, type ActionError, type ActionErrorCode, type ActionExample, type ActionHandler, type ActionId, type ActionKind, type AgentState, type AuthValidation, type BuiltInActionId, type BuiltInPluginCapability, type CIStatus, type CheckRun, type CheckRunConclusion, type CheckRunStatus, type ChecksCapability, type ContextMenuContribution, type ContextMenuLocation, type CreateIssueInput, type Credentials, type FetchOptions, type FileDecoration, type FileDecorationContribution, type FileDecorationProviderDescriptor, type FileDecorationProviderImpl, type ForgeLabel, type ForgeProviderContribution, type ForgeProviderDescriptor, type ForgeProviderImpl, type ForgeProviderKind, type ForgeUser, type Issue, type KeybindingContribution, type ListOptions, type McpServerContribution, type MenuItemContribution, type MenuItemLocation, type NormalizedIssueState, type NormalizedPRState, PLUGIN_PROCESS_STREAM_CHANNEL, PLUGIN_STYLE_ROOT_ATTRIBUTE, type PR, type Page, type PanelContribution, type PanelViewProps, type PluginActionContribution, type PluginActionManifestEntry, type PluginActivate, type PluginActivationApi, type PluginAgentSnapshot, type PluginAuthor, type PluginCanDispatchResult, type PluginCapability, type PluginChannelSchema, type PluginClipboardApi, type PluginConfirmOptions, type PluginDuplexProcessHandle, type PluginDuplexProcessSpawnOptions, type PluginFsApi, type PluginFsDirEntry, type PluginFsScope, type PluginFsStat, type PluginGitApi, type PluginGitCommitOptions, type PluginGitCommitResult, type PluginGitStatus, type PluginGitStatusFile, type PluginHostActionsApi, type PluginHostApi, type PluginHostCallOptions, type PluginHostSubscriptionOptions, type PluginIdentity, type PluginInputBoxOptions, type PluginIpcContext, type PluginIpcHandler, type PluginLocalSocketScope, type PluginLogger, type PluginManifest, type PluginManifestScopes, type PluginNetworkScope, type PluginPanelBadge, type PluginPanelBadgeColor, type PluginPanelLifecycleEvent, type PluginPanelLifecyclePhase, type PluginProcessApi, type PluginProcessDataChunk, type PluginProcessHandle, type PluginProcessMode, type PluginProcessSpawnOptions, type PluginProcessStreamEvent, type PluginPtyProcessHandle, type PluginPtyProcessSpawnOptions, type PluginQuickPickItem, type PluginQuickPickOptions, type PluginSettingsScope, type PluginStorageScope, type PluginSystemApi, type PluginSystemWakeEvent, type PluginToastOptions, type PluginTypedIpcHandler, type PluginWorktreeFileState, type PluginWorktreeLinked, type PluginWorktreeLinkedIssue, type PluginWorktreeLinkedPR, type PluginWorktreeSnapshot, type PluginWorktreeStatus, type PluginWorktreeStatusFile, type PluginWorktreesResult, type PluginWorktreesUnavailableReason, type RateLimitInfo, type RepoMetadata, type RepoRef, type ResourceRef, type SettingDefinition, type SettingFieldType, type SettingsApi, type StorageApi, type ToolbarButtonContribution, type ViewContribution, type ViewLocation, type WaitingReason, localAuthStubs };

--- a/scripts/perf/lib/pluginHostFixture.ts
+++ b/scripts/perf/lib/pluginHostFixture.ts
@@ -445,7 +445,21 @@ export class PluginWorker extends PluginChild {
     timeoutMs: number
   ): Promise<{ activateMs: number; hasCleanup: boolean } | null> {
     const started = performance.now();
-    this.send({ type: "start", bundleUrl: pathToFileURL(bundlePath).href, pluginId });
+    // The worker builds `host.pluginInfo` from this, so it is required even
+    // though this stand-in parent types the channel loosely. The fixture
+    // plugins are app-global, like every installed plugin.
+    this.send({
+      type: "start",
+      bundleUrl: pathToFileURL(bundlePath).href,
+      pluginId,
+      identity: {
+        instanceId: pluginId,
+        manifestId: pluginId,
+        origin: "global",
+        projectId: null,
+        projectRoot: null,
+      },
+    });
     const done = await this.waitFor(
       (message) => message.type === "activated" || message.type === "activate-error",
       timeoutMs

--- a/scripts/perf/lib/supervisionFixture.ts
+++ b/scripts/perf/lib/supervisionFixture.ts
@@ -1230,6 +1230,14 @@ const HEALTH_CHECK_INTERVAL_MS = 3_600_000;
 
 const PERF_PROJECT_PATH = "/perf/supervised-project";
 const PERF_PLUGIN_ID = "perfco.supervised";
+/** App-global, like every installed plugin — the probe never activates a project instance. */
+const PERF_PLUGIN_IDENTITY = {
+  instanceId: PERF_PLUGIN_ID,
+  manifestId: PERF_PLUGIN_ID,
+  origin: "global" as const,
+  projectId: null,
+  projectRoot: null,
+};
 const PERF_PLUGIN_DIR = "/perf/plugins/supervised";
 const PERF_PLUGIN_BUNDLE = "/perf/plugins/supervised/dist/index.js";
 const PTY_SERVICE_NAME = "daintree-pty-host:perf";
@@ -1340,6 +1348,7 @@ async function makePluginAdapter(): Promise<LadderAdapter> {
   let gaveUp = false;
   const host = new PluginDevWorkerHost({
     pluginId: PERF_PLUGIN_ID,
+    identity: PERF_PLUGIN_IDENTITY,
     pluginDir: PERF_PLUGIN_DIR,
     bundlePath: PERF_PLUGIN_BUNDLE,
     // Production mode: no bundle watcher, identical crash supervision. The
@@ -1567,6 +1576,7 @@ async function probeReplay(): Promise<ReplayResult> {
 
   const plugin = new PluginDevWorkerHost({
     pluginId: PERF_PLUGIN_ID,
+    identity: PERF_PLUGIN_IDENTITY,
     pluginDir: PERF_PLUGIN_DIR,
     bundlePath: PERF_PLUGIN_BUNDLE,
     mode: "prod",

--- a/shared/testing/createMockHost.ts
+++ b/shared/testing/createMockHost.ts
@@ -9,6 +9,11 @@
  * method this mock doesn't implement.
  */
 
+import {
+  pluginManifestIdFromInstanceKey,
+  projectIdFromPluginInstanceKey,
+} from "../types/plugin.js";
+import { toRuntimePanelKindId } from "../config/panelKindRegistry.js";
 import type {
   ActionDispatchResult,
   ActionId,
@@ -28,6 +33,7 @@ import type {
   PluginChannelSchema,
   PluginConfirmOptions,
   PluginHostApi,
+  PluginIdentity,
   PluginInputBoxOptions,
   PluginIpcHandler,
   PluginProcessHandle,
@@ -737,8 +743,37 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
     },
   };
 
+  // Identity mirrors the real host: derived from the id via the canonical
+  // parser, so a mock built with a project instance key answers exactly as
+  // production does.
+  const mockManifestId = pluginManifestIdFromInstanceKey(pluginId);
+  const mockProjectId = projectIdFromPluginInstanceKey(pluginId);
+  const pluginInfo: PluginIdentity = Object.freeze({
+    instanceId: pluginId,
+    manifestId: mockManifestId,
+    origin: mockProjectId === null ? ("global" as const) : ("project" as const),
+    projectId: mockProjectId,
+    projectRoot: null,
+  });
+
   const host: PluginHostApi & MockHostState = {
     pluginId,
+    pluginInfo,
+    panelKindId(bareId: string) {
+      if (typeof bareId !== "string" || bareId.length === 0) {
+        throw new Error(`Plugin "${pluginId}" panelKindId: bareId must be a non-empty string`);
+      }
+      const qualified = toRuntimePanelKindId(
+        { origin: pluginInfo.origin, pluginId: mockManifestId, kindId: bareId },
+        mockProjectId
+      );
+      if (qualified === null) {
+        throw new Error(
+          `Plugin "${pluginId}" panelKindId: cannot qualify panel kind "${bareId}" for this plugin`
+        );
+      }
+      return qualified;
+    },
     registerAction(descriptor, handler) {
       // Mirrors PluginService.createHost L1577-L1631. Validation order matches
       // production: non-object descriptor, non-function handler, non-empty

--- a/shared/testing/createMockHost.ts
+++ b/shared/testing/createMockHost.ts
@@ -268,6 +268,12 @@ export interface MockHostState {
 
 export interface CreateMockHostOptions {
   pluginId?: string;
+  /**
+   * Project root for a project-owned `pluginId` (one shaped
+   * `project__{projectId}__{manifestId}`). Defaults to a synthetic path; ignored
+   * for an app-global plugin, which has no project.
+   */
+  projectRoot?: string;
   activeWorktree?: PluginWorktreeSnapshot | null;
   worktrees?: PluginWorktreeSnapshot[];
   /**
@@ -748,12 +754,16 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
   // production does.
   const mockManifestId = pluginManifestIdFromInstanceKey(pluginId);
   const mockProjectId = projectIdFromPluginInstanceKey(pluginId);
+  // `projectRoot` is null iff `projectId` is — a mock that claimed a project
+  // with no root would hand plugin authors a shape production never produces.
+  const mockProjectRoot =
+    mockProjectId === null ? null : (options.projectRoot ?? `/projects/${mockProjectId}`);
   const pluginInfo: PluginIdentity = Object.freeze({
     instanceId: pluginId,
     manifestId: mockManifestId,
     origin: mockProjectId === null ? ("global" as const) : ("project" as const),
     projectId: mockProjectId,
-    projectRoot: null,
+    projectRoot: mockProjectRoot,
   });
 
   const host: PluginHostApi & MockHostState = {

--- a/shared/types/plugin-sdk.ts
+++ b/shared/types/plugin-sdk.ts
@@ -64,6 +64,7 @@ export type { PluginManifest, PluginAuthor } from "./plugin.js";
 export type {
   PluginActivate,
   PluginHostApi,
+  PluginIdentity,
   PluginHostActionsApi,
   PluginActivationApi,
   PluginHostCallOptions,

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -1418,8 +1418,17 @@ export interface LoadedPluginInfo {
    * manifest is left alone — so `manifest.name` alone cannot tell the two
    * apart, and a consumer that filtered on it would treat a project plugin as
    * an installed one.
+   *
+   * This is also the field renderer-side maps key on. Keying them on
+   * `manifest.name` instead is what made every project-plugin lookup miss and
+   * fall back to rendering the raw instance key (#12211): a contribution never
+   * carries the bare manifest id, so the two never met.
    */
   instanceId: string;
+  /** `"project"` for a `.daintree/plugins` contribution, `"global"` otherwise. */
+  origin: "global" | "project";
+  /** Owning project for a project-owned plugin; `null` when `origin` is `"global"`. */
+  projectId: string | null;
   dir: string;
   loadedAt: number;
   /**
@@ -2702,8 +2711,62 @@ export interface PluginHostActionsApi {
   canDispatch(actionId: ActionId): Promise<PluginCanDispatchResult>;
 }
 
+/**
+ * Who this plugin is, as the host knows it — the facts a plugin previously had
+ * to recover by string-splitting its own {@link PluginHostApi.pluginId}
+ * (#12211). Every field is fixed for the life of the host: the binding is
+ * captured once when the host is built, never resolved per call.
+ */
+export interface PluginIdentity {
+  /**
+   * The key this instance is indexed under host-side, byte-identical to
+   * {@link PluginHostApi.pluginId}. Present so a plugin passing identity around
+   * as one object never has to reach back for the bare id.
+   */
+  readonly instanceId: string;
+  /**
+   * The manifest id (`publisher.name`) — what belongs in anything the
+   * *repository* sees, since a project id is machine-local.
+   */
+  readonly manifestId: string;
+  /** `"project"` for a `.daintree/plugins` contribution, `"global"` otherwise. */
+  readonly origin: "global" | "project";
+  /** Owning project, or `null` for an app-global (installed/builtin) plugin. */
+  readonly projectId: string | null;
+  /** Absolute project root. Null iff `projectId` is null. */
+  readonly projectRoot: string | null;
+}
+
 export interface PluginHostApi extends PluginActivationApi {
   readonly pluginId: string;
+  /**
+   * This plugin's own identity, frozen at activation. Read `manifestId` rather
+   * than parsing {@link pluginId}: for a project-owned plugin the id is an
+   * instance key, and splitting it by hand is exactly the coupling to the
+   * host's internal key format that this exists to remove (#12211).
+   *
+   * Always readable — it is static closure data, not a live registration, so
+   * unlike the registration surface it neither throws after `activate()`
+   * resolves nor goes quiet once the plugin unloads.
+   */
+  readonly pluginInfo: PluginIdentity;
+  /**
+   * Qualify one of this plugin's own `contributes.panels[].id` values into the
+   * runtime panel kind id that {@link PluginHostApi.dispatch}'s
+   * `panel.openPluginPanel` expects — `{manifestId}.{bareId}` for a global
+   * plugin, `project:{projectId}/{manifestId}/{bareId}` for a project-owned one.
+   *
+   * Resolution is scoped to this host's own binding, never inferred from the
+   * shape of the string, so a plugin can hand over a bare id and get back the
+   * qualified form without knowing which of the two it lives under.
+   *
+   * Throws on an empty `bareId`, and on a project-owned plugin whose binding
+   * carries no project (a malformed binding cannot name a project kind) — an
+   * authoring or host error either way, surfaced loudly rather than returning
+   * an id that resolves to nothing. Synchronous: pure closure data, no
+   * round-trip. Always callable, for the same reason as {@link pluginInfo}.
+   */
+  panelKindId(bareId: string): string;
   /**
    * Push a fire-and-forget payload to every renderer subscribed to
    * `(pluginId, channel)` via `window.electron.plugin.on(...)`. This is the

--- a/shared/types/pluginDevWorker.ts
+++ b/shared/types/pluginDevWorker.ts
@@ -18,6 +18,7 @@
 // class instances. Requests that expect a reply carry a `requestId`.
 
 import type {
+  PluginIdentity,
   PluginIpcContext,
   PluginSettingsScope,
   PluginStorageScope,
@@ -124,7 +125,17 @@ export type PluginWorkerInvokeKind = "action" | "handler" | "file-decoration-met
 /** Messages sent main → worker. */
 export type PluginHostToWorkerMessage =
   /** Kick off: import the plugin bundle at `bundleUrl` and call `activate(proxy)`. */
-  | { type: "start"; bundleUrl: string; pluginId: string }
+  | {
+      type: "start";
+      bundleUrl: string;
+      pluginId: string;
+      /**
+       * The plugin's identity as the main-process host knows it. Sent rather
+       * than re-derived worker-side because `projectRoot` lives on the host's
+       * binding and cannot be recovered from the instance key alone.
+       */
+      identity: PluginIdentity;
+    }
   /** Graceful shutdown request — worker runs the plugin's cleanup then exits. */
   | { type: "dispose" }
   /** Reply to a worker `host-call`. */

--- a/src/components/Layout/PluginTrayButton.tsx
+++ b/src/components/Layout/PluginTrayButton.tsx
@@ -25,6 +25,7 @@ import { resolvePluginIcon } from "@/components/icons/pluginIconRegistry";
 import { actionService } from "@/services/ActionService";
 import { useToolbarPreferencesStore } from "@/store/toolbarPreferencesStore";
 import { usePluginRuntimeStore } from "@/store/pluginRuntimeStore";
+import { pluginManifestIdFromInstanceKey } from "@shared/types/plugin";
 import { useAriaKeyshortcuts, useKeybindingDisplay, useShortcutHintHover } from "@/hooks";
 import type { ToolbarButtonConfig } from "@shared/config/toolbarButtonRegistry";
 import type { PluginToolbarButtonId } from "@shared/types/toolbar";
@@ -241,7 +242,11 @@ export function PluginTrayButton({
   const lastPinActionAt = useRef(0);
 
   const groups = useMemo(
-    () => groupPluginToolbarButtons(configs, (id) => pluginMetaById.get(id)?.displayName ?? id),
+    () =>
+      groupPluginToolbarButtons(
+        configs,
+        (id) => pluginMetaById.get(id)?.displayName ?? pluginManifestIdFromInstanceKey(id)
+      ),
     [configs, pluginMetaById]
   );
 

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -62,6 +62,7 @@ import {
 import { buildLauncherToolbarMeta, useLauncherToolbarCatalog } from "./launcherToolbarCatalog";
 import { LauncherToolbarButton } from "./LauncherToolbarButton";
 import { usePluginRuntimeStore } from "@/store/pluginRuntimeStore";
+import { pluginManifestIdFromInstanceKey } from "@shared/types/plugin";
 import { resolvePluginIcon } from "@/components/icons/pluginIconRegistry";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import {
@@ -1876,7 +1877,10 @@ export function Toolbar({
 
   const pluginTrayGroups = useMemo(
     () =>
-      groupPluginToolbarButtons(pluginConfigs, (id) => pluginMetaById.get(id)?.displayName ?? id),
+      groupPluginToolbarButtons(
+        pluginConfigs,
+        (id) => pluginMetaById.get(id)?.displayName ?? pluginManifestIdFromInstanceKey(id)
+      ),
     [pluginConfigs, pluginMetaById]
   );
 

--- a/src/components/Panel/PluginPanelBadges.tsx
+++ b/src/components/Panel/PluginPanelBadges.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import type { PluginPanelBadge, PluginPanelBadgeColor } from "@shared/types/plugin";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { usePanelBadges, usePluginPanelBadgeStore } from "@/store/pluginPanelBadgeStore";
+import { usePluginRuntimeStore } from "@/store/pluginRuntimeStore";
 
 /**
  * Live badges a plugin set on this panel via `host.setPanelBadge` (#10585),
@@ -34,17 +35,26 @@ const LABEL_COLOR: Record<PluginPanelBadgeColor, string> = {
 
 function BadgeIndicator({ pluginId, badge }: { pluginId: string; badge: PluginPanelBadge }) {
   const color = badge.color ?? "default";
+  // A primitive selector, read per badge rather than once over the whole map in
+  // the parent: the meta record is rebuilt on every provenance pull, so
+  // selecting it whole would re-render every badge on pulls that changed
+  // nothing (same reasoning as PluginViewContent). `pluginId` here is the
+  // instance key main broadcasts, which is what the store keys on — and the
+  // `?? pluginId` fallback keeps the pre-snapshot render fail-open.
+  const pluginName = usePluginRuntimeStore(
+    (s) => s.pluginMetaById.get(pluginId)?.displayName ?? pluginId
+  );
   const indicator =
     badge.kind === "dot" ? (
       <span
         role="status"
-        aria-label={badge.tooltip ?? `${pluginId} status`}
+        aria-label={badge.tooltip ?? `${pluginName} status`}
         className={`status-mark w-2 h-2 rounded-full shrink-0 ${DOT_COLOR[color]}`}
       />
     ) : (
       <span
         role="status"
-        aria-label={badge.tooltip ?? `${pluginId}: ${badge.text}`}
+        aria-label={badge.tooltip ?? `${pluginName}: ${badge.text}`}
         className={`shrink-0 rounded px-1 text-3xs font-medium leading-4 ${LABEL_COLOR[color]}`}
       >
         {badge.text}
@@ -63,6 +73,13 @@ function BadgeIndicator({ pluginId, badge }: { pluginId: string; badge: PluginPa
 export function PluginPanelBadges({ panelId }: { panelId: string }) {
   const init = usePluginPanelBadgeStore((s) => s.init);
   useEffect(() => init(), [init]);
+
+  // The badge store and the runtime store are subscribed independently — a
+  // panel can carry badges long before anything else in this view has pulled
+  // the plugin list, and without this the labels would name plugins by raw id
+  // until some other surface happened to initialise it.
+  const initPluginRuntime = usePluginRuntimeStore((s) => s.init);
+  useEffect(() => initPluginRuntime(), [initPluginRuntime]);
 
   const badges = usePanelBadges(panelId);
   const entries = Object.entries(badges).sort(([a], [b]) => a.localeCompare(b));

--- a/src/components/Panel/PluginPanelBadges.tsx
+++ b/src/components/Panel/PluginPanelBadges.tsx
@@ -1,8 +1,9 @@
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import type { PluginPanelBadge, PluginPanelBadgeColor } from "@shared/types/plugin";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { usePanelBadges, usePluginPanelBadgeStore } from "@/store/pluginPanelBadgeStore";
 import { usePluginRuntimeStore } from "@/store/pluginRuntimeStore";
+import { pluginManifestIdFromInstanceKey } from "@shared/types/plugin";
 
 /**
  * Live badges a plugin set on this panel via `host.setPanelBadge` (#10585),
@@ -41,8 +42,10 @@ function BadgeIndicator({ pluginId, badge }: { pluginId: string; badge: PluginPa
   // nothing (same reasoning as PluginViewContent). `pluginId` here is the
   // instance key main broadcasts, which is what the store keys on — and the
   // `?? pluginId` fallback keeps the pre-snapshot render fail-open.
+  // The fallback is the manifest id, never the raw key: this renders before the
+  // first snapshot lands, and a machine-local project id is not a name.
   const pluginName = usePluginRuntimeStore(
-    (s) => s.pluginMetaById.get(pluginId)?.displayName ?? pluginId
+    (s) => s.pluginMetaById.get(pluginId)?.displayName ?? pluginManifestIdFromInstanceKey(pluginId)
   );
   const indicator =
     badge.kind === "dot" ? (
@@ -74,15 +77,30 @@ export function PluginPanelBadges({ panelId }: { panelId: string }) {
   const init = usePluginPanelBadgeStore((s) => s.init);
   useEffect(() => init(), [init]);
 
-  // The badge store and the runtime store are subscribed independently — a
-  // panel can carry badges long before anything else in this view has pulled
-  // the plugin list, and without this the labels would name plugins by raw id
-  // until some other surface happened to initialise it.
-  const initPluginRuntime = usePluginRuntimeStore((s) => s.init);
-  useEffect(() => initPluginRuntime(), [initPluginRuntime]);
-
   const badges = usePanelBadges(panelId);
-  const entries = Object.entries(badges).sort(([a], [b]) => a.localeCompare(b));
+  const entries = useMemo(
+    () => Object.entries(badges).sort(([a], [b]) => a.localeCompare(b)),
+    [badges]
+  );
+
+  // Pull the plugin list when a badge arrives from a plugin we have no snapshot
+  // for. `init()` would not do: it only pulls for whoever subscribes *first*,
+  // and by the time a panel renders the toolbar has long since initialised the
+  // store — so a plugin that never announced itself (`daintree-plugin dev`
+  // broadcasts no provenance) would keep its raw id here forever. Keyed on the
+  // owners actually missing rather than on mount, so the common case where
+  // every owner is already known costs no round-trip, and a badge pushed later
+  // still triggers exactly one pull.
+  const refreshPluginRuntime = usePluginRuntimeStore((s) => s.refresh);
+  const hasUnresolvedOwner = usePluginRuntimeStore((s) =>
+    entries.some(([pluginId]) => !s.pluginMetaById.has(pluginId))
+  );
+  useEffect(() => {
+    // No loop: a pull that resolves the owner flips this false, and one that
+    // does not leaves the boolean unchanged, so the effect does not re-fire.
+    if (hasUnresolvedOwner) refreshPluginRuntime();
+  }, [hasUnresolvedOwner, refreshPluginRuntime]);
+
   if (entries.length === 0) return null;
 
   return (

--- a/src/components/Panel/__tests__/PluginPanelBadges.test.tsx
+++ b/src/components/Panel/__tests__/PluginPanelBadges.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { PluginPanelBadges } from "../PluginPanelBadges";
+import { usePluginPanelBadgeStore } from "@/store/pluginPanelBadgeStore";
+import { usePluginRuntimeStore } from "@/store/pluginRuntimeStore";
+import { TooltipProvider } from "@/components/ui/tooltip";
+
+const PANEL_ID = "panel-1";
+const INSTANCE_ID = "project__b6700c7a__gregpriday.video-manager";
+
+beforeEach(() => {
+  usePluginPanelBadgeStore.setState({
+    badgesByPanelId: { [PANEL_ID]: { [INSTANCE_ID]: { kind: "dot", color: "warning" } } },
+    init: () => {},
+  });
+  usePluginRuntimeStore.setState({
+    pluginMetaById: new Map(),
+    disabledPluginIds: new Set<string>(),
+    init: () => {},
+  });
+});
+
+describe("PluginPanelBadges", () => {
+  it("labels a badge with the plugin's display name, not its raw instance key", () => {
+    // #12211: the aria-label interpolated the id straight in, so a project
+    // plugin's badge announced `project__b67…  status`.
+    usePluginRuntimeStore.setState({
+      pluginMetaById: new Map([[INSTANCE_ID, { devMode: false, displayName: "Video Manager" }]]),
+    });
+
+    render(<PluginPanelBadges panelId={PANEL_ID} />);
+
+    expect(screen.getByRole("status").getAttribute("aria-label")).toBe("Video Manager status");
+  });
+
+  it("labels a label-kind badge with the display name too", () => {
+    usePluginPanelBadgeStore.setState({
+      badgesByPanelId: {
+        [PANEL_ID]: { [INSTANCE_ID]: { kind: "label", text: "12", color: "default" } },
+      },
+    });
+    usePluginRuntimeStore.setState({
+      pluginMetaById: new Map([[INSTANCE_ID, { devMode: false, displayName: "Video Manager" }]]),
+    });
+
+    render(<PluginPanelBadges panelId={PANEL_ID} />);
+
+    expect(screen.getByRole("status").getAttribute("aria-label")).toBe("Video Manager: 12");
+  });
+
+  it("falls back to the id before the first snapshot lands, staying fail-open", () => {
+    render(<PluginPanelBadges panelId={PANEL_ID} />);
+
+    expect(screen.getByRole("status").getAttribute("aria-label")).toBe(`${INSTANCE_ID} status`);
+  });
+
+  it("prefers an explicit badge tooltip over any resolved name", () => {
+    usePluginPanelBadgeStore.setState({
+      badgesByPanelId: {
+        [PANEL_ID]: { [INSTANCE_ID]: { kind: "dot", tooltip: "Syncing", color: "default" } },
+      },
+    });
+    usePluginRuntimeStore.setState({
+      pluginMetaById: new Map([[INSTANCE_ID, { devMode: false, displayName: "Video Manager" }]]),
+    });
+
+    render(
+      <TooltipProvider>
+        <PluginPanelBadges panelId={PANEL_ID} />
+      </TooltipProvider>
+    );
+
+    expect(screen.getByRole("status").getAttribute("aria-label")).toBe("Syncing");
+  });
+
+  it("renders nothing when the panel carries no badges", () => {
+    usePluginPanelBadgeStore.setState({ badgesByPanelId: {} });
+
+    const { container } = render(<PluginPanelBadges panelId={PANEL_ID} />);
+
+    expect(container.textContent).toBe("");
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+});

--- a/src/components/Panel/__tests__/PluginPanelBadges.test.tsx
+++ b/src/components/Panel/__tests__/PluginPanelBadges.test.tsx
@@ -1,15 +1,65 @@
 // @vitest-environment jsdom
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
+import type { LoadedPluginInfo } from "@shared/types/plugin";
 import { PluginPanelBadges } from "../PluginPanelBadges";
 import { usePluginPanelBadgeStore } from "@/store/pluginPanelBadgeStore";
-import { usePluginRuntimeStore } from "@/store/pluginRuntimeStore";
+import { _resetPluginRuntimeStoreForTest, usePluginRuntimeStore } from "@/store/pluginRuntimeStore";
 import { TooltipProvider } from "@/components/ui/tooltip";
 
 const PANEL_ID = "panel-1";
 const INSTANCE_ID = "project__b6700c7a__gregpriday.video-manager";
 
+function meta(displayName: string) {
+  return new Map([[INSTANCE_ID, { devMode: false, displayName }]]);
+}
+
+/** A project-owned entry as `plugin.list()` returns it. */
+function listedProjectPlugin(): LoadedPluginInfo {
+  return {
+    instanceId: INSTANCE_ID,
+    origin: "project",
+    projectId: "b6700c7a",
+    manifest: {
+      name: "gregpriday.video-manager",
+      version: "1.0.0",
+      displayName: "Video Manager",
+      contributes: {
+        panels: [],
+        toolbarButtons: [],
+        menuItems: [],
+        commands: [],
+        views: [],
+        mcpServers: [],
+        skills: [],
+        keybindings: [],
+        contextMenus: [],
+        forgeProviders: [],
+        fileDecorationProviders: [],
+        agents: [],
+        processTools: [],
+        recipes: [],
+      },
+    },
+    dir: "/projects/demo/.daintree/plugins/video-manager",
+    loadedAt: 1,
+    isBuiltin: false,
+    source: "sideload",
+    installedAt: 1,
+    archiveHash: null,
+    originalUrl: null,
+    loadError: null,
+    disabled: false,
+    updateAvailable: null,
+    devMode: false,
+    pendingRestart: false,
+    pluginDanger: "safe",
+    blocklisted: false,
+  };
+}
+
 beforeEach(() => {
+  _resetPluginRuntimeStoreForTest();
   usePluginPanelBadgeStore.setState({
     badgesByPanelId: { [PANEL_ID]: { [INSTANCE_ID]: { kind: "dot", color: "warning" } } },
     init: () => {},
@@ -17,17 +67,19 @@ beforeEach(() => {
   usePluginRuntimeStore.setState({
     pluginMetaById: new Map(),
     disabledPluginIds: new Set<string>(),
-    init: () => {},
   });
+});
+
+afterEach(() => {
+  _resetPluginRuntimeStoreForTest();
+  Reflect.deleteProperty(window, "electron");
 });
 
 describe("PluginPanelBadges", () => {
   it("labels a badge with the plugin's display name, not its raw instance key", () => {
     // #12211: the aria-label interpolated the id straight in, so a project
     // plugin's badge announced `project__b67…  status`.
-    usePluginRuntimeStore.setState({
-      pluginMetaById: new Map([[INSTANCE_ID, { devMode: false, displayName: "Video Manager" }]]),
-    });
+    usePluginRuntimeStore.setState({ pluginMetaById: meta("Video Manager") });
 
     render(<PluginPanelBadges panelId={PANEL_ID} />);
 
@@ -40,19 +92,57 @@ describe("PluginPanelBadges", () => {
         [PANEL_ID]: { [INSTANCE_ID]: { kind: "label", text: "12", color: "default" } },
       },
     });
-    usePluginRuntimeStore.setState({
-      pluginMetaById: new Map([[INSTANCE_ID, { devMode: false, displayName: "Video Manager" }]]),
-    });
+    usePluginRuntimeStore.setState({ pluginMetaById: meta("Video Manager") });
 
     render(<PluginPanelBadges panelId={PANEL_ID} />);
 
     expect(screen.getByRole("status").getAttribute("aria-label")).toBe("Video Manager: 12");
   });
 
-  it("falls back to the id before the first snapshot lands, staying fail-open", () => {
+  it("falls back to the manifest id before any snapshot lands, staying fail-open", () => {
     render(<PluginPanelBadges panelId={PANEL_ID} />);
 
-    expect(screen.getByRole("status").getAttribute("aria-label")).toBe(`${INSTANCE_ID} status`);
+    // Fail-open, but never the raw instance key — the fallback drops the
+    // machine-local project id rather than showing it to the user.
+    expect(screen.getByRole("status").getAttribute("aria-label")).toBe(
+      "gregpriday.video-manager status"
+    );
+  });
+
+  it("pulls a snapshot when a badge names a plugin it has no metadata for", async () => {
+    // The store is initialised long before a panel renders, so `init()` would
+    // no-op and a plugin that never broadcast provenance would keep its raw id.
+    const list = vi.fn(() => Promise.resolve([listedProjectPlugin()]));
+    Object.defineProperty(window, "electron", {
+      configurable: true,
+      writable: true,
+      value: { plugin: { list, onProvenanceChanged: vi.fn(() => () => {}) } },
+    });
+
+    render(<PluginPanelBadges panelId={PANEL_ID} />);
+
+    // Renders fail-open first, then upgrades in place once the pull lands.
+    expect(screen.getByRole("status").getAttribute("aria-label")).toBe(
+      "gregpriday.video-manager status"
+    );
+    await vi.waitFor(() =>
+      expect(screen.getByRole("status").getAttribute("aria-label")).toBe("Video Manager status")
+    );
+    expect(list).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not pull when every badge owner is already known", () => {
+    const list = vi.fn(() => Promise.resolve([]));
+    Object.defineProperty(window, "electron", {
+      configurable: true,
+      writable: true,
+      value: { plugin: { list, onProvenanceChanged: vi.fn(() => () => {}) } },
+    });
+    usePluginRuntimeStore.setState({ pluginMetaById: meta("Video Manager") });
+
+    render(<PluginPanelBadges panelId={PANEL_ID} />);
+
+    expect(list).not.toHaveBeenCalled();
   });
 
   it("prefers an explicit badge tooltip over any resolved name", () => {
@@ -61,9 +151,7 @@ describe("PluginPanelBadges", () => {
         [PANEL_ID]: { [INSTANCE_ID]: { kind: "dot", tooltip: "Syncing", color: "default" } },
       },
     });
-    usePluginRuntimeStore.setState({
-      pluginMetaById: new Map([[INSTANCE_ID, { devMode: false, displayName: "Video Manager" }]]),
-    });
+    usePluginRuntimeStore.setState({ pluginMetaById: meta("Video Manager") });
 
     render(
       <TooltipProvider>

--- a/src/components/Plugin/PluginInputBoxDialog.tsx
+++ b/src/components/Plugin/PluginInputBoxDialog.tsx
@@ -2,7 +2,9 @@ import { useCallback, useRef, useState } from "react";
 import { AppDialog } from "@/components/ui/AppDialog";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { usePluginPromptStore } from "@/store/pluginPromptStore";
+import { usePluginRuntimeStore } from "@/store/pluginRuntimeStore";
 import type { PluginInputBoxOptions } from "@shared/types/plugin";
+import { pluginManifestIdFromInstanceKey } from "@shared/types/plugin";
 
 /**
  * Compile a plugin-supplied validation pattern. A malformed pattern is ignored
@@ -30,6 +32,12 @@ function InputBoxForm({ options, pluginId, onSubmit, onCancel }: InputBoxFormPro
   const [showError, setShowError] = useState(false);
   const pattern = compilePattern(options.validationPattern);
   const isValid = pattern ? pattern.test(value) : true;
+  // Provenance copy names the plugin, and `pluginId` is the host's instance key
+  // — raw, a project-owned plugin would attribute the prompt to
+  // `project__{projectId}__{manifestId}`. Fallback is the manifest id (#12211).
+  const pluginName = usePluginRuntimeStore(
+    (s) => s.pluginMetaById.get(pluginId)?.displayName ?? pluginManifestIdFromInstanceKey(pluginId)
+  );
 
   const handleSubmit = () => {
     if (!isValid) {
@@ -72,7 +80,7 @@ function InputBoxForm({ options, pluginId, onSubmit, onCancel }: InputBoxFormPro
             {options.validationMessage || "The value doesn't match the required format"}
           </p>
         )}
-        <p className="text-xs text-text-secondary">Requested by the '{pluginId}' plugin</p>
+        <p className="text-xs text-text-secondary">Requested by the '{pluginName}' plugin</p>
       </AppDialog.Body>
 
       <AppDialog.Footer

--- a/src/components/Plugin/PluginQuickPickDialog.tsx
+++ b/src/components/Plugin/PluginQuickPickDialog.tsx
@@ -7,7 +7,9 @@ import { PaletteFooterHints } from "@/components/ui/AppPaletteDialog";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { useSearchablePalette } from "@/hooks/useSearchablePalette";
 import { usePluginPromptStore } from "@/store/pluginPromptStore";
+import { usePluginRuntimeStore } from "@/store/pluginRuntimeStore";
 import type { PluginQuickPickItem } from "@shared/types/plugin";
+import { pluginManifestIdFromInstanceKey } from "@shared/types/plugin";
 
 const EMPTY_ITEMS: PluginQuickPickItem[] = [];
 
@@ -44,6 +46,14 @@ export function PluginQuickPickDialog() {
   const pluginId = quickPick ? quickPick.pluginId : "";
   const items = quickPick ? quickPick.items : EMPTY_ITEMS;
   const canSelectMany = options?.canSelectMany ?? false;
+
+  // The prompt carries the host's plugin *instance* key, which for a
+  // project-owned plugin is `project__{projectId}__{manifestId}` — never copy a
+  // person reads. Resolved through the runtime store like every other surface
+  // that names a plugin; the fallback is the manifest id, never the raw key.
+  const pluginName = usePluginRuntimeStore(
+    (s) => s.pluginMetaById.get(pluginId)?.displayName ?? pluginManifestIdFromInstanceKey(pluginId)
+  );
 
   const fuseOptions = useMemo(
     () => ({
@@ -210,7 +220,7 @@ export function PluginQuickPickDialog() {
         ariaLabel={options?.title || "Plugin quick pick"}
         searchPlaceholder={options?.placeholder || "Search"}
         itemIdPrefix="plugin-quick-pick"
-        emptyMessage={`No options provided by the '${pluginId}' plugin`}
+        emptyMessage={`No options provided by the '${pluginName}' plugin`}
         footer={footer}
       />
     </ErrorBoundary>

--- a/src/components/Plugin/PluginViewContent.tsx
+++ b/src/components/Plugin/PluginViewContent.tsx
@@ -12,6 +12,7 @@ import {
   type LazyExoticComponent,
 } from "react";
 import type { PanelViewProps } from "@shared/types/plugin";
+import { pluginManifestIdFromInstanceKey } from "@shared/types/plugin";
 import {
   clearViewRenderFailure,
   getPanelRemovedSignal,
@@ -217,7 +218,8 @@ export function makePluginViewContent(
     // the pane on pulls that changed nothing about this plugin.
     const devMode = usePluginRuntimeStore((s) => s.pluginMetaById.get(pluginId)?.devMode === true);
     const pluginDisplayName = usePluginRuntimeStore(
-      (s) => s.pluginMetaById.get(pluginId)?.displayName ?? pluginId
+      (s) =>
+        s.pluginMetaById.get(pluginId)?.displayName ?? pluginManifestIdFromInstanceKey(pluginId)
     );
 
     // Re-pull here rather than at mount, because at mount the plugin may not be

--- a/src/components/Plugin/__tests__/PluginDetailPane.test.tsx
+++ b/src/components/Plugin/__tests__/PluginDetailPane.test.tsx
@@ -64,6 +64,9 @@ beforeEach(() => {
 
 function makePlugin(overrides: Partial<LoadedPluginInfo> = {}): LoadedPluginInfo {
   return {
+    instanceId: "acme.demo",
+    origin: "global",
+    projectId: null,
     manifest: {
       name: "acme.demo",
       version: "1.0.0",
@@ -85,7 +88,6 @@ function makePlugin(overrides: Partial<LoadedPluginInfo> = {}): LoadedPluginInfo
         recipes: [],
       },
     },
-    instanceId: "acme.demo",
     dir: "/plugins/acme.demo",
     loadedAt: 1,
     isBuiltin: false,

--- a/src/components/Plugin/__tests__/PluginManagerView.test.tsx
+++ b/src/components/Plugin/__tests__/PluginManagerView.test.tsx
@@ -46,6 +46,9 @@ vi.stubGlobal("matchMedia", (query: string) => ({
 
 function makePlugin(overrides: Partial<LoadedPluginInfo> = {}): LoadedPluginInfo {
   return {
+    instanceId: "acme.demo",
+    origin: "global",
+    projectId: null,
     manifest: {
       name: "acme.demo",
       version: "1.0.0",
@@ -68,7 +71,6 @@ function makePlugin(overrides: Partial<LoadedPluginInfo> = {}): LoadedPluginInfo
         recipes: [],
       },
     },
-    instanceId: "acme.demo",
     dir: "/plugins/acme.demo",
     loadedAt: 123,
     isBuiltin: false,

--- a/src/components/Plugin/__tests__/PluginPromptDialogs.pluginName.test.tsx
+++ b/src/components/Plugin/__tests__/PluginPromptDialogs.pluginName.test.tsx
@@ -1,0 +1,136 @@
+// @vitest-environment jsdom
+/**
+ * Both imperative prompt dialogs attribute the prompt to a plugin by name. The
+ * id they are handed is the host's plugin *instance* key, so for a
+ * project-owned plugin the raw value is `project__{projectId}__{manifestId}` —
+ * a machine-local project id that must never reach user-facing copy (#12211).
+ */
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+beforeAll(() => {
+  if (typeof globalThis.ResizeObserver === "undefined") {
+    globalThis.ResizeObserver = ResizeObserverStub as typeof ResizeObserver;
+  }
+});
+
+vi.mock("@/hooks", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return { ...actual, useEscapeStack: () => {}, useOverlayState: () => {} };
+});
+
+vi.mock("@/hooks/useAnimatedPresence", () => ({
+  useAnimatedPresence: ({ isOpen }: { isOpen: boolean }) => ({
+    isVisible: isOpen,
+    shouldRender: isOpen,
+  }),
+}));
+
+vi.mock("@/store", () => ({
+  usePortalStore: () => ({ isOpen: false, width: 0 }),
+}));
+
+vi.mock("@/store/paletteStore", () => {
+  const usePaletteStore = (selector?: (s: { activePaletteId: null }) => unknown) =>
+    selector ? selector({ activePaletteId: null }) : { activePaletteId: null };
+  usePaletteStore.getState = () => ({ activePaletteId: null });
+  return { usePaletteStore };
+});
+
+import { PluginInputBoxDialog } from "../PluginInputBoxDialog";
+import { PluginQuickPickDialog } from "../PluginQuickPickDialog";
+import { usePluginPromptStore } from "@/store/pluginPromptStore";
+import {
+  _resetPluginRuntimeStoreForTest,
+  usePluginRuntimeStore,
+  type PluginRuntimeMeta,
+} from "@/store/pluginRuntimeStore";
+
+const INSTANCE_KEY = "project__b6700c7a__gregpriday.video-manager";
+
+function seedMeta(entries: Array<[string, PluginRuntimeMeta]>): void {
+  usePluginRuntimeStore.setState({ pluginMetaById: new Map(entries) });
+}
+
+function seedInputBoxPrompt(pluginId: string): void {
+  usePluginPromptStore.setState({
+    queue: [],
+    current: {
+      promptId: "p1",
+      pluginId,
+      params: { kind: "inputBox", options: { title: "Name it" } },
+      resolve: () => {},
+    },
+  });
+}
+
+function seedQuickPickPrompt(pluginId: string): void {
+  usePluginPromptStore.setState({
+    queue: [],
+    current: {
+      promptId: "p1",
+      pluginId,
+      // No items: the empty message is the copy under test.
+      params: { kind: "quickPick", items: [], options: { title: "Pick one" } },
+      resolve: () => {},
+    },
+  });
+}
+
+afterEach(() => {
+  cleanup();
+  usePluginPromptStore.getState().reset();
+  _resetPluginRuntimeStoreForTest();
+});
+
+describe("PluginInputBoxDialog — plugin attribution", () => {
+  it("names a project plugin by its display name, not its instance key", () => {
+    seedMeta([[INSTANCE_KEY, { devMode: false, displayName: "Video Manager" }]]);
+    seedInputBoxPrompt(INSTANCE_KEY);
+
+    render(<PluginInputBoxDialog />);
+
+    expect(screen.queryByText("Requested by the 'Video Manager' plugin")).not.toBeNull();
+    expect(document.body.textContent).not.toContain("project__b6700c7a__");
+  });
+
+  it("falls back to the manifest id before the runtime snapshot lands", () => {
+    seedInputBoxPrompt(INSTANCE_KEY);
+
+    render(<PluginInputBoxDialog />);
+
+    expect(screen.queryByText("Requested by the 'gregpriday.video-manager' plugin")).not.toBeNull();
+    expect(document.body.textContent).not.toContain("project__b6700c7a__");
+  });
+});
+
+describe("PluginQuickPickDialog — plugin attribution", () => {
+  it("names a project plugin by its display name in the empty message", () => {
+    seedMeta([[INSTANCE_KEY, { devMode: false, displayName: "Video Manager" }]]);
+    seedQuickPickPrompt(INSTANCE_KEY);
+
+    render(<PluginQuickPickDialog />);
+
+    expect(document.body.textContent).toContain(
+      "No options provided by the 'Video Manager' plugin"
+    );
+    expect(document.body.textContent).not.toContain("project__b6700c7a__");
+  });
+
+  it("falls back to the manifest id before the runtime snapshot lands", () => {
+    seedQuickPickPrompt(INSTANCE_KEY);
+
+    render(<PluginQuickPickDialog />);
+
+    expect(document.body.textContent).toContain(
+      "No options provided by the 'gregpriday.video-manager' plugin"
+    );
+    expect(document.body.textContent).not.toContain("project__b6700c7a__");
+  });
+});

--- a/src/components/Settings/__tests__/PluginsTab.test.tsx
+++ b/src/components/Settings/__tests__/PluginsTab.test.tsx
@@ -23,6 +23,9 @@ vi.mock("@/lib/notify", () => ({ notify: vi.fn() }));
 
 function makePlugin(name: string): LoadedPluginInfo {
   return {
+    instanceId: name,
+    origin: "global",
+    projectId: null,
     manifest: {
       name,
       version: "1.0.0",
@@ -44,7 +47,6 @@ function makePlugin(name: string): LoadedPluginInfo {
         recipes: [],
       },
     },
-    instanceId: name,
     dir: `/plugins/${name}`,
     loadedAt: 1,
     isBuiltin: false,

--- a/src/components/Settings/__tests__/ProjectPluginsTab.test.tsx
+++ b/src/components/Settings/__tests__/ProjectPluginsTab.test.tsx
@@ -63,6 +63,8 @@ function installed(over: Partial<LoadedPluginInfo> = {}): LoadedPluginInfo {
       contributes: EMPTY_CONTRIBUTES,
     },
     instanceId: "acme.tools",
+    origin: "global",
+    projectId: null,
     dir: "/tmp/acme.tools",
     loadedAt: 0,
     isBuiltin: false,

--- a/src/components/Worktree/WorktreeMenuItems.tsx
+++ b/src/components/Worktree/WorktreeMenuItems.tsx
@@ -73,6 +73,8 @@ import type { ActionId } from "@shared/types/actions";
 import { OPERATION_LABEL, toRepoOperationState } from "@/components/Git/repoOperationCopy";
 import { resourceLifecycleVisibility } from "./utils/resourceLifecycle";
 import type { PluginContextMenuItemEntry } from "@/hooks/usePluginContextMenuItems";
+import { usePluginRuntimeStore } from "@/store/pluginRuntimeStore";
+import { pluginManifestIdFromInstanceKey } from "@shared/types/plugin";
 
 type MenuComponent = React.ElementType;
 type LaunchAgentIcon = React.ComponentType<{ className?: string }>;
@@ -313,6 +315,10 @@ export function WorktreeMenuItems({
   pluginItems,
 }: WorktreeMenuItemsProps) {
   const source = useMenuActionSource();
+  // Group labels in the Extensions submenu name a plugin to the user, and a
+  // contribution's `pluginId` is the instance key — raw, that prints a
+  // machine-local project id (#12211). Fallback is the manifest id, never the key.
+  const pluginMetaById = usePluginRuntimeStore((s) => s.pluginMetaById);
 
   /** A count is part of what the row does, so it belongs in the accessible
    *  name too — the muted trailing slot is `aria-hidden` decoration. */
@@ -1072,7 +1078,12 @@ export function WorktreeMenuItems({
         {pluginGroups.map(([pluginId, entries], groupIndex) => (
           <Fragment key={pluginId}>
             {pluginGroups.length > 1 && groupIndex > 0 && <C.Separator />}
-            {pluginGroups.length > 1 && <C.Label>{pluginId}</C.Label>}
+            {pluginGroups.length > 1 && (
+              <C.Label>
+                {pluginMetaById.get(pluginId)?.displayName ??
+                  pluginManifestIdFromInstanceKey(pluginId)}
+              </C.Label>
+            )}
             {entries.map((entry) => (
               <C.Item
                 key={`${entry.pluginId}:${entry.item.actionId}`}

--- a/src/components/Worktree/__tests__/WorktreeMenuItems.hierarchy.test.tsx
+++ b/src/components/Worktree/__tests__/WorktreeMenuItems.hierarchy.test.tsx
@@ -18,6 +18,7 @@ import {
   rootSeparatorCount,
   zeroCounts,
 } from "./worktreeMenuHarness";
+import { _resetPluginRuntimeStoreForTest, usePluginRuntimeStore } from "@/store/pluginRuntimeStore";
 
 const dispatch = vi.hoisted(() => vi.fn());
 vi.mock("@/services/ActionService", () => ({ actionService: { dispatch } }));
@@ -25,6 +26,7 @@ vi.mock("@/services/ActionService", () => ({ actionService: { dispatch } }));
 afterEach(() => {
   cleanup();
   dispatch.mockClear();
+  _resetPluginRuntimeStoreForTest();
 });
 
 /** Every optional group present: the widest root the menu can produce. */
@@ -581,6 +583,41 @@ describe("WorktreeMenuItems — Extensions", () => {
       (el) => el.textContent
     );
     expect(labels).toEqual(["acme", "zeta"]);
+  });
+
+  it("labels a group with the plugin's display name, never its instance key", () => {
+    // A contribution's `pluginId` is the host's instance key, so a project-owned
+    // plugin's raw id carries a machine-local project id (#12211).
+    const instanceKey = "project__b6700c7a__gregpriday.video-manager";
+    usePluginRuntimeStore.setState({
+      pluginMetaById: new Map([[instanceKey, { devMode: false, displayName: "Video Manager" }]]),
+    });
+
+    const { container } = renderWorktreeMenu({
+      pluginItems: [
+        item(instanceKey, "Do the thing", "vm.go"),
+        item("zeta", "Zeta thing", "zeta.go"),
+      ],
+    });
+
+    const labels = Array.from(container.querySelectorAll("[data-menu-label]")).map(
+      (el) => el.textContent
+    );
+    expect(labels).toEqual(["Video Manager", "zeta"]);
+  });
+
+  it("labels a group with the manifest id before the runtime snapshot lands", () => {
+    const { container } = renderWorktreeMenu({
+      pluginItems: [
+        item("project__b6700c7a__gregpriday.video-manager", "Do the thing", "vm.go"),
+        item("zeta", "Zeta thing", "zeta.go"),
+      ],
+    });
+
+    const labels = Array.from(container.querySelectorAll("[data-menu-label]")).map(
+      (el) => el.textContent
+    );
+    expect(labels).toEqual(["gregpriday.video-manager", "zeta"]);
   });
 
   it("dispatches the plugin's own action id with the surface source", () => {

--- a/src/lib/__tests__/pluginSearch.test.ts
+++ b/src/lib/__tests__/pluginSearch.test.ts
@@ -13,6 +13,9 @@ function makePlugin(overrides: {
   capabilities?: PluginCapability[];
 }): LoadedPluginInfo {
   return {
+    instanceId: overrides.name,
+    origin: "global",
+    projectId: null,
     manifest: {
       name: overrides.name,
       version: "1.0.0",
@@ -38,7 +41,6 @@ function makePlugin(overrides: {
         recipes: [],
       },
     },
-    instanceId: overrides.name,
     dir: `/plugins/${overrides.name}`,
     loadedAt: 0,
     isBuiltin: overrides.isBuiltin ?? false,

--- a/src/store/__tests__/pluginRuntimeStore.test.ts
+++ b/src/store/__tests__/pluginRuntimeStore.test.ts
@@ -128,6 +128,34 @@ describe("usePluginRuntimeStore", () => {
     ).toBe("gregpriday.video-manager");
   });
 
+  it("keeps a project plugin and an installed plugin sharing a manifest id apart", async () => {
+    // The reason the map is single-keyed on the instance id rather than also
+    // aliased by manifest name: both of these are `acme.tool`, and a bare alias
+    // would let whichever came last overwrite the other's name and disabled
+    // state (`ProjectPluginInfo.collidesWithGlobal` exists for this case).
+    listMock.mockResolvedValue([
+      makePlugin({ id: "acme.tool", displayName: "Acme Tool (installed)" }),
+      makePlugin({
+        id: "acme.tool",
+        displayName: "Acme Tool (project)",
+        projectId: "b6700c7a",
+        disabled: true,
+      }),
+    ]);
+
+    usePluginRuntimeStore.getState().init();
+
+    await vi.waitFor(() => expect(usePluginRuntimeStore.getState().pluginMetaById.size).toBe(2));
+    const state = usePluginRuntimeStore.getState();
+    expect(state.pluginMetaById.get("acme.tool")?.displayName).toBe("Acme Tool (installed)");
+    expect(state.pluginMetaById.get("project__b6700c7a__acme.tool")?.displayName).toBe(
+      "Acme Tool (project)"
+    );
+    // Only the project copy is disabled — the global one is untouched.
+    expect(state.disabledPluginIds.has("project__b6700c7a__acme.tool")).toBe(true);
+    expect(state.disabledPluginIds.has("acme.tool")).toBe(false);
+  });
+
   it("keys the disabled set by instance id so two projects' copies stay separate", async () => {
     listMock.mockResolvedValue([
       makePlugin({ id: "acme.tool", projectId: "proj-a", disabled: true }),

--- a/src/store/__tests__/pluginRuntimeStore.test.ts
+++ b/src/store/__tests__/pluginRuntimeStore.test.ts
@@ -202,6 +202,22 @@ describe("usePluginRuntimeStore", () => {
     );
   });
 
+  it("treats a blank displayName as absent rather than rendering an empty name", async () => {
+    // `displayName` is `z.string().optional()` with no min length, so a blank
+    // one is a well-formed manifest that would otherwise name the plugin "".
+    listMock.mockResolvedValue([
+      makePlugin({ id: "acme.blank", displayName: "" }),
+      makePlugin({ id: "acme.spaces", displayName: "   " }),
+    ]);
+
+    usePluginRuntimeStore.getState().init();
+
+    await vi.waitFor(() => expect(usePluginRuntimeStore.getState().pluginMetaById.size).toBe(2));
+    const state = usePluginRuntimeStore.getState();
+    expect(state.pluginMetaById.get("acme.blank")?.displayName).toBe("acme.blank");
+    expect(state.pluginMetaById.get("acme.spaces")?.displayName).toBe("acme.spaces");
+  });
+
   it("re-pulls on a provenance change and drops metadata for removed plugins", async () => {
     let fire: (() => void) | undefined;
     onProvenanceChangedMock.mockImplementation((cb) => {

--- a/src/store/__tests__/pluginRuntimeStore.test.ts
+++ b/src/store/__tests__/pluginRuntimeStore.test.ts
@@ -16,8 +16,15 @@ function makePlugin(opts: {
   displayName?: string;
   devMode?: boolean;
   disabled?: boolean;
+  /** Project-owned instance: `id` stays the manifest id, the key gets qualified. */
+  projectId?: string;
 }): LoadedPluginInfo {
+  const projectId = opts.projectId ?? null;
+  const instanceId = projectId === null ? opts.id : `project__${projectId}__${opts.id}`;
   return {
+    instanceId,
+    origin: projectId === null ? "global" : "project",
+    projectId,
     manifest: {
       name: opts.id,
       version: "1.0.0",
@@ -39,7 +46,6 @@ function makePlugin(opts: {
         recipes: [],
       },
     },
-    instanceId: opts.id,
     dir: `/plugins/${opts.id}`,
     loadedAt: 1,
     isBuiltin: false,
@@ -84,6 +90,58 @@ afterEach(() => {
 });
 
 describe("usePluginRuntimeStore", () => {
+  it("keys a project plugin's metadata by its instance id, not its manifest name", async () => {
+    // The regression in #12211: every contribution carries the instance key, so
+    // a map keyed by manifest name never matched and the raw key was rendered.
+    listMock.mockResolvedValue([
+      makePlugin({
+        id: "gregpriday.video-manager",
+        displayName: "Video Manager",
+        projectId: "b6700c7a",
+      }),
+    ]);
+
+    usePluginRuntimeStore.getState().init();
+
+    await vi.waitFor(() => expect(usePluginRuntimeStore.getState().pluginMetaById.size).toBe(1));
+    const state = usePluginRuntimeStore.getState();
+    expect(state.pluginMetaById.get("project__b6700c7a__gregpriday.video-manager")).toEqual({
+      devMode: false,
+      displayName: "Video Manager",
+    });
+    // The bare manifest name is deliberately NOT a second key.
+    expect(state.pluginMetaById.has("gregpriday.video-manager")).toBe(false);
+  });
+
+  it("falls back to the manifest id, never the instance key, when no displayName is declared", async () => {
+    listMock.mockResolvedValue([
+      makePlugin({ id: "gregpriday.video-manager", projectId: "b6700c7a" }),
+    ]);
+
+    usePluginRuntimeStore.getState().init();
+
+    await vi.waitFor(() => expect(usePluginRuntimeStore.getState().pluginMetaById.size).toBe(1));
+    expect(
+      usePluginRuntimeStore
+        .getState()
+        .pluginMetaById.get("project__b6700c7a__gregpriday.video-manager")?.displayName
+    ).toBe("gregpriday.video-manager");
+  });
+
+  it("keys the disabled set by instance id so two projects' copies stay separate", async () => {
+    listMock.mockResolvedValue([
+      makePlugin({ id: "acme.tool", projectId: "proj-a", disabled: true }),
+      makePlugin({ id: "acme.tool", projectId: "proj-b" }),
+    ]);
+
+    usePluginRuntimeStore.getState().init();
+
+    await vi.waitFor(() => expect(usePluginRuntimeStore.getState().pluginMetaById.size).toBe(2));
+    const state = usePluginRuntimeStore.getState();
+    expect(state.disabledPluginIds.has("project__proj-a__acme.tool")).toBe(true);
+    expect(state.disabledPluginIds.has("project__proj-b__acme.tool")).toBe(false);
+  });
+
   it("derives the disabled set and per-plugin metadata from one snapshot", async () => {
     listMock.mockResolvedValue([
       makePlugin({ id: "acme.dev", displayName: "Acme Dev", devMode: true }),

--- a/src/store/pluginRuntimeStore.ts
+++ b/src/store/pluginRuntimeStore.ts
@@ -24,15 +24,21 @@ export interface PluginRuntimeMeta {
    * whoever is looking at it is looking at their own build.
    */
   devMode: boolean;
-  /** `manifest.displayName` when the manifest declares one, else the plugin id. */
+  /** `manifest.displayName` when the manifest declares one, else the manifest id. */
   displayName: string;
 }
 
 interface PluginRuntimeState {
   disabledPluginIds: ReadonlySet<string>;
   /**
-   * Keyed by plugin id (`manifest.name`). An absent entry means "no snapshot
-   * yet", not "no such plugin" — read it as non-dev, the conservative default.
+   * Keyed by plugin *instance* id — the host-side key every contribution
+   * carries as its `pluginId`/`extensionId`, which is `manifest.name` for an
+   * installed or builtin plugin and `project__{projectId}__{manifestId}` for a
+   * project-owned one. Keyed on `manifest.name` these lookups missed for every
+   * project plugin and the raw instance key was rendered instead (#12211).
+   *
+   * An absent entry means "no snapshot yet", not "no such plugin" — read it as
+   * non-dev, the conservative default.
    */
   pluginMetaById: ReadonlyMap<string, PluginRuntimeMeta>;
   /** Idempotent: pulls the current snapshot and subscribes to live updates. */
@@ -75,11 +81,19 @@ async function pullPluginRuntimeSnapshot(
     const disabledPluginIds = new Set<string>();
     const pluginMetaById = new Map<string, PluginRuntimeMeta>();
     for (const p of list) {
-      const id = p.manifest.name;
+      // Both maps key on the instance id for the same reason: every consumer
+      // holds a contribution's `pluginId`, which is this key, never the bare
+      // manifest name. Deliberately NOT also keyed by `manifest.name` — a
+      // project plugin may share a manifest id with an installed one
+      // (`ProjectPluginInfo.collidesWithGlobal`), so a second key would let one
+      // silently overwrite the other's metadata.
+      const id = p.instanceId;
       if (p.disabled) disabledPluginIds.add(id);
       pluginMetaById.set(id, {
         devMode: p.devMode,
-        displayName: p.manifest.displayName ?? id,
+        // Falls back to the manifest id, never the instance key: the key
+        // carries a machine-local project id that is not a name for a person.
+        displayName: p.manifest.displayName ?? p.manifest.name,
       });
     }
     // One commit: a consumer must never read a plugin's dev-mode flag from a

--- a/src/store/pluginRuntimeStore.ts
+++ b/src/store/pluginRuntimeStore.ts
@@ -93,7 +93,10 @@ async function pullPluginRuntimeSnapshot(
         devMode: p.devMode,
         // Falls back to the manifest id, never the instance key: the key
         // carries a machine-local project id that is not a name for a person.
-        displayName: p.manifest.displayName ?? p.manifest.name,
+        // `||` rather than `??`: `displayName` is `z.string().optional()` with
+        // no min length, so a blank one is well-formed and would otherwise
+        // render as an empty label everywhere a plugin is named.
+        displayName: p.manifest.displayName?.trim() || p.manifest.name,
       });
     }
     // One commit: a consumer must never read a plugin's dev-mode flag from a


### PR DESCRIPTION
## Summary

- Project owned plugins load under an instance key of the form `project__{projectId}__{manifestId}`, and every contribution from that plugin carries the same key as its `pluginId`. `PluginService.listPlugins()` built `LoadedPluginInfo` from `this.plugins.values()`, discarding the map key that held the real identity, so the renderer's `pluginMetaById` lookup ended up keyed by `manifest.name`, a key no contribution ever holds. Every lookup for a project plugin missed and fell back to rendering the raw internal key.
- That leak showed up in four places: the toolbar plugin tray group header, `host.showToast` messages, the panel view error boundary title, and panel badge aria-labels.
- This closes the leak and adds a small SDK surface so a plugin can learn its own identity instead of string-splitting its own id.

Resolves #12211

## Changes

**Part 1: close the leak**

- `LoadedPluginInfo` now carries `instanceId`, `origin`, and `projectId`. `listPlugins()` walks `entries()` on all three internal maps instead of discarding the keys.
- `pluginRuntimeStore` now keys `pluginMetaById` and `disabledPluginIds` by `instanceId`. It deliberately doesn't also alias by `manifest.name`: a project plugin can share a manifest id with an installed one, and a second key would let one silently overwrite the other.
- The display-name fallback on all four surfaces now resolves to the manifest id rather than the raw instance key, so even the pre-fetch render is clean.
- `PluginPanelBadges` never consulted the store at all. It's now wired in, with a pull keyed on badge owners actually missing from the snapshot.
- `host.showToast` keeps its provenance prefix but now prints the display name.

**Part 2: let plugins learn their own identity**

- Adds `host.pluginInfo`, a frozen readonly property, not a method: the binding is captured once at host construction, so it's static data and needs no async round-trip. Exposes the manifest id, project id, and instance key.
- Adds `host.panelKindId(bareId)`, which qualifies one of the plugin's own `contributes.panels[].id` values into the runtime kind id, resolved against the plugin's own binding rather than by sniffing the string's shape.
- `host.pluginId` is unchanged. It's documented public SDK surface, and transport routing plus settings/storage paths key on it.
- `panel.openPluginPanel` is deliberately not widened to accept bare ids. Its manifest is also the MCP tool surface, and an MCP caller doesn't own a plugin.

**Also fixed during review**

- Project plugins run through the plugin worker like any plugin with a `main`, so the worker-side proxy is what their `activate()` receives. It reconstructed identity by parsing the instance key and always reported `projectRoot: null` even against a real `projectId`. The host's real identity now rides the worker's `start` message instead of being reconstructed.
- `listPlugins()` was checking the disable list and install record by manifest name for every row, so a project plugin was silently inheriting a same-named installed plugin's disabled state and install provenance. Both lookups are now global-only.

**Left out of scope on purpose**

Three pre-existing issues turned up while working on this, noted here rather than folded in:

- `PluginService.setEnabled()` still mishandles a project instance key: disabling one discards the binding, and re-enabling reloads it under the bare manifest name.
- The Plugin Manager lists project plugins that `ProjectPluginSection` already shows. That's now trivially filterable on the new `origin` field, but pulling currently visible rows is a UX change beyond this fix.
- Update-check and plugin diagnostics still assume `manifest.name` is the runtime identity.

## Testing

- 1,254 targeted tests green across every plugin module this touches: the `PluginService` suites, everything under `electron/services/plugin/`, the plugin/panel/settings/layout renderer suites, and the `plugin-sdk` and `panelKindRegistry` contract tests.
- `npm run typecheck` clean, zero eslint errors on changed files, prettier clean.
- `npm run codegen:ipc && npm run codegen:ipc-renderer` produce an empty diff. `LoadedPluginInfo` is printed by reference in the generated types file, so the field additions are a no-op there.
- `npm run api-surface:update` regenerated `packages/plugin-sdk/api-report/index.d.ts`, required because `PluginHostApi` is exported from the SDK barrel and `check:api-surface` runs inside `npm run check`. The regenerated report is committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015D87VGgGBJ39KnYpenwwCi