### PR TITLE
perf(diff): replace superseded tokenize jobs before they reach the worker

### DIFF
--- a/.agents/skills/optimize/metric-class.mjs
+++ b/.agents/skills/optimize/metric-class.mjs
@@ -41,7 +41,7 @@ const RULES = [
   {
     cls: "count",
     pattern:
-      /[Cc]ount|[Ss]pawns|[Ss]tarts|[Ii]nvocations|[Rr]etries|[Cc]alls|[Hh]its|[Mm]isses|[Ee]vents|[Ff]lushes|[Rr]enders|[Mm]essages|[Tt]asks|[Hh]andles|[Dd]escriptors|[Ww]rites|[Rr]eads|[Pp]asses|[Aa]ttempts|[Cc]allbacks|[Kk]eystrokes|[Rr]oundTrips|[Ll]ines|[Pp]anels|[Gg]roups|[Hh]unks|[Tt]argets|[Ff]rames|[Ff]iles|[Tt]okens|[Dd]ecorations|[Cc]hanges|[Bb]atches|[Ii]tems|[Rr]esolved/,
+      /[Cc]ount|[Ss]pawns|[Ss]tarts|[Ii]nvocations|[Rr]etries|[Cc]alls|[Hh]its|[Mm]isses|[Ee]vents|[Ff]lushes|[Rr]enders|[Mm]essages|[Tt]asks|[Hh]andles|[Dd]escriptors|[Ww]rites|[Rr]eads|[Pp]asses|[Aa]ttempts|[Cc]allbacks|[Kk]eystrokes|[Rr]oundTrips|[Ll]ines|[Pp]anels|[Gg]roups|[Hh]unks|[Tt]argets|[Ff]rames|[Ff]iles|[Tt]okens|[Dd]ecorations|[Cc]hanges|[Bb]atches|[Ii]tems|[Rr]esolved|[Jj]obs|[Pp]osted/,
   },
 ];
 

--- a/scripts/perf/__tests__/comparability.test.ts
+++ b/scripts/perf/__tests__/comparability.test.ts
@@ -60,6 +60,9 @@ describe("classifyMetric", () => {
   ];
 
   const REAL_COUNTS = [
+    "executedJobs",
+    "postedJobs",
+    "supersededPosted",
     "gitSpawns",
     "agentCount",
     "batchCount",

--- a/scripts/perf/__tests__/workloadFloors.test.ts
+++ b/scripts/perf/__tests__/workloadFloors.test.ts
@@ -120,6 +120,7 @@ describe("workload floors", () => {
       "PERF-034",
       "PERF-036",
       "PERF-163",
+      "PERF-164",
       "PERF-395",
     ]);
     for (const scenario of declaring) {

--- a/scripts/perf/config/benchmarkClasses.ts
+++ b/scripts/perf/config/benchmarkClasses.ts
@@ -232,6 +232,14 @@ const FAMILIES: readonly Family[] = [
       "The real tokenizer and its oversized fallback. PERF-163 additionally measures how long the main thread was unavailable while it ran, against an idle calibration window — main-thread availability, not painted latency.",
   },
   {
+    label: "diff tokenize admission",
+    ids: ["PERF-164"],
+    kind: "mechanism",
+    fidelity: withFidelity({ entryPoint: "public-api", electronTransport: "node-channel" }),
+    claim:
+      "The real DiffTokenizeClient, unmodified, admitting work to a real worker thread running the real tokenizer. Its own family because the subject is the CLIENT, not the tokenizer, and the transport is node:worker_threads rather than a Chromium Web Worker — so the latency includes real cross-thread serialization but nothing about Chromium's scheduler. It ends at a resolved token tree, not at a highlighted diff on screen.",
+  },
+  {
     label: "action palette ranking",
     ids: ["PERF-170", "PERF-171"],
     kind: "mechanism",

--- a/scripts/perf/lib/comparability.ts
+++ b/scripts/perf/lib/comparability.ts
@@ -163,7 +163,7 @@ const RULES: ReadonlyArray<{ cls: ComparabilityClass; pattern: RegExp }> = [
   {
     cls: "count",
     pattern:
-      /[Cc]ount|[Ss]pawns|[Ss]tarts|[Ii]nvocations|[Rr]etries|[Cc]alls|[Hh]its|[Mm]isses|[Ee]vents|[Ff]lushes|[Rr]enders|[Mm]essages|[Tt]asks|[Hh]andles|[Dd]escriptors|[Ww]rites|[Rr]eads|[Pp]asses|[Aa]ttempts|[Cc]allbacks|[Kk]eystrokes|[Rr]oundTrips|[Ll]ines|[Pp]anels|[Gg]roups|[Hh]unks|[Tt]argets|[Ff]rames|[Ff]iles|[Tt]okens|[Dd]ecorations|[Cc]hanges|[Bb]atches|[Ii]tems|[Rr]esolved|[Rr]eloads/,
+      /[Cc]ount|[Ss]pawns|[Ss]tarts|[Ii]nvocations|[Rr]etries|[Cc]alls|[Hh]its|[Mm]isses|[Ee]vents|[Ff]lushes|[Rr]enders|[Mm]essages|[Tt]asks|[Hh]andles|[Dd]escriptors|[Ww]rites|[Rr]eads|[Pp]asses|[Aa]ttempts|[Cc]allbacks|[Kk]eystrokes|[Rr]oundTrips|[Ll]ines|[Pp]anels|[Gg]roups|[Hh]unks|[Tt]argets|[Ff]rames|[Ff]iles|[Tt]okens|[Dd]ecorations|[Cc]hanges|[Bb]atches|[Ii]tems|[Rr]esolved|[Rr]eloads|[Jj]obs|[Pp]osted/,
   },
 ];
 

--- a/scripts/perf/lib/nodeDiffTokenizeWorker.ts
+++ b/scripts/perf/lib/nodeDiffTokenizeWorker.ts
@@ -72,5 +72,7 @@ port.on("message", (message: DiffTokenizeWorkerRequest | DiffTokenizeStatsReques
         error: formatErrorMessage(err, "Tokenization failed"),
       } satisfies DiffTokenizeWorkerResponse);
     });
-  settled = Promise.all([settled, job]);
+  // Discard the aggregate value: `Promise.all` fulfils with an array holding
+  // the previous fulfilment, which would nest one level deeper per job.
+  settled = Promise.all([settled, job]).then(() => undefined);
 });

--- a/scripts/perf/lib/nodeDiffTokenizeWorker.ts
+++ b/scripts/perf/lib/nodeDiffTokenizeWorker.ts
@@ -1,0 +1,76 @@
+import { parentPort } from "node:worker_threads";
+import { runDiffTokenize } from "../../../src/components/Worktree/diffTokenizer";
+import type {
+  DiffTokenizeWorkerRequest,
+  DiffTokenizeWorkerResponse,
+} from "../../../src/components/Worktree/diffTokenizer";
+import { formatErrorMessage } from "../../../shared/utils/errorMessage";
+
+// node:worker_threads leg of the diff tokenize worker, for PERF-164. It mirrors
+// `src/workers/diffTokenize.worker.ts` message for message and calls the SAME
+// production `runDiffTokenize`, so the thing being measured is the real job,
+// not a stand-in for one. It exists because the renderer's Web Worker has no
+// Node equivalent and the in-thread fallback is not a valid subject for this
+// scenario: `pumpInThread` already drops superseded work before running it, so
+// the fallback would report the same count with or without admission control.
+//
+// The one addition is a job counter, incremented BEFORE the tokenizer is
+// invoked. `executedJobs` is the scenario's whole subject, so it is counted
+// where the work actually happens rather than inferred from what the client
+// posted — the client's own bookkeeping is the thing under test and cannot
+// also be the oracle.
+
+if (!parentPort) {
+  throw new Error("nodeDiffTokenizeWorker must run inside a worker_thread");
+}
+
+const port = parentPort;
+
+/** Out-of-band request for the execution tally. Never forwarded to the client. */
+export interface DiffTokenizeStatsRequest {
+  control: "stats";
+}
+
+export interface DiffTokenizeStatsResponse {
+  control: "stats";
+  executed: number;
+  executedIds: number[];
+}
+
+let executed = 0;
+const executedIds: number[] = [];
+
+// A response is not proof that everything received before it has finished:
+// `runDiffTokenize` awaits a dynamic grammar import, so several jobs can be in
+// flight at once. The tally is answered behind this accumulator so it is read
+// at an idle point rather than mid-job.
+let settled: Promise<unknown> = Promise.resolve();
+
+port.on("message", (message: DiffTokenizeWorkerRequest | DiffTokenizeStatsRequest) => {
+  if ("control" in message) {
+    void settled.then(() => {
+      port.postMessage({
+        control: "stats",
+        executed,
+        executedIds: [...executedIds],
+      } satisfies DiffTokenizeStatsResponse);
+    });
+    return;
+  }
+
+  const { id, ...request } = message;
+  executed += 1;
+  executedIds.push(id);
+  const job = runDiffTokenize(request)
+    .then((result) => {
+      port.postMessage({ id, ok: true, ...result } satisfies DiffTokenizeWorkerResponse);
+    })
+    .catch((err: unknown) => {
+      port.postMessage({
+        id,
+        ok: false,
+        error: formatErrorMessage(err, "Tokenization failed"),
+      } satisfies DiffTokenizeWorkerResponse);
+    });
+  settled = Promise.all([settled, job]);
+});

