### PR TITLE
feat(launcher): make every launcher row pinnable to the toolbar

### DIFF
--- a/shared/types/toolbar.ts
+++ b/shared/types/toolbar.ts
@@ -14,8 +14,31 @@ import { BUILT_IN_AGENT_IDS, type BuiltInAgentId } from "../config/agentIds.js";
  */
 export type PluginToolbarButtonId = `${string}.${string}`;
 
-/** Identifier for any toolbar button (built-in or plugin-contributed) */
-export type AnyToolbarButtonId = ToolbarButtonId | PluginToolbarButtonId;
+/**
+ * Identifier for a launcher row that has no toolbar button id of its own: a
+ * plugin or user-defined agent, a panel kind outside the fixed four, or a
+ * recipe (#12217).
+ *
+ * One prefix for all three categories rather than three sibling prefixes,
+ * because `sweepStalePluginPinnedButtons` has to be taught to leave these keys
+ * alone and one thing to teach it is one thing that can go stale. The category
+ * is the second segment, so a caller that needs it still gets it without a
+ * second guard.
+ *
+ * Deliberately NOT the launcher's own `DockLaunchItem.key`, which happens to
+ * carry the same `agent:`/`panel:`/`recipe:` shape. Those are presentation row
+ * keys — free to change with the launcher's rendering — while these are
+ * persisted user intent. Deriving one from the other would silently orphan
+ * every pin the first time a row key is re-spelled.
+ */
+export type LauncherItemToolbarButtonId =
+  | `${typeof LAUNCHER_ITEM_BUTTON_PREFIX}agent:${string}`
+  | `${typeof LAUNCHER_ITEM_BUTTON_PREFIX}panel:${string}`
+  | `${typeof LAUNCHER_ITEM_BUTTON_PREFIX}recipe:${string}`;
+
+/** Identifier for any toolbar button (built-in, plugin, or launcher item) */
+export type AnyToolbarButtonId =
+  ToolbarButtonId | PluginToolbarButtonId | LauncherItemToolbarButtonId;
 
 /**
  * Unique identifier for built-in toolbar buttons.
@@ -78,6 +101,13 @@ export type ToolbarButtonId =
  *   - `true`             → tray row + top-level button
  *   - `false`/`undefined` → tray row only
  *
+ * Launcher items (#12217 — plugin/user-defined agents, panel kinds outside the
+ * fixed four, recipes) read the same way and for the same reason: they reach
+ * the user through the launcher, so a top-level button is opt-in and only an
+ * explicit `true` grants one. Their key is only ever matched against the live
+ * launcher catalog, so an entry left behind by a deleted recipe or an
+ * uninstalled plugin renders nothing.
+ *
  * Agent-button IDs (entries in `BUILT_IN_AGENT_IDS`) live in
  * `agentSettingsStore`, not here. Only `launcher`, `plugin-tray`, the non-agent
  * built-ins, and plugin buttons are governed by this map.
@@ -132,9 +162,12 @@ export function isLauncherPanelButtonId(id: AnyToolbarButtonId): id is LauncherP
  * `isLauncherPanelButtonId(kindId)` therefore drops that one row silently, which
  * is exactly the bug this map exists to make impossible.
  *
- * Deliberately a lookup rather than a filter: a kind that is absent here is not
- * pinnable at all (review, file, diff and every plugin kind have no toolbar
- * button), so "no entry" and "not pinnable" are the same answer.
+ * Deliberately a lookup rather than a filter: a kind that is absent here owns
+ * none of these four fixed button ids. Since #12217 that no longer means the
+ * kind can't be pinned — review, file and every plugin kind pin through
+ * `launcherItemToolbarButtonId("panel", kindId)` instead — so "no entry" now
+ * means "not one of the four", and the caller falls through to that id rather
+ * than giving up.
  */
 export const LAUNCHER_PANEL_KIND_TO_BUTTON_ID: Readonly<Record<string, LauncherPanelButtonId>> = {
   terminal: "terminal",
@@ -148,6 +181,83 @@ export function getLauncherPanelButtonIdForKind(kindId: string): LauncherPanelBu
   return Object.prototype.hasOwnProperty.call(LAUNCHER_PANEL_KIND_TO_BUTTON_ID, kindId)
     ? LAUNCHER_PANEL_KIND_TO_BUTTON_ID[kindId]
     : undefined;
+}
+
+/**
+ * Namespace every launcher-item button id carries.
+ *
+ * Load-bearing in one specific place: `sweepStalePluginPinnedButtons` finds
+ * plugin keys with a bare `key.includes(".")`, and a launcher item's source id
+ * can itself contain a dot — a plugin-contributed recipe's id is `publisher.name`
+ * (see `TerminalRecipe.provenance`). The prefix is what lets that sweep skip
+ * these keys instead of mistaking one for a plugin button it no longer knows.
+ */
+export const LAUNCHER_ITEM_BUTTON_PREFIX = "launcher:" as const;
+
+/** Which launcher category a launcher-item button id came from. */
+export type LauncherItemCategory = "agent" | "panel" | "recipe";
+
+/**
+ * Build the persisted toolbar button id for a launcher row that has none of its
+ * own. `sourceId` is the agent id, panel kind id, or recipe id — taken verbatim,
+ * because it is only ever compared against a live catalog, never re-parsed into
+ * its parts.
+ */
+export function launcherItemToolbarButtonId(
+  category: LauncherItemCategory,
+  sourceId: string
+): LauncherItemToolbarButtonId {
+  return `${LAUNCHER_ITEM_BUTTON_PREFIX}${category}:${sourceId}` as LauncherItemToolbarButtonId;
+}
+
+/**
+ * Takes a bare `string`, not an `AnyToolbarButtonId`: the callers that most need
+ * it are iterating raw `pinnedButtons` keys, and narrowing the parameter would
+ * make each of them assert its way in — which the lint ratchet scores per rule.
+ * A `AnyToolbarButtonId` argument still narrows, since the predicate's type is a
+ * member of that union.
+ */
+export function isLauncherItemToolbarButtonId(id: string): id is LauncherItemToolbarButtonId {
+  return decodeLauncherItemToolbarButtonId(id) !== null;
+}
+
+/**
+ * The category and source id behind a launcher-item button id, or `null` when
+ * the string isn't one.
+ *
+ * Splits on the first two colons only and takes the rest as the source id, so a
+ * recipe id containing `:` or `.` round-trips unchanged. An empty source id is
+ * rejected: nothing in the launcher has one, and accepting it would mint a key
+ * that can never match a catalog entry.
+ */
+export function decodeLauncherItemToolbarButtonId(
+  id: string
+): { category: LauncherItemCategory; sourceId: string } | null {
+  if (!id.startsWith(LAUNCHER_ITEM_BUTTON_PREFIX)) return null;
+  const rest = id.slice(LAUNCHER_ITEM_BUTTON_PREFIX.length);
+  const separator = rest.indexOf(":");
+  if (separator <= 0) return null;
+  const category = rest.slice(0, separator);
+  const sourceId = rest.slice(separator + 1);
+  if (sourceId.length === 0) return null;
+  if (category !== "agent" && category !== "panel" && category !== "recipe") return null;
+  return { category, sourceId };
+}
+
+/**
+ * Whether a launcher item currently has its own top-level toolbar button.
+ *
+ * Only an explicit `true` counts, matching plugin contributions rather than the
+ * built-in panel buttons above: a launcher item has no default slot to fall
+ * through to, so array membership can only ever be the residue of a pin. The
+ * `false` an unpin writes and the absence a never-pinned row carries are the
+ * same answer, and nothing may seed either (#11667).
+ */
+export function isLauncherItemOnToolbar(
+  id: LauncherItemToolbarButtonId,
+  pinnedButtons: ToolbarPinnedState
+): boolean {
+  return pinnedButtons[id] === true;
 }
 
 /**

--- a/src/components/Layout/DockLaunchButton.tsx
+++ b/src/components/Layout/DockLaunchButton.tsx
@@ -33,9 +33,14 @@ import { isAgentButtonOnToolbar } from "@shared/utils/agentPinned";
 import { isBuiltInAgentId, type BuiltInAgentId } from "@shared/config/agentIds";
 import {
   getLauncherPanelButtonIdForKind,
+  isLauncherItemOnToolbar,
+  isLauncherItemToolbarButtonId,
+  isLauncherPanelButtonId,
   isPanelButtonOnToolbar,
+  type LauncherItemToolbarButtonId,
   type LauncherPanelButtonId,
 } from "@shared/types/toolbar";
+import { resolveLauncherToolbarButtonId } from "./launcherToolbarCatalog";
 import { resolveEffectivePresetId } from "@shared/types";
 import { getMergedPresets } from "@/config/agents";
 import { actionService } from "@/services/ActionService";
@@ -120,13 +125,24 @@ const PLACEMENT_CONFIG = {
 
 /**
  * A row that can be pinned to the toolbar, resolved to the id the write path
- * actually takes. Agents and panels keep separate stores behind the one
- * affordance — `null` means the row has no toolbar representation at all
- * (recipes, cues, plugin panel kinds, non-built-in agents).
+ * actually takes. Three write paths behind the one affordance: a built-in agent's
+ * pin lives in `agentSettingsStore`, one of the four fixed panel buttons goes
+ * through `setPanelButtonOnToolbar`, and every other row — plugin and
+ * user-defined agents, the remaining panel kinds, recipes — through
+ * `setLauncherItemOnToolbar` (#12217).
+ *
+ * `null` now means only that the row launches nothing: a cue, or a preset child
+ * whose parent already carries the button.
  */
 type DockLaunchPinTarget =
   | { category: "agent"; id: BuiltInAgentId; name: string; onToolbar: boolean }
