### PR TITLE
fix(plugin): scope worktree storage to the bound project's worktree

### DIFF
--- a/docs/plugins/project-local.md
+++ b/docs/plugins/project-local.md
@@ -197,7 +197,7 @@ Installed and builtin plugins keep their existing ambient behaviour — they hav
 
 In-repository files are named by the **manifest id**, never by the instance key: the instance key embeds this machine's project id, and writing that into a tracked filename would commit one developer's local identity into everyone's checkout. The project root already provides the isolation. Files under the user's own directory are keyed by the **instance key**, so two projects shipping the same manifest id keep separate state.
 
-The project root a bound plugin writes to is the one from its binding, not the focused project. The `"worktree"` storage scope is the exception today — it still resolves the app-global active worktree, so it can follow the user's focus rather than your project.
+The project root a bound plugin writes to is the one from its binding, not the focused project. The `"worktree"` storage scope follows the same rule: it resolves your bound project's own current worktree, and fails closed — read `undefined`, write throws — when that project has none, rather than falling back to whichever worktree the app considers active. An installed or builtin plugin, having no project of its own, still resolves the app-global active worktree.
 
 The `${worktree}` and `${project}` tokens in `scopes.fs.allowedPaths` expand against the bound project's own worktrees, so a project plugin's containment roots do not move when the user switches projects. An installed or builtin plugin keeps expanding them ambiently — it has no project of its own.
 

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -948,11 +948,14 @@ export class PluginService {
 
     this.storage = new PluginStorageManager({
       getPluginsRoot: () => this.pluginsRoot,
-      // Resolve the active worktree's path the same way host.getActiveWorktree
-      // does — first isCurrent snapshot — so "worktree"-scoped storage tracks the
-      // user's active worktree. Returns undefined when none is active or the
-      // workspace client isn't wired yet, which the storage API treats as
-      // "no target" (read → undefined, write → throw).
+      // The UNBOUND fallback only: an installed or builtin plugin has no project
+      // of its own, so the app-global active worktree — first isCurrent snapshot,
+      // the same rule host.getActiveWorktree uses — is the only thing its
+      // "worktree" scope can mean. A bound host never reaches this; it resolves
+      // its own project's current worktree in PluginHostFactory (#12229).
+      // Returns undefined when none is active or the workspace client isn't
+      // wired yet, which the storage API treats as "no target" (read →
+      // undefined, write → throw).
       getActiveWorktreePath: async () => {
         const snapshots = await this.fetchAllWorktreeSnapshots();
         return snapshots.find((s) => s.isCurrent === true)?.path;

--- a/electron/services/plugin/PluginHostFactory.ts
+++ b/electron/services/plugin/PluginHostFactory.ts
@@ -431,7 +431,8 @@ export function createHost(
    * Not every worktree-derived surface routes through here — worktree-scoped
    * *storage* resolves its target through `resolveBoundWorktreeTarget`, which
    * reads the projected `getWorktreesResult` so it can name one worktree rather
-   * than flatten the set (#12229).
+   * than flatten the set (#12229). Unbound storage skips both and stays on the
+   * manager's own app-global lookup.
    */
   const fetchWorktreeSnapshots = async (): Promise<WorktreeSnapshot[]> => {
     const result = await fetchWorktreeSnapshotsResult();
@@ -572,13 +573,14 @@ export function createHost(
    * lifetime; the active worktree is not — the user switches it while the host
    * stays alive — so this resolves per call rather than once at construction.
    *
-   * Deliberately reads `getWorktreesResult`, the same source `getActiveWorktree`
-   * projects from, so a plugin's storage target and its active-worktree read can
-   * never name different worktrees. Every unavailable reason (including a
-   * projection that threw, and an unload caught by that method's own liveness
-   * re-checks) collapses to `""`, which the manager rejects: for a filesystem
-   * target, failing closed beats salvaging a path out of a snapshot set the
-   * binding boundary already called malformed.
+   * Deliberately reads `getWorktreesResult`, the same project-filtered source
+   * `getActiveWorktree` projects from, so the two agree about which worktree is
+   * active at the moment either resolves. (Only at that moment: calls straddling
+   * a switch see different worktrees, which is the point of resolving per call.)
+   * Every unavailable reason (including a projection that threw, and an unload
+   * caught by that method's own liveness re-checks) collapses to `""`, which the
+   * manager rejects: for a filesystem target, failing closed beats salvaging a
+   * path out of a snapshot set the binding boundary already called malformed.
    *
    * Unbound returns `undefined` so the manager keeps its app-global lookup —
    * an installed or builtin plugin has no project of its own, so the active
@@ -588,7 +590,13 @@ export function createHost(
     if (boundProjectId === null) return undefined;
     const result = await getWorktreesResult();
     if (result.status !== "ok") return "";
-    return result.worktrees.find((w) => w.isCurrent)?.path ?? "";
+    const active = result.worktrees.find((w) => w.isCurrent)?.path;
+    // The projection copies `path` straight off the workspace host's snapshot
+    // without validating it, and this is the one consumer that turns it into a
+    // filesystem root. A non-string would throw out of `path.join`, turning
+    // `storage.get`'s documented quiet "no target" into a rejection; a relative
+    // one would resolve against Electron's cwd, outside every project.
+    return typeof active === "string" && path.isAbsolute(active) ? active : "";
   };
 
   /**

--- a/electron/services/plugin/PluginHostFactory.ts
+++ b/electron/services/plugin/PluginHostFactory.ts
@@ -21,7 +21,11 @@ import type { PluginPanelLifecycleBroker } from "./PluginPanelLifecycleBroker.js
 import type { PluginRendererDispatcher } from "./PluginRendererDispatcher.js";
 import type { PluginUIPromptDispatcher } from "./PluginUIPromptDispatcher.js";
 import { assertSettingsKey, type PluginSettingsManager } from "./PluginSettingsManager.js";
-import { assertStorageKey, type PluginStorageManager } from "./PluginStorageManager.js";
+import {
+  assertStorageKey,
+  type ExplicitStorageTarget,
+  type PluginStorageManager,
+} from "./PluginStorageManager.js";
 import { createListenerFailureState, invokeTrackedListener } from "./pluginCallbackUtils.js";
 import { isChannelSchema } from "./PluginChannelRegistry.js";
 
@@ -425,9 +429,9 @@ export function createHost(
    * default spawn cwd falls back rather than pointing into another project.
    *
    * Not every worktree-derived surface routes through here — worktree-scoped
-   * *storage* resolves its target through `PluginStorageManager`'s own active-
-   * worktree callback, which is still ambient for a bound host. That is a
-   * separate pre-existing gap, not something this read covers.
+   * *storage* resolves its target through `resolveBoundWorktreeTarget`, which
+   * reads the projected `getWorktreesResult` so it can name one worktree rather
+   * than flatten the set (#12229).
    */
   const fetchWorktreeSnapshots = async (): Promise<WorktreeSnapshot[]> => {
     const result = await fetchWorktreeSnapshotsResult();
@@ -560,6 +564,42 @@ export function createHost(
     projectId: boundProjectId,
     projectRoot: boundProjectRoot,
   });
+
+  /**
+   * The worktree a `"worktree"`-scoped storage call targets (#12229).
+   *
+   * The project-root counterpart, `boundScopeRoot`, is fixed for the host's
+   * lifetime; the active worktree is not — the user switches it while the host
+   * stays alive — so this resolves per call rather than once at construction.
+   *
+   * Deliberately reads `getWorktreesResult`, the same source `getActiveWorktree`
+   * projects from, so a plugin's storage target and its active-worktree read can
+   * never name different worktrees. Every unavailable reason (including a
+   * projection that threw, and an unload caught by that method's own liveness
+   * re-checks) collapses to `""`, which the manager rejects: for a filesystem
+   * target, failing closed beats salvaging a path out of a snapshot set the
+   * binding boundary already called malformed.
+   *
+   * Unbound returns `undefined` so the manager keeps its app-global lookup —
+   * an installed or builtin plugin has no project of its own, so the active
+   * worktree is the only thing its worktree scope can mean.
+   */
+  const resolveBoundWorktreeTarget = async (): Promise<string | undefined> => {
+    if (boundProjectId === null) return undefined;
+    const result = await getWorktreesResult();
+    if (result.status !== "ok") return "";
+    return result.worktrees.find((w) => w.isCurrent)?.path ?? "";
+  };
+
+  /**
+   * The target a storage call resolves against. Only `"worktree"` scope pays for
+   * the project-filtered snapshot read — `"user"` and `"project"` need nothing
+   * beyond the static root, and they are the hot path.
+   */
+  const storageTargetFor = async (scope: PluginStorageScope): Promise<ExplicitStorageTarget> =>
+    scope === "worktree"
+      ? { projectRoot: boundScopeRoot, worktreePath: await resolveBoundWorktreeTarget() }
+      : { projectRoot: boundScopeRoot };
 
   const host: PluginHostApi = {
     get pluginId() {
@@ -1525,9 +1565,11 @@ export function createHost(
         scope: PluginStorageScope = "user"
       ): Promise<T | undefined> => {
         assertStorageKey(pluginId, "get", key);
-        const filePath = await deps.storage.resolveStorageFilePath(pluginId, scope, {
-          projectRoot: boundScopeRoot,
-        });
+        const filePath = await deps.storage.resolveStorageFilePath(
+          pluginId,
+          scope,
+          await storageTargetFor(scope)
+        );
         // No active project/worktree (or unset key): read resolves to undefined
         // rather than throwing, matching the "unset key" return.
         if (!filePath || !isBound()) return undefined;
@@ -1545,9 +1587,11 @@ export function createHost(
           );
         }
         deps.storage.assertStorageSerializable(pluginId, key, value);
-        const filePath = await deps.storage.resolveStorageFilePath(pluginId, scope, {
-          projectRoot: boundScopeRoot,
-        });
+        const filePath = await deps.storage.resolveStorageFilePath(
+          pluginId,
+          scope,
+          await storageTargetFor(scope)
+        );
         // Re-check liveness after the async resolve so a racing unloadPlugin()
         // doesn't write into a torn-down plugin's storage file.
         if (!isBound()) return;
@@ -1562,9 +1606,11 @@ export function createHost(
       },
       delete: async (key: string, scope: PluginStorageScope = "user"): Promise<void> => {
         assertStorageKey(pluginId, "delete", key);
-        const filePath = await deps.storage.resolveStorageFilePath(pluginId, scope, {
-          projectRoot: boundScopeRoot,
-        });
+        const filePath = await deps.storage.resolveStorageFilePath(
+          pluginId,
+          scope,
+          await storageTargetFor(scope)
+        );
         // Missing target or unloaded plugin: a delete is a no-op rather than a
         // throw (matching the "already absent" return of the store).
         if (!filePath || !isBound()) return;

--- a/electron/services/plugin/PluginStorageManager.ts
+++ b/electron/services/plugin/PluginStorageManager.ts
@@ -42,9 +42,11 @@ interface PluginStorageManagerDeps {
 
 /**
  * The project / worktree a storage call belongs to, when the caller knows it —
- * a project-bound plugin host pins its own target here so a project or worktree
- * switch can't move its file. An absent or `null` member means unbound, and that
- * scope falls back to the app-global active project / worktree.
+ * a project-bound plugin host pins its own target here so another project's
+ * focus can't move its file. Within the binding a worktree switch still moves
+ * the `"worktree"`-scoped file, which is what that scope means. An absent or
+ * `null` member means unbound, and that scope falls back to the app-global
+ * active project / worktree.
  */
 export interface ExplicitStorageTarget {
   readonly projectRoot?: string | null;

--- a/electron/services/plugin/__tests__/confusedDeputy.test.ts
+++ b/electron/services/plugin/__tests__/confusedDeputy.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Mock } from "vitest";
 import fs from "fs/promises";
 import os from "os";
 import path from "path";
@@ -178,7 +179,7 @@ let storageManager: PluginStorageManager;
 let ambientWorktreeFetch: ReturnType<typeof vi.fn>;
 let projectWorktreeFetch: ReturnType<typeof vi.fn>;
 /** The app-global worktree lookup storage falls back to for an UNBOUND host. */
-let ambientWorktreePathLookup: ReturnType<typeof vi.fn>;
+let ambientWorktreePathLookup: Mock<() => Promise<string | undefined>>;
 
 /** Assert a promise rejected with the frozen `PROJECT_VIEW_UNAVAILABLE` AppError. */
 async function expectProjectViewUnavailable(promise: Promise<unknown>): Promise<void> {
@@ -306,7 +307,9 @@ beforeEach(async () => {
   });
   // The ambient worktree — inside B, the focused project. A spy, so a bound
   // host reaching for it at all is a test failure rather than a silent leak.
-  ambientWorktreePathLookup = vi.fn(async () => path.join(projectRootOf(PROJECT_B), "main"));
+  ambientWorktreePathLookup = vi.fn<() => Promise<string | undefined>>(async () =>
+    path.join(projectRootOf(PROJECT_B), "main")
+  );
   storageManager = new PluginStorageManager({
     getPluginsRoot: () => path.join(tmpDir, "user-plugins", "plugins"),
     getActiveWorktreePath: ambientWorktreePathLookup,

--- a/electron/services/plugin/__tests__/confusedDeputy.test.ts
+++ b/electron/services/plugin/__tests__/confusedDeputy.test.ts
@@ -164,6 +164,7 @@ import { PluginService } from "../../PluginService.js";
 import { PLUGIN_PROCESS_STREAM_CHANNEL } from "../../../../shared/types/ipc/pluginProcess.js";
 import type { ProcessStreamSink } from "../PluginProcessManager.js";
 import type { LoadedPlugin } from "../PluginServiceTypes.js";
+import type { WorktreeSnapshot } from "../../../../shared/types/workspace-host.js";
 
 const PLUGIN_ID = "acme.project-plugin";
 
@@ -176,6 +177,8 @@ let settingsManager: PluginSettingsManager;
 let storageManager: PluginStorageManager;
 let ambientWorktreeFetch: ReturnType<typeof vi.fn>;
 let projectWorktreeFetch: ReturnType<typeof vi.fn>;
+/** The app-global worktree lookup storage falls back to for an UNBOUND host. */
+let ambientWorktreePathLookup: ReturnType<typeof vi.fn>;
 
 /** Assert a promise rejected with the frozen `PROJECT_VIEW_UNAVAILABLE` AppError. */
 async function expectProjectViewUnavailable(promise: Promise<unknown>): Promise<void> {
@@ -290,10 +293,12 @@ beforeEach(async () => {
     getPluginsRoot: () => path.join(tmpDir, "user-plugins", "plugins"),
     getManifest: () => undefined,
   });
+  // The ambient worktree — inside B, the focused project. A spy, so a bound
+  // host reaching for it at all is a test failure rather than a silent leak.
+  ambientWorktreePathLookup = vi.fn(async () => path.join(projectRootOf(PROJECT_B), "main"));
   storageManager = new PluginStorageManager({
     getPluginsRoot: () => path.join(tmpDir, "user-plugins", "plugins"),
-    // The ambient worktree — inside B, the focused project.
-    getActiveWorktreePath: async () => path.join(projectRootOf(PROJECT_B), "main"),
+    getActiveWorktreePath: ambientWorktreePathLookup,
   });
   processStreamSink = null;
 });
@@ -544,6 +549,35 @@ describe("settings and storage roots", () => {
     }
   }
 
+  /** Where a worktree-scoped storage write lands for a given worktree root. */
+  function storageFileIn(root: string): string {
+    return path.join(root, ".daintree", "plugin-storage", `${PLUGIN_ID}.json`);
+  }
+
+  function worktreeSnapshot(root: string, isCurrent = false): WorktreeSnapshot {
+    return {
+      id: root,
+      worktreeId: `wt-${path.basename(root)}`,
+      path: root,
+      name: path.basename(root),
+      isCurrent,
+    };
+  }
+
+  /** A worktree inside A, the BOUND project — never the focused one. */
+  const inA = (name: string): string => path.join(projectRootOf(PROJECT_A), name);
+  /** The ambient worktree, inside focused B — where the bug used to write. */
+  const ambientB = (): string => path.join(projectRootOf(PROJECT_B), "main");
+
+  /** `hostBoundTo`, but keeping the deps so a test can unload the plugin. */
+  function hostAndDepsBoundTo(binding: PluginHostBinding): {
+    host: PluginHostApi;
+    deps: PluginHostFactoryDeps;
+  } {
+    const deps = makeHostDeps();
+    return { host: createHost(deps, PLUGIN_ID, binding).host, deps };
+  }
+
   it("writes a project-scoped setting into A's tree while B is the active project", async () => {
     const manager = settingsManager;
     const filePath = manager.resolveSettingsFilePath(
@@ -639,6 +673,151 @@ describe("settings and storage roots", () => {
     expect(await exists(path.join(projectRootOf(PROJECT_B), ".daintree"))).toBe(false);
   });
 
+  /*
+   * #12229 — the worktree half of the same confused deputy. `createHost` handed
+   * both resolvers a project root but never a worktree, so worktree-scoped
+   * storage fell through to `PluginStorageManager`'s app-global active-worktree
+   * callback: a host bound to A read and overwrote whichever worktree the app
+   * considered current, which is one of focused B's.
+   */
+  it("writes worktree-scoped storage into A's current worktree, never focused B's", async () => {
+    const host = hostBoundTo({ projectId: PROJECT_A, projectRoot: projectRootOf(PROJECT_A) });
+    // Mocks are configured AFTER the host: hostBoundTo calls makeHostDeps(),
+    // which reassigns both fetch spies.
+    projectWorktreeFetch.mockResolvedValue({
+      status: "ok",
+      projectId: PROJECT_A,
+      snapshots: [worktreeSnapshot(inA("main")), worktreeSnapshot(inA("feature-x"), true)],
+    });
+
+    await host.storage.set("cursor", 7, "worktree");
+
+    expect(JSON.parse(await fs.readFile(storageFileIn(inA("feature-x")), "utf8"))).toEqual({
+      cursor: 7,
+    });
+    expect(await host.storage.get("cursor", "worktree")).toBe(7);
+
+    // Nothing anywhere near B, and the ambient lookup was never reached for it.
+    expect(await exists(path.join(projectRootOf(PROJECT_B), ".daintree"))).toBe(false);
+    expect(await exists(storageFileIn(ambientB()))).toBe(false);
+    expect(ambientWorktreePathLookup).not.toHaveBeenCalled();
+    expect(ambientWorktreeFetch).not.toHaveBeenCalled();
+
+    await host.storage.delete("cursor", "worktree");
+    expect(JSON.parse(await fs.readFile(storageFileIn(inA("feature-x")), "utf8"))).toEqual({});
+  });
+
+  it("re-resolves A's current worktree on every call, following a mid-session switch", async () => {
+    // The project root is fixed for the host's lifetime; the active worktree is
+    // not — which is why the target resolves per call rather than at construction.
+    const host = hostBoundTo({ projectId: PROJECT_A, projectRoot: projectRootOf(PROJECT_A) });
+    projectWorktreeFetch.mockResolvedValue({
+      status: "ok",
+      projectId: PROJECT_A,
+      snapshots: [worktreeSnapshot(inA("main"), true), worktreeSnapshot(inA("feature-x"))],
+    });
+
+    await host.storage.set("cursor", 1, "worktree");
+
+    projectWorktreeFetch.mockResolvedValue({
+      status: "ok",
+      projectId: PROJECT_A,
+      snapshots: [worktreeSnapshot(inA("main")), worktreeSnapshot(inA("feature-x"), true)],
+    });
+
+    await host.storage.set("cursor", 2, "worktree");
+
+    expect(JSON.parse(await fs.readFile(storageFileIn(inA("main")), "utf8"))).toEqual({
+      cursor: 1,
+    });
+    expect(JSON.parse(await fs.readFile(storageFileIn(inA("feature-x")), "utf8"))).toEqual({
+      cursor: 2,
+    });
+    expect(await host.storage.get("cursor", "worktree")).toBe(2);
+  });
+
+  it("fails closed when A has no current worktree rather than falling back to B", async () => {
+    const host = hostBoundTo({ projectId: PROJECT_A, projectRoot: projectRootOf(PROJECT_A) });
+    projectWorktreeFetch.mockResolvedValue({
+      status: "ok",
+      projectId: PROJECT_A,
+      snapshots: [worktreeSnapshot(inA("main")), worktreeSnapshot(inA("feature-x"))],
+    });
+
+    await expect(host.storage.set("cursor", 7, "worktree")).rejects.toThrow(
+      'no active worktree — "worktree" scope has no target'
+    );
+    // Read and delete degrade quietly, matching the unset-key / already-absent
+    // returns the other scopes give when they have no target.
+    expect(await host.storage.get("cursor", "worktree")).toBeUndefined();
+    await expect(host.storage.delete("cursor", "worktree")).resolves.toBeUndefined();
+
+    expect(await exists(path.join(projectRootOf(PROJECT_A), ".daintree"))).toBe(false);
+    expect(await exists(path.join(projectRootOf(PROJECT_B), ".daintree"))).toBe(false);
+    expect(ambientWorktreePathLookup).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the worktree read answers for B through an A-bound host", async () => {
+    // The deputy wearing #12174's shape on the persistence side: a dependency
+    // answering with B's project id must not be relabelled as A's target.
+    const host = hostBoundTo({ projectId: PROJECT_A, projectRoot: projectRootOf(PROJECT_A) });
+    projectWorktreeFetch.mockResolvedValue({
+      status: "ok",
+      projectId: PROJECT_B,
+      snapshots: [worktreeSnapshot(ambientB(), true)],
+    });
+
+    await expect(host.storage.set("cursor", 7, "worktree")).rejects.toThrow(
+      'no active worktree — "worktree" scope has no target'
+    );
+
+    expect(await exists(path.join(projectRootOf(PROJECT_B), ".daintree"))).toBe(false);
+    expect(await exists(path.join(projectRootOf(PROJECT_A), ".daintree"))).toBe(false);
+  });
+
+  it("keeps an UNBOUND host's worktree-scoped storage on the ambient worktree", async () => {
+    // The other half of the fix: an installed or builtin plugin has no project
+    // of its own, so the app-global active worktree stays the only thing its
+    // worktree scope can mean. Failing this one closed would break every
+    // unbound plugin's storage.
+    const host = hostBoundTo(UNBOUND_PLUGIN_HOST_BINDING);
+
+    await host.storage.set("cursor", 7, "worktree");
+
+    expect(JSON.parse(await fs.readFile(storageFileIn(ambientB()), "utf8"))).toEqual({ cursor: 7 });
+    expect(ambientWorktreePathLookup).toHaveBeenCalled();
+    // Unbound short-circuits before the snapshot read — the ambient callback is
+    // the whole resolution.
+    expect(projectWorktreeFetch).not.toHaveBeenCalled();
+  });
+
+  it("no-ops a worktree-scoped set when the plugin unloads during target resolution", async () => {
+    const { host, deps } = hostAndDepsBoundTo({
+      projectId: PROJECT_A,
+      projectRoot: projectRootOf(PROJECT_A),
+    });
+    let release!: (value: unknown) => void;
+    projectWorktreeFetch.mockReturnValue(
+      new Promise((resolve) => {
+        release = resolve;
+      })
+    );
+
+    const pending = host.storage.set("cursor", 7, "worktree");
+    // Unloaded mid-resolution: the write is dropped rather than surfacing the
+    // "no target" throw a genuinely absent worktree would raise.
+    deps.plugins.delete(PLUGIN_ID);
+    release({
+      status: "ok",
+      projectId: PROJECT_A,
+      snapshots: [worktreeSnapshot(inA("feature-x"), true)],
+    });
+
+    await expect(pending).resolves.toBeUndefined();
+    expect(await exists(path.join(projectRootOf(PROJECT_A), ".daintree"))).toBe(false);
+    expect(await exists(path.join(projectRootOf(PROJECT_B), ".daintree"))).toBe(false);
+  });
+
   it("fails closed for a malformed bound-but-rootless binding rather than writing into B", async () => {
     // A binding that names a project but carries no root is a loader bug. The
     // host resolves it to "", which both managers reject — the ambient
@@ -647,6 +826,10 @@ describe("settings and storage roots", () => {
 
     await expect(host.settings.set("token", "nowhere", "project")).rejects.toThrow();
     await expect(host.storage.set("cursor", 7, "project")).rejects.toThrow();
+    // Worktree scope too: the rootless binding can't name a project to filter
+    // the snapshot read by, so it resolves to "" rather than the ambient set.
+    await expect(host.storage.set("cursor", 7, "worktree")).rejects.toThrow();
+    expect(ambientWorktreePathLookup).not.toHaveBeenCalled();
 
     expect(await exists(path.join(projectRootOf(PROJECT_B), ".daintree"))).toBe(false);
     expect(await exists(path.join(projectRootOf(PROJECT_A), ".daintree"))).toBe(false);

--- a/electron/services/plugin/__tests__/confusedDeputy.test.ts
+++ b/electron/services/plugin/__tests__/confusedDeputy.test.ts
@@ -209,10 +209,21 @@ function fakePlugin(): LoadedPlugin {
  * `webContents.send` and a `host.settings.set` all the way to a file on disk.
  */
 function makeHostDeps(): PluginHostFactoryDeps {
+  // Deliberately adversarial: focused B really does have a current worktree, so
+  // a surface that wrongly reaches for the ambient set SUCCEEDS at writing into
+  // B rather than failing closed by accident and passing the test anyway.
   ambientWorktreeFetch = vi.fn(async () => ({
     status: "ok",
     projectId: PROJECT_B,
-    snapshots: [],
+    snapshots: [
+      {
+        id: path.join(projectRootOf(PROJECT_B), "main"),
+        worktreeId: "wt-b-main",
+        path: path.join(projectRootOf(PROJECT_B), "main"),
+        name: "main",
+        isCurrent: true,
+      },
+    ],
   }));
   projectWorktreeFetch = vi.fn(async () => ({
     status: "ok",
@@ -569,6 +580,28 @@ describe("settings and storage roots", () => {
   /** The ambient worktree, inside focused B — where the bug used to write. */
   const ambientB = (): string => path.join(projectRootOf(PROJECT_B), "main");
 
+  const B_BYTES = JSON.stringify({ cursor: "b-secret", untouched: true });
+
+  /**
+   * Put real data where the bug used to land. "B was never created" only proves
+   * no write; a byte-for-byte comparison against a pre-seeded file also catches
+   * an overwrite, a delete, and a read that leaked B's value back to the plugin.
+   */
+  async function seedAmbientB(): Promise<void> {
+    await fs.mkdir(path.dirname(storageFileIn(ambientB())), { recursive: true });
+    await fs.writeFile(storageFileIn(ambientB()), B_BYTES, "utf8");
+  }
+
+  async function expectBUntouched(): Promise<void> {
+    expect(await fs.readFile(storageFileIn(ambientB()), "utf8")).toBe(B_BYTES);
+  }
+
+  /** Neither app-global worktree source may be consulted for a BOUND host. */
+  function expectAmbientUnconsulted(): void {
+    expect(ambientWorktreeFetch).not.toHaveBeenCalled();
+    expect(ambientWorktreePathLookup).not.toHaveBeenCalled();
+  }
+
   /** `hostBoundTo`, but keeping the deps so a test can unload the plugin. */
   function hostAndDepsBoundTo(binding: PluginHostBinding): {
     host: PluginHostApi;
@@ -690,21 +723,24 @@ describe("settings and storage roots", () => {
       snapshots: [worktreeSnapshot(inA("main")), worktreeSnapshot(inA("feature-x"), true)],
     });
 
+    await seedAmbientB();
+
     await host.storage.set("cursor", 7, "worktree");
 
     expect(JSON.parse(await fs.readFile(storageFileIn(inA("feature-x")), "utf8"))).toEqual({
       cursor: 7,
     });
+    // A read routed to B would answer "b-secret", one routed nowhere undefined —
+    // only A's own file gives 7.
     expect(await host.storage.get("cursor", "worktree")).toBe(7);
-
-    // Nothing anywhere near B, and the ambient lookup was never reached for it.
-    expect(await exists(path.join(projectRootOf(PROJECT_B), ".daintree"))).toBe(false);
-    expect(await exists(storageFileIn(ambientB()))).toBe(false);
-    expect(ambientWorktreePathLookup).not.toHaveBeenCalled();
-    expect(ambientWorktreeFetch).not.toHaveBeenCalled();
 
     await host.storage.delete("cursor", "worktree");
     expect(JSON.parse(await fs.readFile(storageFileIn(inA("feature-x")), "utf8"))).toEqual({});
+
+    // B's file survives all three operations byte for byte.
+    await expectBUntouched();
+    expect(projectWorktreeFetch).toHaveBeenCalledWith(PROJECT_A, projectRootOf(PROJECT_A));
+    expectAmbientUnconsulted();
   });
 
   it("re-resolves A's current worktree on every call, following a mid-session switch", async () => {
@@ -733,7 +769,13 @@ describe("settings and storage roots", () => {
     expect(JSON.parse(await fs.readFile(storageFileIn(inA("feature-x")), "utf8"))).toEqual({
       cursor: 2,
     });
+
+    // Counted, not inferred: a target cached at construction would answer 2 off
+    // the second write's file without ever fetching a third time.
+    expect(projectWorktreeFetch).toHaveBeenCalledTimes(2);
     expect(await host.storage.get("cursor", "worktree")).toBe(2);
+    expect(projectWorktreeFetch).toHaveBeenCalledTimes(3);
+    expectAmbientUnconsulted();
   });
 
   it("fails closed when A has no current worktree rather than falling back to B", async () => {
@@ -744,17 +786,40 @@ describe("settings and storage roots", () => {
       snapshots: [worktreeSnapshot(inA("main")), worktreeSnapshot(inA("feature-x"))],
     });
 
+    await seedAmbientB();
+
     await expect(host.storage.set("cursor", 7, "worktree")).rejects.toThrow(
-      'no active worktree — "worktree" scope has no target'
+      `Plugin "${PLUGIN_ID}" storage.set: no active worktree — "worktree" scope has no target`
     );
     // Read and delete degrade quietly, matching the unset-key / already-absent
     // returns the other scopes give when they have no target.
     expect(await host.storage.get("cursor", "worktree")).toBeUndefined();
     await expect(host.storage.delete("cursor", "worktree")).resolves.toBeUndefined();
 
-    expect(await exists(path.join(projectRootOf(PROJECT_A), ".daintree"))).toBe(false);
-    expect(await exists(path.join(projectRootOf(PROJECT_B), ".daintree"))).toBe(false);
-    expect(ambientWorktreePathLookup).not.toHaveBeenCalled();
+    // B has a current worktree and a populated file; failing closed means the
+    // bound host neither read it nor touched it.
+    await expectBUntouched();
+    expect(await exists(storageFileIn(inA("main")))).toBe(false);
+    expect(await exists(storageFileIn(inA("feature-x")))).toBe(false);
+    expectAmbientUnconsulted();
+  });
+
+  it("fails closed when A's worktree read rejects rather than falling back to B", async () => {
+    // The `fetch-failed` branch: getWorktreesResult swallows the rejection into
+    // an unavailable status, which must reach storage as "" and not as a raw
+    // rejection escaping through get/delete.
+    const host = hostBoundTo({ projectId: PROJECT_A, projectRoot: projectRootOf(PROJECT_A) });
+    projectWorktreeFetch.mockRejectedValue(new Error("workspace host is gone"));
+    await seedAmbientB();
+
+    await expect(host.storage.set("cursor", 7, "worktree")).rejects.toThrow(
+      `Plugin "${PLUGIN_ID}" storage.set: no active worktree — "worktree" scope has no target`
+    );
+    expect(await host.storage.get("cursor", "worktree")).toBeUndefined();
+    await expect(host.storage.delete("cursor", "worktree")).resolves.toBeUndefined();
+
+    await expectBUntouched();
+    expectAmbientUnconsulted();
   });
 
   it("fails closed when the worktree read answers for B through an A-bound host", async () => {
@@ -767,12 +832,16 @@ describe("settings and storage roots", () => {
       snapshots: [worktreeSnapshot(ambientB(), true)],
     });
 
-    await expect(host.storage.set("cursor", 7, "worktree")).rejects.toThrow(
-      'no active worktree — "worktree" scope has no target'
-    );
+    await seedAmbientB();
 
-    expect(await exists(path.join(projectRootOf(PROJECT_B), ".daintree"))).toBe(false);
+    await expect(host.storage.set("cursor", 7, "worktree")).rejects.toThrow(
+      `Plugin "${PLUGIN_ID}" storage.set: no active worktree — "worktree" scope has no target`
+    );
+    expect(await host.storage.get("cursor", "worktree")).toBeUndefined();
+
+    await expectBUntouched();
     expect(await exists(path.join(projectRootOf(PROJECT_A), ".daintree"))).toBe(false);
+    expectAmbientUnconsulted();
   });
 
   it("keeps an UNBOUND host's worktree-scoped storage on the ambient worktree", async () => {
@@ -785,9 +854,11 @@ describe("settings and storage roots", () => {
     await host.storage.set("cursor", 7, "worktree");
 
     expect(JSON.parse(await fs.readFile(storageFileIn(ambientB()), "utf8"))).toEqual({ cursor: 7 });
-    expect(ambientWorktreePathLookup).toHaveBeenCalled();
-    // Unbound short-circuits before the snapshot read — the ambient callback is
-    // the whole resolution.
+    expect(ambientWorktreePathLookup).toHaveBeenCalledTimes(1);
+    // Unbound short-circuits before the snapshot read, so NEITHER fetch runs.
+    // ambientWorktreeFetch is the load-bearing one: an unbound host that
+    // wrongly fell into getWorktreesResult would reach that, not the project fetch.
+    expect(ambientWorktreeFetch).not.toHaveBeenCalled();
     expect(projectWorktreeFetch).not.toHaveBeenCalled();
   });
 
@@ -797,13 +868,26 @@ describe("settings and storage roots", () => {
       projectRoot: projectRootOf(PROJECT_A),
     });
     let release!: (value: unknown) => void;
-    projectWorktreeFetch.mockReturnValue(
-      new Promise((resolve) => {
+    let markStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+    // Deferred INSIDE the implementation: built eagerly by mockReturnValue,
+    // `release` would already be assigned before the fetch ran and the test
+    // would pass without the new await ever being reached.
+    projectWorktreeFetch.mockImplementation(() => {
+      markStarted();
+      return new Promise((resolve) => {
         release = resolve;
-      })
-    );
+      });
+    });
+    await seedAmbientB();
 
     const pending = host.storage.set("cursor", 7, "worktree");
+    // Proof the call really is parked in target resolution before we unload.
+    await started;
+    expect(projectWorktreeFetch).toHaveBeenCalledWith(PROJECT_A, projectRootOf(PROJECT_A));
+
     // Unloaded mid-resolution: the write is dropped rather than surfacing the
     // "no target" throw a genuinely absent worktree would raise.
     deps.plugins.delete(PLUGIN_ID);
@@ -814,8 +898,11 @@ describe("settings and storage roots", () => {
     });
 
     await expect(pending).resolves.toBeUndefined();
-    expect(await exists(path.join(projectRootOf(PROJECT_A), ".daintree"))).toBe(false);
-    expect(await exists(path.join(projectRootOf(PROJECT_B), ".daintree"))).toBe(false);
+    // Both candidate targets, not just their project roots: the write would have
+    // landed in a worktree subdirectory, which a project-root check never sees.
+    expect(await exists(storageFileIn(inA("feature-x")))).toBe(false);
+    await expectBUntouched();
+    expect(ambientWorktreePathLookup).not.toHaveBeenCalled();
   });
 
   it("fails closed for a malformed bound-but-rootless binding rather than writing into B", async () => {


### PR DESCRIPTION
## Summary

- A project-bound plugin's `host.storage.get/set/delete` with `scope: 'worktree'` only ever passed `projectRoot` into `PluginStorageManager.resolveStorageFilePath()`, never a worktree path. The manager's `target?.worktreePath == null` check was therefore always true, so it always fell back to the ambient, app-global active worktree, which `PluginService` wires to the first `isCurrent` snapshot across every open project.
- A plugin bound to project A could read and overwrite project B's `.daintree/plugin-storage/<id>.json`. Same class of confused deputy bug as #11297. `PluginHostFactory.ts` already carried a comment naming this as an open gap.

Resolves #12229

## The fix

Adds `resolveBoundWorktreeTarget()` to `PluginHostFactory`, which resolves the target from `getWorktreesResult()`, the same project-filtered source `host.getActiveWorktree` already uses. It fetches on every call, not just at construction, because the active worktree can change while the host is alive, unlike its project root.

It follows the existing `boundScopeRoot` sentinel convention:
- `undefined` for an unbound host, so installed and builtin plugins keep the ambient fallback, which is the only thing their worktree scope can mean.
- `''` for a bound host whose worktree can't be resolved. The manager rejects that outright instead of falling through to another project.

Only `worktree` scope pays for the extra project-filtered fetch. `user` and `project` scopes are unchanged. A non-absolute or non-string path is rejected before it becomes a filesystem root: a relative path would resolve against Electron's working directory, and a non-string would throw out of `path.join`, which `storage.get` is documented to never do.

No changes were needed in `PluginStorageManager`'s resolution logic, since it already handled explicit `worktreePath` targets correctly and was already tested. Settings has no worktree scope, so `PluginSettingsManager` is untouched.

## Tests

Six new or extended cases in `electron/services/plugin/__tests__/confusedDeputy.test.ts`, the two-project regression suite. Verified load-bearing by reverting the fix: 5 of them go red.

The suite's default ambient snapshot was made adversarial, so focused project B really does have a current worktree, meaning a wrongly-ambient path succeeds at writing into B instead of failing closed by accident. B's storage file is pre-seeded and asserted byte for byte, which catches a read leak, an overwrite, and a delete that a plain absence check wouldn't.

## Known limitation

Worktree path provenance is still trusted from the workspace host. `WorkspaceClient` stamps the response's `projectId` from its own registry entry, so the existing `result.projectId !== boundProjectId` guard can't catch a response labelled for project A that actually carries project B's path.

That trust gap is shared by `getActiveWorktree`, the default spawn working directory, and `${worktree}` allowlist expansion. Closing it means validating worktree membership against `GitService.listWorktrees()` at the workspace-host seam, deliberately out of scope here and worth a follow-up issue. Lexical under-`projectRoot` containment would be the wrong fix, since linked worktrees can legitimately live outside the project root.

## Local verification

174 targeted tests green across `confusedDeputy`, `PluginHostFactory.binding`, both `PluginStorageManager` suites, `PluginService.hostApiMisc`, and `pluginWorktreeSnapshot`. Full `electron/services/plugin/__tests__` directory at 661 tests green after rebasing onto `develop`. eslint and prettier clean on all changed files.

## Files changed

- `electron/services/plugin/PluginHostFactory.ts`
- `electron/services/plugin/PluginStorageManager.ts` (doc comment only)
- `electron/services/PluginService.ts` (comment only)
- `electron/services/plugin/__tests__/confusedDeputy.test.ts`
- `docs/plugins/project-local.md` (one sentence that had documented the bug as intended behaviour)
