### PR TITLE
fix(pty): back off failed image-path probes instead of re-probing every poll

### DIFF
--- a/electron/services/pty/ImagePathProbe.ts
+++ b/electron/services/pty/ImagePathProbe.ts
@@ -10,16 +10,21 @@ const IMAGE_PATH_PROBE_TIMEOUT_MS = 750;
 // across long sessions with many short-lived children. ProcessDetector also
 // evicts disappeared child PIDs proactively so PID reuse cannot return a
 // stale prior-process basename.
-const IMAGE_PATH_EVICTION_TTL_MS = 30_000;
+export const IMAGE_PATH_EVICTION_TTL_MS = 30_000;
 // Negative-result backoff. A probe that resolves nothing is not retried until
 // the delay has passed, and the delay doubles on each consecutive failure from
 // 3s to a 48s ceiling. ProcessDetector reads every shallow PID on every
 // ProcessTreeCache poll, so without this a PID the probe can never read costs
 // one `lsof`/PowerShell start per poll for as long as the process lives.
-// Every step is a whole multiple of the 1500ms poll interval rather than a
-// value near it, so a retry cannot land between two polls and slip a whole
-// interval (#8794). The resulting ladder — probes at 0s, 3s, 9s, 21s, 45s —
-// is 5 starts a minute against the 40 a 1.5s poll used to produce.
+//
+// Each step is a whole multiple of the 1500ms poll interval rather than a value
+// near it (#8794). That does NOT make retries land exactly on a poll: the
+// cooldown runs from when the probe SETTLED, so a probe that took 40ms pushes
+// eligibility 40ms past the poll boundary and the retry lands on the following
+// poll. With instantaneous settling the ladder is 0s, 3s, 9s, 21s, 45s; with a
+// real lookup it is one poll later at each step from the first retry on. Either
+// way it is 5 starts in the first minute against the 40 a 1.5s poll produced,
+// and roughly one per 48s after that.
 export const IMAGE_PATH_RETRY_BASE_MS = 3_000;
 export const IMAGE_PATH_RETRY_MAX_MS = 48_000;
 