-  | { category: "panel"; id: LauncherPanelButtonId; name: string; onToolbar: boolean };
+  | { category: "panel"; id: LauncherPanelButtonId; name: string; onToolbar: boolean }
+  | {
+      category: "launcher-item";
+      id: LauncherItemToolbarButtonId;
+      name: string;
+      onToolbar: boolean;
+    };
 
 interface DockLaunchButtonProps {
   agents: ReadonlyArray<DockLaunchAgent>;
@@ -197,6 +213,7 @@ export function DockLaunchButton({
   const leftButtons = useToolbarPreferencesStore(useShallow((s) => s.layout.leftButtons));
   const rightButtons = useToolbarPreferencesStore(useShallow((s) => s.layout.rightButtons));
   const setPanelButtonOnToolbar = useToolbarPreferencesStore((s) => s.setPanelButtonOnToolbar);
+  const setLauncherItemOnToolbar = useToolbarPreferencesStore((s) => s.setLauncherItemOnToolbar);
   const positionAgentButton = useToolbarPreferencesStore((s) => s.positionAgentButton);
   const toggleButtonVisibility = useToolbarPreferencesStore((s) => s.toggleButtonVisibility);
 
@@ -286,11 +303,25 @@ export function DockLaunchButton({
       if (row.kind !== "item") return null;
       const { item } = row;
 
+      // One resolver decides which of the three id spaces a row belongs to, so
+      // the launcher's pin affordance and the toolbar's button registry can't
+      // disagree about what a row is called (#12217).
+      const id = resolveLauncherToolbarButtonId(item);
+      if (id === null) return null;
+
+      if (isLauncherItemToolbarButtonId(id)) {
+        return {
+          category: "launcher-item",
+          id,
+          name: item.name,
+          onToolbar: isLauncherItemOnToolbar(id, pinnedButtons),
+        };
+      }
+
       if (item.category === "agent") {
-        // Only built-in agents have a toolbar button id to write. A plugin or
-        // user-defined agent is launchable here but can never reach the toolbar.
-        if (!isBuiltInAgentId(item.agent.id)) return null;
-        const id = item.agent.id;
+        // Narrowed by `resolveLauncherToolbarButtonId`: a non-built-in agent
+        // resolved to a launcher-item id and returned above.
+        if (!isBuiltInAgentId(id)) return null;
         return {
           category: "agent",
           id,
@@ -306,21 +337,18 @@ export function DockLaunchButton({
         };
       }
 
-      if (item.category === "panel") {
-        // Through the kind→button map, never `isLauncherPanelButtonId(kindId)`:
-        // the dev preview kind is `dev-preview` and its button is `dev-server`,
-        // so the direct test drops that row and nothing tells you it did.
-        const id = getLauncherPanelButtonIdForKind(item.kindId);
-        if (!id) return null;
-        return {
-          category: "panel",
-          id,
-          name: item.name,
-          onToolbar: isPanelButtonOnToolbar(id, pinnedButtons, leftButtons, rightButtons),
-        };
-      }
-
-      return null;
+      // One of the four fixed panel buttons. The kind→button map got us here,
+      // never `isLauncherPanelButtonId(kindId)`: the dev preview kind is
+      // `dev-preview` and its button is `dev-server`, so the direct test would
+      // route that row to a second, synthetic id for a button that already has
+      // one.
+      if (!isLauncherPanelButtonId(id)) return null;
+      return {
+        category: "panel",
+        id,
+        name: item.name,
+        onToolbar: isPanelButtonOnToolbar(id, pinnedButtons, leftButtons, rightButtons),
+      };
     },
     [agentSettings, leftButtons, pinnedButtons, rightButtons]
   );
@@ -354,6 +382,10 @@ export function DockLaunchButton({
         );
         return;
       }
+      if (target.category === "launcher-item") {
+        setLauncherItemOnToolbar(target.id, !target.onToolbar);
+        return;
+      }
       setPanelButtonOnToolbar(target.id, !target.onToolbar);
     },
     [
@@ -361,6 +393,7 @@ export function DockLaunchButton({
       agentSettings,
       positionAgentButton,
       setAgentPinned,
+      setLauncherItemOnToolbar,
       setPanelButtonOnToolbar,
       toggleButtonVisibility,
     ]
@@ -1136,10 +1169,10 @@ function DockLaunchOption({
         : item!.name;
 
   // Whether this row reserves the two trailing control slots. See the comment at
-  // the slots themselves for why it is decided by category rather than per row.
-  const reservesControlSlots =
-    row.band === "results" ||
-    (row.kind === "item" && (item!.category === "agent" || item!.category === "panel"));
+  // the slots themselves for why it is decided by row kind rather than per row.
+  // Every item row qualifies since #12217 — all three categories are pinnable —
+  // so this is now the same question as "is this a launchable row".
+  const reservesControlSlots = row.band === "results" || row.kind === "item";
 
   // The one flag that separates the two modes. Browse keeps its per-band rows;
   // search collapses everything into a single `results` band.
@@ -1414,12 +1447,14 @@ function DockLaunchOption({
         {/* Reserved wherever a control can ever appear, so revealing one on hover
             never shifts the row under the pointer.
 
-            Not on every row any more. Recipes, presets and cues can hold neither
-            control in any state, so on them the 48px was buying alignment with a
-            band they are not in — while the recipe band carries the longest names
-            in the palette. Bands are type-homogeneous, so deciding this by
-            category keeps every row within a band on the same edge; search mixes
-            the types under one heading, so there it always reserves. */}
+            Presets and cues can hold neither control in any state — a preset
+            child pins nothing of its own and a cue launches nothing — so on them
+            the 48px would buy alignment with a band they are not in. Recipes
+            were in that group until #12217 and are not any more: every recipe
+            row now carries a pin, so withholding the slot would leave the one
+            control it does have with nowhere to appear. Bands are
+            type-homogeneous, so deciding this by row kind keeps every row within
+            a band on the same edge. */}
         {reservesControlSlots && (
           <>
             <span className="ml-1 w-5 shrink-0" data-launcher-slot="shortcut">

--- a/src/components/Layout/DockLaunchButton.tsx
+++ b/src/components/Layout/DockLaunchButton.tsx
@@ -49,6 +49,7 @@ import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
 import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
 import { usePanelStore } from "@/store/panelStore";
 import { useProjectPresetsStore } from "@/store/projectPresetsStore";
+import { useRecipeStore } from "@/store/recipeStore";
 import { useToolbarPreferencesStore } from "@/store/toolbarPreferencesStore";
 import { dispatchToolbarVisibility } from "@/lib/toolbarVisibilityDispatch";
 import { normalizeKeyForBinding } from "@/services/keybindingUtils";
@@ -214,6 +215,8 @@ export function DockLaunchButton({
   const rightButtons = useToolbarPreferencesStore(useShallow((s) => s.layout.rightButtons));
   const setPanelButtonOnToolbar = useToolbarPreferencesStore((s) => s.setPanelButtonOnToolbar);
   const setLauncherItemOnToolbar = useToolbarPreferencesStore((s) => s.setLauncherItemOnToolbar);
+  // Scopes a project-owned recipe's pin id — see `recipeToolbarSourceId`.
+  const currentProjectId = useRecipeStore((s) => s.currentProjectId);
   const positionAgentButton = useToolbarPreferencesStore((s) => s.positionAgentButton);
   const toggleButtonVisibility = useToolbarPreferencesStore((s) => s.toggleButtonVisibility);
 
@@ -306,7 +309,7 @@ export function DockLaunchButton({
       // One resolver decides which of the three id spaces a row belongs to, so
       // the launcher's pin affordance and the toolbar's button registry can't
       // disagree about what a row is called (#12217).
-      const id = resolveLauncherToolbarButtonId(item);
+      const id = resolveLauncherToolbarButtonId(item, currentProjectId);
       if (id === null) return null;
 
       if (isLauncherItemToolbarButtonId(id)) {
@@ -350,7 +353,7 @@ export function DockLaunchButton({
         onToolbar: isPanelButtonOnToolbar(id, pinnedButtons, leftButtons, rightButtons),
       };
     },
-    [agentSettings, leftButtons, pinnedButtons, rightButtons]
+    [agentSettings, currentProjectId, leftButtons, pinnedButtons, rightButtons]
   );
 
   // Deliberately undebounced, unlike the menu launcher's old `guardPinAction`:

--- a/src/components/Layout/LauncherToolbarButton.tsx
+++ b/src/components/Layout/LauncherToolbarButton.tsx
@@ -1,0 +1,113 @@
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { ContextMenu, ContextMenuContent, ContextMenuTrigger } from "@/components/ui/context-menu";
+import { BrandMark, Workflow } from "@/components/icons";
+import { PanelKindIcon } from "@/components/PanelPalette/PanelKindIcon";
+import { SquareTerminal } from "lucide-react";
+import { useToolbarPreferencesStore } from "@/store/toolbarPreferencesStore";
+import { ToolbarContextMenuItems } from "./ToolbarContextMenuItems";
+import {
+  activateDockLaunchItem,
+  type ActivateDockLaunchItemContext,
+  type DockLaunchItem,
+} from "./dockLaunchItems";
+import type { LauncherToolbarEntry } from "./launcherToolbarCatalog";
+
+/** The glyph for a row, in whatever vocabulary its category speaks. */
+function LauncherItemIcon({ item }: { item: DockLaunchItem }) {
+  if (item.category === "agent") {
+    // Same fallback glyph the launcher's own agent rows use, so a contributed
+    // agent with no icon looks the same in both places rather than borrowing
+    // the recipe mark.
+    const Icon = item.agent.icon ?? SquareTerminal;
+    // Same wrapper the launcher row and the agent tray use, so a plugin agent's
+    // brand colour reads identically wherever it appears.
+    return (
+      <BrandMark brandColor={item.agent.brandColor}>
+        <Icon />
+      </BrandMark>
+    );
+  }
+  if (item.category === "panel") {
+    return <PanelKindIcon iconId={item.iconId} color={item.color} />;
+  }
+  return <Workflow />;
+}
+
+/** What pressing the button does, in one word, for the tooltip and the a11y name. */
+const ACTION_VERB = {
+  agent: "Start",
+  panel: "Open",
+  recipe: "Run",
+} as const;
+
+/**
+ * A launcher row the user pinned to its own top-level toolbar slot (#12217).
+ *
+ * The launcher row keeps its place either way — pinning adds an access point,
+ * it never moves the row out of the launcher, which is the same contract plugin
+ * contributions have with the plugin tray (#11304).
+ *
+ * Activation goes through `activateDockLaunchItem`, the launcher's own seam,
+ * rather than a per-category dispatch of its own. That is what keeps a recipe
+ * (which has no action id at all and runs through `runRecipeWithResults`), a
+ * panel kind (which may or may not name a launch action), and an arbitrary agent
+ * behaving on the toolbar exactly as they do in the launcher — including the
+ * refusal toasts, which a second implementation would have had to reproduce.
+ */
+export function LauncherToolbarButton({
+  entry,
+  activationContext,
+  "data-toolbar-item": dataToolbarItem,
+}: {
+  entry: LauncherToolbarEntry;
+  activationContext: ActivateDockLaunchItemContext;
+  "data-toolbar-item"?: string;
+}) {
+  const setLauncherItemOnToolbar = useToolbarPreferencesStore((s) => s.setLauncherItemOnToolbar);
+  const { item } = entry;
+  const label = `${ACTION_VERB[item.category]} ${item.name}`;
+  const disabledReason = item.disabled?.reason;
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              data-toolbar-item={dataToolbarItem}
+              // A row whose precondition is unmet stays reachable and stays
+              // labelled with why, matching the launcher: the pin is a placement
+              // the user made, and removing the button when a project closes
+              // would rearrange the toolbar under them.
+              disabled={disabledReason !== undefined}
+              onClick={() => activateDockLaunchItem(item, activationContext)}
+              className="toolbar-icon-button text-text-primary relative"
+              aria-label={disabledReason ? `${label} (${disabledReason})` : label}
+            >
+              <LauncherItemIcon item={item} />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">
+            {disabledReason ? `${label} — ${disabledReason}` : label}
+          </TooltipContent>
+        </Tooltip>
+      </ContextMenuTrigger>
+      <ContextMenuContent className="max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto">
+        {/*
+          The generic toggle writes `false`, and for a launcher item only an
+          explicit `true` grants a slot — so it would leave the button on screen
+          while recording a preference that says nothing. The dedicated action
+          deletes the key and the position together.
+        */}
+        <ToolbarContextMenuItems
+          buttonId={entry.buttonId}
+          side="left"
+          onUnpin={() => setLauncherItemOnToolbar(entry.buttonId, false)}
+        />
+      </ContextMenuContent>
+    </ContextMenu>
+  );
+}

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -53,6 +53,13 @@ import { LAUNCHER_PANEL_ITEMS } from "./launcherPanelItems";
 import { deriveAgentDominantStates } from "@/lib/agentDominantStates";
 import { DockLaunchButton } from "./DockLaunchButton";
 import { useLauncherData } from "./useLauncherData";
+import {
+  activateDockLaunchItem,
+  useDockLaunchModel,
+  type ActivateDockLaunchItemContext,
+} from "./dockLaunchItems";
+import { buildLauncherToolbarMeta, useLauncherToolbarCatalog } from "./launcherToolbarCatalog";
+import { LauncherToolbarButton } from "./LauncherToolbarButton";
 import { usePluginRuntimeStore } from "@/store/pluginRuntimeStore";
 import { resolvePluginIcon } from "@/components/icons/pluginIconRegistry";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -206,7 +213,10 @@ interface OverflowMenuProps {
   // skipped entirely in that case.
   forgeProviderName: string | null;
   overflowActions: Partial<Record<AnyToolbarButtonId, () => void>>;
-  pluginOverflowMeta: Record<string, OverflowMenuMeta>;
+  // Display metadata for every dynamically-registered button — plugin
+  // contributions and pinned launcher items (#12217) alike. The overflow menu
+  // only ever reads a label and a glyph off it, so one map covers both.
+  dynamicOverflowMeta: Record<string, OverflowMenuMeta>;
   // Plugin contributions grouped by owning plugin. When `plugin-tray` itself
   // overflows, its dropdown is unreachable, so the overflow menu inlines these
   // groups instead — an un-promoted contribution has no other toolbar route.
@@ -241,7 +251,7 @@ function OverflowMenu({
   forgeStatsRef,
   forgeProviderName,
   overflowActions,
-  pluginOverflowMeta,
+  dynamicOverflowMeta,
   pluginTrayGroups,
   launcherAgentIds,
   panelTrayDisabled,
@@ -482,7 +492,7 @@ function OverflowMenu({
               ...(isLast ? [] : [<DropdownMenuSeparator key="launcher-sep" />]),
             ];
           }
-          const meta = OVERFLOW_MENU_META[id] ?? pluginOverflowMeta[id];
+          const meta = OVERFLOW_MENU_META[id] ?? dynamicOverflowMeta[id];
           if (!meta) return [];
           if (isBuiltInAgentId(id)) {
             const dominantState = agentDominantStates.get(id) ?? null;
@@ -1037,6 +1047,37 @@ export function Toolbar({
   const toolbarDividerClass = "toolbar-divider w-px h-5 mx-1";
 
   const { buttonIds: pluginButtonIds, configs: pluginConfigs } = usePluginToolbarButtons();
+
+  // The same model the launcher builds, from the same inputs, so the toolbar
+  // can never offer a button for a row the launcher isn't showing — or drop one
+  // it is. `surface: "grid"` matches the launcher this toolbar renders.
+  const launcherModel = useDockLaunchModel({
+    agents: launcherData.agents,
+    pinnedCount: launcherData.pinnedCount,
+    activeWorktreeId: launcherData.activeWorktreeId,
+    surface: "grid",
+    agentInventoryState: launcherData.agentInventoryState,
+    hasWorkspace: launcherData.hasWorkspace,
+    hasProject: launcherData.hasProject,
+  });
+  const launcherCatalog = useLauncherToolbarCatalog(launcherModel.searchItems);
+  const launcherActivationContext = useMemo<ActivateDockLaunchItemContext>(
+    () => ({
+      cwd: launcherData.cwd,
+      activeWorktreeId: launcherData.activeWorktreeId,
+      recipeContext: launcherData.recipeContext,
+      onLaunchAgent: launchAgentFromToolbar,
+      // A toolbar click is as foreground as a launcher click; anything else and
+      // the panel actions silently skip their focus handling.
+      source: "user",
+    }),
+    [
+      launcherData.cwd,
+      launcherData.activeWorktreeId,
+      launcherData.recipeContext,
+      launchAgentFromToolbar,
+    ]
+  );
   const pluginMetaById = usePluginRuntimeStore((s) => s.pluginMetaById);
 
   const buttonRegistry = useMemo<
@@ -1431,6 +1472,30 @@ export function Toolbar({
           ];
         })
       ),
+      // Pinned launcher rows (#12217). Registry membership is the whole
+      // stale-entry defense: the catalog holds only rows the launcher is
+      // showing right now, so a pin left behind by a deleted recipe, an
+      // uninstalled plugin, or a project the user has switched away from finds
+      // no entry here and `availableLeftIds`/`availableRightIds` drop it. That
+      // is deliberately not a sweep — the catalog is project- and
+      // worktree-scoped, and erasing a project-A pin because the user is
+      // standing in project B would lose intent that is still good.
+      ...Object.fromEntries(
+        [...launcherCatalog.values()].map((entry) => [
+          entry.buttonId,
+          {
+            render: () => (
+              <LauncherToolbarButton
+                key={entry.buttonId}
+                entry={entry}
+                activationContext={launcherActivationContext}
+                data-toolbar-item=""
+              />
+            ),
+            isAvailable: true,
+          },
+        ])
+      ),
     }),
     [
       isFocusMode,
@@ -1441,6 +1506,8 @@ export function Toolbar({
       onLaunchAgent,
       launcherData,
       launchAgentFromToolbar,
+      launcherCatalog,
+      launcherActivationContext,
       sidebarShortcut,
       sidebarAriaShortcut,
       sidebarHintHover,
@@ -1596,7 +1663,18 @@ export function Toolbar({
     // replaced. Buttons the user already dragged into a side list keep that
     // position and are filtered on promotion below like any other id.
     const extra = pluginButtonIds.filter((id) => !positioned.has(id) && pinnedButtons[id] === true);
-    return [...base, ...extra].filter((id) =>
+    // Same append, same reason, for a pinned launcher item whose position a
+    // stale cross-view write dropped (#12217). The arrays reconcile
+    // last-writer-wins while `pinnedButtons` merges per key, so the explicit
+    // `true` is the durable record and the slot is rebuilt from it here.
+    // Rebuilt at render rather than written back like `restorePromotedPanelButtons`
+    // does: only the live catalog knows which of these ids exist in this
+    // project, and a hydration that can't tell would either resurrect a
+    // position for a row that isn't here or drop one that is.
+    const launcherExtra = [...launcherCatalog.keys()].filter(
+      (id) => !positioned.has(id) && pinnedButtons[id] === true
+    );
+    return [...base, ...extra, ...launcherExtra].filter((id) =>
       isToolbarButtonVisible(
         id,
         pinnedButtons,
@@ -1611,6 +1689,7 @@ export function Toolbar({
     launcherOnRight,
     unpositionedAgentPins,
     pluginButtonIds,
+    launcherCatalog,
     pinnedButtons,
     effectiveAgentSettings,
     agentAvailability,
@@ -1773,9 +1852,16 @@ export function Toolbar({
     [pluginConfigs, pluginMetaById]
   );
 
-  const pluginOverflowMeta = useMemo(
-    () => buildPluginToolbarMeta(pluginButtonIds, pluginConfigs),
-    [pluginButtonIds, pluginConfigs]
+  // One map for both dynamic classes: the overflow menu looks a button's label
+  // and glyph up by id and doesn't care which registry minted it, and merging
+  // here means a launcher item that overflows still renders as itself rather
+  // than falling through to the unnamed-button path.
+  const dynamicOverflowMeta = useMemo(
+    () => ({
+      ...buildPluginToolbarMeta(pluginButtonIds, pluginConfigs),
+      ...buildLauncherToolbarMeta(launcherCatalog),
+    }),
+    [pluginButtonIds, pluginConfigs, launcherCatalog]
   );
 
   const overflowActions = useMemo<Partial<Record<AnyToolbarButtonId, () => void>>>(
@@ -1818,6 +1904,14 @@ export function Toolbar({
           ];
         })
       ),
+      // An overflowed launcher item stays clickable, and clicks through the
+      // same seam its top-level button uses so the two can't diverge.
+      ...Object.fromEntries(
+        [...launcherCatalog.values()].map((entry) => [
+          entry.buttonId,
+          () => activateDockLaunchItem(entry.item, launcherActivationContext),
+        ])
+      ),
     }),
     [
       onLaunchAgent,
@@ -1827,6 +1921,8 @@ export function Toolbar({
       onToggleProblems,
       pluginButtonIds,
       pluginConfigs,
+      launcherCatalog,
+      launcherActivationContext,
     ]
   );
 
@@ -1873,7 +1969,7 @@ export function Toolbar({
       forgeStatsRef={forgeStatsRef}
       forgeProviderName={forgeProviderName}
       overflowActions={overflowActions}
-      pluginOverflowMeta={pluginOverflowMeta}
+      dynamicOverflowMeta={dynamicOverflowMeta}
       pluginTrayGroups={pluginTrayGroups}
       launcherAgentIds={launcherAgentIds}
       panelTrayDisabled={panelTrayDisabled}

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -52,6 +52,7 @@ import {
 import { LAUNCHER_PANEL_ITEMS } from "./launcherPanelItems";
 import { deriveAgentDominantStates } from "@/lib/agentDominantStates";
 import { DockLaunchButton } from "./DockLaunchButton";
+import { useRecipeStore } from "@/store/recipeStore";
 import { useLauncherData } from "./useLauncherData";
 import {
   activateDockLaunchItem,
@@ -1048,6 +1049,9 @@ export function Toolbar({
 
   const { buttonIds: pluginButtonIds, configs: pluginConfigs } = usePluginToolbarButtons();
 
+  // Scopes a project-owned recipe's pin id — see `recipeToolbarSourceId`.
+  const currentRecipeProjectId = useRecipeStore((s) => s.currentProjectId);
+
   // The same model the launcher builds, from the same inputs, so the toolbar
   // can never offer a button for a row the launcher isn't showing — or drop one
   // it is. `surface: "grid"` matches the launcher this toolbar renders.
@@ -1060,7 +1064,10 @@ export function Toolbar({
     hasWorkspace: launcherData.hasWorkspace,
     hasProject: launcherData.hasProject,
   });
-  const launcherCatalog = useLauncherToolbarCatalog(launcherModel.searchItems);
+  const launcherCatalog = useLauncherToolbarCatalog(
+    launcherModel.searchItems,
+    currentRecipeProjectId
+  );
   const launcherActivationContext = useMemo<ActivateDockLaunchItemContext>(
     () => ({
       cwd: launcherData.cwd,
@@ -1591,6 +1598,30 @@ export function Toolbar({
     toolbarLayout.rightButtons.includes("launcher") &&
     !toolbarLayout.leftButtons.includes("launcher");
 
+  // The same repair as `unpositionedAgentPins`, for the same window, over the
+  // ids a launcher item pins under (#12217). Only entries in the live catalog:
+  // a pin whose recipe belongs to another project has nothing to position, and
+  // giving it a slot here would put a dead id in the arrays every project
+  // switch.
+  const unpositionedLauncherItemPins = useMemo(() => {
+    const onEitherSide = new Set([...toolbarLayout.leftButtons, ...toolbarLayout.rightButtons]);
+    return [...launcherCatalog.keys()].filter(
+      (id) => !onEitherSide.has(id) && pinnedButtons[id] === true
+    );
+  }, [toolbarLayout.leftButtons, toolbarLayout.rightButtons, launcherCatalog, pinnedButtons]);
+
+  // Materialized for the same reason the agent repair above is: a
+  // rendered-but-unpositioned button is inert to `moveButton`, which reads the
+  // arrays, so leaving it as a render-time ghost would make a pinned recipe
+  // permanently un-reorderable. `positionAgentButton` is generic over button
+  // ids despite its name — it no-ops on an id that already holds a position and
+  // writes nothing to `pinnedButtons`.
+  useEffect(() => {
+    if (unpositionedLauncherItemPins.length > 0) {
+      positionAgentButton(unpositionedLauncherItemPins);
+    }
+  }, [unpositionedLauncherItemPins, positionAgentButton]);
+
   // Declared group per button, resolved against the live plugin registry so a
   // contribution is classified by membership rather than by parsing its id.
   const resolveToolbarGroup = useCallback(
@@ -1604,7 +1635,10 @@ export function Toolbar({
     // belt-and-suspenders at the render boundary.
     const positioned = Array.from(new Set(toolbarLayout.leftButtons));
 
-    if (!launcherOnRight && unpositionedAgentPins.length > 0) {
+    const unpositionedLeftPins = launcherOnRight
+      ? []
+      : [...unpositionedAgentPins, ...unpositionedLauncherItemPins];
+    if (unpositionedLeftPins.length > 0) {
       // Right after the launcher they were pinned out of, so they lead the
       // agent run in registry order rather than trailing the positioned ones.
       // Grouping below is what keeps the brand marks contiguous; this only
@@ -1613,7 +1647,7 @@ export function Toolbar({
       positioned.splice(
         launcherIndex === -1 ? positioned.length : launcherIndex + 1,
         0,
-        ...unpositionedAgentPins
+        ...unpositionedLeftPins
       );
     }
 
@@ -1637,6 +1671,7 @@ export function Toolbar({
     toolbarLayout.leftButtons,
     launcherOnRight,
     unpositionedAgentPins,
+    unpositionedLauncherItemPins,
     pinnedButtons,
     effectiveAgentSettings,
     agentAvailability,
@@ -1648,12 +1683,16 @@ export function Toolbar({
     // Dedupe the persisted base before appending plugin extras, so duplicate
     // ids (e.g. repeated `forge-stats`, #10937) can't render twice.
     const base = Array.from(new Set(toolbarLayout.rightButtons));
-    if (launcherOnRight && unpositionedAgentPins.length > 0) {
+    if (
+      launcherOnRight &&
+      (unpositionedAgentPins.length > 0 || unpositionedLauncherItemPins.length > 0)
+    ) {
       const launcherIndex = base.indexOf("launcher");
       base.splice(
         launcherIndex === -1 ? base.length : launcherIndex + 1,
         0,
-        ...unpositionedAgentPins
+        ...unpositionedAgentPins,
+        ...unpositionedLauncherItemPins
       );
     }
     const positioned = new Set([...base, ...toolbarLayout.leftButtons]);
@@ -1663,18 +1702,7 @@ export function Toolbar({
     // replaced. Buttons the user already dragged into a side list keep that
     // position and are filtered on promotion below like any other id.
     const extra = pluginButtonIds.filter((id) => !positioned.has(id) && pinnedButtons[id] === true);
-    // Same append, same reason, for a pinned launcher item whose position a
-    // stale cross-view write dropped (#12217). The arrays reconcile
-    // last-writer-wins while `pinnedButtons` merges per key, so the explicit
-    // `true` is the durable record and the slot is rebuilt from it here.
-    // Rebuilt at render rather than written back like `restorePromotedPanelButtons`
-    // does: only the live catalog knows which of these ids exist in this
-    // project, and a hydration that can't tell would either resurrect a
-    // position for a row that isn't here or drop one that is.
-    const launcherExtra = [...launcherCatalog.keys()].filter(
-      (id) => !positioned.has(id) && pinnedButtons[id] === true
-    );
-    return [...base, ...extra, ...launcherExtra].filter((id) =>
+    return [...base, ...extra].filter((id) =>
       isToolbarButtonVisible(
         id,
         pinnedButtons,
@@ -1688,8 +1716,8 @@ export function Toolbar({
     toolbarLayout.leftButtons,
     launcherOnRight,
     unpositionedAgentPins,
+    unpositionedLauncherItemPins,
     pluginButtonIds,
-    launcherCatalog,
     pinnedButtons,
     effectiveAgentSettings,
     agentAvailability,

--- a/src/components/Layout/__tests__/DockLaunchButton.test.tsx
+++ b/src/components/Layout/__tests__/DockLaunchButton.test.tsx
@@ -124,6 +124,7 @@ let mockToolbarLayout: {
 } = { pinnedButtons: {}, leftButtons: [], rightButtons: [] };
 const setAgentPinnedMock = vi.fn();
 const setPanelButtonOnToolbarMock = vi.fn();
+const setLauncherItemOnToolbarMock = vi.fn();
 const positionAgentButtonMock = vi.fn();
 const toggleButtonVisibilityMock = vi.fn();
 
@@ -228,6 +229,7 @@ vi.mock("@/store/toolbarPreferencesStore", () => {
   const getState = () => ({
     layout: mockToolbarLayout,
     setPanelButtonOnToolbar: setPanelButtonOnToolbarMock,
+    setLauncherItemOnToolbar: setLauncherItemOnToolbarMock,
     positionAgentButton: positionAgentButtonMock,
     toggleButtonVisibility: toggleButtonVisibilityMock,
   });
@@ -369,6 +371,7 @@ vi.mock("@/components/ui/AppPaletteDialog", () => {
 import { DockLaunchButton } from "../DockLaunchButton";
 import { TOOLBAR_CUSTOMIZE_LABEL } from "../toolbarMenuStrings";
 import { SlidersHorizontal } from "lucide-react";
+import { DOCK_LAUNCH_CUE_LABELS } from "../dockLaunchItems";
 import type { DockLaunchAgent } from "../DockLaunchMenuItems";
 
 const AGENTS: DockLaunchAgent[] = [
@@ -494,6 +497,7 @@ beforeEach(() => {
   refreshAvailabilityMock.mockClear();
   mockToolbarLayout = { pinnedButtons: {}, leftButtons: [], rightButtons: [] };
   setAgentPinnedMock.mockReset();
+  setLauncherItemOnToolbarMock.mockReset();
   setPanelButtonOnToolbarMock.mockReset();
   positionAgentButtonMock.mockReset();
   toggleButtonVisibilityMock.mockReset();
@@ -1974,16 +1978,93 @@ describe("DockLaunchButton", () => {
       expect(pinControl(rowFor(container, "Dev Preview"))).toBeTruthy();
     });
 
-    it("withholds the pin from rows with nothing to pin to", () => {
+    it("offers a pin on every row the toolbar used to have no id for (#12217)", () => {
+      // The three classes the issue names. Each was launchable from here and
+      // could not reach the toolbar from anywhere.
       mockRecipes = [{ id: "r-1", name: "My recipe", worktreeId: undefined }];
       const { container } = renderButton({
         agents: [{ id: "my-plugin-agent", name: "Plugin agent", availability: "ready" }],
       });
 
-      expect(pinControl(rowFor(container, "My recipe"))).toBeNull();
-      expect(pinControl(rowFor(container, "Review"))).toBeNull();
-      // Not a built-in agent, so there is no toolbar button id to write.
-      expect(pinControl(rowFor(container, "Plugin agent"))).toBeNull();
+      expect(pinControl(rowFor(container, "My recipe"))).toBeTruthy();
+      expect(pinControl(rowFor(container, "Review"))).toBeTruthy();
+      expect(pinControl(rowFor(container, "Plugin agent"))).toBeTruthy();
+    });
+
+    it("leaves every launcher row pinnable, so none is reachable but unreachable", () => {
+      // The exhaustiveness check the issue asks for: "if a row is in the list,
+      // it should be pinnable". Only the cue rows, which launch nothing, may
+      // carry no pin.
+      mockRecipes = [{ id: "r-1", name: "My recipe", worktreeId: undefined }];
+      const { container } = renderButton({
+        agents: [{ id: "my-plugin-agent", name: "Plugin agent", availability: "ready" }],
+      });
+
+      const cueLabels = Object.values(DOCK_LAUNCH_CUE_LABELS);
+      const unpinnable = options(container)
+        .filter((row) => pinControl(row) === null)
+        .map((row) => row.textContent ?? "");
+      // Every remaining unpinnable row is a cue — a row that navigates rather
+      // than launching, and so has nothing to put on the toolbar.
+      expect(unpinnable.filter((text) => !cueLabels.some((label) => text.includes(label)))).toEqual(
+        []
+      );
+      // And there is at least one real launchable row, so an empty list can't
+      // pass this vacuously.
+      expect(options(container).filter((row) => pinControl(row) !== null).length).toBeGreaterThan(
+        0
+      );
+    });
+
+    it("writes a launcher-item pin through its own setter, not the panel one", () => {
+      mockRecipes = [{ id: "r-1", name: "My recipe", worktreeId: undefined }];
+      const { container } = renderButton();
+      const pin = pinControl(rowFor(container, "My recipe"))!;
+      expect(pin.getAttribute("data-pinned")).toBe("false");
+
+      fireEvent.click(pin);
+
+      expect(setLauncherItemOnToolbarMock).toHaveBeenCalledWith("launcher:recipe:r-1", true);
+      expect(setPanelButtonOnToolbarMock).not.toHaveBeenCalled();
+    });
+
+    it("reads a launcher item's pin from the explicit true alone", () => {
+      // No default slot to fall through to, so a position without the flag is
+      // not a pin — unlike the four fixed panel buttons.
+      mockRecipes = [{ id: "r-1", name: "My recipe", worktreeId: undefined }];
+      mockToolbarLayout = {
+        pinnedButtons: {},
+        leftButtons: ["launcher:recipe:r-1"],
+        rightButtons: [],
+      };
+      const { container } = renderButton();
+      expect(pinControl(rowFor(container, "My recipe"))?.getAttribute("data-pinned")).toBe("false");
+
+      mockToolbarLayout = {
+        pinnedButtons: { "launcher:recipe:r-1": true },
+        leftButtons: [],
+        rightButtons: [],
+      };
+      const second = renderButton();
+      expect(pinControl(rowFor(second.container, "My recipe"))?.getAttribute("data-pinned")).toBe(
+        "true"
+      );
+    });
+
+    it("keeps a plugin agent off the built-in agent store", () => {
+      // Its id is not a `BuiltInAgentId`, so `dispatchToolbarVisibility` has no
+      // entry to write and a pin routed there would silently do nothing.
+      const { container } = renderButton({
+        agents: [{ id: "my-plugin-agent", name: "Plugin agent", availability: "ready" }],
+      });
+
+      fireEvent.click(pinControl(rowFor(container, "Plugin agent"))!);
+
+      expect(setLauncherItemOnToolbarMock).toHaveBeenCalledWith(
+        "launcher:agent:my-plugin-agent",
+        true
+      );
+      expect(setAgentPinnedMock).not.toHaveBeenCalled();
     });
 
     it("withholds the pin from the create-recipe cue", () => {
@@ -2141,13 +2222,24 @@ describe("DockLaunchButton", () => {
     });
 
     it("leaves the pin phrase off rows that cannot be pinned", () => {
-      // The phrase is a promise about a key that works — a recipe row has no
-      // pin target, so announcing Alt+P there would send the user nowhere.
+      // The phrase is a promise about a key that works. Since #12217 every
+      // launchable row can take it, so the rows it must stay off are the cues —
+      // which navigate rather than launching and have nothing to pin.
+      mockRecipes = [];
+      const { container } = renderButton();
+      const cue = rowFor(container, "Create a recipe");
+
+      expect(cue.getAttribute("aria-label")).not.toContain("Alt+P");
+      expect(cue.getAttribute("aria-keyshortcuts")).toBeNull();
+    });
+
+    it("announces Alt+P on a recipe row now that it goes somewhere (#12217)", () => {
       mockRecipes = [{ id: "r-1", name: "My recipe", worktreeId: undefined }];
       const { container } = renderButton();
+      const row = rowFor(container, "My recipe");
 
-      expect(rowFor(container, "My recipe").getAttribute("aria-label")).not.toContain("Alt+P");
-      expect(rowFor(container, "My recipe").getAttribute("aria-keyshortcuts")).toBeNull();
+      expect(row.getAttribute("aria-label")).toContain("Press Alt+P to pin to toolbar");
+      expect(row.getAttribute("aria-keyshortcuts")).toBe("Alt+P");
     });
 
     it("leaves the unavailable-agent warning to the description, not the name", () => {
@@ -2295,11 +2387,12 @@ describe("DockLaunchButton", () => {
         expect([band, signatures.size]).toEqual([band, 1]);
       }
 
-      // The rows that can hold a control still reserve both, so revealing one on
-      // hover moves nothing; the recipe band keeps only its disclosure column.
+      // Every launchable row reserves both, so revealing one on hover moves
+      // nothing. The recipe band joined them in #12217 — it now carries a pin,
+      // and withholding the slot would leave that control nowhere to appear.
       expect(slotsOf(rowFor(container, "Claude"))).toBe("disclosure,shortcut,pin");
-      expect(slotsOf(rowFor(container, "My recipe"))).toBe("disclosure");
-      expect(pinControl(rowFor(container, "My recipe"))).toBeNull();
+      expect(slotsOf(rowFor(container, "My recipe"))).toBe("disclosure,shortcut,pin");
+      expect(pinControl(rowFor(container, "My recipe"))).toBeTruthy();
     });
 
     it("activates from the row itself, not only from an inner control", () => {

--- a/src/components/Layout/__tests__/DockLaunchButton.test.tsx
+++ b/src/components/Layout/__tests__/DockLaunchButton.test.tsx
@@ -62,8 +62,8 @@ vi.mock("@/components/PanelPalette/PanelKindIcon", () => ({
 
 vi.mock("@/store/recipeStore", () => ({
   useRecipeStore: Object.assign(
-    (selector: (s: { recipes: typeof mockRecipes }) => unknown) =>
-      selector({ recipes: mockRecipes }),
+    (selector: (s: { recipes: typeof mockRecipes; currentProjectId: string | null }) => unknown) =>
+      selector({ recipes: mockRecipes, currentProjectId: mockCurrentProjectId }),
     {
       getState: () => ({ runRecipeWithResults: runRecipeWithResultsMock }),
     }
@@ -125,6 +125,8 @@ let mockToolbarLayout: {
 const setAgentPinnedMock = vi.fn();
 const setPanelButtonOnToolbarMock = vi.fn();
 const setLauncherItemOnToolbarMock = vi.fn();
+// Drives `recipeToolbarSourceId`: a project-scoped recipe's pin id carries it.
+let mockCurrentProjectId: string | null = null;
 const positionAgentButtonMock = vi.fn();
 const toggleButtonVisibilityMock = vi.fn();
 
@@ -371,7 +373,6 @@ vi.mock("@/components/ui/AppPaletteDialog", () => {
 import { DockLaunchButton } from "../DockLaunchButton";
 import { TOOLBAR_CUSTOMIZE_LABEL } from "../toolbarMenuStrings";
 import { SlidersHorizontal } from "lucide-react";
-import { DOCK_LAUNCH_CUE_LABELS } from "../dockLaunchItems";
 import type { DockLaunchAgent } from "../DockLaunchMenuItems";
 
 const AGENTS: DockLaunchAgent[] = [
@@ -498,6 +499,7 @@ beforeEach(() => {
   mockToolbarLayout = { pinnedButtons: {}, leftButtons: [], rightButtons: [] };
   setAgentPinnedMock.mockReset();
   setLauncherItemOnToolbarMock.mockReset();
+  mockCurrentProjectId = null;
   setPanelButtonOnToolbarMock.mockReset();
   positionAgentButtonMock.mockReset();
   toggleButtonVisibilityMock.mockReset();
@@ -2000,20 +2002,56 @@ describe("DockLaunchButton", () => {
         agents: [{ id: "my-plugin-agent", name: "Plugin agent", availability: "ready" }],
       });
 
-      const cueLabels = Object.values(DOCK_LAUNCH_CUE_LABELS);
-      const unpinnable = options(container)
-        .filter((row) => pinControl(row) === null)
-        .map((row) => row.textContent ?? "");
-      // Every remaining unpinnable row is a cue — a row that navigates rather
-      // than launching, and so has nothing to put on the toolbar.
-      expect(unpinnable.filter((text) => !cueLabels.some((label) => text.includes(label)))).toEqual(
-        []
+      // Classified by `data-row-kind`, not by matching display text: deriving
+      // the exceptions from labels lets a cue that wrongly GAINED a pin pass
+      // silently, because it would just drop out of the unpinnable list.
+      const byKind = new Map<string, { withPin: number; withoutPin: number }>();
+      for (const row of options(container)) {
+        const kind = row.getAttribute("data-row-kind") ?? "unknown";
+        const tally = byKind.get(kind) ?? { withPin: 0, withoutPin: 0 };
+        if (pinControl(row)) tally.withPin += 1;
+        else tally.withoutPin += 1;
+        byKind.set(kind, tally);
+      }
+
+      // Both directions, per kind, with non-zero representatives — so neither
+      // half can pass by the rows simply not being rendered.
+      expect(byKind.get("item")?.withoutPin).toBe(0);
+      expect(byKind.get("item")?.withPin).toBeGreaterThan(0);
+      expect(byKind.get("cue")?.withPin).toBe(0);
+      expect(byKind.get("cue")?.withoutPin).toBeGreaterThan(0);
+    });
+
+    it("scopes a project-owned recipe's pin id to its project (#12217)", () => {
+      // `.daintree/recipes/*.json` is tracked in git and a legacy file carries
+      // no id, so `ProjectIdentityFiles` derives `inrepo-<filename>` — two
+      // projects each holding a `dev.json` produce the same string. Without the
+      // project in the key, pinning one project's recipe shows and launches the
+      // other project's.
+      mockCurrentProjectId = "project-a";
+      mockRecipes = [
+        { id: "inrepo-dev", name: "Dev", worktreeId: undefined, projectId: "project-a" },
+      ];
+      const { container } = renderButton();
+
+      fireEvent.click(pinControl(rowFor(container, "Dev"))!);
+
+      expect(setLauncherItemOnToolbarMock).toHaveBeenCalledWith(
+        "launcher:recipe:project-a:inrepo-dev",
+        true
       );
-      // And there is at least one real launchable row, so an empty list can't
-      // pass this vacuously.
-      expect(options(container).filter((row) => pinControl(row) !== null).length).toBeGreaterThan(
-        0
-      );
+    });
+
+    it("leaves a genuinely global recipe's pin id unscoped", () => {
+      // A global recipe is meant to be reachable from every project; qualifying
+      // it would strand its pin on the next project switch.
+      mockCurrentProjectId = "project-a";
+      mockRecipes = [{ id: "g-1", name: "Global recipe", worktreeId: undefined }];
+      const { container } = renderButton();
+
+      fireEvent.click(pinControl(rowFor(container, "Global recipe"))!);
+
+      expect(setLauncherItemOnToolbarMock).toHaveBeenCalledWith("launcher:recipe:g-1", true);
     });
 
     it("writes a launcher-item pin through its own setter, not the panel one", () => {
@@ -2494,7 +2532,10 @@ describe("DockLaunchButton", () => {
         expect(setAgentPinnedMock).not.toHaveBeenCalled();
       });
 
-      it("does nothing when the selected row has nothing to pin", () => {
+      it("pins the selected recipe through the launcher-item setter (#12217)", () => {
+        // This row used to be the "nothing to pin" case. Asserting only that the
+        // agent and panel setters stayed idle would now pass while the recipe
+        // was in fact being pinned, so the assertion is positive.
         mockRecipes = [{ id: "r-1", name: "My recipe", worktreeId: undefined }];
         const { container } = renderButton();
         const input = searchInput(container);
@@ -2502,8 +2543,24 @@ describe("DockLaunchButton", () => {
 
         fireEvent.keyDown(input, { key: "p", code: "KeyP", altKey: true });
 
+        expect(setLauncherItemOnToolbarMock).toHaveBeenCalledWith("launcher:recipe:r-1", true);
         expect(setAgentPinnedMock).not.toHaveBeenCalled();
         expect(setPanelButtonOnToolbarMock).not.toHaveBeenCalled();
+      });
+
+      it("does nothing when the selected row has nothing to pin", () => {
+        // A cue navigates rather than launching, so it is the only kind of row
+        // left with no pin target at all.
+        mockRecipes = [];
+        const { container } = renderButton();
+        const input = searchInput(container);
+        fireEvent.change(input, { target: { value: "create a recipe" } });
+
+        fireEvent.keyDown(input, { key: "p", code: "KeyP", altKey: true });
+
+        expect(setAgentPinnedMock).not.toHaveBeenCalled();
+        expect(setPanelButtonOnToolbarMock).not.toHaveBeenCalled();
+        expect(setLauncherItemOnToolbarMock).not.toHaveBeenCalled();
       });
     });
   });

--- a/src/components/Layout/__tests__/Toolbar.shortcuts.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.shortcuts.test.ts
@@ -388,25 +388,29 @@ describe("Toolbar shortcut tooltips — issue #3443", () => {
   });
 
   describe("useMemo dependency array", () => {
-    it("includes sidebarShortcut in useMemo deps", () => {
-      const depsMatch = source.match(/\}\),\s*\[([^\]]+)\]\s*\);/s);
+    // Anchored on `buttonRegistry` rather than taken as the file's first
+    // `}), [...]);`. That shortcut only ever worked because the registry
+    // happened to be the first memo of that shape in the file, so any memo
+    // added above it silently retargeted all three assertions at something
+    // else — which is how a dep list can stop being checked without a failure.
+    function buttonRegistryDeps(): string {
+      const start = source.indexOf("const buttonRegistry = useMemo");
+      expect(start).toBeGreaterThan(-1);
+      const depsMatch = source.slice(start).match(/\}\),\s*\[([^\]]+)\]\s*\);/s);
       expect(depsMatch).not.toBeNull();
-      const deps = depsMatch![1];
-      expect(deps).toContain("sidebarShortcut");
+      return depsMatch![1]!;
+    }
+
+    it("includes sidebarShortcut in useMemo deps", () => {
+      expect(buttonRegistryDeps()).toContain("sidebarShortcut");
     });
 
     it("includes copyTreeShortcut in useMemo deps", () => {
-      const depsMatch = source.match(/\}\),\s*\[([^\]]+)\]\s*\);/s);
-      expect(depsMatch).not.toBeNull();
-      const deps = depsMatch![1];
-      expect(deps).toContain("copyTreeShortcut");
+      expect(buttonRegistryDeps()).toContain("copyTreeShortcut");
     });
 
     it("includes showCopyingSpinner in useMemo deps (issue #8179)", () => {
-      const depsMatch = source.match(/\}\),\s*\[([^\]]+)\]\s*\);/s);
-      expect(depsMatch).not.toBeNull();
-      const deps = depsMatch![1];
-      expect(deps).toContain("showCopyingSpinner");
+      expect(buttonRegistryDeps()).toContain("showCopyingSpinner");
     });
 
     it("diagnosticsShortcut is in ToolbarProblemsButton", () => {

--- a/src/components/Layout/__tests__/launcherToolbarCatalog.test.ts
+++ b/src/components/Layout/__tests__/launcherToolbarCatalog.test.ts
@@ -265,3 +265,19 @@ describe("buildLauncherToolbarMeta", () => {
     }
   });
 });
+
+describe("resolveLauncherToolbarButtonId — ids nothing can match", () => {
+  it("refuses to mint an id whose source half is empty", () => {
+    // `decodeLauncherItemToolbarButtonId` rejects an empty source, so minting
+    // one would put a key in `pinnedButtons` that no catalog entry can ever
+    // match and no surface can ever clear.
+    expect(resolveLauncherToolbarButtonId(agentItem(""), PROJECT_ID)).toBeNull();
+    expect(resolveLauncherToolbarButtonId(panelItem(""), PROJECT_ID)).toBeNull();
+    expect(resolveLauncherToolbarButtonId(recipeItem(""), PROJECT_ID)).toBeNull();
+    expect(resolveLauncherToolbarButtonId(recipeItem("", "", PROJECT_ID), PROJECT_ID)).toBeNull();
+  });
+
+  it("keeps those rows out of the catalog rather than adding an unusable entry", () => {
+    expect(buildLauncherToolbarCatalog([recipeItem("")], PROJECT_ID).size).toBe(0);
+  });
+});

--- a/src/components/Layout/__tests__/launcherToolbarCatalog.test.ts
+++ b/src/components/Layout/__tests__/launcherToolbarCatalog.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect } from "vitest";
+import {
+  decodeLauncherItemToolbarButtonId,
+  isLauncherItemToolbarButtonId,
+  launcherItemToolbarButtonId,
+} from "@shared/types/toolbar";
+import { BUILT_IN_AGENT_IDS } from "@shared/config/agentIds";
+import {
+  buildLauncherToolbarCatalog,
+  buildLauncherToolbarMeta,
+  resolveLauncherToolbarButtonId,
+} from "../launcherToolbarCatalog";
+import type { DockLaunchItem } from "../dockLaunchItems";
+
+// The catalog is the render gate: `Toolbar` builds a `buttonRegistry` entry per
+// member and drops any pinned id without one. What it holds is therefore the
+// whole answer to "which pins can currently render", so these tests are about
+// membership and identity rather than presentation.
+
+const builtInAgentId = BUILT_IN_AGENT_IDS[0]!;
+
+function agentItem(id: string, name = id): DockLaunchItem {
+  return {
+    category: "agent",
+    key: `agent:${id}`,
+    name,
+    agent: { id, name },
+    agentBand: "launch",
+  };
+}
+
+function panelItem(kindId: string, name = kindId): DockLaunchItem {
+  return {
+    category: "panel",
+    key: `panel:${kindId}`,
+    name,
+    kindId,
+    iconId: "terminal",
+    color: "#000000",
+    location: "grid",
+  };
+}
+
+function recipeItem(id: string, name = id): DockLaunchItem {
+  return {
+    category: "recipe",
+    key: `recipe:${id}`,
+    name,
+    recipe: { id, name, terminals: [], createdAt: 0 },
+    scopeLabel: "Project",
+    isShadowed: false,
+  };
+}
+
+describe("resolveLauncherToolbarButtonId", () => {
+  it("leaves a built-in agent on the id its own store already keys", () => {
+    // A built-in's pin lives in `agentSettingsStore`. Minting a synthetic id for
+    // it as well would split one button across two stores, and the two would
+    // disagree the moment either was written.
+    expect(resolveLauncherToolbarButtonId(agentItem(builtInAgentId))).toBe(builtInAgentId);
+  });
+
+  it("leaves each of the four fixed panels on its own button id", () => {
+    expect(resolveLauncherToolbarButtonId(panelItem("terminal"))).toBe("terminal");
+    expect(resolveLauncherToolbarButtonId(panelItem("browser"))).toBe("browser");
+    expect(resolveLauncherToolbarButtonId(panelItem("file-browser"))).toBe("file-browser");
+    // The one pair whose kind and button names differ. Resolving `dev-preview`
+    // to a synthetic id would give the dev preview button a second key.
+    expect(resolveLauncherToolbarButtonId(panelItem("dev-preview"))).toBe("dev-server");
+  });
+
+  it("gives every previously unpinnable row an id", () => {
+    // The three classes the issue names: a plugin or user-defined agent, a panel
+    // kind outside the fixed four, and any recipe.
+    for (const item of [
+      agentItem("acme.helper"),
+      agentItem("my-custom-agent"),
+      panelItem("review", "Review"),
+      panelItem("file", "File Viewer"),
+      panelItem("acme.videos", "Videos"),
+      recipeItem("0f8c1d2e-3a4b-5c6d-7e8f-901234567890"),
+      recipeItem("acme.deploy"),
+    ]) {
+      const id = resolveLauncherToolbarButtonId(item);
+      expect(id, `${item.category} ${item.name} must be pinnable`).not.toBeNull();
+      expect(isLauncherItemToolbarButtonId(id!)).toBe(true);
+    }
+  });
+
+  it("tags each id with the category its row came from", () => {
+    expect(
+      decodeLauncherItemToolbarButtonId(resolveLauncherToolbarButtonId(agentItem("x"))!)
+    ).toEqual({ category: "agent", sourceId: "x" });
+    expect(
+      decodeLauncherItemToolbarButtonId(resolveLauncherToolbarButtonId(panelItem("review"))!)
+    ).toEqual({ category: "panel", sourceId: "review" });
+    expect(
+      decodeLauncherItemToolbarButtonId(resolveLauncherToolbarButtonId(recipeItem("r1"))!)
+    ).toEqual({ category: "recipe", sourceId: "r1" });
+  });
+});
+
+describe("buildLauncherToolbarCatalog", () => {
+  it("holds only the rows that need a synthetic id", () => {
+    const catalog = buildLauncherToolbarCatalog([
+      agentItem(builtInAgentId),
+      panelItem("terminal"),
+      panelItem("dev-preview"),
+      agentItem("acme.helper"),
+      panelItem("review"),
+      recipeItem("r1"),
+    ]);
+    expect([...catalog.keys()].sort()).toEqual(
+      [
+        launcherItemToolbarButtonId("agent", "acme.helper"),
+        launcherItemToolbarButtonId("panel", "review"),
+        launcherItemToolbarButtonId("recipe", "r1"),
+      ].sort()
+    );
+  });
+
+  it("keeps a row whose id collides across categories distinct", () => {
+    // A recipe called Review and the Review panel are two different buttons.
+    const catalog = buildLauncherToolbarCatalog([panelItem("review"), recipeItem("review")]);
+    expect(catalog.size).toBe(2);
+  });
+
+  it("does not resolve inherited Object properties as catalog members", () => {
+    // Keys come from arbitrary agent, kind and recipe ids. A `Map` is what keeps
+    // `catalog.get("constructor")` from answering with a function.
+    const catalog = buildLauncherToolbarCatalog([recipeItem("r1")]);
+    expect(catalog.get("constructor" as never)).toBeUndefined();
+    expect(catalog.get("toString" as never)).toBeUndefined();
+    expect(catalog.get("__proto__" as never)).toBeUndefined();
+  });
+
+  it("keeps the first of two rows sharing an id rather than churning the entry", () => {
+    const first = recipeItem("r1", "First");
+    const catalog = buildLauncherToolbarCatalog([first, recipeItem("r1", "Second")]);
+    expect(catalog.size).toBe(1);
+    expect(catalog.get(launcherItemToolbarButtonId("recipe", "r1"))!.item).toBe(first);
+  });
+
+  it("returns the same empty map for input with nothing to pin", () => {
+    // `Toolbar` spreads this into a `useMemo`d registry; a fresh empty map each
+    // render would rebuild every toolbar button on every store tick.
+    const a = buildLauncherToolbarCatalog([agentItem(builtInAgentId)]);
+    const b = buildLauncherToolbarCatalog([]);
+    expect(a.size).toBe(0);
+    expect(a).toBe(b);
+  });
+});
+
+describe("buildLauncherToolbarMeta", () => {
+  it("names each button after its row and says what pressing it does", () => {
+    // The toolbar shows a glyph and nothing else, so the description is the only
+    // thing telling a recipe named Review from the Review panel.
+    const catalog = buildLauncherToolbarCatalog([
+      agentItem("acme.helper", "Helper"),
+      panelItem("review", "Review"),
+      recipeItem("r1", "Review"),
+    ]);
+    const meta = buildLauncherToolbarMeta(catalog);
+
+    expect(meta[launcherItemToolbarButtonId("agent", "acme.helper")]).toMatchObject({
+      label: "Helper",
+      description: "Start Helper",
+    });
+    expect(meta[launcherItemToolbarButtonId("panel", "review")]).toMatchObject({
+      label: "Review",
+      description: "Open Review",
+    });
+    expect(meta[launcherItemToolbarButtonId("recipe", "r1")]).toMatchObject({
+      label: "Review",
+      description: "Run Review",
+    });
+  });
+
+  it("gives every catalog entry an icon, so no pinned row renders a blank slot", () => {
+    const catalog = buildLauncherToolbarCatalog([
+      // No icon on the agent, an unknown glyph id on the panel: both fall back
+      // rather than resolving to undefined.
+      agentItem("acme.helper"),
+      panelItem("acme.unknown-kind"),
+      recipeItem("r1"),
+    ]);
+    const meta = buildLauncherToolbarMeta(catalog);
+    expect(Object.keys(meta)).toHaveLength(3);
+    for (const [id, entry] of Object.entries(meta)) {
+      // Renderable, not merely present: a lucide glyph is a `forwardRef` object
+      // rather than a function, so both shapes are legal and `undefined` — which
+      // renders a blank slot — is the only failure.
+      expect(entry.icon, id).toBeTruthy();
+      expect(["function", "object"], id).toContain(typeof entry.icon);
+    }
+  });
+});

--- a/src/components/Layout/__tests__/launcherToolbarCatalog.test.ts
+++ b/src/components/Layout/__tests__/launcherToolbarCatalog.test.ts
@@ -19,6 +19,11 @@ import type { DockLaunchItem } from "../dockLaunchItems";
 
 const builtInAgentId = BUILT_IN_AGENT_IDS[0]!;
 
+// The project a project-scoped recipe's pin id is qualified by. Fixture recipes
+// below declare `projectId` when they are meant to be project-scoped and omit it
+// when they are meant to be global.
+const PROJECT_ID = "project-a";
+
 function agentItem(id: string, name = id): DockLaunchItem {
   return {
     category: "agent",
@@ -41,13 +46,15 @@ function panelItem(kindId: string, name = kindId): DockLaunchItem {
   };
 }
 
-function recipeItem(id: string, name = id): DockLaunchItem {
+function recipeItem(id: string, name = id, projectId?: string): DockLaunchItem {
   return {
     category: "recipe",
     key: `recipe:${id}`,
     name,
-    recipe: { id, name, terminals: [], createdAt: 0 },
-    scopeLabel: "Project",
+    // `projectId` is what `getRecipeScope` reads to decide global vs
+    // project-scoped, which in turn decides whether the pin id is qualified.
+    recipe: { id, name, terminals: [], createdAt: 0, ...(projectId ? { projectId } : {}) },
+    scopeLabel: projectId ? "Project-wide" : "Global",
     isShadowed: false,
   };
 }
@@ -57,16 +64,20 @@ describe("resolveLauncherToolbarButtonId", () => {
     // A built-in's pin lives in `agentSettingsStore`. Minting a synthetic id for
     // it as well would split one button across two stores, and the two would
     // disagree the moment either was written.
-    expect(resolveLauncherToolbarButtonId(agentItem(builtInAgentId))).toBe(builtInAgentId);
+    expect(resolveLauncherToolbarButtonId(agentItem(builtInAgentId), PROJECT_ID)).toBe(
+      builtInAgentId
+    );
   });
 
   it("leaves each of the four fixed panels on its own button id", () => {
-    expect(resolveLauncherToolbarButtonId(panelItem("terminal"))).toBe("terminal");
-    expect(resolveLauncherToolbarButtonId(panelItem("browser"))).toBe("browser");
-    expect(resolveLauncherToolbarButtonId(panelItem("file-browser"))).toBe("file-browser");
+    expect(resolveLauncherToolbarButtonId(panelItem("terminal"), PROJECT_ID)).toBe("terminal");
+    expect(resolveLauncherToolbarButtonId(panelItem("browser"), PROJECT_ID)).toBe("browser");
+    expect(resolveLauncherToolbarButtonId(panelItem("file-browser"), PROJECT_ID)).toBe(
+      "file-browser"
+    );
     // The one pair whose kind and button names differ. Resolving `dev-preview`
     // to a synthetic id would give the dev preview button a second key.
-    expect(resolveLauncherToolbarButtonId(panelItem("dev-preview"))).toBe("dev-server");
+    expect(resolveLauncherToolbarButtonId(panelItem("dev-preview"), PROJECT_ID)).toBe("dev-server");
   });
 
   it("gives every previously unpinnable row an id", () => {
@@ -81,35 +92,69 @@ describe("resolveLauncherToolbarButtonId", () => {
       recipeItem("0f8c1d2e-3a4b-5c6d-7e8f-901234567890"),
       recipeItem("acme.deploy"),
     ]) {
-      const id = resolveLauncherToolbarButtonId(item);
+      const id = resolveLauncherToolbarButtonId(item, PROJECT_ID);
       expect(id, `${item.category} ${item.name} must be pinnable`).not.toBeNull();
       expect(isLauncherItemToolbarButtonId(id!)).toBe(true);
     }
   });
 
+  it("qualifies a project-scoped recipe's id, and leaves a global one bare", () => {
+    // A legacy in-repo recipe's id is derived from its filename, and
+    // `.daintree/recipes/` is tracked in git — so two projects each holding a
+    // `dev.json` produce the same `inrepo-dev`. Without the project in the key
+    // one project's pin resolves to the other project's recipe.
+    expect(
+      resolveLauncherToolbarButtonId(recipeItem("inrepo-dev", "Dev", PROJECT_ID), PROJECT_ID)
+    ).toBe(launcherItemToolbarButtonId("recipe", `${PROJECT_ID}:inrepo-dev`));
+    // A global recipe is reachable from every project; qualifying it would
+    // strand the pin on the next project switch.
+    expect(resolveLauncherToolbarButtonId(recipeItem("g-1", "Global"), PROJECT_ID)).toBe(
+      launcherItemToolbarButtonId("recipe", "g-1")
+    );
+  });
+
+  it("keeps two projects' same-named legacy recipes on different ids", () => {
+    const inA = resolveLauncherToolbarButtonId(
+      recipeItem("inrepo-dev", "Dev", "project-a"),
+      "project-a"
+    );
+    const inB = resolveLauncherToolbarButtonId(
+      recipeItem("inrepo-dev", "Dev", "project-b"),
+      "project-b"
+    );
+    expect(inA).not.toBe(inB);
+  });
+
   it("tags each id with the category its row came from", () => {
     expect(
-      decodeLauncherItemToolbarButtonId(resolveLauncherToolbarButtonId(agentItem("x"))!)
+      decodeLauncherItemToolbarButtonId(resolveLauncherToolbarButtonId(agentItem("x"), PROJECT_ID)!)
     ).toEqual({ category: "agent", sourceId: "x" });
     expect(
-      decodeLauncherItemToolbarButtonId(resolveLauncherToolbarButtonId(panelItem("review"))!)
+      decodeLauncherItemToolbarButtonId(
+        resolveLauncherToolbarButtonId(panelItem("review"), PROJECT_ID)!
+      )
     ).toEqual({ category: "panel", sourceId: "review" });
     expect(
-      decodeLauncherItemToolbarButtonId(resolveLauncherToolbarButtonId(recipeItem("r1"))!)
+      decodeLauncherItemToolbarButtonId(
+        resolveLauncherToolbarButtonId(recipeItem("r1"), PROJECT_ID)!
+      )
     ).toEqual({ category: "recipe", sourceId: "r1" });
   });
 });
 
 describe("buildLauncherToolbarCatalog", () => {
   it("holds only the rows that need a synthetic id", () => {
-    const catalog = buildLauncherToolbarCatalog([
-      agentItem(builtInAgentId),
-      panelItem("terminal"),
-      panelItem("dev-preview"),
-      agentItem("acme.helper"),
-      panelItem("review"),
-      recipeItem("r1"),
-    ]);
+    const catalog = buildLauncherToolbarCatalog(
+      [
+        agentItem(builtInAgentId),
+        panelItem("terminal"),
+        panelItem("dev-preview"),
+        agentItem("acme.helper"),
+        panelItem("review"),
+        recipeItem("r1"),
+      ],
+      PROJECT_ID
+    );
     expect([...catalog.keys()].sort()).toEqual(
       [
         launcherItemToolbarButtonId("agent", "acme.helper"),
@@ -121,14 +166,31 @@ describe("buildLauncherToolbarCatalog", () => {
 
   it("keeps a row whose id collides across categories distinct", () => {
     // A recipe called Review and the Review panel are two different buttons.
-    const catalog = buildLauncherToolbarCatalog([panelItem("review"), recipeItem("review")]);
+    const catalog = buildLauncherToolbarCatalog(
+      [panelItem("review"), recipeItem("review")],
+      PROJECT_ID
+    );
     expect(catalog.size).toBe(2);
+  });
+
+  it("tells two same-named recipes in different scopes apart", () => {
+    // Both are pinnable and both are called Deploy. The toolbar shows only a
+    // glyph, so if the description did not carry the scope the two buttons,
+    // their tooltips and their Settings switches would all read identically.
+    const catalog = buildLauncherToolbarCatalog(
+      [recipeItem("g-1", "Deploy"), recipeItem("p-1", "Deploy", PROJECT_ID)],
+      PROJECT_ID
+    );
+    expect(catalog.size).toBe(2);
+
+    const descriptions = Object.values(buildLauncherToolbarMeta(catalog)).map((m) => m.description);
+    expect(new Set(descriptions).size).toBe(2);
   });
 
   it("does not resolve inherited Object properties as catalog members", () => {
     // Keys come from arbitrary agent, kind and recipe ids. A `Map` is what keeps
     // `catalog.get("constructor")` from answering with a function.
-    const catalog = buildLauncherToolbarCatalog([recipeItem("r1")]);
+    const catalog = buildLauncherToolbarCatalog([recipeItem("r1")], PROJECT_ID);
     expect(catalog.get("constructor" as never)).toBeUndefined();
     expect(catalog.get("toString" as never)).toBeUndefined();
     expect(catalog.get("__proto__" as never)).toBeUndefined();
@@ -136,7 +198,7 @@ describe("buildLauncherToolbarCatalog", () => {
 
   it("keeps the first of two rows sharing an id rather than churning the entry", () => {
     const first = recipeItem("r1", "First");
-    const catalog = buildLauncherToolbarCatalog([first, recipeItem("r1", "Second")]);
+    const catalog = buildLauncherToolbarCatalog([first, recipeItem("r1", "Second")], PROJECT_ID);
     expect(catalog.size).toBe(1);
     expect(catalog.get(launcherItemToolbarButtonId("recipe", "r1"))!.item).toBe(first);
   });
@@ -144,8 +206,8 @@ describe("buildLauncherToolbarCatalog", () => {
   it("returns the same empty map for input with nothing to pin", () => {
     // `Toolbar` spreads this into a `useMemo`d registry; a fresh empty map each
     // render would rebuild every toolbar button on every store tick.
-    const a = buildLauncherToolbarCatalog([agentItem(builtInAgentId)]);
-    const b = buildLauncherToolbarCatalog([]);
+    const a = buildLauncherToolbarCatalog([agentItem(builtInAgentId)], PROJECT_ID);
+    const b = buildLauncherToolbarCatalog([], PROJECT_ID);
     expect(a.size).toBe(0);
     expect(a).toBe(b);
   });
@@ -155,11 +217,14 @@ describe("buildLauncherToolbarMeta", () => {
   it("names each button after its row and says what pressing it does", () => {
     // The toolbar shows a glyph and nothing else, so the description is the only
     // thing telling a recipe named Review from the Review panel.
-    const catalog = buildLauncherToolbarCatalog([
-      agentItem("acme.helper", "Helper"),
-      panelItem("review", "Review"),
-      recipeItem("r1", "Review"),
-    ]);
+    const catalog = buildLauncherToolbarCatalog(
+      [
+        agentItem("acme.helper", "Helper"),
+        panelItem("review", "Review"),
+        recipeItem("r1", "Review"),
+      ],
+      PROJECT_ID
+    );
     const meta = buildLauncherToolbarMeta(catalog);
 
     expect(meta[launcherItemToolbarButtonId("agent", "acme.helper")]).toMatchObject({
@@ -172,18 +237,23 @@ describe("buildLauncherToolbarMeta", () => {
     });
     expect(meta[launcherItemToolbarButtonId("recipe", "r1")]).toMatchObject({
       label: "Review",
-      description: "Run Review",
+      // Carries the scope: a recipe and a panel can share a name, and so can
+      // two recipes in different scopes.
+      description: "Run Review (Global)",
     });
   });
 
   it("gives every catalog entry an icon, so no pinned row renders a blank slot", () => {
-    const catalog = buildLauncherToolbarCatalog([
-      // No icon on the agent, an unknown glyph id on the panel: both fall back
-      // rather than resolving to undefined.
-      agentItem("acme.helper"),
-      panelItem("acme.unknown-kind"),
-      recipeItem("r1"),
-    ]);
+    const catalog = buildLauncherToolbarCatalog(
+      [
+        // No icon on the agent, an unknown glyph id on the panel: both fall
+        // back rather than resolving to undefined.
+        agentItem("acme.helper"),
+        panelItem("acme.unknown-kind"),
+        recipeItem("r1"),
+      ],
+      PROJECT_ID
+    );
     const meta = buildLauncherToolbarMeta(catalog);
     expect(Object.keys(meta)).toHaveLength(3);
     for (const [id, entry] of Object.entries(meta)) {

--- a/src/components/Layout/__tests__/launcherToolbarPinResolvers.test.tsx
+++ b/src/components/Layout/__tests__/launcherToolbarPinResolvers.test.tsx
@@ -5,6 +5,10 @@ import {
   getLauncherPanelButtonIdForKind,
   isPanelButtonOnToolbar,
   isLauncherPanelButtonId,
+  decodeLauncherItemToolbarButtonId,
+  isLauncherItemOnToolbar,
+  isLauncherItemToolbarButtonId,
+  launcherItemToolbarButtonId,
 } from "@shared/types/toolbar";
 import { isAgentButtonOnToolbar } from "../../../../shared/utils/agentPinned";
 
@@ -80,9 +84,10 @@ describe("getLauncherPanelButtonIdForKind", () => {
     expect([...LAUNCHER_PANEL_BUTTON_IDS].filter((id) => !mapped.has(id))).toEqual([]);
   });
 
-  it("returns undefined for kinds with no toolbar button", () => {
-    // Panel kinds that ship in the launcher but have no button: they need a
-    // resolver that says so rather than one that throws or guesses.
+  it("returns undefined for kinds outside the fixed four", () => {
+    // Since #12217 these are pinnable through a launcher-item id instead; what
+    // this resolver still has to say is that they own none of the four fixed
+    // button ids, rather than throwing or guessing one.
     expect(getLauncherPanelButtonIdForKind("review")).toBeUndefined();
     expect(getLauncherPanelButtonIdForKind("diff")).toBeUndefined();
     expect(getLauncherPanelButtonIdForKind("file")).toBeUndefined();
@@ -119,5 +124,79 @@ describe("isAgentButtonOnToolbar (#11680)", () => {
 
   it("lets an explicit hide win over a position", () => {
     expect(isAgentButtonOnToolbar({ pinned: false }, "ready", true)).toBe(false);
+  });
+});
+
+describe("launcher item button ids (#12217)", () => {
+  it("round-trips a source id that contains the characters the id space is built from", () => {
+    // A plugin-contributed recipe's id is `publisher.name`, and nothing stops a
+    // recipe or plugin kind id carrying a colon either. The encoding splits on
+    // the first two colons and takes the rest verbatim, so neither escapes.
+    for (const sourceId of [
+      "acme.deploy",
+      "with:colons:inside",
+      "0f8c1d2e-3a4b-5c6d-7e8f-901234567890",
+      "inrepo-ship-it",
+      "Ünïcøde ✨",
+    ]) {
+      const id = launcherItemToolbarButtonId("recipe", sourceId);
+      expect(decodeLauncherItemToolbarButtonId(id)).toEqual({ category: "recipe", sourceId });
+    }
+  });
+
+  it("keeps the three categories apart for one source id", () => {
+    // An agent, a panel kind and a recipe may all be called `review`. Three
+    // rows sharing one key would make pinning any of them pin all three.
+    const ids = (["agent", "panel", "recipe"] as const).map((category) =>
+      launcherItemToolbarButtonId(category, "review")
+    );
+    expect(new Set(ids).size).toBe(3);
+  });
+
+  it("never mints an id a built-in or plugin button could also own", () => {
+    // The prefix is what keeps `sweepStalePluginPinnedButtons` from reading a
+    // dotted launcher id as a plugin button it no longer recognises.
+    expect(isLauncherItemToolbarButtonId(launcherItemToolbarButtonId("agent", "acme.helper"))).toBe(
+      true
+    );
+    expect(isLauncherItemToolbarButtonId("claude")).toBe(false);
+    expect(isLauncherItemToolbarButtonId("dev-server")).toBe(false);
+    expect(isLauncherItemToolbarButtonId("acme.deploy")).toBe(false);
+    expect(isLauncherItemToolbarButtonId("plugin-tray")).toBe(false);
+  });
+
+  it("rejects a malformed id rather than guessing at its parts", () => {
+    expect(decodeLauncherItemToolbarButtonId("launcher:")).toBeNull();
+    expect(decodeLauncherItemToolbarButtonId("launcher:recipe")).toBeNull();
+    // An empty source id would mint a key no catalog entry can ever match.
+    expect(decodeLauncherItemToolbarButtonId("launcher:recipe:")).toBeNull();
+    expect(decodeLauncherItemToolbarButtonId("launcher::abc")).toBeNull();
+    // A category outside the three the launcher has.
+    expect(decodeLauncherItemToolbarButtonId("launcher:cue:create-recipe")).toBeNull();
+    expect(decodeLauncherItemToolbarButtonId("not-a-launcher:recipe:abc")).toBeNull();
+  });
+
+  it("does not resolve inherited Object properties as categories", () => {
+    // The category segment is compared, never used to index a lookup table —
+    // this is the regression test that keeps it that way.
+    expect(decodeLauncherItemToolbarButtonId("launcher:constructor:x")).toBeNull();
+    expect(decodeLauncherItemToolbarButtonId("launcher:toString:x")).toBeNull();
+    expect(decodeLauncherItemToolbarButtonId("launcher:__proto__:x")).toBeNull();
+  });
+
+  it("reads only an explicit promotion as on the toolbar", () => {
+    // Unlike the fixed panel buttons, a launcher item has no default slot to
+    // fall through to, so absence and `false` are the same answer and nothing
+    // may seed either (#11667).
+    const id = launcherItemToolbarButtonId("recipe", "r1");
+    expect(isLauncherItemOnToolbar(id, {})).toBe(false);
+    expect(isLauncherItemOnToolbar(id, { [id]: false })).toBe(false);
+    expect(isLauncherItemOnToolbar(id, { [id]: true })).toBe(true);
+  });
+
+  it("does not read an inherited Object property as a pin", () => {
+    // `pinnedButtons` is a plain object carrying arbitrary string keys.
+    const id = launcherItemToolbarButtonId("recipe", "constructor");
+    expect(isLauncherItemOnToolbar(id, {})).toBe(false);
   });
 });

--- a/src/components/Layout/launcherToolbarCatalog.ts
+++ b/src/components/Layout/launcherToolbarCatalog.ts
@@ -59,10 +59,13 @@ export function resolveLauncherToolbarButtonId(
     // The scoped identity, never the bare `recipe.id` — see
     // `recipeToolbarSourceId` on why a legacy in-repo id aliases across
     // projects.
-    return launcherItemToolbarButtonId(
-      "recipe",
-      recipeToolbarSourceId(item.recipe, currentProjectId)
-    );
+    const sourceId = recipeToolbarSourceId(item.recipe, currentProjectId);
+    // An id-less recipe would mint `launcher:recipe:` or `launcher:recipe:p:`,
+    // which the decoder rejects and no catalog entry can match. The schema
+    // forbids one, so this is the resolver refusing to mint what its own guard
+    // would throw away rather than a case that reaches us.
+    if (sourceId.length === 0 || sourceId.endsWith(":")) return null;
+    return launcherItemToolbarButtonId("recipe", sourceId);
   }
   return null;
 }

--- a/src/components/Layout/launcherToolbarCatalog.ts
+++ b/src/components/Layout/launcherToolbarCatalog.ts
@@ -11,6 +11,8 @@ import {
 import { isBuiltInAgentId } from "@shared/config/agentIds";
 import { getPanelKindConfig } from "@shared/config/panelKindRegistry";
 import { getAgentConfig } from "@/config/agents";
+import { getRecipeScope, recipeToolbarSourceId } from "@/utils/recipeScope";
+import type { TerminalRecipe } from "@shared/types";
 import { DEFAULT_PANEL_ICON, resolvePluginIcon } from "@/components/icons/pluginIconRegistry";
 import { Workflow } from "@/components/icons";
 import type { ToolbarButtonMetadata } from "./toolbarButtonMetadata";
@@ -34,9 +36,13 @@ import type { DockLaunchItem } from "./dockLaunchItems";
  * without an `item`. It is kept as a return value so a future category added to
  * `DockLaunchItem` fails closed rather than minting an id nothing renders.
  */
-export function resolveLauncherToolbarButtonId(item: DockLaunchItem): AnyToolbarButtonId | null {
+export function resolveLauncherToolbarButtonId(
+  item: DockLaunchItem,
+  currentProjectId: string | null | undefined
+): AnyToolbarButtonId | null {
   if (item.category === "agent") {
     if (isBuiltInAgentId(item.agent.id)) return item.agent.id;
+    if (item.agent.id.length === 0) return null;
     return launcherItemToolbarButtonId("agent", item.agent.id);
   }
   if (item.category === "panel") {
@@ -44,13 +50,19 @@ export function resolveLauncherToolbarButtonId(item: DockLaunchItem): AnyToolbar
     // dev preview kind is `dev-preview` and its button is `dev-server`, so the
     // direct test would hand that row a synthetic id alongside the fixed one it
     // already has, and two ids for one button disagree about its state.
-    return (
-      getLauncherPanelButtonIdForKind(item.kindId) ??
-      launcherItemToolbarButtonId("panel", item.kindId)
-    );
+    const fixed = getLauncherPanelButtonIdForKind(item.kindId);
+    if (fixed) return fixed;
+    if (item.kindId.length === 0) return null;
+    return launcherItemToolbarButtonId("panel", item.kindId);
   }
   if (item.category === "recipe") {
-    return launcherItemToolbarButtonId("recipe", item.recipe.id);
+    // The scoped identity, never the bare `recipe.id` — see
+    // `recipeToolbarSourceId` on why a legacy in-repo id aliases across
+    // projects.
+    return launcherItemToolbarButtonId(
+      "recipe",
+      recipeToolbarSourceId(item.recipe, currentProjectId)
+    );
   }
   return null;
 }
@@ -92,11 +104,12 @@ const EMPTY_CATALOG: LauncherToolbarCatalog = new Map();
  * wrong: "not live right now" and "gone for good" are not the same fact.
  */
 export function buildLauncherToolbarCatalog(
-  items: readonly DockLaunchItem[]
+  items: readonly DockLaunchItem[],
+  currentProjectId: string | null | undefined
 ): LauncherToolbarCatalog {
   const catalog = new Map<LauncherItemToolbarButtonId, LauncherToolbarEntry>();
   for (const item of items) {
-    const buttonId = resolveLauncherToolbarButtonId(item);
+    const buttonId = resolveLauncherToolbarButtonId(item, currentProjectId);
     if (buttonId === null) continue;
     // Built-in agents and the four fixed panels resolve to ids this catalog
     // does not own — they already have renderers and settings rows.
@@ -111,9 +124,13 @@ export function buildLauncherToolbarCatalog(
 
 /** Memoized {@link buildLauncherToolbarCatalog} over a launcher model's items. */
 export function useLauncherToolbarCatalog(
-  items: readonly DockLaunchItem[]
+  items: readonly DockLaunchItem[],
+  currentProjectId: string | null | undefined
 ): LauncherToolbarCatalog {
-  return useMemo(() => buildLauncherToolbarCatalog(items), [items]);
+  return useMemo(
+    () => buildLauncherToolbarCatalog(items, currentProjectId),
+    [items, currentProjectId]
+  );
 }
 
 /**
@@ -127,6 +144,20 @@ const LAUNCHER_ITEM_ACTION_LABEL = {
   panel: "Open",
   recipe: "Run",
 } as const;
+
+/**
+ * What pressing the button does, plus whatever it takes to tell two rows apart.
+ *
+ * Two recipes can share a name across scopes — a Project "Deploy" and a Team
+ * "Deploy" are different recipes and both are pinnable — and the toolbar shows
+ * only a glyph, so without the scope the two buttons, their tooltips and their
+ * Settings switches would all read identically (#12217).
+ */
+function launcherItemDescription(item: DockLaunchItem): string {
+  const verb = LAUNCHER_ITEM_ACTION_LABEL[item.category];
+  if (item.category === "recipe") return `${verb} ${item.name} (${item.scopeLabel})`;
+  return `${verb} ${item.name}`;
+}
 
 /** The glyph a catalog entry renders, resolved from whatever its category carries. */
 function launcherItemIcon(item: DockLaunchItem): ToolbarButtonMetadata["icon"] {
@@ -153,7 +184,7 @@ export function buildLauncherToolbarMeta(
     meta[entry.buttonId] = {
       label: item.name,
       icon: launcherItemIcon(item),
-      description: `${LAUNCHER_ITEM_ACTION_LABEL[item.category]} ${item.name}`,
+      description: launcherItemDescription(item),
     };
   }
   return meta;
@@ -176,7 +207,8 @@ export function buildLauncherToolbarMeta(
  */
 export function resolveLauncherItemMetadata(
   buttonId: string,
-  recipes: ReadonlyArray<{ id: string; name: string }>
+  recipes: ReadonlyArray<TerminalRecipe>,
+  currentProjectId: string | null | undefined
 ): ToolbarButtonMetadata | undefined {
   const decoded = decodeLauncherItemToolbarButtonId(buttonId);
   if (!decoded) return undefined;
@@ -202,14 +234,21 @@ export function resolveLauncherItemMetadata(
     };
   }
 
-  // Linear scan rather than a keyed lookup built here: a plain-object index
+  // Compared through `recipeToolbarSourceId`, the same function that minted the
+  // id — matching on `candidate.id` would reintroduce the legacy-in-repo
+  // aliasing the scoping exists to close, and would also never match a scoped
+  // id at all. Linear rather than a keyed lookup because a plain-object index
   // keyed by recipe id would inherit `Object.prototype`, and the list is the
   // handful a project holds.
-  const recipe = recipes.find((candidate) => candidate.id === sourceId);
+  const recipe = recipes.find(
+    (candidate) => recipeToolbarSourceId(candidate, currentProjectId) === sourceId
+  );
   if (!recipe) return undefined;
   return {
     label: recipe.name,
     icon: Workflow,
-    description: `${LAUNCHER_ITEM_ACTION_LABEL.recipe} ${recipe.name}`,
+    // Same scope suffix the catalog builds, through the same classifier, so the
+    // two surfaces name a recipe identically.
+    description: `${LAUNCHER_ITEM_ACTION_LABEL.recipe} ${recipe.name} (${getRecipeScope(recipe).label})`,
   };
 }

--- a/src/components/Layout/launcherToolbarCatalog.ts
+++ b/src/components/Layout/launcherToolbarCatalog.ts
@@ -1,0 +1,215 @@
+import { useMemo } from "react";
+import { SquareTerminal } from "lucide-react";
+import {
+  decodeLauncherItemToolbarButtonId,
+  getLauncherPanelButtonIdForKind,
+  isLauncherItemToolbarButtonId,
+  launcherItemToolbarButtonId,
+  type AnyToolbarButtonId,
+  type LauncherItemToolbarButtonId,
+} from "@shared/types/toolbar";
+import { isBuiltInAgentId } from "@shared/config/agentIds";
+import { getPanelKindConfig } from "@shared/config/panelKindRegistry";
+import { getAgentConfig } from "@/config/agents";
+import { DEFAULT_PANEL_ICON, resolvePluginIcon } from "@/components/icons/pluginIconRegistry";
+import { Workflow } from "@/components/icons";
+import type { ToolbarButtonMetadata } from "./toolbarButtonMetadata";
+import type { DockLaunchItem } from "./dockLaunchItems";
+
+/**
+ * The toolbar button id a launcher row pins to, or `null` for a row that pins
+ * nothing at all.
+ *
+ * Three answers, in the order they have to be asked. A built-in agent keeps its
+ * bare agent id — its pin lives in `agentSettingsStore`, not `pinnedButtons`,
+ * and minting a synthetic id for it would split one button across two stores.
+ * One of the four fixed panel kinds keeps its own button id for the same
+ * reason: existing profiles carry it, and `isPanelButtonOnToolbar`'s array
+ * fall-through is what keeps `terminal`/`file-browser` reading as on out of the
+ * box. Everything else — plugin and user-defined agents, every other panel
+ * kind, every recipe — gets the launcher-item id (#12217).
+ *
+ * `null` is now only ever the answer for a row that isn't a launchable item at
+ * all, which this function never sees: cues and preset children are `DockLaunchRow`s
+ * without an `item`. It is kept as a return value so a future category added to
+ * `DockLaunchItem` fails closed rather than minting an id nothing renders.
+ */
+export function resolveLauncherToolbarButtonId(item: DockLaunchItem): AnyToolbarButtonId | null {
+  if (item.category === "agent") {
+    if (isBuiltInAgentId(item.agent.id)) return item.agent.id;
+    return launcherItemToolbarButtonId("agent", item.agent.id);
+  }
+  if (item.category === "panel") {
+    // Through the kind→button map, never `isLauncherPanelButtonId(kindId)`: the
+    // dev preview kind is `dev-preview` and its button is `dev-server`, so the
+    // direct test would hand that row a synthetic id alongside the fixed one it
+    // already has, and two ids for one button disagree about its state.
+    return (
+      getLauncherPanelButtonIdForKind(item.kindId) ??
+      launcherItemToolbarButtonId("panel", item.kindId)
+    );
+  }
+  if (item.category === "recipe") {
+    return launcherItemToolbarButtonId("recipe", item.recipe.id);
+  }
+  return null;
+}
+
+/**
+ * A launcher item that currently has a toolbar button id of the launcher-item
+ * kind, paired with the row it launches.
+ *
+ * The item is carried whole rather than reduced to a label and an icon because
+ * the button activates through `activateDockLaunchItem`, which needs it — one
+ * launch seam for the launcher row and its toolbar button, so the two can't
+ * drift the way the four fixed panel buttons and the launcher's Panels section
+ * once did (#11668).
+ */
+export interface LauncherToolbarEntry {
+  buttonId: LauncherItemToolbarButtonId;
+  item: DockLaunchItem;
+}
+
+export type LauncherToolbarCatalog = ReadonlyMap<LauncherItemToolbarButtonId, LauncherToolbarEntry>;
+
+const EMPTY_CATALOG: LauncherToolbarCatalog = new Map();
+
+/**
+ * Every launcher row that pins to a launcher-item id, keyed by that id.
+ *
+ * A `Map` rather than a plain object because the keys are built from arbitrary
+ * agent ids, panel kind ids and recipe ids — bracket-indexing a plain object
+ * with one would inherit `Object.prototype` members, which is the bug
+ * `getLauncherPanelButtonIdForKind` already guards against with an own-property
+ * check and has a regression test for.
+ *
+ * This is the render gate. `Toolbar` builds its `buttonRegistry` entries from
+ * this map, and `availableLeftIds`/`availableRightIds` drop any id with no
+ * registry entry — so a pin left behind by a deleted recipe, an uninstalled
+ * plugin, or a project the user has switched away from renders nothing and can
+ * launch nothing, without anything having to sweep the persisted map. The
+ * catalog is project- and worktree-scoped, which is exactly why a sweep would be
+ * wrong: "not live right now" and "gone for good" are not the same fact.
+ */
+export function buildLauncherToolbarCatalog(
+  items: readonly DockLaunchItem[]
+): LauncherToolbarCatalog {
+  const catalog = new Map<LauncherItemToolbarButtonId, LauncherToolbarEntry>();
+  for (const item of items) {
+    const buttonId = resolveLauncherToolbarButtonId(item);
+    if (buttonId === null) continue;
+    // Built-in agents and the four fixed panels resolve to ids this catalog
+    // does not own — they already have renderers and settings rows.
+    if (!isLauncherItemToolbarButtonId(buttonId)) continue;
+    // First wins, so a duplicated input can't replace an entry with itself and
+    // churn the memo's identity.
+    if (catalog.has(buttonId)) continue;
+    catalog.set(buttonId, { buttonId, item });
+  }
+  return catalog.size === 0 ? EMPTY_CATALOG : catalog;
+}
+
+/** Memoized {@link buildLauncherToolbarCatalog} over a launcher model's items. */
+export function useLauncherToolbarCatalog(
+  items: readonly DockLaunchItem[]
+): LauncherToolbarCatalog {
+  return useMemo(() => buildLauncherToolbarCatalog(items), [items]);
+}
+
+/**
+ * The verb a launcher item's toolbar button leads with. The toolbar shows a
+ * glyph and nothing else, so this is the tooltip and the accessible name — and
+ * it has to say what pressing it does, because a recipe named "Review" and a
+ * panel named "Review" are otherwise the same button.
+ */
+const LAUNCHER_ITEM_ACTION_LABEL = {
+  agent: "Start",
+  panel: "Open",
+  recipe: "Run",
+} as const;
+
+/** The glyph a catalog entry renders, resolved from whatever its category carries. */
+function launcherItemIcon(item: DockLaunchItem): ToolbarButtonMetadata["icon"] {
+  if (item.category === "agent") return item.agent.icon ?? DEFAULT_PANEL_ICON;
+  if (item.category === "panel") return resolvePluginIcon(item.iconId, DEFAULT_PANEL_ICON);
+  return Workflow;
+}
+
+/**
+ * Display metadata for the launcher items currently on the toolbar, derived
+ * from the live launcher row rather than a table.
+ *
+ * Same shape and the same reason as `buildPluginToolbarMeta`: the toolbar's
+ * overflow menu and Settings → Toolbar both read it, so a button reads the same
+ * everywhere it appears. Keyed by the launcher-item id and merged over
+ * `TOOLBAR_BUTTON_METADATA` by each consumer.
+ */
+export function buildLauncherToolbarMeta(
+  catalog: LauncherToolbarCatalog
+): Record<string, ToolbarButtonMetadata> {
+  const meta: Record<string, ToolbarButtonMetadata> = {};
+  for (const entry of catalog.values()) {
+    const { item } = entry;
+    meta[entry.buttonId] = {
+      label: item.name,
+      icon: launcherItemIcon(item),
+      description: `${LAUNCHER_ITEM_ACTION_LABEL[item.category]} ${item.name}`,
+    };
+  }
+  return meta;
+}
+
+/**
+ * Metadata for a launcher item the user has already pinned, resolved from the
+ * registries directly rather than from a launcher model.
+ *
+ * Settings → Toolbar lists what the user pinned so they can find it and unpin
+ * it; the launcher stays the one place anything gets pinned. That is a narrower
+ * question than the toolbar's — "what is this pinned id called", not "what can
+ * be pinned" — and answering it from the registries keeps a settings tab out of
+ * the launcher's whole dependency graph (`useDockLaunchModel` reaches the panel
+ * definition registry, the action service and the panel store).
+ *
+ * `undefined` when the source is not currently here — an uninstalled plugin, a
+ * deleted recipe, another project's recipe. Callers render nothing for it,
+ * which is the same answer the toolbar's registry gate gives.
+ */
+export function resolveLauncherItemMetadata(
+  buttonId: string,
+  recipes: ReadonlyArray<{ id: string; name: string }>
+): ToolbarButtonMetadata | undefined {
+  const decoded = decodeLauncherItemToolbarButtonId(buttonId);
+  if (!decoded) return undefined;
+  const { category, sourceId } = decoded;
+
+  if (category === "agent") {
+    const config = getAgentConfig(sourceId);
+    if (!config) return undefined;
+    return {
+      label: config.name,
+      icon: config.icon ?? SquareTerminal,
+      description: `${LAUNCHER_ITEM_ACTION_LABEL.agent} ${config.name}`,
+    };
+  }
+
+  if (category === "panel") {
+    const config = getPanelKindConfig(sourceId);
+    if (!config) return undefined;
+    return {
+      label: config.name,
+      icon: resolvePluginIcon(config.iconId, DEFAULT_PANEL_ICON),
+      description: `${LAUNCHER_ITEM_ACTION_LABEL.panel} ${config.name}`,
+    };
+  }
+
+  // Linear scan rather than a keyed lookup built here: a plain-object index
+  // keyed by recipe id would inherit `Object.prototype`, and the list is the
+  // handful a project holds.
+  const recipe = recipes.find((candidate) => candidate.id === sourceId);
+  if (!recipe) return undefined;
+  return {
+    label: recipe.name,
+    icon: Workflow,
+    description: `${LAUNCHER_ITEM_ACTION_LABEL.recipe} ${recipe.name}`,
+  };
+}

--- a/src/components/Layout/toolbarButtonMetadata.ts
+++ b/src/components/Layout/toolbarButtonMetadata.ts
@@ -17,6 +17,12 @@ import {
   isAssistantOnlyAgentId,
 } from "@shared/config/agentIds";
 import type { AnyToolbarButtonId, ToolbarPinnedState } from "@/../../shared/types/toolbar";
+// `@shared/...` because these are value imports — the type-only spelling above
+// is erased at compile time and never has to resolve at runtime.
+import {
+  decodeLauncherItemToolbarButtonId,
+  isLauncherItemToolbarButtonId,
+} from "@shared/types/toolbar";
 import type { AgentSettings, CliAvailability } from "@shared/types";
 import { isAgentToolbarVisible } from "../../../shared/utils/agentPinned";
 import { getAgentConfig } from "@/config/agents";
@@ -179,6 +185,16 @@ export function getToolbarButtonGroup(
 ): ToolbarButtonGroup {
   if (isBuiltInAgentId(buttonId)) return "agents";
   if (isPluginContribution) return "utilities";
+  // Launcher items (#12217) group by the category their id declares, so a
+  // pinned plugin agent stands with the built-in agents and a pinned Review
+  // panel with the panel buttons rather than all of them landing in the
+  // trailing `utilities` catch-all. A recipe is neither, so it does.
+  const launcherItem = decodeLauncherItemToolbarButtonId(buttonId);
+  if (launcherItem) {
+    if (launcherItem.category === "agent") return "agents";
+    if (launcherItem.category === "panel") return "panels";
+    return "utilities";
+  }
   return BUILT_IN_TOOLBAR_GROUPS.get(buttonId) ?? "utilities";
 }
 
@@ -215,5 +231,11 @@ export function isToolbarButtonVisible(
     return isAgentToolbarVisible(agentSettings?.agents?.[buttonId], agentAvailability?.[buttonId]);
   }
   if (isPluginContribution) return pinnedButtons[buttonId] === true;
+  // Launcher items invert the built-in default for the same reason plugin
+  // contributions do (#12217): they already reach the user through the
+  // launcher, so a top-level slot is opt-in and needs the explicit `true` the
+  // pin writes. Without this, "absent means visible" would put every launcher
+  // item that ever held a position onto the toolbar.
+  if (isLauncherItemToolbarButtonId(buttonId)) return pinnedButtons[buttonId] === true;
   return pinnedButtons[buttonId] !== false;
 }

--- a/src/components/Layout/toolbarButtonMetadata.ts
+++ b/src/components/Layout/toolbarButtonMetadata.ts
@@ -176,7 +176,8 @@ const BUILT_IN_TOOLBAR_GROUPS: ReadonlyMap<AnyToolbarButtonId, ToolbarButtonGrou
  *
  * Dispatch order mirrors `isToolbarButtonVisible` below: agent ids first,
  * registered plugin contributions second (registry membership is the
- * discriminator, never string-parsing the dotted id), then the built-in table,
+ * discriminator, never string-parsing the dotted id), launcher items third
+ * (#12217 — a prefix the other two can never carry), then the built-in table,
  * and finally the trailing `utilities` fallback for anything unclassified.
  */
 export function getToolbarButtonGroup(

--- a/src/components/Layout/useLauncherData.ts
+++ b/src/components/Layout/useLauncherData.ts
@@ -47,6 +47,7 @@ export function useLauncherData(): LauncherData {
   const hasRealData = useCliAvailabilityStore((s) => s.hasRealData);
   const leftButtons = useToolbarPreferencesStore(useShallow((s) => s.layout.leftButtons));
   const rightButtons = useToolbarPreferencesStore(useShallow((s) => s.layout.rightButtons));
+  const pinnedButtons = useToolbarPreferencesStore(useShallow((s) => s.layout.pinnedButtons));
   const { worktrees } = useWorktrees();
 
   const activeWorktree = activeWorktreeId ? worktrees.find((w) => w.id === activeWorktreeId) : null;
@@ -110,7 +111,8 @@ export function useLauncherData(): LauncherData {
       launchable,
       leftButtons,
       agentSettings,
-      rightButtons
+      rightButtons,
+      pinnedButtons
     );
     return {
       agents: [...sorted, ...notLaunchable],
@@ -119,7 +121,14 @@ export function useLauncherData(): LauncherData {
         ? "loading"
         : "installed") as DockLaunchInventoryState,
     };
-  }, [agentAvailability, agentSettings, isAvailabilityLoading, leftButtons, rightButtons]);
+  }, [
+    agentAvailability,
+    agentSettings,
+    isAvailabilityLoading,
+    leftButtons,
+    rightButtons,
+    pinnedButtons,
+  ]);
 
   const recipeContext = useMemo(
     () =>

--- a/src/components/Settings/ToolbarSettingsTab.tsx
+++ b/src/components/Settings/ToolbarSettingsTab.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useState, useSyncExternalStore } from "react";
 import {
   DndContext,
   DragOverlay,
@@ -44,6 +44,14 @@ import {
   isPanelButtonOnToolbar,
   isLauncherPanelButtonId,
 } from "@shared/types/toolbar";
+import {
+  subscribeToPanelKindRegistry,
+  getPanelKindRegistrySnapshot,
+} from "@shared/config/panelKindRegistry";
+import {
+  subscribeToPluginAgentRegistry,
+  getPluginAgentRegistrySnapshot,
+} from "@shared/config/pluginAgentRegistry";
 import { useRecipeStore } from "@/store/recipeStore";
 import { resolveLauncherItemMetadata } from "@/components/Layout/launcherToolbarCatalog";
 import { LAUNCHABLE_AGENT_IDS, isBuiltInAgentId } from "@shared/config/agentIds";
@@ -365,7 +373,29 @@ export function ToolbarSettingsTab() {
   // renders nothing, matching the toolbar's own registry gate. Its pin is left
   // alone rather than swept: "not live in this project" is not "gone".
   const recipes = useRecipeStore((s) => s.recipes);
+  const currentProjectId = useRecipeStore((s) => s.currentProjectId);
+  // `resolveLauncherItemMetadata` reads both registries, so the rows have to
+  // re-derive when either mutates. Without these the tab keeps a stale label,
+  // icon and row for a plugin panel or agent that unloaded while Settings was
+  // open, while the toolbar — which does subscribe — has already dropped it.
+  const panelKindRegistry = useSyncExternalStore(
+    subscribeToPanelKindRegistry,
+    getPanelKindRegistrySnapshot,
+    getPanelKindRegistrySnapshot
+  );
+  const pluginAgentRegistry = useSyncExternalStore(
+    subscribeToPluginAgentRegistry,
+    getPluginAgentRegistrySnapshot,
+    getPluginAgentRegistrySnapshot
+  );
   const launcherItemRows = useMemo(() => {
+    // Referenced, not merely listed as dependencies. `resolveLauncherItemMetadata`
+    // reads both registries itself, so these snapshots exist only to invalidate
+    // this memo when one mutates — and a value the body never mentions is one
+    // the React Compiler is free to drop, which would restore the stale row
+    // they are here to prevent.
+    void panelKindRegistry;
+    void pluginAgentRegistry;
     const rows: Array<{ id: LauncherItemToolbarButtonId; metadata: ToolbarButtonMetadata }> = [];
     // `Object.entries` plus the guard rather than a filter over `Object.keys`:
     // both hand back a bare `string`, but only the guard narrows it, and the
@@ -374,14 +404,14 @@ export function ToolbarSettingsTab() {
     for (const [id, isPinned] of Object.entries(layout.pinnedButtons)) {
       if (isPinned !== true) continue;
       if (!isLauncherItemToolbarButtonId(id)) continue;
-      const metadata = resolveLauncherItemMetadata(id, recipes);
+      const metadata = resolveLauncherItemMetadata(id, recipes, currentProjectId);
       if (!metadata) continue;
       rows.push({ id, metadata });
     }
     // Alphabetical, because the pin map's key order is insertion order and the
     // user has no way to see or reason about that.
     return rows.sort((a, b) => a.metadata.label.localeCompare(b.metadata.label));
-  }, [layout.pinnedButtons, recipes]);
+  }, [layout.pinnedButtons, recipes, currentProjectId, panelKindRegistry, pluginAgentRegistry]);
 
   const resolveGroup = useCallback(
     (id: AnyToolbarButtonId) => getToolbarButtonGroup(id, pluginConfigs.has(id)),

--- a/src/components/Settings/ToolbarSettingsTab.tsx
+++ b/src/components/Settings/ToolbarSettingsTab.tsx
@@ -53,6 +53,7 @@ import {
   getPluginAgentRegistrySnapshot,
 } from "@shared/config/pluginAgentRegistry";
 import { useRecipeStore } from "@/store/recipeStore";
+import { useUserAgentRegistryStore } from "@/store/userAgentRegistryStore";
 import { resolveLauncherItemMetadata } from "@/components/Layout/launcherToolbarCatalog";
 import { LAUNCHABLE_AGENT_IDS, isBuiltInAgentId } from "@shared/config/agentIds";
 import { isAgentButtonOnToolbar } from "../../../shared/utils/agentPinned";
@@ -388,6 +389,10 @@ export function ToolbarSettingsTab() {
     getPluginAgentRegistrySnapshot,
     getPluginAgentRegistrySnapshot
   );
+  // The plugin snapshot is only one of the three tiers `getAgentConfig` merges;
+  // a user-defined agent lives here, so without this its row keeps a stale name
+  // and icon after an edit.
+  const userAgentRegistry = useUserAgentRegistryStore((s) => s.registry);
   const launcherItemRows = useMemo(() => {
     // Referenced, not merely listed as dependencies. `resolveLauncherItemMetadata`
     // reads both registries itself, so these snapshots exist only to invalidate
@@ -396,6 +401,7 @@ export function ToolbarSettingsTab() {
     // they are here to prevent.
     void panelKindRegistry;
     void pluginAgentRegistry;
+    void userAgentRegistry;
     const rows: Array<{ id: LauncherItemToolbarButtonId; metadata: ToolbarButtonMetadata }> = [];
     // `Object.entries` plus the guard rather than a filter over `Object.keys`:
     // both hand back a bare `string`, but only the guard narrows it, and the
@@ -411,7 +417,14 @@ export function ToolbarSettingsTab() {
     // Alphabetical, because the pin map's key order is insertion order and the
     // user has no way to see or reason about that.
     return rows.sort((a, b) => a.metadata.label.localeCompare(b.metadata.label));
-  }, [layout.pinnedButtons, recipes, currentProjectId, panelKindRegistry, pluginAgentRegistry]);
+  }, [
+    layout.pinnedButtons,
+    recipes,
+    currentProjectId,
+    panelKindRegistry,
+    pluginAgentRegistry,
+    userAgentRegistry,
+  ]);
 
   const resolveGroup = useCallback(
     (id: AnyToolbarButtonId) => getToolbarButtonGroup(id, pluginConfigs.has(id)),

--- a/src/components/Settings/ToolbarSettingsTab.tsx
+++ b/src/components/Settings/ToolbarSettingsTab.tsx
@@ -25,12 +25,13 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { GripVertical, LayoutGrid, Rocket, RotateCcw } from "lucide-react";
-import { LayoutPanelTop, Plus } from "@/components/icons";
+import { LayoutPanelTop, Plus, Workflow } from "@/components/icons";
 import { useToolbarPreferencesStore } from "@/store";
 import { useAgentSettingsStore } from "@/store/agentSettingsStore";
 import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
 import type {
   AnyToolbarButtonId,
+  LauncherItemToolbarButtonId,
   LauncherPanelButtonId,
   PluginToolbarButtonId,
 } from "@/../../shared/types/toolbar";
@@ -38,9 +39,13 @@ import type {
 // is erased at compile time and never has to resolve at runtime.
 import {
   LAUNCHER_PANEL_BUTTON_IDS,
+  isLauncherItemOnToolbar,
+  isLauncherItemToolbarButtonId,
   isPanelButtonOnToolbar,
   isLauncherPanelButtonId,
 } from "@shared/types/toolbar";
+import { useRecipeStore } from "@/store/recipeStore";
+import { resolveLauncherItemMetadata } from "@/components/Layout/launcherToolbarCatalog";
 import { LAUNCHABLE_AGENT_IDS, isBuiltInAgentId } from "@shared/config/agentIds";
 import { isAgentButtonOnToolbar } from "../../../shared/utils/agentPinned";
 import {
@@ -258,7 +263,15 @@ function ToolbarSideColumn({
   // a cross-side drop (a `SortableContext` registers no droppable of its own
   // when it holds zero items).
   const { setNodeRef, isOver } = useDroppable({ id: side });
-  const visibleCount = buttonIds.filter(isVisible).length;
+  // Count what actually renders. `SortableButtonItem` draws nothing for an id
+  // with no live metadata — an uninstalled plugin's button the user had dragged
+  // here, or a launcher item belonging to another project (#12217) — and a
+  // tally that counted those would report more cards than the column shows.
+  // The ids stay in `buttonIds` regardless: the drag handlers write the whole
+  // array back, so filtering the list itself would drop them on the next
+  // reorder.
+  const renderableIds = buttonIds.filter((id) => allMetadata[id] !== undefined);
+  const visibleCount = renderableIds.filter(isVisible).length;
 
   return (
     <div className="flex-1 min-w-0">
@@ -267,7 +280,7 @@ function ToolbarSideColumn({
           {label}
         </span>
         <span className="text-xs text-text-secondary tabular-nums">
-          {visibleCount}/{buttonIds.length}
+          {visibleCount}/{renderableIds.length}
         </span>
       </div>
       <SortableContext items={buttonIds} strategy={rectSortingStrategy}>
@@ -278,7 +291,7 @@ function ToolbarSideColumn({
             isOver && "ring-1 ring-inset ring-border-default"
           )}
         >
-          {buttonIds.length === 0 ? (
+          {renderableIds.length === 0 ? (
             <div className="flex w-full items-center justify-center py-3 text-xs text-text-placeholder">
               Drop a button here
             </div>
@@ -313,6 +326,7 @@ export function ToolbarSettingsTab() {
   const toggleButtonVisibility = useToolbarPreferencesStore((s) => s.toggleButtonVisibility);
   const setPluginButtonPromoted = useToolbarPreferencesStore((s) => s.setPluginButtonPromoted);
   const setPanelButtonOnToolbar = useToolbarPreferencesStore((s) => s.setPanelButtonOnToolbar);
+  const setLauncherItemOnToolbar = useToolbarPreferencesStore((s) => s.setLauncherItemOnToolbar);
   const positionAgentButton = useToolbarPreferencesStore((s) => s.positionAgentButton);
   const setAlwaysShowDevServer = useToolbarPreferencesStore((s) => s.setAlwaysShowDevServer);
   const setDefaultSelection = useToolbarPreferencesStore((s) => s.setDefaultSelection);
@@ -339,6 +353,36 @@ export function ToolbarSettingsTab() {
 
   const { buttonIds: pluginButtonIds, configs: pluginConfigs } = usePluginToolbarButtons();
 
+  // The launcher stays the one place anything gets pinned (#12217); this page's
+  // job for those rows is to show what the user pinned so they can find it,
+  // reorder it and unpin it — the same job it does for a promoted plugin
+  // button. So it enumerates the pin map, not a second copy of the launcher's
+  // inventory, which would also drag the panel definition registry and the
+  // action service into a settings tab.
+  //
+  // An id whose source is not currently here — an uninstalled plugin, a deleted
+  // recipe, a recipe belonging to another project — resolves to no metadata and
+  // renders nothing, matching the toolbar's own registry gate. Its pin is left
+  // alone rather than swept: "not live in this project" is not "gone".
+  const recipes = useRecipeStore((s) => s.recipes);
+  const launcherItemRows = useMemo(() => {
+    const rows: Array<{ id: LauncherItemToolbarButtonId; metadata: ToolbarButtonMetadata }> = [];
+    // `Object.entries` plus the guard rather than a filter over `Object.keys`:
+    // both hand back a bare `string`, but only the guard narrows it, and the
+    // filtering form would need an assertion per access — which the lint
+    // ratchet scores per rule.
+    for (const [id, isPinned] of Object.entries(layout.pinnedButtons)) {
+      if (isPinned !== true) continue;
+      if (!isLauncherItemToolbarButtonId(id)) continue;
+      const metadata = resolveLauncherItemMetadata(id, recipes);
+      if (!metadata) continue;
+      rows.push({ id, metadata });
+    }
+    // Alphabetical, because the pin map's key order is insertion order and the
+    // user has no way to see or reason about that.
+    return rows.sort((a, b) => a.metadata.label.localeCompare(b.metadata.label));
+  }, [layout.pinnedButtons, recipes]);
+
   const resolveGroup = useCallback(
     (id: AnyToolbarButtonId) => getToolbarButtonGroup(id, pluginConfigs.has(id)),
     [pluginConfigs]
@@ -360,8 +404,9 @@ export function ToolbarSettingsTab() {
       ({
         ...TOOLBAR_BUTTON_METADATA,
         ...buildPluginToolbarMeta(pluginButtonIds, pluginConfigs),
+        ...Object.fromEntries(launcherItemRows.map((row) => [row.id, row.metadata])),
       }) as AllMetadata,
-    [pluginButtonIds, pluginConfigs]
+    [pluginButtonIds, pluginConfigs, launcherItemRows]
   );
 
   const getToolbarButtonLabel = useCallback(
@@ -402,6 +447,15 @@ export function ToolbarSettingsTab() {
   // a toolbar slot now that agent ids left `DEFAULT_LEFT_BUTTONS`. The launcher
   // reads through this same resolver, so the two surfaces can't disagree about
   // which agents are on the toolbar.
+  // Launcher items read only the explicit `true` (#12217) — they have no
+  // default slot, so array membership can only be the residue of a pin and
+  // `isToolbarButtonVisible`'s built-in "absent means visible" default would
+  // report every one of them as on.
+  const isLauncherItemOn = useCallback(
+    (id: LauncherItemToolbarButtonId) => isLauncherItemOnToolbar(id, layout.pinnedButtons),
+    [layout.pinnedButtons]
+  );
+
   const isAgentOnToolbar = useCallback(
     (id: AnyToolbarButtonId) =>
       isAgentButtonOnToolbar(
@@ -570,6 +624,14 @@ export function ToolbarSettingsTab() {
       setPluginButtonPromoted(buttonId, !isVisible(buttonId));
       return;
     }
+    // Before the plugin check would have been wrong and after the panel check
+    // would be unreachable: a launcher item's id can carry a dot (a
+    // plugin-contributed recipe is `publisher.name`), and only the registry
+    // membership test above keeps that from reading as a plugin button here.
+    if (isLauncherItemToolbarButtonId(buttonId)) {
+      setLauncherItemOnToolbar(buttonId, !isLauncherItemOn(buttonId));
+      return;
+    }
     // Launcher panel buttons need the same treatment for a different reason
     // (#11667). `browser` and `dev-server` are not defaults, so the generic
     // toggle's "delete the key to show" leaves nothing recording that the user
@@ -702,6 +764,35 @@ export function ToolbarSettingsTab() {
           ))}
         </div>
       </SettingsSection>
+
+      {/*
+        One section for all three launcher-item classes rather than splicing
+        each into the agent/panel lists above (#12217). Those two enumerate a
+        fixed, known set and answer "which of these do you want"; this one
+        enumerates what the user already chose, from an inventory that is
+        unbounded and project-scoped. Hidden when empty rather than rendering an
+        empty shell — the rule the plugin section follows, and a profile with
+        nothing pinned this way is the common case.
+      */}
+      {launcherItemRows.length > 0 && (
+        <SettingsSection
+          icon={Workflow}
+          title="Pinned from the launcher"
+          description={`Recipes, plugin agents and panels you pinned in the launcher. ${launcherItemRows.length} pinned.`}
+        >
+          <div className="space-y-2">
+            {launcherItemRows.map((row) => (
+              <TrayButtonRow
+                key={row.id}
+                buttonId={row.id}
+                isVisible={isLauncherItemOn(row.id)}
+                onToggle={(id) => handleToggle(id, "left")}
+                metadata={row.metadata}
+              />
+            ))}
+          </div>
+        </SettingsSection>
+      )}
 
       {pluginButtonIds.length > 0 && (
         <SettingsSection

--- a/src/components/Settings/__tests__/ToolbarSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/ToolbarSettingsTab.test.tsx
@@ -9,6 +9,7 @@ const moveButtonMock = vi.fn();
 const toggleButtonVisibilityMock = vi.fn();
 const setPluginButtonPromotedMock = vi.fn();
 const setPanelButtonOnToolbarMock = vi.fn();
+const setLauncherItemOnToolbarMock = vi.fn();
 const setAlwaysShowDevServerMock = vi.fn();
 const setDefaultSelectionMock = vi.fn();
 const resetMock = vi.fn();
@@ -30,6 +31,7 @@ interface ToolbarState {
   toggleButtonVisibility: typeof toggleButtonVisibilityMock;
   setPluginButtonPromoted: typeof setPluginButtonPromotedMock;
   setPanelButtonOnToolbar: typeof setPanelButtonOnToolbarMock;
+  setLauncherItemOnToolbar: typeof setLauncherItemOnToolbarMock;
   setAlwaysShowDevServer: typeof setAlwaysShowDevServerMock;
   setDefaultSelection: typeof setDefaultSelectionMock;
   reset: typeof resetMock;
@@ -52,6 +54,7 @@ function makeToolbarState(
     toggleButtonVisibility: toggleButtonVisibilityMock,
     setPluginButtonPromoted: setPluginButtonPromotedMock,
     setPanelButtonOnToolbar: setPanelButtonOnToolbarMock,
+    setLauncherItemOnToolbar: setLauncherItemOnToolbarMock,
     setAlwaysShowDevServer: setAlwaysShowDevServerMock,
     setDefaultSelection: setDefaultSelectionMock,
     reset: resetMock,
@@ -68,6 +71,7 @@ function clearStoreMocks() {
   toggleButtonVisibilityMock.mockClear();
   setPluginButtonPromotedMock.mockClear();
   setPanelButtonOnToolbarMock.mockClear();
+  setLauncherItemOnToolbarMock.mockClear();
   setAlwaysShowDevServerMock.mockClear();
   setDefaultSelectionMock.mockClear();
   resetMock.mockClear();
@@ -86,6 +90,13 @@ vi.mock("@/store/agentSettingsStore", () => ({
       setAgentPinned: typeof setAgentPinnedMock;
     }) => unknown
   ) => selector({ settings: mockAgentSettings, setAgentPinned: setAgentPinnedMock }),
+}));
+
+const mockRecipes = vi.hoisted(() => ({ list: [] as Array<{ id: string; name: string }> }));
+
+vi.mock("@/store/recipeStore", () => ({
+  useRecipeStore: (selector: (s: { recipes: Array<{ id: string; name: string }> }) => unknown) =>
+    selector({ recipes: mockRecipes.list }),
 }));
 
 vi.mock("@/store/cliAvailabilityStore", () => ({
@@ -893,5 +904,108 @@ describe("ToolbarSettingsTab — panel button pinning (#11667)", () => {
     expect(getByTestId("section-Panel buttons").getAttribute("data-description")).toContain(
       "3 of 4 pinned"
     );
+  });
+});
+
+describe("ToolbarSettingsTab — launcher pins (#12217)", () => {
+  beforeEach(() => {
+    clearStoreMocks();
+    mockAgentSettings = null;
+    mockRecipes.list = [];
+    pluginButtons.configs = new Map();
+  });
+
+  afterEach(() => {
+    mockToolbarState = makeToolbarState();
+    mockRecipes.list = [];
+  });
+
+  function pinned(pinnedButtons: Record<string, boolean>) {
+    mockToolbarState = makeToolbarState({
+      leftButtons: ["launcher"],
+      rightButtons: [],
+      pinnedButtons,
+    });
+  }
+
+  it("has no section at all when nothing was pinned from the launcher", () => {
+    // The common profile. An empty shell would be a heading promising rows the
+    // page can never show.
+    pinned({});
+    const { queryByTestId } = render(<ToolbarSettingsTab />);
+    expect(queryByTestId("section-Pinned from the launcher")).toBeNull();
+  });
+
+  it("lists a pinned recipe under the name the recipe actually has", () => {
+    mockRecipes.list = [{ id: "r-1", name: "Ship it" }];
+    pinned({ "launcher:recipe:r-1": true });
+
+    const { getByTestId, getByLabelText } = render(<ToolbarSettingsTab />);
+    expect(getByTestId("section-Pinned from the launcher")).toBeTruthy();
+    expect(getByLabelText("Show Ship it in toolbar").getAttribute("aria-checked")).toBe("true");
+  });
+
+  it("lists a pinned plugin agent and a pinned panel kind alongside it", () => {
+    // All three classes the issue names reach this one section.
+    mockRecipes.list = [{ id: "r-1", name: "Ship it" }];
+    pinned({
+      "launcher:recipe:r-1": true,
+      "launcher:agent:my-plugin-agent": true,
+      "launcher:panel:review": true,
+    });
+
+    const { getByTestId } = render(<ToolbarSettingsTab />);
+    const section = getByTestId("section-Pinned from the launcher");
+    expect(section.querySelectorAll('[role="switch"]')).toHaveLength(3);
+    expect(section.getAttribute("data-description")).toContain("3 pinned");
+  });
+
+  it("unpins through the launcher-item setter, not the panel or plugin one", () => {
+    mockRecipes.list = [{ id: "r-1", name: "Ship it" }];
+    pinned({ "launcher:recipe:r-1": true });
+
+    const { getByLabelText } = render(<ToolbarSettingsTab />);
+    fireEvent.click(getByLabelText("Show Ship it in toolbar"));
+
+    expect(setLauncherItemOnToolbarMock).toHaveBeenCalledWith("launcher:recipe:r-1", false);
+    expect(setPanelButtonOnToolbarMock).not.toHaveBeenCalled();
+    expect(setPluginButtonPromotedMock).not.toHaveBeenCalled();
+    expect(toggleButtonVisibilityMock).not.toHaveBeenCalled();
+  });
+
+  it("shows no row for a pin whose source is not here, and leaves the pin alone", () => {
+    // A recipe belonging to another project, or one since deleted. The row is
+    // absent because nothing can name or launch it — but "not live right now"
+    // is not "gone", so the page must not write anything to clean it up.
+    pinned({ "launcher:recipe:from-another-project": true });
+
+    const { queryByTestId } = render(<ToolbarSettingsTab />);
+    expect(queryByTestId("section-Pinned from the launcher")).toBeNull();
+    expect(setLauncherItemOnToolbarMock).not.toHaveBeenCalled();
+  });
+
+  it("ignores an entry that is not an explicit promotion", () => {
+    // Unpinning deletes the key, so a `false` should never occur — but if a
+    // stale profile carries one it must not resurrect the row.
+    mockRecipes.list = [{ id: "r-1", name: "Ship it" }];
+    pinned({ "launcher:recipe:r-1": false });
+
+    const { queryByTestId } = render(<ToolbarSettingsTab />);
+    expect(queryByTestId("section-Pinned from the launcher")).toBeNull();
+  });
+
+  it("keeps a dotted launcher id out of the plugin section", () => {
+    // A plugin-contributed recipe's id is `publisher.name`. The dot test that
+    // narrows a plugin button id would claim this one if registry membership
+    // weren't checked first.
+    mockRecipes.list = [{ id: "acme.deploy", name: "Deploy" }];
+    pinned({ "launcher:recipe:acme.deploy": true });
+
+    const { queryByTestId, getByLabelText } = render(<ToolbarSettingsTab />);
+    expect(queryByTestId("section-Plugin buttons")).toBeNull();
+
+    fireEvent.click(getByLabelText("Show Deploy in toolbar"));
+    expect(setLauncherItemOnToolbarMock).toHaveBeenCalledWith("launcher:recipe:acme.deploy", false);
+    expect(setPluginButtonPromotedMock).not.toHaveBeenCalled();
   });
 });

--- a/src/components/Terminal/useContentGridContext.tsx
+++ b/src/components/Terminal/useContentGridContext.tsx
@@ -328,6 +328,7 @@ export function useContentGridContext({
   // hook's "use memo" block on any unrelated toolbar update.
   const leftButtons = useToolbarPreferencesStore(useShallow((s) => s.layout.leftButtons));
   const rightButtons = useToolbarPreferencesStore(useShallow((s) => s.layout.rightButtons));
+  const pinnedButtons = useToolbarPreferencesStore(useShallow((s) => s.layout.pinnedButtons));
   const agentSettings = useAgentSettingsStore((s) => s.settings);
   // Re-derive grid agents when a plugin loads/unloads mid-session so its agents
   // appear / disappear with current icon/name/color (#9879).
@@ -774,12 +775,13 @@ export function useContentGridContext({
           availability: agentAvailability?.[id],
         };
       });
-    return sortAgentsByToolbarPin(agents, leftButtons, agentSettings, rightButtons);
+    return sortAgentsByToolbarPin(agents, leftButtons, agentSettings, rightButtons, pinnedButtons);
   }, [
     agentAvailability,
     gridSelectedAgentIds,
     leftButtons,
     rightButtons,
+    pinnedButtons,
     agentSettings,
     pluginAgentRegistry,
   ]);

--- a/src/lib/__tests__/agentMenuOrder.test.ts
+++ b/src/lib/__tests__/agentMenuOrder.test.ts
@@ -172,13 +172,14 @@ describe("sortAgentsByToolbarPin", () => {
     // pin lives under a launcher-item id (#12217). An entry sitting in
     // `agentSettings` under its raw id is not that pin and must not count.
     const agents = [agent("my-plugin-agent", "ready"), agent("claude", "ready")];
-    const { pinnedCount } = sortAgentsByToolbarPin(
+    const { sorted, pinnedCount } = sortAgentsByToolbarPin(
       agents,
       ["my-plugin-agent", "claude"],
       settings({ "my-plugin-agent": { pinned: true } }),
       [],
       {}
     );
+    expect(sorted.map((a) => a.id)).toEqual(["claude", "my-plugin-agent"]);
     expect(pinnedCount).toBe(1);
   });
 
@@ -192,6 +193,26 @@ describe("sortAgentsByToolbarPin", () => {
     // `claude` holds index 0 in leftButtons; the plugin agent has no position
     // yet, so it trails within the pinned group like any unpositioned pin.
     expect(sorted.map((a) => a.id)).toEqual(["claude", "my-plugin-agent"]);
+    expect(pinnedCount).toBe(2);
+  });
+
+  it("orders a pinned non-built-in agent by its synthetic toolbar id (#12217)", () => {
+    // `leftButtons` holds `launcher:agent:<id>`, not the raw agent id. Looking
+    // the order up by `agent.id` scores every pinned plugin agent as
+    // unpositioned and drops it to the end — the launcher then contradicts the
+    // toolbar it is meant to mirror.
+    const pluginId = launcherItemToolbarButtonId("agent", "my-plugin-agent");
+    const agents = [agent("claude", "ready"), agent("my-plugin-agent", "ready")];
+    const { sorted, pinnedCount } = sortAgentsByToolbarPin(
+      agents,
+      [pluginId, "claude"],
+      settings({}),
+      [],
+      { [pluginId]: true }
+    );
+    // Input order is claude-first; the toolbar order is plugin-first, and the
+    // toolbar wins.
+    expect(sorted.map((a) => a.id)).toEqual(["my-plugin-agent", "claude"]);
     expect(pinnedCount).toBe(2);
   });
 

--- a/src/lib/__tests__/agentMenuOrder.test.ts
+++ b/src/lib/__tests__/agentMenuOrder.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { AgentSettings } from "@shared/types/agentSettings";
 import type { AgentAvailabilityState } from "@shared/types";
+import { launcherItemToolbarButtonId } from "@shared/types/toolbar";
 import { sortAgentsByToolbarPin, type PinnableAgent } from "../agentMenuOrder";
 
 function agent(id: string, availability?: AgentAvailabilityState): PinnableAgent {
@@ -18,7 +19,8 @@ describe("sortAgentsByToolbarPin", () => {
       agents,
       ["codex", "gemini"],
       settings({}),
-      []
+      [],
+      {}
     );
     expect(sorted.map((a) => a.id)).toEqual(["codex", "gemini", "claude"]);
     expect(pinnedCount).toBe(2);
@@ -30,7 +32,8 @@ describe("sortAgentsByToolbarPin", () => {
       agents,
       ["claude"],
       settings({ claude: { pinned: true } }),
-      []
+      [],
+      {}
     );
     expect(sorted.map((a) => a.id)).toEqual(["claude", "gemini"]);
     expect(pinnedCount).toBe(1);
@@ -42,7 +45,8 @@ describe("sortAgentsByToolbarPin", () => {
       agents,
       ["claude", "gemini"],
       settings({ claude: { pinned: false } }),
-      []
+      [],
+      {}
     );
     expect(sorted.map((a) => a.id)).toEqual(["gemini", "claude"]);
     expect(pinnedCount).toBe(1);
@@ -50,7 +54,7 @@ describe("sortAgentsByToolbarPin", () => {
 
   it("returns pinnedCount 0 when no agents are pinned", () => {
     const agents = [agent("claude", "missing"), agent("gemini", undefined)];
-    const { sorted, pinnedCount } = sortAgentsByToolbarPin(agents, [], settings({}), []);
+    const { sorted, pinnedCount } = sortAgentsByToolbarPin(agents, [], settings({}), [], {});
     expect(sorted.map((a) => a.id)).toEqual(["claude", "gemini"]);
     expect(pinnedCount).toBe(0);
   });
@@ -61,7 +65,8 @@ describe("sortAgentsByToolbarPin", () => {
       agents,
       ["gemini", "claude"],
       settings({}),
-      []
+      [],
+      {}
     );
     // leftButtons reverses the input order — guards against a sort that counts
     // pinned agents correctly but ignores the toolbar ordering.
@@ -79,7 +84,8 @@ describe("sortAgentsByToolbarPin", () => {
       agents,
       ["claude"],
       settings({ gemini: { pinned: true } }),
-      []
+      [],
+      {}
     );
     expect(sorted.map((a) => a.id)).toEqual(["claude", "gemini", "codex"]);
     expect(pinnedCount).toBe(2);
@@ -92,7 +98,8 @@ describe("sortAgentsByToolbarPin", () => {
       agents,
       ["claude"],
       settings({ gemini: { pinned: true } }),
-      []
+      [],
+      {}
     );
     expect(sorted.map((a) => a.id)).toEqual(["claude", "gemini"]);
     expect(pinnedCount).toBe(2);
@@ -104,21 +111,22 @@ describe("sortAgentsByToolbarPin", () => {
       agents,
       ["gemini", "claude", "gemini"],
       settings({}),
-      []
+      [],
+      {}
     );
     expect(sorted.map((a) => a.id)).toEqual(["gemini", "claude"]);
   });
 
   it("treats a missing settings entry as following position and availability", () => {
     const agents = [agent("claude", "ready"), agent("gemini", "missing")];
-    const { sorted, pinnedCount } = sortAgentsByToolbarPin(agents, ["claude"], null, []);
+    const { sorted, pinnedCount } = sortAgentsByToolbarPin(agents, ["claude"], null, [], {});
     expect(sorted.map((a) => a.id)).toEqual(["claude", "gemini"]);
     expect(pinnedCount).toBe(1);
   });
 
   it("treats undefined availability with no pin as unpinned", () => {
     const agents = [agent("claude", undefined)];
-    const { pinnedCount } = sortAgentsByToolbarPin(agents, [], settings({}), []);
+    const { pinnedCount } = sortAgentsByToolbarPin(agents, [], settings({}), [], {});
     expect(pinnedCount).toBe(0);
   });
 
@@ -127,13 +135,19 @@ describe("sortAgentsByToolbarPin", () => {
     // stopped implying a toolbar slot, so grouping on availability alone put an
     // agent under "Pinned" while its own pin affordance read as unpinned.
     const agents = [agent("claude", "ready"), agent("gemini", "ready")];
-    const { pinnedCount } = sortAgentsByToolbarPin(agents, [], settings({}), []);
+    const { pinnedCount } = sortAgentsByToolbarPin(agents, [], settings({}), [], {});
     expect(pinnedCount).toBe(0);
   });
 
   it("counts a position on the right side as pinned", () => {
     const agents = [agent("claude", "ready"), agent("gemini", "ready")];
-    const { sorted, pinnedCount } = sortAgentsByToolbarPin(agents, [], settings({}), ["gemini"]);
+    const { sorted, pinnedCount } = sortAgentsByToolbarPin(
+      agents,
+      [],
+      settings({}),
+      ["gemini"],
+      {}
+    );
     expect(sorted.map((a) => a.id)).toEqual(["gemini", "claude"]);
     expect(pinnedCount).toBe(1);
   });
@@ -142,24 +156,56 @@ describe("sortAgentsByToolbarPin", () => {
     // `leftButtons` supplies the order; a right-side agent has no index there,
     // so it sorts to the end of the pinned group rather than interleaving.
     const agents = [agent("gemini", "ready"), agent("claude", "ready")];
-    const { sorted, pinnedCount } = sortAgentsByToolbarPin(agents, ["claude"], settings({}), [
-      "gemini",
-    ]);
+    const { sorted, pinnedCount } = sortAgentsByToolbarPin(
+      agents,
+      ["claude"],
+      settings({}),
+      ["gemini"],
+      {}
+    );
     expect(sorted.map((a) => a.id)).toEqual(["claude", "gemini"]);
     expect(pinnedCount).toBe(2);
   });
 
-  it("never counts a non-built-in agent as pinned, even when positioned", () => {
-    // A plugin or user-defined agent has no toolbar button id to write, so it
-    // cannot be on the toolbar however the arrays read.
+  it("reads a non-built-in agent's pin from pinnedButtons, not agentSettings", () => {
+    // A plugin or user-defined agent has no `agentSettingsStore` button, so its
+    // pin lives under a launcher-item id (#12217). An entry sitting in
+    // `agentSettings` under its raw id is not that pin and must not count.
     const agents = [agent("my-plugin-agent", "ready"), agent("claude", "ready")];
-    const { sorted, pinnedCount } = sortAgentsByToolbarPin(
+    const { pinnedCount } = sortAgentsByToolbarPin(
       agents,
       ["my-plugin-agent", "claude"],
       settings({ "my-plugin-agent": { pinned: true } }),
-      []
+      [],
+      {}
     );
-    expect(sorted.map((a) => a.id)).toEqual(["claude", "my-plugin-agent"]);
     expect(pinnedCount).toBe(1);
+  });
+
+  it("counts a non-built-in agent the launcher pinned (#12217)", () => {
+    // Before this, a plugin agent could carry a filled pin icon while sitting
+    // under "Other" — the launcher contradicting itself in one list.
+    const agents = [agent("my-plugin-agent", "ready"), agent("claude", "ready")];
+    const { sorted, pinnedCount } = sortAgentsByToolbarPin(agents, ["claude"], settings({}), [], {
+      [launcherItemToolbarButtonId("agent", "my-plugin-agent")]: true,
+    });
+    // `claude` holds index 0 in leftButtons; the plugin agent has no position
+    // yet, so it trails within the pinned group like any unpositioned pin.
+    expect(sorted.map((a) => a.id)).toEqual(["claude", "my-plugin-agent"]);
+    expect(pinnedCount).toBe(2);
+  });
+
+  it("does not read a position alone as a non-built-in agent's pin", () => {
+    // A launcher item has no default slot, so array membership can only ever be
+    // the residue of a pin — only the explicit `true` counts.
+    const agents = [agent("my-plugin-agent", "ready")];
+    const { pinnedCount } = sortAgentsByToolbarPin(
+      agents,
+      ["my-plugin-agent"],
+      settings({}),
+      [],
+      {}
+    );
+    expect(pinnedCount).toBe(0);
   });
 });

--- a/src/lib/agentMenuOrder.ts
+++ b/src/lib/agentMenuOrder.ts
@@ -62,11 +62,22 @@ export function sortAgentsByToolbarPin<T extends PinnableAgent>(
 
   const pinned: T[] = [];
   const unpinned: T[] = [];
+  // The id the arrays actually hold, which for a non-built-in agent is not its
+  // agent id: a plugin agent sits in `leftButtons` as
+  // `launcher:agent:{id}` (#12217). Resolved once per agent and used for BOTH
+  // the position test and the ordering lookup below — reading `agent.id` in the
+  // sort would score every pinned plugin agent as unpositioned and drop it to
+  // the end of the group, contradicting the toolbar it is supposed to mirror.
+  const toolbarIdFor = (agent: PinnableAgent): string =>
+    isBuiltInAgentId(agent.id) ? agent.id : launcherItemToolbarButtonId("agent", agent.id);
+
   for (const agent of agents) {
     const onToolbar = isBuiltInAgentId(agent.id)
       ? isAgentButtonOnToolbar(
           agentSettings?.agents?.[agent.id],
           agent.availability,
+          // Identical to `toolbarIdFor(agent)` on this branch — a built-in
+          // agent's toolbar id is its agent id.
           positioned.has(agent.id)
         )
       : isLauncherItemOnToolbar(launcherItemToolbarButtonId("agent", agent.id), pinnedButtons);
@@ -77,7 +88,9 @@ export function sortAgentsByToolbarPin<T extends PinnableAgent>(
     }
   }
 
-  pinned.sort((a, b) => (order.get(a.id) ?? Infinity) - (order.get(b.id) ?? Infinity));
+  pinned.sort(
+    (a, b) => (order.get(toolbarIdFor(a)) ?? Infinity) - (order.get(toolbarIdFor(b)) ?? Infinity)
+  );
 
   return { sorted: [...pinned, ...unpinned], pinnedCount: pinned.length };
 }

--- a/src/lib/agentMenuOrder.ts
+++ b/src/lib/agentMenuOrder.ts
@@ -1,6 +1,8 @@
 import type { AgentSettings } from "@shared/types/agentSettings";
 import type { AgentAvailabilityState } from "@shared/types";
+import type { ToolbarPinnedState } from "@shared/types/toolbar";
 import { isAgentButtonOnToolbar } from "@shared/utils/agentPinned";
+import { isLauncherItemOnToolbar, launcherItemToolbarButtonId } from "@shared/types/toolbar";
 import { isBuiltInAgentId } from "@shared/config/agentIds";
 
 /** Minimal shape needed to order an agent against the toolbar pin state. */
@@ -28,8 +30,12 @@ export interface PinnableAgent {
  * from it (explicitly pinned, never positioned) sorts to the end of the pinned
  * group via a stable sort.
  *
- * Only built-in agents can be pinned: a plugin or user-defined agent has no
- * toolbar button id to write, so it can never be in the pinned group.
+ * Built-in agents and everything else answer the same question from different
+ * stores. A built-in reads `agentSettingsStore` through `isAgentButtonOnToolbar`;
+ * a plugin or user-defined agent has no entry there and reads the explicit
+ * `true` its launcher-item pin writes into `pinnedButtons` (#12217). Before
+ * that they could not be pinned at all and were hard-coded into the unpinned
+ * group — which would now put a filled pin icon on a row sitting under "Other".
  *
  * Returns the concatenated array plus `pinnedCount` so callers can render a
  * separator + labels between the two groups without re-deriving the split.
@@ -41,7 +47,11 @@ export function sortAgentsByToolbarPin<T extends PinnableAgent>(
   // Required rather than defaulted: a caller that forgets it would silently
   // demote every right-side agent out of the pinned group, and there is no
   // value of this argument that is safe to guess.
-  rightButtons: readonly string[]
+  rightButtons: readonly string[],
+  // Required for the same reason, one store over: omitting it would put every
+  // pinned plugin or user-defined agent back under "Other" wearing a filled
+  // pin, which is the contradiction this argument exists to prevent.
+  pinnedButtons: ToolbarPinnedState
 ): { sorted: T[]; pinnedCount: number } {
   const order = new Map<string, number>();
   for (let i = 0; i < leftButtons.length; i++) {
@@ -53,13 +63,13 @@ export function sortAgentsByToolbarPin<T extends PinnableAgent>(
   const pinned: T[] = [];
   const unpinned: T[] = [];
   for (const agent of agents) {
-    const onToolbar =
-      isBuiltInAgentId(agent.id) &&
-      isAgentButtonOnToolbar(
-        agentSettings?.agents?.[agent.id],
-        agent.availability,
-        positioned.has(agent.id)
-      );
+    const onToolbar = isBuiltInAgentId(agent.id)
+      ? isAgentButtonOnToolbar(
+          agentSettings?.agents?.[agent.id],
+          agent.availability,
+          positioned.has(agent.id)
+        )
+      : isLauncherItemOnToolbar(launcherItemToolbarButtonId("agent", agent.id), pinnedButtons);
     if (onToolbar) {
       pinned.push(agent);
     } else {

--- a/src/store/__tests__/recipeStore.test.ts
+++ b/src/store/__tests__/recipeStore.test.ts
@@ -2638,6 +2638,80 @@ describe("recipeStore", () => {
       expect(state.recipes).toHaveLength(1);
     });
 
+    it("clears a deleted recipe's toolbar pin only after the backend confirms (#12217)", async () => {
+      // Sequencing, not just outcome: cleanup beside the optimistic removal
+      // would delete the user's explicit pin on a disk failure that restores
+      // the recipe.
+      const { useToolbarPreferencesStore } = await import("../toolbarPreferencesStore");
+      const inRepoRecipe = {
+        id: "inrepo-pinned",
+        name: "Pinned Recipe",
+        terminals: [{ type: "terminal" as const, title: "Shell", env: {} }],
+        createdAt: 500,
+        projectId: "project-1",
+      };
+      const buttonId = "launcher:recipe:project-1:inrepo-pinned" as const;
+      useRecipeStore.setState({
+        inRepoRecipes: [inRepoRecipe],
+        globalRecipes: [],
+        projectRecipes: [],
+        recipes: [inRepoRecipe],
+        currentProjectId: "project-1",
+      });
+      useToolbarPreferencesStore.getState().setLauncherItemOnToolbar(buttonId, true);
+      expect(useToolbarPreferencesStore.getState().layout.pinnedButtons[buttonId]).toBe(true);
+
+      let releaseDelete: () => void = () => {};
+      deleteInRepoRecipeMock.mockReturnValueOnce(
+        new Promise<void>((resolve) => {
+          releaseDelete = resolve;
+        })
+      );
+      const pending = useRecipeStore.getState().deleteRecipe("inrepo-pinned");
+
+      // Optimistically gone from the list, but the pin is still the user's
+      // until the write lands.
+      expect(useRecipeStore.getState().recipes).toHaveLength(0);
+      expect(useToolbarPreferencesStore.getState().layout.pinnedButtons[buttonId]).toBe(true);
+
+      releaseDelete();
+      await pending;
+
+      const { pinnedButtons, leftButtons, rightButtons } =
+        useToolbarPreferencesStore.getState().layout;
+      expect(buttonId in pinnedButtons).toBe(false);
+      expect([...leftButtons, ...rightButtons]).not.toContain(buttonId);
+    });
+
+    it("keeps the toolbar pin when the delete fails and rolls back (#12217)", async () => {
+      const { useToolbarPreferencesStore } = await import("../toolbarPreferencesStore");
+      const inRepoRecipe = {
+        id: "inrepo-kept",
+        name: "Kept Recipe",
+        terminals: [{ type: "terminal" as const, title: "Shell", env: {} }],
+        createdAt: 500,
+        projectId: "project-1",
+      };
+      const buttonId = "launcher:recipe:project-1:inrepo-kept" as const;
+      useRecipeStore.setState({
+        inRepoRecipes: [inRepoRecipe],
+        globalRecipes: [],
+        projectRecipes: [],
+        recipes: [inRepoRecipe],
+        currentProjectId: "project-1",
+      });
+      useToolbarPreferencesStore.getState().setLauncherItemOnToolbar(buttonId, true);
+
+      deleteInRepoRecipeMock.mockRejectedValueOnce(new Error("disk error"));
+      await expect(useRecipeStore.getState().deleteRecipe("inrepo-kept")).rejects.toThrow(
+        "disk error"
+      );
+
+      // The recipe came back, so its pin must still describe something real.
+      expect(useRecipeStore.getState().recipes).toHaveLength(1);
+      expect(useToolbarPreferencesStore.getState().layout.pinnedButtons[buttonId]).toBe(true);
+    });
+
     it("deleteRecipe drops the ProjectFileStore mirror so no ghost row survives (#11993)", async () => {
       // The mirror shares the canonical recipe's id and carries the frecency the
       // git-tracked file deliberately omits. `mergeRecipes` only hides it while

--- a/src/store/__tests__/toolbarPreferencesStore.test.ts
+++ b/src/store/__tests__/toolbarPreferencesStore.test.ts
@@ -432,15 +432,57 @@ describe("toolbarPreferencesStore", () => {
       expect(Object.keys(store.getState().layout.pinnedButtons)).toEqual([recipeId]);
     });
 
-    it("keeps an existing position rather than adding a second one", async () => {
+    it("adopts an existing right-side position instead of inserting a second one", async () => {
+      // Seeded directly, because the obvious construction — pin, move right,
+      // unpin, repin — deletes the position on the unpin, so the branch under
+      // test never sees one and an implementation that always inserted left
+      // would pass.
       const store = await loadStore();
-      store.getState().setLauncherItemOnToolbar(recipeId, true);
-      store.getState().moveButton(recipeId, "left", "right", 0);
-      store.getState().setLauncherItemOnToolbar(recipeId, false);
+      store.setState((state) => ({
+        layout: { ...state.layout, rightButtons: [...state.layout.rightButtons, recipeId] },
+      }));
+
       store.getState().setLauncherItemOnToolbar(recipeId, true);
 
       const { leftButtons, rightButtons } = store.getState().layout;
-      expect([...leftButtons, ...rightButtons].filter((id) => id === recipeId)).toHaveLength(1);
+      expect(rightButtons.filter((id) => id === recipeId)).toHaveLength(1);
+      expect(leftButtons).not.toContain(recipeId);
+      expect(store.getState().layout.pinnedButtons[recipeId]).toBe(true);
+    });
+
+    it("strips the id from BOTH arrays on unpin", async () => {
+      // A cross-side duplicate is reachable from older profiles, and filtering
+      // only the side the pin happened to create would leave the other behind
+      // rendering a button whose pin is gone.
+      const store = await loadStore();
+      store.setState((state) => ({
+        layout: {
+          ...state.layout,
+          leftButtons: [...state.layout.leftButtons, recipeId],
+          rightButtons: [...state.layout.rightButtons, recipeId],
+          pinnedButtons: { ...state.layout.pinnedButtons, [recipeId]: true },
+        },
+      }));
+
+      store.getState().setLauncherItemOnToolbar(recipeId, false);
+
+      const { leftButtons, rightButtons, pinnedButtons } = store.getState().layout;
+      expect(leftButtons).not.toContain(recipeId);
+      expect(rightButtons).not.toContain(recipeId);
+      expect(recipeId in pinnedButtons).toBe(false);
+    });
+
+    it("clears a position left behind with no pin entry", async () => {
+      // The other half of the same repair: an id positioned but unpinned is a
+      // dead slot, and the unpin path is what removes it.
+      const store = await loadStore();
+      store.setState((state) => ({
+        layout: { ...state.layout, leftButtons: [...state.layout.leftButtons, recipeId] },
+      }));
+
+      store.getState().setLauncherItemOnToolbar(recipeId, false);
+
+      expect(store.getState().layout.leftButtons).not.toContain(recipeId);
     });
   });
 

--- a/src/store/__tests__/toolbarPreferencesStore.test.ts
+++ b/src/store/__tests__/toolbarPreferencesStore.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AnyToolbarButtonId, PluginToolbarButtonId } from "@/../../shared/types/toolbar";
-import { TOOLBAR_BUTTON_PRIORITIES } from "@shared/types/toolbar";
+import { TOOLBAR_BUTTON_PRIORITIES, launcherItemToolbarButtonId } from "@shared/types/toolbar";
 import { LAUNCHABLE_AGENT_IDS } from "@shared/config/agentIds";
 
 // Mirror the production agent IDs so the v5 migration is exercised against
@@ -337,6 +337,110 @@ describe("toolbarPreferencesStore", () => {
       store.getState().sweepStalePluginPinnedButtons([]);
 
       expect(store.getState().layout).toBe(layoutBefore);
+    });
+
+    it("leaves a launcher item alone even when its source id is dotted (#12217)", async () => {
+      // The collision this guard exists for: a plugin-contributed recipe's id is
+      // `publisher.name`, so the bare `key.includes(".")` test reads its pin as a
+      // plugin button this snapshot has never heard of and drops it. The pin is
+      // an explicit `true` here — the exemption below would also save it — and a
+      // `false` cannot occur, because unpinning a launcher item deletes the key.
+      const store = await loadStore();
+      const dotted = launcherItemToolbarButtonId("recipe", "acme.deploy");
+      const plain = launcherItemToolbarButtonId("panel", "review");
+      store.getState().setLauncherItemOnToolbar(dotted, true);
+      store.getState().setLauncherItemOnToolbar(plain, true);
+      store.getState().toggleButtonVisibility("acme.foo.gone" as AnyToolbarButtonId, "right");
+
+      store.getState().sweepStalePluginPinnedButtons([]);
+
+      const { pinnedButtons } = store.getState().layout;
+      expect(pinnedButtons[dotted]).toBe(true);
+      expect(pinnedButtons[plain]).toBe(true);
+      // The genuine stale plugin key still goes.
+      expect(pinnedButtons["acme.foo.gone"]).toBeUndefined();
+    });
+  });
+
+  describe("setLauncherItemOnToolbar (#12217)", () => {
+    const recipeId = launcherItemToolbarButtonId("recipe", "0f8c-1d2e");
+
+    it("records the pin as an explicit true and gives it a position", async () => {
+      // Only an explicit `true` grants a launcher item a slot, and the arrays
+      // reconcile last-writer-wins across project views — so the flag is the
+      // durable record and the position is derived from it.
+      const store = await loadStore();
+      store.getState().setLauncherItemOnToolbar(recipeId, true);
+
+      const { pinnedButtons, leftButtons, rightButtons } = store.getState().layout;
+      expect(pinnedButtons[recipeId]).toBe(true);
+      expect([...leftButtons, ...rightButtons]).toContain(recipeId);
+    });
+
+    it("places the pin beside the launcher, not at the end of the row", async () => {
+      const store = await loadStore();
+      store.getState().setLauncherItemOnToolbar(recipeId, true);
+
+      const { leftButtons } = store.getState().layout;
+      expect(leftButtons[leftButtons.indexOf("launcher") + 1]).toBe(recipeId);
+    });
+
+    it("deletes the key and the position on unpin rather than writing a false", async () => {
+      // Absence and `false` are the same answer for a launcher item, so a
+      // `false` would record nothing while leaving a key and a slot behind for
+      // a recipe that may be deleted tomorrow.
+      const store = await loadStore();
+      store.getState().setLauncherItemOnToolbar(recipeId, true);
+      store.getState().setLauncherItemOnToolbar(recipeId, false);
+
+      const { pinnedButtons, leftButtons, rightButtons } = store.getState().layout;
+      expect(recipeId in pinnedButtons).toBe(false);
+      expect([...leftButtons, ...rightButtons]).not.toContain(recipeId);
+    });
+
+    it("does not duplicate the position when an already-pinned item is pinned again", async () => {
+      const store = await loadStore();
+      store.getState().setLauncherItemOnToolbar(recipeId, true);
+      const layoutBefore = store.getState().layout;
+
+      store.getState().setLauncherItemOnToolbar(recipeId, true);
+
+      // A no-op down to the reference, so the persist layer doesn't churn.
+      expect(store.getState().layout).toBe(layoutBefore);
+      const positions = [
+        ...store.getState().layout.leftButtons,
+        ...store.getState().layout.rightButtons,
+      ];
+      expect(positions.filter((id) => id === recipeId)).toHaveLength(1);
+    });
+
+    it("is a no-op when unpinning something that was never pinned", async () => {
+      const store = await loadStore();
+      const layoutBefore = store.getState().layout;
+
+      store.getState().setLauncherItemOnToolbar(recipeId, false);
+
+      expect(store.getState().layout).toBe(layoutBefore);
+    });
+
+    it("seeds no default for any other button", async () => {
+      // Nothing may ever backfill `pinnedButtons` (#11667) — the pin writes one
+      // key and one key only.
+      const store = await loadStore();
+      store.getState().setLauncherItemOnToolbar(recipeId, true);
+
+      expect(Object.keys(store.getState().layout.pinnedButtons)).toEqual([recipeId]);
+    });
+
+    it("keeps an existing position rather than adding a second one", async () => {
+      const store = await loadStore();
+      store.getState().setLauncherItemOnToolbar(recipeId, true);
+      store.getState().moveButton(recipeId, "left", "right", 0);
+      store.getState().setLauncherItemOnToolbar(recipeId, false);
+      store.getState().setLauncherItemOnToolbar(recipeId, true);
+
+      const { leftButtons, rightButtons } = store.getState().layout;
+      expect([...leftButtons, ...rightButtons].filter((id) => id === recipeId)).toHaveLength(1);
     });
   });
 

--- a/src/store/recipeStore.ts
+++ b/src/store/recipeStore.ts
@@ -3,6 +3,8 @@ import type { TerminalRecipe, RecipeTerminal, RecipeTerminalType } from "@/types
 import { isPluginRecipe } from "@shared/types/project";
 import type { PluginRecipeMetadataPatch } from "@shared/types/project";
 import { usePanelStore } from "./panelStore";
+import { useToolbarPreferencesStore } from "./toolbarPreferencesStore";
+import { launcherItemToolbarButtonId } from "@shared/types/toolbar";
 import { preflightSpawnBatchLimit } from "./panelLimitStore";
 import { countPanelsTowardLimit } from "./slices/panelRegistry/panelCount";
 import { isMcpSpawnFocusSuppressed } from "./mcpSpawnFocusGuard";
@@ -725,6 +727,17 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
       } else {
         await projectClient.deleteRecipe(recipe.projectId!, id);
       }
+      // Only after the backend confirms, and only for a genuine delete. A
+      // recipe id is never reissued, so a pin left behind can't resurrect
+      // anything and the toolbar already renders nothing for it — but the key
+      // and its slot would otherwise outlive the recipe forever, and unlike a
+      // plugin unload (which also fires for an update) this is permanent
+      // (#12217). Rolled-back deletions fall through to the catch and keep the
+      // pin, which is why this sits after the await rather than beside the
+      // optimistic `set` above.
+      useToolbarPreferencesStore
+        .getState()
+        .setLauncherItemOnToolbar(launcherItemToolbarButtonId("recipe", id), false);
     } catch (error) {
       logError("Failed to persist recipe deletion", error);
       set({

--- a/src/store/recipeStore.ts
+++ b/src/store/recipeStore.ts
@@ -5,6 +5,7 @@ import type { PluginRecipeMetadataPatch } from "@shared/types/project";
 import { usePanelStore } from "./panelStore";
 import { useToolbarPreferencesStore } from "./toolbarPreferencesStore";
 import { launcherItemToolbarButtonId } from "@shared/types/toolbar";
+import { recipeToolbarSourceId } from "@/utils/recipeScope";
 import { preflightSpawnBatchLimit } from "./panelLimitStore";
 import { countPanelsTowardLimit } from "./slices/panelRegistry/panelCount";
 import { isMcpSpawnFocusSuppressed } from "./mcpSpawnFocusGuard";
@@ -253,6 +254,28 @@ export { MAX_TERMINALS_PER_RECIPE };
  * radius without blocking legitimate agent use.
  */
 export const MAX_AGENT_RECIPE_TERMINALS = 3;
+
+/**
+ * Drop a permanently-deleted recipe's toolbar pin (#12217).
+ *
+ * Guarded on the pin actually existing, because the setter writes through
+ * Zustand `persist` and every write ships this view's whole layout — including
+ * its side arrays, which reconcile last-writer-wins. An unconditional call on
+ * each delete would let a stale view overwrite a sibling's toolbar arrangement
+ * while "cleaning up" a pin that was never there.
+ */
+function clearRecipeToolbarPin(recipe: TerminalRecipe, currentProjectId: string | null): void {
+  const buttonId = launcherItemToolbarButtonId(
+    "recipe",
+    recipeToolbarSourceId(recipe, currentProjectId)
+  );
+  const toolbar = useToolbarPreferencesStore.getState();
+  const { pinnedButtons, leftButtons, rightButtons } = toolbar.layout;
+  const hasPin = buttonId in pinnedButtons;
+  const isPositioned = leftButtons.includes(buttonId) || rightButtons.includes(buttonId);
+  if (!hasPin && !isPositioned) return;
+  toolbar.setLauncherItemOnToolbar(buttonId, false);
+}
 
 let loadRecipesRequestId = 0;
 
@@ -727,17 +750,13 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
       } else {
         await projectClient.deleteRecipe(recipe.projectId!, id);
       }
-      // Only after the backend confirms, and only for a genuine delete. A
-      // recipe id is never reissued, so a pin left behind can't resurrect
-      // anything and the toolbar already renders nothing for it — but the key
-      // and its slot would otherwise outlive the recipe forever, and unlike a
-      // plugin unload (which also fires for an update) this is permanent
-      // (#12217). Rolled-back deletions fall through to the catch and keep the
-      // pin, which is why this sits after the await rather than beside the
-      // optimistic `set` above.
-      useToolbarPreferencesStore
-        .getState()
-        .setLauncherItemOnToolbar(launcherItemToolbarButtonId("recipe", id), false);
+      // Only after the backend confirms, and only for a genuine delete. The
+      // key and its toolbar slot would otherwise outlive the recipe forever,
+      // and unlike a plugin unload (which also fires for an update) this is
+      // permanent (#12217). Rolled-back deletions fall through to the catch and
+      // keep the pin, which is why this sits after the await rather than beside
+      // the optimistic `set` above.
+      clearRecipeToolbarPin(recipe, get().currentProjectId);
     } catch (error) {
       logError("Failed to persist recipe deletion", error);
       set({
@@ -834,6 +853,14 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
         } else {
           await projectClient.deleteRecipe(recipe.projectId!, recipeId);
         }
+        // The original is gone for good, so its pin goes with it — otherwise a
+        // recipe the user "moved into the repo" leaves a dead key and slot
+        // behind while the promoted copy, which has a different id, carries no
+        // pin (#12217). Deliberately clearing rather than transferring: the
+        // promoted recipe is project-scoped where the original may not have
+        // been, so the two are not the same toolbar identity and silently
+        // moving a pin across that boundary would be a guess.
+        clearRecipeToolbarPin(recipe, get().currentProjectId);
       } catch (error) {
         // In-repo write succeeded; roll back only the delete portion
         logError("Failed to delete original recipe", error);

--- a/src/store/toolbarPreferencesStore.ts
+++ b/src/store/toolbarPreferencesStore.ts
@@ -6,13 +6,14 @@ import type {
   ToolbarButtonId,
   AnyToolbarButtonId,
   LauncherPanelButtonId,
+  LauncherItemToolbarButtonId,
   PluginToolbarButtonId,
   ToolbarPinnedState,
 } from "@/../../shared/types/toolbar";
 // `@shared/...`, not the `@/../../shared/...` spelling the type-only import
 // above uses: that path is erased at compile time and never has to resolve at
 // runtime, but a value import does.
-import { LAUNCHER_PANEL_BUTTON_IDS } from "@shared/types/toolbar";
+import { LAUNCHER_PANEL_BUTTON_IDS, isLauncherItemToolbarButtonId } from "@shared/types/toolbar";
 import { createSafeJSONStorage } from "./persistence/safeStorage";
 import {
   mergeRecordByWriterDelta,
@@ -459,6 +460,26 @@ interface ToolbarPreferencesState extends ToolbarPreferences {
    */
   positionAgentButton: (buttonIds: AnyToolbarButtonId | AnyToolbarButtonId[]) => void;
   /**
+   * Pin or unpin a launcher row that owns no toolbar button id of its own —
+   * a plugin or user-defined agent, a panel kind outside the fixed four, or a
+   * recipe (#12217).
+   *
+   * Asymmetric on purpose, and differently from `setPanelButtonOnToolbar`.
+   * Pinning writes the explicit `true` that `isLauncherItemOnToolbar` reads and
+   * positions the button beside the launcher if it has no slot. Unpinning
+   * *deletes* the key and strips the id from both arrays rather than writing a
+   * `false`: for a launcher item absence and `false` are the same answer (only
+   * an explicit `true` grants a button), so a `false` would record nothing while
+   * leaving a key and a slot behind for a recipe that may be deleted tomorrow.
+   * `setPluginButtonPromoted` deletes for the same reason; it keeps its array
+   * entry only because the v9 migration deliberately preserves plugin ids a user
+   * dragged there, and no launcher item can have one that a pin didn't create.
+   *
+   * Nothing here ever writes a default — the row's absence from the map is what
+   * says "not pinned" (#11667).
+   */
+  setLauncherItemOnToolbar: (buttonId: LauncherItemToolbarButtonId, onToolbar: boolean) => void;
+  /**
    * Prune `pinnedButtons` entries for plugin buttons that are no longer in
    * the loaded plugin set. `pinnedButtons` is renderer-local persisted state
    * with no main-process access, so an uninstalled plugin's stale hide entry
@@ -467,8 +488,10 @@ interface ToolbarPreferencesState extends ToolbarPreferences {
    * canonical namespace (#9281) — built-in button IDs (`sidebar-toggle`,
    * `notification-center`, agent IDs like `claude`, etc.) contain only
    * hyphens or single tokens, never dots, so `key.includes(".")` cleanly
-   * separates the two. No-ops (returns state unchanged) when nothing is
-   * stale so the per-snapshot call doesn't churn the persist layer.
+   * separates the two. Launcher-item ids (#12217) are the one exception that
+   * can carry a dot without being a plugin button, and are excluded by prefix
+   * before the dot test decides. No-ops (returns state unchanged) when nothing
+   * is stale so the per-snapshot call doesn't churn the persist layer.
    *
    * Explicit promotions (`true`, #11304) are exempt — see the filter below.
    */
@@ -587,12 +610,53 @@ export const useToolbarPreferencesStore = create<ToolbarPreferencesState>()(
             layout: { ...state.layout, pinnedButtons: pinned },
           };
         }),
+      setLauncherItemOnToolbar: (buttonId, onToolbar) =>
+        set((state) => {
+          const current = state.layout.pinnedButtons[buttonId];
+          if (onToolbar) {
+            if (current === true) return state;
+            const pinned: ToolbarPinnedState = { ...state.layout.pinnedButtons, [buttonId]: true };
+            const isPositioned =
+              state.layout.leftButtons.includes(buttonId) ||
+              state.layout.rightButtons.includes(buttonId);
+            if (isPositioned) {
+              return { layout: { ...state.layout, pinnedButtons: pinned } };
+            }
+            return {
+              layout: {
+                ...state.layout,
+                pinnedButtons: pinned,
+                ...positionLauncherButton(state.layout, [buttonId]),
+              },
+            };
+          }
+
+          const leftButtons = state.layout.leftButtons.filter((id) => id !== buttonId);
+          const rightButtons = state.layout.rightButtons.filter((id) => id !== buttonId);
+          if (
+            current === undefined &&
+            leftButtons.length === state.layout.leftButtons.length &&
+            rightButtons.length === state.layout.rightButtons.length
+          ) {
+            return state;
+          }
+          const pinned: ToolbarPinnedState = { ...state.layout.pinnedButtons };
+          delete pinned[buttonId];
+          return { layout: { ...state.layout, pinnedButtons: pinned, leftButtons, rightButtons } };
+        }),
       sweepStalePluginPinnedButtons: (validIds) =>
         set((state) => {
           const validSet = new Set(validIds);
           const staleKeys = Object.keys(state.layout.pinnedButtons).filter(
             (key) =>
               key.includes(".") &&
+              // A launcher item's source id can itself be dotted — a
+              // plugin-contributed recipe's id is `publisher.name` — so the dot
+              // test alone reads one as a plugin button this snapshot has never
+              // heard of and drops the user's pin (#12217). The prefix is the
+              // discriminator; `key.includes(".")` stays the one for everything
+              // else.
+              !isLauncherItemToolbarButtonId(key) &&
               !validSet.has(key) &&
               // Never reclaim an explicit promotion (#11304). A `complete`
               // broadcast means "a plugin unloaded", not "a plugin was

--- a/src/store/userAgentRegistryStore.ts
+++ b/src/store/userAgentRegistryStore.ts
@@ -4,6 +4,8 @@ import type { UserAgentRegistry, UserAgentConfig } from "@shared/types";
 import { userAgentRegistryClient } from "@/clients/userAgentRegistryClient";
 import { setUserRegistry } from "../../shared/config/agentRegistry";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
+import { useToolbarPreferencesStore } from "./toolbarPreferencesStore";
+import { launcherItemToolbarButtonId } from "@shared/types/toolbar";
 
 interface UserAgentRegistryState {
   registry: UserAgentRegistry | null;
@@ -112,6 +114,25 @@ export const useUserAgentRegistryStore = create<UserAgentRegistryStore>()(
         if (result.success) {
           const registry = (await userAgentRegistryClient.get()) ?? {};
           set({ registry });
+          // A deleted user agent's toolbar pin goes with it (#12217). Not
+          // merely tidiness: `launcher:agent:{id}` carries no provenance, so a
+          // plugin agent that later registers the same id would inherit the pin
+          // the user made for this one. Only after the backend confirms — a
+          // failed removal keeps the agent, so its pin still describes
+          // something real.
+          const buttonId = launcherItemToolbarButtonId("agent", id);
+          const toolbar = useToolbarPreferencesStore.getState();
+          const { pinnedButtons, leftButtons, rightButtons } = toolbar.layout;
+          // Guarded on there being something to clear: the setter writes
+          // through `persist`, and every write ships this view's whole layout
+          // including its last-writer-wins side arrays.
+          if (
+            buttonId in pinnedButtons ||
+            leftButtons.includes(buttonId) ||
+            rightButtons.includes(buttonId)
+          ) {
+            toolbar.setLauncherItemOnToolbar(buttonId, false);
+          }
         } else {
           set({ error: result.error });
         }

--- a/src/utils/recipeScope.ts
+++ b/src/utils/recipeScope.ts
@@ -43,3 +43,36 @@ export function getRecipeScope(
   const name = resolveWorktreeName?.(recipe.worktreeId);
   return { label: name ? `Worktree: ${name}` : "Worktree", isGlobal: false };
 }
+
+/**
+ * The identity a recipe is persisted under when it is pinned to the toolbar
+ * (#12217).
+ *
+ * `recipe.id` alone is not it, because it is not globally unique. A legacy
+ * in-repo recipe carries no `id` in its file, so `ProjectIdentityFiles` derives
+ * `inrepo-<filename>` deterministically on every read — and `.daintree/recipes/`
+ * is tracked in git, so two unrelated projects that each hold a `dev.json` both
+ * produce `inrepo-dev`. Keying a pin on that alone makes pinning one project's
+ * recipe silently show, and launch, the other project's.
+ *
+ * So a project-scoped recipe is qualified by the project it belongs to, and a
+ * genuinely global one (a user's global recipe, or a plugin contribution whose
+ * id is already the globally-unique `publisher.name`) is not — qualifying those
+ * would strand the pin the moment the user switched projects.
+ *
+ * `getRecipeScope` already draws exactly that line, so this reads it rather than
+ * re-deriving the classification and risking the two disagreeing.
+ */
+export function recipeToolbarSourceId(
+  recipe: TerminalRecipe,
+  currentProjectId: string | null | undefined
+): string {
+  if (getRecipeScope(recipe).isGlobal) return recipe.id;
+  // `recipe.projectId` first: an in-repo recipe only gains one once
+  // ProjectFileStore mirrors it, and the ambient current project is the right
+  // answer until it does. The literal is a stable stand-in rather than a
+  // fallback that silently merges every project's recipes — a launcher with no
+  // project open has no recipes to pin in the first place.
+  const projectId = recipe.projectId ?? currentProjectId ?? "no-project";
+  return `${projectId}:${recipe.id}`;
+}


### PR DESCRIPTION
## Summary

The launcher used to offer a toolbar pin only on built-in agents and four hardcoded panel kinds. Plugin and user-defined agents, the Review and File Viewer rows, and every launch recipe were launchable but had no way to reach the toolbar. Every launcher row is now pinnable.

## How it works

The core addition is a new toolbar button id for the three previously uncovered classes: `launcher:{agent|panel|recipe}:{sourceId}`, declared in `shared/types/toolbar.ts`.

One prefix is used instead of three because `sweepStalePluginPinnedButtons` discriminates plugin ids with a bare `key.includes(".")` check, and a launcher item's own source id can itself contain a dot (a plugin-contributed recipe id looks like `publisher.name`). Built-in agents and the four fixed panel buttons keep the ids they already had, so no button type ends up split across two stores.

`launcherToolbarCatalog` is built directly from the launcher's own model, so the toolbar can never offer a button for a row the launcher itself isn't showing. Pinned entries render through `LauncherToolbarButton` via a dynamic `buttonRegistry` spread, and activate through `activateDockLaunchItem`, the launcher's own activation function, so a toolbar button behaves exactly like its launcher row, refusal toasts included.

Registry membership is the entire defense against stale entries: a pin whose source is gone finds no catalog entry and renders nothing. This is deliberately not an active sweep. The catalog is scoped per project and per worktree, so a recipe missing from the current view isn't necessarily deleted, and a sweep would erase a project A recipe pin when viewed from project B.

`setLauncherItemOnToolbar` writes an explicit `true` value plus a position on pin, and deletes both the key and the two array entries on unpin, keeping the `pinnedButtons` map sparse and never seeding a default into it (preserves the behavior fixed in #11667).

Settings, under Toolbar, gains a new "Pinned from the launcher" section listing everything pinned this way, so it can be found, reordered, and unpinned.

## Identity problem: recipe.id is not globally unique

A legacy in-repo recipe carries no id in its file, so `ProjectIdentityFiles` derives one of the form `inrepo-<filename>` on every read. Because `.daintree/recipes/` is tracked in git, two different projects that each hold a `dev.json` both produce the same derived id, `inrepo-dev`. Pinning one project's recipe could therefore show, and launch, a different project's recipe of the same name.

The fix: project-scoped recipes are now qualified by their project in the pin id, while genuinely global and plugin-contributed recipes stay unqualified so their pins survive a project switch. A deleted user-defined agent's pin is also cleared automatically. The `launcher:agent:{id}` toolbar id carries no provenance, so a plugin agent later registering that same id would otherwise silently inherit the old pin.

## Known limitation

Two agents that share the same id but come from different sources can't hold independent pins today. Fixing that would need provenance tracking added to the agent registries, which nothing currently requires. The one case actually reachable in practice, an agent being deleted, is handled.

## Verification

`npm run typecheck` exits 0. `npm run lint:ratchet` stays at its baseline (3049), nothing widened or suppressed. Prettier is clean on all changed files. 864 targeted tests across 25 files pass, covering the id codec, catalog membership and scoping, pin/unpin store semantics, delete-time cleanup sequencing and rollback, agent ordering, and the launcher, Settings, and Toolbar surfaces.

Reviewed across three Codex passes. Findings on id aliasing, pinned-agent ordering, lost-position repair, cross-view persist churn, Settings registry staleness, and several test weaknesses were fixed in the two follow-up commits.

Resolves #12217
