### PR TITLE
perf(pty): unify periodic and event-driven snapshot scheduling

### DIFF
--- a/electron/services/pty/SessionSnapshotter.ts
+++ b/electron/services/pty/SessionSnapshotter.ts
@@ -200,11 +200,18 @@ export class SessionSnapshotter {
       await persistSessionSnapshotAsync(this.host.id, state);
       // Mark coverage only after a successful persist. Uses the entry epoch, so
       // content that changed mid-serialize (epoch > entry) still triggers a
-      // later flush.
+      // later flush. contentEpoch counts chunk RECEIPT, not parse completion,
+      // so coverage means "the buffer as it serialized" — a chunk still queued
+      // in HeadlessMirrorScheduler lands in the next capture. flushSyncOnKill
+      // is the unconditional backstop on shutdown.
+      //
+      // `dirty` is deliberately NOT cleared here. Resize reflow and mirror
+      // geometry repair bump contentEpoch without calling schedule(), so a
+      // capture that cleared `dirty` would make the pending timer bail at its
+      // `!dirty` guard before ever looking at the newer epoch — and take
+      // flushSyncOnDispose's teardown write with it. The epoch check below is
+      // what makes the pending debounce a no-op when it is genuinely covered.
       this.lastFlushedEpoch = epoch;
-      // A debounced write waiting on these same bytes is now redundant; only
-      // content that arrived mid-capture is still outstanding.
-      if (this.host.contentEpoch === epoch) this.dirty = false;
     } catch (error) {
       console.warn(
         trigger === "periodic"

--- a/electron/services/pty/SessionSnapshotter.ts
+++ b/electron/services/pty/SessionSnapshotter.ts
@@ -160,12 +160,17 @@ export class SessionSnapshotter {
 
     // Buffer unchanged since the last persisted snapshot — nothing to write.
     // Checked before the throttle so an unchanged flush never consumes the
-    // throttle window a later changed-content flush needs. Coverage means those
-    // exact bytes are already on disk, which also satisfies any pending
-    // debounced write.
+    // throttle window a later changed-content flush needs.
+    //
+    // Only a PERIODIC trigger discharges `dirty` here: it is that deadline's own
+    // pending work, and finding it already on disk is what makes the debounce a
+    // no-op. An event call finding coverage says nothing about the debounce, and
+    // clearing it would let an unchanged settle swallow a later geometry-only
+    // change — resize bumps contentEpoch without calling schedule(), so the
+    // timer would bail at `!dirty` before ever comparing the newer epoch.
     const epoch = this.host.contentEpoch;
     if (epoch === this.lastFlushedEpoch) {
-      this.dirty = false;
+      if (trigger === "periodic") this.dirty = false;
       return;
     }
 

--- a/electron/services/pty/SessionSnapshotter.ts
+++ b/electron/services/pty/SessionSnapshotter.ts
@@ -91,12 +91,22 @@ export function createTerminalSessionSnapshotter(
   return new SessionSnapshotter(snapshotterHost);
 }
 
+type CaptureTrigger = "periodic" | "event";
+
 export class SessionSnapshotter {
   private timer: ReturnType<typeof setTimeout> | null = null;
   private dirty = false;
+  // One in-flight flag for both triggers: a capture already running covers the
+  // buffer either of them would serialize, so the second trigger records a
+  // follow-up instead of starting a duplicate serialize + write.
   private inFlight = false;
   private lastEventDrivenFlushAt = -Infinity;
-  private eventDrivenInFlight = false;
+  private pendingEventFlush = false;
+  // Shared "already persisted" identity, stamped by whichever trigger wrote
+  // last. contentEpoch covers geometry as well as output — resize reflow,
+  // geometry resync and preserved-snapshot capture all bump it — so an
+  // unchanged epoch means the bytes on disk are the bytes we would write, and
+  // no separate cols/rows key is needed.
   private lastFlushedEpoch = -1;
   private disposed = false;
 
@@ -110,74 +120,76 @@ export class SessionSnapshotter {
     if (this.disposed) return;
 
     this.dirty = true;
+    // Anchored, not refreshed: an armed timer keeps its original deadline so
+    // sustained output cannot push the durability write out indefinitely.
     if (this.timer) return;
 
     this.timer = setTimeout(() => {
       this.timer = null;
-      void this.persistAsync();
+      void this.captureAsync("periodic");
     }, SESSION_SNAPSHOT_DEBOUNCE_MS);
   }
 
-  private async persistAsync(): Promise<void> {
-    if (!TERMINAL_SESSION_PERSISTENCE_ENABLED) return;
-    if (isSessionPersistSuppressed()) return;
-    if (this.host.launchAgentId) return;
-    if (this.host.wasKilled) return;
-    if (this.disposed) return;
-    if (!this.dirty) return;
-    if (this.inFlight) return;
-
-    this.inFlight = true;
-    try {
-      this.dirty = false;
-      const state = await (this.host.hasBannerMarkers()
-        ? this.host.serializeForPersistence()
-        : this.host.getSerializedStateAsync());
-      // Re-check lifecycle after the await — a kill or dispose during async
-      // serialize would otherwise stomp the sync snapshot written from kill().
-      if (this.disposed || this.host.wasKilled) return;
-      if (!state) return;
-      await persistSessionSnapshotAsync(this.host.id, state);
-    } catch (error) {
-      console.warn(`[TerminalProcess] Failed to persist session for ${this.host.id}:`, error);
-    } finally {
-      this.inFlight = false;
-      if (!this.disposed && this.dirty) {
-        this.schedule();
-      }
-    }
-  }
-
   flushEventDriven(): void {
-    void this.flushEventDrivenAsync();
+    void this.captureAsync("event");
   }
 
-  // Async event-driven flush fired on agent state settles (waiting/completed/
-  // exited). Mirrors persistAsync()'s banner-branch + post-await lifecycle
-  // re-check so serializing up to 10k lines no longer blocks the pty-host event
-  // loop on every transition. Two short-circuits keep it cheap: an unchanged
-  // contentEpoch skips serialization entirely, and a 2s throttle caps churn from
-  // rapid changed-content transitions.
-  private async flushEventDrivenAsync(): Promise<void> {
+  // The one capture path behind both triggers. What stays per-trigger is the
+  // eligibility gate and the timing — periodic is debounced 5s and skips agent
+  // terminals, event-driven is throttled 2s and includes them. What is shared
+  // is the in-flight flag, the persisted-epoch identity, and the serialize +
+  // write itself.
+  //
+  // These were two independent routines with no common state until #12237, so
+  // the end of every agent turn paid for the same buffer twice: the last output
+  // chunk armed the debounce, the FSM settle fired the event flush and
+  // serialized immediately, and the timer then fired and serialized identical
+  // content because it had never looked at the epoch.
+  //
+  // Serializing up to 10k lines must not block the pty-host event loop, so the
+  // work is async and every await is followed by a lifecycle re-check.
+  private async captureAsync(trigger: CaptureTrigger): Promise<void> {
     if (!TERMINAL_SESSION_PERSISTENCE_ENABLED) return;
     if (isSessionPersistSuppressed()) return;
+    // Agent terminals are event-driven only: their scrollback is captured on a
+    // state settle, never on the debounce.
+    if (trigger === "periodic" && this.host.launchAgentId) return;
     if (this.host.wasKilled) return;
     if (this.disposed) return;
+    if (trigger === "periodic" && !this.dirty) return;
 
     // Buffer unchanged since the last persisted snapshot — nothing to write.
     // Checked before the throttle so an unchanged flush never consumes the
-    // throttle window a later changed-content flush needs.
+    // throttle window a later changed-content flush needs. Coverage means those
+    // exact bytes are already on disk, which also satisfies any pending
+    // debounced write.
     const epoch = this.host.contentEpoch;
-    if (epoch === this.lastFlushedEpoch) return;
+    if (epoch === this.lastFlushedEpoch) {
+      this.dirty = false;
+      return;
+    }
 
     const now = performance.now();
-    if (now - this.lastEventDrivenFlushAt < EVENT_DRIVEN_SNAPSHOT_THROTTLE_MS) return;
+    if (
+      trigger === "event" &&
+      now - this.lastEventDrivenFlushAt < EVENT_DRIVEN_SNAPSHOT_THROTTLE_MS
+    ) {
+      return;
+    }
 
-    // Drop overlapping flushes: the in-flight one already covers this settle.
-    if (this.eventDrivenInFlight) return;
-    this.eventDrivenInFlight = true;
-    this.lastEventDrivenFlushAt = now;
+    if (this.inFlight) {
+      // A capture is already running. Record the request rather than starting a
+      // second serialize of the same buffer; the finally block hands it back to
+      // this path once the current write lands. Periodic work needs no flag —
+      // `dirty` is still set and finally re-arms the debounce for it.
+      if (trigger === "event") this.pendingEventFlush = true;
+      return;
+    }
+
+    this.inFlight = true;
+    if (trigger === "event") this.lastEventDrivenFlushAt = now;
     try {
+      if (trigger === "periodic") this.dirty = false;
       const state = await (this.host.hasBannerMarkers()
         ? this.host.serializeForPersistence()
         : this.host.getSerializedStateAsync());
@@ -190,10 +202,25 @@ export class SessionSnapshotter {
       // content that changed mid-serialize (epoch > entry) still triggers a
       // later flush.
       this.lastFlushedEpoch = epoch;
+      // A debounced write waiting on these same bytes is now redundant; only
+      // content that arrived mid-capture is still outstanding.
+      if (this.host.contentEpoch === epoch) this.dirty = false;
     } catch (error) {
-      console.warn(`[TerminalProcess] Event-driven snapshot failed for ${this.host.id}:`, error);
+      console.warn(
+        trigger === "periodic"
+          ? `[TerminalProcess] Failed to persist session for ${this.host.id}:`
+          : `[TerminalProcess] Event-driven snapshot failed for ${this.host.id}:`,
+        error
+      );
     } finally {
-      this.eventDrivenInFlight = false;
+      this.inFlight = false;
+      if (!this.disposed) {
+        if (this.pendingEventFlush) {
+          this.pendingEventFlush = false;
+          void this.captureAsync("event");
+        }
+        if (this.dirty) this.schedule();
+      }
     }
   }
 
@@ -267,5 +294,6 @@ export class SessionSnapshotter {
       this.timer = null;
     }
     this.dirty = false;
+    this.pendingEventFlush = false;
   }
 }

--- a/electron/services/pty/__tests__/SessionSnapshotter.test.ts
+++ b/electron/services/pty/__tests__/SessionSnapshotter.test.ts
@@ -45,9 +45,11 @@ async function flushMicrotasks(): Promise<void> {
 }
 
 // A capture that completes can hand a deferred follow-up straight back into the
-// same path, so the chain is longer than one flush drains.
+// same path, so the chain is longer than one flush drains. Advancing the fake
+// clock by zero yields through a real task, draining the whole chain without
+// making any armed deadline due — deterministic where a tick count is a guess.
 async function drainFollowUp(): Promise<void> {
-  for (let i = 0; i < 12; i += 1) await Promise.resolve();
+  await vi.advanceTimersByTimeAsync(0);
 }
 
 function createHost(overrides: Partial<MutableHost> = {}): MutableHost {
@@ -688,7 +690,34 @@ describe("SessionSnapshotter", () => {
       expect(persistAsyncMock).toHaveBeenCalledTimes(2);
     });
 
-    it("clears pending debounced work once an event flush persisted the same buffer", async () => {
+    it("re-arms the debounce when output outlives the event capture in flight", async () => {
+      const host = createHost();
+      host.asyncResolved = false;
+      const snap = new SessionSnapshotter(host);
+
+      snap.schedule();
+      snap.flushEventDriven();
+      await Promise.resolve(); // the event capture stalls in serialize
+
+      // Newer output arrives, then the armed deadline expires while the capture
+      // still holds the gate — so it fires, defers, and leaves nothing armed.
+      host.contentEpoch = 2;
+      snap.schedule();
+      vi.advanceTimersByTime(5001);
+      expect(persistAsyncMock).not.toHaveBeenCalled();
+
+      // The capture covers only its entry epoch, so the newer output needs a
+      // fresh deadline armed on the way out.
+      host.asyncResolve();
+      await drainFollowUp();
+      expect(persistAsyncMock).toHaveBeenCalledTimes(1);
+
+      vi.advanceTimersByTime(5001);
+      await flushMicrotasks();
+      expect(persistAsyncMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("still persists a geometry-only change after an event flush covered the output", async () => {
       const host = createHost();
       const snap = new SessionSnapshotter(host);
 
@@ -697,9 +726,32 @@ describe("SessionSnapshotter", () => {
       await flushMicrotasks();
       expect(persistAsyncMock).toHaveBeenCalledTimes(1);
 
-      // Teardown must not rewrite bytes the event flush already wrote.
+      // A resize reflow bumps contentEpoch without calling schedule(). The
+      // capture must not have cleared the pending debounce out from under it,
+      // or the timer bails at `!dirty` before ever seeing the newer epoch.
+      host.contentEpoch = 2;
+      vi.advanceTimersByTime(5001);
+      await flushMicrotasks();
+
+      expect(persistAsyncMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("still persists a geometry-only change from teardown", async () => {
+      const host = createHost();
+      const snap = new SessionSnapshotter(host);
+
+      snap.schedule();
+      snap.flushEventDriven();
+      await flushMicrotasks();
+      expect(persistAsyncMock).toHaveBeenCalledTimes(1);
+
+      // Same reflow, but teardown arrives before the deadline. flushSyncOnDispose
+      // is gated on `dirty`, so clearing it on a successful capture would lose
+      // this write entirely.
+      host.contentEpoch = 2;
       snap.flushSyncOnDispose();
-      expect(persistSyncMock).not.toHaveBeenCalled();
+
+      expect(persistSyncMock).toHaveBeenCalledTimes(1);
     });
 
     it("leaves debounced work pending for teardown when the event flush failed", async () => {

--- a/electron/services/pty/__tests__/SessionSnapshotter.test.ts
+++ b/electron/services/pty/__tests__/SessionSnapshotter.test.ts
@@ -44,6 +44,12 @@ async function flushMicrotasks(): Promise<void> {
   await Promise.resolve();
 }
 
+// A capture that completes can hand a deferred follow-up straight back into the
+// same path, so the chain is longer than one flush drains.
+async function drainFollowUp(): Promise<void> {
+  for (let i = 0; i < 12; i += 1) await Promise.resolve();
+}
+
 function createHost(overrides: Partial<MutableHost> = {}): MutableHost {
   // Allow tests to install a deferred async serializer when they need to
   // observe in-flight behavior.
@@ -397,7 +403,7 @@ describe("SessionSnapshotter", () => {
       expect(persistAsyncMock).not.toHaveBeenCalled();
     });
 
-    it("drops a re-entrant flush while one is already in flight", async () => {
+    it("defers a re-entrant flush while one is already in flight", async () => {
       const host = createHost();
       host.asyncResolved = false;
       const serializeSpy = vi.spyOn(host, "getSerializedStateAsync");
@@ -408,7 +414,7 @@ describe("SessionSnapshotter", () => {
 
       // Advance past the throttle window and change content so the second call
       // clears the epoch + throttle gates and actually reaches the in-flight
-      // guard — which must drop it (no second serialize starts).
+      // guard — which must not start a second serialize alongside the first.
       vi.advanceTimersByTime(2001);
       host.contentEpoch = 2;
       snap.flushEventDriven();
@@ -416,10 +422,13 @@ describe("SessionSnapshotter", () => {
 
       expect(serializeSpy).toHaveBeenCalledTimes(1);
 
+      // The deferred request is remembered, not dropped: the changed content it
+      // asked for is written once the in-flight capture releases.
       host.asyncResolve();
-      await flushMicrotasks();
+      await drainFollowUp();
 
-      expect(persistAsyncMock).toHaveBeenCalledTimes(1);
+      expect(serializeSpy).toHaveBeenCalledTimes(2);
+      expect(persistAsyncMock).toHaveBeenCalledTimes(2);
     });
 
     it("does not mark the epoch flushed when persist fails (retries after throttle)", async () => {
@@ -545,6 +554,166 @@ describe("SessionSnapshotter", () => {
       snap.flushSyncOnDispose();
       snap.flushSyncOnDispose();
 
+      expect(persistSyncMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // The two triggers used to keep entirely separate state, so the end of an
+  // agent turn — last output chunk arms the debounce, FSM settle fires the
+  // event flush — serialized and wrote the same buffer twice, in either order
+  // (#12237). These pin the coalescing without loosening the cases that must
+  // still produce two writes.
+  describe("unified periodic + event-driven scheduling", () => {
+    it("persists once when an event flush covers a scheduled periodic snapshot", async () => {
+      const host = createHost();
+      const serializeSpy = vi.spyOn(host, "getSerializedStateAsync");
+      const snap = new SessionSnapshotter(host);
+
+      // Output burst arms the 5s debounce; the agent settles 2s later.
+      snap.schedule();
+      vi.advanceTimersByTime(2000);
+      snap.flushEventDriven();
+      await flushMicrotasks();
+
+      expect(serializeSpy).toHaveBeenCalledTimes(1);
+      expect(persistAsyncMock).toHaveBeenCalledTimes(1);
+
+      // The debounce still expires, on content already on disk.
+      vi.advanceTimersByTime(3001);
+      await flushMicrotasks();
+
+      expect(serializeSpy).toHaveBeenCalledTimes(1);
+      expect(persistAsyncMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("persists once when a debounced snapshot covers a later event flush", async () => {
+      const host = createHost();
+      const serializeSpy = vi.spyOn(host, "getSerializedStateAsync");
+      const snap = new SessionSnapshotter(host);
+
+      snap.schedule();
+      vi.advanceTimersByTime(5000);
+      await flushMicrotasks();
+
+      expect(persistAsyncMock).toHaveBeenCalledTimes(1);
+
+      // The mirror direction: the periodic write now stamps the shared epoch,
+      // so a settle on unchanged content has nothing left to write.
+      snap.flushEventDriven();
+      await flushMicrotasks();
+
+      expect(serializeSpy).toHaveBeenCalledTimes(1);
+      expect(persistAsyncMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("persists twice when output arrives after the event flush", async () => {
+      const host = createHost();
+      const snap = new SessionSnapshotter(host);
+
+      snap.schedule();
+      vi.advanceTimersByTime(2000);
+      snap.flushEventDriven();
+      await flushMicrotasks();
+      expect(persistAsyncMock).toHaveBeenCalledTimes(1);
+
+      // A different buffer, so the debounce that follows is real work.
+      host.contentEpoch = 2;
+      snap.schedule();
+      vi.advanceTimersByTime(5001);
+      await flushMicrotasks();
+
+      expect(persistAsyncMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("persists twice when output arrives after the debounced snapshot", async () => {
+      const host = createHost();
+      const snap = new SessionSnapshotter(host);
+
+      snap.schedule();
+      vi.advanceTimersByTime(5000);
+      await flushMicrotasks();
+      expect(persistAsyncMock).toHaveBeenCalledTimes(1);
+
+      // The 2s throttle stays event-driven only: a periodic write does not
+      // stamp it, so a settle on changed content is eligible immediately.
+      host.contentEpoch = 2;
+      snap.flushEventDriven();
+      await flushMicrotasks();
+
+      expect(persistAsyncMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("starts no second serialize when the debounce expires mid-capture", async () => {
+      const host = createHost();
+      host.asyncResolved = false;
+      const serializeSpy = vi.spyOn(host, "getSerializedStateAsync");
+      const snap = new SessionSnapshotter(host);
+
+      snap.schedule();
+      snap.flushEventDriven();
+      await Promise.resolve(); // the event capture reaches its stalled serialize
+
+      // The debounce expires while that capture is still serializing. One
+      // in-flight flag covers both triggers, so nothing starts alongside it.
+      vi.advanceTimersByTime(5001);
+      expect(serializeSpy).toHaveBeenCalledTimes(1);
+
+      host.asyncResolve();
+      await drainFollowUp();
+
+      expect(serializeSpy).toHaveBeenCalledTimes(1);
+      expect(persistAsyncMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("still persists content that changed while a capture was serializing", async () => {
+      const host = createHost();
+      host.asyncResolved = false;
+      const snap = new SessionSnapshotter(host);
+
+      snap.schedule();
+      vi.advanceTimersByTime(5000);
+      await Promise.resolve();
+
+      // Output lands mid-serialize. Coverage is stamped with the ENTRY epoch,
+      // so it cannot claim the newer buffer.
+      host.contentEpoch = 2;
+      snap.schedule();
+      host.asyncResolve();
+      await drainFollowUp();
+      expect(persistAsyncMock).toHaveBeenCalledTimes(1);
+
+      vi.advanceTimersByTime(5001);
+      await flushMicrotasks();
+
+      expect(persistAsyncMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("clears pending debounced work once an event flush persisted the same buffer", async () => {
+      const host = createHost();
+      const snap = new SessionSnapshotter(host);
+
+      snap.schedule();
+      snap.flushEventDriven();
+      await flushMicrotasks();
+      expect(persistAsyncMock).toHaveBeenCalledTimes(1);
+
+      // Teardown must not rewrite bytes the event flush already wrote.
+      snap.flushSyncOnDispose();
+      expect(persistSyncMock).not.toHaveBeenCalled();
+    });
+
+    it("leaves debounced work pending for teardown when the event flush failed", async () => {
+      const host = createHost();
+      const snap = new SessionSnapshotter(host);
+      persistAsyncMock.mockRejectedValueOnce(new Error("disk full"));
+
+      snap.schedule();
+      snap.flushEventDriven();
+      await flushMicrotasks();
+      expect(persistAsyncMock).toHaveBeenCalledTimes(1);
+
+      // A failed write covers nothing, so the last-chance sync flush still runs.
+      snap.flushSyncOnDispose();
       expect(persistSyncMock).toHaveBeenCalledTimes(1);
     });
   });

--- a/electron/services/pty/__tests__/SessionSnapshotter.test.ts
+++ b/electron/services/pty/__tests__/SessionSnapshotter.test.ts
@@ -736,6 +736,31 @@ describe("SessionSnapshotter", () => {
       expect(persistAsyncMock).toHaveBeenCalledTimes(2);
     });
 
+    it("does not let an unchanged event flush discharge the pending debounce", async () => {
+      const host = createHost();
+      const snap = new SessionSnapshotter(host);
+
+      snap.schedule();
+      snap.flushEventDriven();
+      await flushMicrotasks();
+      expect(persistAsyncMock).toHaveBeenCalledTimes(1);
+
+      // A second settle on unchanged content. It must skip — but skipping is
+      // not the same as satisfying the debounce, which is still holding the
+      // deadline for whatever comes next.
+      vi.advanceTimersByTime(2001);
+      snap.flushEventDriven();
+      await flushMicrotasks();
+      expect(persistAsyncMock).toHaveBeenCalledTimes(1);
+
+      // A resize reflow, then the deadline: the write must still happen.
+      host.contentEpoch = 2;
+      vi.advanceTimersByTime(3000);
+      await flushMicrotasks();
+
+      expect(persistAsyncMock).toHaveBeenCalledTimes(2);
+    });
+
     it("still persists a geometry-only change from teardown", async () => {
       const host = createHost();
       const snap = new SessionSnapshotter(host);

--- a/scripts/perf/__tests__/workloadFloors.test.ts
+++ b/scripts/perf/__tests__/workloadFloors.test.ts
@@ -124,6 +124,7 @@ describe("workload floors", () => {
       "PERF-395",
       "PERF-406",
       "PERF-407",
+      "PERF-408",
     ]);
     for (const scenario of declaring) {
       for (const [metric, floor] of Object.entries(scenario.workloadFloors!)) {

--- a/scripts/perf/config/benchmarkClasses.ts
+++ b/scripts/perf/config/benchmarkClasses.ts
@@ -305,6 +305,14 @@ const FAMILIES: readonly Family[] = [
       "Real SerializeAddon output across a real headless fleet — the teardown cost paid on every quit. Capture only: nothing here says what the payload costs to read back, and no disk write is in the bracket.",
   },
   {
+    label: "session snapshot scheduling",
+    ids: ["PERF-408"],
+    kind: "mechanism",
+    fidelity: withFidelity({ renderer: "headless" }),
+    claim:
+      "The real snapshot coordinator, its real timers and the real session writer against a temporary user-data directory: how many serializes and disk writes an agent turn actually pays for. The triggers are called directly, so nothing here says the pty-host and agent FSM fire them at the right moment, and the write latency is outside the duration.",
+  },
+  {
     label: "session restore parser floor",
     ids: ["PERF-196"],
     kind: "diagnostic",

--- a/scripts/perf/config/benchmarkClasses.ts
+++ b/scripts/perf/config/benchmarkClasses.ts
@@ -310,7 +310,7 @@ const FAMILIES: readonly Family[] = [
     kind: "mechanism",
     fidelity: withFidelity({ renderer: "headless" }),
     claim:
-      "The real snapshot coordinator, its real timers and the real session writer against a temporary user-data directory: how many serializes and disk writes an agent turn actually pays for. The triggers are called directly, so nothing here says the pty-host and agent FSM fire them at the right moment, and the write latency is outside the duration.",
+      "The real snapshot coordinator, its real timers and the real session writer against a temporary user-data directory: how many serializes and disk writes an agent turn actually pays for. The duration is summed SerializeAddon time only — write latency and the coordinator's own bookkeeping are outside it. The triggers are called directly, so nothing here says the pty-host and agent FSM fire them at the right moment, and the counts describe terminals eligible for both triggers, not launched agent terminals that were always event-driven only.",
   },
   {
     label: "session restore parser floor",

--- a/scripts/perf/lib/scrollbackSnapshotFixture.ts
+++ b/scripts/perf/lib/scrollbackSnapshotFixture.ts
@@ -27,7 +27,7 @@ export const REPRESENTATIVE_FLEET = 12;
  * runs — a snapshot that changed size run to run would make the byte metrics
  * unreadable.
  */
-function colourize(corpus: string): string {
+export function colourize(corpus: string): string {
   return corpus
     .split("\r\n")
     .map((line, index) => {
@@ -77,9 +77,18 @@ const fleetCache = new Map<string, Promise<SnapshotFleet>>();
 /**
  * Build a fleet of seeded terminals once per process. `serialize()` does not
  * mutate the buffer, so the same fleet is safe to re-snapshot every iteration.
+ *
+ * `cacheTag` separates callers that DO mutate their fleet. PERF-408 writes fresh
+ * turn output into its terminals, and sharing PERF-195/196's cached sources
+ * would silently move their byte counts — a fixture changing under two
+ * benchmarks depending on which id ran first in the process.
  */
-export function getSnapshotFleet(scrollbackLines: number, size: number): Promise<SnapshotFleet> {
-  const key = `${scrollbackLines}:${size}`;
+export function getSnapshotFleet(
+  scrollbackLines: number,
+  size: number,
+  cacheTag = "shared"
+): Promise<SnapshotFleet> {
+  const key = `${scrollbackLines}:${size}:${cacheTag}`;
   let existing = fleetCache.get(key);
   if (!existing) {
     existing = (async () => {

--- a/scripts/perf/lib/sessionSnapshotSchedulingFixture.ts
+++ b/scripts/perf/lib/sessionSnapshotSchedulingFixture.ts
@@ -1,0 +1,236 @@
+import { mkdtemp, readdir, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+import {
+  SessionSnapshotter,
+  type SessionSnapshotterHost,
+} from "../../../electron/services/pty/SessionSnapshotter";
+import type { SerializedTerminalSnapshot } from "../../../shared/types/terminal";
+import { colourize, type SnapshotSource } from "./scrollbackSnapshotFixture";
+import { buildSearchCorpus } from "./terminalSearchFixture";
+
+/**
+ * Fixture for PERF-408 — the SNAPSHOT SCHEDULER, not the serializer.
+ *
+ * PERF-195 measures what one `SerializeAddon.serialize()` costs. This measures
+ * how many of them an agent turn actually pays for, by driving the real
+ * `SessionSnapshotter` through the sequence that produces the duplicate:
+ * output burst (every chunk calls `schedule()`, arming the 5s debounce), agent
+ * state settle 2s later (`flushEventDriven()`), then quiet past the debounce
+ * deadline. Before #12237 the debounce fired on content the settle had already
+ * written and serialized it again.
+ *
+ * WHAT IS REAL: the snapshotter itself, its timers and throttle against the
+ * real clock, real xterm buffers, real `SerializeAddon` output, and the real
+ * `persistSessionSnapshotAsync` writer against a temporary user-data directory.
+ *
+ * WHAT IS NOT: there is no pty-host, no agent FSM and no analysis worker. The
+ * triggers are called directly, so this says nothing about whether production
+ * fires them at the right moment — only what the coordinator does once they
+ * arrive.
+ *
+ * SCOPE LIMIT ON THE BRACKET: `durationMs` sums SERIALIZE time only, measured
+ * around the addon call, matching PERF-195's exclusion of the disk write. The
+ * writes are real and counted, but their latency is not in the number.
+ */
+
+/** Chunks per burst, each one a `schedule()` call, as a data-pipeline turn produces. */
+const CHUNKS_PER_TURN = 6;
+/** Lines per burst — a turn's worth of new agent output on top of a full scrollback. */
+const LINES_PER_TURN = 120;
+/** Agent state settles this long after the burst, inside the 5s debounce window. */
+const SETTLE_AT_MS = 2000;
+/** Quiet tail: past SESSION_SNAPSHOT_DEBOUNCE_MS (5000) so the debounce deadline lands. */
+const TURN_LENGTH_MS = 5150;
+/** Files must appear within this long after the last turn, or the run is broken. */
+const DRAIN_TIMEOUT_MS = 30_000;
+
+export interface SchedulingProbe {
+  /** Serializes the coordinator asked for. The duplicate this benchmark exists to count. */
+  serializeCalls: number;
+  /** Summed addon time. Disk writes are deliberately outside it. */
+  serializeMs: number;
+}
+
+/**
+ * A host whose terminal id is unique per capture.
+ *
+ * `persistWrites` has to be counted somewhere the host cannot fake, or it is
+ * just `serializeCalls` reported twice and a writer that silently early-returns
+ * (no `DAINTREE_USER_DATA`, an over-cap payload) reads as a healthy write. One
+ * file per capture makes the count a filesystem fact. Captures on a snapshotter
+ * never overlap — the in-flight flag guarantees it — so the id read at persist
+ * time is always the one stamped by the serialize that produced the payload.
+ */
+class ScriptedSnapshotHost implements SessionSnapshotterHost {
+  wasKilled = false;
+  readonly launchAgentId: string | undefined = undefined;
+  contentEpoch = 0;
+  private captureSeq = 0;
+
+  constructor(
+    private readonly baseId: string,
+    private readonly source: SnapshotSource,
+    private readonly probe: SchedulingProbe
+  ) {}
+
+  get id(): string {
+    return `${this.baseId}-c${this.captureSeq}`;
+  }
+
+  hasBannerMarkers(): boolean {
+    return false;
+  }
+
+  getSerializedState(): SerializedTerminalSnapshot {
+    return this.capture();
+  }
+
+  getSerializedStateAsync(): Promise<SerializedTerminalSnapshot> {
+    return Promise.resolve(this.capture());
+  }
+
+  serializeForPersistence(): SerializedTerminalSnapshot {
+    return this.capture();
+  }
+
+  private capture(): SerializedTerminalSnapshot {
+    this.captureSeq += 1;
+    this.probe.serializeCalls += 1;
+    const start = performance.now();
+    const data = this.source.addon.serialize();
+    this.probe.serializeMs += performance.now() - start;
+    return { data, cols: this.source.terminal.cols, rows: this.source.terminal.rows };
+  }
+}
+
+export interface ScriptedTurnResult {
+  serializeCalls: number;
+  persistWrites: number;
+  serializeMs: number;
+  totalPayloadBytes: number;
+  /** Terminals whose final persisted bytes differ from a direct serialize of their buffer. */
+  payloadMisses: number;
+  /** Captures that serialized but produced no file — a writer that quietly did nothing. */
+  writeMisses: number;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function countSessionFiles(dir: string): Promise<string[]> {
+  const entries = await readdir(dir).catch(() => [] as string[]);
+  return entries.filter((name) => name.endsWith(".restore"));
+}
+
+/** Write one turn's output, one `schedule()` per chunk, as PtyDataPipeline does. */
+async function writeBurst(
+  source: SnapshotSource,
+  host: ScriptedSnapshotHost,
+  snapshotter: SessionSnapshotter,
+  seed: number
+) {
+  const corpus = colourize(buildSearchCorpus(LINES_PER_TURN, seed)).split("\r\n");
+  const perChunk = Math.ceil(corpus.length / CHUNKS_PER_TURN);
+  for (let i = 0; i < corpus.length; i += perChunk) {
+    const chunk = `${corpus.slice(i, i + perChunk).join("\r\n")}\r\n`;
+    await new Promise<void>((resolve) => source.terminal.write(chunk, () => resolve()));
+    // Every chunk bumps the epoch and asks for a debounced snapshot, exactly as
+    // the real pipeline does on each PTY data event. The first one arms the
+    // 5s deadline; the rest must not move it.
+    host.contentEpoch += 1;
+    snapshotter.schedule();
+  }
+}
+
+/**
+ * Drive `turns` scripted agent turns across the fleet concurrently.
+ *
+ * Concurrent because a fleet finishing turns together is the case that matters,
+ * and because the debounce is wall-clock: serialising the terminals would cost
+ * `fleetSize * turns * 5s` for the same information.
+ */
+export async function runScriptedTurns(
+  sources: SnapshotSource[],
+  turns: number
+): Promise<ScriptedTurnResult> {
+  const previousUserData = process.env.DAINTREE_USER_DATA;
+  const userData = await mkdtemp(path.join(tmpdir(), "daintree-perf-197-"));
+  process.env.DAINTREE_USER_DATA = userData;
+  const sessionDir = path.join(userData, "terminal-sessions");
+
+  const probe: SchedulingProbe = { serializeCalls: 0, serializeMs: 0 };
+  const hosts = sources.map((source, i) => new ScriptedSnapshotHost(`perf197-${i}`, source, probe));
+  const snapshotters = hosts.map((host) => new SessionSnapshotter(host));
+
+  try {
+    for (let turn = 0; turn < turns; turn += 1) {
+      const turnStart = performance.now();
+      await Promise.all(
+        sources.map((source, i) =>
+          writeBurst(source, hosts[i]!, snapshotters[i]!, 4200 + turn * 100 + i)
+        )
+      );
+
+      // The agent's FSM settles inside the debounce window — the overlap.
+      await sleep(Math.max(0, SETTLE_AT_MS - (performance.now() - turnStart)));
+      snapshotters.forEach((snapshotter) => snapshotter.flushEventDriven());
+
+      // Quiet past the debounce deadline, so its capture (or its skip) lands.
+      await sleep(Math.max(0, TURN_LENGTH_MS - (performance.now() - turnStart)));
+    }
+
+    // Every capture writes its own file, so the run is drained when the file
+    // count stops trailing the serialize count.
+    const drainDeadline = performance.now() + DRAIN_TIMEOUT_MS;
+    let files = await countSessionFiles(sessionDir);
+    while (files.length < probe.serializeCalls && performance.now() < drainDeadline) {
+      await sleep(10);
+      files = await countSessionFiles(sessionDir);
+    }
+
+    // Oracle: the LAST file each terminal wrote must be byte-identical to a
+    // direct serialize of its buffer. A coordinator that coalesced too
+    // aggressively would leave a stale payload on disk and still post a
+    // flattering serialize count. These serializes bypass the host, so they
+    // never enter the workload counters.
+    let payloadMisses = 0;
+    let totalPayloadBytes = 0;
+    for (let i = 0; i < sources.length; i += 1) {
+      const expected = sources[i]!.addon.serialize();
+      const mine = files
+        .filter((name) => name.startsWith(`perf197-${i}-c`))
+        .sort((a, b) => captureIndex(a) - captureIndex(b));
+      const latest = mine[mine.length - 1];
+      if (!latest) {
+        payloadMisses += 1;
+        continue;
+      }
+      const raw = await readFile(path.join(sessionDir, latest), "utf8");
+      // DAINTREE_SESSION_v2\n<cols>x<rows>\n<payload>
+      const payload = raw.slice(raw.indexOf("\n", raw.indexOf("\n") + 1) + 1);
+      totalPayloadBytes += Buffer.byteLength(payload, "utf8");
+      if (payload !== expected) payloadMisses += 1;
+    }
+
+    return {
+      serializeCalls: probe.serializeCalls,
+      persistWrites: files.length,
+      serializeMs: probe.serializeMs,
+      totalPayloadBytes,
+      payloadMisses,
+      writeMisses: probe.serializeCalls - files.length,
+    };
+  } finally {
+    snapshotters.forEach((snapshotter) => snapshotter.dispose());
+    if (previousUserData === undefined) delete process.env.DAINTREE_USER_DATA;
+    else process.env.DAINTREE_USER_DATA = previousUserData;
+    await rm(userData, { recursive: true, force: true });
+  }
+}
+
+function captureIndex(fileName: string): number {
+  return Number(fileName.slice(fileName.lastIndexOf("-c") + 2, -".restore".length));
+}

--- a/scripts/perf/lib/sessionSnapshotSchedulingFixture.ts
+++ b/scripts/perf/lib/sessionSnapshotSchedulingFixture.ts
@@ -41,8 +41,8 @@ const CHUNKS_PER_TURN = 6;
 const LINES_PER_TURN = 120;
 /** Agent state settles this long after the burst, inside the 5s debounce window. */
 const SETTLE_AT_MS = 2000;
-/** Quiet tail: past SESSION_SNAPSHOT_DEBOUNCE_MS (5000) so the debounce deadline lands. */
-const TURN_LENGTH_MS = 5150;
+/** Quiet window after the burst: past SESSION_SNAPSHOT_DEBOUNCE_MS (5000) so every deadline lands. */
+const QUIET_LENGTH_MS = 5150;
 /** Files must appear within this long after the last turn, or the run is broken. */
 const DRAIN_TIMEOUT_MS = 30_000;
 
@@ -65,6 +65,10 @@ export interface SchedulingProbe {
  */
 class ScriptedSnapshotHost implements SessionSnapshotterHost {
   wasKilled = false;
+  // Undefined on purpose: a terminal with launchAgentId set gets no periodic
+  // scheduling in either implementation, so it has no overlap to measure. The
+  // subject is a runtime-detected agent in an ordinary terminal, which receives
+  // both triggers.
   readonly launchAgentId: string | undefined = undefined;
   contentEpoch = 0;
   private captureSeq = 0;
@@ -145,6 +149,70 @@ async function writeBurst(
   }
 }
 
+/** A v2 session file is `DAINTREE_SESSION_v2\n<cols>x<rows>\n<payload>`. */
+const SESSION_HEADER_V2 = "DAINTREE_SESSION_v2\n";
+/** Per terminal, not fleet-average: one healthy payload must not cover eleven empty ones. */
+const MIN_TERMINAL_SNAPSHOT_BYTES = 250_000;
+
+function captureIndex(fileName: string): number {
+  return Number(fileName.slice(fileName.lastIndexOf("-c") + 2, -".restore".length));
+}
+
+/** The newest file this terminal wrote, by capture sequence rather than name order. */
+function latestFileFor(files: string[], terminalIndex: number): string | undefined {
+  return files
+    .filter((name) => name.startsWith(`perf197-${terminalIndex}-c`))
+    .sort((a, b) => captureIndex(a) - captureIndex(b))
+    .at(-1);
+}
+
+/** Wait for the writes behind the captures already counted to land. */
+async function drainWrites(sessionDir: string, probe: SchedulingProbe): Promise<string[]> {
+  const deadline = performance.now() + DRAIN_TIMEOUT_MS;
+  let files = await countSessionFiles(sessionDir);
+  while (files.length < probe.serializeCalls && performance.now() < deadline) {
+    await sleep(10);
+    files = await countSessionFiles(sessionDir);
+  }
+  return files;
+}
+
+/**
+ * Every terminal's newest persisted payload must equal a direct serialize of
+ * its buffer, run after EVERY turn rather than only at the end.
+ *
+ * A final-only check would pass a coordinator that coalesced away whole turns
+ * and happened to write last, reporting fewer serializes and zero misses — the
+ * most flattering possible result for the exact bug this measures. These
+ * serializes bypass the host, so they never enter the workload counters.
+ */
+async function verifyFleet(
+  sources: SnapshotSource[],
+  sessionDir: string,
+  files: string[]
+): Promise<{ misses: number; bytes: number }> {
+  let misses = 0;
+  let bytes = 0;
+  for (let i = 0; i < sources.length; i += 1) {
+    const expected = sources[i]!.addon.serialize();
+    const latest = latestFileFor(files, i);
+    if (!latest) {
+      misses += 1;
+      continue;
+    }
+    const raw = await readFile(path.join(sessionDir, latest), "utf8");
+    if (!raw.startsWith(SESSION_HEADER_V2)) {
+      misses += 1;
+      continue;
+    }
+    const payload = raw.slice(raw.indexOf("\n", SESSION_HEADER_V2.length) + 1);
+    const payloadBytes = Buffer.byteLength(payload, "utf8");
+    bytes += payloadBytes;
+    if (payload !== expected || payloadBytes < MIN_TERMINAL_SNAPSHOT_BYTES) misses += 1;
+  }
+  return { misses, bytes };
+}
+
 /**
  * Drive `turns` scripted agent turns across the fleet concurrently.
  *
@@ -165,54 +233,33 @@ export async function runScriptedTurns(
   const hosts = sources.map((source, i) => new ScriptedSnapshotHost(`perf197-${i}`, source, probe));
   const snapshotters = hosts.map((host) => new SessionSnapshotter(host));
 
+  let payloadMisses = 0;
+  let totalPayloadBytes = 0;
+  let files: string[] = [];
+
   try {
     for (let turn = 0; turn < turns; turn += 1) {
-      const turnStart = performance.now();
       await Promise.all(
         sources.map((source, i) =>
           writeBurst(source, hosts[i]!, snapshotters[i]!, 4200 + turn * 100 + i)
         )
       );
 
+      // Anchored AFTER the burst on purpose. `schedule()` runs during it, so
+      // the latest deadline any terminal armed is burstEnd + 5000; timing the
+      // quiet window from here keeps every one of them inside the turn. Timing
+      // it from the burst START would let a slow burst push a deadline past the
+      // window, and the duplicate it would have produced would go uncounted.
+      const quietStart = performance.now();
+      await sleep(SETTLE_AT_MS);
       // The agent's FSM settles inside the debounce window — the overlap.
-      await sleep(Math.max(0, SETTLE_AT_MS - (performance.now() - turnStart)));
       snapshotters.forEach((snapshotter) => snapshotter.flushEventDriven());
+      await sleep(Math.max(0, QUIET_LENGTH_MS - (performance.now() - quietStart)));
 
-      // Quiet past the debounce deadline, so its capture (or its skip) lands.
-      await sleep(Math.max(0, TURN_LENGTH_MS - (performance.now() - turnStart)));
-    }
-
-    // Every capture writes its own file, so the run is drained when the file
-    // count stops trailing the serialize count.
-    const drainDeadline = performance.now() + DRAIN_TIMEOUT_MS;
-    let files = await countSessionFiles(sessionDir);
-    while (files.length < probe.serializeCalls && performance.now() < drainDeadline) {
-      await sleep(10);
-      files = await countSessionFiles(sessionDir);
-    }
-
-    // Oracle: the LAST file each terminal wrote must be byte-identical to a
-    // direct serialize of its buffer. A coordinator that coalesced too
-    // aggressively would leave a stale payload on disk and still post a
-    // flattering serialize count. These serializes bypass the host, so they
-    // never enter the workload counters.
-    let payloadMisses = 0;
-    let totalPayloadBytes = 0;
-    for (let i = 0; i < sources.length; i += 1) {
-      const expected = sources[i]!.addon.serialize();
-      const mine = files
-        .filter((name) => name.startsWith(`perf197-${i}-c`))
-        .sort((a, b) => captureIndex(a) - captureIndex(b));
-      const latest = mine[mine.length - 1];
-      if (!latest) {
-        payloadMisses += 1;
-        continue;
-      }
-      const raw = await readFile(path.join(sessionDir, latest), "utf8");
-      // DAINTREE_SESSION_v2\n<cols>x<rows>\n<payload>
-      const payload = raw.slice(raw.indexOf("\n", raw.indexOf("\n") + 1) + 1);
-      totalPayloadBytes += Buffer.byteLength(payload, "utf8");
-      if (payload !== expected) payloadMisses += 1;
+      files = await drainWrites(sessionDir, probe);
+      const verdict = await verifyFleet(sources, sessionDir, files);
+      payloadMisses += verdict.misses;
+      totalPayloadBytes = verdict.bytes;
     }
 
     return {
@@ -229,8 +276,4 @@ export async function runScriptedTurns(
     else process.env.DAINTREE_USER_DATA = previousUserData;
     await rm(userData, { recursive: true, force: true });
   }
-}
-
-function captureIndex(fileName: string): number {
-  return Number(fileName.slice(fileName.lastIndexOf("-c") + 2, -".restore".length));
 }

--- a/scripts/perf/scenarios/index.ts
+++ b/scripts/perf/scenarios/index.ts
@@ -255,6 +255,7 @@ export const EXPECTED_SCENARIO_IDS: ReadonlySet<string> = new Set([
   "PERF-405",
   "PERF-406",
   "PERF-407",
+  "PERF-408",
 ]);
 
 /**

--- a/scripts/perf/scenarios/scrollbackSnapshot.ts
+++ b/scripts/perf/scenarios/scrollbackSnapshot.ts
@@ -7,6 +7,7 @@ import {
   replaySnapshot,
   REPRESENTATIVE_FLEET,
 } from "../lib/scrollbackSnapshotFixture";
+import { runScriptedTurns } from "../lib/sessionSnapshotSchedulingFixture";
 import { percentile } from "../lib/stats";
 import type { PerfScenario } from "../types";
 
@@ -36,6 +37,9 @@ import type { PerfScenario } from "../types";
 
 /** A serialized 10k-line coloured buffer is ~600 KiB; well under this is empty or broken. */
 const MIN_LARGE_SNAPSHOT_BYTES = 250_000;
+
+/** Scripted agent turns per terminal in PERF-408. */
+const SCHEDULED_TURNS = 3;
 
 export const scrollbackSnapshotScenarios: PerfScenario[] = [
   {
@@ -183,6 +187,58 @@ export const scrollbackSnapshotScenarios: PerfScenario[] = [
         disposeTerminals(largeTargets);
         disposeTerminals(smallTargets);
       }
+    },
+  },
+  {
+    id: "PERF-408",
+    name: "Session Snapshot Scheduling - Agent Turn Coalescing",
+    description:
+      "Drives the real SessionSnapshotter through the sequence that ends every agent turn — " +
+      "output burst arming the 5s debounce, FSM settle firing the event-driven flush 2s later, " +
+      "then quiet past the debounce deadline — across a 12-terminal fleet at maximum scrollback. " +
+      "serializeCallsPerTurn is the subject: two independent scheduling paths pay for the same " +
+      "buffer twice, one coordinator pays once. payloadMisses checks each terminal's final " +
+      "persisted bytes against a direct serialize, so coalescing cannot be bought with a stale " +
+      "snapshot; writeMisses catches a writer that serialized and quietly wrote nothing.",
+    tier: "heavy",
+    modes: ["smoke", "ci", "nightly"],
+    iterations: { smoke: 3, ci: 4, nightly: 6 },
+    warmups: 1,
+    correctness: ["payloadMisses", "writeMisses"],
+    workloadFloors: {
+      fleetSize: REPRESENTATIVE_FLEET,
+      snapshotKB: MIN_LARGE_SNAPSHOT_BYTES / 1024,
+    },
+    async run() {
+      // Its own fleet: this scenario writes turn output into the buffers, and
+      // PERF-195/196 read their cached sources expecting them unchanged.
+      const fleet = await getSnapshotFleet(SCROLLBACK_MAX, REPRESENTATIVE_FLEET, "scheduling");
+      const result = await runScriptedTurns(fleet.sources, SCHEDULED_TURNS);
+
+      const turnCount = fleet.sources.length * SCHEDULED_TURNS;
+      // Serialize time only, matching PERF-195: the writes are real and counted
+      // but their latency is not in the bracket.
+      const durationMs = result.serializeMs;
+
+      return {
+        durationMs,
+        metrics: {
+          serializeCalls: result.serializeCalls,
+          persistWrites: result.persistWrites,
+          serializeCallsPerTurn: result.serializeCalls / turnCount,
+          persistWritesPerTurn: result.persistWrites / turnCount,
+          msPerTurn: durationMs / turnCount,
+          snapshotKB: result.totalPayloadBytes / 1024 / fleet.sources.length,
+          fleetSize: fleet.sources.length,
+          turnCount,
+          payloadMisses: result.payloadMisses,
+          writeMisses: result.writeMisses,
+        },
+        notes:
+          result.payloadMisses > 0 || result.writeMisses > 0
+            ? `${result.payloadMisses} stale final payloads, ${result.writeMisses} captures wrote nothing`
+            : undefined,
+      };
     },
   },
 ];

--- a/scripts/perf/scenarios/scrollbackSnapshot.ts
+++ b/scripts/perf/scenarios/scrollbackSnapshot.ts
@@ -197,9 +197,12 @@ export const scrollbackSnapshotScenarios: PerfScenario[] = [
       "output burst arming the 5s debounce, FSM settle firing the event-driven flush 2s later, " +
       "then quiet past the debounce deadline — across a 12-terminal fleet at maximum scrollback. " +
       "serializeCallsPerTurn is the subject: two independent scheduling paths pay for the same " +
-      "buffer twice, one coordinator pays once. payloadMisses checks each terminal's final " +
-      "persisted bytes against a direct serialize, so coalescing cannot be bought with a stale " +
-      "snapshot; writeMisses catches a writer that serialized and quietly wrote nothing.",
+      "buffer twice, one coordinator pays once. The hosts have no launchAgentId, so this measures " +
+      "the terminals that get BOTH triggers — a runtime-detected agent in an ordinary terminal. " +
+      "Explicitly launched agent terminals are event-driven only and never had the periodic half " +
+      "to remove. payloadMisses re-checks every terminal's persisted bytes against a direct " +
+      "serialize after EVERY turn, so coalescing cannot be bought with a stale snapshot or a " +
+      "skipped turn; writeMisses catches a writer that serialized and quietly wrote nothing.",
     tier: "heavy",
     modes: ["smoke", "ci", "nightly"],
     iterations: { smoke: 3, ci: 4, nightly: 6 },


### PR DESCRIPTION
`SessionSnapshotter` ran two independent scheduling paths that shared no state: a 5s-debounced periodic path armed by every PTY chunk, and a 2s-throttled event-driven path fired on agent FSM state settles. Only the event path looked at `contentEpoch`, and neither updated the other's bookkeeping — so the end of every agent turn serialized and wrote the same buffer twice, in either order:

- the settle persisted at +2s, then the untouched debounce fired at +5s and re-serialized identical content, because the periodic path never read the epoch;
- and `lastFlushedEpoch` was only ever written by the event path, so the first settle after a periodic write re-serialized content already on disk.

Both paths are now one `captureAsync(trigger)` sharing a single in-flight flag and a single persisted-epoch identity. What stays per-trigger is exactly what differed before: periodic is debounced 5s and skips agent terminals, event-driven is throttled 2s and includes them. The epoch-before-throttle ordering, the post-await `disposed || wasKilled` re-check, the banner-aware serialize branch and the unconditional kill flush are unchanged.

`contentEpoch` alone is a sufficient equivalence key — it is bumped by resize reflow, geometry resync, mirror-divergence repair and preserved-snapshot capture as well as by output, so geometry needs no separate key. It counts chunk *receipt* rather than parse completion, which is noted at the coverage stamp; `flushSyncOnKill` remains the unconditional backstop on shutdown.

## Measurements

New benchmark PERF-408 drives the real `SessionSnapshotter` — real timers, real `SerializeAddon`, real session writer against a temp user-data dir — through scripted agent turns (output burst, settle at +2s, quiet past the debounce deadline), 12 terminals x 3 turns at 10k-line scrollback. Same machine, same session, same fixture on both arms:

| metric | before | after | delta |
|---|---|---|---|
| serializeCallsPerTurn | 2 | 1 | -50% |
| persistWritesPerTurn | 2 | 1 | -50% |
| msPerTurn (serialize) | 101.96 | 52.45 | -48.6% |
| durationMs p95 | 3689.6 | 1949.5 | -47.2% |
| snapshotKB | 599.6 | 599.6 | identical |
| payloadMisses / writeMisses | 0 / 0 | 0 / 0 | - |

PERF-195 is unmoved and structurally unaffected — it never constructs a `SessionSnapshotter`: p95TerminalMs 648.32, snapshotMisses 0.

The counts describe terminals eligible for both triggers — a runtime-detected agent in an ordinary terminal. Explicitly launched agent terminals were always event-driven only and had no periodic half to remove.

**User-facing effect:** less pty-host CPU and less disk traffic at exactly the moment a fleet of agents finishes their turns — which is the moment the user is about to type.

## Verification

- 5 of the new unit tests fail on the pre-change implementation with the expected shape (`getSerializedStateAsync` called 2 times, expected 1), in both trigger orders.
- Two review passes found two durability regressions in the first commit, both fixed and pinned by regression tests: clearing `dirty` on a successful persist, and clearing it when an unchanged *event* flush found coverage. Resize bumps `contentEpoch` without calling `schedule()`, so either clear made the armed timer bail at `!dirty` before comparing the newer epoch — and took `flushSyncOnDispose`'s teardown write with it.
- Local: 304 tests green across `SessionSnapshotter`, `analysisWorkerPool`, `terminalSessionPersistence`, `TerminalProcess.snapshot` and the perf matrix suites; prettier and eslint clean on all changed files.

Resolves #12237

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UQKGhtggmL69qVRxLJ4uUn

Rebased onto `develop`. PERF-197 was taken by #12253 (file-picker cache lifecycle) while this was open, so this benchmark is now **PERF-408**.