@@ -125,12 +130,15 @@ export class ImagePathProbe {
     entry.lastReadAt = now;
 
     // Once a probe has returned a non-null result for a PID we serve it
-    // unconditionally: a process that has exec'd a different image is a
-    // different program under the same number, and ProcessDetector evicts a
-    // PID the moment it leaves probe range, so the entry cannot outlive the
-    // process it describes. A null result is retried, but only once the
-    // backoff earned by the previous failures has elapsed — `retryDelayMs` is
-    // 0 on a fresh entry, so the first probe of a PID is never delayed.
+    // unconditionally, and ProcessDetector evicts a PID the moment it leaves
+    // probe range. That is a retention POLICY, not a guarantee: a process that
+    // exec()s a new image keeps its PID and its probe range, so its entry
+    // still reports the old binary. Unchanged here, and out of scope for
+    // #12239 — the same policy predates the backoff.
+    //
+    // A null result is retried, but only once the backoff earned by the
+    // previous failures has elapsed. `retryDelayMs` is 0 on a fresh entry, so
+    // the first probe of a PID is never delayed.
     if (
       entry.basename === null &&
       !entry.refreshing &&
@@ -204,6 +212,11 @@ export class ImagePathProbe {
     current.basename = basename;
     current.updatedAt = Date.now();
     current.refreshing = false;
+    // The success reset is defensive rather than load-bearing: a non-null
+    // basename is served for the life of the entry, so nothing reads the delay
+    // back. It is kept so the field means one thing — consecutive failures
+    // since the last success — for anyone who later makes a resolved entry
+    // re-probe.
     current.retryDelayMs = basename === null ? nextRetryDelayMs(current.retryDelayMs) : 0;
   }
 

--- a/electron/services/pty/ImagePathProbe.ts
+++ b/electron/services/pty/ImagePathProbe.ts
@@ -11,6 +11,17 @@ const IMAGE_PATH_PROBE_TIMEOUT_MS = 750;
 // evicts disappeared child PIDs proactively so PID reuse cannot return a
 // stale prior-process basename.
 const IMAGE_PATH_EVICTION_TTL_MS = 30_000;
+// Negative-result backoff. A probe that resolves nothing is not retried until
+// the delay has passed, and the delay doubles on each consecutive failure from
+// 3s to a 48s ceiling. ProcessDetector reads every shallow PID on every
+// ProcessTreeCache poll, so without this a PID the probe can never read costs
+// one `lsof`/PowerShell start per poll for as long as the process lives.
+// Every step is a whole multiple of the 1500ms poll interval rather than a
+// value near it, so a retry cannot land between two polls and slip a whole
+// interval (#8794). The resulting ladder — probes at 0s, 3s, 9s, 21s, 45s —
+// is 5 starts a minute against the 40 a 1.5s poll used to produce.
+export const IMAGE_PATH_RETRY_BASE_MS = 3_000;
+export const IMAGE_PATH_RETRY_MAX_MS = 48_000;
 
 // `lsof -Fn` on macOS lists every memory-mapped text segment for the process —
 // the actual executable, plus dylibs/frameworks/system libs that share the
@@ -24,10 +35,25 @@ const MACOS_LIBRARY_SUFFIXES = [".dylib", ".framework", ".bundle"];
 
 interface CacheEntry {
   basename: string | null;
+  /** When the last probe SETTLED. Paired with `retryDelayMs` it gates retries. */
   updatedAt: number;
   lastReadAt: number;
   refreshing: boolean;
   checkId: number;
+  /**
+   * How long after `updatedAt` the next probe of a null result may run. Zero
+   * until a probe has failed, so a fresh entry probes immediately, and back to
+   * zero on success. Lives on the entry rather than beside the map so
+   * `evict()` — which deletes the whole object — resets it for free, and a
+   * recycled PID starts from an unthrottled probe.
+   */
+  retryDelayMs: number;
+}
+
+/** Doubling backoff, capped. `0` is the unthrottled state a fresh entry is in. */
+function nextRetryDelayMs(currentMs: number): number {
+  if (currentMs <= 0) return IMAGE_PATH_RETRY_BASE_MS;
+  return Math.min(currentMs * 2, IMAGE_PATH_RETRY_MAX_MS);
 }
 
 /**
@@ -39,10 +65,10 @@ interface CacheEntry {
  *
  * Async-fill per PID so the synchronous `detectAgent()` contract stays
  * synchronous — the first call schedules an async resolution and returns
- * null; once a probe succeeds the basename is returned permanently (a
- * running process's executable image is immutable), with failed probes
- * retried until one succeeds. `evict()` drops exited PIDs so PID reuse
- * cannot serve a stale prior-process basename.
+ * null; once a probe succeeds the basename is returned permanently, with
+ * failed probes retried on a doubling backoff until one succeeds.
+ * `evict()` drops exited PIDs so PID reuse cannot serve a stale
+ * prior-process basename.
  *
  * Platform dispatch:
  *  - Linux: `readlink /proc/<pid>/exe` (pure Node, ~instant)
@@ -65,9 +91,10 @@ export class ImagePathProbe {
 
   /**
    * Sync read against the per-PID cache. Returns the cached executable
-   * basename (lowercased, extension stripped) or null when unknown / past
-   * the hard-max age. Schedules an async refresh when the entry is missing
-   * or past soft-stale. Eviction TTL: unreferenced entries drop after 30s.
+   * basename (lowercased, extension stripped), or null while the PID is
+   * unresolved. Schedules an async refresh when the entry is missing, and
+   * when a previous probe resolved nothing and its backoff has elapsed.
+   * Eviction TTL: unreferenced entries drop after 30s.
    */
   readBasename(pid: number): string | null {
     if (this.disposed) return null;
@@ -84,6 +111,7 @@ export class ImagePathProbe {
         lastReadAt: now,
         refreshing: false,
         checkId: this.nextCheckId,
+        retryDelayMs: 0,
       };
       this.entries.set(pid, entry);
       this.scheduleRefresh(pid, entry);
@@ -91,24 +119,25 @@ export class ImagePathProbe {
       return null;
     }
 
+    // Read-time bookkeeping, kept independent of the retry gate: a read whose
+    // retry is suppressed still counts as a reference, so a PID being polled
+    // every 1.5s is never swept by the eviction TTL just because it is failing.
     entry.lastReadAt = now;
 
-    const hasEverProbed = entry.updatedAt > 0;
-
-    // A running process's executable image is immutable for its lifetime —
-    // the kernel does not allow exec() to replace the image of an already-
-    // running process. Once we have a successful (non-null) result for a PID
-    // we can return it unconditionally without re-probing; evict() is called
-    // by ProcessDetector when a child exits, so PID-reuse cannot return a
-    // stale prior-process basename. Only schedule refreshes until we get a
-    // non-null result, or while the result is null (failed probe to retry).
-    if (!hasEverProbed || (!entry.refreshing && entry.basename === null)) {
-      if (!entry.refreshing) {
-        this.scheduleRefresh(pid, entry);
-      }
+    // Once a probe has returned a non-null result for a PID we serve it
+    // unconditionally: a process that has exec'd a different image is a
+    // different program under the same number, and ProcessDetector evicts a
+    // PID the moment it leaves probe range, so the entry cannot outlive the
+    // process it describes. A null result is retried, but only once the
+    // backoff earned by the previous failures has elapsed — `retryDelayMs` is
+    // 0 on a fresh entry, so the first probe of a PID is never delayed.
+    if (
+      entry.basename === null &&
+      !entry.refreshing &&
+      now >= entry.updatedAt + entry.retryDelayMs
+    ) {
+      this.scheduleRefresh(pid, entry);
     }
-
-    if (!hasEverProbed) return null;
 
     return entry.basename;
   }
@@ -148,27 +177,34 @@ export class ImagePathProbe {
     entry.refreshing = true;
     const checkId = ++this.nextCheckId;
     entry.checkId = checkId;
-    void this.refresh(pid)
-      .then((basename) => {
-        if (this.disposed) return;
-        const current = this.entries.get(pid);
-        // Stale-write guard: another refresh may have superseded this one if
-        // the entry was evicted and recreated in the meantime.
-        if (!current || current.checkId !== checkId) return;
-        current.basename = basename;
-        current.updatedAt = Date.now();
-        current.refreshing = false;
-      })
-      .catch(() => {
-        if (this.disposed) return;
-        const current = this.entries.get(pid);
-        if (!current || current.checkId !== checkId) return;
-        // Persisting null with a fresh timestamp matches ForegroundProcessGroupProbe:
-        // prevents tight-retry while the underlying failure is still active.
-        current.basename = null;
-        current.updatedAt = Date.now();
-        current.refreshing = false;
-      });
+    // Two-argument `then` rather than `.then().catch()`: `refresh()` already
+    // swallows every resolver error into a null result, so the rejection arm
+    // is only reachable if the probe itself breaks — and chaining a `.catch()`
+    // after the fulfilment arm would also route a bug in `settle()` there.
+    void this.refresh(pid).then(
+      (basename) => this.settle(pid, checkId, basename),
+      () => this.settle(pid, checkId, null)
+    );
+  }
+
+  /**
+   * Write one probe's outcome back into the cache and set the next retry gate.
+   *
+   * Both completion arms land here so the backoff cannot be advanced on one
+   * path and skipped on the other. A null result is the ordinary failure
+   * shape, not the exceptional one: every platform resolver catches its own
+   * errors and returns null, and an empty `lsof`/CIM answer is null too.
+   */
+  private settle(pid: number, checkId: number, basename: string | null): void {
+    if (this.disposed) return;
+    const current = this.entries.get(pid);
+    // Stale-write guard: another refresh may have superseded this one if
+    // the entry was evicted and recreated in the meantime.
+    if (!current || current.checkId !== checkId) return;
+    current.basename = basename;
+    current.updatedAt = Date.now();
+    current.refreshing = false;
+    current.retryDelayMs = basename === null ? nextRetryDelayMs(current.retryDelayMs) : 0;
   }
 
   private async refresh(pid: number): Promise<string | null> {

--- a/electron/services/pty/__tests__/ImagePathProbe.test.ts
+++ b/electron/services/pty/__tests__/ImagePathProbe.test.ts
@@ -113,8 +113,13 @@ async function readAndFail(
 
 /**
  * Drive a PID that has already failed once all the way to the backoff ceiling,
- * one failure per step. Asserts each step launched exactly one probe, so a
- * caller that reaches the ceiling has proved the climb as well as arriving.
+ * one failure per step.
+ *
+ * This is SETUP, and its assertions say only that each scheduled step landed —
+ * a constant short delay would satisfy every one of them. What proves the
+ * climb is the boundary assertion each caller makes afterwards. The step is
+ * named in the assertion message so a setup failure is never mistaken for the
+ * case under test.
  */
 async function climbToCeiling(
   probe: InstanceType<typeof ImagePathProbe>,
@@ -123,7 +128,7 @@ async function climbToCeiling(
   let delay = IMAGE_PATH_RETRY_BASE_MS;
   while (delay < IMAGE_PATH_RETRY_MAX_MS) {
     vi.advanceTimersByTime(delay);
-    expect(await readAndFail(probe, pid)).toBe(1);
+    expect(await readAndFail(probe, pid), `climb setup: pid ${pid} at ${delay}ms`).toBe(1);
     delay = Math.min(delay * 2, IMAGE_PATH_RETRY_MAX_MS);
   }
 }
@@ -134,9 +139,13 @@ async function climbToCeiling(
  *
  * Derived from the exported constants and the doubling rule rather than
  * written out, so retuning the curve retargets the expectation instead of
- * forcing a matching edit — while a change to the SHAPE (dropping the
- * doubling, dropping the cap, charging the cooldown from launch instead of
- * settle) still fails the assertion.
+ * forcing a matching edit — while dropping the doubling still fails it.
+ *
+ * What it does NOT catch, so that the claim stays the size of the check: a
+ * missing cap is invisible inside one minute (the first launch the cap moves
+ * is at 141s), and launch-charged versus settle-charged cooldowns coincide
+ * here because a mock-settled probe advances no fake time. Those two belong to
+ * the dedicated ceiling and settlement tests below.
  */
 function expectedLaunchOffsets(reads: number, intervalMs: number): number[] {
   const offsets: number[] = [];
@@ -432,14 +441,12 @@ describe("ImagePathProbe", () => {
         // curve rather than a copy of it. Catches a missing cap, a missing
         // doubling, and a cooldown charged from launch instead of settle.
         expect(launchOffsets).toEqual(expectedLaunchOffsets(POLL_READS, POLL_INTERVAL_MS));
-        // The bar the issue sets for shipping this at all.
+        // The bar the issue sets for shipping this at all. Note which way the
+        // ratio can be gamed: a probe that stopped retrying scores BETTER
+        // here. The exact-ladder assertion above is what refuses that — a
+        // stopped implementation produces a shorter array — and the ceiling
+        // test is what proves retries continue past the ceiling indefinitely.
         expect(baselineLaunches / launchOffsets.length).toBeGreaterThanOrEqual(5);
-        // Retries were still happening late in the window, not just early —
-        // the reading that separates "backed off" from "stopped retrying",
-        // which the ratio above rewards.
-        expect(launchOffsets[launchOffsets.length - 1]).toBeGreaterThan(
-          (POLL_READS * POLL_INTERVAL_MS) / 2
-        );
       } finally {
         vi.useRealTimers();
       }
@@ -757,13 +764,20 @@ describe("ImagePathProbe", () => {
         readlinkMock.queue[1]!.reject(new Error("EACCES"));
         await flush();
 
+        // Time moves between the two completions on purpose: with identical
+        // timestamps a stale write that only re-stamped `updatedAt` would be
+        // invisible, and that write alone is enough to push the retry out.
+        const gapMs = 500;
+        vi.advanceTimersByTime(gapMs);
+
         // Now the superseded refresh fails. Its checkId no longer matches, so
         // it must not touch the live entry's basename or advance its cooldown.
         readlinkMock.queue[0]!.reject(new Error("EACCES"));
         await flush();
 
-        // Still on the BASE delay, not doubled by the stale completion.
-        vi.advanceTimersByTime(IMAGE_PATH_RETRY_BASE_MS - 1);
+        // Still on the BASE delay measured from the LIVE entry's own
+        // completion — neither doubled nor re-stamped by the stale one.
+        vi.advanceTimersByTime(IMAGE_PATH_RETRY_BASE_MS - gapMs - 1);
         expect(await readAndFail(probe, 123)).toBe(0);
         vi.advanceTimersByTime(1);
         expect(await readAndFail(probe, 123)).toBe(1);

--- a/electron/services/pty/__tests__/ImagePathProbe.test.ts
+++ b/electron/services/pty/__tests__/ImagePathProbe.test.ts
@@ -52,8 +52,12 @@ vi.mock("node:fs/promises", () => ({
   readlink: readlinkMock,
 }));
 
-const { ImagePathProbe, IMAGE_PATH_RETRY_BASE_MS, IMAGE_PATH_RETRY_MAX_MS } =
-  await import("../ImagePathProbe.js");
+const {
+  ImagePathProbe,
+  IMAGE_PATH_RETRY_BASE_MS,
+  IMAGE_PATH_RETRY_MAX_MS,
+  IMAGE_PATH_EVICTION_TTL_MS,
+} = await import("../ImagePathProbe.js");
 
 /** ProcessTreeCache's base poll interval — the cadence `readBasename` is read at. */
 const POLL_INTERVAL_MS = 1_500;
@@ -87,17 +91,65 @@ async function resolveNewestProbe(target: string): Promise<void> {
 }
 
 /**
- * Read `pid` once and report whether that read launched a probe, failing it
- * when it did. The launch count is taken from the mock's own call log rather
- * than from anything the probe exposes, so the reading survives a refactor of
- * the cache internals.
+ * Read `pid` once and report how many probes that read launched, failing the
+ * launched one. The count comes from the mock's own call log rather than from
+ * anything the probe exposes, so the reading survives a refactor of the cache
+ * internals — and it is a COUNT rather than a boolean so a read that launched
+ * twice cannot be recorded as a read that launched once.
  */
-async function readAndFail(probe: InstanceType<typeof ImagePathProbe>, pid: number) {
+async function readAndFail(
+  probe: InstanceType<typeof ImagePathProbe>,
+  pid: number
+): Promise<number> {
   const before = readlinkMock.calls.length;
   probe.readBasename(pid);
-  const launched = readlinkMock.calls.length > before;
-  if (launched) await failNewestProbe();
+  const launched = readlinkMock.calls.length - before;
+  // One read may schedule at most one probe. Anything else means the gate
+  // fired twice and every launch count in these tests is understated.
+  expect(launched).toBeLessThanOrEqual(1);
+  if (launched === 1) await failNewestProbe();
   return launched;
+}
+
+/**
+ * Drive a PID that has already failed once all the way to the backoff ceiling,
+ * one failure per step. Asserts each step launched exactly one probe, so a
+ * caller that reaches the ceiling has proved the climb as well as arriving.
+ */
+async function climbToCeiling(
+  probe: InstanceType<typeof ImagePathProbe>,
+  pid: number
+): Promise<void> {
+  let delay = IMAGE_PATH_RETRY_BASE_MS;
+  while (delay < IMAGE_PATH_RETRY_MAX_MS) {
+    vi.advanceTimersByTime(delay);
+    expect(await readAndFail(probe, pid)).toBe(1);
+    delay = Math.min(delay * 2, IMAGE_PATH_RETRY_MAX_MS);
+  }
+}
+
+/**
+ * The launch instants the published curve implies, at a fixed poll cadence and
+ * with probes that settle instantly (which is what fake timers give us).
+ *
+ * Derived from the exported constants and the doubling rule rather than
+ * written out, so retuning the curve retargets the expectation instead of
+ * forcing a matching edit — while a change to the SHAPE (dropping the
+ * doubling, dropping the cap, charging the cooldown from launch instead of
+ * settle) still fails the assertion.
+ */
+function expectedLaunchOffsets(reads: number, intervalMs: number): number[] {
+  const offsets: number[] = [];
+  let delay = 0;
+  let eligibleAt = 0;
+  for (let read = 0; read < reads; read += 1) {
+    const now = read * intervalMs;
+    if (now < eligibleAt) continue;
+    offsets.push(now);
+    delay = delay === 0 ? IMAGE_PATH_RETRY_BASE_MS : Math.min(delay * 2, IMAGE_PATH_RETRY_MAX_MS);
+    eligibleAt = now + delay;
+  }
+  return offsets;
 }
 
 describe("ImagePathProbe", () => {
@@ -367,7 +419,7 @@ describe("ImagePathProbe", () => {
           if (await readAndFail(probe, 123)) launchOffsets.push(Date.now() - start);
 
           const fresh = new ImagePathProbe();
-          if (await readAndFail(fresh, 123)) baselineLaunches += 1;
+          baselineLaunches += await readAndFail(fresh, 123);
           fresh.dispose();
 
           vi.advanceTimersByTime(POLL_INTERVAL_MS);
@@ -376,11 +428,18 @@ describe("ImagePathProbe", () => {
         // Every read in the baseline arm launched: 40 `lsof`/PowerShell starts
         // a minute for one PID the probe can never read.
         expect(baselineLaunches).toBe(POLL_READS);
-        // 3s, then 6, 12 and 24 — the ladder, stated as instants so a change
-        // to the curve has to be a deliberate edit here.
-        expect(launchOffsets).toEqual([0, 3_000, 9_000, 21_000, 45_000]);
+        // The whole ladder, against a schedule re-derived from the published
+        // curve rather than a copy of it. Catches a missing cap, a missing
+        // doubling, and a cooldown charged from launch instead of settle.
+        expect(launchOffsets).toEqual(expectedLaunchOffsets(POLL_READS, POLL_INTERVAL_MS));
         // The bar the issue sets for shipping this at all.
         expect(baselineLaunches / launchOffsets.length).toBeGreaterThanOrEqual(5);
+        // Retries were still happening late in the window, not just early —
+        // the reading that separates "backed off" from "stopped retrying",
+        // which the ratio above rewards.
+        expect(launchOffsets[launchOffsets.length - 1]).toBeGreaterThan(
+          (POLL_READS * POLL_INTERVAL_MS) / 2
+        );
       } finally {
         vi.useRealTimers();
       }
@@ -441,27 +500,43 @@ describe("ImagePathProbe", () => {
         await failNewestProbe();
 
         // Walk the ladder to the ceiling, one failure per step.
-        let delay = IMAGE_PATH_RETRY_BASE_MS;
-        while (delay < IMAGE_PATH_RETRY_MAX_MS) {
-          vi.advanceTimersByTime(delay);
-          expect(await readAndFail(probe, 123)).toBe(true);
-          delay = Math.min(delay * 2, IMAGE_PATH_RETRY_MAX_MS);
-        }
+        await climbToCeiling(probe, 123);
 
         // Two more failures at the ceiling: the gap must stop growing, and
         // must still be exactly the ceiling rather than creeping past it.
         for (let step = 0; step < 2; step++) {
           vi.advanceTimersByTime(IMAGE_PATH_RETRY_MAX_MS - 1);
-          expect(await readAndFail(probe, 123)).toBe(false);
+          expect(await readAndFail(probe, 123)).toBe(0);
           vi.advanceTimersByTime(1);
-          expect(await readAndFail(probe, 123)).toBe(true);
+          expect(await readAndFail(probe, 123)).toBe(1);
         }
       } finally {
         vi.useRealTimers();
       }
     });
 
-    it("resets the backoff on success and stops probing for good", async () => {
+    it("recovers from a PID that has been failing at the ceiling", async () => {
+      // The direction the storm test cannot see: a probe that stopped retrying
+      // altogether posts the best launch count in the suite, so recovery after
+      // a long run of failures has to be asserted on its own.
+      vi.useFakeTimers();
+      try {
+        const probe = new ImagePathProbe();
+        probe.readBasename(123);
+        await failNewestProbe();
+        await climbToCeiling(probe, 123);
+
+        vi.advanceTimersByTime(IMAGE_PATH_RETRY_MAX_MS);
+        probe.readBasename(123);
+        await resolveNewestProbe("/opt/homebrew/bin/claude");
+
+        expect(probe.readBasename(123)).toBe("claude");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("caches the eventual success and stops probing for good", async () => {
       vi.useFakeTimers();
       try {
         const probe = new ImagePathProbe();
@@ -469,7 +544,7 @@ describe("ImagePathProbe", () => {
         await failNewestProbe();
 
         vi.advanceTimersByTime(IMAGE_PATH_RETRY_BASE_MS);
-        expect(await readAndFail(probe, 123)).toBe(true);
+        expect(await readAndFail(probe, 123)).toBe(1);
 
         vi.advanceTimersByTime(IMAGE_PATH_RETRY_BASE_MS * 2);
         probe.readBasename(123);
@@ -485,36 +560,121 @@ describe("ImagePathProbe", () => {
       }
     });
 
-    it("backs off each PID independently", async () => {
+    it("keeps one PID's backoff out of every other PID's way", async () => {
       vi.useFakeTimers();
       try {
         const probe = new ImagePathProbe();
         probe.readBasename(123);
         await failNewestProbe();
+        await climbToCeiling(probe, 123);
 
-        // A second PID arriving mid-cooldown is a first-ever probe and must
-        // not inherit anything from its neighbour.
-        expect(await readAndFail(probe, 456)).toBe(true);
-        expect(readlinkMock.calls).toEqual(["/proc/123/exe", "/proc/456/exe"]);
+        // A second PID arriving mid-cooldown probes at once — and when IT
+        // fails it must earn the BASE delay, not the ceiling its neighbour is
+        // sitting on. Checking only the first read would miss a pooled delay
+        // entirely: a fresh entry's gate is `now >= 0 + delay`, and Date.now()
+        // is an epoch, so an inherited delay is invisible until the first
+        // failure charges it.
+        expect(await readAndFail(probe, 456)).toBe(1);
+        vi.advanceTimersByTime(IMAGE_PATH_RETRY_BASE_MS - 1);
+        expect(await readAndFail(probe, 456)).toBe(0);
+        vi.advanceTimersByTime(1);
+        expect(await readAndFail(probe, 456)).toBe(1);
+
+        // Only the base delay has elapsed for 123, nowhere near its ceiling.
+        expect(await readAndFail(probe, 123)).toBe(0);
+
+        // A third PID resolving must not clear 123's cooldown either.
+        probe.readBasename(789);
+        await resolveNewestProbe("/usr/bin/codex");
+        expect(probe.readBasename(789)).toBe("codex");
+
+        vi.advanceTimersByTime(IMAGE_PATH_RETRY_MAX_MS - IMAGE_PATH_RETRY_BASE_MS - 1);
+        expect(await readAndFail(probe, 123)).toBe(0);
+        vi.advanceTimersByTime(1);
+        expect(await readAndFail(probe, 123)).toBe(1);
       } finally {
         vi.useRealTimers();
       }
     });
 
-    it("evict() clears the backoff so a recycled PID probes immediately", async () => {
+    it("evict() clears the backoff so a recycled PID starts from the base delay", async () => {
+      vi.useFakeTimers();
+      try {
+        const probe = new ImagePathProbe();
+        probe.readBasename(123);
+        await failNewestProbe();
+        await climbToCeiling(probe, 123);
+
+        // A neighbour that stays in the map across the eviction, so an
+        // implementation that pooled retry state between entries would have
+        // something for the recreated entry to inherit.
+        probe.readBasename(999);
+        await failNewestProbe();
+
+        // Deep into a ceiling-length cooldown, the number is handed to a
+        // different process.
+        probe.evict(123);
+        expect(await readAndFail(probe, 123)).toBe(1);
+
+        // The new entry's FIRST failure must earn the base delay, not resume
+        // the streak the previous process built up. Checked on the boundary in
+        // both directions, so a retained ceiling is caught rather than assumed.
+        vi.advanceTimersByTime(IMAGE_PATH_RETRY_BASE_MS - 1);
+        expect(await readAndFail(probe, 123)).toBe(0);
+        vi.advanceTimersByTime(1);
+        expect(await readAndFail(probe, 123)).toBe(1);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("keeps a suppressed read counting as a reference against the eviction TTL", async () => {
+      // `lastReadAt` is updated on every read, including the ones the backoff
+      // suppresses. If it were only updated when a probe launched, a PID being
+      // polled every 1.5s would be swept mid-cooldown and re-probe at once —
+      // silently undoing the backoff for exactly the PIDs it exists for.
+      vi.useFakeTimers();
+      try {
+        const probe = new ImagePathProbe();
+        probe.readBasename(123);
+        await failNewestProbe();
+        await climbToCeiling(probe, 123);
+
+        // Poll it across the eviction TTL without ever launching anything.
+        const settled = readlinkMock.calls.length;
+        for (let elapsed = 0; elapsed < IMAGE_PATH_EVICTION_TTL_MS + 5_000; elapsed += 1_500) {
+          vi.advanceTimersByTime(1_500);
+          probe.readBasename(123);
+        }
+        expect(readlinkMock.calls).toHaveLength(settled);
+
+        // Creating another entry runs the sweep; the actively read 123 must
+        // survive it and keep its cooldown.
+        probe.readBasename(456);
+        await failNewestProbe();
+        expect(await readAndFail(probe, 123)).toBe(0);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("dedupes reads against an in-flight retry, not just an in-flight first probe", async () => {
       vi.useFakeTimers();
       try {
         const probe = new ImagePathProbe();
         probe.readBasename(123);
         await failNewestProbe();
 
-        // Deep into the cooldown, the number is handed to a different process.
-        vi.advanceTimersByTime(IMAGE_PATH_RETRY_BASE_MS / 2);
-        probe.evict(123);
+        vi.advanceTimersByTime(IMAGE_PATH_RETRY_BASE_MS);
+        probe.readBasename(123); // retry launches
+        expect(readlinkMock.calls).toHaveLength(2);
 
+        // Further polls while that retry is in flight must add nothing, even
+        // though the gate itself is open.
+        vi.advanceTimersByTime(POLL_INTERVAL_MS);
         probe.readBasename(123);
-        await resolveNewestProbe("/usr/bin/codex");
-        expect(probe.readBasename(123)).toBe("codex");
+        vi.advanceTimersByTime(POLL_INTERVAL_MS);
+        probe.readBasename(123);
         expect(readlinkMock.calls).toHaveLength(2);
       } finally {
         vi.useRealTimers();
@@ -530,16 +690,10 @@ describe("ImagePathProbe", () => {
         const probe = new ImagePathProbe();
         probe.readBasename(123);
         await failNewestProbe();
-
-        let delay = IMAGE_PATH_RETRY_BASE_MS;
-        while (delay < IMAGE_PATH_RETRY_MAX_MS) {
-          vi.advanceTimersByTime(delay);
-          expect(await readAndFail(probe, 123)).toBe(true);
-          delay = Math.min(delay * 2, IMAGE_PATH_RETRY_MAX_MS);
-        }
+        await climbToCeiling(probe, 123);
 
         // Idle past the eviction TTL but well short of the ceiling.
-        vi.advanceTimersByTime(31_000);
+        vi.advanceTimersByTime(IMAGE_PATH_EVICTION_TTL_MS + 1_000);
         const before = readlinkMock.calls.length;
         // Reading any PID runs the sweep on entry creation.
         probe.readBasename(456);
@@ -552,7 +706,7 @@ describe("ImagePathProbe", () => {
       }
     });
 
-    it("does not launch or advance the backoff after dispose", async () => {
+    it("launches nothing more when a refresh settles into a disposed probe", async () => {
       const probe = new ImagePathProbe();
       probe.readBasename(123);
       probe.dispose();
@@ -597,15 +751,22 @@ describe("ImagePathProbe", () => {
         probe.evict(123);
         probe.readBasename(123); // new entry, second refresh in flight
 
-        // The superseded refresh fails. Its checkId no longer matches, so it
-        // must not stamp a cooldown onto the entry that replaced it.
+        // Settle the RECREATED entry first, so it owns a base-delay cooldown
+        // of its own. Resolving it instead would wipe any cooldown the stale
+        // completion wrote and hide exactly the bug this guards.
+        readlinkMock.queue[1]!.reject(new Error("EACCES"));
+        await flush();
+
+        // Now the superseded refresh fails. Its checkId no longer matches, so
+        // it must not touch the live entry's basename or advance its cooldown.
         readlinkMock.queue[0]!.reject(new Error("EACCES"));
         await flush();
 
-        readlinkMock.queue[1]!.resolve("/usr/bin/claude");
-        await flush();
-        expect(probe.readBasename(123)).toBe("claude");
-        expect(readlinkMock.calls).toHaveLength(2);
+        // Still on the BASE delay, not doubled by the stale completion.
+        vi.advanceTimersByTime(IMAGE_PATH_RETRY_BASE_MS - 1);
+        expect(await readAndFail(probe, 123)).toBe(0);
+        vi.advanceTimersByTime(1);
+        expect(await readAndFail(probe, 123)).toBe(1);
       } finally {
         vi.useRealTimers();
       }
@@ -676,8 +837,9 @@ describe("ImagePathProbe", () => {
         // Reading a different PID re-runs eviction; the long-idle 123 entry
         // is dropped, so a subsequent read of 123 must re-probe.
         probe.readBasename(456);
-        readlinkMock.queue[0]!.resolve("/usr/bin/codex");
-        await flush();
+        // 456's own probe, not 123's — queue[0] settled two lines above, and
+        // resolving it again left 456 pending forever.
+        await resolveNewestProbe("/usr/bin/codex");
 
         expect(probe.readBasename(123)).toBeNull();
         expect(readlinkMock.calls).toContain("/proc/123/exe");

--- a/electron/services/pty/__tests__/ImagePathProbe.test.ts
+++ b/electron/services/pty/__tests__/ImagePathProbe.test.ts
@@ -52,7 +52,13 @@ vi.mock("node:fs/promises", () => ({
   readlink: readlinkMock,
 }));
 
-const { ImagePathProbe } = await import("../ImagePathProbe.js");
+const { ImagePathProbe, IMAGE_PATH_RETRY_BASE_MS, IMAGE_PATH_RETRY_MAX_MS } =
+  await import("../ImagePathProbe.js");
+
+/** ProcessTreeCache's base poll interval — the cadence `readBasename` is read at. */
+const POLL_INTERVAL_MS = 1_500;
+/** Reads in a 60s window at that cadence: t = 0, 1500 … 58500. */
+const POLL_READS = 40;
 
 const realPlatform = process.platform;
 
@@ -66,6 +72,32 @@ async function flush(): Promise<void> {
   for (let i = 0; i < 10; i++) {
     await Promise.resolve();
   }
+}
+
+/** Settle the most recently launched readlink probe as a failure. */
+async function failNewestProbe(): Promise<void> {
+  readlinkMock.queue[readlinkMock.queue.length - 1]!.reject(new Error("EACCES"));
+  await flush();
+}
+
+/** Settle the most recently launched readlink probe with an image path. */
+async function resolveNewestProbe(target: string): Promise<void> {
+  readlinkMock.queue[readlinkMock.queue.length - 1]!.resolve(target);
+  await flush();
+}
+
+/**
+ * Read `pid` once and report whether that read launched a probe, failing it
+ * when it did. The launch count is taken from the mock's own call log rather
+ * than from anything the probe exposes, so the reading survives a refactor of
+ * the cache internals.
+ */
+async function readAndFail(probe: InstanceType<typeof ImagePathProbe>, pid: number) {
+  const before = readlinkMock.calls.length;
+  probe.readBasename(pid);
+  const launched = readlinkMock.calls.length > before;
+  if (launched) await failNewestProbe();
+  return launched;
 }
 
 describe("ImagePathProbe", () => {
@@ -158,28 +190,36 @@ describe("ImagePathProbe", () => {
       }
     });
 
-    it("retries a failed probe until one succeeds", async () => {
-      const probe = new ImagePathProbe();
-      probe.readBasename(123);
-      readlinkMock.queue[0]!.reject(new Error("EACCES"));
-      await flush();
+    it("retries a failed probe until one succeeds, once the backoff has elapsed", async () => {
+      vi.useFakeTimers();
+      try {
+        const probe = new ImagePathProbe();
+        probe.readBasename(123);
+        await failNewestProbe();
 
-      // Failure cached as null — the next read schedules another attempt.
-      expect(probe.readBasename(123)).toBeNull();
-      readlinkMock.queue[1]!.resolve("/opt/homebrew/bin/claude");
-      await flush();
+        // Failure cached as null. Reads inside the backoff window are served
+        // from the cache without launching anything — this is the whole fix.
+        expect(probe.readBasename(123)).toBeNull();
+        expect(readlinkMock.calls).toHaveLength(1);
 
-      expect(probe.readBasename(123)).toBe("claude");
-      expect(readlinkMock.calls).toHaveLength(2);
+        vi.advanceTimersByTime(IMAGE_PATH_RETRY_BASE_MS);
+        expect(probe.readBasename(123)).toBeNull();
+        await resolveNewestProbe("/opt/homebrew/bin/claude");
+
+        expect(probe.readBasename(123)).toBe("claude");
+        expect(readlinkMock.calls).toHaveLength(2);
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it("survives a 1500ms poll-interval tick without blanking the basename", async () => {
       // Regression guard for the hard-max=poll-interval timing bug. With the
       // ProcessTreeCache poll at 1500ms and (previously) the probe's max age
       // at 1500ms, every poll past the first one would fall past max-age
-      // under setTimeout jitter, return null, and defeat hysteresis. With
-      // the 5000ms ceiling the cached basename survives at least one poll
-      // cycle.
+      // under setTimeout jitter, return null, and defeat hysteresis. A
+      // successful result is now retained for the life of the entry, so the
+      // cached basename survives any number of poll cycles.
       vi.useFakeTimers();
       try {
         const probe = new ImagePathProbe();
@@ -304,6 +344,271 @@ describe("ImagePathProbe", () => {
       execFileMock.calls[0]!.resolve("C:\\npm\\claude.cmd\r\n");
       await flush();
       expect(probe.readBasename(5006)).toBe("claude");
+    });
+  });
+
+  describe("failed-probe backoff", () => {
+    it("collapses a failing PID's probe launches across a 60s poll window", async () => {
+      // The headline reading for #12239, taken in both directions in one pass.
+      //
+      // The baseline arm is the pre-fix rule, MEASURED rather than asserted: a
+      // read of a PID with no result scheduled a probe every time, which is
+      // exactly what a fresh instance does on its first read. Both arms run at
+      // the same cadence against the same failure, so the ratio between them
+      // is the change and nothing else.
+      vi.useFakeTimers();
+      try {
+        const probe = new ImagePathProbe();
+        const launchOffsets: number[] = [];
+        const start = Date.now();
+        let baselineLaunches = 0;
+
+        for (let read = 0; read < POLL_READS; read++) {
+          if (await readAndFail(probe, 123)) launchOffsets.push(Date.now() - start);
+
+          const fresh = new ImagePathProbe();
+          if (await readAndFail(fresh, 123)) baselineLaunches += 1;
+          fresh.dispose();
+
+          vi.advanceTimersByTime(POLL_INTERVAL_MS);
+        }
+
+        // Every read in the baseline arm launched: 40 `lsof`/PowerShell starts
+        // a minute for one PID the probe can never read.
+        expect(baselineLaunches).toBe(POLL_READS);
+        // 3s, then 6, 12 and 24 — the ladder, stated as instants so a change
+        // to the curve has to be a deliberate edit here.
+        expect(launchOffsets).toEqual([0, 3_000, 9_000, 21_000, 45_000]);
+        // The bar the issue sets for shipping this at all.
+        expect(baselineLaunches / launchOffsets.length).toBeGreaterThanOrEqual(5);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("suppresses a retry up to the boundary and allows it on the boundary", async () => {
+      vi.useFakeTimers();
+      try {
+        const probe = new ImagePathProbe();
+        probe.readBasename(123);
+        await failNewestProbe();
+
+        vi.advanceTimersByTime(IMAGE_PATH_RETRY_BASE_MS - 1);
+        probe.readBasename(123);
+        expect(readlinkMock.calls).toHaveLength(1);
+
+        vi.advanceTimersByTime(1);
+        probe.readBasename(123);
+        expect(readlinkMock.calls).toHaveLength(2);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("starts the backoff when the probe settles, not when it launched", async () => {
+      // A probe that hangs to its 750ms timeout has already cost the wall time
+      // it was going to cost; charging its cooldown from the launch would hand
+      // back part of the window it was meant to buy.
+      vi.useFakeTimers();
+      try {
+        const probe = new ImagePathProbe();
+        probe.readBasename(123);
+
+        // In flight across a poll: dedupe holds, nothing new launches.
+        vi.advanceTimersByTime(POLL_INTERVAL_MS);
+        probe.readBasename(123);
+        expect(readlinkMock.calls).toHaveLength(1);
+
+        await failNewestProbe();
+
+        vi.advanceTimersByTime(IMAGE_PATH_RETRY_BASE_MS - 1);
+        probe.readBasename(123);
+        expect(readlinkMock.calls).toHaveLength(1);
+
+        vi.advanceTimersByTime(1);
+        probe.readBasename(123);
+        expect(readlinkMock.calls).toHaveLength(2);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("caps the backoff at the ceiling", async () => {
+      vi.useFakeTimers();
+      try {
+        const probe = new ImagePathProbe();
+        probe.readBasename(123);
+        await failNewestProbe();
+
+        // Walk the ladder to the ceiling, one failure per step.
+        let delay = IMAGE_PATH_RETRY_BASE_MS;
+        while (delay < IMAGE_PATH_RETRY_MAX_MS) {
+          vi.advanceTimersByTime(delay);
+          expect(await readAndFail(probe, 123)).toBe(true);
+          delay = Math.min(delay * 2, IMAGE_PATH_RETRY_MAX_MS);
+        }
+
+        // Two more failures at the ceiling: the gap must stop growing, and
+        // must still be exactly the ceiling rather than creeping past it.
+        for (let step = 0; step < 2; step++) {
+          vi.advanceTimersByTime(IMAGE_PATH_RETRY_MAX_MS - 1);
+          expect(await readAndFail(probe, 123)).toBe(false);
+          vi.advanceTimersByTime(1);
+          expect(await readAndFail(probe, 123)).toBe(true);
+        }
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("resets the backoff on success and stops probing for good", async () => {
+      vi.useFakeTimers();
+      try {
+        const probe = new ImagePathProbe();
+        probe.readBasename(123);
+        await failNewestProbe();
+
+        vi.advanceTimersByTime(IMAGE_PATH_RETRY_BASE_MS);
+        expect(await readAndFail(probe, 123)).toBe(true);
+
+        vi.advanceTimersByTime(IMAGE_PATH_RETRY_BASE_MS * 2);
+        probe.readBasename(123);
+        await resolveNewestProbe("/opt/homebrew/bin/claude");
+        expect(probe.readBasename(123)).toBe("claude");
+
+        const afterSuccess = readlinkMock.calls.length;
+        vi.advanceTimersByTime(IMAGE_PATH_RETRY_MAX_MS * 4);
+        expect(probe.readBasename(123)).toBe("claude");
+        expect(readlinkMock.calls).toHaveLength(afterSuccess);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("backs off each PID independently", async () => {
+      vi.useFakeTimers();
+      try {
+        const probe = new ImagePathProbe();
+        probe.readBasename(123);
+        await failNewestProbe();
+
+        // A second PID arriving mid-cooldown is a first-ever probe and must
+        // not inherit anything from its neighbour.
+        expect(await readAndFail(probe, 456)).toBe(true);
+        expect(readlinkMock.calls).toEqual(["/proc/123/exe", "/proc/456/exe"]);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("evict() clears the backoff so a recycled PID probes immediately", async () => {
+      vi.useFakeTimers();
+      try {
+        const probe = new ImagePathProbe();
+        probe.readBasename(123);
+        await failNewestProbe();
+
+        // Deep into the cooldown, the number is handed to a different process.
+        vi.advanceTimersByTime(IMAGE_PATH_RETRY_BASE_MS / 2);
+        probe.evict(123);
+
+        probe.readBasename(123);
+        await resolveNewestProbe("/usr/bin/codex");
+        expect(probe.readBasename(123)).toBe("codex");
+        expect(readlinkMock.calls).toHaveLength(2);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("sweeps a backed-off entry at the eviction TTL rather than holding its cooldown", async () => {
+      // The two windows overlap: the ceiling (48s) outlives the eviction TTL
+      // (30s), so an entry that stops being read is dropped and the PID that
+      // comes back probes at once instead of serving out a stale cooldown.
+      vi.useFakeTimers();
+      try {
+        const probe = new ImagePathProbe();
+        probe.readBasename(123);
+        await failNewestProbe();
+
+        let delay = IMAGE_PATH_RETRY_BASE_MS;
+        while (delay < IMAGE_PATH_RETRY_MAX_MS) {
+          vi.advanceTimersByTime(delay);
+          expect(await readAndFail(probe, 123)).toBe(true);
+          delay = Math.min(delay * 2, IMAGE_PATH_RETRY_MAX_MS);
+        }
+
+        // Idle past the eviction TTL but well short of the ceiling.
+        vi.advanceTimersByTime(31_000);
+        const before = readlinkMock.calls.length;
+        // Reading any PID runs the sweep on entry creation.
+        probe.readBasename(456);
+        await failNewestProbe();
+
+        probe.readBasename(123);
+        expect(readlinkMock.calls.length).toBe(before + 2);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("does not launch or advance the backoff after dispose", async () => {
+      const probe = new ImagePathProbe();
+      probe.readBasename(123);
+      probe.dispose();
+
+      // The in-flight refresh settles into a disposed probe.
+      await failNewestProbe();
+      expect(probe.readBasename(123)).toBeNull();
+      expect(readlinkMock.calls).toHaveLength(1);
+    });
+
+    it("backs off an empty result the same as a rejection", async () => {
+      // On macOS a process the probe cannot read is an lsof that exits 0 with
+      // nothing usable, not an error — the platform resolvers erase both into
+      // null, so the gate has to treat them alike.
+      setPlatform("darwin");
+      vi.useFakeTimers();
+      try {
+        const probe = new ImagePathProbe();
+        probe.readBasename(4242);
+        execFileMock.calls[0]!.resolve("");
+        await flush();
+        expect(probe.readBasename(4242)).toBeNull();
+        expect(execFileMock.calls).toHaveLength(1);
+
+        vi.advanceTimersByTime(IMAGE_PATH_RETRY_BASE_MS - 1);
+        probe.readBasename(4242);
+        expect(execFileMock.calls).toHaveLength(1);
+
+        vi.advanceTimersByTime(1);
+        probe.readBasename(4242);
+        expect(execFileMock.calls).toHaveLength(2);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("does not let a stale in-flight failure back off a recreated entry", async () => {
+      vi.useFakeTimers();
+      try {
+        const probe = new ImagePathProbe();
+        probe.readBasename(123); // first refresh, in flight
+        probe.evict(123);
+        probe.readBasename(123); // new entry, second refresh in flight
+
+        // The superseded refresh fails. Its checkId no longer matches, so it
+        // must not stamp a cooldown onto the entry that replaced it.
+        readlinkMock.queue[0]!.reject(new Error("EACCES"));
+        await flush();
+
+        readlinkMock.queue[1]!.resolve("/usr/bin/claude");
+        await flush();
+        expect(probe.readBasename(123)).toBe("claude");
+        expect(readlinkMock.calls).toHaveLength(2);
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 

--- a/scripts/perf/__tests__/scenarioLiveness.test.ts
+++ b/scripts/perf/__tests__/scenarioLiveness.test.ts
@@ -119,7 +119,7 @@ const EXPENSIVE_SCENARIOS: Readonly<Record<string, string>> = {
   "PERF-106": "~17s — the same 10s idle window, after a transient probe failure",
   "PERF-138": "~19s — builds real 1/5/20/50-worktree git topologies before it measures",
   "PERF-405":
-    "~62s — a fixed 60s window reading a failing PID at the 1500ms poll cadence; the backoff ladder it measures reaches its 48s ceiling inside that window and nowhere shorter",
+    "~62s — the 40 reads a 1500ms poll makes in a minute, against a failing PID, plus a drain for the last arm's children; a shorter window cannot show the backoff ladder still spacing retries in its back half",
 };
 
 /**

--- a/scripts/perf/__tests__/scenarioLiveness.test.ts
+++ b/scripts/perf/__tests__/scenarioLiveness.test.ts
@@ -91,7 +91,7 @@ const DRIVER = path.join(HERE, "scenarioSmokeDriver.ts");
 /**
  * Scenarios this guard deliberately does NOT run, and why.
  *
- * SIX are excluded on cost: a single `run()` costing more than ~12 seconds on
+ * SEVEN are excluded on cost: a single `run()` costing more than ~12 seconds on
  * the reference machine (M-series macOS, serial). Each is expensive BY DESIGN —
  * it idles for a fixed wall-clock window, or builds real multi-worktree git
  * topologies — so no amount of harness work makes it cheap, and a guard that
@@ -100,14 +100,14 @@ const DRIVER = path.join(HERE, "scenarioSmokeDriver.ts");
  * re-judge the trade rather than inherit it, and so an entry that stops being
  * expensive is visible rather than permanent.
  *
- * The SEVENTH, PERF-004, is not a cost exclusion at all: it launches the
+ * The EIGHTH, PERF-004, is not a cost exclusion at all: it launches the
  * packaged binary, so it cannot run without a `npm run package` build under
  * `release/` that no test environment has. Cheap or not, there is nothing here
  * for it to drive.
  *
- * All seven are a REAL GAP, and exactly as capable of dying silently as the
+ * All eight are a REAL GAP, and exactly as capable of dying silently as the
  * thirteen that did. Run them by hand after touching `lib/idleWindow*`,
- * `lib/gitPipeline*` or `lib/worktreeSidebar*`:
+ * `lib/gitPipeline*`, `lib/worktreeSidebar*` or `pty/ImagePathProbe`:
  *   npx tsx scripts/perf/__tests__/scenarioSmokeDriver.ts PERF-092
  */
 const EXPENSIVE_SCENARIOS: Readonly<Record<string, string>> = {
@@ -118,6 +118,8 @@ const EXPENSIVE_SCENARIOS: Readonly<Record<string, string>> = {
   "PERF-105": "~17s — a fixed 10s idle window on an armed git watcher",
   "PERF-106": "~17s — the same 10s idle window, after a transient probe failure",
   "PERF-138": "~19s — builds real 1/5/20/50-worktree git topologies before it measures",
+  "PERF-405":
+    "~62s — a fixed 60s window reading a failing PID at the 1500ms poll cadence; the backoff ladder it measures reaches its 48s ceiling inside that window and nowhere shorter",
 };
 
 /**

--- a/scripts/perf/config/benchmarkClasses.ts
+++ b/scripts/perf/config/benchmarkClasses.ts
@@ -426,6 +426,14 @@ const FAMILIES: readonly Family[] = [
       "Real ranking and one-edit correction over the real project list. No painted list, no selection, no dispatched action.",
   },
   {
+    label: "image-path probe",
+    ids: ["PERF-405"],
+    kind: "mechanism",
+    fidelity: withFidelity({ entryPoint: "public-api", processTopology: "partial" }),
+    claim:
+      "The real probe making real OS lookups at the pty-host's own poll cadence, with both the current and the pre-backoff read rule measured in the same window. It is how often a permanently failing PID starts a subprocess, NOT what one probe costs against a live process — an absent PID is cheaper for `lsof` to answer — and not the detector latency a user would notice. Skipped on Linux, where the probe is a bare readlink and starts nothing; diagnostic on Windows, where PowerShell start cost dominates the reading.",
+  },
+  {
     label: "terminal submit lane",
     ids: ["PERF-036"],
     kind: "mechanism",

--- a/scripts/perf/scenarios/imagePathProbe.ts
+++ b/scripts/perf/scenarios/imagePathProbe.ts
@@ -27,14 +27,21 @@ import {
  *
  *   - the SUSTAINED arm is one long-lived probe read 40 times, which is what
  *     the product does;
- *   - the BASELINE arm is a fresh probe per read. That is not a simulation of
- *     the old code — it is the old rule exactly, because a read of a PID with
- *     no result scheduled a probe every time, which is what a first read of a
- *     fresh instance does. Same PID, same machine, same session, same minute.
+ *   - the BASELINE arm is a fresh probe per read. A first read on a fresh
+ *     instance takes the same path the old gate took on EVERY read of an
+ *     unresolved PID, so its start count is the old rule's start count —
+ *     subject to the one condition the old gate also carried, `!refreshing`,
+ *     which `baselineFidelityMisses` checks by requiring one start per read.
+ *     Same PID, same machine, same session, same minute.
  *
  * So `baselineToSustainedSpawnRatio` is a measured before/after rather than
  * arithmetic over a remembered number, and it stays honest if the curve is
- * ever retuned.
+ * ever retuned. It is a comparison of START COUNTS and only that: a fresh
+ * instance also allocates a map and runs the creation-time sweep, so the two
+ * arms are not identical in every byte of work, just in the thing being
+ * counted. For a full before/after of the whole implementation, run this
+ * scenario on the parent commit — `backoffMisses` is deliberately not an
+ * integrity predicate so that reading stays valid.
  *
  * PLATFORMS. Linux is declared `unsupported` and skipped rather than reported:
  * there the probe is `readlink /proc/<pid>/exe`, pure Node with no subprocess
@@ -55,10 +62,13 @@ import {
  */
 
 /**
- * A PID no platform will have allocated: above 32-bit `pid_t`'s positive range
- * and far above every default `pid_max`. Chosen over "a PID owned by another
- * user" (which depends on who is running the benchmark) and over "a PID that
- * just exited" (which is a PID-reuse race against the rest of the machine).
+ * `INT32_MAX` — a valid positive PID as far as the probe's own argument check
+ * is concerned, so the lookup really does reach the OS, but far above every
+ * default `pid_max` and above macOS's allocation range, so nothing holds it.
+ * Chosen over "a PID owned by another user" (which depends on who is running
+ * the benchmark) and over "a PID that just exited" (which is a PID-reuse race
+ * against the rest of the machine). `faultQualificationMisses` checks the
+ * choice rather than trusting it.
  */
 const ABSENT_PID = 2_147_483_647;
 
@@ -83,12 +93,26 @@ const QUALIFY_SETTLE_MS = 1_500;
 /** The reduction the issue requires before this change is worth shipping. */
 const REQUIRED_REDUCTION = 5;
 
+/**
+ * Apparatus predicates only.
+ *
+ * `backoffMisses` — the issue's 5x bar — is REPORTED but deliberately not
+ * declared here. It grades the subject rather than the apparatus, so under
+ * `--enforce-integrity` it would make the pre-backoff tree unmeasurable, and a
+ * valid reading of the old behaviour has to stay valid evidence.
+ *
+ * `retryLivenessMisses` is the term that makes the rest safe. Without it a
+ * probe whose retries had stopped completely reports one start against a
+ * forty-start reference — an 8x "improvement" bettered only by breaking it
+ * further — with every other predicate at zero.
+ */
 const CORRECTNESS = [
   "spawnObserverMisses",
   "probeLivenessMisses",
   "faultQualificationMisses",
   "absentPidResolutionMisses",
-  "backoffMisses",
+  "retryLivenessMisses",
+  "baselineFidelityMisses",
   "cadenceMisses",
 ] as const;
 
@@ -155,7 +179,7 @@ export const imagePathProbeScenarios: PerfScenario[] = [
     id: "PERF-405",
     name: "Image-Path Probe Retry Storm",
     description:
-      "A real ImagePathProbe read at the pty-host's own 1500ms cadence for a full 60s window against a PID that can never resolve, counting the `lsof`/PowerShell starts it actually makes. Two arms share the window: one long-lived probe (what the product does) and a fresh probe per read, which is the pre-#12239 rule exactly rather than a stand-in for it — a read of an unresolved PID scheduled a probe every time. The ratio between them is therefore a measured before/after on one machine in one session. Graded against the apparatus rather than against itself: the observer proves it can still see a start, a positive control on this process's own PID proves the probe still resolves anything at all, the absent PID is qualified as genuinely costing a subprocess before the window opens, and the required 5x reduction is a predicate rather than a note. Skipped on Linux, where the probe is a bare readlink and there is no subprocess storm to measure.",
+      "A real ImagePathProbe read at the pty-host's own 1500ms cadence for the 40 polls a minute contains, against a PID that can never resolve, counting the `lsof`/PowerShell starts it actually makes. Two arms share the window: one long-lived probe (what the product does) and a fresh probe per read, whose first read takes the same path the pre-#12239 gate took on every read of an unresolved PID. The ratio between them is a measured before/after on one machine in one session rather than arithmetic over a remembered number. The predicates grade the apparatus, not the feature: the observer proves it can still see a start, a positive control on this process's own PID proves the probe resolves anything at all, the absent PID is qualified as genuinely costing a subprocess, the reference arm must achieve its one-start-per-read workload, and — the one without which none of the rest is safe — the sustained arm must have retried at all and still be retrying in the back half of the window, because a probe whose retries died reports one start against forty and scores better than a working one. The issue's 5x bar is reported but deliberately left out of the predicates, so a reading taken on the pre-backoff tree stays valid evidence. Skipped on Linux, where the probe is a bare readlink and there is no subprocess storm to measure.",
     tier: "heavy",
     modes: ["ci", "nightly"],
     // One 60s window per iteration, and the count is a rate over that window:
@@ -181,16 +205,23 @@ export const imagePathProbeScenarios: PerfScenario[] = [
         // Control: a PID that CAN be read must resolve. Without it, "almost no
         // probe starts" is indistinguishable from a probe that stopped working,
         // and the broken one posts the better number. It is also the only
-        // probe here with an observable end, so it is where the per-probe wall
-        // cost is taken — to a 5ms polling granularity, and against a live
-        // process rather than an absent one.
+        // probe here with an observable end, so it is where the wall cost is
+        // taken — against a live process rather than an absent one, to a 5ms
+        // polling granularity, and measured to PUBLICATION: if the first
+        // lookup failed this includes its cooldown and the retry after it, so
+        // read it as an upper bound on one probe, not as one probe.
         const controlStart = performance.now();
         const controlBasename = await awaitResolution(control, process.pid);
         const controlProbeWallMs = performance.now() - controlStart;
 
-        // Qualification: the absent PID must actually cost a subprocess and
-        // must actually fail. A candidate that resolved, or that never reached
-        // the OS, would make every count below meaningless.
+        // Qualification: the absent PID must cost a start and must not come
+        // back with a basename. A candidate that resolved, or that the probe
+        // rejected before reaching the OS, would make every count below
+        // meaningless. This establishes "a start was attempted and nothing was
+        // published", not the exit status of the command — the observer records
+        // the start before handing off to the real `spawn`. That the lookups
+        // genuinely COMPLETE is established later, by `retryLivenessMisses`:
+        // the gate will not start a second probe while the first is in flight.
         const qualifyMark = allSpawnMark();
         absent.readBasename(ABSENT_PID);
         const qualifySpawns = probeSpawnCount(allSpawnsSince(qualifyMark));
@@ -217,34 +248,39 @@ export const imagePathProbeScenarios: PerfScenario[] = [
           );
         }
 
-        let sustainedSpawns = 0;
         let baselineSpawns = 0;
         let cadenceMisses = 0;
         let absentPidResolutionMisses = 0;
+        /** Offset of every start the sustained arm made, for the liveness read. */
+        const sustainedLaunchOffsets: number[] = [];
 
         const start = performance.now();
         for (let read = 0; read < WINDOW_READS; read += 1) {
           const deadline = start + read * POLL_INTERVAL_MS;
           const waitMs = deadline - performance.now();
-          if (waitMs > 0) {
-            await sleep(waitMs);
-          } else if (waitMs < -POLL_INTERVAL_MS) {
-            // A slot missed by more than a whole interval: the window did not
-            // deliver the cadence it claims, so the rate it reports is not the
-            // rate the product would pay.
-            cadenceMisses += 1;
-          }
+          if (waitMs > 0) await sleep(waitMs);
+
+          // Lateness is read AFTER the wait, not before it. Checking the
+          // pre-sleep clock scores the slot the scheduler was asked for rather
+          // than the one it delivered, so an oversleeping runner produces a
+          // burst of catch-up reads that all look punctual.
+          const offset = performance.now() - start;
+          if (offset - read * POLL_INTERVAL_MS > POLL_INTERVAL_MS) cadenceMisses += 1;
 
           // The shipped path. `readBasename` starts its subprocess
           // synchronously, so the bracket needs no await to be complete.
           const sustainedMark = allSpawnMark();
           const served = sustained.readBasename(ABSENT_PID);
-          sustainedSpawns += probeSpawnCount(allSpawnsSince(sustainedMark));
+          if (probeSpawnCount(allSpawnsSince(sustainedMark)) > 0) {
+            sustainedLaunchOffsets.push(offset);
+          }
           // A PID that does not exist must never acquire a basename. This is
           // the direction a cache bug would break in silently.
           if (served !== null) absentPidResolutionMisses += 1;
 
-          // The pre-fix rule: one probe per read of an unresolved PID.
+          // The reference arm: a first read on a fresh instance, which is what
+          // the pre-fix gate did on EVERY read of an unresolved PID — provided
+          // the previous probe had settled, which the gate also required then.
           const baselineMark = allSpawnMark();
           const fresh = new ImagePathProbe();
           fresh.readBasename(ABSENT_PID);
@@ -254,6 +290,29 @@ export const imagePathProbeScenarios: PerfScenario[] = [
           fresh.dispose();
         }
         const windowMs = performance.now() - start;
+        const sustainedSpawns = sustainedLaunchOffsets.length;
+        const lastLaunchOffset = sustainedLaunchOffsets[sustainedSpawns - 1] ?? 0;
+
+        // Let the last arm's children finish rather than returning over the top
+        // of them: `dispose()` clears cache state and cancels nothing, and the
+        // smoke driver exits the process on return.
+        await sleep(QUALIFY_SETTLE_MS);
+
+        // THE predicate this scenario cannot be trusted without. A probe whose
+        // retries stopped after the first failure reports one start against a
+        // forty-start reference and scores better than a working one. Two
+        // readings, both of which a dead retry path fails: it must have
+        // retried at all, and it must still have been retrying in the back
+        // half of the window. It doubles as proof that the probes COMPLETE —
+        // the gate refuses to start a second one while the first is in flight,
+        // so a second start cannot happen unless the first settled.
+        const retryLivenessMisses =
+          sustainedSpawns >= 2 && lastLaunchOffset >= windowMs / 2 ? 0 : 1;
+
+        // The reference has to be the workload it claims. One start per read is
+        // the pre-fix rule; anything less means its probes were not settling
+        // between polls and it is understating what the old code cost.
+        const baselineFidelityMisses = baselineSpawns === WINDOW_READS ? 0 : 1;
 
         const backoffMisses =
           sustainedSpawns >= 1 && baselineSpawns >= sustainedSpawns * REQUIRED_REDUCTION ? 0 : 1;
@@ -263,9 +322,12 @@ export const imagePathProbeScenarios: PerfScenario[] = [
           sustainedProbeSpawns: sustainedSpawns,
           baselineProbeSpawns: baselineSpawns,
           baselineToSustainedSpawnRatio: sustainedSpawns > 0 ? baselineSpawns / sustainedSpawns : 0,
+          lastSustainedLaunchMs: lastLaunchOffset,
           readCalls: WINDOW_READS,
           windowMs,
           absentPidResolutionMisses,
+          retryLivenessMisses,
+          baselineFidelityMisses,
           backoffMisses,
           cadenceMisses,
         };
@@ -278,8 +340,8 @@ export const imagePathProbeScenarios: PerfScenario[] = [
           metrics,
           notes:
             backoffMisses === 1
-              ? `no meaningful backoff: ${sustainedSpawns} starts against a ${baselineSpawns}-start baseline, short of the required ${REQUIRED_REDUCTION}x`
-              : `control resolved as "${controlBasename}"; ${sustainedSpawns} starts against a ${baselineSpawns}-start baseline over ${WINDOW_READS} reads`,
+              ? `no meaningful backoff: ${sustainedSpawns} starts against a ${baselineSpawns}-start reference, short of the required ${REQUIRED_REDUCTION}x`
+              : `control resolved as "${controlBasename}"; ${sustainedSpawns} starts against a ${baselineSpawns}-start reference over ${WINDOW_READS} reads, last retry at ${Math.round(lastLaunchOffset)}ms`,
         };
       } finally {
         control.dispose();

--- a/scripts/perf/scenarios/imagePathProbe.ts
+++ b/scripts/perf/scenarios/imagePathProbe.ts
@@ -29,10 +29,16 @@ import {
  *     the product does;
  *   - the BASELINE arm is a fresh probe per read. A first read on a fresh
  *     instance takes the same path the old gate took on EVERY read of an
- *     unresolved PID, so its start count is the old rule's start count —
- *     subject to the one condition the old gate also carried, `!refreshing`,
- *     which `baselineFidelityMisses` checks by requiring one start per read.
- *     Same PID, same machine, same session, same minute.
+ *     unresolved PID. Same PID, same machine, same session, same minute.
+ *
+ *     Its equivalence is CONDITIONAL and the condition is not free: the old
+ *     gate also carried `!refreshing`, so it launched once per read only while
+ *     each probe settled inside a poll. A fresh instance has no in-flight
+ *     predecessor and so launches unconditionally — it cannot demonstrate that
+ *     condition, and `baselineFidelityMisses` does not claim to. What does
+ *     demonstrate it is the SUSTAINED arm: its later starts are proof that its
+ *     earlier probes settled, because the gate refuses a second start while
+ *     one is in flight.
  *
  * So `baselineToSustainedSpawnRatio` is a measured before/after rather than
  * arithmetic over a remembered number, and it stays honest if the curve is
@@ -111,6 +117,7 @@ const CORRECTNESS = [
   "probeLivenessMisses",
   "faultQualificationMisses",
   "absentPidResolutionMisses",
+  "doubleStartMisses",
   "retryLivenessMisses",
   "baselineFidelityMisses",
   "cadenceMisses",
@@ -190,7 +197,12 @@ export const imagePathProbeScenarios: PerfScenario[] = [
     correctness: [...CORRECTNESS],
     platforms: { linux: "unsupported", win32: "diagnostic" },
     async run(): Promise<ScenarioSample> {
-      const { ImagePathProbe } = await loadImagePathProbeModule();
+      const { ImagePathProbe, IMAGE_PATH_RETRY_MAX_MS } = await loadImagePathProbeModule();
+      // The longest a healthy probe may go between retries: the published
+      // ceiling, plus the poll a retry that becomes eligible mid-interval has
+      // to wait for. Derived rather than fixed, so retuning the curve retunes
+      // the predicate instead of breaking it.
+      const maxHealthyGapMs = IMAGE_PATH_RETRY_MAX_MS + POLL_INTERVAL_MS;
 
       installGitSpawnCounter();
       // Before any measurement window: the observer's self-validation starts a
@@ -248,10 +260,12 @@ export const imagePathProbeScenarios: PerfScenario[] = [
           );
         }
 
+        let sustainedSpawns = 0;
         let baselineSpawns = 0;
         let cadenceMisses = 0;
         let absentPidResolutionMisses = 0;
-        /** Offset of every start the sustained arm made, for the liveness read. */
+        let doubleStartMisses = 0;
+        /** Offset of each read that started something, for the liveness read. */
         const sustainedLaunchOffsets: number[] = [];
 
         const start = performance.now();
@@ -271,9 +285,15 @@ export const imagePathProbeScenarios: PerfScenario[] = [
           // synchronously, so the bracket needs no await to be complete.
           const sustainedMark = allSpawnMark();
           const served = sustained.readBasename(ABSENT_PID);
-          if (probeSpawnCount(allSpawnsSince(sustainedMark)) > 0) {
-            sustainedLaunchOffsets.push(offset);
-          }
+          // Two separate readings from the same bracket, and they must stay
+          // separate: the SUM is the cost being reported, the offsets are only
+          // for the liveness gap. Counting reads-that-started instead of
+          // starts would let a read that spawned twice report as one and
+          // understate the very number this scenario exists to publish.
+          const started = probeSpawnCount(allSpawnsSince(sustainedMark));
+          sustainedSpawns += started;
+          if (started > 0) sustainedLaunchOffsets.push(offset);
+          if (started > 1) doubleStartMisses += 1;
           // A PID that does not exist must never acquire a basename. This is
           // the direction a cache bug would break in silently.
           if (served !== null) absentPidResolutionMisses += 1;
@@ -290,28 +310,49 @@ export const imagePathProbeScenarios: PerfScenario[] = [
           fresh.dispose();
         }
         const windowMs = performance.now() - start;
-        const sustainedSpawns = sustainedLaunchOffsets.length;
-        const lastLaunchOffset = sustainedLaunchOffsets[sustainedSpawns - 1] ?? 0;
+        const lastLaunchOffset = sustainedLaunchOffsets[sustainedLaunchOffsets.length - 1] ?? 0;
 
-        // Let the last arm's children finish rather than returning over the top
-        // of them: `dispose()` clears cache state and cancels nothing, and the
-        // smoke driver exits the process on return.
+        // Give the last arm's children room to finish rather than returning
+        // over the top of them: `dispose()` clears cache state and cancels
+        // nothing, and the smoke driver exits the process on return. It is a
+        // grace period, not proof — nothing here observes child exit — but it
+        // comfortably clears the 750ms probe timeout for a lookup against a
+        // PID that does not exist.
         await sleep(QUALIFY_SETTLE_MS);
 
         // THE predicate this scenario cannot be trusted without. A probe whose
-        // retries stopped after the first failure reports one start against a
-        // forty-start reference and scores better than a working one. Two
-        // readings, both of which a dead retry path fails: it must have
-        // retried at all, and it must still have been retrying in the back
-        // half of the window. It doubles as proof that the probes COMPLETE —
-        // the gate refuses to start a second one while the first is in flight,
-        // so a second start cannot happen unless the first settled.
+        // retries stopped reports one start against a forty-start reference
+        // and scores better than a working one, with every other term at zero.
+        //
+        // Two readings. It must have retried at all, and no gap between
+        // retries — including the gap from the last one to the end of the
+        // window — may exceed what the published ceiling allows. The gap rule
+        // is derived from the constants rather than fixed at a fraction of the
+        // window, so a retune of the curve retargets it instead of failing it.
+        //
+        // It doubles as proof that the lookups COMPLETE: the gate refuses to
+        // start a second probe while the first is in flight, so a second start
+        // cannot happen unless the first settled.
+        //
+        // The limit worth knowing: a window barely longer than the ceiling
+        // cannot tell "stopped after the last ceiling-length wait" from "still
+        // waiting out the ceiling". The unit suite closes that under fake
+        // timers, where running past several ceilings is free.
+        const launchGaps = sustainedLaunchOffsets.map(
+          (offset, index) => offset - (sustainedLaunchOffsets[index - 1] ?? 0)
+        );
         const retryLivenessMisses =
-          sustainedSpawns >= 2 && lastLaunchOffset >= windowMs / 2 ? 0 : 1;
+          sustainedLaunchOffsets.length >= 2 &&
+          launchGaps.every((gap) => gap <= maxHealthyGapMs) &&
+          windowMs - lastLaunchOffset <= maxHealthyGapMs
+            ? 0
+            : 1;
 
-        // The reference has to be the workload it claims. One start per read is
-        // the pre-fix rule; anything less means its probes were not settling
-        // between polls and it is understating what the old code cost.
+        // The reference achieved the workload it claims: one start per read.
+        // This grades the reference ARM, not the equivalence — a fresh
+        // instance has no in-flight predecessor to suppress it, so it cannot
+        // itself demonstrate the `!refreshing` condition the old gate carried.
+        // The sustained arm is what demonstrates settling between polls.
         const baselineFidelityMisses = baselineSpawns === WINDOW_READS ? 0 : 1;
 
         const backoffMisses =
@@ -326,6 +367,7 @@ export const imagePathProbeScenarios: PerfScenario[] = [
           readCalls: WINDOW_READS,
           windowMs,
           absentPidResolutionMisses,
+          doubleStartMisses,
           retryLivenessMisses,
           baselineFidelityMisses,
           backoffMisses,

--- a/scripts/perf/scenarios/imagePathProbe.ts
+++ b/scripts/perf/scenarios/imagePathProbe.ts
@@ -1,0 +1,291 @@
+import { performance } from "node:perf_hooks";
+
+import type { PerfScenario, ScenarioSample } from "../types";
+import type { ImagePathProbe as ImagePathProbeType } from "../../../electron/services/pty/ImagePathProbe";
+import {
+  allSpawnMark,
+  allSpawnsSince,
+  installGitSpawnCounter,
+  sleep,
+  spawnObserverMisses,
+  type ProcessSpawnWindow,
+} from "../lib/gitPipelineFixture";
+
+/**
+ * What a PID the image-path probe cannot read costs per minute (PERF-405).
+ *
+ * `ProcessDetector` calls `ImagePathProbe.readBasename()` for every process at
+ * depth 2 or less on every ProcessTreeCache poll, and the pty-host polls at
+ * 1500ms. Before #12239 a null result was indistinguishable from "never
+ * probed", so a PID that can never resolve — one owned by another user, one
+ * `lsof` cannot inspect, or any probe that timed out under load — started a
+ * fresh `lsof` (macOS) or `powershell.exe` (Windows) on every single poll, for
+ * as long as the process lived.
+ *
+ * Both directions are measured in ONE window, at the real cadence, against the
+ * same real absent PID:
+ *
+ *   - the SUSTAINED arm is one long-lived probe read 40 times, which is what
+ *     the product does;
+ *   - the BASELINE arm is a fresh probe per read. That is not a simulation of
+ *     the old code — it is the old rule exactly, because a read of a PID with
+ *     no result scheduled a probe every time, which is what a first read of a
+ *     fresh instance does. Same PID, same machine, same session, same minute.
+ *
+ * So `baselineToSustainedSpawnRatio` is a measured before/after rather than
+ * arithmetic over a remembered number, and it stays honest if the curve is
+ * ever retuned.
+ *
+ * PLATFORMS. Linux is declared `unsupported` and skipped rather than reported:
+ * there the probe is `readlink /proc/<pid>/exe`, pure Node with no subprocess
+ * at all, so `probeSpawns` is structurally zero both before and after the fix
+ * and the benchmark could never move. Counting readlink calls instead would
+ * mean wrapping the subject's own dependency, which is the shape this harness
+ * exists to refuse. Windows is `diagnostic`: PowerShell is a direct child and
+ * so is visible to the observer, but its start cost dominates the reading and
+ * the observer's own Windows caveats apply.
+ *
+ * WHAT THIS IS NOT. The counted probes are absent-PID lookups. They exercise
+ * the real failure path end to end, but a failing probe has no observable end,
+ * so their individual cost is not timed here and `lsof` does less work when
+ * there is no process to inspect anyway. `controlProbeWallMs` is timed against
+ * a live process instead — this one — and is the closest thing to the issue's
+ * 40ms figure that this scenario can honestly report. The spawn counts are the
+ * finding; the wall figure is scale for it.
+ */
+
+/**
+ * A PID no platform will have allocated: above 32-bit `pid_t`'s positive range
+ * and far above every default `pid_max`. Chosen over "a PID owned by another
+ * user" (which depends on who is running the benchmark) and over "a PID that
+ * just exited" (which is a PID-reuse race against the rest of the machine).
+ */
+const ABSENT_PID = 2_147_483_647;
+
+/** The pty-host's own `new ProcessTreeCache(1500)` cadence. */
+const POLL_INTERVAL_MS = 1_500;
+
+/** Reads in a 60s window at that cadence: t = 0, 1500 … 58500. */
+const WINDOW_READS = 40;
+
+/** Long enough for the 750ms probe timeout plus the process teardown after it. */
+const SETTLE_TIMEOUT_MS = 5_000;
+const SETTLE_POLL_MS = 5;
+
+/**
+ * How long the absent PID is given to come back with something before it is
+ * accepted as unresolvable. A failing probe publishes nothing, so there is no
+ * edge to wait for — polling it would just burn the timeout. One poll interval
+ * clears the probe's own 750ms cap with room to spare.
+ */
+const QUALIFY_SETTLE_MS = 1_500;
+
+/** The reduction the issue requires before this change is worth shipping. */
+const REQUIRED_REDUCTION = 5;
+
+const CORRECTNESS = [
+  "spawnObserverMisses",
+  "probeLivenessMisses",
+  "faultQualificationMisses",
+  "absentPidResolutionMisses",
+  "backoffMisses",
+  "cadenceMisses",
+] as const;
+
+type ImagePathProbeModule = typeof import("../../../electron/services/pty/ImagePathProbe");
+
+let probeModulePromise: Promise<ImagePathProbeModule> | null = null;
+
+/**
+ * Loaded lazily, per the harness's lazy-fixture rule: `scenarios/index.ts`
+ * imports every scenario module up front, so product code pulled in at module
+ * scope would be charged to every run whichever id was selected.
+ */
+function loadImagePathProbeModule(): Promise<ImagePathProbeModule> {
+  if (!probeModulePromise) {
+    installGitSpawnCounter();
+    probeModulePromise = import("../../../electron/services/pty/ImagePathProbe");
+  }
+  return probeModulePromise;
+}
+
+/**
+ * Probe starts inside a window, by executable.
+ *
+ * Bucketed rather than taken from `count` so an unrelated start — the
+ * observer's own self-validation child, anything the runner does — cannot be
+ * read as a probe.
+ */
+function probeSpawnCount(window: ProcessSpawnWindow): number {
+  const { byExecutable } = window;
+  return (byExecutable.lsof ?? 0) + (byExecutable["powershell.exe"] ?? 0);
+}
+
+/** Read until the probe publishes something, or give up. Null means it never did. */
+async function awaitResolution(
+  probe: ImagePathProbeType,
+  pid: number,
+  timeoutMs = SETTLE_TIMEOUT_MS
+): Promise<string | null> {
+  const deadline = performance.now() + timeoutMs;
+  for (;;) {
+    const basename = probe.readBasename(pid);
+    if (basename !== null) return basename;
+    if (performance.now() >= deadline) return null;
+    await sleep(SETTLE_POLL_MS);
+  }
+}
+
+/**
+ * Every miss set, for the paths where the apparatus itself did not work.
+ *
+ * A scenario that returns partial metrics after failing its own setup reports
+ * a beautifully cheap window that measured nothing at all.
+ */
+function failClosed(reason: string, metrics: Record<string, number>): ScenarioSample {
+  const failed: Record<string, number> = { ...metrics };
+  for (const term of CORRECTNESS) {
+    if (failed[term] === undefined || failed[term] === 0) failed[term] = 1;
+  }
+  return { durationMs: 0, metrics: failed, notes: `INVALID — ${reason}` };
+}
+
+export const imagePathProbeScenarios: PerfScenario[] = [
+  {
+    id: "PERF-405",
+    name: "Image-Path Probe Retry Storm",
+    description:
+      "A real ImagePathProbe read at the pty-host's own 1500ms cadence for a full 60s window against a PID that can never resolve, counting the `lsof`/PowerShell starts it actually makes. Two arms share the window: one long-lived probe (what the product does) and a fresh probe per read, which is the pre-#12239 rule exactly rather than a stand-in for it — a read of an unresolved PID scheduled a probe every time. The ratio between them is therefore a measured before/after on one machine in one session. Graded against the apparatus rather than against itself: the observer proves it can still see a start, a positive control on this process's own PID proves the probe still resolves anything at all, the absent PID is qualified as genuinely costing a subprocess before the window opens, and the required 5x reduction is a predicate rather than a note. Skipped on Linux, where the probe is a bare readlink and there is no subprocess storm to measure.",
+    tier: "heavy",
+    modes: ["ci", "nightly"],
+    // One 60s window per iteration, and the count is a rate over that window:
+    // a warmup would double the wall clock to sharpen a figure that is not
+    // timing-sensitive.
+    warmups: 0,
+    iterations: { ci: 1, nightly: 1 },
+    correctness: [...CORRECTNESS],
+    platforms: { linux: "unsupported", win32: "diagnostic" },
+    async run(): Promise<ScenarioSample> {
+      const { ImagePathProbe } = await loadImagePathProbeModule();
+
+      installGitSpawnCounter();
+      // Before any measurement window: the observer's self-validation starts a
+      // child of its own, which would otherwise land in the count it validates.
+      const observerMisses = spawnObserverMisses();
+
+      const control = new ImagePathProbe();
+      const absent = new ImagePathProbe();
+      const sustained = new ImagePathProbe();
+
+      try {
+        // Control: a PID that CAN be read must resolve. Without it, "almost no
+        // probe starts" is indistinguishable from a probe that stopped working,
+        // and the broken one posts the better number. It is also the only
+        // probe here with an observable end, so it is where the per-probe wall
+        // cost is taken — to a 5ms polling granularity, and against a live
+        // process rather than an absent one.
+        const controlStart = performance.now();
+        const controlBasename = await awaitResolution(control, process.pid);
+        const controlProbeWallMs = performance.now() - controlStart;
+
+        // Qualification: the absent PID must actually cost a subprocess and
+        // must actually fail. A candidate that resolved, or that never reached
+        // the OS, would make every count below meaningless.
+        const qualifyMark = allSpawnMark();
+        absent.readBasename(ABSENT_PID);
+        const qualifySpawns = probeSpawnCount(allSpawnsSince(qualifyMark));
+        await sleep(QUALIFY_SETTLE_MS);
+        const qualifyResult = absent.readBasename(ABSENT_PID);
+
+        const preflight: Record<string, number> = {
+          controlProbeWallMs,
+          spawnObserverMisses: observerMisses,
+          probeLivenessMisses: controlBasename === null ? 1 : 0,
+          faultQualificationMisses: qualifySpawns >= 1 && qualifyResult === null ? 0 : 1,
+        };
+
+        if (preflight.probeLivenessMisses === 1) {
+          return failClosed(
+            "the probe could not resolve this process's own image path, so a low count here is a dead probe rather than a cheap one",
+            preflight
+          );
+        }
+        if (preflight.faultQualificationMisses === 1) {
+          return failClosed(
+            `the absent PID ${ABSENT_PID} did not produce a failing probe that costs a subprocess (${qualifySpawns} starts, resolved ${qualifyResult ?? "null"})`,
+            preflight
+          );
+        }
+
+        let sustainedSpawns = 0;
+        let baselineSpawns = 0;
+        let cadenceMisses = 0;
+        let absentPidResolutionMisses = 0;
+
+        const start = performance.now();
+        for (let read = 0; read < WINDOW_READS; read += 1) {
+          const deadline = start + read * POLL_INTERVAL_MS;
+          const waitMs = deadline - performance.now();
+          if (waitMs > 0) {
+            await sleep(waitMs);
+          } else if (waitMs < -POLL_INTERVAL_MS) {
+            // A slot missed by more than a whole interval: the window did not
+            // deliver the cadence it claims, so the rate it reports is not the
+            // rate the product would pay.
+            cadenceMisses += 1;
+          }
+
+          // The shipped path. `readBasename` starts its subprocess
+          // synchronously, so the bracket needs no await to be complete.
+          const sustainedMark = allSpawnMark();
+          const served = sustained.readBasename(ABSENT_PID);
+          sustainedSpawns += probeSpawnCount(allSpawnsSince(sustainedMark));
+          // A PID that does not exist must never acquire a basename. This is
+          // the direction a cache bug would break in silently.
+          if (served !== null) absentPidResolutionMisses += 1;
+
+          // The pre-fix rule: one probe per read of an unresolved PID.
+          const baselineMark = allSpawnMark();
+          const fresh = new ImagePathProbe();
+          fresh.readBasename(ABSENT_PID);
+          baselineSpawns += probeSpawnCount(allSpawnsSince(baselineMark));
+          // Disposed immediately: its refresh settles into a disposed probe and
+          // writes nothing, so the arm costs one start and no retained state.
+          fresh.dispose();
+        }
+        const windowMs = performance.now() - start;
+
+        const backoffMisses =
+          sustainedSpawns >= 1 && baselineSpawns >= sustainedSpawns * REQUIRED_REDUCTION ? 0 : 1;
+
+        const metrics: Record<string, number> = {
+          ...preflight,
+          sustainedProbeSpawns: sustainedSpawns,
+          baselineProbeSpawns: baselineSpawns,
+          baselineToSustainedSpawnRatio: sustainedSpawns > 0 ? baselineSpawns / sustainedSpawns : 0,
+          readCalls: WINDOW_READS,
+          windowMs,
+          absentPidResolutionMisses,
+          backoffMisses,
+          cadenceMisses,
+        };
+
+        return {
+          // Self-timed against nothing: the reading is a start count over a
+          // fixed 60s window, and 60s of deliberate waiting is not a duration
+          // anything should compare.
+          durationMs: 0,
+          metrics,
+          notes:
+            backoffMisses === 1
+              ? `no meaningful backoff: ${sustainedSpawns} starts against a ${baselineSpawns}-start baseline, short of the required ${REQUIRED_REDUCTION}x`
+              : `control resolved as "${controlBasename}"; ${sustainedSpawns} starts against a ${baselineSpawns}-start baseline over ${WINDOW_READS} reads`,
+        };
+      } finally {
+        control.dispose();
+        absent.dispose();
+        sustained.dispose();
+      }
+    },
+  },
+];

--- a/scripts/perf/scenarios/index.ts
+++ b/scripts/perf/scenarios/index.ts
@@ -35,6 +35,7 @@ import { copyTreeScenarios } from "./copyTree";
 import { cliAvailabilityScenarios } from "./cliAvailability";
 import { sidebarFilterScenarios } from "./sidebarFilters";
 import { switcherSearchScenarios } from "./switcherSearch";
+import { imagePathProbeScenarios } from "./imagePathProbe";
 
 export const allScenarios: PerfScenario[] = [
   ...startupScenarios,
@@ -73,6 +74,7 @@ export const allScenarios: PerfScenario[] = [
   ...cliAvailabilityScenarios,
   ...sidebarFilterScenarios,
   ...switcherSearchScenarios,
+  ...imagePathProbeScenarios,
 ];
 
 export function getScenariosForMode(mode: PerfMode): PerfScenario[] {
@@ -246,6 +248,7 @@ export const EXPECTED_SCENARIO_IDS: ReadonlySet<string> = new Set([
   "PERF-402",
   "PERF-403",
   "PERF-404",
+  "PERF-405",
 ]);
 
 /**


### PR DESCRIPTION
WHAT WAS WRONG
`ImagePathProbe.readBasename()` treated a null result as "never probed", so a PID that can never resolve re-probed on every read. `ProcessDetector` reads every process at depth <= 2 on every ProcessTreeCache poll (1500ms), so one unreadable PID meant one `lsof` (macOS) or `powershell.exe` (Windows) subprocess start every 1.5s for as long as the process lived. The catch handler stamped `updatedAt` with a comment saying it "prevents tight-retry", but nothing ever read that stamp back.

Worth calling out: that catch handler was never reached anyway. `refresh()` catches every resolver error and RESOLVES null, so failures arrive on the fulfilled path. Both arms now route through one guarded `settle()`.

THE FIX
One new field on the cache entry, `retryDelayMs`, with the gate `now >= entry.updatedAt + entry.retryDelayMs`. `updatedAt` was already being written and never read, so it becomes the cooldown origin and no second timestamp is needed. Doubling curve: 3s, 6, 12, 24, capped at 48s, reset on success, all whole multiples of the 1500ms poll (#8794). Zero on a fresh entry, so a PID's first probe is never delayed. No jitter — each PID backs off independently, there is no thundering herd.

State lives on the entry `evict()` deletes, so a recycled PID starts clean for free. The in-flight `refreshing` dedupe, the `checkId` stale-write guard, the 30s eviction TTL and permanent positive caching are all untouched.

Failure kind (timeout vs error vs empty) is NOT reported: the platform resolvers erase all three into null, so carrying it up would need new plumbing. The issue asked for it "only if free" — it isn't.

MEASUREMENTS — macOS (darwin-arm64, M-series), Electron 42.7.1, same machine and session
| | probe starts / minute |
|---|---|
| before | 40 |
| after | 5 |
| reduction | 8x |

Both numbers are measured, not one measured and one remembered: PERF-405 runs two arms in the same 60s window against the same absent PID — one long-lived probe (shipped behaviour) and a fresh probe per read (a first read on a fresh instance takes the same path the old gate took on every read). Also: `controlProbeWallMs` 26.7ms per probe against a live process, last retry at 51.0s, `--enforce-integrity` clean.

The real ladder is 0, 4.5, 12, 25.5, 51s rather than the idealised 0, 3, 9, 21, 45 — the cooldown runs from when the probe SETTLED, so a ~26ms lookup pushes each retry to the following poll. Recovery after a transient failure is bounded by the 48s ceiling, inside the 30-60s the issue asked for.

VERIFICATION
Mutation-tested rather than asserted. Six deliberate breakages, all caught by the unit suite: backoff removed entirely, ceiling removed, cooldown charged from launch instead of settle, retry state pooled across PIDs, `checkId` stale-write guard removed, and retries stopping after the first retry.

Three Codex review passes. The one that mattered: PERF-405 originally would have reported a flawless 8x with every predicate at 0 if retries had stopped completely — one start against a forty-start reference scores better than a working probe. `retryLivenessMisses` now requires the sustained arm to have retried at all and for no gap between retries to exceed the ceiling plus a poll, derived from the constants so retuning the curve retargets it. `backoffMisses` (the issue's 5x bar) is reported but deliberately NOT an integrity predicate — it grades the feature, not the apparatus, and as a predicate it would make the pre-backoff tree unmeasurable.

Local: 181 tests (probe, ProcessDetector, sibling probe) and 996 (full perf harness suite incl. scenarioLiveness). Prettier and eslint clean on changed files.

KNOWN BOUNDS (deliberate, not oversights)
- A PID that exits and is recycled WITHOUT an intervening `evict()` — it would have to leave and re-enter the probed set inside one 1.5s poll — inherits the old cooldown for up to 48s. Closing that needs a PID+start-time identity key; `ProcessInfo.startTime` exists only on Windows today. Pre-existing identity gap, and the issue scopes reuse handling to `evict()`.
- PERF-405 is skipped on Linux: there the probe is `readlink /proc/<pid>/exe`, no subprocess at all, so the count is structurally zero before and after and the benchmark could never move. Counting readlink calls would mean wrapping the subject's own dependency. Diagnostic on Windows.
- PERF-405 is in `EXPENSIVE_SCENARIOS` (60s window), like PERF-092/093/094/105/106, so `npm test` does not drive it.

FILES
- electron/services/pty/ImagePathProbe.ts — the backoff
- electron/services/pty/__tests__/ImagePathProbe.test.ts — new backoff coverage; also fixes a pre-existing bug that resolved PID 123's already-settled promise a second time, leaving 456's probe pending forever
- scripts/perf/scenarios/imagePathProbe.ts — PERF-405 (new)
- scripts/perf/scenarios/index.ts, scripts/perf/config/benchmarkClasses.ts — registration
- scripts/perf/__tests__/scenarioLiveness.test.ts — expensive-scenario exclusion

Resolves #12239

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017X8TLGcgfLEp9uPGJEEeua