--- a/scripts/perf/lib/nodeDiffTokenizeWorkerTransport.ts
+++ b/scripts/perf/lib/nodeDiffTokenizeWorkerTransport.ts
@@ -1,0 +1,125 @@
+// Aliased so bare `Worker` in type position stays the DOM interface — the one
+// `DiffTokenizeClient` is written against.
+import { Worker as NodeWorker } from "node:worker_threads";
+import type {
+  DiffTokenizeWorkerRequest,
+  DiffTokenizeWorkerResponse,
+} from "../../../src/components/Worktree/diffTokenizer";
+import type { DiffTokenizeStatsRequest, DiffTokenizeStatsResponse } from "./nodeDiffTokenizeWorker";
+
+// Presents the browser `Worker` surface `DiffTokenizeClient` drives — over a
+// real `node:worker_threads` thread running the production tokenizer. The
+// client is measured UNMODIFIED: PERF-164's subject is its admission
+// behaviour, so anything that changed the client to make it observable would
+// measure a different client. Child threads do not inherit tsx's loader, so it
+// is re-registered through `execArgv`, the same way
+// `nodeParseWorkerTransport.ts` does it.
+//
+// The transport observes two things the client does not expose: which ids
+// actually crossed `postMessage`, and (via the worker's own tally) which the
+// worker actually ran. Control traffic is answered here and never forwarded to
+// the client, so the client sees exactly the protocol it sees in production.
+
+export interface DiffTokenizeWorkerStats {
+  executed: number;
+  executedIds: number[];
+}
+
+export class NodeDiffTokenizeWorkerHarness {
+  onmessage: ((event: MessageEvent<DiffTokenizeWorkerResponse>) => void) | null = null;
+  onerror: ((event: ErrorEvent) => void) | null = null;
+  onmessageerror: (() => void) | null = null;
+
+  /** Ids that actually crossed `postMessage`, in order. */
+  readonly posted: number[] = [];
+  /** Transport-level breakage. A scenario that saw any of this measured nothing. */
+  readonly failures: string[] = [];
+
+  private readonly thread: NodeWorker;
+  private readonly exited: Promise<void>;
+  private statsWaiters: Array<(stats: DiffTokenizeWorkerStats) => void> = [];
+  private closing = false;
+
+  constructor() {
+    this.thread = new NodeWorker(new URL("./nodeDiffTokenizeWorker.ts", import.meta.url), {
+      execArgv: ["--import", "tsx"],
+    });
+    this.exited = new Promise<void>((resolve) => {
+      this.thread.once("exit", () => resolve());
+    });
+
+    this.thread.on("message", (message: DiffTokenizeWorkerResponse | DiffTokenizeStatsResponse) => {
+      if ("control" in message) {
+        this.settleStats(message);
+        return;
+      }
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- minimal MessageEvent shape, the only part of it the client reads
+      this.onmessage?.({ data: message } as MessageEvent<DiffTokenizeWorkerResponse>);
+    });
+
+    this.thread.on("error", (error: Error) => {
+      this.fail(error.message || "node diff tokenize worker error", error);
+    });
+
+    // An exit with no error event (loader failure, OOM kill) must still settle
+    // anything waiting, or the scenario hangs instead of reporting a failure.
+    this.thread.on("exit", (code: number) => {
+      if (this.closing) return;
+      this.fail(`node diff tokenize worker exited (code ${code})`);
+    });
+  }
+
+  postMessage(message: DiffTokenizeWorkerRequest): void {
+    this.posted.push(message.id);
+    this.thread.postMessage(message);
+  }
+
+  terminate(): void {
+    this.closing = true;
+    void this.thread.terminate();
+  }
+
+  /** The worker's own execution tally, read once everything already sent has settled. */
+  stats(): Promise<DiffTokenizeWorkerStats> {
+    if (this.closing) return Promise.resolve({ executed: 0, executedIds: [] });
+    return new Promise<DiffTokenizeWorkerStats>((resolve) => {
+      this.statsWaiters.push(resolve);
+      this.thread.postMessage({ control: "stats" } satisfies DiffTokenizeStatsRequest);
+    });
+  }
+
+  /** Terminate and wait for the thread to actually go, so the process can exit. */
+  async close(): Promise<void> {
+    this.closing = true;
+    this.settleStats({ control: "stats", executed: 0, executedIds: [] });
+    await this.thread.terminate();
+    await this.exited;
+  }
+
+  private settleStats(message: DiffTokenizeStatsResponse): void {
+    const waiters = this.statsWaiters;
+    this.statsWaiters = [];
+    for (const waiter of waiters) {
+      waiter({ executed: message.executed, executedIds: message.executedIds });
+    }
+  }
+
+  private fail(message: string, error?: Error): void {
+    this.failures.push(message);
+    this.settleStats({ control: "stats", executed: 0, executedIds: [] });
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- minimal ErrorEvent shape, the only part of it the client reads
+    this.onerror?.({ message, error } as unknown as ErrorEvent);
+  }
+}
+
+export function createNodeDiffTokenizeWorker(): {
+  harness: NodeDiffTokenizeWorkerHarness;
+  factory: () => Worker;
+} {
+  const harness = new NodeDiffTokenizeWorkerHarness();
+  return {
+    harness,
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- the harness implements exactly the Worker surface DiffTokenizeClient uses
+    factory: () => harness as unknown as Worker,
+  };
+}

--- a/scripts/perf/lib/nodeDiffTokenizeWorkerTransport.ts
+++ b/scripts/perf/lib/nodeDiffTokenizeWorkerTransport.ts
@@ -1,6 +1,7 @@
 // Aliased so bare `Worker` in type position stays the DOM interface — the one
 // `DiffTokenizeClient` is written against.
 import { Worker as NodeWorker } from "node:worker_threads";
