### PR TITLE
fix(plugins): reconcile a plugins folder that appears already populated

### DIFF
--- a/electron/services/plugin/ProjectPluginWatcher.ts
+++ b/electron/services/plugin/ProjectPluginWatcher.ts
@@ -578,6 +578,11 @@ export class ProjectPluginWatcher {
     }
     state.running = true;
     const generation = state.generation;
+    // Claimed inside the settle, but only discharged once the controller has
+    // actually been told. A reconcile that threw on the way there has not
+    // happened, so the catch puts the latch back rather than letting a folder
+    // that fingerprints as unchanged against its own seed go dark.
+    let forced = false;
 
     try {
       if (await this.deferForGitOperation(state, generation)) return;
@@ -647,7 +652,7 @@ export class ProjectPluginWatcher {
       // paths above both return and reschedule, so a flag spent before them
       // would be spent on a settle that never got as far as the controller. A
       // checkout — the case the latch exists for — takes the git-lock path.
-      const forced = state.forceReconcile;
+      forced = state.forceReconcile;
       state.forceReconcile = false;
 
       const rowByDir = new Map(scan.plugins.map((p) => [p.dirName, p] as const));
@@ -682,6 +687,7 @@ export class ProjectPluginWatcher {
       });
 
       await this.deps.reload(state.projectId, state.projectRoot, targets);
+      forced = false;
       if (this.isStale(state, generation)) return;
       this.commitFingerprints(state, nextFingerprints);
 
@@ -697,6 +703,7 @@ export class ProjectPluginWatcher {
         viewGenerationsAllocated: this.deps.viewGenerationsAllocated(),
       });
     } catch (err) {
+      if (forced && !state.stopped && !this.disposed) state.forceReconcile = true;
       logger.warn("Project plugin hot reload failed", {
         projectId: state.projectId,
         error: formatErrorMessage(err, "reload failed"),

--- a/electron/services/plugin/ProjectPluginWatcher.ts
+++ b/electron/services/plugin/ProjectPluginWatcher.ts
@@ -113,6 +113,13 @@ interface WatchState {
   changedDirs: Set<string>;
   /** True when the burst touched the plugins root itself and cannot be attributed. */
   reloadAll: boolean;
+  /**
+   * The plugins folder appeared under the sentinel, so the next settle has to
+   * reach the controller even though the arm it triggered just seeded
+   * fingerprints matching what is on disk. Without it, a folder that arrives
+   * already populated fingerprints as unchanged and is never loaded.
+   */
+  forceReconcile: boolean;
   invalidRetries: number;
   /** The unreadable set the current retry budget belongs to. */
   invalidRetryKey: string;
@@ -302,6 +309,7 @@ export class ProjectPluginWatcher {
       timer: null,
       changedDirs: new Set(),
       reloadAll: false,
+      forceReconcile: false,
       invalidRetries: 0,
       invalidRetryKey: "",
       gitLockWaitStartedAt: null,
@@ -483,6 +491,10 @@ export class ProjectPluginWatcher {
         if (this.isStale(state, generation)) return;
         if (!existsSync(state.pluginsRoot)) return;
         this.disarmSentinel(state);
+        // Latched before the arm rather than after it: `doArm` subscribes
+        // part-way through, and an event landing on that fresh subscription
+        // can reach a settle before the continuation below runs.
+        state.forceReconcile = true;
         void this.arm(state).then(() => {
           // The folder appeared with content already in it, so reconcile once.
           if (!this.isStale(state, generation)) {
@@ -631,6 +643,12 @@ export class ProjectPluginWatcher {
       );
       state.reloadAll = false;
       state.changedDirs.clear();
+      // Claimed here rather than on entry: the git-lock and unreadable-manifest
+      // paths above both return and reschedule, so a flag spent before them
+      // would be spent on a settle that never got as far as the controller. A
+      // checkout — the case the latch exists for — takes the git-lock path.
+      const forced = state.forceReconcile;
+      state.forceReconcile = false;
 
       const rowByDir = new Map(scan.plugins.map((p) => [p.dirName, p] as const));
       const changed = new Set<string>();
@@ -648,8 +666,10 @@ export class ProjectPluginWatcher {
 
       // Nothing the host loads actually differs. The commonest cause is
       // FSEvents replaying writes that predate the subscription; a touch or a
-      // branch switch back to identical content lands here too.
-      if (changed.size === 0) {
+      // branch switch back to identical content lands here too. A folder that
+      // just appeared is the exception: it fingerprints as unchanged against
+      // its own seed, and nothing has told the controller it exists.
+      if (changed.size === 0 && !forced) {
         this.commitFingerprints(state, nextFingerprints);
         return;
       }

--- a/electron/services/plugin/__tests__/ProjectPluginWatcher.test.ts
+++ b/electron/services/plugin/__tests__/ProjectPluginWatcher.test.ts
@@ -450,30 +450,36 @@ describe("ProjectPluginWatcher", () => {
     expect(await waitFor(() => reload.mock.calls.length > 0)).toBe(true);
     // Nothing was loaded before, so nothing is named. Asking the controller to
     // rescan at all is what loads the plugin that arrived with the folder.
-    expect((reload.mock.calls[0] as [string, string, string[]])[2]).toEqual([]);
+    // Exactly once: the latch is spent by the settle that discharges it, and a
+    // replayed burst over identical bytes must not reconcile a second time.
+    await settleFor(200);
+    expect(reload.mock.calls).toEqual([[PROJECT_ID, root, []]]);
+    expect(watcher.isWatching(PROJECT_ID)).toBe(true);
   });
 
-  it("holds an appearing folder's reconcile behind .git/index.lock", async () => {
+  it("carries an appearing folder's reconcile across a git-lock deferral", async () => {
     const root = await fsp.mkdtemp(path.join(os.tmpdir(), `dt-ppw-appears-lock-${randomUUID()}-`));
     roots.push(root);
     await fsp.mkdir(path.join(root, ".daintree"), { recursive: true });
     const gitDir = path.join(root, ".git");
     await fsp.mkdir(gitDir, { recursive: true });
-    const { watcher, reload, loaded } = makeWatcher({ gitDir });
+    const { watcher, reload, loaded } = makeWatcher({
+      gitDir,
+      timings: { ...FAST, gitLockMaxDeferMs: 120 },
+    });
     loaded.clear();
     await watcher.ensure(PROJECT_ID, root);
 
-    // The deferral reschedules the settle, so the appearance has to survive
-    // however many polls the checkout takes rather than being spent on the
-    // first one.
+    // Held for the whole appearance, so the first settle cannot do anything
+    // but defer and reschedule — the ceiling is what eventually releases it.
+    // The reconcile has to survive that round trip instead of being spent on a
+    // settle that never reached the controller, which is the case a checkout
+    // hits every time.
     await fsp.writeFile(path.join(gitDir, "index.lock"), "");
     await movePopulatedPluginsFolderInto(root);
-    await settleFor(400);
-    expect(reload).not.toHaveBeenCalled();
 
-    await fsp.rm(path.join(gitDir, "index.lock"));
     expect(await waitFor(() => reload.mock.calls.length > 0)).toBe(true);
-    expect((reload.mock.calls[0] as [string, string, string[]])[2]).toEqual([]);
+    expect(reload.mock.calls).toEqual([[PROJECT_ID, root, []]]);
   });
 
   it("registers an app-quit disposer", async () => {

--- a/electron/services/plugin/__tests__/ProjectPluginWatcher.test.ts
+++ b/electron/services/plugin/__tests__/ProjectPluginWatcher.test.ts
@@ -65,6 +65,21 @@ async function makeProject(opts: { withGitDir?: boolean } = {}): Promise<{
   return { root, pluginDir, gitDir };
 }
 
+/**
+ * Build a complete plugin outside the project, then move the whole folder into
+ * place in one rename. That is the shape a checkout presents: the plugins root
+ * exists and is already populated in the same instant.
+ */
+async function movePopulatedPluginsFolderInto(root: string): Promise<void> {
+  const staging = await fsp.mkdtemp(path.join(os.tmpdir(), `dt-ppw-staged-${randomUUID()}-`));
+  roots.push(staging);
+  const pluginDir = path.join(staging, "plugins", "acme.hello");
+  await fsp.mkdir(path.join(pluginDir, "dist"), { recursive: true });
+  await fsp.writeFile(path.join(pluginDir, "plugin.json"), manifestJson("acme.hello"));
+  await fsp.writeFile(path.join(pluginDir, "dist", "index.js"), "export function activate() {}\n");
+  await fsp.rename(path.join(staging, "plugins"), path.join(root, ".daintree", "plugins"));
+}
+
 function makeWatcher(
   overrides: Partial<ProjectPluginWatcherDeps> & { gitDir?: string | null } = {}
 ): {
@@ -416,6 +431,49 @@ describe("ProjectPluginWatcher", () => {
     // The sentinel may already be arming when the explicit ensure() lands, and
     // the subscribe itself is async either way.
     expect(await waitFor(() => watcher.isWatching(PROJECT_ID))).toBe(true);
+  });
+
+  it("reconciles a plugin folder that appears already complete", async () => {
+    const root = await fsp.mkdtemp(path.join(os.tmpdir(), `dt-ppw-appears-${randomUUID()}-`));
+    roots.push(root);
+    await fsp.mkdir(path.join(root, ".daintree"), { recursive: true });
+    const { watcher, reload, loaded } = makeWatcher();
+    // Nothing of this project's has ever been loaded; the folder is brand new.
+    loaded.clear();
+    await watcher.ensure(PROJECT_ID, root);
+    expect(watcher.isWatching(PROJECT_ID)).toBe(false);
+
+    // No second ensure(): the sentinel is what has to notice this, and the arm
+    // it triggers seeds fingerprints that already match the folder's contents.
+    await movePopulatedPluginsFolderInto(root);
+
+    expect(await waitFor(() => reload.mock.calls.length > 0)).toBe(true);
+    // Nothing was loaded before, so nothing is named. Asking the controller to
+    // rescan at all is what loads the plugin that arrived with the folder.
+    expect((reload.mock.calls[0] as [string, string, string[]])[2]).toEqual([]);
+  });
+
+  it("holds an appearing folder's reconcile behind .git/index.lock", async () => {
+    const root = await fsp.mkdtemp(path.join(os.tmpdir(), `dt-ppw-appears-lock-${randomUUID()}-`));
+    roots.push(root);
+    await fsp.mkdir(path.join(root, ".daintree"), { recursive: true });
+    const gitDir = path.join(root, ".git");
+    await fsp.mkdir(gitDir, { recursive: true });
+    const { watcher, reload, loaded } = makeWatcher({ gitDir });
+    loaded.clear();
+    await watcher.ensure(PROJECT_ID, root);
+
+    // The deferral reschedules the settle, so the appearance has to survive
+    // however many polls the checkout takes rather than being spent on the
+    // first one.
+    await fsp.writeFile(path.join(gitDir, "index.lock"), "");
+    await movePopulatedPluginsFolderInto(root);
+    await settleFor(400);
+    expect(reload).not.toHaveBeenCalled();
+
+    await fsp.rm(path.join(gitDir, "index.lock"));
+    expect(await waitFor(() => reload.mock.calls.length > 0)).toBe(true);
+    expect((reload.mock.calls[0] as [string, string, string[]])[2]).toEqual([]);
   });
 
   it("registers an app-quit disposer", async () => {


### PR DESCRIPTION
## Summary

- If `.daintree/plugins/` doesn't exist yet, `ProjectPluginWatcher` watches the parent directory with a plain `fs.watch` sentinel. When the folder appears, the sentinel's callback calls `arm()`, which seeds the fingerprint map from a fresh `discover()` scan, then schedules a `settle()`. That `settle()` re-fingerprints, diffs against the baseline it just seeded, sees no difference, and returns before calling `deps.reload()`.
- So a folder that arrives already populated (a `git checkout` that adds it, or an `mv` of a built folder) gets watched but never loaded, until the next project switch. Adding plugins one at a time after the folder already exists works fine, since those arrive as ordinary watcher events.
- The fix adds a one-shot `forceReconcile` latch on `WatchState`, so a folder appearance always reconciles with the controller regardless of whether the fingerprint diff finds a change.

Resolves #12233

## Changes

- `armSentinel()`'s `fs.watch` callback sets the latch synchronously, before `arm()` runs. `doArm` subscribes part-way through, and an event landing on that fresh subscription could otherwise reach a settle before the post-arm continuation runs.
- `settle()` claims the latch after the git-lock and unreadable-manifest reschedule paths, but before the async fingerprint loop. Both of those paths return and reschedule, so claiming the latch earlier would spend it on a settle that never reached the controller, and a git checkout (the case the latch exists for) always takes the git-lock path.
- The no-change early return changes from `changed.size === 0` to `changed.size === 0 && !forced`, so a forced settle falls through to `deps.reload()` with an empty target list. That's correct: `ProjectPluginController.reloadChanged` skips its unload loop but still calls `doOpen()`, so an empty list means rescan-only, and that rescan is what loads the new plugins.
- If the reload throws, the catch block puts the latch back, since a reconcile the controller never received hasn't actually happened. Same posture the class already takes with `commitFingerprints`, which is deliberately skipped on a failed reload so the change retries.

## Testing

Two tests added to `ProjectPluginWatcher.test.ts`, using real temp directories and real watcher subscriptions to match the existing house style:

- `reconciles a plugin folder that appears already complete`: builds a plugin in a staging directory, then moves the whole folder into place with a single rename, matching the shape a git checkout presents. Asserts the controller is asked to rescan exactly once with an empty target list.
- `carries an appearing folder's reconcile across a git-lock deferral`: holds `.git/index.lock` for the entire folder appearance with `gitLockMaxDeferMs` set to 120, so the settle provably goes through at least one defer-and-reschedule cycle before the ceiling releases it.

Both were verified load-bearing: reverting just the `&& !forced` guard fails exactly these two tests and passes the other 23.

Local verification:

- `ProjectPluginWatcher.test.ts`: 25 passed
- `projectPluginHotReload.integration.test.ts`: 5 passed
- `ProjectPluginController.test.ts`: 35 passed
- `projectPluginVisibility.test.ts`: 22 passed
- `prettier --check` and `eslint` on both changed files: clean, exit 0

## Notes

PR #12219, for issue #12212, carries the same `forceReconcile` mechanism, bundled together with unrelated sentinelPath-migration and trust-gate work. This PR is the narrow standalone fix for #12233. Whichever of the two lands second will need a small conflict resolution in `settle()`.

Deliberately out of scope here:

- `rearmAfterError()` re-arms with no reconcile follow-up at all. That's a distinct gap, with a different repro.
- The sentinel can't see `.daintree/plugins` created two levels down when `.daintree` itself doesn't exist yet. That's #12212's separate sentinelPath fix.
