### PR TITLE
perf(git): skip the status refresh for watcher bursts confined to ignored paths

### DIFF
--- a/electron/utils/__tests__/gitCheckIgnore.test.ts
+++ b/electron/utils/__tests__/gitCheckIgnore.test.ts
@@ -1,0 +1,208 @@
+import { EventEmitter } from "node:events";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { spawn } from "node:child_process";
+import { checkIgnoredPaths } from "../gitCheckIgnore.js";
+import { GIT_BLOCK_TIMEOUT_MS } from "../hardenedGit.js";
+
+vi.mock("node:child_process", () => ({ spawn: vi.fn() }));
+
+interface FakeChild extends EventEmitter {
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  stdin: EventEmitter & { end: ReturnType<typeof vi.fn> };
+  kill: ReturnType<typeof vi.fn>;
+}
+
+function createChild(): FakeChild {
+  const child = new EventEmitter() as FakeChild;
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  const stdin = new EventEmitter() as FakeChild["stdin"];
+  stdin.end = vi.fn();
+  child.stdin = stdin;
+  child.kill = vi.fn();
+  return child;
+}
+
+/** Install a child the next `spawn` returns, and hand it back for driving. */
+function nextChild(): FakeChild {
+  const child = createChild();
+  vi.mocked(spawn).mockReturnValueOnce(child as never);
+  return child;
+}
+
+function spawnArgs(): string[] {
+  return vi.mocked(spawn).mock.calls[0][1] as string[];
+}
+
+describe("checkIgnoredPaths", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("returns an empty set without spawning for an empty path list", async () => {
+    await expect(checkIgnoredPaths("/repo", [])).resolves.toEqual(new Set());
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it("feeds paths over NUL-terminated stdin and keeps argv constant-size", async () => {
+    const child = nextChild();
+    const promise = checkIgnoredPaths("/repo", ["a.log", "sub/b.log"]);
+    child.stdout.emit("data", Buffer.from("a.log\0sub/b.log\0"));
+    child.emit("close", 0, null);
+
+    await expect(promise).resolves.toEqual(new Set(["a.log", "sub/b.log"]));
+    // The whole point of --stdin: simple-git's argv-based checkIgnoreTask
+    // blows past ARG_MAX on a large burst (#10234).
+    expect(child.stdin.end).toHaveBeenCalledWith("a.log\0sub/b.log\0");
+    const args = spawnArgs();
+    expect(args.slice(-3)).toEqual(["check-ignore", "--stdin", "-z"]);
+    // No path may reach argv at all — argv stays the fixed hardened prefix
+    // plus the subcommand, whatever the burst size.
+    expect(args).not.toContain("a.log");
+    expect(args).not.toContain("sub/b.log");
+  });
+
+  it("spawns with the hardened config and env", async () => {
+    const child = nextChild();
+    const promise = checkIgnoredPaths("/repo", ["a.log"], { platform: "linux" });
+    child.emit("close", 1, null);
+    await promise;
+
+    const args = spawnArgs();
+    expect(args.filter((a) => a === "-c").length).toBeGreaterThan(0);
+    expect(args.some((a) => a.startsWith("core.fsmonitor="))).toBe(true);
+    const options = vi.mocked(spawn).mock.calls[0][2] as {
+      cwd: string;
+      env: NodeJS.ProcessEnv;
+      windowsHide: boolean;
+    };
+    expect(options.cwd).toBe("/repo");
+    expect(options.windowsHide).toBe(true);
+    expect(options.env.GIT_LITERAL_PATHSPECS).toBe("1");
+    expect(options.env.GIT_OPTIONAL_LOCKS).toBe("0");
+  });
+
+  it("does not pass --no-index, so tracked paths stay out of the result", async () => {
+    // Default mode is what makes one spawn answer "ignored AND untracked":
+    // git omits tracked files from check-ignore output entirely. --no-index
+    // would report them and silently break the caller's skip predicate.
+    const child = nextChild();
+    const promise = checkIgnoredPaths("/repo", ["a.log"]);
+    child.emit("close", 1, null);
+    await promise;
+    expect(spawnArgs()).not.toContain("--no-index");
+    expect(spawnArgs()).not.toContain("-v");
+  });
+
+  it("reassembles output split across chunks and drops the trailing empty token", async () => {
+    const child = nextChild();
+    const promise = checkIgnoredPaths("/repo", ["one.log", "two.log"]);
+    child.stdout.emit("data", Buffer.from("one.l"));
+    child.stdout.emit("data", Buffer.from("og\0two.log\0"));
+    child.emit("close", 0, null);
+    await expect(promise).resolves.toEqual(new Set(["one.log", "two.log"]));
+  });
+
+  it("preserves paths containing spaces, newlines and unicode", async () => {
+    const odd = ["a b.log", "line\nbreak.log", "café/ünïcode.log"];
+    const child = nextChild();
+    const promise = checkIgnoredPaths("/repo", odd);
+    child.stdout.emit("data", Buffer.from(odd.join("\0") + "\0", "utf8"));
+    child.emit("close", 0, null);
+    // NUL framing is why these survive: no shell quoting, no line splitting.
+    await expect(promise).resolves.toEqual(new Set(odd));
+  });
+
+  it("treats exit 1 as a valid empty result, not a failure", async () => {
+    const child = nextChild();
+    const promise = checkIgnoredPaths("/repo", ["tracked.ts"]);
+    child.emit("close", 1, null);
+    await expect(promise).resolves.toEqual(new Set());
+  });
+
+  it.each([
+    [2, "generic failure"],
+    [128, "fatal: outside repository"],
+    [129, "usage error"],
+  ])("rejects on exit %i and discards partial output", async (code, stderr) => {
+    const child = nextChild();
+    const promise = checkIgnoredPaths("/repo", ["a.log", "/etc/hosts"]);
+    // A fatal can arrive after git already wrote matches for the paths it
+    // processed. Trusting that prefix would skip a status refresh on a burst
+    // that was never fully classified.
+    child.stdout.emit("data", Buffer.from("a.log\0"));
+    child.stderr.emit("data", Buffer.from(stderr));
+    child.emit("close", code, null);
+    await expect(promise).rejects.toThrow(`exit ${code}`);
+  });
+
+  it("rejects when git is killed by a signal", async () => {
+    const child = nextChild();
+    const promise = checkIgnoredPaths("/repo", ["a.log"]);
+    // code is null on signal death; without this branch it would fall through
+    // the `code === 0` / `code === 1` checks into a confusing "exit null".
+    child.emit("close", null, "SIGKILL");
+    await expect(promise).rejects.toThrow("killed by SIGKILL");
+  });
+
+  it("rejects on a spawn error", async () => {
+    const child = nextChild();
+    const promise = checkIgnoredPaths("/repo", ["a.log"]);
+    child.emit("error", new Error("ENOENT"));
+    await expect(promise).rejects.toThrow("ENOENT");
+  });
+
+  it("swallows stdin EPIPE and still settles from close", async () => {
+    const child = nextChild();
+    const promise = checkIgnoredPaths("/repo", ["a.log"]);
+    // git can exit before the body finishes writing; the stream then errors
+    // after the process is already gone. `close` is the source of truth.
+    child.stdin.emit("error", new Error("EPIPE"));
+    child.emit("close", 1, null);
+    await expect(promise).resolves.toEqual(new Set());
+  });
+
+  it("kills and rejects when the deadline expires", async () => {
+    vi.useFakeTimers();
+    const child = nextChild();
+    const promise = checkIgnoredPaths("/repo", ["a.log"], { timeoutMs: 250 });
+    const assertion = expect(promise).rejects.toThrow("timed out after 250ms");
+    await vi.advanceTimersByTimeAsync(250);
+    await assertion;
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+  });
+
+  it("clamps a caller deadline to the hard block ceiling", async () => {
+    vi.useFakeTimers();
+    nextChild();
+    const promise = checkIgnoredPaths("/repo", ["a.log"], {
+      timeoutMs: GIT_BLOCK_TIMEOUT_MS * 10,
+    });
+    const assertion = expect(promise).rejects.toThrow(`timed out after ${GIT_BLOCK_TIMEOUT_MS}ms`);
+    await vi.advanceTimersByTimeAsync(GIT_BLOCK_TIMEOUT_MS);
+    await assertion;
+  });
+
+  it("settles once: a close after the deadline cannot resolve the rejected promise", async () => {
+    vi.useFakeTimers();
+    const child = nextChild();
+    const promise = checkIgnoredPaths("/repo", ["a.log"], { timeoutMs: 100 });
+    const assertion = expect(promise).rejects.toThrow("timed out");
+    await vi.advanceTimersByTimeAsync(100);
+    child.stdout.emit("data", Buffer.from("a.log\0"));
+    child.emit("close", 0, null);
+    await assertion;
+  });
+
+  it("forwards the abort signal to spawn", async () => {
+    const controller = new AbortController();
+    const child = nextChild();
+    const promise = checkIgnoredPaths("/repo", ["a.log"], { signal: controller.signal });
+    const options = vi.mocked(spawn).mock.calls[0][2] as { signal?: AbortSignal };
+    expect(options.signal).toBe(controller.signal);
+    child.emit("close", 1, null);
+    await promise;
+  });
+});

--- a/electron/utils/__tests__/gitCheckIgnore.test.ts
+++ b/electron/utils/__tests__/gitCheckIgnore.test.ts
@@ -80,8 +80,21 @@ describe("checkIgnoredPaths", () => {
     };
     expect(options.cwd).toBe("/repo");
     expect(options.windowsHide).toBe(true);
-    expect(options.env.GIT_LITERAL_PATHSPECS).toBe("1");
     expect(options.env.GIT_OPTIONAL_LOCKS).toBe("0");
+  });
+
+  it("drops GIT_LITERAL_PATHSPECS, which check-ignore refuses to run under", async () => {
+    // The hardened env sets it, and check-ignore rejects pathspec magic
+    // outright: every call dies `fatal: pathspec magic not supported by this
+    // command: 'literal'` (exit 128) while it is present. Safe to drop only
+    // for this command — it selects no files, it matches the literal pathname
+    // it was handed against the repo's ignore patterns.
+    const child = nextChild();
+    const promise = checkIgnoredPaths("/repo", ["a.log"], { platform: "linux" });
+    child.emit("close", 1, null);
+    await promise;
+    const options = vi.mocked(spawn).mock.calls[0][2] as { env: NodeJS.ProcessEnv };
+    expect(options.env.GIT_LITERAL_PATHSPECS).toBeUndefined();
   });
 
   it("does not pass --no-index, so tracked paths stay out of the result", async () => {

--- a/electron/utils/__tests__/gitFileWatcher.ignoreClassification.integration.test.ts
+++ b/electron/utils/__tests__/gitFileWatcher.ignoreClassification.integration.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, appendFileSync, renameSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { GitFileWatcher } from "../gitFileWatcher.js";
+
+/**
+ * The burst-skip decision rests on claims about what real `git check-ignore`
+ * reports, and the unit tests mock exactly those claims away. Two of them are
+ * counter-intuitive enough that they were both wrong in review before being
+ * measured against a real repository:
+ *
+ *  - a `.gitignore` that ignores ITSELF is untracked and ignored, so plain
+ *    check-ignore reports it — editing it still changes what git status shows;
+ *  - git's tracked-file exemption is a case-SENSITIVE index lookup, so on a
+ *    case-insensitive filesystem a force-added `Keep.txt` renamed on disk to
+ *    `keep.txt` stays tracked while check-ignore calls it ignored.
+ *
+ * These run the real watcher against real repositories with real git, so a
+ * change to either assumption fails here rather than silently stranding the
+ * sidebar on stale status.
+ */
+
+const GIT_ENV = {
+  ...process.env,
+  GIT_CONFIG_GLOBAL: "/dev/null",
+  GIT_CONFIG_SYSTEM: "/dev/null",
+  GIT_AUTHOR_NAME: "test",
+  GIT_AUTHOR_EMAIL: "test@example.invalid",
+  GIT_COMMITTER_NAME: "test",
+  GIT_COMMITTER_EMAIL: "test@example.invalid",
+};
+
+const roots: string[] = [];
+const watchers: GitFileWatcher[] = [];
+
+function makeRepo(): { root: string; git: (args: string[]) => void } {
+  const root = mkdtempSync(join(tmpdir(), "daintree-ignore-"));
+  roots.push(root);
+  const git = (args: string[]) => {
+    execFileSync("git", args, { cwd: root, stdio: ["ignore", "ignore", "pipe"], env: GIT_ENV });
+  };
+  git(["init", "-b", "main", "."]);
+  return { root, git };
+}
+
+interface Observed {
+  changes: number;
+  fileSignals: number;
+}
+
+/** Arm a real watcher on `root`, run `act`, and report what the callbacks saw. */
+async function observe(root: string, act: () => void): Promise<Observed> {
+  let changes = 0;
+  let fileSignals = 0;
+  const watcher = new GitFileWatcher({
+    worktreePath: root,
+    branch: "main",
+    debounceMs: 300,
+    watchWorktree: true,
+    worktreeMinDebounceMs: 150,
+    worktreeMaxDebounceMs: 400,
+    onChange: () => {
+      changes++;
+    },
+    onWorktreeFilesChanged: () => {
+      fileSignals++;
+    },
+  });
+  watchers.push(watcher);
+  expect(await watcher.start()).toBe(true);
+  // The recursive subscription arms asynchronously; let it settle so the
+  // mutation under test is not raced by the arm itself.
+  await new Promise((resolve) => setTimeout(resolve, 900));
+  changes = 0;
+  fileSignals = 0;
+  act();
+  await new Promise((resolve) => setTimeout(resolve, 3500));
+  return { changes, fileSignals };
+}
+
+afterEach(() => {
+  for (const watcher of watchers.splice(0)) watcher.dispose();
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("worktree burst ignore classification against real git", () => {
+  it("skips the status recompute for a burst confined to an ignored directory", async () => {
+    const { root, git } = makeRepo();
+    writeFileSync(join(root, ".gitignore"), ".output/\n");
+    writeFileSync(join(root, "src.txt"), "committed\n");
+    mkdirSync(join(root, ".output"));
+    git(["add", "-A"]);
+    git(["commit", "-m", "init"]);
+
+    const observed = await observe(root, () => {
+      for (let i = 0; i < 15; i++) {
+        writeFileSync(join(root, ".output", `chunk-${i}.js`), `build output ${i}\n`);
+      }
+    });
+
+    expect(observed.changes).toBe(0);
+    // The file browser must still learn about the writes (#11330).
+    expect(observed.fileSignals).toBeGreaterThan(0);
+  });
+
+  it("refreshes for a tracked write in the same shape", async () => {
+    const { root, git } = makeRepo();
+    writeFileSync(join(root, ".gitignore"), ".output/\n");
+    writeFileSync(join(root, "src.txt"), "committed\n");
+    mkdirSync(join(root, ".output"));
+    git(["add", "-A"]);
+    git(["commit", "-m", "init"]);
+
+    const observed = await observe(root, () => {
+      writeFileSync(join(root, "src.txt"), "modified\n");
+    });
+
+    expect(observed.changes).toBeGreaterThan(0);
+  });
+
+  it("refreshes for an edit to a .gitignore that ignores itself", async () => {
+    const { root, git } = makeRepo();
+    // Ignoring itself makes `.gitignore` untracked AND ignored, so plain
+    // check-ignore reports it — the burst would classify as skippable on
+    // membership alone while the rule change it carries alters status.
+    writeFileSync(join(root, ".gitignore"), ".gitignore\n.output/\n");
+    writeFileSync(join(root, "scratch.txt"), "visible\n");
+    mkdirSync(join(root, ".output"));
+    git(["add", "scratch.txt"]);
+    git(["commit", "-m", "init"]);
+
+    const observed = await observe(root, () => {
+      appendFileSync(join(root, ".gitignore"), "scratch.txt\n");
+    });
+
+    expect(observed.changes).toBeGreaterThan(0);
+  });
+
+  it("refreshes for a modified tracked file whose on-disk case left the index behind", async () => {
+    const { root, git } = makeRepo();
+    writeFileSync(join(root, ".gitignore"), ".output/\n");
+    mkdirSync(join(root, ".output"));
+    writeFileSync(join(root, ".output", "Keep.txt"), "v1\n");
+    git(["add", ".gitignore"]);
+    git(["add", "-f", ".output/Keep.txt"]);
+    git(["commit", "-m", "init"]);
+    // Case-only rename through a temp name so it works on case-insensitive
+    // filesystems too. The index keeps saying `Keep.txt`.
+    renameSync(join(root, ".output", "Keep.txt"), join(root, ".output", "tmp-rename"));
+    renameSync(join(root, ".output", "tmp-rename"), join(root, ".output", "keep.txt"));
+
+    const observed = await observe(root, () => {
+      writeFileSync(join(root, ".output", "keep.txt"), "v2 modified\n");
+    });
+
+    // On a case-insensitive filesystem check-ignore calls this path ignored
+    // even though it is tracked and modified; the tracked-ignored guard is
+    // what keeps the refresh happening. On a case-sensitive filesystem the
+    // file is genuinely untracked-and-ignored, but the guard still fires
+    // because `.output/Keep.txt` remains a tracked path matching an ignore
+    // rule — so the expectation holds on both.
+    expect(observed.changes).toBeGreaterThan(0);
+  });
+});

--- a/electron/utils/__tests__/gitFileWatcher.ignoreClassification.integration.test.ts
+++ b/electron/utils/__tests__/gitFileWatcher.ignoreClassification.integration.test.ts
@@ -35,6 +35,15 @@ const GIT_ENV = {
 const roots: string[] = [];
 const watchers: GitFileWatcher[] = [];
 
+/** Porcelain status, so a test can prove a rule edit changed what git reports. */
+function status(root: string): string {
+  return execFileSync("git", ["status", "--porcelain"], {
+    cwd: root,
+    encoding: "utf8",
+    env: GIT_ENV,
+  });
+}
+
 function makeRepo(): { root: string; git: (args: string[]) => void } {
   const root = mkdtempSync(join(tmpdir(), "daintree-ignore-"));
   roots.push(root);
@@ -126,16 +135,25 @@ describe("worktree burst ignore classification against real git", () => {
     // check-ignore reports it — the burst would classify as skippable on
     // membership alone while the rule change it carries alters status.
     writeFileSync(join(root, ".gitignore"), ".gitignore\n.output/\n");
-    writeFileSync(join(root, "scratch.txt"), "visible\n");
+    writeFileSync(join(root, "seed.txt"), "committed\n");
+    // `scratch.txt` stays UNTRACKED on purpose. Committing it and then
+    // ignoring it would leave it in status either way AND create a
+    // tracked/ignored overlap, which trips the hazard probe — so the test
+    // would still pass with the `.gitignore` guard deleted, proving nothing.
+    writeFileSync(join(root, "scratch.txt"), "untracked and visible\n");
     mkdirSync(join(root, ".output"));
-    git(["add", "scratch.txt"]);
+    git(["add", "seed.txt"]);
     git(["commit", "-m", "init"]);
+    expect(status(root)).toContain("scratch.txt");
 
     const observed = await observe(root, () => {
       appendFileSync(join(root, ".gitignore"), "scratch.txt\n");
     });
 
     expect(observed.changes).toBeGreaterThan(0);
+    // The rule edit really did change what status reports — otherwise the
+    // refresh would be guarding nothing.
+    expect(status(root)).not.toContain("scratch.txt");
   });
 
   it("refreshes for a modified tracked file whose on-disk case left the index behind", async () => {

--- a/electron/utils/__tests__/gitFileWatcher.test.ts
+++ b/electron/utils/__tests__/gitFileWatcher.test.ts
@@ -2062,6 +2062,54 @@ describe("GitFileWatcher", () => {
       expect(checkIgnoredPaths).not.toHaveBeenCalled();
     });
 
+    it.each([".gitattributes", ".gitmodules", ".GITIGNORE"])(
+      "refreshes for a %s write",
+      async (name) => {
+        const onChange = vi.fn();
+        // `.gitattributes` changes normalisation, so it decides whether a CRLF
+        // working file still compares equal to its LF blob; `.gitmodules`
+        // carries submodule.<name>.ignore. Both change what status reports
+        // about OTHER paths. The name is matched case-insensitively because on
+        // APFS or NTFS `.GITIGNORE` is the same file to git.
+        vi.mocked(checkIgnoredPaths).mockResolvedValue(new Set([p(name)]));
+
+        const { cb } = await startClassifyingWatcher({ onChange });
+        fireEvents(cb, [{ type: "update", path: p(name) }]);
+        await vi.advanceTimersByTimeAsync(100);
+        expect(onChange).toHaveBeenCalledTimes(1);
+        expect(checkIgnoredPaths).not.toHaveBeenCalled();
+      }
+    );
+
+    it("drops the cached tracked-ignored answer when a .gitignore is written", async () => {
+      const onChange = vi.fn();
+      vi.mocked(checkIgnoredPaths).mockResolvedValue(new Set([IGNORED_A]));
+      const { cb } = await startClassifyingWatcher({ onChange });
+
+      // Warm the probe to "no hazard" through a normal skippable burst.
+      fireEvents(cb, [{ type: "create", path: IGNORED_A }]);
+      await vi.advanceTimersByTimeAsync(100);
+      await flushClassification();
+      expect(onChange).not.toHaveBeenCalled();
+      expect(hasTrackedIgnoredPaths).toHaveBeenCalledTimes(1);
+
+      // A rule edit can newly ignore a directory holding a tracked file, which
+      // creates the hazard the cached answer denies — and it reaches no
+      // watched git-internal file, so nothing else would invalidate it.
+      fireEvents(cb, [{ type: "update", path: p(".gitignore") }]);
+      await vi.advanceTimersByTimeAsync(100);
+      vi.mocked(hasTrackedIgnoredPaths).mockResolvedValue(true);
+
+      // Same skippable shape as the first burst, so the flow reaches the
+      // probe again rather than short-circuiting on membership.
+      onChange.mockClear();
+      fireEvents(cb, [{ type: "create", path: IGNORED_A }]);
+      await vi.advanceTimersByTimeAsync(100);
+      await flushClassification();
+      expect(hasTrackedIgnoredPaths).toHaveBeenCalledTimes(2);
+      expect(onChange).toHaveBeenCalledTimes(1);
+    });
+
     it("refreshes for a nested .gitignore write", async () => {
       const onChange = vi.fn();
       const { cb } = await startClassifyingWatcher({ onChange });

--- a/electron/utils/__tests__/gitFileWatcher.test.ts
+++ b/electron/utils/__tests__/gitFileWatcher.test.ts
@@ -1,12 +1,21 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { watch, type FSWatcher } from "fs";
-import { readFile } from "fs/promises";
+import { readFile, realpath } from "fs/promises";
 import { join as pathJoin } from "path";
 import { getGitDir } from "../gitUtils.js";
+import { checkIgnoredPaths } from "../gitCheckIgnore.js";
 import { GitFileWatcher } from "../gitFileWatcher.js";
 import { settleParcelWatcherLifecycle } from "../parcelWatcherBackend.js";
 
 const { subscribeMock } = vi.hoisted(() => ({ subscribeMock: vi.fn() }));
+
+/**
+ * The slice of `@parcel/watcher`'s Event the watcher reads. `path` is optional
+ * here on purpose: most tests only exercise debounce timing and pass `{ type }`
+ * alone, which the watcher must treat as an unclassifiable burst and refresh
+ * for — the conservative default the ignore classification is built on.
+ */
+type WatcherEvent = { type: string; path?: string };
 
 vi.mock("../parcelWatcherBackend.js", () => ({
   subscribeParcelWatcher: subscribeMock,
@@ -19,6 +28,7 @@ vi.mock("fs", () => ({
 
 vi.mock("fs/promises", () => ({
   readFile: vi.fn(),
+  realpath: vi.fn(),
 }));
 
 vi.mock("../gitUtils.js", () => ({
@@ -27,6 +37,10 @@ vi.mock("../gitUtils.js", () => ({
 
 vi.mock("../logger.js", () => ({
   logWarn: vi.fn(),
+}));
+
+vi.mock("../gitCheckIgnore.js", () => ({
+  checkIgnoredPaths: vi.fn(),
 }));
 
 function createMockWatcher() {
@@ -46,7 +60,7 @@ function createMockSubscription(): { unsubscribe: () => Promise<void> } {
  * subscribe promise and access the captured callback.
  */
 function setupSubscribeMock() {
-  let capturedCallback: ((err: Error | null, events: Array<{ type: string }>) => void) | undefined;
+  let capturedCallback: ((err: Error | null, events: Array<WatcherEvent>) => void) | undefined;
   let capturedOptions: Record<string, unknown> | undefined;
   let resolvePromise: ((sub: { unsubscribe: () => Promise<void> }) => void) | undefined;
   let rejectPromise: ((err: Error) => void) | undefined;
@@ -54,7 +68,7 @@ function setupSubscribeMock() {
   subscribeMock.mockImplementation(
     (
       _dir: string,
-      cb: (err: Error | null, events: Array<{ type: string }>) => void,
+      cb: (err: Error | null, events: Array<WatcherEvent>) => void,
       opts?: Record<string, unknown>
     ) => {
       capturedCallback = cb;
@@ -89,15 +103,15 @@ function setupSubscribeMock() {
 
 /** Fire synthetic events through the captured parcel file watcher callback. */
 function fireEvents(
-  cb: ((err: Error | null, events: Array<{ type: string }>) => void) | undefined,
-  events: Array<{ type: string }>
+  cb: ((err: Error | null, events: Array<WatcherEvent>) => void) | undefined,
+  events: Array<WatcherEvent>
 ) {
   cb?.(null, events);
 }
 
 /** Fire a synthetic error through the captured parcel file watcher callback. */
 function fireError(
-  cb: ((err: Error | null, events: Array<{ type: string }>) => void) | undefined,
+  cb: ((err: Error | null, events: Array<WatcherEvent>) => void) | undefined,
   err: Error
 ) {
   cb?.(err, []);
@@ -110,6 +124,21 @@ async function flushParcelWatcherCallbacks(): Promise<void> {
   await Promise.resolve();
 }
 
+/**
+ * Drain the promise chain a classified flush starts.
+ *
+ * Advancing fake timers runs the debounce callback, but the flush then hands
+ * off to `checkIgnoredPaths` and decides in a `.then`. Timer advancement does
+ * not settle that chain, so a test asserting on `onChange` after a burst with
+ * real paths has to drain the microtask queue explicitly. Kept separate from
+ * `flushParcelWatcherCallbacks`, which is about subscription lifecycle.
+ */
+async function flushClassification(): Promise<void> {
+  for (let i = 0; i < 5; i++) {
+    await Promise.resolve();
+  }
+}
+
 describe("GitFileWatcher", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -117,6 +146,12 @@ describe("GitFileWatcher", () => {
 
     vi.mocked(getGitDir).mockResolvedValue(pathJoin("/repo", ".git"));
     vi.mocked(readFile).mockRejectedValue(new Error("commondir missing"));
+    // No symlink alias by default: the configured root IS the canonical one.
+    vi.mocked(realpath).mockImplementation(((p: string) => Promise.resolve(p)) as never);
+    // Default classification: nothing is ignored, so every classified burst
+    // refreshes. `clearAllMocks` resets calls but not implementations, so the
+    // implementation is (re)installed here rather than once at module scope.
+    vi.mocked(checkIgnoredPaths).mockResolvedValue(new Set());
     vi.mocked(watch).mockImplementation(() => createMockWatcher());
     // Default subscribe: resolve immediately so non-worktree tests don't hang
     subscribeMock.mockResolvedValue(createMockSubscription());
@@ -1658,6 +1693,362 @@ describe("GitFileWatcher", () => {
   });
 
   // ---- Ignore filter tests ----
+
+  // ---- Ignored-burst classification (#12235) ----
+
+  describe("worktree burst ignore classification", () => {
+    /** Start a watcher whose worktree bursts are eligible for classification. */
+    async function startClassifyingWatcher(overrides: {
+      onChange: () => void;
+      onWorktreeFilesChanged?: () => void;
+    }) {
+      const mock = setupSubscribeMock();
+      const gitWatcher = new GitFileWatcher({
+        worktreePath: "/repo",
+        branch: "main",
+        debounceMs: 300,
+        watchWorktree: true,
+        worktreeMinDebounceMs: 100,
+        worktreeMaxDebounceMs: 100,
+        ...overrides,
+      });
+      await expect(gitWatcher.start()).resolves.toBe(true);
+      mock.resolve();
+      await flushParcelWatcherCallbacks();
+      return { gitWatcher, cb: mock.getCallback() };
+    }
+
+    it("skips the status recompute when every path in the burst is ignored and untracked", async () => {
+      const onChange = vi.fn();
+      const onWorktreeFilesChanged = vi.fn();
+      vi.mocked(checkIgnoredPaths).mockResolvedValue(
+        new Set(["/repo/.output/a.js", "/repo/.output/b.js"])
+      );
+
+      const { cb } = await startClassifyingWatcher({ onChange, onWorktreeFilesChanged });
+      fireEvents(cb, [
+        { type: "create", path: "/repo/.output/a.js" },
+        { type: "update", path: "/repo/.output/b.js" },
+      ]);
+      await vi.advanceTimersByTimeAsync(100);
+      // The file browser's signal is never gated on the classification: it
+      // fires at the flush boundary, before the verdict exists (#11330).
+      expect(onWorktreeFilesChanged).toHaveBeenCalledTimes(1);
+      expect(onChange).not.toHaveBeenCalled();
+
+      await flushClassification();
+      expect(onChange).not.toHaveBeenCalled();
+      expect(onWorktreeFilesChanged).toHaveBeenCalledTimes(1);
+
+      expect(checkIgnoredPaths).toHaveBeenCalledTimes(1);
+      const [cwd, paths] = vi.mocked(checkIgnoredPaths).mock.calls[0];
+      expect(cwd).toBe("/repo");
+      expect([...paths].sort()).toEqual(["/repo/.output/a.js", "/repo/.output/b.js"]);
+    });
+
+    it("refreshes when one path in the burst is not ignored", async () => {
+      const onChange = vi.fn();
+      // Mixed bursts exit 0 too, so the exit code cannot be the test —
+      // membership is. `src/main.ts` is absent from the ignored set.
+      vi.mocked(checkIgnoredPaths).mockResolvedValue(new Set(["/repo/.output/a.js"]));
+
+      const { cb } = await startClassifyingWatcher({ onChange });
+      fireEvents(cb, [
+        { type: "create", path: "/repo/.output/a.js" },
+        { type: "update", path: "/repo/src/main.ts" },
+      ]);
+      await vi.advanceTimersByTimeAsync(100);
+      await flushClassification();
+      expect(onChange).toHaveBeenCalledTimes(1);
+    });
+
+    it("refreshes for a tracked file that matches an ignore rule", async () => {
+      const onChange = vi.fn();
+      // Plain `git check-ignore` never reports a tracked path, so a
+      // tracked-but-matching file is simply absent from the result set — the
+      // whole reason no separate index lookup is needed.
+      vi.mocked(checkIgnoredPaths).mockResolvedValue(new Set());
+
+      const { cb } = await startClassifyingWatcher({ onChange });
+      fireEvents(cb, [{ type: "update", path: "/repo/build/tracked.log" }]);
+      await vi.advanceTimersByTimeAsync(100);
+      await flushClassification();
+      expect(onChange).toHaveBeenCalledTimes(1);
+    });
+
+    it("refreshes when the burst edits .gitignore alongside ignored writes", async () => {
+      const onChange = vi.fn();
+      // Nothing ignores `.gitignore`, so it fails membership on its own. No
+      // filename special-case is involved.
+      vi.mocked(checkIgnoredPaths).mockResolvedValue(new Set(["/repo/.output/a.js"]));
+
+      const { cb } = await startClassifyingWatcher({ onChange });
+      fireEvents(cb, [
+        { type: "update", path: "/repo/.output/a.js" },
+        { type: "update", path: "/repo/.gitignore" },
+      ]);
+      await vi.advanceTimersByTimeAsync(100);
+      await flushClassification();
+      expect(onChange).toHaveBeenCalledTimes(1);
+    });
+
+    it("refreshes without classifying when an event carries no path", async () => {
+      const onChange = vi.fn();
+      const { cb } = await startClassifyingWatcher({ onChange });
+
+      fireEvents(cb, [{ type: "update", path: "/repo/.output/a.js" }, { type: "update" }]);
+      await vi.advanceTimersByTimeAsync(100);
+      // Unknown is sticky for the whole burst and resolved synchronously, so
+      // onChange lands without waiting on a classification that never runs.
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(checkIgnoredPaths).not.toHaveBeenCalled();
+    });
+
+    it("refreshes without classifying for a path outside the worktree", async () => {
+      const onChange = vi.fn();
+      const { cb } = await startClassifyingWatcher({ onChange });
+
+      // `/repo-other` must not read as living under `/repo`, and the watch
+      // root itself is the Windows "unknown filename" signal.
+      fireEvents(cb, [{ type: "update", path: "/repo-other/a.js" }]);
+      await vi.advanceTimersByTimeAsync(100);
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(checkIgnoredPaths).not.toHaveBeenCalled();
+
+      onChange.mockClear();
+      fireEvents(cb, [{ type: "update", path: "/repo" }]);
+      await vi.advanceTimersByTimeAsync(100);
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(checkIgnoredPaths).not.toHaveBeenCalled();
+    });
+
+    it("classifies paths reported under the worktree's canonical alias", async () => {
+      // macOS FSEvents reports realpath'd paths, so a worktree reached through
+      // a symlinked ancestor emits events under /private/var while the
+      // configured root is /var. Without the alias the optimisation would
+      // never fire on any temp-dir worktree.
+      vi.mocked(realpath).mockResolvedValue("/private/var/wt" as never);
+      vi.mocked(getGitDir).mockResolvedValue(pathJoin("/var/wt", ".git"));
+      vi.mocked(checkIgnoredPaths).mockResolvedValue(new Set(["/private/var/wt/.output/a.js"]));
+      const onChange = vi.fn();
+      const mock = setupSubscribeMock();
+
+      const gitWatcher = new GitFileWatcher({
+        worktreePath: "/var/wt",
+        branch: "main",
+        debounceMs: 300,
+        onChange,
+        watchWorktree: true,
+        worktreeMinDebounceMs: 100,
+        worktreeMaxDebounceMs: 100,
+      });
+      await expect(gitWatcher.start()).resolves.toBe(true);
+      mock.resolve();
+      await flushParcelWatcherCallbacks();
+
+      fireEvents(mock.getCallback(), [
+        { type: "create", path: "/private/var/wt/.output/a.js" },
+      ]);
+      await vi.advanceTimersByTimeAsync(100);
+      await flushClassification();
+      expect(onChange).not.toHaveBeenCalled();
+      // cwd stays the configured root; git resolves it itself.
+      expect(vi.mocked(checkIgnoredPaths).mock.calls[0][0]).toBe("/var/wt");
+    });
+
+    it("degrades to a full refresh past the burst path cap", async () => {
+      const onChange = vi.fn();
+      const { cb } = await startClassifyingWatcher({ onChange });
+
+      // 2049 unique paths: one past the cap. Retaining more buys nothing —
+      // a burst that large is never going to be ignored-only.
+      fireEvents(
+        cb,
+        Array.from({ length: 2049 }, (_, i) => ({
+          type: "create",
+          path: `/repo/.output/f-${i}.js`,
+        }))
+      );
+      await vi.advanceTimersByTimeAsync(100);
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(checkIgnoredPaths).not.toHaveBeenCalled();
+    });
+
+    it("classifies a burst sitting exactly on the cap", async () => {
+      vi.mocked(checkIgnoredPaths).mockImplementation(
+        (_cwd, paths) => Promise.resolve(new Set(paths)) as never
+      );
+      const onChange = vi.fn();
+      const { cb } = await startClassifyingWatcher({ onChange });
+
+      fireEvents(
+        cb,
+        Array.from({ length: 2048 }, (_, i) => ({
+          type: "create",
+          path: `/repo/.output/f-${i}.js`,
+        }))
+      );
+      await vi.advanceTimersByTimeAsync(100);
+      await flushClassification();
+      expect(onChange).not.toHaveBeenCalled();
+      expect(vi.mocked(checkIgnoredPaths).mock.calls[0][1]).toHaveLength(2048);
+    });
+
+    it("unions paths across batches and starts the next burst clean", async () => {
+      vi.mocked(checkIgnoredPaths).mockResolvedValue(new Set(["/repo/.output/a.js"]));
+      const onChange = vi.fn();
+      const { cb } = await startClassifyingWatcher({ onChange });
+
+      fireEvents(cb, [{ type: "create", path: "/repo/.output/a.js" }]);
+      fireEvents(cb, [{ type: "update", path: "/repo/.output/a.js" }]);
+      fireEvents(cb, [{ type: "update", path: "/repo/src/main.ts" }]);
+      await vi.advanceTimersByTimeAsync(100);
+      await flushClassification();
+      // Deduplicated union of all three batches, and the un-ignored member
+      // forces the refresh.
+      expect(vi.mocked(checkIgnoredPaths).mock.calls[0][1]).toHaveLength(2);
+      expect(onChange).toHaveBeenCalledTimes(1);
+
+      // The second burst must not inherit the first burst's paths.
+      onChange.mockClear();
+      vi.mocked(checkIgnoredPaths).mockClear();
+      fireEvents(cb, [{ type: "update", path: "/repo/.output/a.js" }]);
+      await vi.advanceTimersByTimeAsync(100);
+      await flushClassification();
+      expect(vi.mocked(checkIgnoredPaths).mock.calls[0][1]).toEqual(["/repo/.output/a.js"]);
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it("refreshes when the watcher reports a rescan overflow", async () => {
+      const onChange = vi.fn();
+      const onWorktreeFilesChanged = vi.fn();
+      const { cb } = await startClassifyingWatcher({ onChange, onWorktreeFilesChanged });
+
+      // Events were LOST, so the burst's paths are unknowable even though the
+      // batch that follows may look ignored-only.
+      fireEvents(cb, [{ type: "create", path: "/repo/.output/a.js" }]);
+      fireError(cb, new Error("Events were dropped and must be re-scanned"));
+      await vi.advanceTimersByTimeAsync(100);
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onWorktreeFilesChanged).toHaveBeenCalledTimes(1);
+      expect(checkIgnoredPaths).not.toHaveBeenCalled();
+    });
+
+    it("refreshes when the classification fails", async () => {
+      const onChange = vi.fn();
+      vi.mocked(checkIgnoredPaths).mockRejectedValue(new Error("exit 128: outside repository"));
+
+      const { cb } = await startClassifyingWatcher({ onChange });
+      fireEvents(cb, [{ type: "create", path: "/repo/.output/a.js" }]);
+      await vi.advanceTimersByTimeAsync(100);
+      await flushClassification();
+      expect(onChange).toHaveBeenCalledTimes(1);
+    });
+
+    it("refreshes for both bursts when a new flush supersedes a pending classification", async () => {
+      const onChange = vi.fn();
+      let releaseFirst: ((ignored: Set<string>) => void) | undefined;
+      vi.mocked(checkIgnoredPaths)
+        .mockImplementationOnce(
+          () =>
+            new Promise<Set<string>>((resolve) => {
+              releaseFirst = resolve;
+            }) as never
+        )
+        .mockResolvedValue(new Set(["/repo/.output/b.js"]));
+
+      const { cb } = await startClassifyingWatcher({ onChange });
+      fireEvents(cb, [{ type: "create", path: "/repo/.output/a.js" }]);
+      await vi.advanceTimersByTimeAsync(100);
+      expect(onChange).not.toHaveBeenCalled();
+
+      // A second flush arrives while the first verdict is still pending. The
+      // first burst's refresh was never fired and its decision is now lost, so
+      // the flush that supersedes it must refresh for both rather than
+      // classify itself.
+      fireEvents(cb, [{ type: "create", path: "/repo/.output/b.js" }]);
+      await vi.advanceTimersByTimeAsync(100);
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(checkIgnoredPaths).toHaveBeenCalledTimes(1);
+
+      // The retired verdict must not fire a second, duplicate refresh.
+      releaseFirst?.(new Set(["/repo/.output/a.js"]));
+      await flushClassification();
+      expect(onChange).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not refresh from a classification that lands after dispose", async () => {
+      const onChange = vi.fn();
+      let release: ((ignored: Set<string>) => void) | undefined;
+      vi.mocked(checkIgnoredPaths).mockImplementation(
+        () =>
+          new Promise<Set<string>>((resolve) => {
+            release = resolve;
+          }) as never
+      );
+
+      const { gitWatcher, cb } = await startClassifyingWatcher({ onChange });
+      fireEvents(cb, [{ type: "update", path: "/repo/src/main.ts" }]);
+      await vi.advanceTimersByTimeAsync(100);
+      expect(onChange).not.toHaveBeenCalled();
+
+      gitWatcher.dispose();
+      release?.(new Set());
+      await flushClassification();
+      expect(onChange).not.toHaveBeenCalled();
+      await flushParcelWatcherCallbacks();
+    });
+
+    it("aborts the in-flight classification on dispose", async () => {
+      let captured: AbortSignal | undefined;
+      vi.mocked(checkIgnoredPaths).mockImplementation(((
+        _cwd: string,
+        _paths: readonly string[],
+        options?: { signal?: AbortSignal }
+      ) => {
+        captured = options?.signal;
+        return new Promise<Set<string>>(() => {});
+      }) as never);
+
+      const { gitWatcher, cb } = await startClassifyingWatcher({ onChange: vi.fn() });
+      fireEvents(cb, [{ type: "update", path: "/repo/src/main.ts" }]);
+      await vi.advanceTimersByTimeAsync(100);
+      expect(captured?.aborted).toBe(false);
+
+      gitWatcher.dispose();
+      expect(captured?.aborted).toBe(true);
+      await flushParcelWatcherCallbacks();
+    });
+
+    it("keeps the adaptive debounce ramp driven by raw event count", async () => {
+      const onChange = vi.fn();
+      const mock = setupSubscribeMock();
+      const gitWatcher = new GitFileWatcher({
+        worktreePath: "/repo",
+        branch: "main",
+        debounceMs: 300,
+        onChange,
+        watchWorktree: true,
+        worktreeMinDebounceMs: 150,
+        worktreeMaxDebounceMs: 800,
+      });
+      await expect(gitWatcher.start()).resolves.toBe(true);
+      mock.resolve();
+      await flushParcelWatcherCallbacks();
+
+      // Ten events on ONE path: the ramp counts events, not unique paths, so
+      // carrying a deduplicated set must not shorten the delay.
+      fireEvents(
+        mock.getCallback(),
+        Array.from({ length: 10 }, () => ({ type: "update", path: "/repo/.output/a.js" }))
+      );
+      await vi.advanceTimersByTimeAsync(150);
+      expect(onChange).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(90);
+      await flushClassification();
+      expect(onChange).toHaveBeenCalledTimes(1);
+    });
+  });
 
   describe("worktree ignore filter", () => {
     it("passes WORKTREE_IGNORE_GLOBS to subscribe as native ignore option", async () => {

--- a/electron/utils/__tests__/gitFileWatcher.test.ts
+++ b/electron/utils/__tests__/gitFileWatcher.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { watch, type FSWatcher } from "fs";
 import { readFile, realpath } from "fs/promises";
-import { join as pathJoin } from "path";
+import { join as pathJoin, resolve as pathResolve } from "path";
 import { getGitDir } from "../gitUtils.js";
-import { checkIgnoredPaths } from "../gitCheckIgnore.js";
+import { logWarn } from "../logger.js";
+import { checkIgnoredPaths, hasTrackedIgnoredPaths } from "../gitCheckIgnore.js";
 import { GitFileWatcher } from "../gitFileWatcher.js";
 import { settleParcelWatcherLifecycle } from "../parcelWatcherBackend.js";
 
@@ -41,6 +42,7 @@ vi.mock("../logger.js", () => ({
 
 vi.mock("../gitCheckIgnore.js", () => ({
   checkIgnoredPaths: vi.fn(),
+  hasTrackedIgnoredPaths: vi.fn(),
 }));
 
 function createMockWatcher() {
@@ -152,6 +154,9 @@ describe("GitFileWatcher", () => {
     // refreshes. `clearAllMocks` resets calls but not implementations, so the
     // implementation is (re)installed here rather than once at module scope.
     vi.mocked(checkIgnoredPaths).mockResolvedValue(new Set());
+    // No tracked file matches an ignore rule — the state of essentially every
+    // repo, and the precondition that makes check-ignore's answer trustworthy.
+    vi.mocked(hasTrackedIgnoredPaths).mockResolvedValue(false);
     vi.mocked(watch).mockImplementation(() => createMockWatcher());
     // Default subscribe: resolve immediately so non-worktree tests don't hang
     subscribeMock.mockResolvedValue(createMockSubscription());
@@ -1697,6 +1702,19 @@ describe("GitFileWatcher", () => {
   // ---- Ignored-burst classification (#12235) ----
 
   describe("worktree burst ignore classification", () => {
+    // Native separators throughout: containment builds its prefix with the
+    // platform separator, so POSIX literals would make every event on Windows
+    // fall out as "outside the worktree" and the tests would pass through the
+    // unknown branch instead of exercising classification at all.
+    const REPO = pathResolve("/repo");
+    const p = (...parts: string[]) => pathJoin(REPO, ...parts);
+    const IGNORED_A = p(".output", "a.js");
+    const IGNORED_B = p(".output", "b.js");
+    const TRACKED = p("src", "main.ts");
+    const VAR_WT = pathResolve("/var/wt");
+    const PRIVATE_VAR_WT = pathResolve("/private/var/wt");
+    const ALIASED_A = pathJoin(PRIVATE_VAR_WT, ".output", "a.js");
+
     /** Start a watcher whose worktree bursts are eligible for classification. */
     async function startClassifyingWatcher(overrides: {
       onChange: () => void;
@@ -1704,7 +1722,7 @@ describe("GitFileWatcher", () => {
     }) {
       const mock = setupSubscribeMock();
       const gitWatcher = new GitFileWatcher({
-        worktreePath: "/repo",
+        worktreePath: REPO,
         branch: "main",
         debounceMs: 300,
         watchWorktree: true,
@@ -1722,13 +1740,13 @@ describe("GitFileWatcher", () => {
       const onChange = vi.fn();
       const onWorktreeFilesChanged = vi.fn();
       vi.mocked(checkIgnoredPaths).mockResolvedValue(
-        new Set(["/repo/.output/a.js", "/repo/.output/b.js"])
+        new Set([IGNORED_A, IGNORED_B])
       );
 
       const { cb } = await startClassifyingWatcher({ onChange, onWorktreeFilesChanged });
       fireEvents(cb, [
-        { type: "create", path: "/repo/.output/a.js" },
-        { type: "update", path: "/repo/.output/b.js" },
+        { type: "create", path: IGNORED_A },
+        { type: "update", path: IGNORED_B },
       ]);
       await vi.advanceTimersByTimeAsync(100);
       // The file browser's signal is never gated on the classification: it
@@ -1742,20 +1760,20 @@ describe("GitFileWatcher", () => {
 
       expect(checkIgnoredPaths).toHaveBeenCalledTimes(1);
       const [cwd, paths] = vi.mocked(checkIgnoredPaths).mock.calls[0];
-      expect(cwd).toBe("/repo");
-      expect([...paths].sort()).toEqual(["/repo/.output/a.js", "/repo/.output/b.js"]);
+      expect(cwd).toBe(REPO);
+      expect([...paths].sort()).toEqual([IGNORED_A, IGNORED_B]);
     });
 
     it("refreshes when one path in the burst is not ignored", async () => {
       const onChange = vi.fn();
       // Mixed bursts exit 0 too, so the exit code cannot be the test —
       // membership is. `src/main.ts` is absent from the ignored set.
-      vi.mocked(checkIgnoredPaths).mockResolvedValue(new Set(["/repo/.output/a.js"]));
+      vi.mocked(checkIgnoredPaths).mockResolvedValue(new Set([IGNORED_A]));
 
       const { cb } = await startClassifyingWatcher({ onChange });
       fireEvents(cb, [
-        { type: "create", path: "/repo/.output/a.js" },
-        { type: "update", path: "/repo/src/main.ts" },
+        { type: "create", path: IGNORED_A },
+        { type: "update", path: TRACKED },
       ]);
       await vi.advanceTimersByTimeAsync(100);
       await flushClassification();
@@ -1768,9 +1786,12 @@ describe("GitFileWatcher", () => {
       // tracked-but-matching file is simply absent from the result set — the
       // whole reason no separate index lookup is needed.
       vi.mocked(checkIgnoredPaths).mockResolvedValue(new Set());
+    // No tracked file matches an ignore rule — the state of essentially every
+    // repo, and the precondition that makes check-ignore's answer trustworthy.
+    vi.mocked(hasTrackedIgnoredPaths).mockResolvedValue(false);
 
       const { cb } = await startClassifyingWatcher({ onChange });
-      fireEvents(cb, [{ type: "update", path: "/repo/build/tracked.log" }]);
+      fireEvents(cb, [{ type: "update", path: p(".output", "tracked.log") }]);
       await vi.advanceTimersByTimeAsync(100);
       await flushClassification();
       expect(onChange).toHaveBeenCalledTimes(1);
@@ -1780,12 +1801,12 @@ describe("GitFileWatcher", () => {
       const onChange = vi.fn();
       // Nothing ignores `.gitignore`, so it fails membership on its own. No
       // filename special-case is involved.
-      vi.mocked(checkIgnoredPaths).mockResolvedValue(new Set(["/repo/.output/a.js"]));
+      vi.mocked(checkIgnoredPaths).mockResolvedValue(new Set([IGNORED_A]));
 
       const { cb } = await startClassifyingWatcher({ onChange });
       fireEvents(cb, [
-        { type: "update", path: "/repo/.output/a.js" },
-        { type: "update", path: "/repo/.gitignore" },
+        { type: "update", path: IGNORED_A },
+        { type: "update", path: p(".gitignore") },
       ]);
       await vi.advanceTimersByTimeAsync(100);
       await flushClassification();
@@ -1796,7 +1817,7 @@ describe("GitFileWatcher", () => {
       const onChange = vi.fn();
       const { cb } = await startClassifyingWatcher({ onChange });
 
-      fireEvents(cb, [{ type: "update", path: "/repo/.output/a.js" }, { type: "update" }]);
+      fireEvents(cb, [{ type: "update", path: IGNORED_A }, { type: "update" }]);
       await vi.advanceTimersByTimeAsync(100);
       // Unknown is sticky for the whole burst and resolved synchronously, so
       // onChange lands without waiting on a classification that never runs.
@@ -1810,13 +1831,13 @@ describe("GitFileWatcher", () => {
 
       // `/repo-other` must not read as living under `/repo`, and the watch
       // root itself is the Windows "unknown filename" signal.
-      fireEvents(cb, [{ type: "update", path: "/repo-other/a.js" }]);
+      fireEvents(cb, [{ type: "update", path: pathResolve("/repo-other/a.js") }]);
       await vi.advanceTimersByTimeAsync(100);
       expect(onChange).toHaveBeenCalledTimes(1);
       expect(checkIgnoredPaths).not.toHaveBeenCalled();
 
       onChange.mockClear();
-      fireEvents(cb, [{ type: "update", path: "/repo" }]);
+      fireEvents(cb, [{ type: "update", path: REPO }]);
       await vi.advanceTimersByTimeAsync(100);
       expect(onChange).toHaveBeenCalledTimes(1);
       expect(checkIgnoredPaths).not.toHaveBeenCalled();
@@ -1827,14 +1848,14 @@ describe("GitFileWatcher", () => {
       // a symlinked ancestor emits events under /private/var while the
       // configured root is /var. Without the alias the optimisation would
       // never fire on any temp-dir worktree.
-      vi.mocked(realpath).mockResolvedValue("/private/var/wt" as never);
-      vi.mocked(getGitDir).mockResolvedValue(pathJoin("/var/wt", ".git"));
-      vi.mocked(checkIgnoredPaths).mockResolvedValue(new Set(["/private/var/wt/.output/a.js"]));
+      vi.mocked(realpath).mockResolvedValue(PRIVATE_VAR_WT as never);
+      vi.mocked(getGitDir).mockResolvedValue(pathJoin(VAR_WT, ".git"));
+      vi.mocked(checkIgnoredPaths).mockResolvedValue(new Set([ALIASED_A]));
       const onChange = vi.fn();
       const mock = setupSubscribeMock();
 
       const gitWatcher = new GitFileWatcher({
-        worktreePath: "/var/wt",
+        worktreePath: VAR_WT,
         branch: "main",
         debounceMs: 300,
         onChange,
@@ -1847,13 +1868,13 @@ describe("GitFileWatcher", () => {
       await flushParcelWatcherCallbacks();
 
       fireEvents(mock.getCallback(), [
-        { type: "create", path: "/private/var/wt/.output/a.js" },
+        { type: "create", path: ALIASED_A },
       ]);
       await vi.advanceTimersByTimeAsync(100);
       await flushClassification();
       expect(onChange).not.toHaveBeenCalled();
       // cwd stays the configured root; git resolves it itself.
-      expect(vi.mocked(checkIgnoredPaths).mock.calls[0][0]).toBe("/var/wt");
+      expect(vi.mocked(checkIgnoredPaths).mock.calls[0][0]).toBe(VAR_WT);
     });
 
     it("degrades to a full refresh past the burst path cap", async () => {
@@ -1866,7 +1887,7 @@ describe("GitFileWatcher", () => {
         cb,
         Array.from({ length: 2049 }, (_, i) => ({
           type: "create",
-          path: `/repo/.output/f-${i}.js`,
+          path: p(".output", `f-${i}.js`),
         }))
       );
       await vi.advanceTimersByTimeAsync(100);
@@ -1885,7 +1906,7 @@ describe("GitFileWatcher", () => {
         cb,
         Array.from({ length: 2048 }, (_, i) => ({
           type: "create",
-          path: `/repo/.output/f-${i}.js`,
+          path: p(".output", `f-${i}.js`),
         }))
       );
       await vi.advanceTimersByTimeAsync(100);
@@ -1895,13 +1916,13 @@ describe("GitFileWatcher", () => {
     });
 
     it("unions paths across batches and starts the next burst clean", async () => {
-      vi.mocked(checkIgnoredPaths).mockResolvedValue(new Set(["/repo/.output/a.js"]));
+      vi.mocked(checkIgnoredPaths).mockResolvedValue(new Set([IGNORED_A]));
       const onChange = vi.fn();
       const { cb } = await startClassifyingWatcher({ onChange });
 
-      fireEvents(cb, [{ type: "create", path: "/repo/.output/a.js" }]);
-      fireEvents(cb, [{ type: "update", path: "/repo/.output/a.js" }]);
-      fireEvents(cb, [{ type: "update", path: "/repo/src/main.ts" }]);
+      fireEvents(cb, [{ type: "create", path: IGNORED_A }]);
+      fireEvents(cb, [{ type: "update", path: IGNORED_A }]);
+      fireEvents(cb, [{ type: "update", path: TRACKED }]);
       await vi.advanceTimersByTimeAsync(100);
       await flushClassification();
       // Deduplicated union of all three batches, and the un-ignored member
@@ -1912,10 +1933,10 @@ describe("GitFileWatcher", () => {
       // The second burst must not inherit the first burst's paths.
       onChange.mockClear();
       vi.mocked(checkIgnoredPaths).mockClear();
-      fireEvents(cb, [{ type: "update", path: "/repo/.output/a.js" }]);
+      fireEvents(cb, [{ type: "update", path: IGNORED_A }]);
       await vi.advanceTimersByTimeAsync(100);
       await flushClassification();
-      expect(vi.mocked(checkIgnoredPaths).mock.calls[0][1]).toEqual(["/repo/.output/a.js"]);
+      expect(vi.mocked(checkIgnoredPaths).mock.calls[0][1]).toEqual([IGNORED_A]);
       expect(onChange).not.toHaveBeenCalled();
     });
 
@@ -1926,7 +1947,7 @@ describe("GitFileWatcher", () => {
 
       // Events were LOST, so the burst's paths are unknowable even though the
       // batch that follows may look ignored-only.
-      fireEvents(cb, [{ type: "create", path: "/repo/.output/a.js" }]);
+      fireEvents(cb, [{ type: "create", path: IGNORED_A }]);
       fireError(cb, new Error("Events were dropped and must be re-scanned"));
       await vi.advanceTimersByTimeAsync(100);
       expect(onChange).toHaveBeenCalledTimes(1);
@@ -1939,7 +1960,7 @@ describe("GitFileWatcher", () => {
       vi.mocked(checkIgnoredPaths).mockRejectedValue(new Error("exit 128: outside repository"));
 
       const { cb } = await startClassifyingWatcher({ onChange });
-      fireEvents(cb, [{ type: "create", path: "/repo/.output/a.js" }]);
+      fireEvents(cb, [{ type: "create", path: IGNORED_A }]);
       await vi.advanceTimersByTimeAsync(100);
       await flushClassification();
       expect(onChange).toHaveBeenCalledTimes(1);
@@ -1955,10 +1976,10 @@ describe("GitFileWatcher", () => {
               releaseFirst = resolve;
             }) as never
         )
-        .mockResolvedValue(new Set(["/repo/.output/b.js"]));
+        .mockResolvedValue(new Set([IGNORED_B]));
 
       const { cb } = await startClassifyingWatcher({ onChange });
-      fireEvents(cb, [{ type: "create", path: "/repo/.output/a.js" }]);
+      fireEvents(cb, [{ type: "create", path: IGNORED_A }]);
       await vi.advanceTimersByTimeAsync(100);
       expect(onChange).not.toHaveBeenCalled();
 
@@ -1966,13 +1987,16 @@ describe("GitFileWatcher", () => {
       // first burst's refresh was never fired and its decision is now lost, so
       // the flush that supersedes it must refresh for both rather than
       // classify itself.
-      fireEvents(cb, [{ type: "create", path: "/repo/.output/b.js" }]);
+      fireEvents(cb, [{ type: "create", path: IGNORED_B }]);
       await vi.advanceTimersByTimeAsync(100);
       expect(onChange).toHaveBeenCalledTimes(1);
       expect(checkIgnoredPaths).toHaveBeenCalledTimes(1);
 
-      // The retired verdict must not fire a second, duplicate refresh.
-      releaseFirst?.(new Set(["/repo/.output/a.js"]));
+      // The retired verdict lands with an EMPTY set — i.e. "nothing was
+      // ignored, refresh". If the generation guard were missing it would call
+      // onChange a second time; resolving it as all-ignored would have passed
+      // either way and tested nothing.
+      releaseFirst?.(new Set());
       await flushClassification();
       expect(onChange).toHaveBeenCalledTimes(1);
     });
@@ -1988,7 +2012,7 @@ describe("GitFileWatcher", () => {
       );
 
       const { gitWatcher, cb } = await startClassifyingWatcher({ onChange });
-      fireEvents(cb, [{ type: "update", path: "/repo/src/main.ts" }]);
+      fireEvents(cb, [{ type: "update", path: TRACKED }]);
       await vi.advanceTimersByTimeAsync(100);
       expect(onChange).not.toHaveBeenCalled();
 
@@ -2011,7 +2035,7 @@ describe("GitFileWatcher", () => {
       }) as never);
 
       const { gitWatcher, cb } = await startClassifyingWatcher({ onChange: vi.fn() });
-      fireEvents(cb, [{ type: "update", path: "/repo/src/main.ts" }]);
+      fireEvents(cb, [{ type: "update", path: TRACKED }]);
       await vi.advanceTimersByTimeAsync(100);
       expect(captured?.aborted).toBe(false);
 
@@ -2020,11 +2044,135 @@ describe("GitFileWatcher", () => {
       await flushParcelWatcherCallbacks();
     });
 
+    it("refreshes for a .gitignore write even when git reports it as ignored", async () => {
+      const onChange = vi.fn();
+      // A `.gitignore` that is itself ignored — by `.git/info/exclude`, or by a
+      // rule inside it naming itself — is untracked and ignored, so plain
+      // check-ignore DOES report it. Classifying on that membership would skip
+      // a refresh the rule change just made necessary.
+      vi.mocked(checkIgnoredPaths).mockResolvedValue(new Set([p(".gitignore"), IGNORED_A]));
+
+      const { cb } = await startClassifyingWatcher({ onChange });
+      fireEvents(cb, [
+        { type: "update", path: IGNORED_A },
+        { type: "update", path: p(".gitignore") },
+      ]);
+      await vi.advanceTimersByTimeAsync(100);
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(checkIgnoredPaths).not.toHaveBeenCalled();
+    });
+
+    it("refreshes for a nested .gitignore write", async () => {
+      const onChange = vi.fn();
+      const { cb } = await startClassifyingWatcher({ onChange });
+      // Rules apply per-directory, so a nested file changes status too.
+      fireEvents(cb, [{ type: "update", path: p("packages", "web", ".gitignore") }]);
+      await vi.advanceTimersByTimeAsync(100);
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(checkIgnoredPaths).not.toHaveBeenCalled();
+    });
+
+    it("refuses to skip while the repo has tracked files matching an ignore rule", async () => {
+      const onChange = vi.fn();
+      // git's tracked-file exemption is a case-SENSITIVE index lookup, so on a
+      // case-insensitive filesystem a force-added `.output/Keep.txt` renamed to
+      // `.output/keep.txt` is still tracked and still reports as ignored. The
+      // skip is only sound while no tracked file matches an ignore rule.
+      vi.mocked(hasTrackedIgnoredPaths).mockResolvedValue(true);
+      vi.mocked(checkIgnoredPaths).mockResolvedValue(new Set([IGNORED_A]));
+
+      const { cb } = await startClassifyingWatcher({ onChange });
+      fireEvents(cb, [{ type: "create", path: IGNORED_A }]);
+      await vi.advanceTimersByTimeAsync(100);
+      await flushClassification();
+      expect(onChange).toHaveBeenCalledTimes(1);
+    });
+
+    it("refreshes when the tracked-ignored probe fails, and retries it next burst", async () => {
+      const onChange = vi.fn();
+      vi.mocked(checkIgnoredPaths).mockResolvedValue(new Set([IGNORED_A]));
+      vi.mocked(hasTrackedIgnoredPaths).mockRejectedValueOnce(new Error("probe failed"));
+
+      const { cb } = await startClassifyingWatcher({ onChange });
+      fireEvents(cb, [{ type: "create", path: IGNORED_A }]);
+      await vi.advanceTimersByTimeAsync(100);
+      await flushClassification();
+      expect(onChange).toHaveBeenCalledTimes(1);
+
+      // A failed probe must not be cached as "safe" — nor as permanently
+      // broken. The next burst asks again and can skip.
+      vi.mocked(hasTrackedIgnoredPaths).mockResolvedValue(false);
+      onChange.mockClear();
+      fireEvents(cb, [{ type: "update", path: IGNORED_A }]);
+      await vi.advanceTimersByTimeAsync(100);
+      await flushClassification();
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it("keeps a burst unknown once any event in it was unclassifiable", async () => {
+      const onChange = vi.fn();
+      const { cb } = await startClassifyingWatcher({ onChange });
+
+      // Unknown is sticky for the rest of the burst: a later well-formed batch
+      // must not rehabilitate a burst that already lost a path.
+      fireEvents(cb, [{ type: "update" }]);
+      fireEvents(cb, [{ type: "update", path: IGNORED_A }]);
+      await vi.advanceTimersByTimeAsync(100);
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(checkIgnoredPaths).not.toHaveBeenCalled();
+
+      // …and it must not leak into the next burst.
+      vi.mocked(checkIgnoredPaths).mockResolvedValue(new Set([IGNORED_A]));
+      onChange.mockClear();
+      fireEvents(cb, [{ type: "update", path: IGNORED_A }]);
+      await vi.advanceTimersByTimeAsync(100);
+      await flushClassification();
+      expect(onChange).not.toHaveBeenCalled();
+      expect(checkIgnoredPaths).toHaveBeenCalledTimes(1);
+    });
+
+    it("stays silent when a classification rejects after dispose", async () => {
+      let reject: ((error: Error) => void) | undefined;
+      vi.mocked(checkIgnoredPaths).mockImplementation(
+        () =>
+          new Promise<Set<string>>((_resolve, rej) => {
+            reject = rej;
+          }) as never
+      );
+      const onChange = vi.fn();
+      const { gitWatcher, cb } = await startClassifyingWatcher({ onChange });
+      fireEvents(cb, [{ type: "update", path: TRACKED }]);
+      await vi.advanceTimersByTimeAsync(100);
+
+      gitWatcher.dispose();
+      reject?.(new Error("spawn failed"));
+      await flushClassification();
+      expect(onChange).not.toHaveBeenCalled();
+      expect(logWarn).not.toHaveBeenCalled();
+      await flushParcelWatcherCallbacks();
+    });
+
+    it("throttles the classification-failure warning but never the refresh", async () => {
+      const onChange = vi.fn();
+      vi.mocked(checkIgnoredPaths).mockRejectedValue(new Error("exit 128"));
+      const { cb } = await startClassifyingWatcher({ onChange });
+
+      for (let burst = 0; burst < 3; burst++) {
+        fireEvents(cb, [{ type: "update", path: IGNORED_A }]);
+        await vi.advanceTimersByTimeAsync(100);
+        await flushClassification();
+      }
+      // Every failure still refreshes — only the log line is rate-limited,
+      // because this fires per flush rather than on demand.
+      expect(onChange).toHaveBeenCalledTimes(3);
+      expect(vi.mocked(logWarn).mock.calls.length).toBe(1);
+    });
+
     it("keeps the adaptive debounce ramp driven by raw event count", async () => {
       const onChange = vi.fn();
       const mock = setupSubscribeMock();
       const gitWatcher = new GitFileWatcher({
-        worktreePath: "/repo",
+        worktreePath: REPO,
         branch: "main",
         debounceMs: 300,
         onChange,
@@ -2040,7 +2188,7 @@ describe("GitFileWatcher", () => {
       // carrying a deduplicated set must not shorten the delay.
       fireEvents(
         mock.getCallback(),
-        Array.from({ length: 10 }, () => ({ type: "update", path: "/repo/.output/a.js" }))
+        Array.from({ length: 10 }, () => ({ type: "update", path: IGNORED_A }))
       );
       await vi.advanceTimersByTimeAsync(150);
       expect(onChange).not.toHaveBeenCalled();
@@ -2121,8 +2269,11 @@ describe("GitFileWatcher", () => {
       mock.resolve();
       const cb = mock.getCallback();
 
-      fireEvents(cb, [{ type: "update" }]);
+      // A real path, so this exercises the classification path rejecting an
+      // un-ignored file rather than the anonymous-event fallback.
+      fireEvents(cb, [{ type: "update", path: pathJoin(pathResolve("/repo"), "src", "app.ts") }]);
       await vi.advanceTimersByTimeAsync(100);
+      await flushClassification();
       expect(onChange).toHaveBeenCalledTimes(1);
     });
 

--- a/electron/utils/__tests__/gitFileWatcher.test.ts
+++ b/electron/utils/__tests__/gitFileWatcher.test.ts
@@ -1739,9 +1739,7 @@ describe("GitFileWatcher", () => {
     it("skips the status recompute when every path in the burst is ignored and untracked", async () => {
       const onChange = vi.fn();
       const onWorktreeFilesChanged = vi.fn();
-      vi.mocked(checkIgnoredPaths).mockResolvedValue(
-        new Set([IGNORED_A, IGNORED_B])
-      );
+      vi.mocked(checkIgnoredPaths).mockResolvedValue(new Set([IGNORED_A, IGNORED_B]));
 
       const { cb } = await startClassifyingWatcher({ onChange, onWorktreeFilesChanged });
       fireEvents(cb, [
@@ -1786,9 +1784,9 @@ describe("GitFileWatcher", () => {
       // tracked-but-matching file is simply absent from the result set — the
       // whole reason no separate index lookup is needed.
       vi.mocked(checkIgnoredPaths).mockResolvedValue(new Set());
-    // No tracked file matches an ignore rule — the state of essentially every
-    // repo, and the precondition that makes check-ignore's answer trustworthy.
-    vi.mocked(hasTrackedIgnoredPaths).mockResolvedValue(false);
+      // No tracked file matches an ignore rule — the state of essentially every
+      // repo, and the precondition that makes check-ignore's answer trustworthy.
+      vi.mocked(hasTrackedIgnoredPaths).mockResolvedValue(false);
 
       const { cb } = await startClassifyingWatcher({ onChange });
       fireEvents(cb, [{ type: "update", path: p(".output", "tracked.log") }]);
@@ -1867,9 +1865,7 @@ describe("GitFileWatcher", () => {
       mock.resolve();
       await flushParcelWatcherCallbacks();
 
-      fireEvents(mock.getCallback(), [
-        { type: "create", path: ALIASED_A },
-      ]);
+      fireEvents(mock.getCallback(), [{ type: "create", path: ALIASED_A }]);
       await vi.advanceTimersByTimeAsync(100);
       await flushClassification();
       expect(onChange).not.toHaveBeenCalled();

--- a/electron/utils/gitCheckIgnore.ts
+++ b/electron/utils/gitCheckIgnore.ts
@@ -35,39 +35,36 @@ export interface CheckIgnoreOptions {
   timeoutMs?: number;
 }
 
-export async function checkIgnoredPaths(
-  cwd: string,
-  paths: readonly string[],
-  options: CheckIgnoreOptions = {}
-): Promise<Set<string>> {
-  if (paths.length === 0) {
-    return new Set();
-  }
+interface RunOptions extends CheckIgnoreOptions {
+  /** Written to stdin and closed. Omit for commands that read no input. */
+  input?: string;
+  /** Exit codes to treat as a successful empty result rather than an error. */
+  emptyResultCodes: readonly number[];
+}
 
+/** Spawn one hardened git command and return its NUL-separated stdout tokens. */
+function runGitTokens(cwd: string, gitArgs: string[], options: RunOptions): Promise<Set<string>> {
   const platform = options.platform ?? process.platform;
   const env = buildHardenedGitEnv(platform);
   // `git check-ignore` is the one command that cannot run under the hardened
   // env as-is: it refuses pathspec magic outright, so every call dies with
   // `fatal: pathspec magic not supported by this command: 'literal'` (exit
-  // 128) while GIT_LITERAL_PATHSPECS is set. Dropping it here is safe because
-  // the risk that variable exists to close does not apply to this command.
-  // Elsewhere a wildmatch metacharacter in a legal filename makes git SELECT
-  // the wrong files (`pages/[...slug].tsx` resolving to `pages/s.tsx`);
-  // check-ignore selects nothing. It matches the literal pathname it was
-  // handed against the repo's ignore PATTERNS and echoes that same token back
-  // — verified: `a.tx?` reports nothing even when `a.txt` is ignored. A
-  // pathname git cannot parse at all (a literal leading `:`) still fails
-  // closed as exit 128, which the caller reads as "refresh".
+  // 128) while GIT_LITERAL_PATHSPECS is set. Dropping it is safe for the way
+  // these commands are used here. Elsewhere a wildmatch metacharacter in a
+  // legal filename makes git SELECT the wrong files (`pages/[...slug].tsx`
+  // resolving to `pages/s.tsx`); check-ignore selects nothing — it matches the
+  // literal pathname it was handed against the repo's ignore PATTERNS and
+  // echoes that token back. Verified against git 2.55.0: `secre?.txt`,
+  // `secre[t].txt`, `secret.*` and `{secret,plain}.txt` all report NOTHING
+  // while `secret.txt` is ignored, so no metacharacter yields a false
+  // positive. Pathspec magic needs a LEADING `:`, which callers here cannot
+  // produce (see the absolute-path contract on `checkIgnoredPaths`), and an
+  // unparseable pathname still fails closed as exit 128.
   delete env.GIT_LITERAL_PATHSPECS;
   const timeoutMs = Math.min(options.timeoutMs ?? GIT_BLOCK_TIMEOUT_MS, GIT_BLOCK_TIMEOUT_MS);
 
-  // `git check-ignore -z` reads NUL-separated paths from stdin. A trailing NUL
-  // terminates the last path even when no further data follows (matching the
-  // output convention of `-z`).
-  const body = paths.join("\0") + "\0";
-
   const configArgs = getHardenedGitConfig(platform).flatMap((entry) => ["-c", entry]);
-  const args = [...configArgs, "check-ignore", "--stdin", "-z"];
+  const args = [...configArgs, ...gitArgs];
 
   return new Promise<Set<string>>((resolve, reject) => {
     const child = spawn("git", args, {
@@ -94,7 +91,7 @@ export async function checkIgnoredPaths(
       } catch {
         // already exited
       }
-      settle(() => reject(new Error(`git check-ignore timed out after ${timeoutMs}ms`)));
+      settle(() => reject(new Error(`git ${gitArgs[0]} timed out after ${timeoutMs}ms`)));
     }, timeoutMs);
 
     const stdoutChunks: Buffer[] = [];
@@ -115,32 +112,98 @@ export async function checkIgnoredPaths(
 
     child.on("close", (code, signal) => {
       if (signal !== null) {
-        settle(() => reject(new Error(`git check-ignore killed by ${signal}`)));
+        settle(() => reject(new Error(`git ${gitArgs[0]} killed by ${signal}`)));
         return;
       }
       if (code === 0) {
+        // Chunks are concatenated before decoding, never decoded one at a
+        // time: a multi-byte UTF-8 sequence can straddle a chunk boundary.
         const stdout = Buffer.concat(stdoutChunks).toString("utf8");
-        const ignored = new Set<string>();
+        const tokens = new Set<string>();
         for (const entry of stdout.split("\0")) {
-          if (entry) ignored.add(entry);
+          if (entry) tokens.add(entry);
         }
-        settle(() => resolve(ignored));
+        settle(() => resolve(tokens));
         return;
       }
-      if (code === 1) {
-        // Exit 1 means none of the supplied paths are ignored — a valid empty
-        // result, not a failure.
+      if (code !== null && options.emptyResultCodes.includes(code)) {
         settle(() => resolve(new Set()));
         return;
       }
-      // Everything above 1 is a real failure: 128 for a fatal (a path outside
-      // the repository), 129 for a usage error. A fatal can arrive mid-batch
-      // with partial stdout already written, so the output is discarded rather
-      // than trusted. Gated on `code > 1`, never `code === 128`.
+      // Everything else is a real failure: 128 for a fatal (a path outside the
+      // repository), 129 for a usage error. A fatal can arrive mid-batch with
+      // partial stdout already written, so the output is discarded rather than
+      // trusted. Gated on the caller's empty-result list, never `code === 128`.
       const stderr = Buffer.concat(stderrChunks).toString("utf8");
-      settle(() => reject(new Error(`git check-ignore failed: exit ${code}: ${stderr.trim()}`)));
+      settle(() =>
+        reject(new Error(`git ${gitArgs[0]} failed: exit ${code}: ${stderr.trim()}`))
+      );
     });
 
-    child.stdin?.end(body);
+    if (options.input === undefined) {
+      child.stdin?.end();
+    } else {
+      child.stdin?.end(options.input);
+    }
   });
+}
+
+/**
+ * Which of `paths` git considers ignored AND untracked.
+ *
+ * CONTRACT: every path must be ABSOLUTE and inside `cwd`'s worktree. git parses
+ * these as pathspecs, so a token with a leading `:` would be read as pathspec
+ * magic (`:!foo` excludes, `:/foo` is repo-root-relative) rather than as a
+ * filename. An absolute path cannot start with `:`, which is what makes the
+ * literal reading safe; relative input has no such guarantee and is not
+ * supported. The returned tokens are the submitted strings verbatim, so
+ * callers compare by exact equality.
+ */
+export async function checkIgnoredPaths(
+  cwd: string,
+  paths: readonly string[],
+  options: CheckIgnoreOptions = {}
+): Promise<Set<string>> {
+  if (paths.length === 0) {
+    return new Set();
+  }
+  // `git check-ignore -z` reads NUL-separated paths from stdin. A trailing NUL
+  // terminates the last path even when no further data follows (matching the
+  // output convention of `-z`). Over stdin rather than argv so the argv stays
+  // constant-size: simple-git's argv-based checkIgnoreTask hits E2BIG on a
+  // large burst (#10234).
+  return runGitTokens(cwd, ["check-ignore", "--stdin", "-z"], {
+    ...options,
+    input: paths.join("\0") + "\0",
+    // Exit 1 means none of the supplied paths are ignored — a valid empty
+    // result, not a failure.
+    emptyResultCodes: [1],
+  });
+}
+
+/**
+ * Whether the repo contains any TRACKED file that also matches an ignore rule.
+ *
+ * This is the hazard set for `checkIgnoredPaths`' tracked-file exemption. git
+ * exempts tracked paths from check-ignore by looking them up in the index, and
+ * that lookup is case-SENSITIVE even when the filesystem is not. So on APFS or
+ * NTFS a file force-added as `.output/Keep.txt` and then renamed on disk to
+ * `.output/keep.txt` is still tracked, still shows as modified in `git status`,
+ * and yet check-ignore reports the on-disk spelling as ignored — verified
+ * against git 2.55.0. A caller that skips work on "ignored" would miss a real
+ * change.
+ *
+ * Empty for essentially every repository, which is why the caller can treat a
+ * cached "no hazard" as licence to trust check-ignore outright, and only pay
+ * this spawn again when the index changes.
+ */
+export async function hasTrackedIgnoredPaths(
+  cwd: string,
+  options: CheckIgnoreOptions = {}
+): Promise<boolean> {
+  const tokens = await runGitTokens(cwd, ["ls-files", "-z", "-i", "-c", "--exclude-standard"], {
+    ...options,
+    emptyResultCodes: [],
+  });
+  return tokens.size > 0;
 }

--- a/electron/utils/gitCheckIgnore.ts
+++ b/electron/utils/gitCheckIgnore.ts
@@ -1,0 +1,133 @@
+import { spawn } from "node:child_process";
+import { getHardenedGitConfig, buildHardenedGitEnv, GIT_BLOCK_TIMEOUT_MS } from "./hardenedGit.js";
+
+/**
+ * Direct-spawn wrapper around `git check-ignore --stdin -z`.
+ *
+ * Bypasses simple-git because simple-git 3.36 has no stdin plumbing for
+ * `check-ignore` — its `checkIgnoreTask` builds `["check-ignore", ...paths]`
+ * as argv, which fails with E2BIG (or ENOMEM) once the OS argv limit is
+ * exceeded. Pushing paths over stdin makes the argv constant-size (#10234).
+ *
+ * The hardened `-c` config flags from `getHardenedGitConfig()` are spread into
+ * the argv so the call inherits every security-relevant git override the
+ * simple-git factory applies (`core.fsmonitor=false`, `protocol.ext.allow=never`,
+ * credential-blocking entries, an app-owned `core.hooksPath`, …). Env comes from
+ * `buildHardenedGitEnv` so locale and lock-suppression match the simple-git path.
+ *
+ * Default mode is deliberate: without `--no-index`, git never reports a
+ * TRACKED path as ignored even when it matches an exclude rule ("tracked files
+ * are not shown at all since they are not subject to exclude rules"). So the
+ * returned set answers "ignored AND untracked" in a single spawn, and callers
+ * need no separate index lookup. Negated rules (`!keep.log`) are likewise
+ * resolved by git, so plain mode needs none of the `-v` record parsing.
+ */
+
+export interface CheckIgnoreOptions {
+  signal?: AbortSignal;
+  /** Override platform detection — test-only. */
+  platform?: NodeJS.Platform;
+  /**
+   * Deadline for this call. Callers on a latency-sensitive path pass something
+   * far below `GIT_BLOCK_TIMEOUT_MS`, which stays the hard ceiling: a wedged
+   * git must not hold a decision open for 30 seconds. Clamped to the ceiling.
+   */
+  timeoutMs?: number;
+}
+
+export async function checkIgnoredPaths(
+  cwd: string,
+  paths: readonly string[],
+  options: CheckIgnoreOptions = {}
+): Promise<Set<string>> {
+  if (paths.length === 0) {
+    return new Set();
+  }
+
+  const platform = options.platform ?? process.platform;
+  const env = buildHardenedGitEnv(platform);
+  const timeoutMs = Math.min(options.timeoutMs ?? GIT_BLOCK_TIMEOUT_MS, GIT_BLOCK_TIMEOUT_MS);
+
+  // `git check-ignore -z` reads NUL-separated paths from stdin. A trailing NUL
+  // terminates the last path even when no further data follows (matching the
+  // output convention of `-z`).
+  const body = paths.join("\0") + "\0";
+
+  const configArgs = getHardenedGitConfig(platform).flatMap((entry) => ["-c", entry]);
+  const args = [...configArgs, "check-ignore", "--stdin", "-z"];
+
+  return new Promise<Set<string>>((resolve, reject) => {
+    const child = spawn("git", args, {
+      cwd,
+      env,
+      stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
+      signal: options.signal,
+    });
+
+    let settled = false;
+    const settle = (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      fn();
+    };
+    const timer = setTimeout(() => {
+      // Kill the child so `close` fires, but reject here directly: a caller
+      // blocked on this promise must be released even if the child is stuck in
+      // an uninterruptible syscall.
+      try {
+        child.kill("SIGTERM");
+      } catch {
+        // already exited
+      }
+      settle(() => reject(new Error(`git check-ignore timed out after ${timeoutMs}ms`)));
+    }, timeoutMs);
+
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
+
+    child.stdout?.on("data", (chunk: Buffer) => stdoutChunks.push(chunk));
+    child.stderr?.on("data", (chunk: Buffer) => stderrChunks.push(chunk));
+
+    // Swallow stdin EPIPE: when git exits before we finish writing the body
+    // (fast failure, e.g. an unknown flag triggers an early exit), the stdin
+    // stream emits `error` after the process is already gone. The `close`
+    // handler is the source of truth; any stdio error here is already terminal.
+    child.stdin?.on("error", () => {});
+
+    child.on("error", (err) => {
+      settle(() => reject(err));
+    });
+
+    child.on("close", (code, signal) => {
+      if (signal !== null) {
+        settle(() => reject(new Error(`git check-ignore killed by ${signal}`)));
+        return;
+      }
+      if (code === 0) {
+        const stdout = Buffer.concat(stdoutChunks).toString("utf8");
+        const ignored = new Set<string>();
+        for (const entry of stdout.split("\0")) {
+          if (entry) ignored.add(entry);
+        }
+        settle(() => resolve(ignored));
+        return;
+      }
+      if (code === 1) {
+        // Exit 1 means none of the supplied paths are ignored — a valid empty
+        // result, not a failure.
+        settle(() => resolve(new Set()));
+        return;
+      }
+      // Everything above 1 is a real failure: 128 for a fatal (a path outside
+      // the repository), 129 for a usage error. A fatal can arrive mid-batch
+      // with partial stdout already written, so the output is discarded rather
+      // than trusted. Gated on `code > 1`, never `code === 128`.
+      const stderr = Buffer.concat(stderrChunks).toString("utf8");
+      settle(() => reject(new Error(`git check-ignore failed: exit ${code}: ${stderr.trim()}`)));
+    });
+
+    child.stdin?.end(body);
+  });
+}

--- a/electron/utils/gitCheckIgnore.ts
+++ b/electron/utils/gitCheckIgnore.ts
@@ -46,6 +46,19 @@ export async function checkIgnoredPaths(
 
   const platform = options.platform ?? process.platform;
   const env = buildHardenedGitEnv(platform);
+  // `git check-ignore` is the one command that cannot run under the hardened
+  // env as-is: it refuses pathspec magic outright, so every call dies with
+  // `fatal: pathspec magic not supported by this command: 'literal'` (exit
+  // 128) while GIT_LITERAL_PATHSPECS is set. Dropping it here is safe because
+  // the risk that variable exists to close does not apply to this command.
+  // Elsewhere a wildmatch metacharacter in a legal filename makes git SELECT
+  // the wrong files (`pages/[...slug].tsx` resolving to `pages/s.tsx`);
+  // check-ignore selects nothing. It matches the literal pathname it was
+  // handed against the repo's ignore PATTERNS and echoes that same token back
+  // — verified: `a.tx?` reports nothing even when `a.txt` is ignored. A
+  // pathname git cannot parse at all (a literal leading `:`) still fails
+  // closed as exit 128, which the caller reads as "refresh".
+  delete env.GIT_LITERAL_PATHSPECS;
   const timeoutMs = Math.min(options.timeoutMs ?? GIT_BLOCK_TIMEOUT_MS, GIT_BLOCK_TIMEOUT_MS);
 
   // `git check-ignore -z` reads NUL-separated paths from stdin. A trailing NUL

--- a/electron/utils/gitCheckIgnore.ts
+++ b/electron/utils/gitCheckIgnore.ts
@@ -135,9 +135,7 @@ function runGitTokens(cwd: string, gitArgs: string[], options: RunOptions): Prom
       // partial stdout already written, so the output is discarded rather than
       // trusted. Gated on the caller's empty-result list, never `code === 128`.
       const stderr = Buffer.concat(stderrChunks).toString("utf8");
-      settle(() =>
-        reject(new Error(`git ${gitArgs[0]} failed: exit ${code}: ${stderr.trim()}`))
-      );
+      settle(() => reject(new Error(`git ${gitArgs[0]} failed: exit ${code}: ${stderr.trim()}`)));
     });
 
     if (options.input === undefined) {

--- a/electron/utils/gitFileWatcher.ts
+++ b/electron/utils/gitFileWatcher.ts
@@ -835,33 +835,57 @@ export class GitFileWatcher {
     // its own and needs no special case: a `.gitignore` edit (nothing ignores
     // it), a delete of a tracked file (still in the index), the create half of
     // a rename into a tracked location.
-    // Both run concurrently so the guard costs no extra latency, and the probe
-    // is cached across flushes so it usually costs no extra spawn either.
-    void Promise.all([
-      checkIgnoredPaths(this.worktreePath, paths, {
-        signal: controller.signal,
-        timeoutMs: WORKTREE_CLASSIFY_TIMEOUT_MS,
-      }),
-      this.probeTrackedIgnored(),
-    ]).then(
-      ([ignored, hasTrackedIgnored]) => {
-        if (this.disposed || generation !== this.classifyGeneration) return;
-        this.classifyController = null;
-        // Skip only when EVERY path is provably irrelevant. A mixed burst
-        // exits 0 too, so the exit code is not the test — membership is.
-        if (!hasTrackedIgnored && paths.every((path) => ignored.has(path))) return;
-        this.onChange();
-      },
-      // Two-argument form, not `.catch`: a `.catch` chained after the success
-      // handler would also catch an exception thrown by `onChange()` itself
-      // and call it a second time.
-      (error: unknown) => {
-        if (this.disposed || generation !== this.classifyGeneration) return;
-        this.classifyController = null;
-        this.warnClassifyFailure(error);
-        this.onChange();
-      }
-    );
+    void checkIgnoredPaths(this.worktreePath, paths, {
+      signal: controller.signal,
+      timeoutMs: WORKTREE_CLASSIFY_TIMEOUT_MS,
+    })
+      .then(
+        async (ignored) => {
+          if (this.disposed || generation !== this.classifyGeneration) return;
+          // Skip only when EVERY path is provably irrelevant. A mixed burst
+          // exits 0 too, so the exit code is not the test — membership is.
+          if (!paths.every((path) => ignored.has(path))) {
+            this.classifyController = null;
+            this.onChange();
+            return;
+          }
+          // Only a burst we are about to SKIP needs the hazard answer, so the
+          // probe stays off the path of every burst that was going to refresh
+          // anyway — a checkout storm pays check-ignore and nothing more. It
+          // is cached besides, so even the skip path usually spends no spawn.
+          let hasTrackedIgnored: boolean;
+          try {
+            hasTrackedIgnored = await this.probeTrackedIgnored();
+          } catch (error) {
+            if (this.disposed || generation !== this.classifyGeneration) return;
+            this.classifyController = null;
+            this.warnClassifyFailure(error);
+            this.onChange();
+            return;
+          }
+          if (this.disposed || generation !== this.classifyGeneration) return;
+          this.classifyController = null;
+          if (hasTrackedIgnored) this.onChange();
+        },
+        // Two-argument form, not a chained `.catch`: a `.catch` here would
+        // also catch an exception thrown by `onChange()` in the success
+        // handler and call `onChange()` a second time.
+        (error: unknown) => {
+          if (this.disposed || generation !== this.classifyGeneration) return;
+          this.classifyController = null;
+          this.warnClassifyFailure(error);
+          this.onChange();
+        }
+      )
+      .catch((error: unknown) => {
+        // Only reachable when `onChange()` itself threw. Report it rather than
+        // retrying it — a retry is what the two-argument form above avoids —
+        // and never leave it as an unhandled rejection.
+        logWarn("Worktree status refresh threw after ignore classification", {
+          path: this.worktreePath,
+          error: (error as Error)?.message ?? String(error),
+        });
+      });
   }
 
   /**

--- a/electron/utils/gitFileWatcher.ts
+++ b/electron/utils/gitFileWatcher.ts
@@ -78,8 +78,26 @@ const WORKTREE_CLASSIFY_TIMEOUT_MS = 2_000;
 /** Minimum gap between classification-failure warnings, per watcher. */
 const CLASSIFY_WARN_THROTTLE_MS = 30_000;
 
-/** The ignore-rule file, at any depth. A burst touching one always refreshes. */
-const GITIGNORE_FILE_NAME = ".gitignore";
+/**
+ * Worktree files whose contents change what `git status` reports about OTHER
+ * paths, at any depth. A burst touching one always refreshes.
+ *
+ * None of them can be classified on their own membership: each may itself be
+ * untracked and ignored — `.gitignore` can name itself, or `.git/info/exclude`
+ * can name it — in which case plain check-ignore reports it and the burst
+ * would look skippable while the rule change it carried altered the listing.
+ *
+ * `.gitattributes` earns its place through normalisation rather than ignore
+ * rules: flipping `text`/`-text` changes whether a CRLF working file still
+ * compares equal to its LF blob. `.gitmodules` carries
+ * `submodule.<name>.ignore`, which hides or reveals submodule modifications.
+ *
+ * Compared case-insensitively: on APFS or NTFS a file written as `.GITIGNORE`
+ * is the same file to git. On a case-sensitive filesystem that name is a
+ * different file and matching it merely costs one refresh — the conservative
+ * direction.
+ */
+const STATUS_AFFECTING_FILE_NAMES = new Set([".gitignore", ".gitattributes", ".gitmodules"]);
 
 /** A `@parcel/watcher` event as far as this file needs to read it. */
 interface WorktreeEvent {
@@ -711,14 +729,12 @@ export class GitFileWatcher {
         this.pendingWorktreePaths = null;
         return;
       }
-      // A `.gitignore` write changes what git considers ignored, so the burst
-      // can move OTHER files in or out of the status listing while touching
-      // only this one path. It cannot be classified on its own membership:
-      // a `.gitignore` that is itself ignored — by `.git/info/exclude`, or by
-      // a rule inside it naming itself — is untracked and ignored, so plain
-      // check-ignore reports it, and the burst would skip a refresh that the
-      // rule change made necessary. Verified against git 2.55.0.
-      if (basename(path) === GITIGNORE_FILE_NAME) {
+      if (STATUS_AFFECTING_FILE_NAMES.has(basename(path).toLowerCase())) {
+        // Such a write can also create the tracked/ignored overlap the hazard
+        // probe caches an answer about — newly ignoring a directory that holds
+        // a tracked file — and that change reaches no watched git-internal
+        // file, so the cached answer has to be dropped here too.
+        this.trackedIgnoredProbe = null;
         this.pendingWorktreePaths = null;
         return;
       }
@@ -762,14 +778,20 @@ export class GitFileWatcher {
    */
   private probeTrackedIgnored(): Promise<boolean> {
     if (!this.trackedIgnoredProbe) {
-      this.trackedIgnoredProbe = hasTrackedIgnoredPaths(this.worktreePath, {
+      // `attempt` is the promise the slot actually holds, so the identity
+      // check below compares like with like. Its own handler runs on a later
+      // tick, well after the assignment.
+      const attempt: Promise<boolean> = hasTrackedIgnoredPaths(this.worktreePath, {
         timeoutMs: WORKTREE_CLASSIFY_TIMEOUT_MS,
       }).catch((error: unknown) => {
         // Fail closed and do not cache the failure: an unanswerable probe must
-        // mean "refresh", not "assume safe forever".
-        this.trackedIgnoredProbe = null;
+        // mean "refresh", not "assume safe forever". Clear the slot only if it
+        // still holds THIS attempt — an invalidation may already have replaced
+        // it, and erasing a newer probe would just re-spawn for nothing.
+        if (this.trackedIgnoredProbe === attempt) this.trackedIgnoredProbe = null;
         throw error;
       });
+      this.trackedIgnoredProbe = attempt;
     }
     return this.trackedIgnoredProbe;
   }

--- a/electron/utils/gitFileWatcher.ts
+++ b/electron/utils/gitFileWatcher.ts
@@ -1,7 +1,15 @@
 import { watch as fsWatch, FSWatcher } from "fs";
-import { readFile } from "fs/promises";
-import { join as pathJoin, dirname, isAbsolute, basename, normalize as pathNormalize } from "path";
+import { readFile, realpath } from "fs/promises";
+import {
+  join as pathJoin,
+  dirname,
+  isAbsolute,
+  basename,
+  sep as pathSep,
+  normalize as pathNormalize,
+} from "path";
 import { getGitDir } from "./gitUtils.js";
+import { checkIgnoredPaths } from "./gitCheckIgnore.js";
 import { OPERATION_SENTINEL_NAMES } from "./gitRepoOperationState.js";
 import { subscribeParcelWatcher } from "./parcelWatcherBackend.js";
 import { logWarn } from "./logger.js";
@@ -50,6 +58,31 @@ const WORKTREE_IGNORE_GLOBS = [
   "**/.git",
   "**/.git/**",
 ];
+
+/**
+ * Cap on the paths retained for one burst. Past it the burst degrades to
+ * "unknown" and takes the full refresh — a checkout storm rewriting thousands
+ * of files is never going to classify as ignored-only, so the memory is spent
+ * for nothing. Bounds both the retained set and the stdin body written to git.
+ */
+const WORKTREE_BURST_PATH_CAP = 2048;
+
+/**
+ * Deadline for the per-flush classification. `GIT_BLOCK_TIMEOUT_MS` (30s) stays
+ * the hard ceiling inside the helper, but this path is latency-sensitive: a
+ * wedged git must not hold an isolated save's status refresh open for half a
+ * minute. On expiry the burst falls back to the full refresh.
+ */
+const WORKTREE_CLASSIFY_TIMEOUT_MS = 2_000;
+
+/** Minimum gap between classification-failure warnings, per watcher. */
+const CLASSIFY_WARN_THROTTLE_MS = 30_000;
+
+/** A `@parcel/watcher` event as far as this file needs to read it. */
+interface WorktreeEvent {
+  path?: string;
+  type?: string;
+}
 
 export interface GitFileWatcherOptions {
   worktreePath: string;
@@ -138,6 +171,20 @@ export class GitFileWatcher {
   private readonly onWorktreeFilesChanged: (() => void) | undefined;
   /** Set when the current (unflushed) burst touched `.git/config`. */
   private gitConfigChangePending = false;
+  /**
+   * Absolute paths seen in the current (unflushed) worktree burst, or `null`
+   * once the burst is "unknown" — an overflow signal, an event without a
+   * usable path, a path outside the worktree, or more paths than the cap. An
+   * unknown burst always takes the full refresh.
+   */
+  private pendingWorktreePaths: Set<string> | null = new Set();
+  /** Canonical form of `worktreePath`, when it differs (macOS /var -> /private/var). */
+  private worktreeRealPath: string | null = null;
+  /** Aborts the in-flight classification when it is superseded or disposed. */
+  private classifyController: AbortController | null = null;
+  /** Bumped on every flush and on disposal so a stale result cannot act. */
+  private classifyGeneration = 0;
+  private lastClassifyWarnAt = 0;
   /** Directory holding `.git/config` — always the common dir. */
   private gitConfigDir: string | null = null;
   private readonly onWatcherFailed: (() => void) | undefined;
@@ -232,6 +279,21 @@ export class GitFileWatcher {
       this.watchRemoteRefsDir(pathJoin(commonDir, "refs", "remotes", "origin"));
 
       if (this.watchWorktree) {
+        // Resolve the canonical root once so burst paths can be proved to live
+        // inside this worktree. macOS FSEvents reports realpath'd paths, so a
+        // worktree reached through a symlinked ancestor (/var -> /private/var,
+        // the shape every temp-dir fixture has) yields events that match
+        // neither the configured root nor each other. Best-effort: a failure
+        // costs the optimisation for this watcher, never the watching.
+        try {
+          const resolved = await realpath(this.worktreePath);
+          this.worktreeRealPath = resolved === this.worktreePath ? null : resolved;
+        } catch {
+          this.worktreeRealPath = null;
+        }
+        if (this.disposed) {
+          return false;
+        }
         // Fire-and-forget: subscribe() schedules the platform watcher
         // asynchronously. Startup failures (ENOSPC, EMFILE) route through
         // onWatcherFailed / onInotifyLimitReached / onEmfileLimitReached
@@ -271,6 +333,11 @@ export class GitFileWatcher {
     }
     this.worktreeBurstCount = 0;
     this.gitConfigChangePending = false;
+    // Retire any in-flight classification: the generation bump makes its
+    // result inert, and the abort stops the subprocess rather than leaving it
+    // to run out its deadline against a worktree nobody is watching.
+    this.abortClassification();
+    this.pendingWorktreePaths = new Set();
 
     for (const watcher of this.watchers) {
       try {
@@ -319,11 +386,12 @@ export class GitFileWatcher {
           return;
         }
         if (this.disposed || !events || events.length === 0) return;
-        // Passing the batch size preserves the burstCount-driven adaptive
-        // debounce ramp (100 files in a batch -> burstCount=100 ->
-        // maxDebounce) while clearing/setting the debounce timer once per
-        // batch instead of once per event.
-        this.handleWorktreeChange(events.length);
+        // The batch drives two things: its size preserves the burstCount
+        // adaptive debounce ramp (100 files in a batch -> burstCount=100 ->
+        // maxDebounce) while the timer is still cleared/set once per batch,
+        // and its paths let the flush decide whether the burst can affect
+        // tracked status at all (#12235).
+        this.handleWorktreeChange(events);
       },
       { ignore: WORKTREE_IGNORE_GLOBS }
     )
@@ -388,7 +456,10 @@ export class GitFileWatcher {
       // raw-filesystem signal the file browser reads and the git-status
       // recompute. `handleGitFileChange` would only do the latter, leaving
       // writes to gitignored paths invisible (#11330).
-      this.handleWorktreeChange();
+      //
+      // `null` rather than an empty batch: events were LOST, so the burst's
+      // paths are unknowable and the flush must not classify it as skippable.
+      this.handleWorktreeChange(null);
       return;
     }
 
@@ -551,11 +622,23 @@ export class GitFileWatcher {
    * period flushes on the short leading delay instead — an isolated save
    * surfaces near-instantly, while continued events replace the leading timer
    * with the trailing ramp so real bursts still coalesce.
+   *
+   * `events` is the raw batch: its length drives the ramp exactly as the old
+   * count did, and its paths accumulate for the flush's ignore classification.
+   * `null` means the paths are unknowable (overflow/rescan) and forces the
+   * full refresh.
    */
-  private handleWorktreeChange(eventCount = 1): void {
+  private handleWorktreeChange(events: readonly WorktreeEvent[] | null = null): void {
     if (this.disposed) {
       return;
     }
+
+    // A null batch is the overflow/rescan signal: something happened but what
+    // is unknowable, so the burst can never be proved skippable. An empty array
+    // is not reachable from the subscribe callback (it returns early), and is
+    // treated as one anonymous event to preserve the old default of 1.
+    const eventCount = events === null ? 1 : Math.max(1, events.length);
+    this.collectWorktreePaths(events);
 
     const burstStart = this.worktreeBurstCount === 0;
     this.worktreeBurstCount += eventCount;
@@ -584,6 +667,64 @@ export class GitFileWatcher {
     }
   }
 
+  /**
+   * Accumulate the burst's changed paths, or mark the burst unknown.
+   *
+   * Unknown is the conservative answer and it is sticky for the rest of the
+   * burst: once anything in it cannot be classified, the whole flush takes the
+   * full refresh. Deliberately cheap — no filesystem calls, no realpath per
+   * event — because this runs once per watcher event.
+   */
+  private collectWorktreePaths(events: readonly WorktreeEvent[] | null): void {
+    const pending = this.pendingWorktreePaths;
+    if (pending === null) return;
+
+    if (events === null) {
+      this.pendingWorktreePaths = null;
+      return;
+    }
+
+    for (const event of events) {
+      const path = event?.path;
+      // A non-string path is an event shape we cannot reason about. The
+      // Windows adapter also collapses a null fs.watch filename to the watch
+      // root itself, which means "something under here changed" — equally
+      // unclassifiable.
+      if (typeof path !== "string" || path.length === 0 || !this.isInsideWorktree(path)) {
+        this.pendingWorktreePaths = null;
+        return;
+      }
+      pending.add(path);
+      if (pending.size > WORKTREE_BURST_PATH_CAP) {
+        this.pendingWorktreePaths = null;
+        return;
+      }
+    }
+  }
+
+  /**
+   * Whether an absolute event path lives strictly inside the watched worktree,
+   * against the configured root or its canonical alias. Separator-aware so
+   * `/repo-other/x` is not read as living under `/repo`, and strict so the root
+   * itself (the Windows "unknown filename" signal) does not qualify.
+   */
+  private isInsideWorktree(path: string): boolean {
+    for (const root of [this.worktreePath, this.worktreeRealPath]) {
+      if (!root) continue;
+      const prefix = root.endsWith(pathSep) ? root : root + pathSep;
+      if (path.startsWith(prefix) && path.length > prefix.length) return true;
+    }
+    return false;
+  }
+
+  private abortClassification(): void {
+    this.classifyGeneration += 1;
+    if (this.classifyController) {
+      this.classifyController.abort();
+      this.classifyController = null;
+    }
+  }
+
   private flushWorktreeChange(): void {
     if (this.worktreeDebounceTimer) {
       clearTimeout(this.worktreeDebounceTimer);
@@ -595,13 +736,80 @@ export class GitFileWatcher {
     }
     this.worktreeBurstCount = 0;
     this.lastWorktreeFlushAt = Date.now();
-    if (!this.disposed) {
-      // Raw-filesystem signal first, then the git-status recompute: a browser
-      // subscriber that only cares about files-on-disk shouldn't have to wait
-      // for the status pass, and firing it here (not the git-internal path)
-      // keeps it scoped to actual working-tree writes.
-      this.onWorktreeFilesChanged?.();
+
+    // Detach the burst and re-arm collection before any callback runs: a write
+    // landing while they execute belongs to the next burst, not this one.
+    const burst = this.pendingWorktreePaths;
+    this.pendingWorktreePaths = new Set();
+
+    // A classification still in flight belongs to an older burst whose
+    // `onChange` was never fired. Retire it and refresh for both: the newer
+    // burst is unclassified, and dropping the old job must not drop the
+    // refresh it was still deciding about.
+    const superseded = this.classifyController !== null;
+    this.abortClassification();
+
+    if (this.disposed) return;
+
+    // Raw-filesystem signal first, and unconditionally: a browser subscriber
+    // that only cares about files-on-disk shouldn't have to wait for the
+    // status pass, let alone for a classification that may decide to skip it
+    // (#11330). Firing it here (not the git-internal path) keeps it scoped to
+    // actual working-tree writes.
+    this.onWorktreeFilesChanged?.();
+
+    // The callback above is synchronous and may dispose this watcher.
+    if (this.disposed) return;
+
+    const paths = burst === null || superseded ? null : [...burst];
+    if (paths === null || paths.length === 0) {
       this.onChange();
+      return;
     }
+
+    const generation = this.classifyGeneration;
+    const controller = new AbortController();
+    this.classifyController = controller;
+
+    // One `git check-ignore --stdin -z` answers the whole question. In default
+    // mode git never reports a TRACKED path as ignored, so a path present in
+    // the result is ignored AND untracked — the exact predicate for "cannot
+    // affect git status". Everything ambiguous therefore fails membership on
+    // its own and needs no special case: a `.gitignore` edit (nothing ignores
+    // it), a delete of a tracked file (still in the index), the create half of
+    // a rename into a tracked location.
+    void checkIgnoredPaths(this.worktreePath, paths, {
+      signal: controller.signal,
+      timeoutMs: WORKTREE_CLASSIFY_TIMEOUT_MS,
+    })
+      .then((ignored) => {
+        if (this.disposed || generation !== this.classifyGeneration) return;
+        this.classifyController = null;
+        // Skip only when EVERY path is provably irrelevant. A mixed burst
+        // exits 0 too, so the exit code is not the test — membership is.
+        if (paths.every((path) => ignored.has(path))) return;
+        this.onChange();
+      })
+      .catch((error: unknown) => {
+        if (this.disposed || generation !== this.classifyGeneration) return;
+        this.classifyController = null;
+        this.warnClassifyFailure(error);
+        this.onChange();
+      });
+  }
+
+  /**
+   * Throttled because this runs per flush, not on demand: a repo that makes
+   * check-ignore fail (a wedged filesystem, a hostile git on PATH) would
+   * otherwise write a log line for every debounce during a build.
+   */
+  private warnClassifyFailure(error: unknown): void {
+    const now = Date.now();
+    if (now - this.lastClassifyWarnAt < CLASSIFY_WARN_THROTTLE_MS) return;
+    this.lastClassifyWarnAt = now;
+    logWarn("Worktree burst ignore-classification failed; refreshing status", {
+      path: this.worktreePath,
+      error: (error as Error)?.message ?? String(error),
+    });
   }
 }

--- a/electron/utils/gitFileWatcher.ts
+++ b/electron/utils/gitFileWatcher.ts
@@ -9,7 +9,7 @@ import {
   normalize as pathNormalize,
 } from "path";
 import { getGitDir } from "./gitUtils.js";
-import { checkIgnoredPaths } from "./gitCheckIgnore.js";
+import { checkIgnoredPaths, hasTrackedIgnoredPaths } from "./gitCheckIgnore.js";
 import { OPERATION_SENTINEL_NAMES } from "./gitRepoOperationState.js";
 import { subscribeParcelWatcher } from "./parcelWatcherBackend.js";
 import { logWarn } from "./logger.js";
@@ -77,6 +77,9 @@ const WORKTREE_CLASSIFY_TIMEOUT_MS = 2_000;
 
 /** Minimum gap between classification-failure warnings, per watcher. */
 const CLASSIFY_WARN_THROTTLE_MS = 30_000;
+
+/** The ignore-rule file, at any depth. A burst touching one always refreshes. */
+const GITIGNORE_FILE_NAME = ".gitignore";
 
 /** A `@parcel/watcher` event as far as this file needs to read it. */
 interface WorktreeEvent {
@@ -185,6 +188,13 @@ export class GitFileWatcher {
   /** Bumped on every flush and on disposal so a stale result cannot act. */
   private classifyGeneration = 0;
   private lastClassifyWarnAt = 0;
+  /**
+   * Cached "does this repo contain tracked files that match an ignore rule?".
+   * Dropped whenever a git-internal file changes, which is where `git add -f`
+   * shows up (the index is watched). Null means "ask again on the next skip
+   * opportunity".
+   */
+  private trackedIgnoredProbe: Promise<boolean> | null = null;
   /** Directory holding `.git/config` — always the common dir. */
   private gitConfigDir: string | null = null;
   private readonly onWatcherFailed: (() => void) | undefined;
@@ -338,6 +348,7 @@ export class GitFileWatcher {
     // to run out its deadline against a worktree nobody is watching.
     this.abortClassification();
     this.pendingWorktreePaths = new Set();
+    this.trackedIgnoredProbe = null;
 
     for (const watcher of this.watchers) {
       try {
@@ -595,6 +606,12 @@ export class GitFileWatcher {
       return;
     }
 
+    // A git-internal write is where the tracked/ignored overlap can change:
+    // `git add -f` of an ignored file writes the index, and a checkout can
+    // move a tracked file into an ignored directory. Drop the cached answer
+    // rather than reasoning about which write it was.
+    this.trackedIgnoredProbe = null;
+
     if (this.debounceTimer) {
       clearTimeout(this.debounceTimer);
     }
@@ -694,6 +711,17 @@ export class GitFileWatcher {
         this.pendingWorktreePaths = null;
         return;
       }
+      // A `.gitignore` write changes what git considers ignored, so the burst
+      // can move OTHER files in or out of the status listing while touching
+      // only this one path. It cannot be classified on its own membership:
+      // a `.gitignore` that is itself ignored — by `.git/info/exclude`, or by
+      // a rule inside it naming itself — is untracked and ignored, so plain
+      // check-ignore reports it, and the burst would skip a refresh that the
+      // rule change made necessary. Verified against git 2.55.0.
+      if (basename(path) === GITIGNORE_FILE_NAME) {
+        this.pendingWorktreePaths = null;
+        return;
+      }
       pending.add(path);
       if (pending.size > WORKTREE_BURST_PATH_CAP) {
         this.pendingWorktreePaths = null;
@@ -715,6 +743,35 @@ export class GitFileWatcher {
       if (path.startsWith(prefix) && path.length > prefix.length) return true;
     }
     return false;
+  }
+
+  /**
+   * Whether check-ignore's answer can be trusted outright for this repo.
+   *
+   * git exempts tracked paths from check-ignore via a case-SENSITIVE index
+   * lookup, even on a case-insensitive filesystem. So a file force-added as
+   * `.output/Keep.txt` and renamed on disk to `.output/keep.txt` stays tracked
+   * and shows as modified, while check-ignore reports the on-disk spelling as
+   * ignored — skipping a refresh that was needed. Reproduced on APFS with git
+   * 2.55.0.
+   *
+   * The hazard needs a tracked file matching an ignore rule to exist at all,
+   * which is empty for essentially every repo, so the answer is cached and
+   * costs nothing per flush. It is dropped on any git-internal write, which is
+   * where `git add -f` lands.
+   */
+  private probeTrackedIgnored(): Promise<boolean> {
+    if (!this.trackedIgnoredProbe) {
+      this.trackedIgnoredProbe = hasTrackedIgnoredPaths(this.worktreePath, {
+        timeoutMs: WORKTREE_CLASSIFY_TIMEOUT_MS,
+      }).catch((error: unknown) => {
+        // Fail closed and do not cache the failure: an unanswerable probe must
+        // mean "refresh", not "assume safe forever".
+        this.trackedIgnoredProbe = null;
+        throw error;
+      });
+    }
+    return this.trackedIgnoredProbe;
   }
 
   private abortClassification(): void {
@@ -778,24 +835,33 @@ export class GitFileWatcher {
     // its own and needs no special case: a `.gitignore` edit (nothing ignores
     // it), a delete of a tracked file (still in the index), the create half of
     // a rename into a tracked location.
-    void checkIgnoredPaths(this.worktreePath, paths, {
-      signal: controller.signal,
-      timeoutMs: WORKTREE_CLASSIFY_TIMEOUT_MS,
-    })
-      .then((ignored) => {
+    // Both run concurrently so the guard costs no extra latency, and the probe
+    // is cached across flushes so it usually costs no extra spawn either.
+    void Promise.all([
+      checkIgnoredPaths(this.worktreePath, paths, {
+        signal: controller.signal,
+        timeoutMs: WORKTREE_CLASSIFY_TIMEOUT_MS,
+      }),
+      this.probeTrackedIgnored(),
+    ]).then(
+      ([ignored, hasTrackedIgnored]) => {
         if (this.disposed || generation !== this.classifyGeneration) return;
         this.classifyController = null;
         // Skip only when EVERY path is provably irrelevant. A mixed burst
         // exits 0 too, so the exit code is not the test — membership is.
-        if (paths.every((path) => ignored.has(path))) return;
+        if (!hasTrackedIgnored && paths.every((path) => ignored.has(path))) return;
         this.onChange();
-      })
-      .catch((error: unknown) => {
+      },
+      // Two-argument form, not `.catch`: a `.catch` chained after the success
+      // handler would also catch an exception thrown by `onChange()` itself
+      // and call it a second time.
+      (error: unknown) => {
         if (this.disposed || generation !== this.classifyGeneration) return;
         this.classifyController = null;
         this.warnClassifyFailure(error);
         this.onChange();
-      });
+      }
+    );
   }
 
   /**

--- a/scripts/perf/config/benchmarkClasses.ts
+++ b/scripts/perf/config/benchmarkClasses.ts
@@ -187,7 +187,16 @@ const FAMILIES: readonly Family[] = [
   },
   {
     label: "git pipeline",
-    ids: ["PERF-100", "PERF-101", "PERF-102", "PERF-103", "PERF-104", "PERF-105", "PERF-106"],
+    ids: [
+      "PERF-100",
+      "PERF-101",
+      "PERF-102",
+      "PERF-103",
+      "PERF-104",
+      "PERF-105",
+      "PERF-106",
+      "PERF-107",
+    ],
     kind: "mechanism",
     fidelity: withFidelity({ processTopology: "partial" }),
     claim:

--- a/scripts/perf/config/budgets.json
+++ b/scripts/perf/config/budgets.json
@@ -316,10 +316,10 @@
       }
     },
     "PERF-107": {
-      "p95Ms": 12000,
+      "p95Ms": 3000,
       "maxRegressionPct": 100,
       "maxMetricValues": {
-        "gitSpawnsPerIgnoredFlush": 1,
+        "gitSpawnsPerIgnoredFlush": 2,
         "statusPassesPerIgnoredFlush": 0,
         "checkIgnoresPerIgnoredFlush": 1,
         "browserSignalMisses": 0,

--- a/scripts/perf/config/budgets.json
+++ b/scripts/perf/config/budgets.json
@@ -321,6 +321,7 @@
       "maxMetricValues": {
         "gitSpawnsPerIgnoredFlush": 1,
         "statusPassesPerIgnoredFlush": 0,
+        "checkIgnoresPerIgnoredFlush": 1,
         "browserSignalMisses": 0,
         "trackedRefreshMisses": 0,
         "ignoreEditRefreshMisses": 0,

--- a/scripts/perf/config/budgets.json
+++ b/scripts/perf/config/budgets.json
@@ -315,6 +315,18 @@
         "residualGitSpawns": 0
       }
     },
+    "PERF-107": {
+      "p95Ms": 12000,
+      "maxRegressionPct": 100,
+      "maxMetricValues": {
+        "gitSpawnsPerIgnoredFlush": 1,
+        "statusPassesPerIgnoredFlush": 0,
+        "browserSignalMisses": 0,
+        "trackedRefreshMisses": 0,
+        "ignoreEditRefreshMisses": 0,
+        "spawnObserverMisses": 0
+      }
+    },
     "PERF-130": {
       "p95Ms": 400,
       "maxRegressionPct": 75,

--- a/scripts/perf/lib/gitPipelineFixture.ts
+++ b/scripts/perf/lib/gitPipelineFixture.ts
@@ -320,7 +320,14 @@ export interface GitPipelineFixture {
    *  path-keyed cache for 600s — sharing one worktree would leak the fault
    *  state into the healthy reading. */
   faultPath: string;
+  /** PERF-107 worktree whose own `.gitignore` excludes a directory that is
+   *  deliberately absent from WORKTREE_IGNORE_GLOBS, so writes there reach the
+   *  recursive watcher and have to be classified rather than filtered. */
+  ignoredPath: string;
 }
+
+/** Directory PERF-107's fixture gitignores. Not a WORKTREE_IGNORE_GLOBS name. */
+export const IGNORED_BURST_DIR = ".output";
 
 let fixture: GitPipelineFixture | null = null;
 
@@ -440,6 +447,19 @@ export function getGitPipelineFixture(): GitPipelineFixture {
   const faultPath = join(root, "wt-fault");
   git(mainPath, ["worktree", "add", faultPath, "-b", "wt-fault-branch", "main"]);
 
+  // PERF-107: a repo that gitignores its own build directory. `.output/` is
+  // chosen precisely because it is NOT in WORKTREE_IGNORE_GLOBS — the watcher
+  // therefore delivers every write there, which is the whole cost this
+  // scenario measures. The directory is created up front so the burst does not
+  // also measure a mkdir, and `.gitignore` is committed so the worktree starts
+  // clean.
+  const ignoredPath = join(root, "wt-ignored");
+  git(mainPath, ["worktree", "add", ignoredPath, "-b", "wt-ignored-branch", "main"]);
+  writeFileSync(join(ignoredPath, ".gitignore"), `${IGNORED_BURST_DIR}/\n`);
+  mkdirSync(join(ignoredPath, IGNORED_BURST_DIR), { recursive: true });
+  git(ignoredPath, ["add", ".gitignore"]);
+  git(ignoredPath, ["commit", "-m", "ignore build output"]);
+
   fixture = {
     root,
     mainPath,
@@ -450,6 +470,7 @@ export function getGitPipelineFixture(): GitPipelineFixture {
     stormBranches: ["storm-alt", "storm-base"],
     idlePath,
     faultPath,
+    ignoredPath,
   };
 
   return fixture;

--- a/scripts/perf/lib/gitPipelineFixture.ts
+++ b/scripts/perf/lib/gitPipelineFixture.ts
@@ -459,6 +459,21 @@ export function getGitPipelineFixture(): GitPipelineFixture {
   mkdirSync(join(ignoredPath, IGNORED_BURST_DIR), { recursive: true });
   git(ignoredPath, ["add", ".gitignore"]);
   git(ignoredPath, ["commit", "-m", "ignore build output"]);
+  // The same standing dirty set as `dirtyPath`, and for the same reason the
+  // issue gives: a full status pass on a CLEAN worktree is one cheap spawn on
+  // the stat-skip fast path, while the ~3-5 spawn chain this scenario exists
+  // to avoid (numstat + per-file line counts) only appears once the worktree
+  // has real work in it. A developer running a build has uncommitted work;
+  // measuring the clean case would price the cheapest possible baseline.
+  const ignoredDirtyBody = fileBody("ignored-dirty");
+  for (let i = 0; i < DIRTY_MODIFIED_FILES; i++) {
+    const dir = i % BASE_FILE_DIRS;
+    const file = i % BASE_FILES_PER_DIR;
+    writeFileSync(join(ignoredPath, `module-${dir}`, `file-${file}.txt`), ignoredDirtyBody);
+  }
+  for (let i = 0; i < DIRTY_UNTRACKED_FILES; i++) {
+    writeFileSync(join(ignoredPath, `untracked-${i}.txt`), ignoredDirtyBody);
+  }
 
   fixture = {
     root,

--- a/scripts/perf/scenarios/gitPipeline.ts
+++ b/scripts/perf/scenarios/gitPipeline.ts
@@ -2,7 +2,9 @@ import { basename, join } from "node:path";
 import type { PerfScenario, ScenarioSample } from "../types";
 import type PQueueType from "p-queue";
 import type { WorktreeMonitor } from "../../../electron/workspace-host/WorktreeMonitor";
+import { appendFileSync, mkdirSync, writeFileSync } from "node:fs";
 import {
+  IGNORED_BURST_DIR,
   SCALING_WORKTREE_COUNTS,
   allSpawnMark,
   allSpawnsSince,
@@ -60,6 +62,34 @@ const DIRTY_MIN_CHANGED_FILES = 40;
 const STORM_SETTLE_MS = 2_000;
 const STORM_TIMEOUT_MS = 20_000;
 const WARM_STALENESS_MS = 60_000;
+
+// --- Ignored-burst classification (PERF-107) ---------------------------------
+
+/** Files written into the gitignored directory per burst. */
+const IGNORED_BURST_FILES = 40;
+/** How long one arm waits for its flush to surface and settle. Deliberately
+ *  tight: the scenarioLiveness guard DRIVES this scenario, and three arms each
+ *  waiting out a long deadline on a machine whose watcher never armed would
+ *  push a single run() past the ~12s the guard's cost exclusions are drawn at. */
+const BURST_FLUSH_TIMEOUT_MS = 6_000;
+const BURST_SETTLE_MS = 1_200;
+
+/**
+ * Count of distinct file-browser notifications in a window.
+ *
+ * `WorktreeMonitor.handleWorktreeFilesChanged` bumps `workingTreeChangedAt` and
+ * emits, so DISTINCT values of that stamp count raw-filesystem signals. Total
+ * emits would not: a status pass emits too, which is exactly the thing this
+ * scenario is trying to prove did NOT happen.
+ */
+function browserSignals(recorder: EmitRecorder, from: number): number {
+  const stamps = new Set<number>();
+  for (const emit of recorder.emits.slice(from)) {
+    const at = emit.snapshot.workingTreeChangedAt;
+    if (typeof at === "number" && at > 0) stamps.add(at);
+  }
+  return stamps.size;
+}
 
 // --- Idle spawn-rate scenarios (PERF-105/106) --------------------------------
 
@@ -506,6 +536,127 @@ export const gitPipelineScenarios: PerfScenario[] = [
         };
       } finally {
         monitor.stop();
+      }
+    },
+  },
+  {
+    id: "PERF-107",
+    name: "Git Ignored-Burst Classification",
+    description:
+      "Watcher bursts confined to a repo-gitignored directory: git spawns and status passes per flush, against tracked-write and gitignore-edit controls.",
+    tier: "heavy",
+    modes: ["smoke", "ci", "nightly"],
+    iterations: { smoke: 3, ci: 5, nightly: 8 },
+    warmups: 1,
+    correctness: ["browserSignalMisses", "trackedRefreshMisses", "ignoreEditRefreshMisses", "spawnObserverMisses"],
+    async run() {
+      const fixture = getGitPipelineFixture();
+      const recorder = new EmitRecorder();
+      // Fresh monitor per iteration for the same reason PERF-104 uses one: the
+      // recursive parcel subscription is a live native handle, and leaking it
+      // would distort whatever scenario runs next in this process.
+      const monitor = await createMonitorHarness(fixture.ignoredPath, "wt-ignored-branch", {
+        isCurrent: true,
+        gitWatchEnabled: true,
+        onUpdate: (snapshot) => recorder.record(snapshot),
+      });
+      const outputDir = join(fixture.ignoredPath, IGNORED_BURST_DIR);
+      const trackedFile = join(fixture.ignoredPath, "module-0", "file-0.txt");
+      const gitignoreFile = join(fixture.ignoredPath, ".gitignore");
+      const stamp = uid();
+
+      /**
+       * Write a burst, wait for the file-browser signal, then wait for git to
+       * go quiet. The second wait is what makes the reading honest: the
+       * browser signal fires at the flush boundary, BEFORE the classification
+       * has decided anything, so stopping there would report zero spawns for
+       * a classifier that had merely not finished yet.
+       */
+      async function runBurst(write: () => void): Promise<{
+        spawns: number;
+        statusPasses: number;
+        signals: number;
+        settled: boolean;
+      }> {
+        const from = recorder.cursor();
+        const mark = gitSpawnMark();
+        write();
+        const sawSignal = await pollUntil(
+          () => browserSignals(recorder, from) > 0,
+          BURST_FLUSH_TIMEOUT_MS
+        );
+        const settled = await quiesceGitSpawns(BURST_SETTLE_MS, BURST_FLUSH_TIMEOUT_MS);
+        const window = gitSpawnsSince(mark);
+        return {
+          spawns: window.count,
+          statusPasses: window.bySubcommand["status"] ?? 0,
+          signals: sawSignal ? browserSignals(recorder, from) : 0,
+          settled,
+        };
+      }
+
+      try {
+        await monitor.start();
+        // The recursive parcel subscription arms asynchronously; let it arm and
+        // let the startup status pass drain so neither lands in a burst window.
+        await sleep(500);
+        await quiesceGitSpawns(BURST_SETTLE_MS, BURST_FLUSH_TIMEOUT_MS);
+
+        const observerMisses = spawnObserverMisses();
+        const start = performance.now();
+
+        // Arm 1 — the case the whole change exists for. Every path is ignored
+        // by the repo's own rules and untracked, so nothing here can move
+        // tracked status and the status recompute must not run.
+        mkdirSync(outputDir, { recursive: true });
+        const ignoredArm = await runBurst(() => {
+          for (let i = 0; i < IGNORED_BURST_FILES; i++) {
+            writeFileSync(join(outputDir, `chunk-${stamp}-${i}.js`), `build output ${i}\n`);
+          }
+        });
+        const durationMs = performance.now() - start;
+
+        // Arm 2 — tracked control. A real edit inside the same burst shape must
+        // still produce the correct snapshot, not just any refresh.
+        const trackedFrom = recorder.cursor();
+        const trackedArm = await runBurst(() => {
+          writeFileSync(trackedFile, `tracked edit ${stamp}\n`.repeat(8));
+        });
+        const trackedRefreshed = await recorder.waitFor(
+          (snapshot) => snapshotChangedFileCount(snapshot) > 0,
+          BURST_FLUSH_TIMEOUT_MS,
+          trackedFrom
+        );
+
+        // Arm 3 — ignore-rule control. `.gitignore` is not itself ignored, so
+        // it fails the all-ignored test on its own and forces the refresh.
+        const ignoreEditArm = await runBurst(() => {
+          appendFileSync(gitignoreFile, `# touched ${stamp}\n`);
+        });
+
+        return {
+          durationMs,
+          metrics: {
+            gitSpawnsPerIgnoredFlush: ignoredArm.spawns,
+            statusPassesPerIgnoredFlush: ignoredArm.statusPasses,
+            gitSpawnsPerTrackedFlush: trackedArm.spawns,
+            gitSpawnsPerIgnoreEditFlush: ignoreEditArm.spawns,
+            // Fail closed: a watcher that never fired is the cheapest possible
+            // sample, and would otherwise read as a perfect result.
+            browserSignalMisses: ignoredArm.signals >= 1 && ignoredArm.settled ? 0 : 1,
+            trackedRefreshMisses: trackedArm.statusPasses > 0 && trackedRefreshed ? 0 : 1,
+            ignoreEditRefreshMisses: ignoreEditArm.statusPasses > 0 ? 0 : 1,
+            spawnObserverMisses: observerMisses,
+          },
+          notes:
+            ignoredArm.signals === 0
+              ? "no file-browser signal observed for the ignored burst"
+              : undefined,
+        };
+      } finally {
+        monitor.stop();
+        // Leave the fixture as the next iteration expects to find it.
+        writeFileSync(gitignoreFile, `${IGNORED_BURST_DIR}/\n`);
       }
     },
   },

--- a/scripts/perf/scenarios/gitPipeline.ts
+++ b/scripts/perf/scenarios/gitPipeline.ts
@@ -575,7 +575,8 @@ export const gitPipelineScenarios: PerfScenario[] = [
       async function runBurst(write: () => void): Promise<{
         spawns: number;
         statusPasses: number;
-        signals: number;
+        checkIgnores: number;
+        flushes: number;
         settled: boolean;
       }> {
         const from = recorder.cursor();
@@ -587,10 +588,19 @@ export const gitPipelineScenarios: PerfScenario[] = [
         );
         const settled = await quiesceGitSpawns(BURST_SETTLE_MS, BURST_FLUSH_TIMEOUT_MS);
         const window = gitSpawnsSince(mark);
+        // One write burst does not produce one flush: the leading-edge fast
+        // path fires on the first batch the watcher delivers and the ramp
+        // trails the rest, so a burst of N files routinely flushes twice.
+        // Dividing by the observed flush count is what makes these numbers
+        // per-flush, which is how the issue frames the cost — a raw per-burst
+        // tally would read as double the real figure.
+        const flushes = sawSignal ? browserSignals(recorder, from) : 0;
+        const per = (n: number) => (flushes > 0 ? n / flushes : 0);
         return {
-          spawns: window.count,
-          statusPasses: window.bySubcommand["status"] ?? 0,
-          signals: sawSignal ? browserSignals(recorder, from) : 0,
+          spawns: per(window.count),
+          statusPasses: per(window.bySubcommand["status"] ?? 0),
+          checkIgnores: per(window.bySubcommand["check-ignore"] ?? 0),
+          flushes,
           settled,
         };
       }
@@ -641,17 +651,23 @@ export const gitPipelineScenarios: PerfScenario[] = [
           metrics: {
             gitSpawnsPerIgnoredFlush: ignoredArm.spawns,
             statusPassesPerIgnoredFlush: ignoredArm.statusPasses,
+            // Named separately so the composition is legible rather than
+            // inferred: the whole change is one status pass per flush becoming
+            // one check-ignore, and a flat total would hide that.
+            checkIgnoresPerIgnoredFlush: ignoredArm.checkIgnores,
+            ignoredFlushes: ignoredArm.flushes,
             gitSpawnsPerTrackedFlush: trackedArm.spawns,
+            statusPassesPerTrackedFlush: trackedArm.statusPasses,
             gitSpawnsPerIgnoreEditFlush: ignoreEditArm.spawns,
             // Fail closed: a watcher that never fired is the cheapest possible
             // sample, and would otherwise read as a perfect result.
-            browserSignalMisses: ignoredArm.signals >= 1 && ignoredArm.settled ? 0 : 1,
+            browserSignalMisses: ignoredArm.flushes >= 1 && ignoredArm.settled ? 0 : 1,
             trackedRefreshMisses: trackedArm.statusPasses > 0 && trackedRefreshed ? 0 : 1,
             ignoreEditRefreshMisses: ignoreEditArm.statusPasses > 0 ? 0 : 1,
             spawnObserverMisses: observerMisses,
           },
           notes:
-            ignoredArm.signals === 0
+            ignoredArm.flushes === 0
               ? "no file-browser signal observed for the ignored burst"
               : undefined,
         };

--- a/scripts/perf/scenarios/gitPipeline.ts
+++ b/scripts/perf/scenarios/gitPipeline.ts
@@ -565,7 +565,12 @@ export const gitPipelineScenarios: PerfScenario[] = [
     modes: ["smoke", "ci", "nightly"],
     iterations: { smoke: 3, ci: 5, nightly: 8 },
     warmups: 1,
-    correctness: ["browserSignalMisses", "trackedRefreshMisses", "ignoreEditRefreshMisses", "spawnObserverMisses"],
+    correctness: [
+      "browserSignalMisses",
+      "trackedRefreshMisses",
+      "ignoreEditRefreshMisses",
+      "spawnObserverMisses",
+    ],
     async run() {
       const fixture = getGitPipelineFixture();
       const recorder = new EmitRecorder();

--- a/scripts/perf/scenarios/gitPipeline.ts
+++ b/scripts/perf/scenarios/gitPipeline.ts
@@ -601,10 +601,12 @@ export const gitPipelineScenarios: PerfScenario[] = [
         checkIgnores: number;
         flushes: number;
         settled: boolean;
+        workMs: number;
       }> {
         const from = recorder.cursor();
         const since = latestBrowserStamp(recorder);
         const mark = gitSpawnMark();
+        const startedAt = performance.now();
         write();
         const sawSignal = await pollUntil(
           () => browserSignals(recorder, from, since) > 0,
@@ -633,6 +635,11 @@ export const gitPipelineScenarios: PerfScenario[] = [
           checkIgnores: per(window.bySubcommand["check-ignore"] ?? 0),
           flushes,
           settled,
+          // Timed to the last git spawn in the window, the way PERF-104 times
+          // its storm — NOT wall clock, which now carries the fixed
+          // classifier-deadline sleep above and would report the
+          // instrumentation instead of the work.
+          workMs: window.lastAtMs === null ? 0 : Math.max(0, window.lastAtMs - startedAt),
         };
       }
 
@@ -644,7 +651,6 @@ export const gitPipelineScenarios: PerfScenario[] = [
         await quiesceGitSpawns(BURST_SETTLE_MS, BURST_FLUSH_TIMEOUT_MS);
 
         const observerMisses = spawnObserverMisses();
-        const start = performance.now();
 
         // Arm 1 — the case the whole change exists for. Every path is ignored
         // by the repo's own rules and untracked, so nothing here can move
@@ -655,7 +661,10 @@ export const gitPipelineScenarios: PerfScenario[] = [
             writeFileSync(join(outputDir, `chunk-${stamp}-${i}.js`), `build output ${i}\n`);
           }
         });
-        const durationMs = performance.now() - start;
+        // Fail closed on the duration too: a watcher that never spawned git
+        // has workMs 0, which would read as the cheapest possible sample AND
+        // trip the liveness guard's "must self-time a positive duration" rule.
+        const durationMs = ignoredArm.workMs > 0 ? ignoredArm.workMs : BURST_FLUSH_TIMEOUT_MS;
 
         // A dead watcher makes every later arm wait out its full deadline for
         // a signal that cannot come. Stop here and report the miss instead:

--- a/scripts/perf/scenarios/gitPipeline.ts
+++ b/scripts/perf/scenarios/gitPipeline.ts
@@ -613,12 +613,23 @@ export const gitPipelineScenarios: PerfScenario[] = [
           BURST_FLUSH_TIMEOUT_MS
         );
         // `quiesceGitSpawns` watches process STARTS, not completions, so a
-        // classifier that is still running looks identical to one that
-        // finished. Waiting past the classifier's own deadline is what closes
-        // that hole: if it hung, its 2s timeout has fired by now and the
-        // fallback refresh it triggers is inside this window, where it counts
-        // against this arm instead of contaminating the next one.
-        await sleep(WORKTREE_CLASSIFY_DEADLINE_MS);
+        // classifier still running looks identical to one that finished.
+        // Waiting past the classifier's own deadline is what closes that hole:
+        // a hung classifier has timed out by then and the fallback refresh it
+        // triggers lands inside this window, where it counts against this arm
+        // instead of contaminating the next one.
+        //
+        // The wait has to hang off the LAST flush, not the first. One write
+        // burst routinely flushes twice, and a second flush arriving 800ms in
+        // starts its own classifier; sleeping from the first signal would let
+        // that one's deadline fall outside the window.
+        let seen = browserSignals(recorder, from, since);
+        for (;;) {
+          await sleep(WORKTREE_CLASSIFY_DEADLINE_MS);
+          const now = browserSignals(recorder, from, since);
+          if (now === seen) break;
+          seen = now;
+        }
         const settled = await quiesceGitSpawns(BURST_SETTLE_MS, BURST_FLUSH_TIMEOUT_MS);
         const window = gitSpawnsSince(mark);
         // One write burst does not produce one flush: the leading-edge fast

--- a/scripts/perf/scenarios/gitPipeline.ts
+++ b/scripts/perf/scenarios/gitPipeline.ts
@@ -2,7 +2,7 @@ import { basename, join } from "node:path";
 import type { PerfScenario, ScenarioSample } from "../types";
 import type PQueueType from "p-queue";
 import type { WorktreeMonitor } from "../../../electron/workspace-host/WorktreeMonitor";
-import { appendFileSync, mkdirSync, writeFileSync } from "node:fs";
+import { appendFileSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import {
   IGNORED_BURST_DIR,
   SCALING_WORKTREE_COUNTS,
@@ -73,6 +73,8 @@ const IGNORED_BURST_FILES = 40;
  *  push a single run() past the ~12s the guard's cost exclusions are drawn at. */
 const BURST_FLUSH_TIMEOUT_MS = 6_000;
 const BURST_SETTLE_MS = 1_200;
+/** Mirrors WORKTREE_CLASSIFY_TIMEOUT_MS in gitFileWatcher.ts. */
+const WORKTREE_CLASSIFY_DEADLINE_MS = 2_000;
 
 /**
  * Count of distinct file-browser notifications in a window.
@@ -82,13 +84,28 @@ const BURST_SETTLE_MS = 1_200;
  * emits would not: a status pass emits too, which is exactly the thing this
  * scenario is trying to prove did NOT happen.
  */
-function browserSignals(recorder: EmitRecorder, from: number): number {
+function browserSignals(recorder: EmitRecorder, from: number, since: number): number {
   const stamps = new Set<number>();
   for (const emit of recorder.emits.slice(from)) {
     const at = emit.snapshot.workingTreeChangedAt;
-    if (typeof at === "number" && at > 0) stamps.add(at);
+    // Strictly newer than the window's baseline, not merely present: a
+    // status-only emit landing after the cursor still carries the PREVIOUS
+    // flush's stamp, and counting it would invent a flush that never happened
+    // and halve the reported per-flush cost. The stamp is strictly increasing
+    // (WorktreeMonitor bumps it with Math.max(now, prev + 1)), so ">" is exact.
+    if (typeof at === "number" && at > since) stamps.add(at);
   }
   return stamps.size;
+}
+
+/** The newest file-browser stamp the recorder has seen, or 0. */
+function latestBrowserStamp(recorder: EmitRecorder): number {
+  let latest = 0;
+  for (const emit of recorder.emits) {
+    const at = emit.snapshot.workingTreeChangedAt;
+    if (typeof at === "number" && at > latest) latest = at;
+  }
+  return latest;
 }
 
 // --- Idle spawn-rate scenarios (PERF-105/106) --------------------------------
@@ -561,8 +578,14 @@ export const gitPipelineScenarios: PerfScenario[] = [
         onUpdate: (snapshot) => recorder.record(snapshot),
       });
       const outputDir = join(fixture.ignoredPath, IGNORED_BURST_DIR);
-      const trackedFile = join(fixture.ignoredPath, "module-0", "file-0.txt");
+      // module-11/file-9.txt is the one (dir, file) pair the standing dirty
+      // loop misses: it writes (i % 12, i % 10) for i < 40, and that pair needs
+      // i = 59. Editing a CLEAN tracked file is what lets the control assert a
+      // strict increase in the changed-file count — editing an already-dirty
+      // one leaves the count flat, which the standing set satisfies anyway.
+      const trackedFile = join(fixture.ignoredPath, "module-11", "file-9.txt");
       const gitignoreFile = join(fixture.ignoredPath, ".gitignore");
+      const trackedOriginal = readFileSync(trackedFile, "utf8");
       const stamp = uid();
 
       /**
@@ -580,12 +603,20 @@ export const gitPipelineScenarios: PerfScenario[] = [
         settled: boolean;
       }> {
         const from = recorder.cursor();
+        const since = latestBrowserStamp(recorder);
         const mark = gitSpawnMark();
         write();
         const sawSignal = await pollUntil(
-          () => browserSignals(recorder, from) > 0,
+          () => browserSignals(recorder, from, since) > 0,
           BURST_FLUSH_TIMEOUT_MS
         );
+        // `quiesceGitSpawns` watches process STARTS, not completions, so a
+        // classifier that is still running looks identical to one that
+        // finished. Waiting past the classifier's own deadline is what closes
+        // that hole: if it hung, its 2s timeout has fired by now and the
+        // fallback refresh it triggers is inside this window, where it counts
+        // against this arm instead of contaminating the next one.
+        await sleep(WORKTREE_CLASSIFY_DEADLINE_MS);
         const settled = await quiesceGitSpawns(BURST_SETTLE_MS, BURST_FLUSH_TIMEOUT_MS);
         const window = gitSpawnsSince(mark);
         // One write burst does not produce one flush: the leading-edge fast
@@ -594,7 +625,7 @@ export const gitPipelineScenarios: PerfScenario[] = [
         // Dividing by the observed flush count is what makes these numbers
         // per-flush, which is how the issue frames the cost — a raw per-burst
         // tally would read as double the real figure.
-        const flushes = sawSignal ? browserSignals(recorder, from) : 0;
+        const flushes = sawSignal ? browserSignals(recorder, from, since) : 0;
         const per = (n: number) => (flushes > 0 ? n / flushes : 0);
         return {
           spawns: per(window.count),
@@ -626,16 +657,43 @@ export const gitPipelineScenarios: PerfScenario[] = [
         });
         const durationMs = performance.now() - start;
 
-        // Arm 2 — tracked control. A real edit inside the same burst shape must
-        // still produce the correct snapshot, not just any refresh. The file is
-        // already in the standing dirty set, so this changes its content again
-        // rather than adding to the change count.
+        // A dead watcher makes every later arm wait out its full deadline for
+        // a signal that cannot come. Stop here and report the miss instead:
+        // three timed-out arms would cost ~18s and add nothing the first miss
+        // has not already said.
+        if (ignoredArm.flushes === 0) {
+          return {
+            durationMs,
+            metrics: {
+              gitSpawnsPerIgnoredFlush: 0,
+              statusPassesPerIgnoredFlush: 0,
+              checkIgnoresPerIgnoredFlush: 0,
+              ignoredFlushes: 0,
+              gitSpawnsPerTrackedFlush: 0,
+              statusPassesPerTrackedFlush: 0,
+              gitSpawnsPerIgnoreEditFlush: 0,
+              browserSignalMisses: 1,
+              trackedRefreshMisses: 1,
+              ignoreEditRefreshMisses: 1,
+              spawnObserverMisses: observerMisses,
+            },
+            notes: "no file-browser signal observed for the ignored burst",
+          };
+        }
+
+        // Arm 2 — tracked control. A real edit must produce the correct
+        // snapshot, not merely some refresh. The oracle is a STRICT increase in
+        // the changed-file count: `> 0` was already true of the standing dirty
+        // set before the arm ran, so it would have been satisfied by the
+        // browser notification re-emitting the old snapshot, even if the status
+        // recompute that followed had failed outright.
         const trackedFrom = recorder.cursor();
+        const changedBefore = snapshotChangedFileCount(monitor.getSnapshot());
         const trackedArm = await runBurst(() => {
           writeFileSync(trackedFile, `tracked edit ${stamp}\n`.repeat(8));
         });
         const trackedRefreshed = await recorder.waitFor(
-          (snapshot) => snapshotChangedFileCount(snapshot) > 0,
+          (snapshot) => snapshotChangedFileCount(snapshot) > changedBefore,
           BURST_FLUSH_TIMEOUT_MS,
           trackedFrom
         );
@@ -673,8 +731,13 @@ export const gitPipelineScenarios: PerfScenario[] = [
         };
       } finally {
         monitor.stop();
-        // Leave the fixture as the next iteration expects to find it.
+        // Leave the fixture exactly as the next iteration expects to find it.
+        // Without this the ignored directory grows by 40 files per iteration,
+        // so later iterations watch a bigger tree than earlier ones and the
+        // samples stop being comparable.
         writeFileSync(gitignoreFile, `${IGNORED_BURST_DIR}/\n`);
+        writeFileSync(trackedFile, trackedOriginal);
+        rmSync(outputDir, { recursive: true, force: true });
       }
     },
   },

--- a/scripts/perf/scenarios/gitPipeline.ts
+++ b/scripts/perf/scenarios/gitPipeline.ts
@@ -617,7 +617,9 @@ export const gitPipelineScenarios: PerfScenario[] = [
         const durationMs = performance.now() - start;
 
         // Arm 2 — tracked control. A real edit inside the same burst shape must
-        // still produce the correct snapshot, not just any refresh.
+        // still produce the correct snapshot, not just any refresh. The file is
+        // already in the standing dirty set, so this changes its content again
+        // rather than adding to the change count.
         const trackedFrom = recorder.cursor();
         const trackedArm = await runBurst(() => {
           writeFileSync(trackedFile, `tracked edit ${stamp}\n`.repeat(8));

--- a/scripts/perf/scenarios/index.ts
+++ b/scripts/perf/scenarios/index.ts
@@ -142,6 +142,7 @@ export const EXPECTED_SCENARIO_IDS: ReadonlySet<string> = new Set([
   "PERF-104",
   "PERF-105",
   "PERF-106",
+  "PERF-107",
   "PERF-110",
   "PERF-111",
   "PERF-112",


### PR DESCRIPTION
The recursive worktree watcher threw away the changed paths `@parcel/watcher` hands it and forwarded only `events.length`, so every debounced flush ran the full git status recompute — even when every path in the burst was a build artefact in a gitignored, untracked directory. A project whose build writes to `.output/`, `generated/`, `.parcel-cache/` or any other name outside the fixed `WORKTREE_IGNORE_GLOBS` list paid that chain on every flush for the whole build, and so did every agent writing scratch files into an ignored folder.

Burst paths now ride through the adaptive debounce (bounded at 2048, coalesced into a set). At flush time one `git check-ignore --stdin -z` classifies the burst, and `onChange` is skipped only when every path in it is provably irrelevant. `onWorktreeFilesChanged` still fires unconditionally at the flush boundary, before any verdict exists, so the file browser is unaffected (#11330).

**User-facing effect:** a build or an agent writing into an ignored folder no longer keeps git busy in the background. The sidebar still updates for anything that can actually change tracked status, and the file browser still sees every write exactly as before.

## Why `git check-ignore`, not an in-process matcher

Plain `git check-ignore` — no `--no-index`, no `-v` — never reports a *tracked* path as ignored, so a path present in its output is ignored **and** untracked: exactly the predicate for "cannot affect git status", in one spawn. That is what makes the ambiguous cases free rather than special-cased. A rename arrives as delete+create and the create half fails membership; a delete of a tracked file stays in the index and fails membership; a mixed burst fails membership. Set-membership is the test, never the exit code — a mixed burst still exits 0.

An in-process matcher was rejected: `ignore` evaluates one flat ruleset with no nested `.gitignore`, `core.excludesFile`, `info/exclude` or index-tracked exemption, and a second engine that disagrees with git is the failure this repo already had with CopyTree.

## Measured, one machine and session (M1 Max, git 2.55.0)

New `PERF-107` drives the real `WorktreeMonitor` and watcher against a fixture worktree that gitignores `.output/` and carries a standing dirty set (40 modified + 12 untracked, matching `dirtyPath`) — a clean worktree's status pass is one cheap spawn on the stat-skip fast path and would have priced the wrong thing. Metrics are per flush; one write burst routinely flushes twice.

| metric | before | after |
| --- | --- | --- |
| `statusPassesPerIgnoredFlush` | 1 | **0** |
| `gitSpawnsPerIgnoredFlush` | 1 | 1.5 |
| `checkIgnoresPerIgnoredFlush` | 0 | 1 |
| ignored-burst git work, p50 | 1060 ms | **406 ms** |
| ignored-burst git work, p95 | 1062 ms | 534 ms |
| `gitSpawnsPerTrackedFlush` (control) | 2 | 3 |
| `gitSpawnsPerIgnoreEditFlush` (control) | 2 | 2 |
| PERF-104 spawns / p95 | 4 / 590 ms | 5 / **560 ms** |

Read that honestly: the spawn *count* per ignored flush does not fall. One `git status` becomes one `git check-ignore`, plus a single cold hazard probe per watcher amortised over the burst (hence 1.5). What falls is the work — status passes go to zero and the burst's git activity drops 62% at p50, because check-ignore reads ignore rules and the index while `status` walks a dirty tree. The issue's "3 to 5 spawns" figure describes the chain on a cold monitor; on a warm one it had already collapsed to a single `status`, so there was less spawn count available to remove than the issue assumed.

The cost is one extra spawn on flushes that *do* refresh (2 → 3 tracked, 4 → 5 on PERF-104's storm). PERF-104's p95 does not regress. The hazard probe sits behind the membership test, so bursts heading for a refresh never pay it.

## Correctness

Anything ambiguous falls back to a full refresh: rescan overflow (`isRescanRequest`), an event with no usable path, the Windows adapter's root-path signal, a path outside the worktree, a burst past the cap, and any classification failure, timeout or `exit > 1`. Unknown is sticky for the rest of the burst and reset for the next.

Two holes were found in review and reproduced against real git before being closed:

- **A `.gitignore` can be ignored itself** — by `.git/info/exclude`, or by a rule inside it naming itself. It is then untracked and ignored, so check-ignore reports it and the burst looked skippable while the rule change altered what status lists. Any `.gitignore`, `.gitattributes` or `.gitmodules` write at any depth now forces a refresh with no classification spawn, matched case-insensitively because `.GITIGNORE` is the same file to git on APFS and NTFS.
- **git's tracked-file exemption is a case-SENSITIVE index lookup** even when the filesystem is not. A file force-added as `.output/Keep.txt` and renamed on disk to `.output/keep.txt` stays tracked and shows as modified while check-ignore calls the on-disk spelling ignored. Reproduced on APFS. The skip is now gated on the repo having no tracked file matching an ignore rule — empty for essentially every repo, so the answer is cached and dropped only when a git-internal write or an ignore-rule write lands.

`gitCheckIgnore.ts` returns from PR #10234 (stdin-fed to dodge the E2BIG trap in simple-git's argv-based `checkIgnoreTask`, hardened config and env, `exit > 1` as the only error). One addition: `GIT_LITERAL_PATHSPECS` has to be dropped for this command, which refuses pathspec magic outright and would otherwise die `fatal: pathspec magic not supported by this command: 'literal'` on every call. Safe here and only here — check-ignore selects no files, it matches the literal pathname it was handed against the repo's ignore patterns and echoes that token back. Verified against git 2.55.0: `secre?.txt`, `secre[t].txt`, `secret.*` and `{secret,plain}.txt` all report nothing while `secret.txt` is ignored, so no metacharacter yields a false positive; magic needs a leading `:`, which an absolute path cannot have; and an unparseable pathname still fails closed as exit 128.

## Known limits

- A `core.excludesFile` living inside the worktree and ignoring itself recreates the `.gitignore` hole under an arbitrary filename. Not covered — it would need a git-config read per flush.
- A repo left on `core.ignoreCase=false` while sitting on case-insensitive storage may still alias; unverified, needs a writable reproduction.
- `.git/info/exclude` edits remain invisible to this watcher, as they were before: `**/.git/**` is a watcher-level exclusion. No classification state is cached across flushes, so there is nothing stale to invalidate.

## Tests

`gitFileWatcher.test.ts` gains 20 cases (path carrying, cap and overflow, the canonical-root alias, supersede/abort/disposal, both invalidation holes, warn throttling), `gitCheckIgnore.test.ts` is new, and `gitFileWatcher.ignoreClassification.integration.test.ts` runs the real watcher against real repositories — the unit tests mock exactly the git semantics the design rests on, and both holes above were mocked away before they were measured.

Resolves #12235

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PU2MfTeSRUDP5DBwE99K3h