### PR TITLE
feat(launcher): add Customize toolbar to the More section

### DIFF
--- a/src/components/Layout/DockLaunchButton.tsx
+++ b/src/components/Layout/DockLaunchButton.tsx
@@ -1,7 +1,17 @@
 import { Fragment, useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
 import Fuse, { type IFuseOptions } from "fuse.js";
-import { ChevronRight, Keyboard, Pin, Plug, Plus, Settings2, SquareTerminal } from "lucide-react";
+import {
+  ChevronRight,
+  Keyboard,
+  Pin,
+  Plug,
+  Plus,
+  Settings2,
+  SlidersHorizontal,
+  SquareTerminal,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { ContextMenu, ContextMenuContent, ContextMenuTrigger } from "@/components/ui/context-menu";
@@ -53,6 +63,7 @@ import {
   DOCK_LAUNCH_CATEGORY_LABELS,
   DOCK_LAUNCH_CUE_LABELS,
   type DockLaunchAgent,
+  type DockLaunchCueId,
   type DockLaunchInventoryState,
   type DockLaunchItem,
   type DockLaunchRow,
@@ -1498,15 +1509,28 @@ function DockLaunchOption({
   );
 }
 
+/**
+ * A glyph per cue, exhaustive by type. The ternary this replaced ended in the
+ * recipe `Workflow` as its else — a cue added without a branch drew the wrong
+ * icon silently, the presentation half of the routing bug #12218 fixed.
+ *
+ * `SlidersHorizontal` rather than the `Settings2` the plugin tray's Customize
+ * entry carries: that glyph already belongs to Manage agents, the row directly
+ * above this one under the same heading, and two neighbours sharing a gear read
+ * as one destination listed twice. It is the toolbar's own settings glyph
+ * (`ToolbarSettingsButton`), so the row still points where its label says.
+ */
+const DOCK_LAUNCH_CUE_ICONS: Record<DockLaunchCueId, LucideIcon> = {
+  "create-recipe": Workflow,
+  "setup-agents": Plug,
+  "manage-agents": Settings2,
+  "customize-toolbar": SlidersHorizontal,
+};
+
 function DockLaunchOptionIcon({ row }: { row: DockLaunchRow }) {
   if (row.kind === "cue") {
-    return row.cue === "setup-agents" ? (
-      <Plug className="w-3.5 h-3.5 mr-2 shrink-0" />
-    ) : row.cue === "manage-agents" ? (
-      <Settings2 className="w-3.5 h-3.5 mr-2 shrink-0" />
-    ) : (
-      <Workflow className="w-3.5 h-3.5 mr-2 shrink-0" />
-    );
+    const CueIcon = DOCK_LAUNCH_CUE_ICONS[row.cue];
+    return <CueIcon className="w-3.5 h-3.5 mr-2 shrink-0" />;
   }
 
   const { item } = row;

--- a/src/components/Layout/__tests__/DockLaunchButton.test.tsx
+++ b/src/components/Layout/__tests__/DockLaunchButton.test.tsx
@@ -1438,7 +1438,9 @@ describe("DockLaunchButton", () => {
       under.set(heading, [...(under.get(heading) ?? []), node.textContent ?? ""]);
     }
 
-    expect(getAllByTestId("dock-launcher-band").filter((el) => el.textContent === "More")).toHaveLength(1);
+    expect(
+      getAllByTestId("dock-launcher-band").filter((el) => el.textContent === "More")
+    ).toHaveLength(1);
     const more = under.get("More") ?? [];
     expect(more).toHaveLength(2);
     expect(more[0]).toContain("Manage agents");

--- a/src/components/Layout/__tests__/DockLaunchButton.test.tsx
+++ b/src/components/Layout/__tests__/DockLaunchButton.test.tsx
@@ -367,6 +367,7 @@ vi.mock("@/components/ui/AppPaletteDialog", () => {
 });
 
 import { DockLaunchButton } from "../DockLaunchButton";
+import { TOOLBAR_CUSTOMIZE_LABEL } from "../toolbarMenuStrings";
 import type { DockLaunchAgent } from "../DockLaunchMenuItems";
 
 const AGENTS: DockLaunchAgent[] = [
@@ -1414,6 +1415,44 @@ describe("DockLaunchButton", () => {
       "recipe.editor.open",
       expect.anything(),
       expect.anything()
+    );
+  });
+
+  it("footers the More band with both action cues under one heading", () => {
+    const { getAllByTestId, getByText } = renderButton();
+
+    // `shouldShowBandLabel` prints a heading only on a band's first row, so a
+    // second "More" would mean the pair had drifted into separate bands.
+    const more = getAllByTestId("dock-launcher-band").filter((el) => el.textContent === "More");
+    expect(more).toHaveLength(1);
+    expect(getByText("Manage agents")).toBeTruthy();
+    expect(getByText(TOOLBAR_CUSTOMIZE_LABEL)).toBeTruthy();
+  });
+
+  it("opens the toolbar settings tab from the Customize toolbar cue", () => {
+    const { getByText } = renderButton();
+
+    fireEvent.click(getByText(TOOLBAR_CUSTOMIZE_LABEL));
+    expect(actionDispatchMock).toHaveBeenCalledWith(
+      "app.settings.openTab",
+      { tab: "toolbar" },
+      { source: "menu" }
+    );
+  });
+
+  it("lands on the Customize toolbar cue at the end of the browse list", () => {
+    // The footer is the last thing End can reach, so this is also the assertion
+    // that the row took an index in the flat navigation space at all.
+    const { container } = renderButton();
+    const input = searchInput(container);
+
+    fireEvent.keyDown(input, { key: "End" });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(actionDispatchMock).toHaveBeenCalledWith(
+      "app.settings.openTab",
+      { tab: "toolbar" },
+      { source: "menu" }
     );
   });
 

--- a/src/components/Layout/__tests__/DockLaunchButton.test.tsx
+++ b/src/components/Layout/__tests__/DockLaunchButton.test.tsx
@@ -368,6 +368,7 @@ vi.mock("@/components/ui/AppPaletteDialog", () => {
 
 import { DockLaunchButton } from "../DockLaunchButton";
 import { TOOLBAR_CUSTOMIZE_LABEL } from "../toolbarMenuStrings";
+import { SlidersHorizontal } from "lucide-react";
 import type { DockLaunchAgent } from "../DockLaunchMenuItems";
 
 const AGENTS: DockLaunchAgent[] = [
@@ -1419,14 +1420,59 @@ describe("DockLaunchButton", () => {
   });
 
   it("footers the More band with both action cues under one heading", () => {
-    const { getAllByTestId, getByText } = renderButton();
+    const { container, getAllByTestId } = renderButton();
 
-    // `shouldShowBandLabel` prints a heading only on a band's first row, so a
-    // second "More" would mean the pair had drifted into separate bands.
-    const more = getAllByTestId("dock-launcher-band").filter((el) => el.textContent === "More");
-    expect(more).toHaveLength(1);
-    expect(getByText("Manage agents")).toBeTruthy();
-    expect(getByText(TOOLBAR_CUSTOMIZE_LABEL)).toBeTruthy();
+    // Walk the listbox in DOM order and file each option under the heading
+    // above it. Counting headings alone would not do: a row that drifted into
+    // another band leaves exactly one "More" behind and still renders its label
+    // somewhere on screen, which is all a `getByText` pair can see.
+    const under = new Map<string, string[]>();
+    let heading = "";
+    for (const node of listbox(container).querySelectorAll<HTMLElement>(
+      '[data-testid="dock-launcher-band"], [role="option"]'
+    )) {
+      if (node.getAttribute("data-testid") === "dock-launcher-band") {
+        heading = node.textContent ?? "";
+        continue;
+      }
+      under.set(heading, [...(under.get(heading) ?? []), node.textContent ?? ""]);
+    }
+
+    expect(getAllByTestId("dock-launcher-band").filter((el) => el.textContent === "More")).toHaveLength(1);
+    const more = under.get("More") ?? [];
+    expect(more).toHaveLength(2);
+    expect(more[0]).toContain("Manage agents");
+    expect(more[1]).toContain(TOOLBAR_CUSTOMIZE_LABEL);
+  });
+
+  it("draws the Customize toolbar cue with a glyph of its own", () => {
+    // Compared against a live render of the icon rather than Lucide's class
+    // string, which is the package's business and not a contract. Without this
+    // the row could regress to the `Workflow` the old cue ternary fell through
+    // to, or to the `Settings2` the row directly above it already carries, and
+    // every other assertion here would stay green.
+    const { container } = renderButton();
+    const glyphOf = (label: string) => {
+      const row = options(container).find((option) => option.textContent?.includes(label));
+      if (!row) throw new Error(`no option row for ${label}`);
+      return row.querySelector("svg")!.innerHTML;
+    };
+    const slidersGlyph = render(<SlidersHorizontal />).container.querySelector("svg")!.innerHTML;
+
+    expect(glyphOf(TOOLBAR_CUSTOMIZE_LABEL)).toBe(slidersGlyph);
+    expect(glyphOf(TOOLBAR_CUSTOMIZE_LABEL)).not.toBe(glyphOf("Manage agents"));
+  });
+
+  it("leaves the action cues out of search results", () => {
+    // Fuse is built from `searchItems` — agents, panels and recipes — and the
+    // placeholder promises exactly those. A cue that leaked into the ranked list
+    // would be an action offered where the user is picking something to launch.
+    const { container, queryByText } = renderButton();
+
+    fireEvent.change(searchInput(container), { target: { value: "customize" } });
+
+    expect(queryByText(TOOLBAR_CUSTOMIZE_LABEL)).toBeNull();
+    expect(queryByText("Manage agents")).toBeNull();
   });
 
   it("opens the toolbar settings tab from the Customize toolbar cue", () => {

--- a/src/components/Layout/__tests__/dockLaunchItems.test.ts
+++ b/src/components/Layout/__tests__/dockLaunchItems.test.ts
@@ -457,30 +457,54 @@ describe("buildDockLaunchModel — browse rows", () => {
 });
 
 describe("activateDockLaunchCue", () => {
-  it("sends each settings cue to its own tab, and nowhere else", () => {
-    // The call COUNT is half the assertion. Routing is a switch now, so a
-    // dropped `return` would open the right tab and then the next case's tab
-    // on top of it — which `toHaveBeenCalledWith` alone reads as a pass.
-    const dispatchedTabs = (cue: Parameters<typeof activateDockLaunchCue>[0]) => {
+  const dispatchEventMock = vi.fn();
+
+  beforeEach(() => {
+    dispatchEventMock.mockReset();
+    // This suite runs in the node environment, where the setup cue's reach for
+    // `window` throws. Stubbed rather than skipped: a dropped `return` in the
+    // case above it lands here, and an exception is not a reading of that.
+    vi.stubGlobal("window", { dispatchEvent: dispatchEventMock });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("gives every cue exactly one effect, on exactly one channel", () => {
+    const effectsOf = (cue: Parameters<typeof activateDockLaunchCue>[0]) => {
       actionDispatchMock.mockClear();
+      dispatchEventMock.mockClear();
       activateDockLaunchCue(cue, "wt-1", "menu");
-      return actionDispatchMock.mock.calls;
+      return {
+        dispatched: [...actionDispatchMock.mock.calls],
+        events: dispatchEventMock.mock.calls.map(([event]) => (event as Event).type),
+      };
     };
 
-    // Pinned as a pair because routing used to end in an unconditional dispatch
-    // to `agents`: the two destinations are one edit away from being swapped,
-    // and either swap is silent.
-    expect(dispatchedTabs("customize-toolbar")).toEqual([
-      ["app.settings.openTab", { tab: "toolbar" }, { source: "menu" }],
-    ]);
-    expect(dispatchedTabs("manage-agents")).toEqual([
-      ["app.settings.openTab", { tab: "agents" }, { source: "menu" }],
-    ]);
-    // The recipe cue routes elsewhere entirely; falling into either settings
-    // case would be the same dropped `return` seen from above.
-    expect(dispatchedTabs("create-recipe")).toEqual([
-      ["recipe.editor.open", { worktreeId: "wt-1" }, { source: "menu" }],
-    ]);
+    // Exact call lists, both channels, all four cues. Routing is a switch now,
+    // and a dropped `return` runs the next case's effect on top of this one —
+    // which a matcher that only asks whether the expected call happened reads
+    // as a pass.
+    expect(effectsOf("create-recipe")).toEqual({
+      dispatched: [["recipe.editor.open", { worktreeId: "wt-1" }, { source: "menu" }]],
+      events: [],
+    });
+    expect(effectsOf("setup-agents")).toEqual({
+      dispatched: [],
+      events: ["daintree:open-agent-setup-wizard"],
+    });
+    // The two settings cues are one edit apart from being swapped, and either
+    // swap is silent: this used to route on two `if`s and then dispatch `agents`
+    // unconditionally.
+    expect(effectsOf("manage-agents")).toEqual({
+      dispatched: [["app.settings.openTab", { tab: "agents" }, { source: "menu" }]],
+      events: [],
+    });
+    expect(effectsOf("customize-toolbar")).toEqual({
+      dispatched: [["app.settings.openTab", { tab: "toolbar" }, { source: "menu" }]],
+      events: [],
+    });
   });
 });
 

--- a/src/components/Layout/__tests__/dockLaunchItems.test.ts
+++ b/src/components/Layout/__tests__/dockLaunchItems.test.ts
@@ -71,7 +71,9 @@ vi.mock("@/utils/logger", () => ({
 
 import {
   buildDockLaunchModel,
+  activateDockLaunchCue,
   activateDockLaunchItem,
+  DOCK_LAUNCH_CUE_LABELS,
   buildPresetChoices,
   buildPresetRows,
   getDockLaunchRowItem,
@@ -84,6 +86,7 @@ import {
   type DockLaunchRow,
 } from "../dockLaunchItems";
 import type { TerminalRecipe } from "@shared/types";
+import { TOOLBAR_CUSTOMIZE_LABEL } from "../toolbarMenuStrings";
 import { PANEL_LIMIT_ERROR_SUFFIX } from "@/services/actions/definitions/panelLimitError";
 
 const AGENTS: DockLaunchAgent[] = [
@@ -421,6 +424,48 @@ describe("buildDockLaunchModel — browse rows", () => {
     // With recipes present the cue is gone, so it can't be navigated to.
     const withSome = build({ recipes: [recipe({ id: "r-1", name: "Deploy" })] });
     expect(createRecipeRows(withSome)).toEqual([]);
+  });
+
+  it("footers the More band with Manage agents and then Customize toolbar", () => {
+    const actionCues = build().browseRows.filter((row) => row.band === "actions");
+
+    // Both rows unconditionally: unlike the recipe and setup cues, neither
+    // depends on inventory. Order is the assertion — Manage agents has held
+    // this footer alone, and moving it would relocate a row under the cursor.
+    expect(actionCues.map((row) => (row.kind === "cue" ? row.cue : row.kind))).toEqual([
+      "manage-agents",
+      "customize-toolbar",
+    ]);
+    expect(new Set(actionCues.map((row) => row.rowKey)).size).toBe(2);
+  });
+
+  it("labels the toolbar cue with the plugin tray's own wording", () => {
+    // The issue asks for one string, not a second that agrees today: the launcher
+    // and the tray point at the same settings page, so a copy edit to either has
+    // to move both.
+    expect(DOCK_LAUNCH_CUE_LABELS["customize-toolbar"]).toBe(TOOLBAR_CUSTOMIZE_LABEL);
+  });
+});
+
+describe("activateDockLaunchCue", () => {
+  it("sends each settings cue to its own tab", () => {
+    activateDockLaunchCue("customize-toolbar", "wt-1", "menu");
+    expect(actionDispatchMock).toHaveBeenCalledWith(
+      "app.settings.openTab",
+      { tab: "toolbar" },
+      { source: "menu" }
+    );
+
+    // Pinned alongside it because routing used to end in an unconditional
+    // dispatch to `agents`: the two destinations are one edit away from being
+    // swapped, and either swap is silent.
+    actionDispatchMock.mockClear();
+    activateDockLaunchCue("manage-agents", "wt-1", "menu");
+    expect(actionDispatchMock).toHaveBeenCalledWith(
+      "app.settings.openTab",
+      { tab: "agents" },
+      { source: "menu" }
+    );
   });
 });
 

--- a/src/components/Layout/__tests__/dockLaunchItems.test.ts
+++ b/src/components/Layout/__tests__/dockLaunchItems.test.ts
@@ -427,16 +427,25 @@ describe("buildDockLaunchModel — browse rows", () => {
   });
 
   it("footers the More band with Manage agents and then Customize toolbar", () => {
-    const actionCues = build().browseRows.filter((row) => row.band === "actions");
+    const actionRows = (model: ReturnType<typeof build>) =>
+      model.browseRows.filter((row) => row.band === "actions");
+    const cuesOf = (model: ReturnType<typeof build>) =>
+      actionRows(model).map((row) => (row.kind === "cue" ? row.cue : row.kind));
+    const FOOTER = ["manage-agents", "customize-toolbar"];
 
-    // Both rows unconditionally: unlike the recipe and setup cues, neither
-    // depends on inventory. Order is the assertion — Manage agents has held
-    // this footer alone, and moving it would relocate a row under the cursor.
-    expect(actionCues.map((row) => (row.kind === "cue" ? row.cue : row.kind))).toEqual([
-      "manage-agents",
-      "customize-toolbar",
-    ]);
-    expect(new Set(actionCues.map((row) => row.rowKey)).size).toBe(2);
+    // Order is the assertion — Manage agents has held this footer alone, and
+    // moving it would relocate a row out from under the cursor.
+    expect(cuesOf(build())).toEqual(FOOTER);
+    expect(new Set(actionRows(build()).map((row) => row.rowKey)).size).toBe(2);
+
+    // Unconditional, unlike the recipe and setup cues, which the inventory
+    // withdraws once it can offer the real thing. Both of these rows reach
+    // global settings pages, so nothing about what a project holds may hide
+    // the route to them — asserted against the shapes that DO move the other
+    // cues, since a gate copied from one of them would pass the default build.
+    expect(cuesOf(build({ recipes: [recipe({ id: "r-1", name: "Deploy" })] }))).toEqual(FOOTER);
+    expect(cuesOf(build({ agents: [], agentInventoryState: "loading" }))).toEqual(FOOTER);
+    expect(cuesOf(build({ agentInventoryState: "fallback" }))).toEqual(FOOTER);
   });
 
   it("labels the toolbar cue with the plugin tray's own wording", () => {
@@ -448,24 +457,30 @@ describe("buildDockLaunchModel — browse rows", () => {
 });
 
 describe("activateDockLaunchCue", () => {
-  it("sends each settings cue to its own tab", () => {
-    activateDockLaunchCue("customize-toolbar", "wt-1", "menu");
-    expect(actionDispatchMock).toHaveBeenCalledWith(
-      "app.settings.openTab",
-      { tab: "toolbar" },
-      { source: "menu" }
-    );
+  it("sends each settings cue to its own tab, and nowhere else", () => {
+    // The call COUNT is half the assertion. Routing is a switch now, so a
+    // dropped `return` would open the right tab and then the next case's tab
+    // on top of it — which `toHaveBeenCalledWith` alone reads as a pass.
+    const dispatchedTabs = (cue: Parameters<typeof activateDockLaunchCue>[0]) => {
+      actionDispatchMock.mockClear();
+      activateDockLaunchCue(cue, "wt-1", "menu");
+      return actionDispatchMock.mock.calls;
+    };
 
-    // Pinned alongside it because routing used to end in an unconditional
-    // dispatch to `agents`: the two destinations are one edit away from being
-    // swapped, and either swap is silent.
-    actionDispatchMock.mockClear();
-    activateDockLaunchCue("manage-agents", "wt-1", "menu");
-    expect(actionDispatchMock).toHaveBeenCalledWith(
-      "app.settings.openTab",
-      { tab: "agents" },
-      { source: "menu" }
-    );
+    // Pinned as a pair because routing used to end in an unconditional dispatch
+    // to `agents`: the two destinations are one edit away from being swapped,
+    // and either swap is silent.
+    expect(dispatchedTabs("customize-toolbar")).toEqual([
+      ["app.settings.openTab", { tab: "toolbar" }, { source: "menu" }],
+    ]);
+    expect(dispatchedTabs("manage-agents")).toEqual([
+      ["app.settings.openTab", { tab: "agents" }, { source: "menu" }],
+    ]);
+    // The recipe cue routes elsewhere entirely; falling into either settings
+    // case would be the same dropped `return` seen from above.
+    expect(dispatchedTabs("create-recipe")).toEqual([
+      ["recipe.editor.open", { worktreeId: "wt-1" }, { source: "menu" }],
+    ]);
   });
 });
 

--- a/src/components/Layout/dockLaunchItems.ts
+++ b/src/components/Layout/dockLaunchItems.ts
@@ -20,6 +20,7 @@ import { notifyRecipeSpawnFailures } from "@/utils/recipeNotify";
 import { getRecipeScope } from "@/utils/recipeScope";
 import { logError } from "@/utils/logger";
 import { isAgentLaunchable } from "@shared/utils/agentAvailability";
+import { TOOLBAR_CUSTOMIZE_LABEL } from "./toolbarMenuStrings";
 import type {
   ActionSource,
   AgentAvailabilityState,
@@ -176,7 +177,11 @@ export const DOCK_LAUNCH_CATEGORY_LABELS: Record<DockLaunchItem["category"], str
 };
 
 /** A row that runs something other than a launchable item. */
-export type DockLaunchCueId = "create-recipe" | "setup-agents" | "manage-agents";
+export type DockLaunchCueId =
+  | "create-recipe"
+  | "setup-agents"
+  | "manage-agents"
+  | "customize-toolbar";
 
 /** Heading for each named provenance group, matching the old preset submenu. */
 export const DOCK_LAUNCH_PRESET_GROUP_LABELS: Record<DockLaunchPresetGroup, string> = {
@@ -190,6 +195,9 @@ export const DOCK_LAUNCH_CUE_LABELS: Record<DockLaunchCueId, string> = {
   "create-recipe": "Create a recipe",
   "setup-agents": "Set up agents",
   "manage-agents": "Manage agents",
+  // The plugin tray's own entry, word for word: two routes to one settings page
+  // that disagreed about its name would read as two destinations (#12218).
+  "customize-toolbar": TOOLBAR_CUSTOMIZE_LABEL,
 };
 
 interface DockLaunchRowBase {
@@ -648,6 +656,15 @@ export function buildDockLaunchModel({
   }
 
   browseRows.push({ kind: "cue", rowKey: "manage-agents", band: "actions", cue: "manage-agents" });
+  // Second, not first: Manage agents has held this footer alone and the launcher
+  // is an agent list before it is anything else. The pair reads outward from
+  // what gets launched to where the launchers sit.
+  browseRows.push({
+    kind: "cue",
+    rowKey: "customize-toolbar",
+    band: "actions",
+    cue: "customize-toolbar",
+  });
 
   return {
     recentAgents,
@@ -820,15 +837,25 @@ export function activateDockLaunchCue(
   activeWorktreeId: string | null,
   source: ActionSource
 ): void {
-  if (cue === "create-recipe") {
-    activateCreateRecipeCue(activeWorktreeId, source);
-    return;
+  switch (cue) {
+    case "create-recipe":
+      activateCreateRecipeCue(activeWorktreeId, source);
+      return;
+    case "setup-agents":
+      window.dispatchEvent(new CustomEvent("daintree:open-agent-setup-wizard"));
+      return;
+    case "manage-agents":
+      void actionService.dispatch("app.settings.openTab", { tab: "agents" }, { source });
+      return;
+    case "customize-toolbar":
+      void actionService.dispatch("app.settings.openTab", { tab: "toolbar" }, { source });
+      return;
   }
-  if (cue === "setup-agents") {
-    window.dispatchEvent(new CustomEvent("daintree:open-agent-setup-wizard"));
-    return;
-  }
-  void actionService.dispatch("app.settings.openTab", { tab: "agents" }, { source });
+  // Every cue names its own destination. This routed on two `if`s and then fell
+  // through to the agents tab, so a cue added without a branch opened the wrong
+  // settings page and nothing — not a type error, not a test — said so.
+  const _exhaustive: never = cue;
+  return _exhaustive;
 }
 
 /**

--- a/src/components/Layout/dockLaunchItems.ts
+++ b/src/components/Layout/dockLaunchItems.ts
@@ -178,10 +178,7 @@ export const DOCK_LAUNCH_CATEGORY_LABELS: Record<DockLaunchItem["category"], str
 
 /** A row that runs something other than a launchable item. */
 export type DockLaunchCueId =
-  | "create-recipe"
-  | "setup-agents"
-  | "manage-agents"
-  | "customize-toolbar";
+  "create-recipe" | "setup-agents" | "manage-agents" | "customize-toolbar";
 
 /** Heading for each named provenance group, matching the old preset submenu. */
 export const DOCK_LAUNCH_PRESET_GROUP_LABELS: Record<DockLaunchPresetGroup, string> = {


### PR DESCRIPTION
## Summary

- Adds a "Customize toolbar..." row to the More section of the launcher dropdown, after the existing Manage agents row. The launcher is where toolbar buttons get pinned, so it should also be where the pinned set gets rearranged.
- Clicking it dispatches the same action already used by the plugin tray and the toolbar context menu: `app.settings.openTab` with `tab` set to `toolbar`.
- Reuses the existing `TOOLBAR_CUSTOMIZE_LABEL` constant from `toolbarMenuStrings.ts` instead of writing new copy, so the launcher and the plugin tray can't drift apart in wording.

Resolves #12218

## Changes

- Icon is `SlidersHorizontal`, the same one the toolbar settings button itself uses, not the `Settings2` the plugin tray uses. `Settings2` already belongs to the Manage agents row directly above it under the same heading, and two neighboring rows sharing a gear icon would read as the same destination listed twice.
- Both the cue routing logic and the cue icon lookup are now exhaustive over `DockLaunchCueId`. Both previously ended in a fallback case, so adding a new cue without a branch would compile fine but silently open the wrong settings tab or draw the wrong icon. Routing is now a `switch` with a compile-time exhaustiveness check at the end, matching the pattern already used elsewhere in the codebase. Icon lookup is now a typed record mapping every cue id to its icon.
- The comment in `ToolbarSettingsTab.tsx` that already anticipated this launcher entry now describes something that exists.

## Testing

- `npm test` on the 2 touched test files plus 8 existing suites that import the changed modules: 10 files, 368 tests, all passing.
- `npx prettier --check` and `npx eslint` on the 4 changed files: both clean.
- The new icon test was mutation tested by swapping in `Settings2`, which failed exactly that test and nothing else.
- No E2E run (requires explicit request); the existing launcher E2E specs use lower-bound row counts and early-row selectors, so a new footer row can't break them.
- Reviewed by Codex across three passes (two in parallel, one confirming). Correctness came back clean; all seven test-quality findings raised were fixed.