+import type { HunkData } from "react-diff-view";
 import type {
   DiffTokenizeWorkerRequest,
   DiffTokenizeWorkerResponse,
@@ -25,13 +26,40 @@ export interface DiffTokenizeWorkerStats {
   executedIds: number[];
 }
 
+/** One posted request, tagged with enough content to say WHICH selection it was. */
+export interface PostedRequest {
+  id: number;
+  sample: string;
+}
+
+/**
+ * The first changed line of a request.
+ *
+ * The client never exposes its request ids, so this is how an observer tells
+ * one selection from another. The burst fixture gives every entry its own seed
+ * and the generator writes that seed into the changed lines, so this string is
+ * unique per selection — which is what lets the scenario assert that the FINAL
+ * selection is the one that reached the worker, rather than inferring it from
+ * id ordering.
+ */
+export function requestSample(hunks: readonly HunkData[]): string {
+  for (const hunk of hunks) {
+    for (const change of hunk.changes) {
+      if (change.type !== "normal") return change.content;
+    }
+  }
+  return "";
+}
+
 export class NodeDiffTokenizeWorkerHarness {
   onmessage: ((event: MessageEvent<DiffTokenizeWorkerResponse>) => void) | null = null;
   onerror: ((event: ErrorEvent) => void) | null = null;
   onmessageerror: (() => void) | null = null;
 
-  /** Ids that actually crossed `postMessage`, in order. */
-  readonly posted: number[] = [];
+  /** Requests that actually crossed `postMessage`, in order, tagged by content. */
+  readonly posted: PostedRequest[] = [];
+  /** Ids whose worker response was handed to the client, in order. */
+  readonly delivered: number[] = [];
   /** Transport-level breakage. A scenario that saw any of this measured nothing. */
   readonly failures: string[] = [];
 
@@ -53,8 +81,13 @@ export class NodeDiffTokenizeWorkerHarness {
         this.settleStats(message);
         return;
       }
+      this.delivered.push(message.id);
       // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- minimal MessageEvent shape, the only part of it the client reads
       this.onmessage?.({ data: message } as MessageEvent<DiffTokenizeWorkerResponse>);
+    });
+
+    this.thread.on("messageerror", () => {
+      this.onmessageerror?.();
     });
 
     this.thread.on("error", (error: Error) => {
@@ -70,12 +103,15 @@ export class NodeDiffTokenizeWorkerHarness {
   }
 
   postMessage(message: DiffTokenizeWorkerRequest): void {
-    this.posted.push(message.id);
+    this.posted.push({ id: message.id, sample: requestSample(message.hunks) });
     this.thread.postMessage(message);
   }
 
   terminate(): void {
     this.closing = true;
+    // Settle first: `closing` makes the exit handler skip `fail()`, so a stats
+    // request already in flight would otherwise never be answered.
+    this.settleStats({ control: "stats", executed: 0, executedIds: [] });
     void this.thread.terminate();
   }
 

--- a/scripts/perf/scenarios/diffTokenize.ts
+++ b/scripts/perf/scenarios/diffTokenize.ts
@@ -6,6 +6,12 @@ import {
   runDiffTokenize,
   MAX_INTRALINE_CHANGES,
 } from "../../../src/components/Worktree/diffTokenizer";
+import type {
+  DiffTokenizeRequest,
+  DiffTokenizeResult,
+} from "../../../src/components/Worktree/diffTokenizer";
+import { DiffTokenizeClient } from "../../../src/services/DiffTokenizeService";
+import { createNodeDiffTokenizeWorker } from "../lib/nodeDiffTokenizeWorkerTransport";
 
 // Diff tokenization — the syntax-highlight + intra-line edit-marking pass that
 // the review workspace runs for every file diff (runDiffTokenize, the one
@@ -808,6 +814,53 @@ function addTokenGrade(into: TokenGrade, from: TokenGrade): TokenGrade {
   return into;
 }
 
+/** How many selections PERF-164's burst issues under one key. */
+const BURST_REQUESTS = 20;
+
+/** One consumer key: a reviewer holding j/k down inside ONE diff viewer. */
+const BURST_KEY = "perf-164-review-viewer";
+
+/**
+ * The entries of the review changeset whose fixture REQUIRES syntax tokens.
+ *
+ * PERF-164 grades only its final selection, so that selection has to be one
+ * the strict oracle applies to. Cycling all five entries over twenty requests
+ * would land the last one on markdown, whose entry deliberately declines to
+ * assert highlighting over this corpus.
+ */
+const HIGHLIGHTED_REVIEW_FILES = REVIEW_CHANGESET.filter(
+  (file) => file.syntaxTokens === "required"
+);
+
+/**
+ * PERF-162's changeset, scaled to twenty distinct selections.
+ *
+ * Every entry gets its own path and seed. `generateUnifiedDiff` writes the seed
+ * into each changed line, so a client that resolved an EARLIER selection's
+ * token tree fails the content term rather than passing quietly.
+ */
+const ADMISSION_BURST: ReadonlyArray<{
+  spec: DiffSpec;
+  language: string;
+  syntaxTokens: SyntaxTokenExpectation;
+  reservedWords: readonly string[];
+}> = Array.from({ length: BURST_REQUESTS }, (_unused, index) => {
+  const source = HIGHLIGHTED_REVIEW_FILES[index % HIGHLIGHTED_REVIEW_FILES.length]!;
+  return {
+    spec: {
+      path: `burst-${index}/${source.spec.path}`,
+      changedLines: source.spec.changedLines,
+      seed: source.spec.seed + index * 97,
+    },
+    language: source.language,
+    syntaxTokens: source.syntaxTokens,
+    reservedWords: source.reservedWords,
+  };
+});
+
+/** Every grammar the burst touches, warmed before the bracket opens. */
+const BURST_LANGUAGES = [...new Set(ADMISSION_BURST.map((file) => file.language))];
+
 export const diffTokenizeScenarios: PerfScenario[] = [
   {
     id: "PERF-160",
@@ -1121,6 +1174,160 @@ export const diffTokenizeScenarios: PerfScenario[] = [
             ? `only ${filesTokenized}/${prepared.length} files tokenized`
             : `longest block ${underLoad.longestStallMs.toFixed(1)}ms vs ${idle.longestStallMs.toFixed(1)}ms idle`,
       };
+    },
+  },
+  {
+    id: "PERF-164",
+    name: "Diff Tokenize - Superseded Selection Burst",
+    description:
+      "Twenty selections under ONE consumer key, issued back to back with no await between them — " +
+      "a reviewer holding j/k down through a changeset while each file asks to be tokenized. The " +
+      "subject is DiffTokenizeClient's admission control, not the tokenizer: PERF-160..163 all call " +
+      "runDiffTokenize directly and none of them post work the client has already given up on. The " +
+      "client is driven UNMODIFIED against a real node:worker_threads thread running the production " +
+      "tokenizer, so executedJobs is counted where the work happens rather than inferred from what " +
+      "the client posted — the client's own bookkeeping is the thing under test and cannot also be " +
+      "the oracle. finalSelectionMs is the number a user feels: the wait from the last keypress to a " +
+      "highlighted diff. executedJobs and supersededPosted are raw counts and deliberately NOT " +
+      "correctness terms — a predicate asserting 'exactly two jobs ran' would fail on an unmodified " +
+      "client, which is precisely the arm this scenario has to be able to measure. Only the final " +
+      "selection is graded, on PERF-162's terms: it is the one result a caller consumes, and each " +
+      "entry carries its own seed so an earlier selection's tree fails the content term instead of " +
+      "passing quietly. Main-thread admission and completion latency, NOT painted latency — there " +
+      "is no renderer, no Chromium scheduler and no React commit here.",
+    tier: "heavy",
+    modes: ["smoke", "ci", "nightly"],
+    iterations: { smoke: 8, ci: 8, nightly: 12 },
+    warmups: 1,
+    correctness: [
+      "tokenizeMisses",
+      "supersededResolutionMisses",
+      "executionAccountingMisses",
+      "workerRoutingMisses",
+      "tokenLineMisses",
+      "tokenContentMisses",
+      "tokenHighlightMisses",
+      "tokenCategoryMisses",
+      "tokenLexicalMisses",
+      "tokenStringMisses",
+    ],
+    // The burst IS the workload. A fixture that quietly issued two requests
+    // would report executedJobs: 2 with every predicate at zero — the best
+    // result this scenario can post, from doing none of the work.
+    workloadFloors: {
+      requestCount: BURST_REQUESTS,
+      fileCount: BURST_REQUESTS,
+      changedLines: 6_400,
+      minChangedLinesPerRequest: 320,
+    },
+    async run() {
+      const prepared = ADMISSION_BURST.map((file) => ({
+        ...hunksFor(file.spec),
+        language: file.language,
+        syntaxTokens: file.syntaxTokens,
+        reservedWords: file.reservedWords,
+      }));
+      const requestFor = (file: (typeof prepared)[number]): DiffTokenizeRequest => ({
+        hunks: file.hunks,
+        language: file.language,
+        highlight: true,
+        extraRanges: null,
+      });
+
+      const { harness, factory } = createNodeDiffTokenizeWorker();
+      let factoryCalls = 0;
+      const client = new DiffTokenizeClient(() => {
+        factoryCalls += 1;
+        return factory();
+      });
+
+      try {
+        // Warm every grammar the burst uses, outside the bracket. The worker
+        // lazy-loads a language on first use, and that import inside the
+        // measurement would report a grammar load as tokenize latency.
+        for (const language of BURST_LANGUAGES) {
+          await client.tokenize(`perf-164-warmup-${language}`, {
+            ...requestFor(prepared[0]!),
+            language,
+          });
+        }
+        const warm = await harness.stats();
+        const postedBeforeBurst = harness.posted.length;
+
+        const supersededPromises: Array<Promise<DiffTokenizeResult | null>> = [];
+        const start = performance.now();
+        for (let index = 0; index < prepared.length - 1; index += 1) {
+          // No await between calls. A loop that waited would measure a queue
+          // nobody has, and would never supersede anything.
+          supersededPromises.push(client.tokenize(BURST_KEY, requestFor(prepared[index]!)));
+        }
+        const finalFile = prepared[prepared.length - 1]!;
+        const finalStart = performance.now();
+        const finalResult = await client.tokenize(BURST_KEY, requestFor(finalFile));
+        const finished = performance.now();
+        const finalSelectionMs = finished - finalStart;
+        const durationMs = finished - start;
+
+        // Everything below is outside both clocks: the superseded promises are
+        // already settled, and the tally and the grade are the oracle, not the
+        // subject.
+        const superseded = await Promise.all(supersededPromises);
+        const after = await harness.stats();
+
+        const burstPosted = harness.posted.slice(postedBeforeBurst);
+        const burstExecuted = after.executedIds.slice(warm.executedIds.length);
+        // Ids rise monotonically, and the final selection is the last one the
+        // client issued — so on either arm it is the highest id that reached
+        // the worker. Read from the transport rather than assumed, because the
+        // client never exposes its ids.
+        const finalId = burstPosted.length > 0 ? Math.max(...burstPosted) : -1;
+
+        const postedIds = new Set(burstPosted);
+        const executedIds = new Set(burstExecuted);
+        let executionAccountingMisses =
+          burstPosted.length - postedIds.size + (burstExecuted.length - executedIds.size);
+        for (const id of postedIds) if (!executedIds.has(id)) executionAccountingMisses += 1;
+        for (const id of executedIds) if (!postedIds.has(id)) executionAccountingMisses += 1;
+        if (finalId < 0 || !executedIds.has(finalId)) executionAccountingMisses += 1;
+
+        const tokenizeMisses =
+          finalResult && finalResult.tokens && !finalResult.langLoadFailed ? 0 : 1;
+        const tokenGrade = gradeTokens(
+          finalResult?.tokens ?? null,
+          finalFile.hunks,
+          finalFile.syntaxTokens,
+          finalFile.reservedWords
+        );
+
+        const changedLines = prepared.reduce((total, file) => total + file.changedLines, 0);
+
+        return {
+          durationMs,
+          metrics: {
+            finalSelectionMs,
+            executedJobs: burstExecuted.length,
+            postedJobs: burstPosted.length,
+            // Jobs that DID cross postMessage and whose result nobody used. A
+            // request held back and never posted is not one of these — that is
+            // the whole difference the gate makes.
+            supersededPosted: burstPosted.filter((id) => id !== finalId).length,
+            requestCount: prepared.length,
+            fileCount: new Set(ADMISSION_BURST.map((file) => file.spec.path)).size,
+            changedLines,
+            minChangedLinesPerRequest: Math.min(...prepared.map((file) => file.changedLines)),
+            tokenizeMisses,
+            supersededResolutionMisses: superseded.filter((result) => result !== null).length,
+            executionAccountingMisses,
+            workerRoutingMisses: (factoryCalls === 1 ? 0 : 1) + harness.failures.length,
+            ...tokenGrade,
+          },
+          notes: `${burstExecuted.length}/${prepared.length} selections reached the worker`,
+        };
+      } finally {
+        // The thread holds the process open, and the liveness driver's own
+        // process.exit would mask that rather than prove it was cleaned up.
+        await harness.close();
+      }
     },
   },
 ];

--- a/scripts/perf/scenarios/diffTokenize.ts
+++ b/scripts/perf/scenarios/diffTokenize.ts
@@ -11,7 +11,10 @@ import type {
   DiffTokenizeResult,
 } from "../../../src/components/Worktree/diffTokenizer";
 import { DiffTokenizeClient } from "../../../src/services/DiffTokenizeService";
-import { createNodeDiffTokenizeWorker } from "../lib/nodeDiffTokenizeWorkerTransport";
+import {
+  createNodeDiffTokenizeWorker,
+  requestSample,
+} from "../lib/nodeDiffTokenizeWorkerTransport";
 
 // Diff tokenization — the syntax-highlight + intra-line edit-marking pass that
 // the review workspace runs for every file diff (runDiffTokenize, the one
@@ -1180,21 +1183,26 @@ export const diffTokenizeScenarios: PerfScenario[] = [
     id: "PERF-164",
     name: "Diff Tokenize - Superseded Selection Burst",
     description:
-      "Twenty selections under ONE consumer key, issued back to back with no await between them — " +
-      "a reviewer holding j/k down through a changeset while each file asks to be tokenized. The " +
-      "subject is DiffTokenizeClient's admission control, not the tokenizer: PERF-160..163 all call " +
-      "runDiffTokenize directly and none of them post work the client has already given up on. The " +
-      "client is driven UNMODIFIED against a real node:worker_threads thread running the production " +
-      "tokenizer, so executedJobs is counted where the work happens rather than inferred from what " +
-      "the client posted — the client's own bookkeeping is the thing under test and cannot also be " +
-      "the oracle. finalSelectionMs is the number a user feels: the wait from the last keypress to a " +
-      "highlighted diff. executedJobs and supersededPosted are raw counts and deliberately NOT " +
+      "Twenty tokenize requests under ONE consumer key, issued back to back with no await between " +
+      "them. One key is one MOUNTED FILE DIFF, not a whole review: DiffViewer's useTokens takes its " +
+      "key from useId(), so each file gets its own and different files are independent consumers by " +
+      "design. What re-requests the same key twenty times is a search query being typed — " +
+      "extraRanges is deliberately ungated in that effect, so every keystroke re-tokenizes the file " +
+      "— along with collapse, wrap and view-type changes. The subject is DiffTokenizeClient's " +
+      "admission control, not the tokenizer: PERF-160..163 all call runDiffTokenize directly and " +
+      "none of them post work the client has already given up on. The client is driven UNMODIFIED " +
+      "against a real node:worker_threads thread running the production tokenizer, so executedJobs " +
+      "is counted where the work happens rather than inferred from what the client posted — the " +
+      "client's own bookkeeping is the thing under test and cannot also be the oracle. " +
+      "finalSelectionMs is the last tokenize() call to its resolved result: a service-level " +
+      "completion time, NOT keystroke-to-paint — there is no renderer, no Chromium scheduler and no " +
+      "React commit here. executedJobs and supersededPosted are raw counts and deliberately NOT " +
       "correctness terms — a predicate asserting 'exactly two jobs ran' would fail on an unmodified " +
       "client, which is precisely the arm this scenario has to be able to measure. Only the final " +
-      "selection is graded, on PERF-162's terms: it is the one result a caller consumes, and each " +
-      "entry carries its own seed so an earlier selection's tree fails the content term instead of " +
-      "passing quietly. Main-thread admission and completion latency, NOT painted latency — there " +
-      "is no renderer, no Chromium scheduler and no React commit here.",
+      "selection is graded, on PERF-162's terms: it is the one result a caller consumes, each entry " +
+      "carries its own seed so an earlier selection's tree fails the content term instead of " +
+      "passing quietly, and that seed is also how the oracle identifies WHICH posted request was " +
+      "the final one rather than trusting id order.",
     tier: "heavy",
     modes: ["smoke", "ci", "nightly"],
     iterations: { smoke: 8, ci: 8, nightly: 12 },
@@ -1253,43 +1261,33 @@ export const diffTokenizeScenarios: PerfScenario[] = [
         }
         const warm = await harness.stats();
         const postedBeforeBurst = harness.posted.length;
+        const deliveredBeforeBurst = harness.delivered.length;
 
+        // The workload has to be counted where the calls are MADE, not read off
+        // the prepared fixture. A submission loop that quietly issued two
+        // requests would still let the fixture report twenty — the exact
+        // flattering shortfall the floors below exist to catch.
+        const issued: number[] = [];
         const supersededPromises: Array<Promise<DiffTokenizeResult | null>> = [];
         const start = performance.now();
         for (let index = 0; index < prepared.length - 1; index += 1) {
           // No await between calls. A loop that waited would measure a queue
           // nobody has, and would never supersede anything.
+          issued.push(index);
           supersededPromises.push(client.tokenize(BURST_KEY, requestFor(prepared[index]!)));
         }
-        const finalFile = prepared[prepared.length - 1]!;
+        const finalIndex = prepared.length - 1;
+        const finalFile = prepared[finalIndex]!;
+        issued.push(finalIndex);
         const finalStart = performance.now();
         const finalResult = await client.tokenize(BURST_KEY, requestFor(finalFile));
         const finished = performance.now();
         const finalSelectionMs = finished - finalStart;
         const durationMs = finished - start;
 
-        // Everything below is outside both clocks: the superseded promises are
-        // already settled, and the tally and the grade are the oracle, not the
-        // subject.
-        const superseded = await Promise.all(supersededPromises);
-        const after = await harness.stats();
-
-        const burstPosted = harness.posted.slice(postedBeforeBurst);
-        const burstExecuted = after.executedIds.slice(warm.executedIds.length);
-        // Ids rise monotonically, and the final selection is the last one the
-        // client issued — so on either arm it is the highest id that reached
-        // the worker. Read from the transport rather than assumed, because the
-        // client never exposes its ids.
-        const finalId = burstPosted.length > 0 ? Math.max(...burstPosted) : -1;
-
-        const postedIds = new Set(burstPosted);
-        const executedIds = new Set(burstExecuted);
-        let executionAccountingMisses =
-          burstPosted.length - postedIds.size + (burstExecuted.length - executedIds.size);
-        for (const id of postedIds) if (!executedIds.has(id)) executionAccountingMisses += 1;
-        for (const id of executedIds) if (!postedIds.has(id)) executionAccountingMisses += 1;
-        if (finalId < 0 || !executedIds.has(finalId)) executionAccountingMisses += 1;
-
+        // Graded HERE, before any further await. A client that resolved early
+        // with a stale tree and repaired it once the real response landed would
+        // otherwise report the early timestamp and still pass the content term.
         const tokenizeMisses =
           finalResult && finalResult.tokens && !finalResult.langLoadFailed ? 0 : 1;
         const tokenGrade = gradeTokens(
@@ -1299,7 +1297,39 @@ export const diffTokenizeScenarios: PerfScenario[] = [
           finalFile.reservedWords
         );
 
-        const changedLines = prepared.reduce((total, file) => total + file.changedLines, 0);
+        // Everything below is outside both clocks: the superseded promises are
+        // already settled, and the tally is the oracle, not the subject.
+        const superseded = await Promise.all(supersededPromises);
+        const after = await harness.stats();
+
+        const burstPosted = harness.posted.slice(postedBeforeBurst);
+        const burstDelivered = harness.delivered.slice(deliveredBeforeBurst);
+        const burstExecuted = after.executedIds.slice(warm.executedIds.length);
+        // Identify the final selection by its CONTENT, not by id order. Correct
+        // final tokens are not by themselves evidence the worker produced them:
+        // a client that ran the held request in-thread would return the right
+        // tree, resolve the other nineteen null and post a flattering count
+        // with every term at zero. Matching the seed the generator wrote into
+        // the fixture, and requiring that id's response to have been delivered,
+        // is what makes the route part of the measurement.
+        const finalSample = requestSample(finalFile.hunks);
+        const finalPost = burstPosted.find((post) => post.sample === finalSample);
+        const finalId = finalPost?.id ?? -1;
+
+        const postedIds = new Set(burstPosted.map((post) => post.id));
+        const deliveredIds = new Set(burstDelivered);
+        const executedIds = new Set(burstExecuted);
+        let executionAccountingMisses =
+          burstPosted.length - postedIds.size + (burstExecuted.length - executedIds.size);
+        for (const id of postedIds) if (!executedIds.has(id)) executionAccountingMisses += 1;
+        for (const id of executedIds) if (!postedIds.has(id)) executionAccountingMisses += 1;
+        if (finalId < 0) executionAccountingMisses += 1;
+        else if (!executedIds.has(finalId) || !deliveredIds.has(finalId)) {
+          executionAccountingMisses += 1;
+        }
+
+        const issuedFiles = issued.map((index) => prepared[index]!);
+        const changedLines = issuedFiles.reduce((total, file) => total + file.changedLines, 0);
 
         return {
           durationMs,
@@ -1310,18 +1340,18 @@ export const diffTokenizeScenarios: PerfScenario[] = [
             // Jobs that DID cross postMessage and whose result nobody used. A
             // request held back and never posted is not one of these — that is
             // the whole difference the gate makes.
-            supersededPosted: burstPosted.filter((id) => id !== finalId).length,
-            requestCount: prepared.length,
-            fileCount: new Set(ADMISSION_BURST.map((file) => file.spec.path)).size,
+            supersededPosted: burstPosted.filter((post) => post.id !== finalId).length,
+            requestCount: issued.length,
+            fileCount: new Set(issued.map((index) => ADMISSION_BURST[index]!.spec.path)).size,
             changedLines,
-            minChangedLinesPerRequest: Math.min(...prepared.map((file) => file.changedLines)),
+            minChangedLinesPerRequest: Math.min(...issuedFiles.map((file) => file.changedLines)),
             tokenizeMisses,
             supersededResolutionMisses: superseded.filter((result) => result !== null).length,
             executionAccountingMisses,
             workerRoutingMisses: (factoryCalls === 1 ? 0 : 1) + harness.failures.length,
             ...tokenGrade,
           },
-          notes: `${burstExecuted.length}/${prepared.length} selections reached the worker`,
+          notes: `${burstExecuted.length}/${issued.length} selections reached the worker`,
         };
       } finally {
         // The thread holds the process open, and the liveness driver's own

--- a/scripts/perf/scenarios/index.ts
+++ b/scripts/perf/scenarios/index.ts
@@ -164,6 +164,7 @@ export const EXPECTED_SCENARIO_IDS: ReadonlySet<string> = new Set([
   "PERF-161",
   "PERF-162",
   "PERF-163",
+  "PERF-164",
   "PERF-170",
   "PERF-171",
   "PERF-190",

--- a/src/services/DiffTokenizeService.ts
+++ b/src/services/DiffTokenizeService.ts
@@ -5,6 +5,19 @@
  * a newer request under the same key supersedes the older one (its promise
  * resolves null and any late worker response is dropped).
  *
+ * Admission control:
+ * - At most ONE job per key is ever on the worker. A request arriving while its
+ *   key already has one in flight is HELD — not posted, no timeout timer — and
+ *   replaces whatever was held before it. When the in-flight job settles, the
+ *   held request is posted; everything superseded in between never reaches the
+ *   worker at all. Stepping through a 20-file review therefore costs two jobs,
+ *   not twenty: the worker is single-threaded, so a queue of jobs the client
+ *   has already given up on IS the latency of the file the user is looking at.
+ *   A posted job cannot be recalled (there is no cancel for postMessage, and
+ *   terminating the worker would cost more than finishing one job and would
+ *   drop the lazy grammar cache), so the gate has to sit in front of it.
+ * - Keys are independent: a burst under one key never delays another's.
+ *
  * Failure handling:
  * - A request unanswered for REQUEST_TIMEOUT_MS means the worker thread is
  *   wedged (pathological grammar regex or markEdits input). The request
@@ -39,9 +52,21 @@ interface PendingRequest {
   request: DiffTokenizeRequest;
   resolve: (result: DiffTokenizeResult | null) => void;
   timer: ReturnType<typeof setTimeout>;
+  /**
+   * A newer same-key request arrived after this one was already on the worker.
+   *
+   * Its promise is settled null the moment that happens, exactly as before —
+   * but the entry STAYS in `pending`, because the worker cannot un-run a job it
+   * has already been handed. The entry is what the response (or the timeout)
+   * lands on to release the key's in-flight slot and let the held request go;
+   * dropping it here would strand that slot and the held request behind it
+   * forever. Its result is discarded when it arrives, side effects included.
+   */
+  superseded: boolean;
 }
 
-interface InThreadJob {
+/** A request that has not been handed to anything yet: held behind its key's in-flight job, or queued in-thread. */
+interface TokenizeJob {
   key: string;
   id: number;
   request: DiffTokenizeRequest;
@@ -69,7 +94,11 @@ export class DiffTokenizeClient {
   private nextId = 1;
   private readonly pending = new Map<number, PendingRequest>();
   private readonly latestByKey = new Map<string, number>();
-  private readonly inThreadQueue: InThreadJob[] = [];
+  /** The one id currently posted to the worker for each key. The admission gate. */
+  private readonly inFlightByKey = new Map<string, number>();
+  /** At most one not-yet-posted request per key, waiting for the in-flight one to settle. */
+  private readonly heldByKey = new Map<string, TokenizeJob>();
+  private readonly inThreadQueue: TokenizeJob[] = [];
   private draining = false;
 
   constructor(createWorker: () => Worker = createDefaultWorker) {
@@ -82,30 +111,93 @@ export class DiffTokenizeClient {
    */
   tokenize(key: string, request: DiffTokenizeRequest): Promise<DiffTokenizeResult | null> {
     const id = this.nextId++;
-    const previousId = this.latestByKey.get(key);
-    if (previousId !== undefined) {
-      const previous = this.pending.get(previousId);
-      if (previous) {
-        clearTimeout(previous.timer);
-        this.pending.delete(previousId);
-        previous.resolve(null);
-      }
-    }
+    this.supersedePrevious(key);
     this.latestByKey.set(key, id);
 
     const worker = this.workerFailed ? null : this.ensureWorker();
     if (!worker) return this.enqueueInThread(key, id, request);
 
+    // The key is busy: hold this one instead of posting it. No timer either —
+    // a job that was never posted cannot have wedged anything.
+    if (this.inFlightByKey.has(key)) {
+      return new Promise<DiffTokenizeResult | null>((resolve) => {
+        this.heldByKey.set(key, { key, id, request, resolve });
+      });
+    }
+
     return new Promise<DiffTokenizeResult | null>((resolve) => {
-      const timer = setTimeout(() => this.handleTimeout(id), REQUEST_TIMEOUT_MS);
-      this.pending.set(id, { key, request, resolve, timer });
-      const message: DiffTokenizeWorkerRequest = { id, ...request };
-      try {
-        worker.postMessage(message);
-      } catch (err) {
-        this.failOver(err);
-      }
+      this.dispatch(worker, { key, id, request, resolve });
     });
+  }
+
+  /**
+   * Settle whatever this key was already waiting on, newest-wins.
+   *
+   * A held request is dropped outright — it never reached the worker, so there
+   * is nothing to clean up. An in-flight one is settled null but deliberately
+   * left in `pending`; see `PendingRequest.superseded`.
+   */
+  private supersedePrevious(key: string): void {
+    const held = this.heldByKey.get(key);
+    if (held) {
+      this.heldByKey.delete(key);
+      held.resolve(null);
+      return;
+    }
+    const previousId = this.latestByKey.get(key);
+    if (previousId === undefined) return;
+    const previous = this.pending.get(previousId);
+    if (!previous || previous.superseded) return;
+    previous.superseded = true;
+    previous.resolve(null);
+  }
+
+  /** Post a job to the worker and open the key's in-flight slot behind it. */
+  private dispatch(worker: Worker, job: TokenizeJob): void {
+    const timer = setTimeout(() => this.handleTimeout(job.id), REQUEST_TIMEOUT_MS);
+    this.pending.set(job.id, {
+      key: job.key,
+      request: job.request,
+      resolve: job.resolve,
+      timer,
+      superseded: false,
+    });
+    this.inFlightByKey.set(job.key, job.id);
+    const message: DiffTokenizeWorkerRequest = { id: job.id, ...job.request };
+    try {
+      worker.postMessage(message);
+    } catch (err) {
+      this.failOver(err);
+    }
+  }
+
+  private releaseInFlight(key: string, id: number): void {
+    if (this.inFlightByKey.get(key) === id) this.inFlightByKey.delete(key);
+  }
+
+  /**
+   * Post the request held behind this key, now that the slot is free.
+   *
+   * Called on every path that settles an in-flight job. A held request that a
+   * newer one superseded while it waited resolves null without running, and one
+   * whose worker died on the way here goes to the in-thread queue rather than
+   * being posted to nothing.
+   */
+  private dispatchHeld(key: string): void {
+    const held = this.heldByKey.get(key);
+    if (!held) return;
+    this.heldByKey.delete(key);
+    if (this.latestByKey.get(key) !== held.id) {
+      held.resolve(null);
+      return;
+    }
+    const worker = this.workerFailed ? null : this.ensureWorker();
+    if (!worker) {
+      this.inThreadQueue.push(held);
+      void this.pumpInThread();
+      return;
+    }
+    this.dispatch(worker, held);
   }
 
   private ensureWorker(): Worker | null {
@@ -131,6 +223,19 @@ export class DiffTokenizeClient {
   private handleResponse(response: DiffTokenizeWorkerResponse): void {
     const entry = this.pending.get(response.id);
     if (!entry) return;
+    // A superseded entry is a slot release and nothing else: its caller was
+    // settled null when it was superseded, so neither its tokens nor its
+    // failure are acted on. Before the gate, this response was dropped whole by
+    // the `!entry` guard above — an obsolete error must not newly cost the
+    // session its worker, and the grammar-failure signal it carries is
+    // re-learned by the held request that takes its place.
+    if (entry.superseded) {
+      clearTimeout(entry.timer);
+      this.pending.delete(response.id);
+      this.releaseInFlight(entry.key, response.id);
+      this.dispatchHeld(entry.key);
+      return;
+    }
     if (!response.ok) {
       this.failOver(new Error(response.error));
       return;
@@ -138,8 +243,10 @@ export class DiffTokenizeClient {
     clearTimeout(entry.timer);
     this.pending.delete(response.id);
     this.clearLatest(entry.key, response.id);
+    this.releaseInFlight(entry.key, response.id);
     if (response.langLoadFailed) markLanguageFailed(entry.request.language);
     entry.resolve({ tokens: response.tokens, langLoadFailed: response.langLoadFailed });
+    this.dispatchHeld(entry.key);
   }
 
   private handleTimeout(id: number): void {
@@ -154,6 +261,7 @@ export class DiffTokenizeClient {
     // the replacement worker re-serves all subsequent work, and a genuinely
     // poisoned input just times out again and triggers the next replacement.
     entry.resolve(null);
+    this.releaseInFlight(entry.key, id);
     if (this.replacements >= MAX_WORKER_REPLACEMENTS) {
       this.failOver(new Error("Diff tokenize worker kept timing out"));
       return;
@@ -163,6 +271,9 @@ export class DiffTokenizeClient {
       `Diff tokenize request timed out after ${REQUEST_TIMEOUT_MS}ms; replacing the worker (${this.replacements}/${MAX_WORKER_REPLACEMENTS})`
     );
     this.replaceWorker();
+    // After the replacement exists, so the held request is posted to a live
+    // worker rather than the one just terminated.
+    this.dispatchHeld(entry.key);
   }
 
   /** Terminate the wedged worker and move surviving requests to a fresh one. */
@@ -176,11 +287,16 @@ export class DiffTokenizeClient {
       this.failOver(new Error("Diff tokenize worker replacement failed"));
       return;
     }
+    // Keys whose in-flight job was dropped here rather than re-posted: their
+    // held request is next in line, but only once the loop is done posting.
+    const freed: string[] = [];
     for (const [id, entry] of [...this.pending.entries()]) {
       clearTimeout(entry.timer);
       if (this.latestByKey.get(entry.key) !== id) {
         this.pending.delete(id);
         entry.resolve(null);
+        this.releaseInFlight(entry.key, id);
+        freed.push(entry.key);
         continue;
       }
       entry.timer = setTimeout(() => this.handleTimeout(id), REQUEST_TIMEOUT_MS);
@@ -192,6 +308,7 @@ export class DiffTokenizeClient {
         return;
       }
     }
+    for (const key of freed) this.dispatchHeld(key);
   }
 
   private async runInThread(
@@ -226,8 +343,14 @@ export class DiffTokenizeClient {
   /** Fail over to in-thread tokenization, queueing still-relevant pending requests. */
   private failOver(err: unknown): void {
     this.enterFallback(err);
+    this.inFlightByKey.clear();
     const entries = [...this.pending.entries()];
     this.pending.clear();
+    // Held requests never reached the worker, so they survive its death — but
+    // they carry no `pending` row, so the sweep below would miss them and leave
+    // their callers waiting on a promise nothing will ever settle.
+    const held = [...this.heldByKey.values()];
+    this.heldByKey.clear();
     for (const [id, entry] of entries) {
       clearTimeout(entry.timer);
       if (this.latestByKey.get(entry.key) !== id) {
@@ -240,6 +363,13 @@ export class DiffTokenizeClient {
         request: entry.request,
         resolve: entry.resolve,
       });
+    }
+    for (const job of held) {
+      if (this.latestByKey.get(job.key) !== job.id) {
+        job.resolve(null);
+        continue;
+      }
+      this.inThreadQueue.push(job);
     }
     void this.pumpInThread();
   }

--- a/src/services/DiffTokenizeService.ts
+++ b/src/services/DiffTokenizeService.ts
@@ -171,6 +171,15 @@ export class DiffTokenizeClient {
     }
   }
 
+  /** Settle a held request null without running it anywhere. */
+  private dropHeld(key: string): void {
+    const held = this.heldByKey.get(key);
+    if (!held) return;
+    this.heldByKey.delete(key);
+    this.clearLatest(key, held.id);
+    held.resolve(null);
+  }
+
   private releaseInFlight(key: string, id: number): void {
     if (this.inFlightByKey.get(key) === id) this.inFlightByKey.delete(key);
   }
@@ -263,6 +272,12 @@ export class DiffTokenizeClient {
     entry.resolve(null);
     this.releaseInFlight(entry.key, id);
     if (this.replacements >= MAX_WORKER_REPLACEMENTS) {
+      // Fallback runs on the main thread, and this key's held successor is the
+      // likeliest carrier of the input that just wedged three workers in a row
+      // — same viewer, same file. Handing it to the fallback would freeze the
+      // UI with exactly the pathology the timeout exists to contain, so it is
+      // dropped for the same reason the timed-out request is never re-run.
+      this.dropHeld(entry.key);
       this.failOver(new Error("Diff tokenize worker kept timing out"));
       return;
     }

--- a/src/services/__tests__/DiffTokenizeService.test.ts
+++ b/src/services/__tests__/DiffTokenizeService.test.ts
@@ -422,6 +422,38 @@ describe("DiffTokenizeClient timeout", () => {
     expect(mockRunDiffTokenize).not.toHaveBeenCalled();
   });
 
+  it("never hands a held successor to the fallback once the budget is exhausted", async () => {
+    vi.useFakeTimers();
+    const { client, workers } = createReplacingClient();
+    mockRunDiffTokenize.mockResolvedValue(tokensA);
+
+    // Same key throughout: one wedging request on the worker and one identical
+    // successor held behind it, re-held after each replacement.
+    const first = client.tokenize("viewer-1", makeRequest());
+    let held = client.tokenize("viewer-1", makeRequest());
+    await expect(first).resolves.toBeNull();
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    const second = held;
+    held = client.tokenize("viewer-1", makeRequest());
+    await expect(second).resolves.toBeNull();
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    const third = held;
+    held = client.tokenize("viewer-1", makeRequest());
+    await expect(third).resolves.toBeNull();
+
+    // Budget exhausted: the client gives up on the worker. The successor is
+    // the same viewer asking for the same file that wedged three workers, and
+    // the fallback runs on the main thread — so it is dropped, not run.
+    await vi.advanceTimersByTimeAsync(30_000);
+    await vi.runAllTimersAsync();
+
+    await expect(held).resolves.toBeNull();
+    expect(mockRunDiffTokenize).not.toHaveBeenCalled();
+    expect(workers).toHaveLength(3);
+  });
+
   it("falls back permanently once the replacement budget is exhausted", async () => {
     vi.useFakeTimers();
     const { client, workers, factory } = createReplacingClient();

--- a/src/services/__tests__/DiffTokenizeService.test.ts
+++ b/src/services/__tests__/DiffTokenizeService.test.ts
@@ -109,20 +109,68 @@ describe("DiffTokenizeClient worker path", () => {
     expect(mockRunDiffTokenize).not.toHaveBeenCalled();
   });
 
-  it("discards a superseded request and keeps the latest for the same key", async () => {
+  it("holds a superseded request off the worker and posts only the latest", async () => {
     const { client, worker } = createClient();
     const first = client.tokenize("viewer-1", makeRequest());
     const second = client.tokenize("viewer-1", makeRequest());
 
     await expect(first).resolves.toBeNull();
+    // The key already had a job in flight, so the second never reached the
+    // worker at all. Before admission control both were posted and the worker
+    // ran the obsolete one ahead of the one the user is waiting for.
+    expect(worker.posted).toHaveLength(1);
 
-    const [firstMessage, secondMessage] = worker.posted;
-    worker.respond({ id: secondMessage!.id, ok: true, ...tokensA });
-    await expect(second).resolves.toEqual(tokensA);
+    worker.respond({ id: worker.posted[0]!.id, ok: true, tokens: null, langLoadFailed: true });
 
-    // A late response for the superseded id is ignored without side effects.
-    worker.respond({ id: firstMessage!.id, ok: true, tokens: null, langLoadFailed: true });
+    // The in-flight job's result is discarded, side effects included: its
+    // caller was settled null the moment it was superseded.
     expect(mockMarkLanguageFailed).not.toHaveBeenCalled();
+
+    // Releasing the slot is what posts the request held behind it.
+    expect(worker.posted).toHaveLength(2);
+    worker.respond({ id: worker.posted[1]!.id, ok: true, ...tokensA });
+    await expect(second).resolves.toEqual(tokensA);
+  });
+
+  it("posts two messages for a burst of ten requests under one key", async () => {
+    const { client, worker } = createClient();
+    const burst = Array.from({ length: 10 }, () => client.tokenize("viewer-1", makeRequest()));
+
+    // One in flight; the other nine collapse into a single held slot.
+    expect(worker.posted).toHaveLength(1);
+    await expect(Promise.all(burst.slice(0, 9))).resolves.toEqual(Array(9).fill(null));
+
+    worker.respond({ id: worker.posted[0]!.id, ok: true, ...tokensA });
+
+    expect(worker.posted).toHaveLength(2);
+    // The survivor is the NEWEST request, not the second one issued — the held
+    // slot holds one request and every arrival replaces it.
+    expect(worker.posted[1]!.id).toBe(worker.posted[0]!.id + 9);
+
+    worker.respond({ id: worker.posted[1]!.id, ok: true, ...tokensA });
+    await expect(burst[9]!).resolves.toEqual(tokensA);
+    expect(mockRunDiffTokenize).not.toHaveBeenCalled();
+  });
+
+  it("ignores an error from a superseded job instead of failing over", async () => {
+    const { client, worker, factory } = createClient();
+    const first = client.tokenize("viewer-1", makeRequest());
+    const second = client.tokenize("viewer-1", makeRequest());
+    await expect(first).resolves.toBeNull();
+
+    worker.respond({ id: worker.posted[0]!.id, ok: false, error: "tokenize blew up" });
+
+    // The superseded entry survives in `pending` only to release the key's
+    // slot, so its error has to stay as ignored as its tokens are. Treating it
+    // as evidence the environment is broken would cost the session its worker
+    // over a request nobody is waiting for.
+    expect(worker.terminated).toBe(false);
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(worker.posted).toHaveLength(2);
+
+    worker.respond({ id: worker.posted[1]!.id, ok: true, ...tokensA });
+    await expect(second).resolves.toEqual(tokensA);
+    expect(mockRunDiffTokenize).not.toHaveBeenCalled();
   });
 
   it("keeps requests under different keys independent", async () => {
@@ -261,6 +309,24 @@ describe("DiffTokenizeClient fallback", () => {
     expect(order).toEqual(["replacement"]);
   });
 
+  it("moves a held request in-thread when the worker dies", async () => {
+    vi.useFakeTimers();
+    const { client, worker } = createClient();
+    mockRunDiffTokenize.mockResolvedValue(tokensA);
+
+    const superseded = client.tokenize("viewer-a", makeRequest("stale"));
+    const held = client.tokenize("viewer-a", makeRequest("held"));
+
+    worker.fail("worker crashed");
+    await vi.runAllTimersAsync();
+
+    await expect(superseded).resolves.toBeNull();
+    // A held request carries no `pending` row, so a failover sweep that walked
+    // only `pending` would leave this promise unsettled for the whole session.
+    await expect(held).resolves.toEqual(tokensA);
+    expect(mockRunDiffTokenize).toHaveBeenCalledTimes(1);
+  });
+
   it("re-runs only newest-per-key requests sequentially on failover", async () => {
     vi.useFakeTimers();
     const { client, worker } = createClient();
@@ -333,6 +399,26 @@ describe("DiffTokenizeClient timeout", () => {
 
     workers[1]!.respond({ id: workers[1]!.posted[0]!.id, ok: true, ...tokensA });
     await expect(queued).resolves.toEqual(tokensA);
+    expect(mockRunDiffTokenize).not.toHaveBeenCalled();
+  });
+
+  it("starts no timeout for a request it never posted", async () => {
+    vi.useFakeTimers();
+    const { client, workers } = createReplacingClient();
+    const wedged = client.tokenize("viewer-1", makeRequest());
+    const held = client.tokenize("viewer-1", makeRequest());
+    await expect(wedged).resolves.toBeNull();
+
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    // One watchdog fired, not two: a request that was never posted cannot have
+    // wedged anything, so it spends none of the replacement budget.
+    expect(workers).toHaveLength(2);
+    // It goes to the replacement, and only now does its own timeout start.
+    expect(workers[1]!.posted).toHaveLength(1);
+
+    workers[1]!.respond({ id: workers[1]!.posted[0]!.id, ok: true, ...tokensA });
+    await expect(held).resolves.toEqual(tokensA);
     expect(mockRunDiffTokenize).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary

- `DiffTokenizeClient.tokenize()` only superseded requests on the client. It resolved the previous same-key request as `null` and dropped it from `pending`, but the message had already been posted to the worker, so the worker ran it anyway and the result was thrown away on arrival. The worker is single threaded, so that queue of obsolete work was literally the latency of the selection the user was waiting on.
- Fix: per-key admission control in front of the worker. At most one job per key is in flight. A request that arrives while its key is busy is held, not posted, no timeout timer, and it replaces whatever was held before it. When the in-flight job settles, the held request is posted and everything superseded in between never reaches the worker. Superseded requests still resolve `null`, so the "ignore null" contract callers already rely on doesn't change.

Resolves #12236

## The subtle part

A superseded job that's already running on the worker keeps its `pending` row and its watchdog, because it can't be recalled. That row is what its response (or timeout) lands on to release the key's slot and let the held successor go. Delete it and both are stranded forever. Its result is discarded, grammar-load signal included, and an error from it no longer costs the session its worker. Before this change, that response was dropped whole by the `!entry` guard, so a stale error must not newly trigger permanent fallback.

Held requests are also swept through both failure paths. They carry no `pending` row, so `failOver` would otherwise leave their promises unsettled. And when the replacement budget runs out, the held successor under the timed-out key is dropped rather than run in-thread. Same key means same file, and the fallback runs on the main thread, so handing it the input that just wedged three workers would freeze the UI with the exact pathology the timeout exists to contain.

## Measurements

Same machine (M4 Max), same session, 8 iterations each, identical perf harness on both arms. Control arm is this branch with only `src/services/DiffTokenizeService.ts` reverted to `develop`.

**PERF-164**

| metric | before | after | change |
| --- | --- | --- | --- |
| executedJobs | 20 (min=max=20) | 2 (min=max=2) | -90% |
| supersededPosted | 19 | 1 | -95% |
| postedJobs | 20 | 2 | -90% |
| finalSelectionMs mean | 206.18 ms | 35.28 ms | -82.9% |
| durationMs p50 | 205.91 ms | 34.90 ms | -82.9% |
| durationMs p95 | 216.15 ms | 37.57 ms | -82.6% |

**PERF-162**

| metric | before | after | change |
| --- | --- | --- | --- |
| durationMs p50 | 30.03 ms | 29.76 ms | -0.9% (noise) |
| durationMs p95 | 32.20 ms | 33.74 ms | +4.8% (noise) |

PERF-162 doesn't move because the tokenizer itself is untouched, this is admission control in front of it. Every declared correctness term read 0 on both arms. One caveat on the numbers: the harness JSON only retains mean/min/max/sum/count per metric, not percentiles, so `finalSelectionMs` is reported as a mean; `durationMs` carries the p50/p95 and tracks it closely.

## Why the user feels it

For a given file diff, the wait from the last re-request to a highlighted diff is now bounded by two jobs (the one already running, plus the newest) instead of the whole queue of superseded ones. To be precise about the trigger: one consumer key is one mounted file diff, since `useTokens` keys off `useId()`, so different files are independent consumers by design. What re-requests the same key many times over is a search query being typed, since `extraRanges` is deliberately ungated in that effect and every keystroke re-tokenizes the file, plus collapse, wrap, and view-type changes. This is a per-key bound. The optional cross-key concurrency cap the issue raises is deliberately deferred and not measured here.

## New benchmark

Added PERF-164, "Diff Tokenize - Superseded Selection Burst," in its own "diff tokenize admission" benchmark class, because the subject under test is the client, not the tokenizer, and the transport is `node:worker_threads` rather than a Chromium web worker. It drives the client unmodified against a real worker thread running the production `runDiffTokenize`. `executedJobs` is counted worker-side. The client's own bookkeeping is the thing under test and can't also be the oracle.

The final selection is identified by the seed the fixture generator writes into its changed lines, and it must have been both executed worker-side and delivered back, so a client that ran the held request in-thread would fail rather than return correct tokens. "Exactly two jobs ran" is deliberately not a correctness term. As an integrity predicate it would fail on the unmodified control arm, and that's the arm the comparison needs.

## Testing

- 111 service + `DiffViewer` consumer tests, 999 perf-harness tests across 65 files, `tsconfig.perf` typecheck clean, `prettier` + `eslint` clean on changed files.
- New service tests cover: a burst of ten under one key posting exactly two messages, a superseded error not failing over, a held request carrying no watchdog until it's dispatched, a held request surviving worker death into the in-thread queue, and a held successor being dropped rather than run in-thread once the replacement budget is exhausted.
- Rewrote the existing test "discards a superseded request and keeps the latest for the same key." It asserted both messages were posted before either responded, which encoded the bug.
