### PR TITLE
perf(state): coalesce project-state updates queued behind an in-flight save

### DIFF
--- a/electron/services/ProjectStateManager.ts
+++ b/electron/services/ProjectStateManager.ts
@@ -185,8 +185,31 @@ export class ProjectStateManager {
    * Serialize read-merge-write updates per project. ipcMain.handle runs
    * handlers concurrently, so two unqueued read-modify-write cycles for the
    * same projectId read the same snapshot and the last write silently reverts
-   * the other's field. Each queued updater sees the previous update's
-   * committed state. Returning null from the updater skips the save.
+   * the other's field. Returning null from the updater skips the save.
+   *
+   * Updates that arrive while one is already being applied are folded into a
+   * single batch: each still runs, in order, against the previous one's result,
+   * but the batch costs ONE save instead of one per update. The returned
+   * promise still resolves only once that save is durable, and a failed save
+   * rejects every caller whose update it carried.
+   *
+   * The one guarantee that narrowed: an updater now sees the previous update's
+   * ACCEPTED state, which for a folded batch has not reached disk yet — before,
+   * it always saw committed state. Three consequences worth knowing:
+   *
+   *   - An updater must not await another update for the SAME project. Its own
+   *     batch cannot save until every updater in it has returned, so waiting on
+   *     one of them — including one enqueued earlier — deadlocks. Enqueuing
+   *     without awaiting is fine; it simply lands in a later batch.
+   *   - Terminal validation runs once, over the batch's final state, not after
+   *     every updater. Nothing invalid can reach disk either way, because the
+   *     filter is a per-entry predicate over whatever is saved; what changed is
+   *     that a mid-batch entry another updater goes on to repair is no longer
+   *     dropped before that updater can see it.
+   *   - Returning null means "I want no write", and such a caller resolves even
+   *     if the batch's save fails. An updater that returns null because the
+   *     state ALREADY satisfies it is making a claim about durability it cannot
+   *     see, and should return the state instead so it shares the save's fate.
    */
   enqueueProjectStateUpdate(projectId: string, updater: ProjectStateUpdater): Promise<void> {
     let resolve!: () => void;
@@ -233,7 +256,15 @@ export class ProjectStateManager {
     try {
       let batch = firstBatch;
       for (;;) {
-        await this.runBatch(projectId, batch);
+        // `runBatch` settles every entry itself and is not supposed to throw.
+        // If it ever does, this catch keeps the runner alive: the alternative
+        // is an exception unwinding out of a promise nobody awaits, leaving
+        // this batch AND everything queued behind it pending forever.
+        try {
+          await this.runBatch(projectId, batch);
+        } catch (error) {
+          for (const entry of batch) entry.reject(error);
+        }
         const pending = this.writeQueues.get(projectId);
         // Nothing waiting. The `finally` below releases the claim in this same
         // synchronous step, so no enqueue can slip in between the two and be
@@ -283,20 +314,26 @@ export class ProjectStateManager {
     const outcomes: UpdateOutcome[] = [];
 
     for (const entry of batch) {
-      // Every updater gets its own copy, including the first.
-      //
-      // An updater may mutate what it is handed and THEN throw or return null,
-      // and that mutation has to be discarded — which is what happens today,
-      // where each update reads its own copy and a declined write simply
-      // abandons it. `shutdown.ts` and `projectSessionJournal.ts` both mutate
-      // `state.terminals[n]` in place and return the same object, so this is
-      // the live shape, not a hypothetical one.
-      //
-      // Handing the first updater the read's own clone would save a copy and
-      // was tried: it lets a first updater that mutates and then declines write
-      // straight through to the state the rest of the batch builds on.
-      const input = this.cloneProjectState(state);
       try {
+        // Every updater gets its own copy, including the first.
+        //
+        // An updater may mutate what it is handed and THEN throw or return
+        // null, and that mutation has to be discarded — which is what happens
+        // today, where each update reads its own copy and a declined write
+        // simply abandons it. `shutdown.ts` and `projectSessionJournal.ts` both
+        // mutate `state.terminals[n]` in place and return the same object, so
+        // this is the live shape, not a hypothetical one.
+        //
+        // Handing the first updater the read's own clone would save a copy and
+        // was tried: it lets a first updater that mutates and then declines
+        // write straight through to the state the rest of the batch builds on.
+        //
+        // INSIDE the try: `state` is a previous updater's return value, which
+        // is arbitrary caller data. A value structuredClone rejects (a function,
+        // a proxy, a class with an unclonable field) throws here, and an escape
+        // would kill the runner and leave every caller in this batch — and
+        // everything queued behind it — pending forever.
+        const input = this.cloneProjectState(state);
         const updated = await entry.updater(input);
         if (updated === null) {
           outcomes.push({ entry, kind: "noop" });
@@ -319,7 +356,11 @@ export class ProjectStateManager {
     let saveError: { error: unknown } | undefined;
     if (pendingSave) {
       try {
-        await this.saveProjectState(projectId, pendingSave);
+        // The last accepted result is the one object in the batch nothing else
+        // re-copies: every earlier one was cloned to become the next updater's
+        // input. Take an owned snapshot so a caller that kept a reference to
+        // what it returned cannot change what gets written after the fact.
+        await this.saveProjectState(projectId, this.cloneProjectState(pendingSave)!);
       } catch (error) {
         saveError = { error };
       }

--- a/electron/services/ProjectStateManager.ts
+++ b/electron/services/ProjectStateManager.ts
@@ -36,6 +36,28 @@ export interface ProjectStateReadResult {
  */
 export type ProjectStatePersistedObserver = (projectId: string, state: ProjectState | null) => void;
 
+type ProjectStateUpdater = (
+  existing: ProjectState | null
+) => ProjectState | null | Promise<ProjectState | null>;
+
+/** One caller's update, plus the settlement of the promise it was handed. */
+interface QueuedUpdate {
+  updater: ProjectStateUpdater;
+  resolve: () => void;
+  reject: (error: unknown) => void;
+}
+
+/**
+ * What one updater in a batch did, recorded rather than acted on.
+ *
+ * Settlement waits for the batch's save: a later updater that throws must not
+ * resolve ahead of an earlier one whose result is still unwritten.
+ */
+type UpdateOutcome =
+  | { entry: QueuedUpdate; kind: "wrote" }
+  | { entry: QueuedUpdate; kind: "noop" }
+  | { entry: QueuedUpdate; kind: "threw"; error: unknown };
+
 export class ProjectStateManager {
   private projectStateCache = new Map<string, ProjectStateCacheEntry>();
   private pendingQuarantines = new Map<string, string>();
@@ -49,7 +71,16 @@ export class ProjectStateManager {
   // (genuinely no saved state) is authoritative emptiness, not unreadability,
   // and must never land here.
   private unreadableProjectIds = new Set<string>();
-  private writeQueues = new Map<string, Promise<void>>();
+  /**
+   * Updates waiting BEHIND the batch a project's runner is currently applying.
+   *
+   * Not a promise tail any more: the whole point is that several updates
+   * waiting together become one save, and a chain of `.then()` links can only
+   * express one save each.
+   */
+  private writeQueues = new Map<string, QueuedUpdate[]>();
+  /** Projects whose runner is live. Claimed before the runner starts. */
+  private drainingProjects = new Set<string>();
   private sweepTimer: ReturnType<typeof setInterval> | null = null;
   private onStatePersisted: ProjectStatePersistedObserver | null = null;
 
@@ -122,9 +153,23 @@ export class ProjectStateManager {
   }
 
   private setProjectStateCache(projectId: string, state: ProjectState | null): void {
+    this.cacheUnsharedProjectState(projectId, this.cloneProjectState(state));
+  }
+
+  /**
+   * Cache a value nothing else holds a reference to.
+   *
+   * {@link setProjectStateCache} clones because its argument is normally the
+   * caller's object. A freshly parsed disk read is not: it is built here field
+   * by field, and the only other reference handed out is the clone returned to
+   * the caller. Cloning it a second time buys no isolation the first one did
+   * not already provide, and a project's state is the largest thing this class
+   * copies.
+   */
+  private cacheUnsharedProjectState(projectId: string, state: ProjectState | null): void {
     this.projectStateCache.set(projectId, {
       expiresAt: Date.now() + PROJECT_STATE_CACHE_TTL_MS,
-      value: this.cloneProjectState(state),
+      value: state,
     });
   }
 
@@ -143,32 +188,154 @@ export class ProjectStateManager {
    * the other's field. Each queued updater sees the previous update's
    * committed state. Returning null from the updater skips the save.
    */
-  enqueueProjectStateUpdate(
-    projectId: string,
-    updater: (existing: ProjectState | null) => ProjectState | null | Promise<ProjectState | null>
-  ): Promise<void> {
-    const current = this.writeQueues.get(projectId) ?? Promise.resolve();
-    // .catch() keeps one failed update from poisoning the chain for later
-    // updates; the failure still propagates to that update's own caller.
-    const next = current
-      .catch(() => {})
-      .then(async () => {
-        const existing = await this.getProjectState(projectId);
-        const updated = await updater(existing);
+  enqueueProjectStateUpdate(projectId: string, updater: ProjectStateUpdater): Promise<void> {
+    let resolve!: () => void;
+    let reject!: (error: unknown) => void;
+    const promise = new Promise<void>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+    // The old chain hung `.then(cleanup, cleanup)` off the promise it returned,
+    // which incidentally marked a rejection as handled. Callers that never
+    // await (relocation fans several of these into allSettled) relied on that,
+    // so keep it: this handler settles a derived promise, not the returned one,
+    // and the caller still sees the rejection.
+    void promise.catch(() => {});
+
+    const entry: QueuedUpdate = { updater, resolve, reject };
+
+    if (this.drainingProjects.has(projectId)) {
+      // A batch is already applying. Wait behind it — with everything else that
+      // arrives before it finishes, so the whole group costs one save.
+      const pending = this.writeQueues.get(projectId);
+      if (pending) pending.push(entry);
+      else this.writeQueues.set(projectId, [entry]);
+    } else {
+      this.drainingProjects.add(projectId);
+      // Claimed before the runner starts, and the batch handed straight to it:
+      // nothing here depends on how much of `drainQueue` happens to run before
+      // its first await.
+      void this.drainQueue(projectId, [entry]);
+    }
+
+    return promise;
+  }
+
+  /**
+   * Apply batches for one project, back to back, until nothing is waiting.
+   *
+   * A batch is frozen when the runner picks it up, so an update arriving later
+   * can never postpone a save that is already due — the longest anything waits
+   * is the batch in front of it, never a deadline that keeps moving. That is
+   * why there is no flush ceiling here: there is no timer to starve.
+   */
+  private async drainQueue(projectId: string, firstBatch: QueuedUpdate[]): Promise<void> {
+    try {
+      let batch = firstBatch;
+      for (;;) {
+        await this.runBatch(projectId, batch);
+        const pending = this.writeQueues.get(projectId);
+        // Nothing waiting. The `finally` below releases the claim in this same
+        // synchronous step, so no enqueue can slip in between the two and be
+        // left with no runner to pick it up.
+        if (!pending) return;
+        this.writeQueues.delete(projectId);
+        batch = pending;
+      }
+    } finally {
+      this.drainingProjects.delete(projectId);
+    }
+  }
+
+  /**
+   * Read once, apply every updater in order, save once.
+   *
+   * `runBatch` never throws: each caller's outcome is delivered through its own
+   * promise, and a runner that died would strand every update behind it.
+   */
+  private async runBatch(projectId: string, batch: QueuedUpdate[]): Promise<void> {
+    let existing: ProjectState | null;
+    try {
+      existing = await this.getProjectState(projectId);
+    } catch (error) {
+      for (const entry of batch) entry.reject(error);
+      return;
+    }
+
+    // One update is by far the common case. Keep it on the original path so an
+    // isolated write pays nothing at all for the batching machinery.
+    const only = batch.length === 1 ? batch[0] : undefined;
+    if (only) {
+      try {
+        const updated = await only.updater(existing);
         if (updated !== null) {
           await this.saveProjectState(projectId, updated);
         }
-      });
-    this.writeQueues.set(projectId, next);
-    const cleanup = () => {
-      if (this.writeQueues.get(projectId) === next) {
-        this.writeQueues.delete(projectId);
+        only.resolve();
+      } catch (error) {
+        only.reject(error);
       }
-    };
-    // .then(cleanup, cleanup) instead of .finally(): .finally would create a
-    // new rejected promise nobody handles when the update fails.
-    next.then(cleanup, cleanup);
-    return next;
+      return;
+    }
+
+    let state = existing;
+    let pendingSave: ProjectState | null = null;
+    const outcomes: UpdateOutcome[] = [];
+
+    for (const entry of batch) {
+      // Every updater gets its own copy, including the first.
+      //
+      // An updater may mutate what it is handed and THEN throw or return null,
+      // and that mutation has to be discarded — which is what happens today,
+      // where each update reads its own copy and a declined write simply
+      // abandons it. `shutdown.ts` and `projectSessionJournal.ts` both mutate
+      // `state.terminals[n]` in place and return the same object, so this is
+      // the live shape, not a hypothetical one.
+      //
+      // Handing the first updater the read's own clone would save a copy and
+      // was tried: it lets a first updater that mutates and then declines write
+      // straight through to the state the rest of the batch builds on.
+      const input = this.cloneProjectState(state);
+      try {
+        const updated = await entry.updater(input);
+        if (updated === null) {
+          outcomes.push({ entry, kind: "noop" });
+          continue;
+        }
+        // Stamp the id the state directory says, which is what the next updater
+        // would have read back through the cache had this update saved on its
+        // own. Deliberately NOT re-running terminal validation per step: the
+        // save filters the batch's final state, and a filter is a per-entry
+        // predicate, so no entry survives to disk that a per-step pass would
+        // have dropped.
+        state = updated.projectId === projectId ? updated : { ...updated, projectId };
+        pendingSave = state;
+        outcomes.push({ entry, kind: "wrote" });
+      } catch (error) {
+        outcomes.push({ entry, kind: "threw", error });
+      }
+    }
+
+    let saveError: { error: unknown } | undefined;
+    if (pendingSave) {
+      try {
+        await this.saveProjectState(projectId, pendingSave);
+      } catch (error) {
+        saveError = { error };
+      }
+    }
+
+    for (const outcome of outcomes) {
+      if (outcome.kind === "threw") {
+        outcome.entry.reject(outcome.error);
+      } else if (outcome.kind === "wrote" && saveError) {
+        // Everything this save carried fails together — it is one write.
+        outcome.entry.reject(saveError.error);
+      } else {
+        // A null updater asked for no write, so a failed one is not its failure.
+        outcome.entry.resolve();
+      }
+    }
   }
 
   async saveProjectState(projectId: string, state: ProjectState): Promise<void> {
@@ -352,7 +519,9 @@ export class ProjectStateManager {
           : undefined,
       };
 
-      this.setProjectStateCache(projectId, state);
+      // `state` was just built from parsed JSON and is shared with nothing, so
+      // the cache can take it as-is and the caller gets the only other copy.
+      this.cacheUnsharedProjectState(projectId, state);
       return this.cloneProjectState(state);
     } catch (error) {
       const code =

--- a/electron/services/ProjectStateManager.ts
+++ b/electron/services/ProjectStateManager.ts
@@ -210,6 +210,12 @@ export class ProjectStateManager {
    *     if the batch's save fails. An updater that returns null because the
    *     state ALREADY satisfies it is making a claim about durability it cannot
    *     see, and should return the state instead so it shares the save's fate.
+   *   - An updater must hand over the value it returns rather than keep hold of
+   *     it. The queue may carry that object until the batch's save, so mutating
+   *     it after returning changes what gets written. This was always racy —
+   *     the old path serialized the returned object a microtask later — but the
+   *     window is now the rest of the batch. Return a fresh value, or the
+   *     object you were given; every caller here does one of those.
    */
   enqueueProjectStateUpdate(projectId: string, updater: ProjectStateUpdater): Promise<void> {
     let resolve!: () => void;
@@ -263,6 +269,14 @@ export class ProjectStateManager {
         try {
           await this.runBatch(projectId, batch);
         } catch (error) {
+          // Reaching here means `runBatch` has a hole. Entries it already
+          // settled ignore this (a promise settles once); the rest get the
+          // failure rather than hanging. Logged because an exception swallowed
+          // to keep the runner alive is otherwise invisible.
+          console.error(
+            `[ProjectStateManager] Batch failed outside its own handling for project ${projectId}:`,
+            error
+          );
           for (const entry of batch) entry.reject(error);
         }
         const pending = this.writeQueues.get(projectId);

--- a/electron/services/ProjectStore.ts
+++ b/electron/services/ProjectStore.ts
@@ -1347,9 +1347,16 @@ export class ProjectStore {
       () =>
         this.enqueueProjectStateUpdate(projectId, (existing) => {
           if (!existing) return null;
-          const rewritten = rewriteProjectStatePaths(existing, oldPath, newPath);
-          // Same object reference back ⇒ nothing rebased ⇒ skip the disk write.
-          return rewritten === existing ? null : rewritten;
+          // Returned even when nothing was rebased, rather than null.
+          //
+          // "Nothing to rebase" and "someone else already rebased this" look
+          // identical from here — both hand back the same object reference. A
+          // null would resolve this promise without sharing the save's outcome,
+          // so a batch-mate's rewrite that then failed to reach disk would be
+          // reported to the relocation as a success. Returning the state costs
+          // an unchanged write on the genuinely-nothing-to-do path, which a
+          // relocation does once.
+          return rewriteProjectStatePaths(existing, oldPath, newPath);
         }),
       async () => {
         // Dynamic import breaks the ProjectStore ⇄ windowState cycle at module

--- a/electron/services/__tests__/ProjectStateManager.test.ts
+++ b/electron/services/__tests__/ProjectStateManager.test.ts
@@ -508,18 +508,15 @@ describe("ProjectStateManager.enqueueProjectStateUpdate coalescing", () => {
   });
 
   it("lets a batch queued across a completed deletion recreate the state", async () => {
-    // Gate the FOLLOWERS rather than the parked update, so the deletion is
-    // provably finished — file unlinked, cache invalidated — before the next
-    // batch takes its read. Without that the unlink races the read and the test
-    // can pass while observing the pre-deletion file.
-    let releaseFollowers!: () => void;
-    const followerGate = new Promise<void>((resolve) => (releaseFollowers = resolve));
+    // The batch takes its read when the RUNNER picks it up, before any of its
+    // updaters run — so gating inside an updater is too late to order this
+    // against the delete. Hold the first batch instead: the followers cannot
+    // start, and therefore cannot read, until it is released.
     const { release, parked } = openQueue({ persist: false });
 
     const seen: Array<ProjectState | null> = [];
     const followers = [
-      manager.enqueueProjectStateUpdate(projectId, async (existing) => {
-        await followerGate;
+      manager.enqueueProjectStateUpdate(projectId, (existing) => {
         seen.push(existing);
         return makeState({ projectId, sidebarWidth: 777 });
       }),
@@ -529,10 +526,11 @@ describe("ProjectStateManager.enqueueProjectStateUpdate coalescing", () => {
       })),
     ];
 
+    // Fully awaited while the queue is still parked, so the unlink and the
+    // cache invalidation are both finished before the next batch can begin.
+    await manager.clearProjectState(projectId);
     release();
     await parked;
-    await manager.clearProjectState(projectId);
-    releaseFollowers();
     await Promise.all(followers);
 
     // The batch read AFTER the delete, so it started from nothing.

--- a/electron/services/__tests__/ProjectStateManager.test.ts
+++ b/electron/services/__tests__/ProjectStateManager.test.ts
@@ -268,6 +268,284 @@ describe("ProjectStateManager.enqueueProjectStateUpdate concurrency", () => {
   });
 });
 
+describe("ProjectStateManager.enqueueProjectStateUpdate coalescing", () => {
+  let tempDir: string;
+  let manager: ProjectStateManager;
+  let projectId: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "daintree-state-coalesce-"));
+    manager = new ProjectStateManager(tempDir);
+    projectId = generateProjectId("/test/coalesce-project");
+    await fs.mkdir(path.join(tempDir, projectId), { recursive: true });
+    await manager.saveProjectState(projectId, makeState({ sidebarWidth: 100 }));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  /**
+   * Hold the queue open on a first update, so everything enqueued while it is
+   * parked lands in ONE batch behind it. Without the gate the updates race the
+   * runner and the batch boundary is a timing accident.
+   */
+  function openQueue(options?: { persist?: boolean }): {
+    release: () => void;
+    parked: Promise<void>;
+  } {
+    const persist = options?.persist ?? true;
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => (release = resolve));
+    const parked = manager.enqueueProjectStateUpdate(projectId, async (existing) => {
+      await gate;
+      // `persist: false` declines the write, so the batch behind this one owns
+      // the only save the test performs — which is what lets a test make that
+      // save fail without the parked update consuming the failure first.
+      return persist ? { ...existing!, sidebarWidth: 1 } : null;
+    });
+    return { release, parked };
+  }
+
+  it("folds every update queued behind an in-flight save into one write", async () => {
+    const saves = vi.spyOn(manager, "saveProjectState");
+    const { release, parked } = openQueue();
+
+    const folded = [
+      manager.enqueueProjectStateUpdate(projectId, (existing) => ({
+        ...existing!,
+        focusMode: true,
+      })),
+      manager.enqueueProjectStateUpdate(projectId, (existing) => ({
+        ...existing!,
+        activeWorktreeId: "wt-9",
+      })),
+      manager.enqueueProjectStateUpdate(projectId, (existing) => ({
+        ...existing!,
+        draftInputs: { t1: "typed" },
+      })),
+    ];
+
+    release();
+    await Promise.all([parked, ...folded]);
+
+    // One for the parked update, one for the three that piled up behind it.
+    expect(saves).toHaveBeenCalledTimes(2);
+
+    // Every field survives: a save that wrote only the last updater's object
+    // would still land the draft and silently drop the other two.
+    const result = await manager.getProjectState(projectId);
+    expect(result!.focusMode).toBe(true);
+    expect(result!.activeWorktreeId).toBe("wt-9");
+    expect(result!.draftInputs).toEqual({ t1: "typed" });
+    expect(result!.sidebarWidth).toBe(1);
+  });
+
+  it("applies folded updaters in order, each seeing the previous one's result", async () => {
+    const { release, parked } = openQueue();
+    const seen: number[] = [];
+
+    const folded = [10, 100, 1000].map((step) =>
+      manager.enqueueProjectStateUpdate(projectId, (existing) => {
+        seen.push(existing!.sidebarWidth);
+        return { ...existing!, sidebarWidth: existing!.sidebarWidth + step };
+      })
+    );
+
+    release();
+    await Promise.all([parked, ...folded]);
+
+    // The parked update committed 1, then each folded updater reads the one
+    // before it — from memory, since only the batch's final state is saved.
+    expect(seen).toEqual([1, 11, 111]);
+    const result = await manager.getProjectState(projectId);
+    expect(result!.sidebarWidth).toBe(1111);
+  });
+
+  it("rejects only the folded updater that throws, and still saves the rest", async () => {
+    const { release, parked } = openQueue();
+
+    const before = manager.enqueueProjectStateUpdate(projectId, (existing) => ({
+      ...existing!,
+      activeWorktreeId: "wt-before",
+    }));
+    const boom = manager.enqueueProjectStateUpdate(projectId, () => {
+      throw new Error("updater boom");
+    });
+    const after = manager.enqueueProjectStateUpdate(projectId, (existing) => ({
+      ...existing!,
+      focusMode: true,
+    }));
+
+    release();
+    await parked;
+    await expect(boom).rejects.toThrow("updater boom");
+    await expect(before).resolves.toBeUndefined();
+    await expect(after).resolves.toBeUndefined();
+
+    const result = await manager.getProjectState(projectId);
+    expect(result!.activeWorktreeId).toBe("wt-before");
+    expect(result!.focusMode).toBe(true);
+  });
+
+  it("discards a mutation made by a folded updater that then returns null", async () => {
+    const { release, parked } = openQueue();
+
+    const vandal = manager.enqueueProjectStateUpdate(projectId, (existing) => {
+      // shutdown.ts and projectSessionJournal.ts both mutate in place like
+      // this. Declining the write afterwards has to undo it.
+      existing!.terminals[0]!.title = "should not be persisted";
+      return null;
+    });
+    const follower = manager.enqueueProjectStateUpdate(projectId, (existing) => ({
+      ...existing!,
+      focusMode: true,
+    }));
+
+    release();
+    await Promise.all([parked, vandal, follower]);
+
+    const result = await manager.getProjectState(projectId);
+    expect(result!.terminals[0]!.title).toBe("Terminal 1");
+    expect(result!.focusMode).toBe(true);
+  });
+
+  it("discards a mutation made by a folded updater that then throws", async () => {
+    const { release, parked } = openQueue();
+
+    const vandal = manager.enqueueProjectStateUpdate(projectId, (existing) => {
+      existing!.terminals[0]!.title = "should not be persisted";
+      throw new Error("after mutating");
+    });
+    const follower = manager.enqueueProjectStateUpdate(projectId, (existing) => ({
+      ...existing!,
+      focusMode: true,
+    }));
+
+    release();
+    await parked;
+    await expect(vandal).rejects.toThrow("after mutating");
+    await follower;
+
+    const result = await manager.getProjectState(projectId);
+    expect(result!.terminals[0]!.title).toBe("Terminal 1");
+  });
+
+  it("rejects every folded caller whose update the failed save carried", async () => {
+    const { release, parked } = openQueue({ persist: false });
+
+    const folded = [
+      manager.enqueueProjectStateUpdate(projectId, (existing) => ({
+        ...existing!,
+        focusMode: true,
+      })),
+      manager.enqueueProjectStateUpdate(projectId, (existing) => ({
+        ...existing!,
+        activeWorktreeId: "wt-9",
+      })),
+    ];
+    // Declined the write, so the failure below is not its failure.
+    const abstainer = manager.enqueueProjectStateUpdate(projectId, () => null);
+
+    const saves = vi.spyOn(manager, "saveProjectState");
+    saves.mockRejectedValueOnce(Object.assign(new Error("ENOSPC"), { code: "ENOSPC" }));
+
+    release();
+    await parked;
+    await expect(folded[0]).rejects.toThrow("ENOSPC");
+    await expect(folded[1]).rejects.toThrow("ENOSPC");
+    await expect(abstainer).resolves.toBeUndefined();
+  });
+
+  it("keeps serving updates queued after a batch whose save failed", async () => {
+    const { release, parked } = openQueue({ persist: false });
+
+    const saves = vi.spyOn(manager, "saveProjectState");
+    saves.mockRejectedValueOnce(Object.assign(new Error("EPIPE"), { code: "EPIPE" }));
+
+    const doomed = manager.enqueueProjectStateUpdate(projectId, (existing) => ({
+      ...existing!,
+      focusMode: true,
+    }));
+    const alsoDoomed = manager.enqueueProjectStateUpdate(projectId, (existing) => ({
+      ...existing!,
+      activeWorktreeId: "wt-doomed",
+    }));
+
+    release();
+    await parked;
+    await expect(doomed).rejects.toThrow("EPIPE");
+    await expect(alsoDoomed).rejects.toThrow("EPIPE");
+
+    // The runner survives its batch failing.
+    saves.mockRestore();
+    await manager.enqueueProjectStateUpdate(projectId, (existing) => ({
+      ...existing!,
+      sidebarWidth: 512,
+    }));
+    const result = await manager.getProjectState(projectId);
+    expect(result!.sidebarWidth).toBe(512);
+  });
+
+  it("lets updates queued across a deletion recreate the state", async () => {
+    const { release, parked } = openQueue();
+
+    const recreate = manager.enqueueProjectStateUpdate(projectId, (existing) =>
+      makeState({ ...existing, sidebarWidth: 777 })
+    );
+
+    release();
+    await parked;
+    await manager.clearProjectState(projectId);
+    await recreate;
+
+    // The delete lands between the two batches, so the queued update writes a
+    // fresh file rather than resurrecting a half-deleted one.
+    const result = await manager.getProjectState(projectId);
+    expect(result!.sidebarWidth).toBe(777);
+  });
+
+  it("drains in order when a shutdown awaits each project's update in turn", async () => {
+    const otherProjectId = generateProjectId("/test/coalesce-project-other");
+    await fs.mkdir(path.join(tempDir, otherProjectId), { recursive: true });
+
+    const order: string[] = [];
+    // The shutdown shape: one project at a time, each awaited to completion, so
+    // every write is on disk before the next project starts.
+    for (const [id, width] of [
+      [projectId, 11],
+      [otherProjectId, 22],
+    ] as const) {
+      await manager.enqueueProjectStateUpdate(id, (existing) => {
+        order.push(id);
+        return makeState({ ...existing, projectId: id, sidebarWidth: width });
+      });
+    }
+
+    expect(order).toEqual([projectId, otherProjectId]);
+    const fresh = new ProjectStateManager(tempDir);
+    expect((await fresh.getProjectState(projectId))!.sidebarWidth).toBe(11);
+    expect((await fresh.getProjectState(otherProjectId))!.sidebarWidth).toBe(22);
+    fresh.dispose();
+  });
+
+  it("still costs one save per update when nothing overlaps", async () => {
+    const saves = vi.spyOn(manager, "saveProjectState");
+
+    await manager.enqueueProjectStateUpdate(projectId, (existing) => ({
+      ...existing!,
+      sidebarWidth: 2,
+    }));
+    await manager.enqueueProjectStateUpdate(projectId, (existing) => ({
+      ...existing!,
+      sidebarWidth: 3,
+    }));
+
+    // Nothing to coalesce: each update was durable before the next was made.
+    expect(saves).toHaveBeenCalledTimes(2);
+  });
+});
+
 describe("ProjectStateManager telemetry", () => {
   let tempDir: string;
   let manager: ProjectStateManager;

--- a/electron/services/__tests__/ProjectStateManager.test.ts
+++ b/electron/services/__tests__/ProjectStateManager.test.ts
@@ -282,6 +282,9 @@ describe("ProjectStateManager.enqueueProjectStateUpdate coalescing", () => {
   });
 
   afterEach(async () => {
+    // The sweep interval keeps an undisposed manager (and its cached state)
+    // reachable for the life of the run.
+    manager.dispose();
     await fs.rm(tempDir, { recursive: true, force: true });
   });
 
@@ -457,52 +460,88 @@ describe("ProjectStateManager.enqueueProjectStateUpdate coalescing", () => {
     await expect(abstainer).resolves.toBeUndefined();
   });
 
-  it("keeps serving updates queued after a batch whose save failed", async () => {
+  it("keeps serving a batch that was already queued when an earlier save failed", async () => {
     const { release, parked } = openQueue({ persist: false });
 
-    const saves = vi.spyOn(manager, "saveProjectState");
-    saves.mockRejectedValueOnce(Object.assign(new Error("EPIPE"), { code: "EPIPE" }));
+    let doomedStarted!: () => void;
+    const started = new Promise<void>((resolve) => (doomedStarted = resolve));
+    let releaseDoomed!: () => void;
+    const doomedGate = new Promise<void>((resolve) => (releaseDoomed = resolve));
 
-    const doomed = manager.enqueueProjectStateUpdate(projectId, (existing) => ({
-      ...existing!,
-      focusMode: true,
-    }));
+    vi.spyOn(manager, "saveProjectState").mockRejectedValueOnce(
+      Object.assign(new Error("EPIPE"), { code: "EPIPE" })
+    );
+
+    const doomed = manager.enqueueProjectStateUpdate(projectId, async (existing) => {
+      doomedStarted();
+      await doomedGate;
+      return { ...existing!, focusMode: true };
+    });
     const alsoDoomed = manager.enqueueProjectStateUpdate(projectId, (existing) => ({
       ...existing!,
       activeWorktreeId: "wt-doomed",
     }));
 
     release();
-    await parked;
-    await expect(doomed).rejects.toThrow("EPIPE");
-    await expect(alsoDoomed).rejects.toThrow("EPIPE");
-
-    // The runner survives its batch failing.
-    saves.mockRestore();
-    await manager.enqueueProjectStateUpdate(projectId, (existing) => ({
+    // The doomed batch is now running and frozen, so this lands in the NEXT
+    // one — a batch the runner is already holding when the failure hits, rather
+    // than a fresh enqueue after the queue went idle, which a runner that
+    // dropped its followers on failure would also survive.
+    await started;
+    const follower = manager.enqueueProjectStateUpdate(projectId, (existing) => ({
       ...existing!,
       sidebarWidth: 512,
     }));
+    releaseDoomed();
+
+    await parked;
+    await expect(doomed).rejects.toThrow("EPIPE");
+    await expect(alsoDoomed).rejects.toThrow("EPIPE");
+    await expect(follower).resolves.toBeUndefined();
+
+    // Nothing the failed batch produced was committed, so the follower built on
+    // the last state that actually reached disk.
     const result = await manager.getProjectState(projectId);
     expect(result!.sidebarWidth).toBe(512);
+    expect(result!.focusMode).toBeUndefined();
+    expect(result!.activeWorktreeId).not.toBe("wt-doomed");
   });
 
-  it("lets updates queued across a deletion recreate the state", async () => {
-    const { release, parked } = openQueue();
+  it("lets a batch queued across a completed deletion recreate the state", async () => {
+    // Gate the FOLLOWERS rather than the parked update, so the deletion is
+    // provably finished — file unlinked, cache invalidated — before the next
+    // batch takes its read. Without that the unlink races the read and the test
+    // can pass while observing the pre-deletion file.
+    let releaseFollowers!: () => void;
+    const followerGate = new Promise<void>((resolve) => (releaseFollowers = resolve));
+    const { release, parked } = openQueue({ persist: false });
 
-    const recreate = manager.enqueueProjectStateUpdate(projectId, (existing) =>
-      makeState({ ...existing, sidebarWidth: 777 })
-    );
+    const seen: Array<ProjectState | null> = [];
+    const followers = [
+      manager.enqueueProjectStateUpdate(projectId, async (existing) => {
+        await followerGate;
+        seen.push(existing);
+        return makeState({ projectId, sidebarWidth: 777 });
+      }),
+      manager.enqueueProjectStateUpdate(projectId, (existing) => ({
+        ...existing!,
+        activeWorktreeId: "wt-after-delete",
+      })),
+    ];
 
     release();
     await parked;
     await manager.clearProjectState(projectId);
-    await recreate;
+    releaseFollowers();
+    await Promise.all(followers);
 
-    // The delete lands between the two batches, so the queued update writes a
-    // fresh file rather than resurrecting a half-deleted one.
-    const result = await manager.getProjectState(projectId);
+    // The batch read AFTER the delete, so it started from nothing.
+    expect(seen).toEqual([null]);
+    const fresh = new ProjectStateManager(tempDir);
+    const result = await fresh.getProjectState(projectId);
     expect(result!.sidebarWidth).toBe(777);
+    expect(result!.activeWorktreeId).toBe("wt-after-delete");
+    fresh.dispose();
   });
 
   it("drains in order when a shutdown awaits each project's update in turn", async () => {
@@ -527,6 +566,133 @@ describe("ProjectStateManager.enqueueProjectStateUpdate coalescing", () => {
     expect((await fresh.getProjectState(projectId))!.sidebarWidth).toBe(11);
     expect((await fresh.getProjectState(otherProjectId))!.sidebarWidth).toBe(22);
     fresh.dispose();
+  });
+
+  it("keeps folded callers pending until the save that carries them lands", async () => {
+    const { release, parked } = openQueue({ persist: false });
+
+    let releaseSave!: () => void;
+    const saveGate = new Promise<void>((resolve) => (releaseSave = resolve));
+    const realSave = manager.saveProjectState.bind(manager);
+    const saves = vi.spyOn(manager, "saveProjectState").mockImplementation(async (id, state) => {
+      await saveGate;
+      return realSave(id, state);
+    });
+
+    const settled: string[] = [];
+    const a = manager
+      .enqueueProjectStateUpdate(projectId, (existing) => ({ ...existing!, focusMode: true }))
+      .then(() => settled.push("a"));
+    const b = manager
+      .enqueueProjectStateUpdate(projectId, (existing) => ({
+        ...existing!,
+        activeWorktreeId: "wt-9",
+      }))
+      .then(() => settled.push("b"));
+
+    release();
+    await parked;
+    // Both updaters have run and the save is dispatched and blocked. Drain the
+    // microtask queue: anything that was going to settle early would have.
+    for (let i = 0; i < 20; i += 1) await Promise.resolve();
+    expect(saves).toHaveBeenCalledTimes(1);
+    expect(settled).toEqual([]);
+
+    releaseSave();
+    await Promise.all([a, b]);
+    expect(settled).toEqual(["a", "b"]);
+  });
+
+  it("survives an updater whose result cannot be structured-cloned", async () => {
+    const { release, parked } = openQueue({ persist: false });
+
+    // A function is not transferable, so cloning this to hand it to the next
+    // updater throws DataCloneError. Escaping the batch would kill the runner
+    // and leave every caller — and everything queued behind — pending forever.
+    const poisoner = manager.enqueueProjectStateUpdate(projectId, (existing) => ({
+      ...existing!,
+      onSomething: () => {},
+    }));
+    const follower = manager.enqueueProjectStateUpdate(projectId, (existing) => ({
+      ...existing!,
+      focusMode: true,
+    }));
+
+    release();
+    await parked;
+    // The guarantee is that everything SETTLES rather than hanging.
+    const outcomes = await Promise.allSettled([poisoner, follower]);
+    expect(outcomes.map((o) => o.status)).toEqual(["rejected", "rejected"]);
+
+    // And the runner is still alive for the next update.
+    await manager.enqueueProjectStateUpdate(projectId, (existing) => ({
+      ...existing!,
+      sidebarWidth: 321,
+    }));
+    const result = await manager.getProjectState(projectId);
+    expect(result!.sidebarWidth).toBe(321);
+  });
+
+  it("writes nothing when every folded updater declines", async () => {
+    const { release, parked } = openQueue({ persist: false });
+    const saves = vi.spyOn(manager, "saveProjectState");
+
+    const declined = [
+      manager.enqueueProjectStateUpdate(projectId, () => null),
+      manager.enqueueProjectStateUpdate(projectId, () => null),
+    ];
+
+    release();
+    await parked;
+    await expect(Promise.all(declined)).resolves.toEqual([undefined, undefined]);
+    expect(saves).not.toHaveBeenCalled();
+  });
+
+  it("writes nothing when every folded updater throws, and each caller gets its own error", async () => {
+    const { release, parked } = openQueue({ persist: false });
+    const saves = vi.spyOn(manager, "saveProjectState");
+
+    const first = manager.enqueueProjectStateUpdate(projectId, () => {
+      throw new Error("first boom");
+    });
+    const second = manager.enqueueProjectStateUpdate(projectId, () => {
+      throw new Error("second boom");
+    });
+
+    release();
+    await parked;
+    await expect(first).rejects.toThrow("first boom");
+    await expect(second).rejects.toThrow("second boom");
+    expect(saves).not.toHaveBeenCalled();
+  });
+
+  it("picks up an update enqueued from inside a running updater", async () => {
+    const { release, parked } = openQueue({ persist: false });
+
+    let reentrant!: Promise<void>;
+    const outer = manager.enqueueProjectStateUpdate(projectId, (existing) => {
+      // Fire-and-forget from inside a running batch. It cannot join this batch,
+      // which is already frozen, so it must be picked up by a later one rather
+      // than left sitting in the queue with no runner.
+      reentrant = manager.enqueueProjectStateUpdate(projectId, (later) => ({
+        ...later!,
+        activeWorktreeId: "wt-reentrant",
+      }));
+      return { ...existing!, focusMode: true };
+    });
+    const sibling = manager.enqueueProjectStateUpdate(projectId, (existing) => ({
+      ...existing!,
+      sidebarWidth: 246,
+    }));
+
+    release();
+    await Promise.all([parked, outer, sibling]);
+    await reentrant;
+
+    const result = await manager.getProjectState(projectId);
+    expect(result!.activeWorktreeId).toBe("wt-reentrant");
+    expect(result!.focusMode).toBe(true);
+    expect(result!.sidebarWidth).toBe(246);
   });
 
   it("still costs one save per update when nothing overlaps", async () => {

--- a/scripts/perf/__tests__/bystander.test.ts
+++ b/scripts/perf/__tests__/bystander.test.ts
@@ -245,6 +245,8 @@ describe("bystander probe", () => {
       probeMisses: 0,
       longestStallMs: 4,
       blockedMs: 0,
+      p95StallMs: 3,
+      p95DelayMs: 1,
       windowMs: 100,
       blockedFraction: 0,
     });
@@ -252,11 +254,45 @@ describe("bystander probe", () => {
       "workerBlockedMs",
       "workerBlockedPct",
       "workerLongestStallMs",
+      "workerP95DelayMs",
+      "workerP95StallMs",
       "workerProbeTicks",
     ]);
     // Not folded into the prefix: one scenario declares one predicate for the
     // probe regardless of how many arms it runs, and an undeclared one is
     // invisible to the runner.
     expect(metrics).not.toHaveProperty("workerProbeMisses");
+  });
+
+  it("reports a gap percentile at or below the worst freeze, and a delay percentile below it", async () => {
+    const probe = await armBystanderProbe({ cadenceMs: 8 });
+    blockFor(60);
+    await sleep(60);
+    const reading = probe.stop();
+
+    // The percentile describes the distribution the max is the tail of, so it
+    // can never exceed it. Both are boundary-inclusive over the same gaps.
+    expect(reading.p95StallMs).toBeLessThanOrEqual(reading.longestStallMs);
+    // One cadence of every gap was always going to be spent waiting, so the
+    // delay figure trails the raw gap figure by exactly that much.
+    expect(reading.p95DelayMs).toBeLessThanOrEqual(reading.p95StallMs);
+    expect(reading.p95DelayMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("reports zero percentiles for a window that observed nothing at all", () => {
+    // `percentile` over an empty gap list must not read NaN: a non-finite
+    // measurement moves the exit code under --enforce-integrity.
+    const metrics = bystanderMetrics("idle", {
+      ticksObserved: 0,
+      probeMisses: 1,
+      longestStallMs: 0,
+      blockedMs: 0,
+      p95StallMs: 0,
+      p95DelayMs: 0,
+      windowMs: 0,
+      blockedFraction: 0,
+    });
+    expect(Number.isFinite(metrics.idleP95StallMs)).toBe(true);
+    expect(Number.isFinite(metrics.idleP95DelayMs)).toBe(true);
   });
 });

--- a/scripts/perf/__tests__/bystander.test.ts
+++ b/scripts/perf/__tests__/bystander.test.ts
@@ -264,35 +264,54 @@ describe("bystander probe", () => {
     expect(metrics).not.toHaveProperty("workerProbeMisses");
   });
 
-  it("reports a gap percentile at or below the worst freeze, and a delay percentile below it", async () => {
+  it("carries each percentile through to its own prefixed metric", () => {
+    // Distinct non-zero values, because an implementation that reported a
+    // constant 0 — or wired both keys to the same field — satisfies any
+    // assertion written as an inequality.
+    const metrics = bystanderMetrics("burst", {
+      ticksObserved: 12,
+      probeMisses: 0,
+      longestStallMs: 91,
+      blockedMs: 40,
+      p95StallMs: 7,
+      p95DelayMs: 3,
+      windowMs: 100,
+      blockedFraction: 0.4,
+    });
+    expect(metrics.burstP95StallMs).toBe(7);
+    expect(metrics.burstP95DelayMs).toBe(3);
+  });
+
+  it("reports a gap percentile well below the one freeze that dominates the max", async () => {
     const probe = await armBystanderProbe({ cadenceMs: 8 });
-    blockFor(60);
-    await sleep(60);
+    // Many ordinary gaps around a single long block, so the distribution and
+    // its extreme are far apart and a p95 cannot be confused with either.
+    await sleep(120);
+    blockFor(120);
+    await sleep(120);
     const reading = probe.stop();
 
-    // The percentile describes the distribution the max is the tail of, so it
-    // can never exceed it. Both are boundary-inclusive over the same gaps.
-    expect(reading.p95StallMs).toBeLessThanOrEqual(reading.longestStallMs);
-    // One cadence of every gap was always going to be spent waiting, so the
-    // delay figure trails the raw gap figure by exactly that much.
+    expect(reading.ticksObserved).toBeGreaterThan(10);
+    // The block owns the max...
+    expect(reading.longestStallMs).toBeGreaterThan(100);
+    // ...but it is one sample among many, so it must not own the percentile.
+    // This is what fails for an implementation returning the maximum.
+    expect(reading.p95StallMs).toBeLessThan(reading.longestStallMs / 2);
+    // And a real cadence still separates it from an implementation that
+    // returns a constant zero.
+    expect(reading.p95StallMs).toBeGreaterThan(0);
     expect(reading.p95DelayMs).toBeLessThanOrEqual(reading.p95StallMs);
     expect(reading.p95DelayMs).toBeGreaterThanOrEqual(0);
   });
 
-  it("reports zero percentiles for a window that observed nothing at all", () => {
-    // `percentile` over an empty gap list must not read NaN: a non-finite
-    // measurement moves the exit code under --enforce-integrity.
-    const metrics = bystanderMetrics("idle", {
-      ticksObserved: 0,
-      probeMisses: 1,
-      longestStallMs: 0,
-      blockedMs: 0,
-      p95StallMs: 0,
-      p95DelayMs: 0,
-      windowMs: 0,
-      blockedFraction: 0,
-    });
-    expect(Number.isFinite(metrics.idleP95StallMs)).toBe(true);
-    expect(Number.isFinite(metrics.idleP95DelayMs)).toBe(true);
+  it("analyses once, so a second stop() returns the same reading it already computed", () => {
+    // `stop()` sorts the gap list to produce percentiles. A `finally` that
+    // stops an already-stopped probe must not repeat that work inside a
+    // scenario's measured bracket.
+    const probe = startBystanderProbe({ cadenceMs: 8 });
+    blockFor(20);
+    const first = probe.stop();
+    const second = probe.stop();
+    expect(second).toBe(first);
   });
 });

--- a/scripts/perf/__tests__/bystander.test.ts
+++ b/scripts/perf/__tests__/bystander.test.ts
@@ -300,8 +300,11 @@ describe("bystander probe", () => {
     // And a real cadence still separates it from an implementation that
     // returns a constant zero.
     expect(reading.p95StallMs).toBeGreaterThan(0);
-    expect(reading.p95DelayMs).toBeLessThanOrEqual(reading.p95StallMs);
-    expect(reading.p95DelayMs).toBeGreaterThanOrEqual(0);
+    // Strictly between the two bounds, which is what separates a real excess
+    // calculation from the two ways of getting it wrong: hardcoding zero, and
+    // reporting the same figure as the raw gap percentile.
+    expect(reading.p95DelayMs).toBeGreaterThan(0);
+    expect(reading.p95DelayMs).toBeLessThan(reading.p95StallMs);
   });
 
   it("analyses once, so a second stop() returns the same reading it already computed", () => {

--- a/scripts/perf/__tests__/workloadFloors.test.ts
+++ b/scripts/perf/__tests__/workloadFloors.test.ts
@@ -122,8 +122,8 @@ describe("workload floors", () => {
       "PERF-163",
       "PERF-164",
       "PERF-395",
-      "PERF-405",
       "PERF-406",
+      "PERF-407",
     ]);
     for (const scenario of declaring) {
       for (const [metric, floor] of Object.entries(scenario.workloadFloors!)) {

--- a/scripts/perf/__tests__/workloadFloors.test.ts
+++ b/scripts/perf/__tests__/workloadFloors.test.ts
@@ -122,6 +122,8 @@ describe("workload floors", () => {
       "PERF-163",
       "PERF-164",
       "PERF-395",
+      "PERF-405",
+      "PERF-406",
     ]);
     for (const scenario of declaring) {
       for (const [metric, floor] of Object.entries(scenario.workloadFloors!)) {

--- a/scripts/perf/config/benchmarkClasses.ts
+++ b/scripts/perf/config/benchmarkClasses.ts
@@ -139,6 +139,14 @@ const FAMILIES: readonly Family[] = [
       "Real better-sqlite3 and real electron-store writes, including WAL and whole-file amplification. Nothing here says how much of a save or an open the user perceives.",
   },
   {
+    label: "project-state-queue",
+    ids: ["PERF-405", "PERF-406"],
+    kind: "mechanism",
+    fidelity: PURE,
+    claim:
+      "The real ProjectStateManager write queue over real temp storage: real validation, real JSON.stringify, real atomic writes, and a real main-thread availability probe alongside them. The updaters are called directly, so the IPC hop that carries them, the renderer's own 500ms debounce upstream, and ProjectStore's derived-metadata observer downstream are all absent — this prices the queue, not the layout change a user makes.",
+  },
+  {
     label: "soak",
     ids: ["PERF-060", "PERF-061", "PERF-062", "PERF-063"],
     kind: "mechanism",

--- a/scripts/perf/config/benchmarkClasses.ts
+++ b/scripts/perf/config/benchmarkClasses.ts
@@ -140,7 +140,7 @@ const FAMILIES: readonly Family[] = [
   },
   {
     label: "project-state-queue",
-    ids: ["PERF-405", "PERF-406"],
+    ids: ["PERF-406", "PERF-407"],
     kind: "mechanism",
     fidelity: PURE,
     claim:

--- a/scripts/perf/lib/bystander.ts
+++ b/scripts/perf/lib/bystander.ts
@@ -109,26 +109,32 @@ export interface BystanderReading {
    */
   blockedMs: number;
   /**
-   * 95th percentile of the raw observation gaps, boundary-inclusive.
+   * 95th percentile of the OBSERVED GAPS, boundary-inclusive.
    *
-   * The gap distribution, not the worst gap: `longestStallMs` reports the one
-   * worst freeze in the window, which a single unlucky collection can own, and
-   * `blockedMs` sums the excess without saying how any single pause felt. A
-   * percentile is what survives both — the pause a caller can expect to hit
-   * near the tail rather than at the extreme.
+   * The gap distribution rather than its extreme: `longestStallMs` reports the
+   * single worst freeze, which one unlucky collection can own, and `blockedMs`
+   * sums excess without saying how any individual pause looked.
    *
-   * Includes one cadence of ordinary waiting, because a gap always does. Read
-   * it as "the loop went unobserved this long", and use {@link p95DelayMs} for
-   * the part attributable to the workload.
+   * Read it as exactly what it is — a percentile over this window's gaps — and
+   * nothing more. It is NOT a caller's waiting-time distribution, and it is not
+   * a rate: among 100 gaps, one 100ms freeze beside 99 ordinary 4ms gaps has a
+   * p95 of 4ms, because the freeze is a single sample. Catch-up scheduling
+   * (`schedule()` anchors to absolute expected times) adds short gaps after a
+   * block, which pulls the distribution further from timer lateness.
+   *
+   * So it needs a control measured the same way on the same machine, like every
+   * other reading in this file — more so, because a window that is mostly idle
+   * puts the 95th percentile among idle gaps, where the workload cannot move it.
    */
   p95StallMs: number;
   /**
-   * 95th percentile of gap MINUS one cadence, floored at zero — the tail of
-   * timer lateness with the cadence the probe was always going to wait removed.
+   * The same percentile over gaps with one cadence subtracted, floored at zero.
    *
-   * This is the comparable figure across two arms measured at the same cadence:
-   * an idle loop reports ~0 here while still reporting a full cadence in
-   * {@link p95StallMs}.
+   * One cadence of every gap was always going to be spent waiting, so removing
+   * it makes two arms measured at the SAME cadence comparable — an idle loop
+   * reads ~0 here and a full cadence in {@link p95StallMs}. It is a percentile
+   * of excess gap, not an attribution of that excess to the workload: the
+   * caveats on {@link p95StallMs} apply unchanged.
    */
   p95DelayMs: number;
   /** Wall clock the probe covered. */
@@ -232,6 +238,15 @@ function start(options: BystanderOptions): InternalProbe {
    * `startBystanderProbe` documents.
    */
   let windowApparatusSound: boolean | undefined;
+  /**
+   * The analysed reading, computed once.
+   *
+   * `stop()` sorts the gap list twice to produce percentiles. That work is not
+   * the subject of any scenario, so it must not be repeated by a second
+   * `stop()` in a `finally`, and callers should capture their workload's end
+   * timestamp BEFORE the first one.
+   */
+  let closedReading: BystanderReading | undefined;
 
   let resolveArmed: (value: boolean) => void = () => {};
   const armed = new Promise<boolean>((resolve) => {
@@ -323,6 +338,8 @@ function start(options: BystanderOptions): InternalProbe {
         if (timer) clearTimeout(timer);
         settleArming(everFired);
       }
+      if (closedReading) return closedReading;
+
       const closedAt = endedAt ?? performance.now();
       const windowMs = closedAt - startedAt;
 
@@ -342,7 +359,7 @@ function start(options: BystanderOptions): InternalProbe {
         previous = at;
       }
 
-      return {
+      closedReading = {
         ticksObserved: observations.length,
         probeMisses: (windowApparatusSound ?? everFired) ? 0 : 1,
         longestStallMs,
@@ -355,6 +372,7 @@ function start(options: BystanderOptions): InternalProbe {
         windowMs,
         blockedFraction: windowMs > 0 ? blockedMs / windowMs : 0,
       };
+      return closedReading;
     },
   };
 }

--- a/scripts/perf/lib/bystander.ts
+++ b/scripts/perf/lib/bystander.ts
@@ -1,4 +1,5 @@
 import { performance } from "node:perf_hooks";
+import { percentile } from "./stats";
 
 /**
  * How responsive the rest of the process stayed while something else ran.
@@ -107,6 +108,29 @@ export interface BystanderReading {
    * unavailable", which a median cannot express and a max hides the frequency of.
    */
   blockedMs: number;
+  /**
+   * 95th percentile of the raw observation gaps, boundary-inclusive.
+   *
+   * The gap distribution, not the worst gap: `longestStallMs` reports the one
+   * worst freeze in the window, which a single unlucky collection can own, and
+   * `blockedMs` sums the excess without saying how any single pause felt. A
+   * percentile is what survives both — the pause a caller can expect to hit
+   * near the tail rather than at the extreme.
+   *
+   * Includes one cadence of ordinary waiting, because a gap always does. Read
+   * it as "the loop went unobserved this long", and use {@link p95DelayMs} for
+   * the part attributable to the workload.
+   */
+  p95StallMs: number;
+  /**
+   * 95th percentile of gap MINUS one cadence, floored at zero — the tail of
+   * timer lateness with the cadence the probe was always going to wait removed.
+   *
+   * This is the comparable figure across two arms measured at the same cadence:
+   * an idle loop reports ~0 here while still reporting a full cadence in
+   * {@link p95StallMs}.
+   */
+  p95DelayMs: number;
   /** Wall clock the probe covered. */
   windowMs: number;
   /** Share of the window spent blocked, 0..1. */
@@ -304,6 +328,7 @@ function start(options: BystanderOptions): InternalProbe {
 
       let longestStallMs = 0;
       let blockedMs = 0;
+      const gaps: number[] = [];
       const stallFloor = cadenceMs * 2;
       let previous = startedAt;
       // The tail counts: a block that is still running when the workload
@@ -311,6 +336,7 @@ function start(options: BystanderOptions): InternalProbe {
       // observations would discard the largest gap in the window.
       for (const at of [...observations, closedAt]) {
         const gap = at - previous;
+        gaps.push(gap);
         if (gap > longestStallMs) longestStallMs = gap;
         if (gap > stallFloor) blockedMs += gap - cadenceMs;
         previous = at;
@@ -321,6 +347,11 @@ function start(options: BystanderOptions): InternalProbe {
         probeMisses: (windowApparatusSound ?? everFired) ? 0 : 1,
         longestStallMs,
         blockedMs,
+        p95StallMs: percentile(gaps, 95),
+        p95DelayMs: percentile(
+          gaps.map((gap) => Math.max(0, gap - cadenceMs)),
+          95
+        ),
         windowMs,
         blockedFraction: windowMs > 0 ? blockedMs / windowMs : 0,
       };
@@ -344,6 +375,8 @@ export function bystanderMetrics(
     [`${prefix}LongestStallMs`]: reading.longestStallMs,
     [`${prefix}BlockedMs`]: reading.blockedMs,
     [`${prefix}BlockedPct`]: reading.blockedFraction * 100,
+    [`${prefix}P95StallMs`]: reading.p95StallMs,
+    [`${prefix}P95DelayMs`]: reading.p95DelayMs,
     [`${prefix}ProbeTicks`]: reading.ticksObserved,
   };
 }

--- a/scripts/perf/lib/persistenceFixture.ts
+++ b/scripts/perf/lib/persistenceFixture.ts
@@ -32,6 +32,8 @@ import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import * as schema from "../../../electron/services/persistence/schema";
+import type { ProjectState } from "../../../electron/types/index";
+import type { ProjectStateManager } from "../../../electron/services/ProjectStateManager";
 import { createPerfTempRoot, releasePerfTempRoot } from "./tempRoots";
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -354,6 +356,7 @@ export const POST_MIGRATION_PROJECT_COLUMNS: readonly string[] = [
 ];
 
 let migrationSeq = 0;
+let projectStateSeq = 0;
 
 /**
  * A database sitting at the baseline schema with `count` project rows in it,
@@ -530,4 +533,198 @@ export function appStateSnapshot(panelCount: number): Record<string, unknown> {
     })),
     mruList: Array.from({ length: Math.min(panelCount, 64) }, (_, i) => `panel-${i}`),
   };
+}
+
+// --- Project state: the per-project state.json queue -------------------------
+
+/**
+ * A realistic project state: a full terminal list with draft inputs and tab
+ * groups, which is what makes a one-field update expensive.
+ *
+ * The size is the point. `saveProjectState` validates every terminal entry and
+ * stringifies the whole payload on each call, so the cost a coalesced burst
+ * avoids is proportional to this fixture, not to the field being written.
+ */
+export function projectStateSnapshot(projectId: string, panelCount: number): ProjectState {
+  const terminals = Array.from({ length: panelCount }, (_, i) => ({
+    id: `panel-${i}`,
+    title: `agent ${i} — feature/some-reasonably-long-branch-name-${i}`,
+    location: (i % 5 === 0 ? "dock" : "grid") as "dock" | "grid",
+    kind: "terminal" as const,
+    cwd: `/Users/perf/code/repo-${String(i % 200).padStart(5, "0")}/packages/app`,
+    worktreeId: `wt-perf-${i % 24}`,
+    command: i % 3 === 0 ? "claude --dangerously-skip-permissions" : "codex",
+    agentSessionId: i % 4 === 0 ? `sess-${i}-0191f2c8-4a1b-7c3d-9e5f-a6b7c8d9e0f1` : undefined,
+  }));
+
+  return {
+    projectId,
+    activeWorktreeId: "wt-perf-0",
+    sidebarWidth: 350,
+    terminals,
+    tabGroups: Array.from({ length: Math.ceil(panelCount / 8) }, (_, g) => ({
+      id: `group-${g}`,
+      location: "grid" as const,
+      activeTabId: `panel-${g * 8}`,
+      panelIds: terminals.slice(g * 8, g * 8 + 8).map((t) => t.id),
+    })),
+    terminalSizes: Object.fromEntries(terminals.map((t) => [t.id, { cols: 120, rows: 40 }])),
+    draftInputs: Object.fromEntries(
+      terminals
+        .filter((_, i) => i % 3 === 0)
+        .map((t) => [t.id, `a half-typed prompt for ${t.id} that was never sent`])
+    ),
+    mruList: terminals.slice(0, 24).map((t) => t.id),
+  } as ProjectState;
+}
+
+export interface ProjectStateFixture {
+  manager: ProjectStateManager;
+  projectId: string;
+  filePath: string;
+  dispose(): void;
+}
+
+/**
+ * A real {@link ProjectStateManager} over a real temp config dir, seeded and
+ * cache-warm.
+ *
+ * Seeded through the manager's own save path rather than by writing JSON
+ * directly, so the on-disk bytes are exactly what the product writes and the
+ * read the burst starts from is a cache hit, as it is in a running app.
+ */
+export async function createProjectStateFixture(panelCount: number): Promise<ProjectStateFixture> {
+  projectStateSeq += 1;
+  const configDir = join(getTempRoot(), `project-state-${projectStateSeq}`);
+  mkdirSync(configDir, { recursive: true });
+
+  const { ProjectStateManager } = await import("../../../electron/services/ProjectStateManager");
+  const { generateProjectId, stateFilePath } =
+    await import("../../../electron/services/projectStorePaths");
+
+  const projectId = generateProjectId(`/Users/perf/code/state-project-${projectStateSeq}`);
+  mkdirSync(join(configDir, projectId), { recursive: true });
+
+  const manager = new ProjectStateManager(configDir);
+  await manager.saveProjectState(projectId, projectStateSnapshot(projectId, panelCount));
+
+  const filePath = stateFilePath(configDir, projectId);
+  if (!filePath) throw new Error(`[perf] could not resolve a state path for ${projectId}`);
+
+  return {
+    manager,
+    projectId,
+    filePath,
+    dispose() {
+      manager.dispose();
+      rmSync(configDir, { recursive: true, force: true });
+    },
+  };
+}
+
+export interface ProjectStateCounts {
+  /** `saveProjectState` calls that ran to completion for the subject project. */
+  saves: number;
+  /** Atomic temp-file renames onto the subject's state.json. */
+  atomicReplaces: number;
+  /** `structuredClone` calls whose argument was a whole project state. */
+  clones: number;
+  /** Bytes handed to `JSON.stringify` for a versioned save payload. */
+  stringifyBytes: number;
+}
+
+/**
+ * Count the real operations a burst performs, with no production instrumentation.
+ *
+ * Every seam here is one the product already uses dynamically: `saveProjectState`
+ * is a public method (an own property shadows the prototype for `this` calls),
+ * `stubborn-fs` exports a mutable object whose `retry.rename` is read per call,
+ * and `structuredClone`/`JSON.stringify` are globals. Nothing under `electron/`
+ * changes to be measurable.
+ *
+ * INSTALL INSIDE `run()`, NEVER AT MODULE SCOPE — `scenarios/index.ts` imports
+ * every scenario eagerly, so a module-scope patch would be live in every perf
+ * process whichever id `--scenario` names (`moduleHookHygiene.test.ts`).
+ *
+ * The global proxies cost a trap per call, so this belongs in its own pass
+ * rather than inside a latency or bystander bracket: counting the work and
+ * timing it in the same window inflates the very number the counts explain.
+ */
+export async function withProjectStateCounters<T>(
+  fixture: ProjectStateFixture,
+  body: () => Promise<T>
+): Promise<{ result: T; counts: ProjectStateCounts }> {
+  const counts: ProjectStateCounts = {
+    saves: 0,
+    atomicReplaces: 0,
+    clones: 0,
+    stringifyBytes: 0,
+  };
+
+  const { manager, projectId, filePath } = fixture;
+  const stubbornFs = (await import("stubborn-fs")).default as {
+    retry: { rename: (options: unknown) => (from: string, to: string) => Promise<void> };
+  };
+
+  const ownSave = Object.getOwnPropertyDescriptor(manager, "saveProjectState");
+  const originalSave = manager.saveProjectState.bind(manager);
+  const originalRename = stubbornFs.retry.rename;
+  const originalClone = globalThis.structuredClone;
+  const originalStringify = JSON.stringify;
+
+  // A whole project state, not an arbitrary object: the manager clones and
+  // stringifies plenty of small things, and counting those would drown the
+  // signal the scenario exists to report.
+  const isWholeState = (value: unknown): boolean =>
+    typeof value === "object" &&
+    value !== null &&
+    (value as { projectId?: unknown }).projectId === projectId &&
+    Array.isArray((value as { terminals?: unknown }).terminals);
+
+  manager.saveProjectState = async (id: string, state: ProjectState): Promise<void> => {
+    await originalSave(id, state);
+    if (id === projectId) counts.saves += 1;
+  };
+
+  stubbornFs.retry.rename = (options: unknown) => {
+    const rename = originalRename(options);
+    return async (from: string, to: string): Promise<void> => {
+      await rename(from, to);
+      if (to === filePath) counts.atomicReplaces += 1;
+    };
+  };
+
+  globalThis.structuredClone = ((value: unknown, options?: unknown) => {
+    if (isWholeState(value)) counts.clones += 1;
+    return (originalClone as (v: unknown, o?: unknown) => unknown)(value, options);
+  }) as typeof structuredClone;
+
+  JSON.stringify = ((value: unknown, replacer?: unknown, space?: unknown) => {
+    const out = (originalStringify as (v: unknown, r?: unknown, s?: unknown) => string)(
+      value,
+      replacer,
+      space
+    );
+    // The versioned write payload specifically — the manager's own save, not a
+    // logger or a caller serializing something unrelated on the same tick.
+    if (
+      typeof out === "string" &&
+      isWholeState(value) &&
+      (value as { _schemaVersion?: unknown })._schemaVersion !== undefined
+    ) {
+      counts.stringifyBytes += Buffer.byteLength(out, "utf8");
+    }
+    return out;
+  }) as typeof JSON.stringify;
+
+  try {
+    const result = await body();
+    return { result, counts };
+  } finally {
+    if (ownSave) Object.defineProperty(manager, "saveProjectState", ownSave);
+    else Reflect.deleteProperty(manager, "saveProjectState");
+    stubbornFs.retry.rename = originalRename;
+    globalThis.structuredClone = originalClone;
+    JSON.stringify = originalStringify;
+  }
 }

--- a/scripts/perf/scenarios/index.ts
+++ b/scripts/perf/scenarios/index.ts
@@ -252,6 +252,7 @@ export const EXPECTED_SCENARIO_IDS: ReadonlySet<string> = new Set([
   "PERF-403",
   "PERF-404",
   "PERF-405",
+  "PERF-406",
 ]);
 
 /**

--- a/scripts/perf/scenarios/index.ts
+++ b/scripts/perf/scenarios/index.ts
@@ -253,6 +253,7 @@ export const EXPECTED_SCENARIO_IDS: ReadonlySet<string> = new Set([
   "PERF-404",
   "PERF-405",
   "PERF-406",
+  "PERF-407",
 ]);
 
 /**

--- a/scripts/perf/scenarios/persistence.ts
+++ b/scripts/perf/scenarios/persistence.ts
@@ -636,7 +636,7 @@ async function fireStateBurst(
   burstSize: number,
   round: number,
   latencies: number[]
-): Promise<{ expected: BurstExpectation[]; rejected: number }> {
+): Promise<BurstRun> {
   const expected: BurstExpectation[] = Array.from({ length: burstSize }, (_, i) => ({
     key: `burst-${round}-${i}`,
     value: `draft-${round}-${i}`,
@@ -677,34 +677,101 @@ async function fireStateBurst(
     })
   );
 
-  return { expected, rejected: settled.filter((s) => s.status === "rejected").length };
+  return {
+    enqueued: settled.length,
+    fulfilled: settled.filter((s) => s.status === "fulfilled").length,
+    rejected: settled.filter((s) => s.status === "rejected").length,
+  };
+}
+
+/**
+ * Every key the whole workload owes, built BEFORE any of it runs.
+ *
+ * Deriving the expectation from what executed is the trap this avoids: a loop
+ * that skipped rounds would shrink its own oracle to match, and a workload that
+ * did nothing at all would be graded against an empty list and post the best
+ * numbers in the suite.
+ */
+function burstExpectations(burstSize: number): BurstExpectation[] {
+  const expected: BurstExpectation[] = [];
+  for (let round = 0; round < STATE_BURST_REPEATS; round += 1) {
+    for (let i = 0; i < burstSize; i += 1) {
+      expected.push({ key: `burst-${round}-${i}`, value: `draft-${round}-${i}` });
+    }
+  }
+  return expected;
+}
+
+interface BurstRun {
+  /** Updates actually handed to the queue. */
+  enqueued: number;
+  /** Promises that came back fulfilled. */
+  fulfilled: number;
+  /** Promises that came back rejected. */
+  rejected: number;
 }
 
 async function runStateBurstWorkload(
   fixture: ProjectStateFixture,
   burstSize: number,
   latencies: number[]
-): Promise<{ expected: BurstExpectation[]; rejected: number }> {
-  const expected: BurstExpectation[] = [];
-  let rejected = 0;
+): Promise<BurstRun> {
+  const run: BurstRun = { enqueued: 0, fulfilled: 0, rejected: 0 };
   for (let round = 0; round < STATE_BURST_REPEATS; round += 1) {
     const outcome = await fireStateBurst(fixture, burstSize, round, latencies);
-    expected.push(...outcome.expected);
-    rejected += outcome.rejected;
+    run.enqueued += outcome.enqueued;
+    run.fulfilled += outcome.fulfilled;
+    run.rejected += outcome.rejected;
   }
-  return { expected, rejected };
+  return run;
 }
 
 /** Read back what actually landed, never what the manager's cache believes. */
 async function readStateFromDisk(fixture: ProjectStateFixture): Promise<{
   draftInputs?: Record<string, string>;
-  terminals?: unknown[];
+  terminals?: Array<{ title?: string; cwd?: string }>;
   tabGroups?: unknown[];
+  mruList?: unknown[];
 }> {
   return JSON.parse(await readFile(fixture.filePath, "utf8"));
 }
 
+/**
+ * Everything the burst was supposed to leave alone, plus everything it was
+ * supposed to change. Graded on BOTH passes.
+ *
+ * Counting terminals is not preservation: a save that kept 40 entries but
+ * stripped their titles and paths writes a much smaller payload and would score
+ * better on every number this scenario reports.
+ */
+function stateBurstMisses(
+  onDisk: Awaited<ReturnType<typeof readStateFromDisk>>,
+  expected: BurstExpectation[]
+): { updateMisses: number; preservationMisses: number } {
+  const drafts = onDisk.draftInputs ?? {};
+  const terminals = onDisk.terminals ?? [];
+  let preservationMisses = 0;
+
+  if (terminals.length !== STATE_PANELS) preservationMisses += 1;
+  if ((onDisk.tabGroups?.length ?? 0) !== Math.ceil(STATE_PANELS / 8)) preservationMisses += 1;
+  if ((onDisk.mruList?.length ?? 0) !== 24) preservationMisses += 1;
+  // The seeded payload itself, not just its shape: these strings are most of
+  // the bytes the coalescing is supposed to stop rewriting.
+  if (terminals.some((t) => !t.title || !t.cwd)) preservationMisses += 1;
+  // A seeded draft, which the burst adds to and must never replace wholesale.
+  if (drafts["panel-0"] === undefined) preservationMisses += 1;
+
+  return {
+    updateMisses: expected.filter(({ key, value }) => drafts[key] !== value).length,
+    preservationMisses,
+  };
+}
+
 async function runStateBurstScenario(burstSize: number): Promise<ScenarioSample> {
+  // Owed up front, so a workload that ran fewer rounds than it claims is graded
+  // against what it PROMISED rather than against what it happened to do.
+  const expected = burstExpectations(burstSize);
+
   // PASS 1 — timing and main-thread availability, with NO global instrumentation
   // installed. The counter proxies in pass 2 cost a trap per clone and per
   // stringify, which is work proportional to exactly the operations under
@@ -713,8 +780,7 @@ async function runStateBurstScenario(burstSize: number): Promise<ScenarioSample>
   const timed = await createProjectStateFixture(STATE_PANELS);
   let burstMs: number;
   let reading;
-  let expected: BurstExpectation[];
-  let rejected: number;
+  let timedRun: BurstRun;
   const latencies: number[] = [];
   let onDiskTimed;
 
@@ -726,14 +792,15 @@ async function runStateBurstScenario(burstSize: number): Promise<ScenarioSample>
     const startedAt = performance.now();
     let endedAt = startedAt;
     try {
-      ({ expected, rejected } = await runStateBurstWorkload(timed, burstSize, latencies));
+      timedRun = await runStateBurstWorkload(timed, burstSize, latencies);
     } finally {
       // Workload end recorded BEFORE any analysis: `stop()` sorts the gap list
       // to compute percentiles, and that work is not the subject.
       endedAt = performance.now();
       probe.stop();
     }
-    // Idempotent — the same window, analysed now rather than at close.
+    // Idempotent, and analysed once — this returns the reading `stop()` already
+    // computed rather than recomputing it.
     reading = probe.stop();
     burstMs = endedAt - startedAt;
     onDiskTimed = await readStateFromDisk(timed);
@@ -744,39 +811,39 @@ async function runStateBurstScenario(burstSize: number): Promise<ScenarioSample>
   // PASS 2 — the same workload on a fresh fixture, counted.
   const counted = await createProjectStateFixture(STATE_PANELS);
   let counts;
+  let countedRun: BurstRun;
   let onDiskCounted;
   try {
-    ({ counts } = await withProjectStateCounters(counted, () =>
+    const outcome = await withProjectStateCounters(counted, () =>
       runStateBurstWorkload(counted, burstSize, [])
-    ));
+    );
+    counts = outcome.counts;
+    countedRun = outcome.result;
     onDiskCounted = await readStateFromDisk(counted);
   } finally {
     counted.dispose();
   }
 
-  const totalUpdates = burstSize * STATE_BURST_REPEATS;
-  const draftsTimed = onDiskTimed.draftInputs ?? {};
-  const draftsCounted = onDiskCounted.draftInputs ?? {};
   // Both passes are graded. A pass that silently dropped half a burst would
   // otherwise hide behind the other one's clean predicate.
-  const onDiskUpdateMisses =
-    expected.filter(({ key, value }) => draftsTimed[key] !== value).length +
-    expected.filter(({ key, value }) => draftsCounted[key] !== value).length;
+  const timedMisses = stateBurstMisses(onDiskTimed, expected);
+  const countedMisses = stateBurstMisses(onDiskCounted, expected);
 
-  // The seeded fixture must survive the burst intact: a coalesced save that
-  // wrote only the last updater's object would land every draft key and quietly
-  // drop the terminal list the whole cost model rests on.
-  const fixturePreservationMisses =
-    (onDiskTimed.terminals?.length === STATE_PANELS ? 0 : 1) +
-    (onDiskCounted.terminals?.length === STATE_PANELS ? 0 : 1) +
-    (onDiskTimed.tabGroups?.length === Math.ceil(STATE_PANELS / 8) ? 0 : 1);
+  const owed = expected.length;
+  const enqueued = timedRun.enqueued + countedRun.enqueued;
+  const fulfilled = timedRun.fulfilled + countedRun.fulfilled;
 
   return {
     durationMs: burstMs,
     metrics: {
       burstSize,
       burstRepeats: STATE_BURST_REPEATS,
-      updatesRequested: totalUpdates,
+      // What the scenario OWES, and what it actually handed to the queue. The
+      // floors below sit on the observed pair, so a fixture or loop that quietly
+      // scaled itself down is a measurement failure rather than a better number.
+      updatesRequested: owed,
+      updatesEnqueued: enqueued,
+      updatesSettled: fulfilled,
       fixturePanelCount: onDiskTimed.terminals?.length ?? 0,
 
       // The headline: how many durable writes a burst of `burstSize` costs.
@@ -796,9 +863,11 @@ async function runStateBurstScenario(burstSize: number): Promise<ScenarioSample>
       callerAwaitMaxMs: latencies.length > 0 ? Math.max(...latencies) : 0,
 
       probeMisses: reading.probeMisses,
-      callerResolutionMisses: rejected,
-      onDiskUpdateMisses,
-      fixturePreservationMisses,
+      // Graded across BOTH passes: a rejection in the counted pass is just as
+      // much a failed durable write as one in the timed pass.
+      callerResolutionMisses: timedRun.rejected + countedRun.rejected + (owed * 2 - enqueued),
+      onDiskUpdateMisses: timedMisses.updateMisses + countedMisses.updateMisses,
+      fixturePreservationMisses: timedMisses.preservationMisses + countedMisses.preservationMisses,
     },
   };
 }
@@ -897,7 +966,12 @@ export const persistenceScenarios: PerfScenario[] = [
       "fixturePreservationMisses",
       "probeMisses",
     ],
-    workloadFloors: { updatesRequested: 5 * STATE_BURST_REPEATS, fixturePanelCount: STATE_PANELS },
+    workloadFloors: {
+      updatesRequested: 5 * STATE_BURST_REPEATS,
+      updatesEnqueued: 2 * 5 * STATE_BURST_REPEATS,
+      updatesSettled: 2 * 5 * STATE_BURST_REPEATS,
+      fixturePanelCount: STATE_PANELS,
+    },
     run: () => runStateBurstScenario(5),
   },
   {
@@ -915,7 +989,12 @@ export const persistenceScenarios: PerfScenario[] = [
       "fixturePreservationMisses",
       "probeMisses",
     ],
-    workloadFloors: { updatesRequested: 20 * STATE_BURST_REPEATS, fixturePanelCount: STATE_PANELS },
+    workloadFloors: {
+      updatesRequested: 20 * STATE_BURST_REPEATS,
+      updatesEnqueued: 2 * 20 * STATE_BURST_REPEATS,
+      updatesSettled: 2 * 20 * STATE_BURST_REPEATS,
+      fixturePanelCount: STATE_PANELS,
+    },
     run: () => runStateBurstScenario(20),
   },
 ];

--- a/scripts/perf/scenarios/persistence.ts
+++ b/scripts/perf/scenarios/persistence.ts
@@ -843,7 +843,7 @@ async function runStateBurstScenario(burstSize: number): Promise<ScenarioSample>
       // scaled itself down is a measurement failure rather than a better number.
       updatesRequested: owed,
       updatesEnqueued: enqueued,
-      updatesSettled: fulfilled,
+      updatesFulfilled: fulfilled,
       fixturePanelCount: onDiskTimed.terminals?.length ?? 0,
 
       // The headline: how many durable writes a burst of `burstSize` costs.
@@ -969,7 +969,7 @@ export const persistenceScenarios: PerfScenario[] = [
     workloadFloors: {
       updatesRequested: 5 * STATE_BURST_REPEATS,
       updatesEnqueued: 2 * 5 * STATE_BURST_REPEATS,
-      updatesSettled: 2 * 5 * STATE_BURST_REPEATS,
+      updatesFulfilled: 2 * 5 * STATE_BURST_REPEATS,
       fixturePanelCount: STATE_PANELS,
     },
     run: () => runStateBurstScenario(5),
@@ -992,7 +992,7 @@ export const persistenceScenarios: PerfScenario[] = [
     workloadFloors: {
       updatesRequested: 20 * STATE_BURST_REPEATS,
       updatesEnqueued: 2 * 20 * STATE_BURST_REPEATS,
-      updatesSettled: 2 * 20 * STATE_BURST_REPEATS,
+      updatesFulfilled: 2 * 20 * STATE_BURST_REPEATS,
       fixturePanelCount: STATE_PANELS,
     },
     run: () => runStateBurstScenario(20),

--- a/scripts/perf/scenarios/persistence.ts
+++ b/scripts/perf/scenarios/persistence.ts
@@ -17,7 +17,11 @@ import Database from "better-sqlite3";
 import { desc, eq } from "drizzle-orm";
 import { readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
+import { performance } from "node:perf_hooks";
+import { readFile } from "node:fs/promises";
 import type { PerfScenario, ScenarioSample } from "../types";
+import { armBystanderProbe, bystanderMetrics } from "../lib/bystander";
+import { percentile } from "../lib/stats";
 import * as schema from "../../../electron/services/persistence/schema";
 import {
   appliedMigrationCount,
@@ -39,6 +43,9 @@ import {
   seededProjectPath,
   trackConnection,
   walKB,
+  createProjectStateFixture,
+  withProjectStateCounters,
+  type ProjectStateFixture,
 } from "../lib/persistenceFixture";
 
 const BATCH_ROWS = 200;
@@ -48,6 +55,19 @@ const WAL_ROWS_PER_TRANSACTION = 25;
 const APP_STATE_PANELS = 400;
 const SETTINGS_WRITES = 12;
 const KEY_READS = 200;
+const STATE_PANELS = 40;
+/**
+ * Bursts per measured window.
+ *
+ * One burst is far too short to describe a loop: a coalesced K=20 burst is two
+ * atomic writes, which at a 4ms cadence can finish between two probe ticks and
+ * leave a single gap equal to the whole burst. A percentile over that is the
+ * burst duration wearing a percentile's name. Ten back-to-back bursts give both
+ * arms a real gap distribution and match the thing being claimed anyway —
+ * sustained layout traffic during a fleet launch, not one isolated write.
+ */
+const STATE_BURST_REPEATS = 10;
+const STATE_PROBE_CADENCE_MS = 4;
 
 const MIGRATION_COUNT = countRealMigrations();
 
@@ -594,6 +614,195 @@ async function runStoreOpenScenario(): Promise<ScenarioSample> {
   };
 }
 
+// --- PERF-405/406: coalescing the project-state write queue -------------------
+
+interface BurstExpectation {
+  key: string;
+  value: string;
+}
+
+/**
+ * One burst: K updates fired with NO await between them, exactly as the
+ * per-field IPC handlers do during a drag or a fleet launch.
+ *
+ * Every update writes a UNIQUE draft key, so the on-disk oracle proves all K
+ * landed. Overwriting one shared field instead would prove only that the last
+ * writer ran — the coalescing failure mode that drops the middle of a burst
+ * would score perfectly. A rotating second field keeps the shape realistic
+ * without weakening that.
+ */
+async function fireStateBurst(
+  fixture: ProjectStateFixture,
+  burstSize: number,
+  round: number,
+  latencies: number[]
+): Promise<{ expected: BurstExpectation[]; rejected: number }> {
+  const expected: BurstExpectation[] = Array.from({ length: burstSize }, (_, i) => ({
+    key: `burst-${round}-${i}`,
+    value: `draft-${round}-${i}`,
+  }));
+
+  const settled = await Promise.allSettled(
+    expected.map(({ key, value }, i) => {
+      const startedAt = performance.now();
+      return fixture.manager
+        .enqueueProjectStateUpdate(fixture.projectId, (existing) => {
+          if (!existing) return null;
+          const next = {
+            ...existing,
+            draftInputs: { ...existing.draftInputs, [key]: value },
+          };
+          // A rotating second field, so the burst touches the spread of state a
+          // real layout change does rather than one key repeatedly.
+          switch (i % 4) {
+            case 0:
+              return { ...next, sidebarWidth: 320 + (i % 60) };
+            case 1:
+              return { ...next, focusMode: i % 8 === 1 };
+            case 2:
+              return { ...next, activeWorktreeId: `wt-perf-${i % 24}` };
+            default:
+              return {
+                ...next,
+                terminalSizes: {
+                  ...next.terminalSizes,
+                  [`panel-${i % STATE_PANELS}`]: { cols: 100 + (i % 40), rows: 30 + (i % 20) },
+                },
+              };
+          }
+        })
+        .then(() => {
+          latencies.push(performance.now() - startedAt);
+        });
+    })
+  );
+
+  return { expected, rejected: settled.filter((s) => s.status === "rejected").length };
+}
+
+async function runStateBurstWorkload(
+  fixture: ProjectStateFixture,
+  burstSize: number,
+  latencies: number[]
+): Promise<{ expected: BurstExpectation[]; rejected: number }> {
+  const expected: BurstExpectation[] = [];
+  let rejected = 0;
+  for (let round = 0; round < STATE_BURST_REPEATS; round += 1) {
+    const outcome = await fireStateBurst(fixture, burstSize, round, latencies);
+    expected.push(...outcome.expected);
+    rejected += outcome.rejected;
+  }
+  return { expected, rejected };
+}
+
+/** Read back what actually landed, never what the manager's cache believes. */
+async function readStateFromDisk(fixture: ProjectStateFixture): Promise<{
+  draftInputs?: Record<string, string>;
+  terminals?: unknown[];
+  tabGroups?: unknown[];
+}> {
+  return JSON.parse(await readFile(fixture.filePath, "utf8"));
+}
+
+async function runStateBurstScenario(burstSize: number): Promise<ScenarioSample> {
+  // PASS 1 — timing and main-thread availability, with NO global instrumentation
+  // installed. The counter proxies in pass 2 cost a trap per clone and per
+  // stringify, which is work proportional to exactly the operations under
+  // measurement; counting and timing in one window inflates the number the
+  // counts exist to explain.
+  const timed = await createProjectStateFixture(STATE_PANELS);
+  let burstMs: number;
+  let reading;
+  let expected: BurstExpectation[];
+  let rejected: number;
+  const latencies: number[] = [];
+  let onDiskTimed;
+
+  try {
+    // The probe's own window must not inherit a collection that fell due for
+    // the fixture build.
+    globalThis.gc?.();
+    const probe = await armBystanderProbe({ cadenceMs: STATE_PROBE_CADENCE_MS });
+    const startedAt = performance.now();
+    let endedAt = startedAt;
+    try {
+      ({ expected, rejected } = await runStateBurstWorkload(timed, burstSize, latencies));
+    } finally {
+      // Workload end recorded BEFORE any analysis: `stop()` sorts the gap list
+      // to compute percentiles, and that work is not the subject.
+      endedAt = performance.now();
+      probe.stop();
+    }
+    // Idempotent — the same window, analysed now rather than at close.
+    reading = probe.stop();
+    burstMs = endedAt - startedAt;
+    onDiskTimed = await readStateFromDisk(timed);
+  } finally {
+    timed.dispose();
+  }
+
+  // PASS 2 — the same workload on a fresh fixture, counted.
+  const counted = await createProjectStateFixture(STATE_PANELS);
+  let counts;
+  let onDiskCounted;
+  try {
+    ({ counts } = await withProjectStateCounters(counted, () =>
+      runStateBurstWorkload(counted, burstSize, [])
+    ));
+    onDiskCounted = await readStateFromDisk(counted);
+  } finally {
+    counted.dispose();
+  }
+
+  const totalUpdates = burstSize * STATE_BURST_REPEATS;
+  const draftsTimed = onDiskTimed.draftInputs ?? {};
+  const draftsCounted = onDiskCounted.draftInputs ?? {};
+  // Both passes are graded. A pass that silently dropped half a burst would
+  // otherwise hide behind the other one's clean predicate.
+  const onDiskUpdateMisses =
+    expected.filter(({ key, value }) => draftsTimed[key] !== value).length +
+    expected.filter(({ key, value }) => draftsCounted[key] !== value).length;
+
+  // The seeded fixture must survive the burst intact: a coalesced save that
+  // wrote only the last updater's object would land every draft key and quietly
+  // drop the terminal list the whole cost model rests on.
+  const fixturePreservationMisses =
+    (onDiskTimed.terminals?.length === STATE_PANELS ? 0 : 1) +
+    (onDiskCounted.terminals?.length === STATE_PANELS ? 0 : 1) +
+    (onDiskTimed.tabGroups?.length === Math.ceil(STATE_PANELS / 8) ? 0 : 1);
+
+  return {
+    durationMs: burstMs,
+    metrics: {
+      burstSize,
+      burstRepeats: STATE_BURST_REPEATS,
+      updatesRequested: totalUpdates,
+      fixturePanelCount: onDiskTimed.terminals?.length ?? 0,
+
+      // The headline: how many durable writes a burst of `burstSize` costs.
+      saves: counts.saves,
+      savesPerBurst: counts.saves / STATE_BURST_REPEATS,
+      atomicReplaces: counts.atomicReplaces,
+      clones: counts.clones,
+      clonesPerBurst: counts.clones / STATE_BURST_REPEATS,
+      stringifyBytes: counts.stringifyBytes,
+      stringifyBytesPerBurst: counts.stringifyBytes / STATE_BURST_REPEATS,
+
+      // What the burst cost the rest of the main process.
+      ...bystanderMetrics("burst", reading),
+
+      // What a caller actually waited for its own update to be durable.
+      callerAwaitP95Ms: percentile(latencies, 95),
+      callerAwaitMaxMs: latencies.length > 0 ? Math.max(...latencies) : 0,
+
+      probeMisses: reading.probeMisses,
+      callerResolutionMisses: rejected,
+      onDiskUpdateMisses,
+      fixturePreservationMisses,
+    },
+  };
+}
+
 export const persistenceScenarios: PerfScenario[] = [
   {
     id: "PERF-053",
@@ -672,5 +881,41 @@ export const persistenceScenarios: PerfScenario[] = [
     warmups: 1,
     correctness: ["keyReadMisses", "hydrationMisses"],
     run: runStoreOpenScenario,
+  },
+  {
+    id: "PERF-405",
+    name: "Project State Write Queue — 5-update burst",
+    description:
+      "A real ProjectStateManager over a real temp config dir holding a 40-panel project with draft inputs and tab groups, taking ten back-to-back bursts of 5 per-field updates enqueued with no await between them. Reports durable writes, whole-state clones and payload bytes per burst alongside main-thread availability. The IPC hop, the renderer debounce and ProjectStore's derived metadata are out of frame.",
+    tier: "fast",
+    modes: ["smoke", "ci", "nightly"],
+    iterations: { smoke: 3, ci: 8, nightly: 12 },
+    warmups: 1,
+    correctness: [
+      "onDiskUpdateMisses",
+      "callerResolutionMisses",
+      "fixturePreservationMisses",
+      "probeMisses",
+    ],
+    workloadFloors: { updatesRequested: 5 * STATE_BURST_REPEATS, fixturePanelCount: STATE_PANELS },
+    run: () => runStateBurstScenario(5),
+  },
+  {
+    id: "PERF-406",
+    name: "Project State Write Queue — 20-update burst",
+    description:
+      "The PERF-405 workload at the burst size a fleet launch or a drag actually produces: twenty per-field updates enqueued with no await between them, ten times over. The burst size is the variable; fixture, probe cadence and predicates are identical.",
+    tier: "fast",
+    modes: ["smoke", "ci", "nightly"],
+    iterations: { smoke: 3, ci: 8, nightly: 12 },
+    warmups: 1,
+    correctness: [
+      "onDiskUpdateMisses",
+      "callerResolutionMisses",
+      "fixturePreservationMisses",
+      "probeMisses",
+    ],
+    workloadFloors: { updatesRequested: 20 * STATE_BURST_REPEATS, fixturePanelCount: STATE_PANELS },
+    run: () => runStateBurstScenario(20),
   },
 ];

--- a/scripts/perf/scenarios/persistence.ts
+++ b/scripts/perf/scenarios/persistence.ts
@@ -614,7 +614,7 @@ async function runStoreOpenScenario(): Promise<ScenarioSample> {
   };
 }
 
-// --- PERF-405/406: coalescing the project-state write queue -------------------
+// --- PERF-406/407: coalescing the project-state write queue -------------------
 
 interface BurstExpectation {
   key: string;
@@ -952,7 +952,7 @@ export const persistenceScenarios: PerfScenario[] = [
     run: runStoreOpenScenario,
   },
   {
-    id: "PERF-405",
+    id: "PERF-406",
     name: "Project State Write Queue — 5-update burst",
     description:
       "A real ProjectStateManager over a real temp config dir holding a 40-panel project with draft inputs and tab groups, taking ten back-to-back bursts of 5 per-field updates enqueued with no await between them. Reports durable writes, whole-state clones and payload bytes per burst alongside main-thread availability. The IPC hop, the renderer debounce and ProjectStore's derived metadata are out of frame.",
@@ -975,10 +975,10 @@ export const persistenceScenarios: PerfScenario[] = [
     run: () => runStateBurstScenario(5),
   },
   {
-    id: "PERF-406",
+    id: "PERF-407",
     name: "Project State Write Queue — 20-update burst",
     description:
-      "The PERF-405 workload at the burst size a fleet launch or a drag actually produces: twenty per-field updates enqueued with no await between them, ten times over. The burst size is the variable; fixture, probe cadence and predicates are identical.",
+      "The PERF-406 workload at the burst size a fleet launch or a drag actually produces: twenty per-field updates enqueued with no await between them, ten times over. The burst size is the variable; fixture, probe cadence and predicates are identical.",
     tier: "fast",
     modes: ["smoke", "ci", "nightly"],
     iterations: { smoke: 3, ci: 8, nightly: 12 },


### PR DESCRIPTION
`ProjectStateManager.enqueueProjectStateUpdate` serialised updates per project correctly, but every queued update paid for the whole project: its own read (a `structuredClone` out of the cache), its own terminal validation, its own `JSON.stringify`, and its own atomic write. A layout change during a fleet launch lands five to twenty of these in the same queue, so one durable state cost twenty full saves.

Updates that arrive while a save is in flight now fold into one batch. Each updater still runs, in order, against the previous one's result — the batch just costs one save instead of one per update.

## Measured

Paired A/B on the identical harness, same machine and session, working tree verified clean between arms. New scenarios PERF-405 (K=5) and PERF-406 (K=20), ten bursts per measured window. Per burst:

| | K=5 before | K=5 after | K=20 before | K=20 after |
|---|---:|---:|---:|---:|
| saves | 5 | **2** | 20 | **2** |
| stringifyBytes | 68,798 | **27,518** | 313,128 | **31,320** |
| clones | 10 | 9 | 40 | 24 |
| caller await p95 (ms) | 53.3 | **21.7** | 193.5 | **23.7** |
| burst duration (ms) | 589.3 | 204.7 | 2028.0 | 218.8 |
| main-loop blocked (ms) | 0 | 0 | 0.582 | 0 |
| **main-loop p95 delay (ms)** | 1.195 | 1.259 | **1.134** | **1.586** |

The counts are exact and had 0% spread across seven runs: K=20's 24 clones are `2 + (1 + 19 + 1 + 1)`, precisely what the code does.

## The bail-out gate, honestly

The issue says not to open a PR unless saves drop **and** K=20 main-loop delay improves by at least 30%. Saves dropped 90%. **The main-loop delay gate is not met** — it moved 1.134 → 1.586 ms, i.e. the wrong way.

I do not think that number can carry the decision, and the evidence is that `npm run perf calibrate -- --scenario PERF-406` reports a **47.6% run-to-run range for `burstP95DelayMs` on an unchanged tree**. The observed move sits inside the noise band of a tree that did not change. Per `.claude/rules/perf-benchmarks.md`, "a threshold below that fires on nothing having changed".

What that metric cannot see also matters, and cuts against me as much as for me: `blockedMs` only counts gaps wider than twice the 4 ms cadence, so 0 does not mean zero synchronous cost — it means every individual chunk was under 8 ms. This scenario also omits two things production pays per save: the IPC hop, and `ProjectStore`'s synchronous resumable-count observer that writes to SQLite. So the real main-loop saving is probably larger than measured here, and this harness is the wrong instrument to size it.

**This is the repo owner's call, not mine.** I opened the PR rather than closing the issue because the change is plainly not the no-op the bail-out exists to catch, and a PR is reversible while a closed issue tends not to be. If you read the gate strictly, close this and I will close #12238 with these numbers.

## What the contract now says

Every caller's promise still resolves only after the save that carried its update, and a failed save rejects every caller folded into it. Clone-on-read isolation, schema validation and the atomic write are all unchanged, and `ProjectStateManager.adversarial.test.ts` passes untouched. Three narrowings are documented on the method:

- An updater must not await another update for the **same** project — its batch cannot save until every updater in it has returned. Enqueuing without awaiting is fine.
- Terminal validation runs once per save rather than once per update. Nothing invalid can reach disk either way; what changed is that a mid-batch entry a later updater repairs is no longer dropped before that updater sees it.
- Returning `null` means "no write", and such a caller resolves even if the batch's save fails. `ProjectStore`'s relocation rewrite returned `null` when it found paths a batch-mate had already rewritten, which reported success for a write that never landed — it now returns the state so it shares the save's outcome.

An updater also hands over the value it returns; the queue may carry that object until the batch's save. That was always racy, over a one-microtask window; it is now the rest of the batch.

Also drops the second full clone of a freshly parsed disk read, which was copying the whole project once for the cache and once for the caller.

## Not fixed here

`ProjectSwitchService.ts:181` and `clearProjectState` both read-modify-write outside this queue and can still race it. Pre-existing, unchanged by this PR, worth its own issue.

## Verification

`ProjectStateManager` + `ProjectStore` suites (216 tests) and the full `scripts/perf` suite (999 tests) pass; `tsc -p tsconfig.perf.json` clean; prettier and eslint clean on all changed files. One pre-existing `no-useless-assignment` warning at `ProjectStore.ts:1288` is byte-identical on `develop` and left alone.

Resolves #12238