### PR TITLE
fix(plugins): unload project plugins on sleep and idle auto-close

### DIFF
--- a/electron/ipc/handlers/__tests__/project.close.test.ts
+++ b/electron/ipc/handlers/__tests__/project.close.test.ts
@@ -47,6 +47,15 @@ vi.mock("../../../projectMenuState.js", () => ({
   refreshProjectMenuState: refreshProjectMenuStateMock,
 }));
 
+// Unmocked this resolves through the real fire-and-forget dynamic import, which
+// pulls in the whole of `PluginService` and proves nothing about the call. It is
+// the canonical close edge that `project:sleep` and the idle sweep copy, so it
+// needs a baseline of its own (#12231).
+const pluginLifecycleMock = vi.hoisted(() => ({
+  notifyProjectPluginsClosed: vi.fn<(projectId: string) => void>(),
+}));
+vi.mock("../../../window/projectPluginLifecycle.js", () => pluginLifecycleMock);
+
 const teardownMock = vi.hoisted(() => ({
   gracefulTeardownAndJournalProject:
     vi.fn<(...args: unknown[]) => Promise<{ confirmed: boolean; terminalsKilled: number }>>(),
@@ -164,6 +173,14 @@ describe("project:close handler", () => {
     expect(refreshProjectMenuStateMock.mock.invocationCallOrder[0]).toBeGreaterThan(
       projectStoreMock.updateProjectStatus.mock.invocationCallOrder[0]
     );
+
+    // Every plugin the project owns unloads with it, after the "closed" write —
+    // that write is the commit point for the close.
+    expect(pluginLifecycleMock.notifyProjectPluginsClosed).toHaveBeenCalledTimes(1);
+    expect(pluginLifecycleMock.notifyProjectPluginsClosed).toHaveBeenCalledWith("project-active");
+    expect(
+      pluginLifecycleMock.notifyProjectPluginsClosed.mock.invocationCallOrder[0]!
+    ).toBeGreaterThan(projectStoreMock.updateProjectStatus.mock.invocationCallOrder[0]!);
   });
 
   it("rejects closing the active project when not killing terminals", async () => {
@@ -455,6 +472,8 @@ describe("project:close handler", () => {
       expect(projectStoreMock.clearProjectState).not.toHaveBeenCalled();
       expect(projectStoreMock.clearCurrentProject).not.toHaveBeenCalled();
       expect(projectStoreMock.updateProjectStatus).not.toHaveBeenCalled();
+      // The project is still open with live agents behind it.
+      expect(pluginLifecycleMock.notifyProjectPluginsClosed).not.toHaveBeenCalled();
     });
 
     it("waits for the capture to settle before tearing the project down", async () => {
@@ -606,8 +625,10 @@ describe("project:close handler", () => {
     expect(projectStoreMock.updateProjectStatus).toHaveBeenCalledWith("project-bg", "background");
     expect(worktreeService.pauseProject).toHaveBeenCalledWith("/test/project-bg");
     // Backgrounding leaves every terminal running, the assistant's included —
-    // revoking here would kill the live session it is meant to preserve.
+    // revoking here would kill the live session it is meant to preserve. The
+    // project is still open, so its plugins stay loaded for the same reason.
     expect(helpSessionServiceMock.revokeByProjectId).not.toHaveBeenCalled();
+    expect(pluginLifecycleMock.notifyProjectPluginsClosed).not.toHaveBeenCalled();
   });
 
   it("does NOT call pauseProject when killing terminals", async () => {

--- a/electron/ipc/handlers/__tests__/project.remove.test.ts
+++ b/electron/ipc/handlers/__tests__/project.remove.test.ts
@@ -56,6 +56,13 @@ const teardownMock = vi.hoisted(() => ({
 }));
 vi.mock("../../../services/pty/projectSessionJournal.js", () => teardownMock);
 
+// Unmocked this resolves through the real fire-and-forget dynamic import, so
+// deleting the notify from the remove path left this whole file green (#12231).
+const pluginLifecycleMock = vi.hoisted(() => ({
+  notifyProjectPluginsClosed: vi.fn<(projectId: string) => void>(),
+}));
+vi.mock("../../../window/projectPluginLifecycle.js", () => pluginLifecycleMock);
+
 import { ipcMain } from "electron";
 import { CHANNELS } from "../../channels.js";
 import { createProjectCrudRegistrar } from "./helpers/projectCrudLifecycle.js";
@@ -119,6 +126,15 @@ describe("project:remove handler", () => {
 
     // The row is gone, so a window still bound to it has no project open (#11136).
     expect(refreshProjectMenuStateMock).toHaveBeenCalled();
+
+    // A removed project's plugins must not outlive it, and the notify has to
+    // land BEFORE the row goes: afterwards the controller can no longer resolve
+    // the project to reconcile it away.
+    expect(pluginLifecycleMock.notifyProjectPluginsClosed).toHaveBeenCalledTimes(1);
+    expect(pluginLifecycleMock.notifyProjectPluginsClosed).toHaveBeenCalledWith("proj-1");
+    expect(
+      pluginLifecycleMock.notifyProjectPluginsClosed.mock.invocationCallOrder[0]!
+    ).toBeLessThan(removeOrder);
   });
 
   it("fails closed: does NOT remove the project when the teardown is unconfirmed", async () => {
@@ -149,6 +165,8 @@ describe("project:remove handler", () => {
     expect(projectStoreMock.removeProject).not.toHaveBeenCalled();
     expect(windowStateMock.pruneWindowStateForPath).not.toHaveBeenCalled();
     expect(refreshProjectMenuStateMock).not.toHaveBeenCalled();
+    // The row survives with its agents still running, so its plugins do too.
+    expect(pluginLifecycleMock.notifyProjectPluginsClosed).not.toHaveBeenCalled();
   });
 
   it("fails closed when the teardown throws: the old swallow-and-remove is gone", async () => {

--- a/electron/ipc/handlers/__tests__/project.sleep.test.ts
+++ b/electron/ipc/handlers/__tests__/project.sleep.test.ts
@@ -289,7 +289,14 @@ describe("project:sleep", () => {
       // spawned children and the native watcher with it. Before #12216 nothing
       // ran the unload cascade here, so they survived until the user happened
       // to switch into a different project.
+      expect(pluginLifecycleMock.notifyProjectPluginsClosed).toHaveBeenCalledTimes(1);
       expect(pluginLifecycleMock.notifyProjectPluginsClosed).toHaveBeenCalledWith("proj-1");
+
+      // Order is load-bearing, not cosmetic: the status write is the commit
+      // point, so close intent must not be published before the row carries it.
+      expect(projectStoreMock.updateProjectStatus.mock.invocationCallOrder[0]!).toBeLessThan(
+        pluginLifecycleMock.notifyProjectPluginsClosed.mock.invocationCallOrder[0]!
+      );
     });
 
     it("does not unload plugins for a project it refused to sleep (#12216)", async () => {
@@ -385,6 +392,9 @@ describe("project:sleep", () => {
       expect(result.terminalsKilled).toBe(2);
       expect(projectStoreMock.updateProjectStatus).toHaveBeenCalledWith("proj-1", "closed");
       expect(broadcastMock).toHaveBeenCalledWith(CHANNELS.PROJECT_SLEPT, "proj-1");
+      // Same reason the status write survives: the row says closed, so the
+      // plugins behind it have to go too.
+      expect(pluginLifecycleMock.notifyProjectPluginsClosed).toHaveBeenCalledWith("proj-1");
     });
   });
 
@@ -410,6 +420,9 @@ describe("project:sleep", () => {
       expect(persistenceMock.writeHibernatedMarker).not.toHaveBeenCalled();
       expect(hibernationMock.evictProjectRenderer).not.toHaveBeenCalled();
       expect(broadcastMock).not.toHaveBeenCalled();
+      // The project is still open with live agents behind it — unloading its
+      // plugins here would tear down half a project the user still has.
+      expect(pluginLifecycleMock.notifyProjectPluginsClosed).not.toHaveBeenCalled();
     });
 
     it("surfaces a teardown rejection without marking the project closed", async () => {
@@ -418,6 +431,7 @@ describe("project:sleep", () => {
 
       await expect(invoke("proj-1")).rejects.toBeInstanceOf(AppError);
       expect(projectStoreMock.updateProjectStatus).not.toHaveBeenCalled();
+      expect(pluginLifecycleMock.notifyProjectPluginsClosed).not.toHaveBeenCalled();
     });
   });
 

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -3862,7 +3862,7 @@ export class PluginService {
     await this.syncProjectPluginWatcher(projectId, projectRoot);
   }
 
-  /** The user closed this project: unload everything it owns. */
+  /** This project stopped being live: unload everything it owns. */
   async onProjectClosed(projectId: string): Promise<void> {
     // Stop the watcher first: it is the one thing that could otherwise queue a
     // reload behind the teardown.
@@ -3999,10 +3999,11 @@ export class PluginService {
    */
   private async syncProjectPluginWatcher(projectId: string, projectRoot?: string): Promise<void> {
     const trust = this.projectPlugins.getTrustState(projectId);
-    // A close can land while an open is still awaiting its snapshot push, and
-    // the idle auto-close service and the free-memory IPC flip a row to
-    // "closed" without ever reaching `onProjectClosed`. Re-reading the row here
-    // is what keeps either from leaving a live native watcher behind.
+    // A close can land while an open is still awaiting its snapshot push, every
+    // close notification is fire-and-forget, and the project store's own status
+    // reconciliation flips a row to "closed" without ever reaching
+    // `onProjectClosed`. Re-reading the row here is what keeps any of them from
+    // leaving a live native watcher behind.
     if (
       this.disposed ||
       this.isProjectRowClosed(projectId) ||

--- a/electron/services/__tests__/IdleBackgroundAutoCloseService.test.ts
+++ b/electron/services/__tests__/IdleBackgroundAutoCloseService.test.ts
@@ -284,7 +284,33 @@ describe("IdleBackgroundAutoCloseService", () => {
       // The whole point of the sweep is reclaiming memory; leaving the plugin
       // workers, timers and spawned children resident defeats it. Before
       // #12216 nothing ran the unload cascade on this path.
+      expect(pluginLifecycleMock.notifyProjectPluginsClosed).toHaveBeenCalledTimes(1);
       expect(pluginLifecycleMock.notifyProjectPluginsClosed).toHaveBeenCalledWith("proj-1");
+
+      // Order is load-bearing, not cosmetic: the status write is the commit
+      // point, so close intent must not be published before the row carries it.
+      expect(projectStoreMock.updateProjectStatus.mock.invocationCallOrder[0]!).toBeLessThan(
+        pluginLifecycleMock.notifyProjectPluginsClosed.mock.invocationCallOrder[0]!
+      );
+    });
+
+    it("notifies once per parked project, not once per sweep", async () => {
+      enable();
+      projectStoreMock.getAllProjects.mockReturnValue([
+        makeIdleProject("proj-1"),
+        makeIdleProject("proj-2"),
+      ]);
+      const service = makeService();
+      await runCheck(service);
+
+      // A single-close fixture cannot tell "per successful project" apart from
+      // "once per sweep" — a regression that hoisted the call out of the loop
+      // would pass it. Two closes is the smallest fixture that can.
+      expect(pluginLifecycleMock.notifyProjectPluginsClosed).toHaveBeenCalledTimes(2);
+      expect(pluginLifecycleMock.notifyProjectPluginsClosed.mock.calls.map(([id]) => id)).toEqual([
+        "proj-1",
+        "proj-2",
+      ]);
     });
 
     it("skips a project that still has a terminal", async () => {
@@ -390,6 +416,11 @@ describe("IdleBackgroundAutoCloseService", () => {
         expect.anything()
       );
       expect(helpSessionServiceMock.revokeByProjectId).not.toHaveBeenCalledWith("proj-1");
+
+      // Per successfully parked project, not per candidate and not once per
+      // sweep: proj-1 never closed, so its plugins must still be running.
+      expect(pluginLifecycleMock.notifyProjectPluginsClosed).toHaveBeenCalledTimes(1);
+      expect(pluginLifecycleMock.notifyProjectPluginsClosed).toHaveBeenCalledWith("proj-2");
 
       const skipLogs = logInfoMock.mock.calls.filter(
         ([event]) => event === "idle-background-auto-close-skip-live-assistant"
@@ -502,6 +533,9 @@ describe("IdleBackgroundAutoCloseService", () => {
       expect(ptyClientMock.gracefulKillByProject).not.toHaveBeenCalled();
       expect(evictProjectRendererMock).not.toHaveBeenCalled();
       expect(projectStoreMock.updateProjectStatus).not.toHaveBeenCalled();
+      // Representative LATE bail: the notification hangs off the status write,
+      // so a project that bails after the revoke keeps its plugins.
+      expect(pluginLifecycleMock.notifyProjectPluginsClosed).not.toHaveBeenCalled();
     });
 
     it("a failed capture-revoke of a dead session degrades gracefully and never blocks the reclaim", async () => {

--- a/electron/services/plugin/ProjectPluginController.ts
+++ b/electron/services/plugin/ProjectPluginController.ts
@@ -205,11 +205,11 @@ export class ProjectPluginController {
     if (this.disposed) return;
     if (this.superseded(projectId, requested, requestedGeneration)) return;
 
-    // Safety net for the close paths this controller cannot be called from —
-    // the idle auto-close service, the free-memory IPC and the project store's
-    // own status reconciliation all flip a row to "closed" without routing
-    // through `project:close`. Sweeping on the next project switch bounds how
-    // long a closed project's plugins can outlive it to one user action.
+    // Safety net for closes this controller has not been told about yet — the
+    // notification is fire-and-forget, and the project store's own status
+    // reconciliation flips a row to "closed" without routing through one at all.
+    // Sweeping on the next project switch bounds how long a closed project's
+    // plugins can outlive it to one user action.
     for (const trackedId of [...this.entries.keys()]) {
       if (trackedId !== projectId && this.deps.isProjectClosed(trackedId)) {
         await this.onProjectClosed(trackedId);
@@ -271,9 +271,9 @@ export class ProjectPluginController {
   }
 
   /**
-   * The user closed this project. Every plugin it owns is unloaded now —
-   * contributions unregistered, `plugin://` authorities invalidated, workers
-   * killed by the unload cascade.
+   * This project stopped being live — closed, removed, slept or auto-parked.
+   * Every plugin it owns is unloaded now — contributions unregistered,
+   * `plugin://` authorities invalidated, workers killed by the unload cascade.
    *
    * Trust is NOT forgotten here. A close is not a revoke, and re-prompting on
    * every reopen would defeat the "once, at the folder" contract.

--- a/electron/window/projectPluginLifecycle.ts
+++ b/electron/window/projectPluginLifecycle.ts
@@ -12,9 +12,11 @@
  * trimming, hibernation, a cold-start rollback and window disposal with no way
  * to tell them apart — and the user-facing close never reaches it at all. So
  * "opened" hangs off the switch (which is what actually brings a project into
- * use) and "closed" hangs off `project:close` (which is where the user says so).
- * Eviction is not a close: the project is still open, its terminals still run,
- * and its plugins must survive the renderer being reclaimed.
+ * use), and "closed" hangs off each operation's commit point: right after the
+ * `closed` status write for `project:close`, `project:sleep` and the idle
+ * background sweep, and right before `project:remove` deletes the row. Eviction
+ * is not a close: the project is still open, its terminals still run, and its
+ * plugins must survive the renderer being reclaimed.
  */
 
 /** A project came into use in some window. Idempotent; also the reconcile trigger. */
@@ -27,7 +29,7 @@ export function notifyProjectPluginsOpened(projectId: string, projectPath: strin
     });
 }
 
-/** The user closed this project. Unload everything it owns. */
+/** This project stopped being live — closed, removed, slept or auto-parked. Unload everything it owns. */
 export function notifyProjectPluginsClosed(projectId: string): void {
   if (!projectId) return;
   void import("../services/PluginService.js")


### PR DESCRIPTION
## Summary

- `project:sleep` and the idle background auto-park both flip a project's status to `closed`, killing its terminals, evicting its renderer views, and dropping its workspace host, but neither one told the plugin system. That left timers, workers, sockets, and file watchers running behind a project the UI already showed as shut, with no way for the user to see or stop them.
- `project:close` and `project:remove` already did this right, calling `notifyProjectPluginsClosed` right after writing the closed status. This PR makes `project:sleep` and the idle auto-close path do the same thing, immediately after their own closed status write, matching `project:close` exactly.
- The status write is the commit point, so close intent is never published before the project row carries it. The call itself is the existing synchronous fire-and-forget seam, so it can't throw into the handler or add latency, and `onProjectClosed` is idempotent, so a sleep racing a manual close is safe.

Resolves #12231

## Changes

- `electron/ipc/handlers/projectSleep.ts`: call `notifyProjectPluginsClosed(projectId)` right after the closed status write.
- `electron/services/IdleBackgroundAutoCloseService.ts`: same call, same placement, for the idle auto-park path.
- `electron/services/PluginService.ts` and `electron/services/plugin/ProjectPluginController.ts`: refreshed outdated safety-net comments that named a `project:free-memory` IPC handler no longer in the codebase and claimed idle auto-close never reaches `onProjectClosed`. Comments now name what actually still bypasses it. The `isProjectRowClosed` guard code itself is unchanged, since it's a genuine race safety-net given the notification is fire-and-forget.
- `electron/window/projectPluginLifecycle.ts`: minor changes supporting the above.
- Test files updated: `project.close.test.ts` and `project.remove.test.ts` ran the real dynamic import but asserted nothing about it, so deleting either canonical notify call would have left both green. Both now pin the call, its argument, and its ordering. `project.sleep.test.ts` and `IdleBackgroundAutoCloseService.test.ts` gain matching coverage for the new call.

**Behavior note:** a project slept or auto-parked while holding only an in-memory `"session"` plugin-trust grant will now re-prompt on reopen. That's exactly what a full `project:close` already does, the bug was just masking it. Not a new UX change.

**Deliberately out of scope**, each its own issue:
- `ProjectStore.checkMissingProjects()` and generic status reconciliation write `"closed"` without notifying. That's store self-heal, a different category from a lifecycle transition.
- `project:update` accepts a `status` field, so a renderer can write `{status: "closed"}` with no teardown at all. Deliberate today, via an explicit `updates.status !== undefined` branch. Narrowing it needs its own design pass.
- `ProjectRelocationCoordinator` picks its reattach delegate on "not visible," which treats a background project with live terminals and plugins as dormant.
- Idle auto-close re-checks status, activity, and terminals after the capture-revoke `await`, but not `lastOpened`. A project opened and left during that window can still get parked.

## Testing

- 96 targeted tests across `project.sleep`, `project.close`, `project.remove`, and `IdleBackgroundAutoCloseService`, plus the full 611-test plugin suite (29 files), all green on the rebased tree.
- Load-bearingness proven by mutation: reverting the two production calls fails 4 tests, including both new ordering assertions.
- `eslint` and `prettier` exit 0 on all 9 changed files.
- Reviewed across two parallel adversarial passes (correctness/logic, tests/edge cases) at max reasoning effort. Every confirmed finding is either fixed above or listed above as out of scope.