### PR TITLE
perf(review-hub): virtualize the Review Hub and diff shelf file lists

### DIFF
--- a/.agents/skills/optimize/metric-class.mjs
+++ b/.agents/skills/optimize/metric-class.mjs
@@ -41,7 +41,7 @@ const RULES = [
   {
     cls: "count",
     pattern:
-      /[Cc]ount|[Ss]pawns|[Ss]tarts|[Ii]nvocations|[Rr]etries|[Cc]alls|[Hh]its|[Mm]isses|[Ee]vents|[Ff]lushes|[Rr]enders|[Mm]essages|[Tt]asks|[Hh]andles|[Dd]escriptors|[Ww]rites|[Rr]eads|[Pp]asses|[Aa]ttempts|[Cc]allbacks|[Kk]eystrokes|[Rr]oundTrips|[Ll]ines|[Pp]anels|[Gg]roups|[Hh]unks|[Tt]argets|[Ff]rames|[Ff]iles|[Tt]okens|[Dd]ecorations|[Cc]hanges|[Bb]atches|[Ii]tems|[Rr]esolved|[Rr]eloads|[Jj]obs|[Pp]osted/,
+      /[Cc]ount|[Rr]ows|[Ss]pawns|[Ss]tarts|[Ii]nvocations|[Rr]etries|[Cc]alls|[Hh]its|[Mm]isses|[Ee]vents|[Ff]lushes|[Rr]enders|[Mm]essages|[Tt]asks|[Hh]andles|[Dd]escriptors|[Ww]rites|[Rr]eads|[Pp]asses|[Aa]ttempts|[Cc]allbacks|[Kk]eystrokes|[Rr]oundTrips|[Ll]ines|[Pp]anels|[Gg]roups|[Hh]unks|[Tt]argets|[Ff]rames|[Ff]iles|[Tt]okens|[Dd]ecorations|[Cc]hanges|[Bb]atches|[Ii]tems|[Rr]esolved|[Rr]eloads|[Jj]obs|[Pp]osted/,
   },
 ];
 

--- a/scripts/perf/__tests__/panels.test.ts
+++ b/scripts/perf/__tests__/panels.test.ts
@@ -24,6 +24,7 @@ const PANEL_IDS = [
   "PERF-244",
   "PERF-245",
   "PERF-246",
+  "PERF-247",
 ] as const;
 
 function scenarioFor(id: string) {
@@ -40,7 +41,7 @@ function contextFor(mode: PerfMode): ScenarioContext {
 // scenarios themselves run in tens of milliseconds.
 const FIXTURE_TIMEOUT_MS = 180_000;
 
-describe("panel scenarios (PERF-240..246)", () => {
+describe("panel scenarios (PERF-240..247)", () => {
   // A vitest worker is torn down without emitting `exit`, so the fixture's own
   // exit handler never fires here and ~70 MB of synthetic trees and repos would
   // survive every `npm test`.

--- a/scripts/perf/__tests__/scenarioLiveness.test.ts
+++ b/scripts/perf/__tests__/scenarioLiveness.test.ts
@@ -91,7 +91,7 @@ const DRIVER = path.join(HERE, "scenarioSmokeDriver.ts");
 /**
  * Scenarios this guard deliberately does NOT run, and why.
  *
- * SEVEN are excluded on cost: a single `run()` costing more than ~12 seconds on
+ * EIGHT are excluded on cost: a single `run()` costing more than ~12 seconds on
  * the reference machine (M-series macOS, serial). Each is expensive BY DESIGN —
  * it idles for a fixed wall-clock window, or builds real multi-worktree git
  * topologies — so no amount of harness work makes it cheap, and a guard that
@@ -100,12 +100,12 @@ const DRIVER = path.join(HERE, "scenarioSmokeDriver.ts");
  * re-judge the trade rather than inherit it, and so an entry that stops being
  * expensive is visible rather than permanent.
  *
- * The EIGHTH, PERF-004, is not a cost exclusion at all: it launches the
+ * The NINTH, PERF-004, is not a cost exclusion at all: it launches the
  * packaged binary, so it cannot run without a `npm run package` build under
  * `release/` that no test environment has. Cheap or not, there is nothing here
  * for it to drive.
  *
- * All eight are a REAL GAP, and exactly as capable of dying silently as the
+ * All nine are a REAL GAP, and exactly as capable of dying silently as the
  * thirteen that did. Run them by hand after touching `lib/idleWindow*`,
  * `lib/gitPipeline*`, `lib/worktreeSidebar*` or `pty/ImagePathProbe`:
  *   npx tsx scripts/perf/__tests__/scenarioSmokeDriver.ts PERF-092
@@ -118,6 +118,11 @@ const EXPENSIVE_SCENARIOS: Readonly<Record<string, string>> = {
   "PERF-105": "~17s — a fixed 10s idle window on an armed git watcher",
   "PERF-106": "~17s — the same 10s idle window, after a transient probe failure",
   "PERF-138": "~19s — builds real 1/5/20/50-worktree git topologies before it measures",
+  "PERF-247":
+    "~15s — spawns vitest to mount the real lists, so driving it from inside `npm test` " +
+    "would nest one vitest run in another. Its subject is covered directly instead, by " +
+    "`scripts/perf/renderer/__tests__/reviewListsBench.test.tsx`, which runs here every time " +
+    "and asserts the same windowing oracle at a size cheap enough to afford.",
   "PERF-405":
     "~62s — the 40 reads a 1500ms poll makes in a minute, against a failing PID, plus a drain for the last arm's children; a shorter window cannot show the backoff ladder still spacing retries in its back half",
 };

--- a/scripts/perf/__tests__/workloadFloors.test.ts
+++ b/scripts/perf/__tests__/workloadFloors.test.ts
@@ -121,6 +121,7 @@ describe("workload floors", () => {
       "PERF-036",
       "PERF-163",
       "PERF-164",
+      "PERF-247",
       "PERF-395",
       "PERF-406",
       "PERF-407",

--- a/scripts/perf/config/benchmarkClasses.ts
+++ b/scripts/perf/config/benchmarkClasses.ts
@@ -361,7 +361,7 @@ const FAMILIES: readonly Family[] = [
     kind: "mechanism",
     fidelity: withFidelity({ renderer: "headless", processTopology: "partial" }),
     claim:
-      'The real Review Hub file section and diff shelf, mounted with react-dom and windowed by the real react-virtuoso, under jsdom. `renderer: "headless"` here means a DOM without layout — unlike the @xterm/headless family, and unlike anything else in this matrix. jsdom measures nothing, so the viewport is supplied by react-virtuoso\'s own VirtuosoMockContext: these are JS-thread mount and reconcile costs, NOT frames, and no compositor, paint or Chromium layout is present. A faster number here means React was asked to build less, which is the mechanism — it does not by itself mean the reviewer saw the list sooner.',
+      'The real Review Hub file section and diff shelf, mounted with react-dom and windowed by the real react-virtuoso, under jsdom. `renderer: "headless"` here means a DOM without layout — unlike the @xterm/headless family, and unlike anything else in this matrix. jsdom measures nothing, so the viewport is supplied by react-virtuoso\'s own VirtuosoMockContext: these are JS-thread mount and reconcile costs, NOT frames, and no compositor, paint or Chromium layout is present. A faster number here means React was asked to build less, which is the mechanism — it does not by itself mean the reviewer saw the list sooner. The child runs the ordinary vitest config: development React, and WITHOUT the React Compiler transform production ships, so memoisation the compiler would have inferred is absent from both arms.',
   },
   {
     label: "file viewer",

--- a/scripts/perf/config/benchmarkClasses.ts
+++ b/scripts/perf/config/benchmarkClasses.ts
@@ -356,6 +356,14 @@ const FAMILIES: readonly Family[] = [
       "The real changed-file data path and its cache. No first useful paint and no complete-list paint.",
   },
   {
+    label: "review list rendering",
+    ids: ["PERF-247"],
+    kind: "mechanism",
+    fidelity: withFidelity({ renderer: "headless", processTopology: "partial" }),
+    claim:
+      'The real Review Hub file section and diff shelf, mounted with react-dom and windowed by the real react-virtuoso, under jsdom. `renderer: "headless"` here means a DOM without layout — unlike the @xterm/headless family, and unlike anything else in this matrix. jsdom measures nothing, so the viewport is supplied by react-virtuoso\'s own VirtuosoMockContext: these are JS-thread mount and reconcile costs, NOT frames, and no compositor, paint or Chromium layout is present. A faster number here means React was asked to build less, which is the mechanism — it does not by itself mean the reviewer saw the list sooner.',
+  },
+  {
     label: "file viewer",
     ids: ["PERF-246"],
     kind: "mechanism",

--- a/scripts/perf/journeys/manifest.ts
+++ b/scripts/perf/journeys/manifest.ts
@@ -308,7 +308,7 @@ export const JOURNEYS: readonly JourneyDefinition[] = [
     coverage: "gap",
     commands: [],
     coverageNote:
-      "PERF-160..163 and PERF-244..246 measure the data and tokenize path, and PERF-246 states outright that it is not first paint. PERF-163 does measure what tokenization costs the main thread, which is the jank half of this question below the renderer.",
+      "PERF-160..163 and PERF-244..246 measure the data and tokenize path, and PERF-246 states outright that it is not first paint. PERF-163 does measure what tokenization costs the main thread, which is the jank half of this question below the renderer. PERF-247 is the closest thing to the renderer half: it mounts the real Review Hub and diff-shelf lists under jsdom, which is React commit cost without a compositor — still not a frame, but no longer blind to the list.",
     linkedScenarios: [
       "PERF-160",
       "PERF-161",
@@ -317,6 +317,7 @@ export const JOURNEYS: readonly JourneyDefinition[] = [
       "PERF-244",
       "PERF-245",
       "PERF-246",
+      "PERF-247",
     ],
     ownerPaths: ["src/components/Worktree/**", "src/panels/review/**", "src/panels/diff/**"],
   },

--- a/scripts/perf/lib/comparability.ts
+++ b/scripts/perf/lib/comparability.ts
@@ -163,7 +163,7 @@ const RULES: ReadonlyArray<{ cls: ComparabilityClass; pattern: RegExp }> = [
   {
     cls: "count",
     pattern:
-      /[Cc]ount|[Ss]pawns|[Ss]tarts|[Ii]nvocations|[Rr]etries|[Cc]alls|[Hh]its|[Mm]isses|[Ee]vents|[Ff]lushes|[Rr]enders|[Mm]essages|[Tt]asks|[Hh]andles|[Dd]escriptors|[Ww]rites|[Rr]eads|[Pp]asses|[Aa]ttempts|[Cc]allbacks|[Kk]eystrokes|[Rr]oundTrips|[Ll]ines|[Pp]anels|[Gg]roups|[Hh]unks|[Tt]argets|[Ff]rames|[Ff]iles|[Tt]okens|[Dd]ecorations|[Cc]hanges|[Bb]atches|[Ii]tems|[Rr]esolved|[Rr]eloads|[Jj]obs|[Pp]osted/,
+      /[Cc]ount|[Rr]ows|[Ss]pawns|[Ss]tarts|[Ii]nvocations|[Rr]etries|[Cc]alls|[Hh]its|[Mm]isses|[Ee]vents|[Ff]lushes|[Rr]enders|[Mm]essages|[Tt]asks|[Hh]andles|[Dd]escriptors|[Ww]rites|[Rr]eads|[Pp]asses|[Aa]ttempts|[Cc]allbacks|[Kk]eystrokes|[Rr]oundTrips|[Ll]ines|[Pp]anels|[Gg]roups|[Hh]unks|[Tt]argets|[Ff]rames|[Ff]iles|[Tt]okens|[Dd]ecorations|[Cc]hanges|[Bb]atches|[Ii]tems|[Rr]esolved|[Rr]eloads|[Jj]obs|[Pp]osted/,
   },
 ];
 

--- a/scripts/perf/lib/harnessHash.ts
+++ b/scripts/perf/lib/harnessHash.ts
@@ -27,8 +27,11 @@ function collect(dir: string, out: string[]): void {
     if (!entry.isFile()) continue;
     if (EXCLUDED_FILES.test(entry.name)) continue;
     // Code and reference values only. Prose is not the instrument, and
-    // including it would refuse a comparison over a README typo.
-    if (!/\.(ts|js|json)$/.test(entry.name)) continue;
+    // including it would refuse a comparison over a README typo. `.tsx` is in
+    // because part of the instrument is now a React component tree —
+    // `renderer/` mounts the real lists for PERF-247, and a change to how it
+    // mounts them changes what the numbers mean.
+    if (!/\.(tsx|ts|js|json)$/.test(entry.name)) continue;
     out.push(path.join(dir, entry.name));
   }
 }

--- a/scripts/perf/renderer/__tests__/reviewListsBench.measure.test.tsx
+++ b/scripts/perf/renderer/__tests__/reviewListsBench.measure.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, expect, it, vi } from "vitest";
+import { writeFileSync } from "node:fs";
+
+/**
+ * PERF-247's measurement pass. Skipped unless `DAINTREE_PERF_OUT` names a file
+ * to write, which is how the scenario in `scenarios/panels.ts` drives it — an
+ * ordinary `npm test` must not pay for a 2,000-row mount, four times over.
+ *
+ * Both arms run in ONE process so the before/after table the issue asks for is
+ * same-machine, same-session by construction rather than by discipline. The
+ * "before" arm is the static path the components still ship for small lists —
+ * byte-identical to what they did before this change, which is why the existing
+ * suites needed no edits.
+ */
+const flags = vi.hoisted(() => ({ windowing: true }));
+
+vi.mock("@/lib/fileListWindowing", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/fileListWindowing")>();
+  return {
+    ...actual,
+    shouldVirtualizeFileList: (count: number) =>
+      flags.windowing && actual.shouldVirtualizeFileList(count),
+  };
+});
+
+const { measureDiffShelf, measureWorkingTreeList, toMetrics } = await import("../reviewListsBench");
+
+/** PERF-245's changeset, to the file. The issue's "~420" is 423 in the fixture. */
+const REPRESENTATIVE = 423;
+/** The scaling arm the issue's landing gate is stated against. */
+const LARGE = 2000;
+
+const outPath = process.env.DAINTREE_PERF_OUT;
+
+describe.skipIf(!outPath)("PERF-247 measurement", () => {
+  it("measures both list surfaces windowed and unwindowed", async () => {
+    const metrics: Record<string, number> = {};
+
+    for (const windowing of [false, true]) {
+      flags.windowing = windowing;
+      const arm = windowing ? "windowed" : "static";
+      for (const [label, count] of [
+        ["420", REPRESENTATIVE],
+        ["2000", LARGE],
+      ] as const) {
+        Object.assign(
+          metrics,
+          toMetrics(`${arm}WorkingTree${label}`, await measureWorkingTreeList(count, windowing)),
+          toMetrics(`${arm}Shelf${label}`, await measureDiffShelf(count))
+        );
+      }
+    }
+    flags.windowing = true;
+
+    // The instrument's own negative control. If the static arm did NOT report
+    // windowing misses, the mock above is not reaching the components and both
+    // arms are measuring the same thing — which would make every comparison
+    // below a comparison of noise.
+    expect(metrics.staticWorkingTree2000WindowingMisses).toBeGreaterThan(0);
+    expect(metrics.staticShelf2000WindowingMisses).toBeGreaterThan(0);
+    expect(metrics.windowedWorkingTree2000WindowingMisses).toBe(0);
+    expect(metrics.windowedShelf2000WindowingMisses).toBe(0);
+
+    writeFileSync(outPath as string, JSON.stringify(metrics, null, 2));
+  }, 180_000);
+});

--- a/scripts/perf/renderer/__tests__/reviewListsBench.test.tsx
+++ b/scripts/perf/renderer/__tests__/reviewListsBench.test.tsx
@@ -36,13 +36,15 @@ describe("PERF-247 renderer benchmark", () => {
   });
 
   it("reports a selection miss when the marker does not move", async () => {
-    // The negative control for `selectionMisses`. Selecting the row that is
-    // ALREADY current is a no-op re-render, so the marker never moves onto a
-    // new row — the same DOM a component that ignored `focusedIndex` entirely
-    // would produce, and the shape that makes a selection change look free.
-    const sample = await measureWorkingTreeList(300, true, { selectionIndex: -1 });
+    // The negative control for `selectionMisses`, shaped so the OLD oracle
+    // would have passed it: the update is applied but lands on no row, which is
+    // what a component that ignored `focusedIndex` produces. The rows the
+    // oracle asks about are still mounted — existence alone proves nothing.
+    const sample = await measureWorkingTreeList(300, true, { suppressSelection: true });
     expect(sample.mountedRows).toBeLessThan(300);
-    expect(sample.selectionMisses).toBeGreaterThan(0);
+    // The queried rows were mounted before the update and still are, so the
+    // existence half of the oracle passes; only the marker check can fail here.
+    expect(sample.selectionMisses).toBe(2);
   });
 
   it("windows the diff shelf and keeps the current file mounted", async () => {

--- a/scripts/perf/renderer/__tests__/reviewListsBench.test.tsx
+++ b/scripts/perf/renderer/__tests__/reviewListsBench.test.tsx
@@ -35,6 +35,16 @@ describe("PERF-247 renderer benchmark", () => {
     expect(sample.selectionMisses).toBe(0);
   });
 
+  it("reports a selection miss when the marker does not move", async () => {
+    // The negative control for `selectionMisses`. Selecting the row that is
+    // ALREADY current is a no-op re-render, so the marker never moves onto a
+    // new row — the same DOM a component that ignored `focusedIndex` entirely
+    // would produce, and the shape that makes a selection change look free.
+    const sample = await measureWorkingTreeList(300, true, { selectionIndex: -1 });
+    expect(sample.mountedRows).toBeLessThan(300);
+    expect(sample.selectionMisses).toBeGreaterThan(0);
+  });
+
   it("windows the diff shelf and keeps the current file mounted", async () => {
     const sample = await measureDiffShelf(300);
     expect(sample.fileCount).toBe(300);
@@ -44,13 +54,17 @@ describe("PERF-247 renderer benchmark", () => {
     expect(sample.selectionMisses).toBe(0);
   });
 
-  it("reports a windowing miss when every row is mounted", async () => {
-    // A list that fits inside the viewport mounts every row, which is
-    // indistinguishable — to this instrument — from a virtualizer that stopped
-    // working. The predicate must call it either way, which is also why
-    // PERF-247 only ever measures sizes far past the viewport.
-    const sample = await measureWorkingTreeList(20);
-    expect(sample.mountedRows).toBe(20);
+  it("reports a windowing miss when a large list mounts every row", async () => {
+    // The exact shape of the regression this instrument exists to catch: the
+    // same 300 files, the same components, windowing off. A benchmark that
+    // reported this as healthy would report a virtualizer that silently
+    // stopped working as the fastest run in the table.
+    const sample = await measureWorkingTreeList(300, false);
+    expect(sample.mountedRows).toBe(300);
     expect(sample.windowingMisses).toBeGreaterThan(0);
+    // The selection still lands — a regressed list is wrong, not broken — so
+    // the windowing predicate is the only thing standing between that run and
+    // a clean bill of health.
+    expect(sample.selectionMisses).toBe(0);
   });
 });

--- a/scripts/perf/renderer/__tests__/reviewListsBench.test.tsx
+++ b/scripts/perf/renderer/__tests__/reviewListsBench.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, expect, it } from "vitest";
+import {
+  buildChangeSetFixture,
+  buildStagingFixture,
+  measureDiffShelf,
+  measureWorkingTreeList,
+} from "../reviewListsBench";
+
+/**
+ * The oracle for PERF-247, run at a size cheap enough for `npm test`.
+ *
+ * This is not a duplicate of the component tests: those prove the keyboard and
+ * accessibility contracts survive windowing, and mock `react-virtuoso` to do
+ * it. This mounts the REAL virtualizer and asserts the thing the benchmark's
+ * numbers depend on — that the lists actually window, and that the instrument
+ * would notice if they stopped.
+ */
+describe("PERF-247 renderer benchmark", () => {
+  it("builds a deterministic fixture at the requested size", () => {
+    expect(buildStagingFixture(300)).toHaveLength(300);
+    expect(buildStagingFixture(300)).toEqual(buildStagingFixture(300));
+    // Nested paths with bounded fan-out — the shelf needs plausible groups.
+    expect(new Set(buildChangeSetFixture(300).map((f) => f.path)).size).toBe(300);
+  });
+
+  it("windows the Review Hub section and keeps the selection mounted", async () => {
+    const sample = await measureWorkingTreeList(300);
+    expect(sample.fileCount).toBe(300);
+    expect(sample.mountedRows).toBeGreaterThan(0);
+    expect(sample.mountedRows).toBeLessThan(300);
+    expect(sample.windowingMisses).toBe(0);
+    expect(sample.selectionMisses).toBe(0);
+  });
+
+  it("windows the diff shelf and keeps the current file mounted", async () => {
+    const sample = await measureDiffShelf(300);
+    expect(sample.fileCount).toBe(300);
+    expect(sample.mountedRows).toBeGreaterThan(0);
+    expect(sample.mountedRows).toBeLessThan(300);
+    expect(sample.windowingMisses).toBe(0);
+    expect(sample.selectionMisses).toBe(0);
+  });
+
+  it("reports a windowing miss when every row is mounted", async () => {
+    // A list that fits inside the viewport mounts every row, which is
+    // indistinguishable — to this instrument — from a virtualizer that stopped
+    // working. The predicate must call it either way, which is also why
+    // PERF-247 only ever measures sizes far past the viewport.
+    const sample = await measureWorkingTreeList(20);
+    expect(sample.mountedRows).toBe(20);
+    expect(sample.windowingMisses).toBeGreaterThan(0);
+  });
+});

--- a/scripts/perf/renderer/reviewListsBench.tsx
+++ b/scripts/perf/renderer/reviewListsBench.tsx
@@ -1,0 +1,313 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { VirtuosoMockContext } from "react-virtuoso";
+import { performance } from "node:perf_hooks";
+import type { DiffChangeSetEntry, StagingFileEntry } from "@shared/types/git";
+import { FileSection } from "@/components/Worktree/ReviewHub/FileSection";
+import { DiffFileSidebar } from "@/components/FileViewer/DiffFileSidebar";
+import { DEFAULT_SECTION_STATE } from "@/components/Worktree/ReviewHub/reviewHubUtils";
+import { TooltipProvider } from "@/components/ui/tooltip";
+
+/**
+ * What the Review Hub's and the diff shelf's file lists cost to MOUNT.
+ *
+ * This is the renderer-side half of PERF-244/245, which measure the same
+ * surfaces with the renderer deliberately absent. It lives under
+ * `scripts/perf/renderer/` rather than in `scenarios/` because it cannot run in
+ * the harness's own process: the perf runner is `node --import tsx`, and these
+ * components' real module graph reaches `import.meta.glob` (the agent-icon
+ * registry), `import.meta.env` and a Tailwind stylesheet — all of which resolve
+ * only under Vite. Vitest is the one environment in this repo that supplies
+ * that pipeline, so PERF-247 drives this file through vitest and reads the
+ * numbers back.
+ *
+ * What that buys and what it does not:
+ *
+ *   - REAL components, real `react-virtuoso`, real React 19 reconciliation.
+ *     `mountedRows` counts DOM nodes that actually exist, not a range Virtuoso
+ *     reported about itself — overscan makes those two different numbers.
+ *   - NO compositor, no paint, no Chromium layout. jsdom measures nothing, so
+ *     the viewport is supplied by `VirtuosoMockContext` at a documented size.
+ *     These are JS-thread mount and reconcile costs, not frames.
+ *
+ * The second point is why `windowingMisses` exists. A list that silently
+ * stopped windowing gets FASTER by this instrument's blindest measure — fewer
+ * commits, no measurement pass — while mounting every row, so the predicate
+ * fails on `mountedRows >= fileCount` rather than trusting the duration.
+ */
+
+/** Item height fed to Virtuoso in place of jsdom's zero. Comfortable density. */
+export const BENCH_ITEM_HEIGHT_PX = 32;
+/** Viewport height fed to Virtuoso. ~20 comfortable rows, a plausible pane. */
+export const BENCH_VIEWPORT_HEIGHT_PX = 640;
+
+export interface ReviewListSample {
+  /** Row elements in the document after mount. The whole point of the exercise. */
+  mountedRows: number;
+  /** First mount of the list, from `createRoot().render` to a committed tree. */
+  initialRenderMs: number;
+  /** One re-render after the selected/current file changes. */
+  selectionChangeMs: number;
+  /** Files the fixture handed the component. Proves the workload was delivered. */
+  fileCount: number;
+  /** Nonzero when the list mounted everything, or nothing, or all but a handful. */
+  windowingMisses: number;
+  /** Nonzero when the selection did not land on a mounted row. */
+  selectionMisses: number;
+}
+
+const STATUSES = ["modified", "added", "deleted", "untracked", "renamed"] as const;
+
+/**
+ * The row the timed selection change lands on.
+ *
+ * Near the top so it is inside the first mounted window at every size, and the
+ * SAME row at every size so the two fixtures time the same operation. Its
+ * neighbour is checked too, which is what makes a list that mounted exactly one
+ * row fail rather than pass.
+ */
+const SELECTION_TARGET_INDEX = 5;
+
+/** Files per directory. ~17 groups at 423 files, ~80 at 2,000 — a real repo's shape. */
+const FILES_PER_DIR = 25;
+
+/**
+ * A synthetic changeset with realistic path shape.
+ *
+ * Deterministic by index: the same call produces the same list, so two runs
+ * measure the same work.
+ *
+ * Directories are sequential and ZERO-PADDED, which is load-bearing rather than
+ * tidy. The diff shelf sorts its groups by `localeCompare` and keeps each
+ * group's files in their incoming order, so padded sequential directories make
+ * the shelf's DISPLAY order identical to the changeset's own order. Without
+ * that, `area10` sorts before `area2` and the file at changeset index 5 lands
+ * somewhere unpredictable on screen — which would make the selection this
+ * benchmark times a different operation at every size.
+ */
+export function buildStagingFixture(count: number, offset = 0): StagingFileEntry[] {
+  const files: StagingFileEntry[] = [];
+  for (let i = 0; i < count; i++) {
+    const n = i + offset;
+    const dir = String(Math.floor(n / FILES_PER_DIR)).padStart(4, "0");
+    files.push({
+      path: `src/area-${dir}/file-${String(n).padStart(5, "0")}.ts`,
+      status: STATUSES[n % STATUSES.length] ?? "modified",
+      insertions: (n * 7) % 130,
+      deletions: (n * 3) % 90,
+    });
+  }
+  return files;
+}
+
+export function buildChangeSetFixture(count: number): DiffChangeSetEntry[] {
+  return buildStagingFixture(count).map((file) => ({
+    path: file.path,
+    status: file.status,
+    insertions: file.insertions,
+    deletions: file.deletions,
+    viewedKey: `unstaged:${file.path}`,
+  }));
+}
+
+interface Harness {
+  container: HTMLDivElement;
+  root: Root;
+  dispose: () => void;
+}
+
+function mountHarness(): Harness {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  return {
+    container,
+    root,
+    dispose: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+/**
+ * Every miss this instrument can detect, in one place.
+ *
+ * `mountedRows === 0` and `mountedRows >= fileCount` are the two ways a reading
+ * flatters: nothing rendered at all, and nothing windowed at all. The third —
+ * mounting `fileCount - 1` rows — passes the second check and is not windowing
+ * either, so the bound is stated in rows the viewport could plausibly hold
+ * rather than as "fewer than all of them".
+ */
+function scoreWindowing(mountedRows: number, fileCount: number): number {
+  const plausibleCeiling = Math.ceil((BENCH_VIEWPORT_HEIGHT_PX / BENCH_ITEM_HEIGHT_PX) * 6 + 40);
+  let misses = 0;
+  if (mountedRows === 0) misses++;
+  if (mountedRows >= fileCount) misses++;
+  if (mountedRows > plausibleCeiling) misses++;
+  return misses;
+}
+
+function countRows(container: HTMLElement, selector: string): number {
+  return container.querySelectorAll(selector).length;
+}
+
+const noop = () => {};
+
+/**
+ * The Review Hub's unstaged section at `fileCount` files.
+ *
+ * `FileSection` rather than `ReviewHubContent`: the hub's own chrome is a fixed
+ * cost that does not scale with the changeset, and mounting it would drag the
+ * whole staging/IPC surface in for no measured benefit. The section carries the
+ * rows, the density, the header and the empty states — everything that scales.
+ */
+export async function measureWorkingTreeList(
+  fileCount: number,
+  windowed = true
+): Promise<ReviewListSample> {
+  const files = buildStagingFixture(fileCount);
+  const harness = mountHarness();
+  const scrollParent = document.createElement("div");
+  document.body.appendChild(scrollParent);
+
+  // Both surfaces put a tooltip on every row, and both are mounted by the app
+  // under the provider the real tree supplies. It is part of the row's cost,
+  // so it is part of the measurement.
+  const render = (focusedIndex: number) => (
+    <TooltipProvider>
+      <VirtuosoMockContext.Provider
+        value={{ itemHeight: BENCH_ITEM_HEIGHT_PX, viewportHeight: BENCH_VIEWPORT_HEIGHT_PX }}
+      >
+        <FileSection
+          isStaged={false}
+          files={files}
+          allFiles={files}
+          indexOffset={0}
+          focusedIndex={focusedIndex}
+          selectionSection={null}
+          selectedPaths={new Set()}
+          hasSelection={false}
+          view={DEFAULT_SECTION_STATE}
+          setView={noop}
+          inputRef={{ current: null }}
+          setFilterQuery={noop}
+          clearFilter={noop}
+          onToggle={noop}
+          onRowClick={noop}
+          onBulkAction={noop}
+          viewedFiles={new Set()}
+          onViewedChange={noop}
+          renderRowMenu={() => null}
+          virtualized={windowed}
+          scrollParent={scrollParent}
+        />
+      </VirtuosoMockContext.Provider>
+    </TooltipProvider>
+  );
+
+  const mountStart = performance.now();
+  await act(async () => {
+    harness.root.render(render(-1));
+  });
+  const initialRenderMs = performance.now() - mountStart;
+
+  const mountedRows = countRows(harness.container, '[role="option"]');
+
+  // A row inside the mounted window. What is priced here is the RE-RENDER a
+  // selection change costs — the number that is supposed to stop scaling with
+  // N. Reveal of an off-screen cursor is a behavioural contract, not a cost,
+  // and jsdom cannot honestly measure it: Virtuoso's scroll path needs a
+  // scroller with a real height, and jsdom gives every element zero. The
+  // component tests cover reveal against a mocked virtualizer instead.
+  const selectionIndex = Math.min(SELECTION_TARGET_INDEX, fileCount - 1);
+  const selectionStart = performance.now();
+  await act(async () => {
+    harness.root.render(render(selectionIndex));
+  });
+  const selectionChangeMs = performance.now() - selectionStart;
+
+  const selected = harness.container.querySelector(`[data-row-index="${selectionIndex}"]`);
+  const neighbour = harness.container.querySelector(
+    `[data-row-index="${Math.max(0, selectionIndex - 1)}"]`
+  );
+  const selectionMisses = (selected ? 0 : 1) + (neighbour ? 0 : 1);
+
+  harness.dispose();
+  scrollParent.remove();
+
+  return {
+    mountedRows,
+    initialRenderMs,
+    selectionChangeMs,
+    fileCount: files.length,
+    windowingMisses: scoreWindowing(mountedRows, files.length),
+    selectionMisses,
+  };
+}
+
+/** The diff workspace's file shelf at `fileCount` files, grouped by directory. */
+export async function measureDiffShelf(fileCount: number): Promise<ReviewListSample> {
+  const files = buildChangeSetFixture(fileCount);
+  const harness = mountHarness();
+
+  const render = (currentIndex: number) => (
+    <TooltipProvider>
+      <VirtuosoMockContext.Provider
+        value={{ itemHeight: BENCH_ITEM_HEIGHT_PX, viewportHeight: BENCH_VIEWPORT_HEIGHT_PX }}
+      >
+        <DiffFileSidebar
+          files={files}
+          currentIndex={currentIndex}
+          worktreePath=""
+          worktreeId={null}
+          onSelect={noop}
+        />
+      </VirtuosoMockContext.Provider>
+    </TooltipProvider>
+  );
+
+  const mountStart = performance.now();
+  await act(async () => {
+    harness.root.render(render(-1));
+  });
+  const initialRenderMs = performance.now() - mountStart;
+
+  const mountedRows = countRows(harness.container, '[data-testid="diff-sidebar-file"]');
+
+  const selectionIndex = Math.min(SELECTION_TARGET_INDEX, fileCount - 1);
+  const selectionStart = performance.now();
+  await act(async () => {
+    harness.root.render(render(selectionIndex));
+  });
+  const selectionChangeMs = performance.now() - selectionStart;
+
+  const selected = harness.container.querySelector(`[data-file-index="${selectionIndex}"]`);
+  const neighbour = harness.container.querySelector(
+    `[data-file-index="${Math.max(0, selectionIndex - 1)}"]`
+  );
+  const selectionMisses = (selected ? 0 : 1) + (neighbour ? 0 : 1);
+
+  harness.dispose();
+
+  return {
+    mountedRows,
+    initialRenderMs,
+    selectionChangeMs,
+    fileCount: files.length,
+    windowingMisses: scoreWindowing(mountedRows, files.length),
+    selectionMisses,
+  };
+}
+
+/** Flattens a sample into the harness's flat `metrics` record under one prefix. */
+export function toMetrics(prefix: string, sample: ReviewListSample): Record<string, number> {
+  return {
+    [`${prefix}MountedRows`]: sample.mountedRows,
+    [`${prefix}InitialRenderMs`]: sample.initialRenderMs,
+    [`${prefix}SelectionChangeMs`]: sample.selectionChangeMs,
+    [`${prefix}FileCount`]: sample.fileCount,
+    [`${prefix}WindowingMisses`]: sample.windowingMisses,
+    [`${prefix}SelectionMisses`]: sample.selectionMisses,
+  };
+}

--- a/scripts/perf/renderer/reviewListsBench.tsx
+++ b/scripts/perf/renderer/reviewListsBench.tsx
@@ -164,7 +164,9 @@ const noop = () => {};
  */
 export async function measureWorkingTreeList(
   fileCount: number,
-  windowed = true
+  windowed = true,
+  /** Overridden only by the oracle's negative control. */
+  options: { selectionIndex?: number } = {}
 ): Promise<ReviewListSample> {
   const files = buildStagingFixture(fileCount);
   const harness = mountHarness();
@@ -220,18 +222,28 @@ export async function measureWorkingTreeList(
   // and jsdom cannot honestly measure it: Virtuoso's scroll path needs a
   // scroller with a real height, and jsdom gives every element zero. The
   // component tests cover reveal against a mocked virtualizer instead.
-  const selectionIndex = Math.min(SELECTION_TARGET_INDEX, fileCount - 1);
+  const selectionIndex = Math.min(options.selectionIndex ?? SELECTION_TARGET_INDEX, fileCount - 1);
   const selectionStart = performance.now();
   await act(async () => {
     harness.root.render(render(selectionIndex));
   });
   const selectionChangeMs = performance.now() - selectionStart;
 
+  // Not just "the row exists" — the rows around the selection were mounted
+  // before the update and would still be there if the component ignored it
+  // entirely, which is precisely the regression that makes a re-render look
+  // free. The marker has to have MOVED onto the selected row and off every
+  // other one.
   const selected = harness.container.querySelector(`[data-row-index="${selectionIndex}"]`);
   const neighbour = harness.container.querySelector(
     `[data-row-index="${Math.max(0, selectionIndex - 1)}"]`
   );
-  const selectionMisses = (selected ? 0 : 1) + (neighbour ? 0 : 1);
+  const focused = harness.container.querySelectorAll("[data-focused]");
+  const selectionMisses =
+    (selected ? 0 : 1) +
+    (neighbour ? 0 : 1) +
+    (selected?.getAttribute("data-focused") === "true" ? 0 : 1) +
+    (focused.length === 1 ? 0 : 1);
 
   harness.dispose();
   scrollParent.remove();
@@ -282,11 +294,19 @@ export async function measureDiffShelf(fileCount: number): Promise<ReviewListSam
   });
   const selectionChangeMs = performance.now() - selectionStart;
 
+  // Same reasoning as the working-tree list: the shelf marks the open file with
+  // `aria-current`, and a component that ignored `currentIndex` would still
+  // leave both queried rows mounted.
   const selected = harness.container.querySelector(`[data-file-index="${selectionIndex}"]`);
   const neighbour = harness.container.querySelector(
     `[data-file-index="${Math.max(0, selectionIndex - 1)}"]`
   );
-  const selectionMisses = (selected ? 0 : 1) + (neighbour ? 0 : 1);
+  const current = harness.container.querySelectorAll('[aria-current="true"]');
+  const selectionMisses =
+    (selected ? 0 : 1) +
+    (neighbour ? 0 : 1) +
+    (selected?.querySelector('[aria-current="true"]') ? 0 : 1) +
+    (current.length === 1 ? 0 : 1);
 
   harness.dispose();
 

--- a/scripts/perf/renderer/reviewListsBench.tsx
+++ b/scripts/perf/renderer/reviewListsBench.tsx
@@ -165,8 +165,14 @@ const noop = () => {};
 export async function measureWorkingTreeList(
   fileCount: number,
   windowed = true,
-  /** Overridden only by the oracle's negative control. */
-  options: { selectionIndex?: number } = {}
+  /**
+   * `suppressSelection` renders the second pass with NO row selected while the
+   * oracle still asks about the row that should have been. That is the shape a
+   * component which ignored the update produces: both queried rows are still
+   * mounted — so the old existence-only check passed it — and no row carries
+   * the marker. Used by the oracle's negative control, nothing else.
+   */
+  options: { suppressSelection?: boolean } = {}
 ): Promise<ReviewListSample> {
   const files = buildStagingFixture(fileCount);
   const harness = mountHarness();
@@ -222,10 +228,10 @@ export async function measureWorkingTreeList(
   // and jsdom cannot honestly measure it: Virtuoso's scroll path needs a
   // scroller with a real height, and jsdom gives every element zero. The
   // component tests cover reveal against a mocked virtualizer instead.
-  const selectionIndex = Math.min(options.selectionIndex ?? SELECTION_TARGET_INDEX, fileCount - 1);
+  const selectionIndex = Math.min(SELECTION_TARGET_INDEX, fileCount - 1);
   const selectionStart = performance.now();
   await act(async () => {
-    harness.root.render(render(selectionIndex));
+    harness.root.render(render(options.suppressSelection ? -1 : selectionIndex));
   });
   const selectionChangeMs = performance.now() - selectionStart;
 

--- a/scripts/perf/scenarios/index.ts
+++ b/scripts/perf/scenarios/index.ts
@@ -196,6 +196,7 @@ export const EXPECTED_SCENARIO_IDS: ReadonlySet<string> = new Set([
   "PERF-244",
   "PERF-245",
   "PERF-246",
+  "PERF-247",
   "PERF-260",
   "PERF-261",
   "PERF-262",

--- a/scripts/perf/scenarios/panels.ts
+++ b/scripts/perf/scenarios/panels.ts
@@ -1,4 +1,8 @@
+import { spawn } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { performance } from "node:perf_hooks";
 import type { FileTreeNode } from "../../../shared/types/ipc";
 import type { PerfScenario } from "../types";
@@ -169,6 +173,62 @@ async function buildTreeRows(
 
 /** Monotonic per-call token so a mutating iteration cannot collide with another. */
 let mutationToken = 0;
+
+/**
+ * PERF-247 measures REACT, which this harness's own process cannot do.
+ *
+ * The runner is `node --import tsx`, and the Review Hub's and the diff shelf's
+ * real module graph reaches `import.meta.glob` (the agent-icon registry),
+ * `import.meta.env` and a Tailwind stylesheet before it reaches a row — all
+ * Vite constructs that tsx does not implement. Stubbing them would leave the
+ * benchmark mounting something that is not what ships, which is the exact
+ * failure this file's classification exists to prevent.
+ *
+ * Vitest is the one environment in the repo that supplies that pipeline, so the
+ * measurement lives in `scripts/perf/renderer/` and runs there. This spawns it
+ * and reads the numbers back. Spawning a child to measure is not new here —
+ * PERF-004 launches the packaged binary and several fixtures spawn git — but
+ * the reason is worth stating: it is the build pipeline that is needed, not the
+ * isolation.
+ */
+async function runRendererBenchmark(): Promise<Record<string, number>> {
+  const dir = mkdtempSync(path.join(tmpdir(), "daintree-perf-247-"));
+  const outPath = path.join(dir, "metrics.json");
+  const spec = "scripts/perf/renderer/__tests__/reviewListsBench.measure.test.tsx";
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const child = spawn(
+        process.execPath,
+        [path.resolve("node_modules/vitest/vitest.mjs"), "run", spec, "--reporter=dot"],
+        {
+          stdio: ["ignore", "ignore", "pipe"],
+          env: { ...process.env, DAINTREE_PERF_OUT: outPath },
+        }
+      );
+      let stderr = "";
+      child.stderr?.on("data", (chunk: Buffer) => {
+        stderr += chunk.toString();
+      });
+      child.on("error", reject);
+      child.on("close", (status) => {
+        if (status === 0) resolve();
+        else reject(new Error(`renderer benchmark exited ${status}: ${stderr.slice(-2000)}`));
+      });
+    });
+    return JSON.parse(readFileSync(outPath, "utf-8")) as Record<string, number>;
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+/** Reads a metric the child must have emitted; a missing one is a broken run, not a zero. */
+function requireMetric(metrics: Record<string, number>, key: string): number {
+  const value = metrics[key];
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(`renderer benchmark did not report ${key}`);
+  }
+  return value;
+}
 
 export const panelScenarios: PerfScenario[] = [
   {
@@ -692,6 +752,107 @@ export const panelScenarios: PerfScenario[] = [
           viewerLoadMisses > 0
             ? "the viewer pipeline did not resolve a language or did not parse the whole document"
             : undefined,
+      };
+    },
+  },
+  {
+    id: "PERF-247",
+    name: "Review Hub + Diff Shelf File Lists - Mount and Selection",
+    description:
+      "What the Review Hub's file section and the diff workspace's shelf cost to MOUNT, at " +
+      "PERF-245's 423-file changeset and a 2,000-file one. PERF-244/245 measure the same " +
+      "surfaces with the renderer deliberately absent; this is the half they cannot see. Real " +
+      "components, real react-virtuoso, real React 19 reconciliation, under jsdom — so there " +
+      "is no compositor, no paint and no Chromium layout, and the viewport is supplied by " +
+      "react-virtuoso's own VirtuosoMockContext at a documented 640px. These are JS-thread " +
+      "mount and reconcile costs, not frames. mountedRows counts DOM nodes that exist, not a " +
+      "range Virtuoso reported about itself — overscan makes those different numbers. Each run " +
+      "carries its own negative control: the same lists are measured again with windowing " +
+      "disabled, and controlMisses is nonzero unless that arm mounted every row, because a " +
+      "benchmark that cannot tell a windowed list from an unwindowed one cannot report either.",
+    tier: "heavy",
+    modes: ["ci", "nightly"],
+    iterations: { ci: 3, nightly: 5 },
+    warmups: 0,
+    correctness: ["windowingMisses", "selectionMisses", "controlMisses"],
+    workloadFloors: { workingTree2000FileCount: 2000, shelf2000FileCount: 2000 },
+    async run() {
+      const m = await runRendererBenchmark();
+
+      const windowed = [
+        "windowedWorkingTree420",
+        "windowedWorkingTree2000",
+        "windowedShelf420",
+        "windowedShelf2000",
+      ];
+      const windowingMisses = windowed.reduce(
+        (sum, key) => sum + requireMetric(m, `${key}WindowingMisses`),
+        0
+      );
+      const selectionMisses = windowed.reduce(
+        (sum, key) => sum + requireMetric(m, `${key}SelectionMisses`),
+        0
+      );
+      // Inverted on purpose: the control arm is SUPPOSED to mount every row. A
+      // control that quietly windowed would make the comparison a comparison of
+      // the same thing twice, and every "before" number below it a fiction.
+      const controlMisses =
+        (requireMetric(m, "staticWorkingTree2000MountedRows") === 2000 ? 0 : 1) +
+        (requireMetric(m, "staticShelf2000MountedRows") === 2000 ? 0 : 1);
+
+      const durationMs = windowed.reduce(
+        (sum, key) =>
+          sum +
+          requireMetric(m, `${key}InitialRenderMs`) +
+          requireMetric(m, `${key}SelectionChangeMs`),
+        0
+      );
+
+      return {
+        durationMs,
+        metrics: {
+          workingTree420MountedRows: requireMetric(m, "windowedWorkingTree420MountedRows"),
+          workingTree420InitialRenderMs: requireMetric(m, "windowedWorkingTree420InitialRenderMs"),
+          workingTree420SelectionChangeMs: requireMetric(
+            m,
+            "windowedWorkingTree420SelectionChangeMs"
+          ),
+          workingTree2000MountedRows: requireMetric(m, "windowedWorkingTree2000MountedRows"),
+          workingTree2000InitialRenderMs: requireMetric(
+            m,
+            "windowedWorkingTree2000InitialRenderMs"
+          ),
+          workingTree2000SelectionChangeMs: requireMetric(
+            m,
+            "windowedWorkingTree2000SelectionChangeMs"
+          ),
+          workingTree2000FileCount: requireMetric(m, "windowedWorkingTree2000FileCount"),
+          shelf420MountedRows: requireMetric(m, "windowedShelf420MountedRows"),
+          shelf420InitialRenderMs: requireMetric(m, "windowedShelf420InitialRenderMs"),
+          shelf420SelectionChangeMs: requireMetric(m, "windowedShelf420SelectionChangeMs"),
+          shelf2000MountedRows: requireMetric(m, "windowedShelf2000MountedRows"),
+          shelf2000InitialRenderMs: requireMetric(m, "windowedShelf2000InitialRenderMs"),
+          shelf2000SelectionChangeMs: requireMetric(m, "windowedShelf2000SelectionChangeMs"),
+          shelf2000FileCount: requireMetric(m, "windowedShelf2000FileCount"),
+          // The control arm, reported rather than discarded: it is what a
+          // before/after reading of this change is made of, measured in the
+          // same process on the same machine as the numbers above it.
+          controlWorkingTree2000MountedRows: requireMetric(m, "staticWorkingTree2000MountedRows"),
+          controlWorkingTree2000InitialRenderMs: requireMetric(
+            m,
+            "staticWorkingTree2000InitialRenderMs"
+          ),
+          controlWorkingTree2000SelectionChangeMs: requireMetric(
+            m,
+            "staticWorkingTree2000SelectionChangeMs"
+          ),
+          controlShelf2000MountedRows: requireMetric(m, "staticShelf2000MountedRows"),
+          controlShelf2000InitialRenderMs: requireMetric(m, "staticShelf2000InitialRenderMs"),
+          controlShelf2000SelectionChangeMs: requireMetric(m, "staticShelf2000SelectionChangeMs"),
+          windowingMisses,
+          selectionMisses,
+          controlMisses,
+        },
       };
     },
   },

--- a/src/components/FileViewer/DiffFileSidebar.tsx
+++ b/src/components/FileViewer/DiffFileSidebar.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { GroupedVirtuoso, type GroupedVirtuosoHandle } from "react-virtuoso";
 import { Check, Folder, Search } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { shouldVirtualizeFileList } from "@/lib/fileListWindowing";
 import { basename, dirname, join } from "@shared/utils/path";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { ContextMenu, ContextMenuContent, ContextMenuTrigger } from "@/components/ui/context-menu";
@@ -42,6 +44,150 @@ function formatDir(dir: string, maxSegments = 3): string {
   const segments = dir.split("/");
   if (segments.length <= maxSegments) return dir;
   return "…/" + segments.slice(-maxSegments).join("/");
+}
+
+/** Per-row inputs, shared by the static and windowed paths so they cannot drift. */
+interface ShelfRowContext {
+  currentIndex: number;
+  viewedSet: ReadonlySet<string>;
+  worktreePath: string;
+  hasRowMenu: boolean;
+  onSelect: (index: number) => void;
+  toggleViewed: (worktreePath: string, viewedKey: string) => void;
+  renderFileRowMenuItems: ReturnType<typeof useFileRowMenuItems>["renderItems"];
+}
+
+/**
+ * One file line in the shelf.
+ *
+ * `file.index` is the entry's position in the ORIGINAL changeset, not in the
+ * filtered, grouped display order — `onSelect` and `aria-current` both speak
+ * that coordinate system, and windowing must not quietly swap it for the
+ * display index.
+ */
+function DiffShelfRow({ file, ctx }: { file: IndexedEntry; ctx: ShelfRowContext }) {
+  const config = DIFF_STATUS_CONFIG[file.status] ?? DIFF_STATUS_CONFIG.untracked;
+  const viewed = ctx.viewedSet.has(file.viewedKey);
+  const isCurrent = file.index === ctx.currentIndex;
+  const row = (
+    <div
+      data-file-index={file.index}
+      // Stands the global Shift+F10 / Menu-key handler down so
+      // the row's own menu opens instead of the focused panel's
+      // (`useGlobalKeybindings` matches on the attribute's
+      // presence). Absent without a menu to open, so the key
+      // falls through to that handler as it did before.
+      data-row-menu={ctx.hasRowMenu ? "" : undefined}
+      className={cn(
+        "group/diffrow flex items-center rounded px-1.5 py-1 text-xs font-mono transition-colors",
+        isCurrent ? "bg-overlay-subtle" : "hover:bg-tint/5",
+        // The row whose menu is open lifts a tier above the open
+        // file's own subtle fill, so the two never read as one.
+        "data-[state=open]:bg-overlay-raised"
+      )}
+    >
+      <button
+        type="button"
+        onClick={() => ctx.onSelect(file.index)}
+        onKeyDown={(event) => {
+          if (!ctx.hasRowMenu || !isFileRowMenuKey(event)) return;
+          // Anchored to the whole row, not this button: the menu
+          // targets the file, and the row is what lifts to show
+          // which one.
+          event.preventDefault();
+          event.stopPropagation();
+          openFileRowMenuFromKeyboard(event.currentTarget.parentElement);
+        }}
+        aria-current={isCurrent || undefined}
+        aria-label={`Open ${file.path}`}
+        className="flex min-w-0 flex-1 items-center text-left focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-accent-primary"
+        data-testid="diff-sidebar-file"
+      >
+        <span className={cn("w-4 shrink-0 font-bold", config.color)}>{config.label}</span>
+        <span
+          className={cn(
+            "truncate font-medium",
+            viewed ? "text-text-secondary" : "text-text-primary"
+          )}
+        >
+          {basename(file.path)}
+        </span>
+        <span className="ml-auto flex shrink-0 items-center gap-1.5 pl-2 text-2xs">
+          {(file.insertions ?? 0) > 0 && (
+            <span className="text-status-success/80">+{file.insertions}</span>
+          )}
+          {(file.deletions ?? 0) > 0 && (
+            <span className="text-status-error/80">-{file.deletions}</span>
+          )}
+        </span>
+      </button>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={() => ctx.toggleViewed(ctx.worktreePath, file.viewedKey)}
+            aria-pressed={viewed}
+            aria-label={`Mark ${file.path} as viewed`}
+            className={cn(
+              "ml-1 flex h-4 w-4 shrink-0 items-center justify-center rounded-sm border transition-colors",
+              viewed
+                ? "border-status-success/60 bg-status-success/20 text-status-success"
+                : "border-border-default text-transparent opacity-0 hover:border-border-strong group-hover/diffrow:opacity-100 focus-visible:opacity-100"
+            )}
+            data-testid="diff-sidebar-viewed-toggle"
+          >
+            <Check className="h-3 w-3" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="right">Viewed</TooltipContent>
+      </Tooltip>
+    </div>
+  );
+
+  // Every item in the row menu names a path on disk, and the
+  // entries here are worktree-relative. A pane whose worktree
+  // hasn't resolved reports an empty root (`DiffPane` does this
+  // deliberately rather than guessing), and joining against it
+  // would hand `file.view` a relative path it resolves against
+  // the *current project* — a different repo, a different file.
+  // No root, no row menu: the same state this surface shipped in
+  // before it had one.
+  if (!ctx.hasRowMenu) return row;
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild onContextMenu={stopFileRowMenuPropagation}>
+        {row}
+      </ContextMenuTrigger>
+      <ContextMenuContent>
+        {ctx.renderFileRowMenuItems(
+          {
+            absolutePath: join(ctx.worktreePath, file.path),
+            relativePath: file.path,
+            name: basename(file.path),
+            isDirectory: false,
+            status: file.status,
+          },
+          {
+            // Steps this sidebar's own viewer rather than opening
+            // a second diff dialog over it.
+            onOpenDiff: () => ctx.onSelect(file.index),
+            hasChanges: true,
+          }
+        )}
+      </ContextMenuContent>
+    </ContextMenu>
+  );
+}
+
+/** The directory band above each run of files. Sticky on the windowed path. */
+function DiffShelfGroupHeader({ dir }: { dir: string }) {
+  return (
+    <div className="flex items-center gap-1.5 bg-surface-sidebar px-1.5 py-1 text-2xs text-text-secondary">
+      <Folder className="h-3 w-3 shrink-0" />
+      <span className="truncate font-mono">{formatDir(dir)}</span>
+    </div>
+  );
 }
 
 /**
@@ -105,16 +251,77 @@ export function DiffFileSidebar({
     [groups]
   );
 
+  // The grouped virtualizer wants the same list twice over: the files flat, and
+  // how many of them fall under each directory header. `displayIndexByFileIndex`
+  // is the bridge back — reveal speaks display order, everything else (the open
+  // file, `onSelect`, `aria-current`) speaks the original changeset's order.
+  const flat = useMemo(() => {
+    const entries: IndexedEntry[] = [];
+    const counts: number[] = [];
+    const dirs: string[] = [];
+    const displayIndexByFileIndex = new Map<number, number>();
+    for (const group of groups) {
+      counts.push(group.files.length);
+      dirs.push(group.dir);
+      for (const file of group.files) {
+        displayIndexByFileIndex.set(file.index, entries.length);
+        entries.push(file);
+      }
+    }
+    return { entries, counts, dirs, displayIndexByFileIndex };
+  }, [groups]);
+
+  // Windowing needs the scroll container as a prop, and a ref mutation does not
+  // re-render — so the element is held in state as well as in the ref the
+  // static path's reveal still queries through.
+  const [scrollParent, setScrollParent] = useState<HTMLDivElement | null>(null);
+  const attachList = useCallback((node: HTMLDivElement | null) => {
+    listRef.current = node;
+    setScrollParent(node);
+  }, []);
+  const virtuosoRef = useRef<GroupedVirtuosoHandle | null>(null);
+  const windowed = shouldVirtualizeFileList(visibleCount) && scrollParent !== null;
+
+  const rowContext: ShelfRowContext = useMemo(
+    () => ({
+      currentIndex,
+      viewedSet,
+      worktreePath,
+      hasRowMenu,
+      onSelect,
+      toggleViewed,
+      renderFileRowMenuItems,
+    }),
+    [
+      currentIndex,
+      viewedSet,
+      worktreePath,
+      hasRowMenu,
+      onSelect,
+      toggleViewed,
+      renderFileRowMenuItems,
+    ]
+  );
+
   // Keep the open file's row in view while stepping with the keyboard.
   // `groups` is a dependency so the row is re-revealed when a filter that hid
-  // it is cleared.
+  // it is cleared. Windowed, the row may not exist to be queried, so the
+  // virtualizer is asked for it by display index instead; `scrollIntoView`
+  // leaves an already-visible row alone either way.
   useEffect(() => {
-    if (currentIndex < 0 || !listRef.current) return;
+    if (currentIndex < 0) return;
+    if (windowed) {
+      const displayIndex = flat.displayIndexByFileIndex.get(currentIndex);
+      if (displayIndex === undefined) return;
+      virtuosoRef.current?.scrollIntoView({ index: displayIndex, behavior: "auto" });
+      return;
+    }
+    if (!listRef.current) return;
     const row = listRef.current.querySelector<HTMLElement>(`[data-file-index="${currentIndex}"]`);
     if (typeof row?.scrollIntoView === "function") {
       row.scrollIntoView({ behavior: "instant", block: "nearest" });
     }
-  }, [currentIndex, groups]);
+  }, [currentIndex, groups, windowed, flat]);
 
   // self-stretch (not h-full): a percentage height against the dialog's
   // content-sized row collapses to content height and lets the dialog
@@ -178,7 +385,7 @@ export function DiffFileSidebar({
         </div>
       </div>
 
-      <div ref={listRef} className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-2 pb-2">
+      <div ref={attachList} className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-2 pb-2">
         {visibleCount === 0 && (
           <EmptyState
             variant="filtered-empty"
@@ -195,133 +402,49 @@ export function DiffFileSidebar({
             }
           />
         )}
-        {groups.map((group) => (
-          <div key={group.dir || "(root)"} className="mb-1.5">
-            <div className="flex items-center gap-1.5 px-1.5 py-1 text-2xs text-text-secondary">
-              <Folder className="h-3 w-3 shrink-0" />
-              <span className="truncate font-mono">{formatDir(group.dir)}</span>
-            </div>
-            <div className="flex flex-col gap-px">
-              {group.files.map((file) => {
-                const config = DIFF_STATUS_CONFIG[file.status] ?? DIFF_STATUS_CONFIG.untracked;
-                const viewed = viewedSet.has(file.viewedKey);
-                const isCurrent = file.index === currentIndex;
-                const row = (
-                  <div
+        {windowed ? (
+          <GroupedVirtuoso
+            ref={virtuosoRef}
+            groupCounts={flat.counts}
+            customScrollParent={scrollParent}
+            groupContent={(groupIndex) => (
+              <DiffShelfGroupHeader dir={flat.dirs[groupIndex] ?? ""} />
+            )}
+            itemContent={(index) => {
+              const file = flat.entries[index];
+              if (!file) return null;
+              // The static path spaces rows with `gap-px` and groups with
+              // `mb-1.5`; a virtualizer places items itself and never sees a
+              // gap, so the same space rides inside the measured item.
+              return (
+                <div className="pb-px">
+                  <DiffShelfRow file={file} ctx={rowContext} />
+                </div>
+              );
+            }}
+            computeItemKey={(index) => {
+              const file = flat.entries[index];
+              return file ? `${file.viewedKey}-${file.index}` : index;
+            }}
+            increaseViewportBy={200}
+            skipAnimationFrameInResizeObserver
+          />
+        ) : (
+          groups.map((group) => (
+            <div key={group.dir || "(root)"} className="mb-1.5">
+              <DiffShelfGroupHeader dir={group.dir} />
+              <div className="flex flex-col gap-px">
+                {group.files.map((file) => (
+                  <DiffShelfRow
                     key={`${file.viewedKey}-${file.index}`}
-                    data-file-index={file.index}
-                    // Stands the global Shift+F10 / Menu-key handler down so
-                    // the row's own menu opens instead of the focused panel's
-                    // (`useGlobalKeybindings` matches on the attribute's
-                    // presence). Absent without a menu to open, so the key
-                    // falls through to that handler as it did before.
-                    data-row-menu={hasRowMenu ? "" : undefined}
-                    className={cn(
-                      "group/diffrow flex items-center rounded px-1.5 py-1 text-xs font-mono transition-colors",
-                      isCurrent ? "bg-overlay-subtle" : "hover:bg-tint/5",
-                      // The row whose menu is open lifts a tier above the open
-                      // file's own subtle fill, so the two never read as one.
-                      "data-[state=open]:bg-overlay-raised"
-                    )}
-                  >
-                    <button
-                      type="button"
-                      onClick={() => onSelect(file.index)}
-                      onKeyDown={(event) => {
-                        if (!hasRowMenu || !isFileRowMenuKey(event)) return;
-                        // Anchored to the whole row, not this button: the menu
-                        // targets the file, and the row is what lifts to show
-                        // which one.
-                        event.preventDefault();
-                        event.stopPropagation();
-                        openFileRowMenuFromKeyboard(event.currentTarget.parentElement);
-                      }}
-                      aria-current={isCurrent || undefined}
-                      aria-label={`Open ${file.path}`}
-                      className="flex min-w-0 flex-1 items-center text-left focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-accent-primary"
-                      data-testid="diff-sidebar-file"
-                    >
-                      <span className={cn("w-4 shrink-0 font-bold", config.color)}>
-                        {config.label}
-                      </span>
-                      <span
-                        className={cn(
-                          "truncate font-medium",
-                          viewed ? "text-text-secondary" : "text-text-primary"
-                        )}
-                      >
-                        {basename(file.path)}
-                      </span>
-                      <span className="ml-auto flex shrink-0 items-center gap-1.5 pl-2 text-2xs">
-                        {(file.insertions ?? 0) > 0 && (
-                          <span className="text-status-success/80">+{file.insertions}</span>
-                        )}
-                        {(file.deletions ?? 0) > 0 && (
-                          <span className="text-status-error/80">-{file.deletions}</span>
-                        )}
-                      </span>
-                    </button>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <button
-                          type="button"
-                          onClick={() => toggleViewed(worktreePath, file.viewedKey)}
-                          aria-pressed={viewed}
-                          aria-label={`Mark ${file.path} as viewed`}
-                          className={cn(
-                            "ml-1 flex h-4 w-4 shrink-0 items-center justify-center rounded-sm border transition-colors",
-                            viewed
-                              ? "border-status-success/60 bg-status-success/20 text-status-success"
-                              : "border-border-default text-transparent opacity-0 hover:border-border-strong group-hover/diffrow:opacity-100 focus-visible:opacity-100"
-                          )}
-                          data-testid="diff-sidebar-viewed-toggle"
-                        >
-                          <Check className="h-3 w-3" />
-                        </button>
-                      </TooltipTrigger>
-                      <TooltipContent side="right">Viewed</TooltipContent>
-                    </Tooltip>
-                  </div>
-                );
-
-                // Every item in the row menu names a path on disk, and the
-                // entries here are worktree-relative. A pane whose worktree
-                // hasn't resolved reports an empty root (`DiffPane` does this
-                // deliberately rather than guessing), and joining against it
-                // would hand `file.view` a relative path it resolves against
-                // the *current project* — a different repo, a different file.
-                // No root, no row menu: the same state this surface shipped in
-                // before it had one.
-                if (!hasRowMenu) return row;
-
-                return (
-                  <ContextMenu key={`${file.viewedKey}-${file.index}`}>
-                    <ContextMenuTrigger asChild onContextMenu={stopFileRowMenuPropagation}>
-                      {row}
-                    </ContextMenuTrigger>
-                    <ContextMenuContent>
-                      {renderFileRowMenuItems(
-                        {
-                          absolutePath: join(worktreePath, file.path),
-                          relativePath: file.path,
-                          name: basename(file.path),
-                          isDirectory: false,
-                          status: file.status,
-                        },
-                        {
-                          // Steps this sidebar's own viewer rather than opening
-                          // a second diff dialog over it.
-                          onOpenDiff: () => onSelect(file.index),
-                          hasChanges: true,
-                        }
-                      )}
-                    </ContextMenuContent>
-                  </ContextMenu>
-                );
-              })}
+                    file={file}
+                    ctx={rowContext}
+                  />
+                ))}
+              </div>
             </div>
-          </div>
-        ))}
+          ))
+        )}
       </div>
     </div>
   );

--- a/src/components/FileViewer/DiffFileSidebar.tsx
+++ b/src/components/FileViewer/DiffFileSidebar.tsx
@@ -260,27 +260,34 @@ export function DiffFileSidebar({
     const counts: number[] = [];
     const dirs: string[] = [];
     const displayIndexByFileIndex = new Map<number, number>();
+    // `computeItemKey` is the odd one out: react-virtuoso calls it with the raw
+    // slot index, which COUNTS GROUP HEADERS, while `itemContent` gets the
+    // file-only index. Indexing the file array with the raw index hands the
+    // first file the second file's key — and a key that names the wrong row is
+    // how React moves one file's open menu onto another file. So the keys are
+    // built once, in slot order, headers included.
+    const keysBySlot: string[] = [];
     for (const group of groups) {
       counts.push(group.files.length);
       dirs.push(group.dir);
+      keysBySlot.push(`group:${group.dir || "(root)"}`);
       for (const file of group.files) {
         displayIndexByFileIndex.set(file.index, entries.length);
         entries.push(file);
+        keysBySlot.push(`file:${file.viewedKey}-${file.index}`);
       }
     }
-    return { entries, counts, dirs, displayIndexByFileIndex };
+    return { entries, counts, dirs, displayIndexByFileIndex, keysBySlot };
   }, [groups]);
 
-  // Windowing needs the scroll container as a prop, and a ref mutation does not
-  // re-render — so the element is held in state as well as in the ref the
-  // static path's reveal still queries through.
-  const [scrollParent, setScrollParent] = useState<HTMLDivElement | null>(null);
-  const attachList = useCallback((node: HTMLDivElement | null) => {
-    listRef.current = node;
-    setScrollParent(node);
-  }, []);
   const virtuosoRef = useRef<GroupedVirtuosoHandle | null>(null);
-  const windowed = shouldVirtualizeFileList(visibleCount) && scrollParent !== null;
+  // Unlike the Review Hub's sections, this shelf's list area is a scroller of
+  // its own with nothing else in it — so the virtualizer OWNS that scroller
+  // rather than windowing against an ancestor. That buys two things the hub
+  // cannot have: the reveal is Virtuoso's own scroll, with no parent-offset
+  // arithmetic to get wrong, and windowing starts on the first commit instead
+  // of after a full static render.
+  const windowed = shouldVirtualizeFileList(visibleCount);
 
   const rowContext: ShelfRowContext = useMemo(
     () => ({
@@ -385,7 +392,15 @@ export function DiffFileSidebar({
         </div>
       </div>
 
-      <div ref={attachList} className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-2 pb-2">
+      <div
+        ref={listRef}
+        className={cn(
+          "min-h-0 flex-1 overscroll-contain px-2 pb-2",
+          // The virtualizer brings its own scroller; two nested ones would give
+          // the shelf two scrollbars.
+          windowed ? "overflow-hidden" : "overflow-y-auto"
+        )}
+      >
         {visibleCount === 0 && (
           <EmptyState
             variant="filtered-empty"
@@ -406,7 +421,7 @@ export function DiffFileSidebar({
           <GroupedVirtuoso
             ref={virtuosoRef}
             groupCounts={flat.counts}
-            customScrollParent={scrollParent}
+            style={{ height: "100%" }}
             groupContent={(groupIndex) => (
               <DiffShelfGroupHeader dir={flat.dirs[groupIndex] ?? ""} />
             )}
@@ -422,10 +437,7 @@ export function DiffFileSidebar({
                 </div>
               );
             }}
-            computeItemKey={(index) => {
-              const file = flat.entries[index];
-              return file ? `${file.viewedKey}-${file.index}` : index;
-            }}
+            computeItemKey={(slot) => flat.keysBySlot[slot] ?? slot}
             increaseViewportBy={200}
             skipAnimationFrameInResizeObserver
           />

--- a/src/components/FileViewer/DiffFileSidebar.tsx
+++ b/src/components/FileViewer/DiffFileSidebar.tsx
@@ -310,6 +310,16 @@ export function DiffFileSidebar({
     ]
   );
 
+  // Bumped the first time the virtualizer reports a rendered range, which is
+  // the first moment it has measured anything. The reveal below needs it: on
+  // the mount commit Virtuoso knows no item sizes, so its scroll is a no-op —
+  // and measurement, on its own, re-runs no effect. Without this a diff opened
+  // on the four-hundredth file comes up at the top of the shelf.
+  const [measuredGeneration, setMeasuredGeneration] = useState(0);
+  const handleRangeChanged = useCallback(() => {
+    setMeasuredGeneration((current) => (current === 0 ? 1 : current));
+  }, []);
+
   // Keep the open file's row in view while stepping with the keyboard.
   // `groups` is a dependency so the row is re-revealed when a filter that hid
   // it is cleared. Windowed, the row may not exist to be queried, so the
@@ -328,7 +338,7 @@ export function DiffFileSidebar({
     if (typeof row?.scrollIntoView === "function") {
       row.scrollIntoView({ behavior: "instant", block: "nearest" });
     }
-  }, [currentIndex, groups, windowed, flat]);
+  }, [currentIndex, groups, windowed, flat, measuredGeneration]);
 
   // self-stretch (not h-full): a percentage height against the dialog's
   // content-sized row collapses to content height and lets the dialog
@@ -422,6 +432,7 @@ export function DiffFileSidebar({
             ref={virtuosoRef}
             groupCounts={flat.counts}
             style={{ height: "100%" }}
+            rangeChanged={handleRangeChanged}
             groupContent={(groupIndex) => (
               <DiffShelfGroupHeader dir={flat.dirs[groupIndex] ?? ""} />
             )}

--- a/src/components/FileViewer/DiffFileSidebar.tsx
+++ b/src/components/FileViewer/DiffFileSidebar.tsx
@@ -252,32 +252,35 @@ export function DiffFileSidebar({
   );
 
   // The grouped virtualizer wants the same list twice over: the files flat, and
-  // how many of them fall under each directory header. `displayIndexByFileIndex`
-  // is the bridge back — reveal speaks display order, everything else (the open
+  // how many of them fall under each directory header. `slotIndexByFileIndex`
+  // is the bridge back — reveal speaks slot order, everything else (the open
   // file, `onSelect`, `aria-current`) speaks the original changeset's order.
   const flat = useMemo(() => {
     const entries: IndexedEntry[] = [];
     const counts: number[] = [];
     const dirs: string[] = [];
-    const displayIndexByFileIndex = new Map<number, number>();
-    // `computeItemKey` is the odd one out: react-virtuoso calls it with the raw
-    // slot index, which COUNTS GROUP HEADERS, while `itemContent` gets the
-    // file-only index. Indexing the file array with the raw index hands the
-    // first file the second file's key — and a key that names the wrong row is
-    // how React moves one file's open menu onto another file. So the keys are
-    // built once, in slot order, headers included.
+    // `itemContent` is the odd one out: it is called with the file-only index,
+    // while `computeItemKey` and the imperative handle's `scrollIntoView` /
+    // `scrollToIndex` all speak the raw SLOT index, which COUNTS GROUP HEADERS.
+    // Indexing the file array with a slot hands the first file the second
+    // file's key — and a key that names the wrong row is how React moves one
+    // file's open menu onto another file. Handing a file-only index to the
+    // reveal scrolls short by every header ahead of it. So the keys are built
+    // once, in slot order, and `keysBySlot.length` IS the slot the next file
+    // lands on, headers already counted.
     const keysBySlot: string[] = [];
+    const slotIndexByFileIndex = new Map<number, number>();
     for (const group of groups) {
       counts.push(group.files.length);
       dirs.push(group.dir);
       keysBySlot.push(`group:${group.dir || "(root)"}`);
       for (const file of group.files) {
-        displayIndexByFileIndex.set(file.index, entries.length);
+        slotIndexByFileIndex.set(file.index, keysBySlot.length);
         entries.push(file);
         keysBySlot.push(`file:${file.viewedKey}-${file.index}`);
       }
     }
-    return { entries, counts, dirs, displayIndexByFileIndex, keysBySlot };
+    return { entries, counts, dirs, slotIndexByFileIndex, keysBySlot };
   }, [groups]);
 
   const virtuosoRef = useRef<GroupedVirtuosoHandle | null>(null);
@@ -323,14 +326,14 @@ export function DiffFileSidebar({
   // Keep the open file's row in view while stepping with the keyboard.
   // `groups` is a dependency so the row is re-revealed when a filter that hid
   // it is cleared. Windowed, the row may not exist to be queried, so the
-  // virtualizer is asked for it by display index instead; `scrollIntoView`
-  // leaves an already-visible row alone either way.
+  // virtualizer is asked for it by SLOT index instead — the handle counts group
+  // headers; `scrollIntoView` leaves an already-visible row alone either way.
   useEffect(() => {
     if (currentIndex < 0) return;
     if (windowed) {
-      const displayIndex = flat.displayIndexByFileIndex.get(currentIndex);
-      if (displayIndex === undefined) return;
-      virtuosoRef.current?.scrollIntoView({ index: displayIndex, behavior: "auto" });
+      const slotIndex = flat.slotIndexByFileIndex.get(currentIndex);
+      if (slotIndex === undefined) return;
+      virtuosoRef.current?.scrollIntoView({ index: slotIndex, behavior: "auto" });
       return;
     }
     if (!listRef.current) return;

--- a/src/components/FileViewer/__tests__/DiffFileSidebar.test.tsx
+++ b/src/components/FileViewer/__tests__/DiffFileSidebar.test.tsx
@@ -267,7 +267,13 @@ describe("DiffFileSidebar — windowed file shelf (#12241)", () => {
     expect(onSelect).toHaveBeenCalledWith(119);
   });
 
-  it("marks the open file current even when it is not the first row shown", () => {
+  it("marks the open file current by its changeset index, not its display position", () => {
+    // File 119 sits in the FIRST directory on screen, because the directories
+    // sort in reverse. That is the point: display position 0 and changeset
+    // index 119 are different numbers, and `aria-current` has to follow the
+    // second one. (Revealing a genuinely off-screen row is not asserted here —
+    // Virtuoso's scroll path needs a scroller with a real height, and jsdom
+    // gives every element zero.)
     const files = reversedGroups(120);
     renderWindowed(files, 119);
     const current = screen

--- a/src/components/FileViewer/__tests__/DiffFileSidebar.test.tsx
+++ b/src/components/FileViewer/__tests__/DiffFileSidebar.test.tsx
@@ -39,6 +39,7 @@ vi.mock("@/store/diffViewedStore", () => ({
   selectViewedSet: () => new Set<string>(),
 }));
 
+import { VirtuosoMockContext } from "react-virtuoso";
 import { ContextMenu, ContextMenuContent, ContextMenuTrigger } from "@/components/ui/context-menu";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { primeRadix } from "@/components/ui/radix-loader";
@@ -204,5 +205,84 @@ describe("DiffFileSidebar — file row menu", () => {
     const call = dispatchMock.mock.calls.find(([id]) => id === "acme.do");
     expect(call).toBeDefined();
     expect(call![1]).toMatchObject({ path: "/repo/src/index.ts", worktreePath: WORKTREE });
+  });
+});
+
+describe("DiffFileSidebar — windowed file shelf (#12241)", () => {
+  /**
+   * Directory names that sort in the OPPOSITE order to their files' changeset
+   * indices. Display position and file index are then genuinely different
+   * numbers, which is the only way to prove the shelf keeps them apart: it
+   * reveals by display position and selects by file index.
+   */
+  /**
+   * jsdom measures nothing, so the real virtualizer would see a zero-height
+   * viewport and mount no rows at all. `VirtuosoMockContext` is react-virtuoso's
+   * own answer to that — it supplies fixed dimensions and lets the REAL grouped
+   * windowing run, which is the point: these tests are about the group/item
+   * index arithmetic, and a stub would be asserting the stub.
+   */
+  const renderWindowed = (files: DiffChangeSetEntry[], currentIndex: number) => {
+    const onSelect = vi.fn();
+    render(
+      <TooltipProvider>
+        <VirtuosoMockContext.Provider value={{ itemHeight: 32, viewportHeight: 640 }}>
+          <DiffFileSidebar
+            files={files}
+            currentIndex={currentIndex}
+            worktreePath={WORKTREE}
+            worktreeId="wt-1"
+            onSelect={onSelect}
+          />
+        </VirtuosoMockContext.Provider>
+      </TooltipProvider>
+    );
+    return { onSelect };
+  };
+
+  const reversedGroups = (count: number): DiffChangeSetEntry[] =>
+    Array.from({ length: count }, (_, i) =>
+      entry(`src/z${String(count - 1 - i).padStart(4, "0")}/file-${String(i).padStart(4, "0")}.ts`)
+    );
+
+  it("renders every row below the windowing threshold", () => {
+    renderSidebar({ files: reversedGroups(20), currentIndex: 0 });
+    expect(screen.getAllByTestId("diff-sidebar-file")).toHaveLength(20);
+  });
+
+  it("keeps the directory headers and the file's own index once it windows", () => {
+    const files = reversedGroups(120);
+    const { onSelect } = renderWindowed(files, 0);
+
+    // A row per directory here, so headers and rows are 1:1 — what matters is
+    // that the headers survived windowing at all.
+    expect(screen.getAllByText(/^src\/z\d{4}$/).length).toBeGreaterThan(0);
+
+    const rows = screen.getAllByTestId("diff-sidebar-file");
+    expect(rows.length).toBeLessThan(120);
+
+    // The first row on screen is the LAST file in the changeset, because the
+    // directories sort in reverse. Clicking it must report 119, not 0.
+    fireEvent.click(rows[0]!);
+    expect(onSelect).toHaveBeenCalledWith(119);
+  });
+
+  it("marks the open file current even when it is not the first row shown", () => {
+    const files = reversedGroups(120);
+    renderWindowed(files, 119);
+    const current = screen
+      .getAllByTestId("diff-sidebar-file")
+      .find((row) => row.getAttribute("aria-current") === "true");
+    expect(current?.getAttribute("aria-label")).toBe(`Open ${files[119]!.path}`);
+  });
+
+  it("still filters, and falls back to every row when the filter narrows it", () => {
+    renderWindowed(reversedGroups(120), 0);
+    fireEvent.change(screen.getByTestId("diff-sidebar-filter"), {
+      target: { value: "file-0001." },
+    });
+    const rows = screen.getAllByTestId("diff-sidebar-file");
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.getAttribute("aria-label")).toContain("file-0001.ts");
   });
 });

--- a/src/components/FileViewer/__tests__/DiffFileSidebar.test.tsx
+++ b/src/components/FileViewer/__tests__/DiffFileSidebar.test.tsx
@@ -31,6 +31,43 @@ vi.mock("@/hooks/usePluginContextMenuItems", () => ({
   usePluginContextMenuItems: () => itemsRef.current,
 }));
 
+/**
+ * The shelf reveals an off-screen row through the virtualizer's imperative
+ * handle, and jsdom measures nothing, so no scroll it performs is observable.
+ * This wraps the REAL `GroupedVirtuoso` rather than replacing it — the grouped
+ * windowing below still has to be the library's own — and only taps the handle
+ * on the way past, so the index the shelf asks for can be asserted.
+ */
+const { scrollIntoViewMock } = vi.hoisted(() => ({
+  scrollIntoViewMock: vi.fn<(location: { index: number; behavior?: string }) => void>(),
+}));
+
+vi.mock("react-virtuoso", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-virtuoso")>();
+  const { createElement, forwardRef, useImperativeHandle, useRef } = await import("react");
+  const Actual = actual.GroupedVirtuoso as unknown as React.ComponentType<
+    Record<string, unknown> & { ref?: unknown }
+  >;
+  return {
+    ...actual,
+    GroupedVirtuoso: forwardRef(function GroupedVirtuosoSpy(
+      props: Record<string, unknown>,
+      ref: React.ForwardedRef<Partial<GroupedVirtuosoHandle>>
+    ) {
+      const inner = useRef<GroupedVirtuosoHandle | null>(null);
+      useImperativeHandle(ref, () => ({
+        scrollIntoView: (location: Parameters<GroupedVirtuosoHandle["scrollIntoView"]>[0]) => {
+          scrollIntoViewMock(location as { index: number; behavior?: string });
+          inner.current?.scrollIntoView(location);
+        },
+        scrollToIndex: (location: Parameters<GroupedVirtuosoHandle["scrollToIndex"]>[0]) =>
+          inner.current?.scrollToIndex(location),
+      }));
+      return createElement(Actual, { ...props, ref: inner });
+    }),
+  };
+});
+
 vi.mock("@/store/diffViewedStore", () => ({
   useDiffViewedStore: (selector?: (state: unknown) => unknown) => {
     const state = { toggleViewed: () => {} };
@@ -39,7 +76,7 @@ vi.mock("@/store/diffViewedStore", () => ({
   selectViewedSet: () => new Set<string>(),
 }));
 
-import { VirtuosoMockContext } from "react-virtuoso";
+import { VirtuosoMockContext, type GroupedVirtuosoHandle } from "react-virtuoso";
 import { ContextMenu, ContextMenuContent, ContextMenuTrigger } from "@/components/ui/context-menu";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { primeRadix } from "@/components/ui/radix-loader";
@@ -96,6 +133,7 @@ beforeAll(async () => {
 
 beforeEach(() => {
   dispatchMock.mockClear();
+  scrollIntoViewMock.mockClear();
   itemsRef.current = [];
 });
 
@@ -224,7 +262,7 @@ describe("DiffFileSidebar — windowed file shelf (#12241)", () => {
    */
   const renderWindowed = (files: DiffChangeSetEntry[], currentIndex: number) => {
     const onSelect = vi.fn();
-    render(
+    const { container } = render(
       <TooltipProvider>
         <VirtuosoMockContext.Provider value={{ itemHeight: 32, viewportHeight: 640 }}>
           <DiffFileSidebar
@@ -237,13 +275,30 @@ describe("DiffFileSidebar — windowed file shelf (#12241)", () => {
         </VirtuosoMockContext.Provider>
       </TooltipProvider>
     );
-    return { onSelect };
+    return { onSelect, container };
   };
 
   const reversedGroups = (count: number): DiffChangeSetEntry[] =>
     Array.from({ length: count }, (_, i) =>
       entry(`src/z${String(count - 1 - i).padStart(4, "0")}/file-${String(i).padStart(4, "0")}.ts`)
     );
+
+  /**
+   * `groupCount` directories of `perGroup` files each, named so the directories
+   * sort into the order they were built in. File index and DISPLAY index are
+   * then the same number — which is exactly the confusion this fixture is here
+   * to catch, because neither of them is the SLOT index the virtualizer's
+   * handle speaks. The slot of the nth file is `n + (its group ordinal + 1)`.
+   */
+  const GROUP_COUNT = 20;
+  const PER_GROUP = 10;
+  const groupedFiles = (): DiffChangeSetEntry[] =>
+    Array.from({ length: GROUP_COUNT * PER_GROUP }, (_, i) =>
+      entry(
+        `src/g${String(Math.floor(i / PER_GROUP)).padStart(2, "0")}/file-${String(i).padStart(3, "0")}.ts`
+      )
+    );
+  const slotOf = (fileIndex: number) => fileIndex + Math.floor(fileIndex / PER_GROUP) + 1;
 
   it("renders every row below the windowing threshold", () => {
     renderSidebar({ files: reversedGroups(20), currentIndex: 0 });
@@ -290,5 +345,59 @@ describe("DiffFileSidebar — windowed file shelf (#12241)", () => {
     const rows = screen.getAllByTestId("diff-sidebar-file");
     expect(rows).toHaveLength(1);
     expect(rows[0]!.getAttribute("aria-label")).toContain("file-0001.ts");
+  });
+
+  it("lays its rows out in slot space, group headers included", () => {
+    // The premise every reveal assertion below rests on, taken from the real
+    // virtualizer rather than from the docs: the slots react-virtuoso indexes
+    // COUNT the group headers, so the first file sits at slot 1, not slot 0.
+    const { container } = renderWindowed(groupedFiles(), 0);
+    const slots = Array.from(container.querySelectorAll<HTMLElement>("[data-index]"));
+    const firstFileSlot = slots.find((slot) => slot.querySelector("[data-file-index]"));
+    expect(firstFileSlot?.getAttribute("data-index")).toBe(String(slotOf(0)));
+  });
+
+  it("reveals the open file by its flat slot index, not its file-only index", () => {
+    // File 95 is the sixth file of the tenth directory: ten group headers sit
+    // ahead of it, so its slot is 105 while its position among the files is 95.
+    // Handing the handle 95 scrolls ten rows short of the row the user opened.
+    const target = 95;
+    renderWindowed(groupedFiles(), target);
+
+    expect(scrollIntoViewMock).toHaveBeenCalled();
+    expect(scrollIntoViewMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ index: slotOf(target) })
+    );
+    expect(slotOf(target)).toBe(105);
+  });
+
+  it("counts the header ahead of even the first file when it reveals it", () => {
+    // The smallest version of the same mistake, and the one an off-by-"a few
+    // headers" test can still pass through: file 0 is slot 1.
+    renderWindowed(groupedFiles(), 0);
+
+    expect(scrollIntoViewMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ index: 1, behavior: "auto" })
+    );
+  });
+
+  it("re-reveals in slot space after a filter renumbers the groups", () => {
+    // A filter rebuilds the groups, so the slot has to be rebuilt with them
+    // rather than carried over from the unfiltered list.
+    const target = 155;
+    renderWindowed(groupedFiles(), target);
+    expect(scrollIntoViewMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ index: slotOf(target) })
+    );
+    scrollIntoViewMock.mockClear();
+
+    // Keeps g10..g19 — a hundred files, still windowed — and drops the ten
+    // directories ahead of them. The target is then the sixth file of the sixth
+    // surviving group: display index 55, six headers ahead of it, slot 61.
+    fireEvent.change(screen.getByTestId("diff-sidebar-filter"), {
+      target: { value: "src/g1" },
+    });
+
+    expect(scrollIntoViewMock).toHaveBeenLastCalledWith(expect.objectContaining({ index: 61 }));
   });
 });

--- a/src/components/Worktree/ReviewHub/BaseBranchFileList.tsx
+++ b/src/components/Worktree/ReviewHub/BaseBranchFileList.tsx
@@ -73,10 +73,16 @@ export function BaseBranchFileList({
     [decorations, onOpenFile, onOpenDecorationUrl]
   );
 
-  // Same rule as the working-tree sections: over the threshold AND a scroll
-  // container to window against. Before the hub's first commit there is no
-  // element yet, and the static list is the correct thing to render.
-  if (!shouldVirtualizeFileList(files.length) || scrollParent === null) {
+  // Over the threshold but with nowhere to window yet: the scroll container is
+  // an ancestor, so it only exists from the hub's first commit onward. Render
+  // the empty body rather than the full static list — mounting hundreds of rows
+  // for one frame, to unmount them on the next, is the cost this change exists
+  // to remove.
+  if (shouldVirtualizeFileList(files.length) && scrollParent === null) {
+    return <div className="px-2 py-1" />;
+  }
+
+  if (!shouldVirtualizeFileList(files.length)) {
     return (
       <div className="px-2 py-1 flex flex-col gap-0.5">
         {files.map((file) => {
@@ -101,7 +107,7 @@ export function BaseBranchFileList({
       <Virtuoso<CrossWorktreeFile, BaseRowContext>
         data={files}
         context={context}
-        customScrollParent={scrollParent}
+        customScrollParent={scrollParent ?? undefined}
         computeItemKey={computeBaseRowKey}
         itemContent={renderVirtualizedBaseRow}
         increaseViewportBy={200}

--- a/src/components/Worktree/ReviewHub/BaseBranchFileList.tsx
+++ b/src/components/Worktree/ReviewHub/BaseBranchFileList.tsx
@@ -1,0 +1,112 @@
+import type React from "react";
+import { useMemo } from "react";
+import { Virtuoso } from "react-virtuoso";
+import type { CrossWorktreeFile } from "@shared/types/ipc/git";
+import type { FileDecoration } from "@shared/types/forge";
+import { shouldVirtualizeFileList } from "@/lib/fileListWindowing";
+import { BaseBranchFileRow } from "./BaseBranchFileRow";
+
+interface BaseBranchFileListProps {
+  files: CrossWorktreeFile[];
+  /** Forge-authored badges, keyed by path. Absent for most files. */
+  decorations: Record<string, FileDecoration | undefined>;
+  onOpenFile: (file: CrossWorktreeFile, trigger: HTMLElement) => void;
+  onOpenDecorationUrl: (url: string) => void;
+  /**
+   * The hub's scroll container. Windowing happens against it rather than in a
+   * scroller of this list's own, so the sticky "Changed vs {base}" band and the
+   * rows below it stay in one continuous scroll.
+   */
+  scrollParent: HTMLElement | null;
+}
+
+interface BaseRowContext {
+  decorations: Record<string, FileDecoration | undefined>;
+  onOpenFile: (file: CrossWorktreeFile, trigger: HTMLElement) => void;
+  onOpenDecorationUrl: (url: string) => void;
+}
+
+/** Status is part of the key because a path can change status between refreshes. */
+function computeBaseRowKey(_index: number, file: CrossWorktreeFile) {
+  return `${file.status}:${file.path}`;
+}
+
+function renderBaseRow(_index: number, file: CrossWorktreeFile, ctx: BaseRowContext) {
+  const decoration = ctx.decorations[file.path];
+  const url = decoration?.url;
+  return (
+    <BaseBranchFileRow
+      file={file}
+      onClick={(e: React.MouseEvent<HTMLButtonElement>) => ctx.onOpenFile(file, e.currentTarget)}
+      unresolvedDecoration={decoration}
+      onBadgeClick={url ? () => ctx.onOpenDecorationUrl(url) : undefined}
+    />
+  );
+}
+
+/**
+ * The windowed path's per-row wrapper: the static path's flex `gap-0.5` becomes
+ * bottom padding inside the measured item, because a virtualizer places items
+ * itself and never sees a gap between them.
+ */
+function renderVirtualizedBaseRow(index: number, file: CrossWorktreeFile, ctx: BaseRowContext) {
+  return <div className="pb-0.5">{renderBaseRow(index, file, ctx)}</div>;
+}
+
+/**
+ * The Review Hub's "changed vs base branch" file list.
+ *
+ * Read-only next to the working-tree sections — no staging, no selection, no
+ * keyboard cursor — so windowing it costs nothing but the threshold check. Its
+ * rows carry native buttons rather than listbox options, and that stays true on
+ * both paths.
+ */
+export function BaseBranchFileList({
+  files,
+  decorations,
+  onOpenFile,
+  onOpenDecorationUrl,
+  scrollParent,
+}: BaseBranchFileListProps) {
+  const context: BaseRowContext = useMemo(
+    () => ({ decorations, onOpenFile, onOpenDecorationUrl }),
+    [decorations, onOpenFile, onOpenDecorationUrl]
+  );
+
+  // Same rule as the working-tree sections: over the threshold AND a scroll
+  // container to window against. Before the hub's first commit there is no
+  // element yet, and the static list is the correct thing to render.
+  if (!shouldVirtualizeFileList(files.length) || scrollParent === null) {
+    return (
+      <div className="px-2 py-1 flex flex-col gap-0.5">
+        {files.map((file) => {
+          const decoration = decorations[file.path];
+          const url = decoration?.url;
+          return (
+            <BaseBranchFileRow
+              key={`${file.status}:${file.path}`}
+              file={file}
+              onClick={(e) => onOpenFile(file, e.currentTarget)}
+              unresolvedDecoration={decoration}
+              onBadgeClick={url ? () => onOpenDecorationUrl(url) : undefined}
+            />
+          );
+        })}
+      </div>
+    );
+  }
+
+  return (
+    <div className="px-2 py-1">
+      <Virtuoso<CrossWorktreeFile, BaseRowContext>
+        data={files}
+        context={context}
+        customScrollParent={scrollParent}
+        computeItemKey={computeBaseRowKey}
+        itemContent={renderVirtualizedBaseRow}
+        increaseViewportBy={200}
+        skipAnimationFrameInResizeObserver
+      />
+    </div>
+  );
+}

--- a/src/components/Worktree/ReviewHub/FileSection.tsx
+++ b/src/components/Worktree/ReviewHub/FileSection.tsx
@@ -1,5 +1,7 @@
 import type React from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import type { Dispatch, Ref, RefObject, SetStateAction } from "react";
+import { Virtuoso, type VirtuosoHandle } from "react-virtuoso";
 import type { GitStatus, StagingFileEntry } from "@shared/types";
 import { ChevronDown, ChevronUp, Minus, Plus, Search, SlidersHorizontal } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -73,6 +75,118 @@ interface FileSectionProps {
     section: FileStageRowSection,
     triggerRef: RefObject<HTMLElement | null>
   ) => React.ReactNode;
+  /**
+   * Whether this section's rows window. Decided by the hub across BOTH
+   * sections, not per section — they share one scroll container and one
+   * keyboard cursor, so windowing one and not the other would leave the cursor
+   * crossing a boundary between two different reveal mechanisms.
+   */
+  virtualized?: boolean;
+  /**
+   * The hub's scroll container. Virtuoso windows against it rather than owning
+   * a scroller of its own, which is what keeps the section headers, the
+   * conflict banner and the two sections in one continuous scroll the way they
+   * render today.
+   */
+  scrollParent?: HTMLElement | null;
+  /** Reveal handle for the hub's keyboard cursor. Unused on the static path. */
+  listRef?: RefObject<VirtuosoHandle | null>;
+  /**
+   * The slice Virtuoso currently has MOUNTED, in this section's local index
+   * space. `null` means "every row is mounted" — the static path, and the state
+   * the hub must assume before the first `rangeChanged`.
+   */
+  onRenderedRangeChange?: (range: { start: number; end: number } | null) => void;
+}
+
+/**
+ * Rows kept mounted above and below the viewport.
+ *
+ * Sized in pixels rather than rows because the two densities are 24px and 32px:
+ * ~200px is six compact rows or four comfortable ones either side, which is
+ * enough that stepping the keyboard cursor past the fold finds a mounted row
+ * and the reveal only has to scroll, never to mount-then-find.
+ */
+const VIRTUALIZED_OVERSCAN_PX = 200;
+
+/** Per-row inputs, passed through Virtuoso's `context` rather than closed over per row. */
+interface SectionRowContext {
+  section: FileStageRowSection;
+  isStaged: boolean;
+  indexOffset: number;
+  focusedIndex: number;
+  selectionSection: FileStageRowSection | null;
+  selectedPaths: Set<string>;
+  density: SectionViewState["density"];
+  virtualized: boolean;
+  viewedFiles: ReadonlySet<string>;
+  onToggle: (filePath: string) => void;
+  onRowClick: (
+    section: FileStageRowSection,
+    filePath: string,
+    status: GitStatus,
+    e: React.MouseEvent
+  ) => void;
+  onViewedChange: (viewedKey: string, viewed: boolean) => void;
+  renderRowMenu: (
+    file: StagingFileEntry,
+    section: FileStageRowSection,
+    triggerRef: RefObject<HTMLElement | null>
+  ) => React.ReactNode;
+}
+
+/**
+ * Keyed by section and path, never by index: an index key makes Virtuoso reuse
+ * a row's DOM for a different file the moment a filter, a sort or a stage
+ * changes the list's length, and the height it cached with it.
+ */
+function computeSectionRowKey(_index: number, file: StagingFileEntry, ctx: SectionRowContext) {
+  return `${ctx.section}-${file.path}`;
+}
+
+/**
+ * The one row renderer, shared by the static and windowed paths so the markup
+ * cannot drift between them. `index` is section-local; `rowIndex` is the flat
+ * staged+unstaged coordinate the hub's cursor and `aria-activedescendant` use.
+ */
+function renderSectionRow(index: number, file: StagingFileEntry, ctx: SectionRowContext) {
+  const rowIndex = ctx.indexOffset + index;
+  const viewedKey = `${ctx.section}:${file.path}`;
+  return (
+    <FileStageRow
+      id={`review-hub-row-${rowIndex}`}
+      rowIndex={rowIndex}
+      isFocused={ctx.focusedIndex === rowIndex}
+      file={file}
+      section={ctx.section}
+      isStaged={ctx.isStaged}
+      isSelected={ctx.selectionSection === ctx.section && ctx.selectedPaths.has(file.path)}
+      onToggle={ctx.onToggle}
+      onRowClick={ctx.onRowClick}
+      density={ctx.density}
+      virtualized={ctx.virtualized}
+      viewed={ctx.viewedFiles.has(viewedKey)}
+      onViewedChange={(v) => ctx.onViewedChange(viewedKey, v)}
+      renderRowMenu={ctx.renderRowMenu}
+    />
+  );
+}
+
+/**
+ * The windowed path's per-row wrapper.
+ *
+ * The static path spaces rows with a flex `gap`, which a virtualizer cannot
+ * reproduce — it stacks absolutely positioned items and measures each one, so a
+ * gap between them is height it never sees. The same space is applied as
+ * bottom padding INSIDE the measured item instead, which keeps the two paths
+ * pixel-identical and the height cache honest.
+ */
+function renderVirtualizedRow(index: number, file: StagingFileEntry, ctx: SectionRowContext) {
+  return (
+    <div className={ctx.density === "compact" ? undefined : "pb-0.5"}>
+      {renderSectionRow(index, file, ctx)}
+    </div>
+  );
 }
 
 export function FileSection({
@@ -96,6 +210,10 @@ export function FileSection({
   onViewedChange,
   sectionRef,
   renderRowMenu,
+  virtualized = false,
+  scrollParent = null,
+  listRef,
+  onRenderedRangeChange,
 }: FileSectionProps) {
   const section: FileStageRowSection = isStaged ? "staged" : "unstaged";
   const title = isStaged ? "Staged" : "Changes";
@@ -149,6 +267,68 @@ export function FileSection({
   // at any width; a user cannot clear what they cannot see.
   const churnDropClass = "@max-[560px]/file-section:hidden";
   const filterDropClass = view.filterQuery ? "" : "@max-[460px]/file-section:hidden";
+
+  // Windowing needs the scroll container it windows against, and that element
+  // only exists after the hub's first commit — so a section can be over the
+  // threshold for one render and still have nowhere to window. Rendering the
+  // static list for that render is correct, not a fallback: it is what the
+  // list looked like a frame earlier.
+  const windowed = virtualized && scrollParent !== null;
+
+  const rowContext: SectionRowContext = useMemo(
+    () => ({
+      section,
+      isStaged,
+      indexOffset,
+      focusedIndex,
+      selectionSection,
+      selectedPaths,
+      density: view.density,
+      virtualized: windowed,
+      viewedFiles,
+      onToggle,
+      onRowClick,
+      onViewedChange,
+      renderRowMenu,
+    }),
+    [
+      section,
+      isStaged,
+      indexOffset,
+      focusedIndex,
+      selectionSection,
+      selectedPaths,
+      view.density,
+      windowed,
+      viewedFiles,
+      onToggle,
+      onRowClick,
+      onViewedChange,
+      renderRowMenu,
+    ]
+  );
+
+  // Reported during render rather than from an effect: the hub gates
+  // `aria-activedescendant` on this range, and an effect would leave it
+  // pointing at an id that is not in the document for a commit. `null` is the
+  // static path's honest answer — every row is mounted — and it is also what
+  // the windowed path must report before Virtuoso's first `rangeChanged`,
+  // which is why the transition out of windowing clears it here.
+  const reportRange = onRenderedRangeChange;
+  useEffect(() => {
+    if (!windowed || files.length === 0) reportRange?.(null);
+  }, [windowed, files.length, reportRange]);
+
+  // A plain callback, not a `useEffectEvent`: Virtuoso takes this as a prop,
+  // and an effect event cannot be passed down. Identity is stable as long as
+  // the hub's own handler is, which is what keeps Virtuoso from resubscribing
+  // on every scroll frame.
+  const handleRangeChanged = useCallback(
+    ({ startIndex, endIndex }: { startIndex: number; endIndex: number }) => {
+      reportRange?.({ start: startIndex, end: endIndex });
+    },
+    [reportRange]
+  );
 
   return (
     <div
@@ -357,21 +537,36 @@ export function FileSection({
         </div>
       </div>
       {files.length > 0 ? (
-        <div
-          className={cn(
-            "px-2 py-1 flex flex-col",
-            view.density === "compact" ? "gap-0" : "gap-0.5"
-          )}
-        >
-          {files.map((file, i) => {
-            const viewedKey = `${section}:${file.path}`;
-            const rowIndex = indexOffset + i;
-            return (
+        windowed ? (
+          <div className="px-2 py-1">
+            <Virtuoso<StagingFileEntry, SectionRowContext>
+              ref={listRef}
+              data={files}
+              context={rowContext}
+              customScrollParent={scrollParent ?? undefined}
+              computeItemKey={computeSectionRowKey}
+              itemContent={renderVirtualizedRow}
+              // Keeps a screenful of rows mounted either side of the viewport so
+              // an arrow key that steps just past the fold lands on a row that
+              // already exists, rather than on one the reveal has to conjure.
+              increaseViewportBy={VIRTUALIZED_OVERSCAN_PX}
+              rangeChanged={handleRangeChanged}
+              skipAnimationFrameInResizeObserver
+            />
+          </div>
+        ) : (
+          <div
+            className={cn(
+              "px-2 py-1 flex flex-col",
+              view.density === "compact" ? "gap-0" : "gap-0.5"
+            )}
+          >
+            {files.map((file, i) => (
               <FileStageRow
                 key={`${section}-${file.path}`}
-                id={`review-hub-row-${rowIndex}`}
-                rowIndex={rowIndex}
-                isFocused={focusedIndex === rowIndex}
+                id={`review-hub-row-${indexOffset + i}`}
+                rowIndex={indexOffset + i}
+                isFocused={focusedIndex === indexOffset + i}
                 file={file}
                 section={section}
                 isStaged={isStaged}
@@ -379,13 +574,13 @@ export function FileSection({
                 onToggle={onToggle}
                 onRowClick={onRowClick}
                 density={view.density}
-                viewed={viewedFiles.has(viewedKey)}
-                onViewedChange={(v) => onViewedChange(viewedKey, v)}
+                viewed={viewedFiles.has(`${section}:${file.path}`)}
+                onViewedChange={(v) => onViewedChange(`${section}:${file.path}`, v)}
                 renderRowMenu={renderRowMenu}
               />
-            );
-          })}
-        </div>
+            ))}
+          </div>
+        )
       ) : hiddenGeneratedMatches > 0 ? (
         /* The query DOES match — those matches are just hidden as generated.
            Reaching the plain filter branch here would name the wrong cause and

--- a/src/components/Worktree/ReviewHub/FileSection.tsx
+++ b/src/components/Worktree/ReviewHub/FileSection.tsx
@@ -1,5 +1,5 @@
 import type React from "react";
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import type { Dispatch, Ref, RefObject, SetStateAction } from "react";
 import { Virtuoso, type VirtuosoHandle } from "react-virtuoso";
 import type { GitStatus, StagingFileEntry } from "@shared/types";
@@ -18,6 +18,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { FileStageRow, type FileStageRowSection } from "./FileStageRow";
+import { type MountedRange } from "@/lib/fileListWindowing";
 import { isGeneratedFile } from "../generatedFileClassifier";
 import {
   REVIEW_HUB_STICKY_BAND,
@@ -92,11 +93,12 @@ interface FileSectionProps {
   /** Reveal handle for the hub's keyboard cursor. Unused on the static path. */
   listRef?: RefObject<VirtuosoHandle | null>;
   /**
-   * The slice Virtuoso currently has MOUNTED, in this section's local index
-   * space. `null` means "every row is mounted" — the static path, and the state
-   * the hub must assume before the first `rangeChanged`.
+   * The slice Virtuoso currently has MOUNTED, in this section's LOCAL index
+   * space — reported only while windowed, and never converted to the hub's flat
+   * coordinates on the way out: the staged count shifts every unstaged row's
+   * flat index, and Virtuoso does not re-emit a range that has not changed.
    */
-  onRenderedRangeChange?: (range: { start: number; end: number } | null) => void;
+  onRenderedRangeChange?: (range: MountedRange) => void;
 }
 
 /**
@@ -308,16 +310,7 @@ export function FileSection({
     ]
   );
 
-  // Reported during render rather than from an effect: the hub gates
-  // `aria-activedescendant` on this range, and an effect would leave it
-  // pointing at an id that is not in the document for a commit. `null` is the
-  // static path's honest answer — every row is mounted — and it is also what
-  // the windowed path must report before Virtuoso's first `rangeChanged`,
-  // which is why the transition out of windowing clears it here.
   const reportRange = onRenderedRangeChange;
-  useEffect(() => {
-    if (!windowed || files.length === 0) reportRange?.(null);
-  }, [windowed, files.length, reportRange]);
 
   // A plain callback, not a `useEffectEvent`: Virtuoso takes this as a prop,
   // and an effect event cannot be passed down. Identity is stable as long as
@@ -329,6 +322,13 @@ export function FileSection({
     },
     [reportRange]
   );
+
+  // Over the threshold but with nowhere to window yet: the scroll container is
+  // an ancestor, so it only exists from the hub's first commit onward. Render
+  // the empty body rather than the full static list — mounting four hundred
+  // rows for one frame, to unmount them on the next, is exactly the cost this
+  // change exists to remove.
+  const awaitingScrollParent = virtualized && scrollParent === null;
 
   return (
     <div
@@ -537,7 +537,9 @@ export function FileSection({
         </div>
       </div>
       {files.length > 0 ? (
-        windowed ? (
+        awaitingScrollParent ? (
+          <div className="px-2 py-1" />
+        ) : windowed ? (
           <div className="px-2 py-1">
             <Virtuoso<StagingFileEntry, SectionRowContext>
               ref={listRef}

--- a/src/components/Worktree/ReviewHub/FileSection.tsx
+++ b/src/components/Worktree/ReviewHub/FileSection.tsx
@@ -1,5 +1,5 @@
 import type React from "react";
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import type { Dispatch, Ref, RefObject, SetStateAction } from "react";
 import { Virtuoso, type VirtuosoHandle } from "react-virtuoso";
 import type { GitStatus, StagingFileEntry } from "@shared/types";
@@ -310,7 +310,15 @@ export function FileSection({
     ]
   );
 
+  // Retract the range when this section stops windowing — a threshold crossing,
+  // a collapse, a worktree switch. Without it the hub keeps describing rows a
+  // virtualizer that no longer exists once had, and the NEXT windowed instance
+  // is judged against its predecessor's window until it first reports.
   const reportRange = onRenderedRangeChange;
+  useEffect(() => {
+    if (!windowed) return;
+    return () => reportRange?.(null);
+  }, [windowed, reportRange]);
 
   // A plain callback, not a `useEffectEvent`: Virtuoso takes this as a prop,
   // and an effect event cannot be passed down. Identity is stable as long as

--- a/src/components/Worktree/ReviewHub/FileStageRow.tsx
+++ b/src/components/Worktree/ReviewHub/FileStageRow.tsx
@@ -77,6 +77,15 @@ interface FileStageRowProps {
     e: React.MouseEvent
   ) => void;
   density?: "comfortable" | "compact";
+  /**
+   * Whether the parent list is windowing. Turns OFF the `content-visibility`
+   * hint below: a virtualizer measures each mounted row to place the ones after
+   * it, and `content-visibility: auto` answers that measurement with
+   * `contain-intrinsic-size` — the guess — rather than the row's real height.
+   * The two optimisations solve the same problem and cannot be stacked; the
+   * windowed list already mounts nothing off-screen, so it wins.
+   */
+  virtualized?: boolean;
   viewed?: boolean;
   onViewedChange?: (viewed: boolean) => void;
   /**
@@ -109,6 +118,7 @@ function FileStageRowComponent({
   onToggle,
   onRowClick,
   density = "comfortable",
+  virtualized = false,
   viewed = false,
   onViewedChange,
   renderRowMenu,
@@ -169,15 +179,21 @@ function FileStageRowComponent({
         "data-[state=open]:bg-overlay-raised",
         viewed && "opacity-60"
       )}
-      // The staging lists render every changed file with no windowing; a big
-      // changeset (lockfiles, codegen) mounts thousands of tooltip-wrapped
-      // rows. Off-screen rows skip layout/paint; the intrinsic-size hint keeps
-      // the scrollbar stable and roving-focus scrollIntoView still works
-      // because scrolling renders the target row.
-      style={{
-        contentVisibility: "auto",
-        containIntrinsicSize: density === "compact" ? "auto 24px" : "auto 32px",
-      }}
+      // Below the windowing threshold the staging lists still render every
+      // changed file, and a big changeset (lockfiles, codegen) mounts thousands
+      // of tooltip-wrapped rows. Off-screen rows skip layout/paint; the
+      // intrinsic-size hint keeps the scrollbar stable and roving-focus
+      // scrollIntoView still works because scrolling renders the target row.
+      // Above the threshold the list windows instead and this must come off —
+      // see `virtualized`.
+      style={
+        virtualized
+          ? undefined
+          : {
+              contentVisibility: "auto",
+              containIntrinsicSize: density === "compact" ? "auto 24px" : "auto 32px",
+            }
+      }
     >
       {isSelected && (
         <div

--- a/src/components/Worktree/ReviewHub/ReviewHubContent.tsx
+++ b/src/components/Worktree/ReviewHub/ReviewHubContent.tsx
@@ -15,7 +15,13 @@ import type { CrossWorktreeFile } from "@shared/types/ipc/git";
 import type { PushProgressEvent } from "@shared/types/ipc/gitPush";
 import { isClientAppError } from "@/utils/clientAppError";
 import { cn } from "@/lib/utils";
-import { shouldVirtualizeFileList } from "@/lib/fileListWindowing";
+import {
+  EMPTY_MOUNTED_RANGE,
+  rangeCovers,
+  sameRange,
+  shouldVirtualizeFileList,
+  type MountedRange,
+} from "@/lib/fileListWindowing";
 import type { VirtuosoHandle } from "react-virtuoso";
 
 import { TruncatedTooltip } from "@/components/ui/TruncatedTooltip";
@@ -288,14 +294,20 @@ export function ReviewHubContent({
   // where the DOM query below still finds every row.
   const stagedListRef = useRef<VirtuosoHandle | null>(null);
   const unstagedListRef = useRef<VirtuosoHandle | null>(null);
-  // What each section currently has MOUNTED, in flat staged+unstaged
-  // coordinates. `null` means "everything" — the static path's honest answer,
-  // and the only one available before Virtuoso's first `rangeChanged`.
-  const [stagedRange, setStagedRange] = useState<{ start: number; end: number } | null>(null);
-  const [unstagedRange, setUnstagedRange] = useState<{ start: number; end: number } | null>(null);
+  // What each section currently has MOUNTED, in that section's OWN index space.
+  // Deliberately not converted to flat coordinates on the way in: the staged
+  // count shifts every unstaged row's flat index, and Virtuoso does not re-emit
+  // an unchanged local range, so a stored flat range would silently describe
+  // rows that had moved out from under it. `null` means no virtualizer has
+  // reported yet — read as "nothing mounted", never as "everything".
+  const [stagedRange, setStagedRange] = useState<MountedRange>(null);
+  const [unstagedRange, setUnstagedRange] = useState<MountedRange>(null);
   // A row menu asked for on a row the window had scrolled past. Held until the
   // reveal mounts the row, then replayed — see the effect near the key handler.
-  const [pendingMenuIndex, setPendingMenuIndex] = useState<number | null>(null);
+  // Carries the file's identity as well as its index: a refresh can put a
+  // DIFFERENT file at the same index, and opening that file's menu is worse
+  // than dropping the key.
+  const [pendingMenu, setPendingMenu] = useState<{ index: number; key: string } | null>(null);
   const focusedItemKeyRef = useRef<string | null>(null);
   const refreshIdRef = useRef(0);
   const bgRefreshIdRef = useRef(0);
@@ -412,20 +424,31 @@ export function ReviewHubContent({
   // other would leave the cursor crossing a seam between two reveal mechanisms.
   const workingTreeVirtualized = shouldVirtualizeFileList(navigableItems.length);
 
-  // The windowed reveal, split back out to the section that owns the index.
-  // `scrollIntoView` leaves an already-visible row alone, so a click on a
-  // visible row never yanks the list.
+  // Reveal, in two steps rather than one, because react-virtuoso cannot do the
+  // first one correctly here.
+  //
+  // A MOUNTED row is scrolled natively, exactly as this list always did. That
+  // is not a fallback: with `customScrollParent`, Virtuoso clamps its
+  // section-local scrollTop to zero while keeping the PARENT's full viewport
+  // height, so a section sitting below the fold believes its first rows are on
+  // screen. `scrollIntoView`'s already-visible check reads those numbers and
+  // no-ops on a row the user cannot see. The DOM knows the truth.
+  //
+  // An ABSENT row only the virtualizer can place, and `scrollToIndex` is the
+  // right call there precisely because it skips that visibility check — the
+  // destination it computes is in parent coordinates and is correct.
   const revealRow = useEffectEvent((index: number) => {
-    if (!workingTreeVirtualized) {
-      fileListRef.current
-        ?.querySelector<HTMLElement>(`[data-row-index="${index}"]`)
-        ?.scrollIntoView({ behavior: "instant", block: "nearest" });
+    const row = fileListRef.current?.querySelector<HTMLElement>(`[data-row-index="${index}"]`);
+    if (row) {
+      row.scrollIntoView({ behavior: "instant", block: "nearest" });
       return;
     }
+    if (!workingTreeVirtualized) return;
     const stagedCount = derivedStaged.length;
     const handle = index < stagedCount ? stagedListRef.current : unstagedListRef.current;
-    handle?.scrollIntoView({
+    handle?.scrollToIndex({
       index: index < stagedCount ? index : index - stagedCount,
+      align: "center",
       behavior: "auto",
     });
   });
@@ -443,6 +466,17 @@ export function ReviewHubContent({
   useLayoutEffect(() => {
     const item = focusedIndex >= 0 ? navigableItems[focusedIndex] : undefined;
     const key = item ? `${item.section}:${item.file.path}` : null;
+
+    // A refresh replaces `navigableItems` one commit BEFORE the reconcile
+    // effect below moves `focusedIndex` to follow the file. On that commit the
+    // old index names a DIFFERENT file, which reads as a cursor move and
+    // scrolls — twice, once on the way in and once on the way back. So the
+    // reveal only trusts an index the cursor's own identity agrees with, and
+    // records nothing until it does: overwriting the baseline mid-reconcile
+    // would make the settled commit look like a move as well.
+    const intended = focusedItemKeyRef.current;
+    if (item && intended !== null && key !== intended) return;
+
     const previous = previousFocusKeyRef.current;
     previousFocusKeyRef.current = { key, found: item !== undefined };
     if (!item) return;
@@ -455,43 +489,53 @@ export function ReviewHubContent({
   // Dropped rather than retried if the row leaves the list first — a filter, a
   // stage or a refresh means the menu no longer names anything.
   useEffect(() => {
-    if (pendingMenuIndex === null) return;
-    // The cursor moved on, or the list changed under it. The request named a
-    // row that is no longer the one the user asked about, so it is dropped
-    // rather than left armed to open a menu on something else later.
-    if (pendingMenuIndex !== focusedIndex) {
-      setPendingMenuIndex(null);
+    if (pendingMenu === null) return;
+    const item = navigableItems[pendingMenu.index];
+    const key = item ? `${item.section}:${item.file.path}` : null;
+    // Everything that makes the request meaningless cancels it. An armed
+    // request that outlives its reason is the failure mode here: it would open
+    // a menu the user never asked for, on whatever file happens to occupy that
+    // index by the time a row mounts.
+    if (
+      pendingMenu.index !== focusedIndex ||
+      key !== pendingMenu.key ||
+      !fileListExpanded ||
+      diffMode === "base-branch" ||
+      selectedFile !== null ||
+      selectedBaseBranchFile !== null
+    ) {
+      setPendingMenu(null);
       return;
     }
     const row = fileListRef.current?.querySelector<HTMLElement>(
-      `[data-row-index="${pendingMenuIndex}"]`
+      `[data-row-index="${pendingMenu.index}"]`
     );
     if (!row) return;
-    setPendingMenuIndex(null);
+    setPendingMenu(null);
     openFileRowMenuFromKeyboard(row);
-  }, [pendingMenuIndex, focusedIndex, navigableItems, stagedRange, unstagedRange]);
+  }, [
+    pendingMenu,
+    focusedIndex,
+    navigableItems,
+    fileListExpanded,
+    diffMode,
+    selectedFile,
+    selectedBaseBranchFile,
+    stagedRange,
+    unstagedRange,
+  ]);
 
-  // Sections report their mounted slice in LOCAL indices; the cursor lives in
-  // flat staged+unstaged coordinates, so shift the unstaged one by the staged
-  // count. Guarded rather than set unconditionally: Virtuoso fires
-  // `rangeChanged` on every scroll frame, and re-rendering the hub at that
-  // cadence would cost far more than the attribute it feeds is worth.
-  const stagedCount = derivedStaged.length;
-  const handleStagedRangeChange = useCallback((range: { start: number; end: number } | null) => {
-    setStagedRange((current) =>
-      current?.start === range?.start && current?.end === range?.end ? current : range
-    );
+  // Guarded rather than set unconditionally: Virtuoso fires `rangeChanged` on
+  // every scroll frame, and re-rendering the hub at that cadence would cost far
+  // more than the attribute it feeds is worth. Stable identities, so a changing
+  // staged count cannot make Virtuoso resubscribe — it would not replay the
+  // current range if it did.
+  const handleStagedRangeChange = useCallback((range: MountedRange) => {
+    setStagedRange((current) => (sameRange(current, range) ? current : range));
   }, []);
-  const handleUnstagedRangeChange = useCallback(
-    (range: { start: number; end: number } | null) => {
-      const shifted =
-        range === null ? null : { start: range.start + stagedCount, end: range.end + stagedCount };
-      setUnstagedRange((current) =>
-        current?.start === shifted?.start && current?.end === shifted?.end ? current : shifted
-      );
-    },
-    [stagedCount]
-  );
+  const handleUnstagedRangeChange = useCallback((range: MountedRange) => {
+    setUnstagedRange((current) => (sameRange(current, range) ? current : range));
+  }, []);
 
   // Never point `aria-activedescendant` at a row that is not in the document.
   // On the static path every row is mounted and the answer is always yes; the
@@ -502,10 +546,8 @@ export function ReviewHubContent({
     focusedRowExists &&
     (!workingTreeVirtualized ||
       (focusedIndex < derivedStaged.length
-        ? stagedRange === null ||
-          (focusedIndex >= stagedRange.start && focusedIndex <= stagedRange.end)
-        : unstagedRange === null ||
-          (focusedIndex >= unstagedRange.start && focusedIndex <= unstagedRange.end)));
+        ? rangeCovers(stagedRange ?? EMPTY_MOUNTED_RANGE, focusedIndex)
+        : rangeCovers(unstagedRange ?? EMPTY_MOUNTED_RANGE, focusedIndex - derivedStaged.length)));
 
   const sortedBaseBranchFiles = useMemo(
     () =>
@@ -1634,8 +1676,10 @@ export function ReviewHubContent({
       if (rowElement === null && focusedRowExists) {
         e.preventDefault();
         e.stopPropagation();
+        const item = navigableItems[focusedIndex];
+        if (!item) return;
         revealRow(focusedIndex);
-        setPendingMenuIndex(focusedIndex);
+        setPendingMenu({ index: focusedIndex, key: `${item.section}:${item.file.path}` });
       }
       return;
     }

--- a/src/components/Worktree/ReviewHub/ReviewHubContent.tsx
+++ b/src/components/Worktree/ReviewHub/ReviewHubContent.tsx
@@ -15,6 +15,8 @@ import type { CrossWorktreeFile } from "@shared/types/ipc/git";
 import type { PushProgressEvent } from "@shared/types/ipc/gitPush";
 import { isClientAppError } from "@/utils/clientAppError";
 import { cn } from "@/lib/utils";
+import { shouldVirtualizeFileList } from "@/lib/fileListWindowing";
+import type { VirtuosoHandle } from "react-virtuoso";
 
 import { TruncatedTooltip } from "@/components/ui/TruncatedTooltip";
 import {
@@ -49,11 +51,11 @@ import { usePanelStore } from "@/store/panelStore";
 import { useWorktreeIdForPath } from "@/panels/diff/useWorktreeIdForPath";
 import { type FileStageRowSection } from "./FileStageRow";
 import { FileSection } from "./FileSection";
+import { BaseBranchFileList } from "./BaseBranchFileList";
 import {
   useReviewHubStagingActions,
   type ReviewHubActionFailure,
 } from "./useReviewHubStagingActions";
-import { BaseBranchFileRow } from "./BaseBranchFileRow";
 import { PushErrorBanner } from "./PushErrorBanner";
 import { PrStatusChip } from "./PrStatusChip";
 import { CommitPanel } from "./CommitPanel";
@@ -282,11 +284,31 @@ export function ReviewHubContent({
   // (a `section:path` key) preserves focus on the same file across list mutations.
   const [focusedIndex, setFocusedIndex] = useState(-1);
   const fileListRef = useRef<HTMLDivElement | null>(null);
+  // Reveal handles for the two windowed sections. Null on the static path,
+  // where the DOM query below still finds every row.
+  const stagedListRef = useRef<VirtuosoHandle | null>(null);
+  const unstagedListRef = useRef<VirtuosoHandle | null>(null);
+  // What each section currently has MOUNTED, in flat staged+unstaged
+  // coordinates. `null` means "everything" — the static path's honest answer,
+  // and the only one available before Virtuoso's first `rangeChanged`.
+  const [stagedRange, setStagedRange] = useState<{ start: number; end: number } | null>(null);
+  const [unstagedRange, setUnstagedRange] = useState<{ start: number; end: number } | null>(null);
+  // A row menu asked for on a row the window had scrolled past. Held until the
+  // reveal mounts the row, then replayed — see the effect near the key handler.
+  const [pendingMenuIndex, setPendingMenuIndex] = useState<number | null>(null);
   const focusedItemKeyRef = useRef<string | null>(null);
   const refreshIdRef = useRef(0);
   const bgRefreshIdRef = useRef(0);
   const baseBranchRequestRef = useRef(0);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  // The same element as `scrollContainerRef`, held in STATE as well: Virtuoso
+  // needs it as a prop, and a ref mutation does not re-render, so windowing
+  // would otherwise never learn the container exists.
+  const [scrollParent, setScrollParent] = useState<HTMLDivElement | null>(null);
+  const attachScrollContainer = useCallback((node: HTMLDivElement | null) => {
+    scrollContainerRef.current = node;
+    setScrollParent(node);
+  }, []);
   const savedScrollTop = useRef(0);
   const debouncedBgRefreshRef = useRef<ReturnType<typeof debounce> | null>(null);
   const conflictSectionRef = useRef<HTMLDivElement>(null);
@@ -385,15 +407,105 @@ export function ReviewHubContent({
     }
   }, [navigableItems, focusedIndex]);
 
-  // Scroll the focused row into view. `useLayoutEffect` so the scroll lands in
-  // the same frame as the focus change, avoiding lag during key-repeat.
+  // Whether the working-tree list windows. Decided across BOTH sections: they
+  // share one scroll container and one cursor, so windowing one and not the
+  // other would leave the cursor crossing a seam between two reveal mechanisms.
+  const workingTreeVirtualized = shouldVirtualizeFileList(navigableItems.length);
+
+  // The windowed reveal, split back out to the section that owns the index.
+  // `scrollIntoView` leaves an already-visible row alone, so a click on a
+  // visible row never yanks the list.
+  const revealRow = useEffectEvent((index: number) => {
+    if (!workingTreeVirtualized) {
+      fileListRef.current
+        ?.querySelector<HTMLElement>(`[data-row-index="${index}"]`)
+        ?.scrollIntoView({ behavior: "instant", block: "nearest" });
+      return;
+    }
+    const stagedCount = derivedStaged.length;
+    const handle = index < stagedCount ? stagedListRef.current : unstagedListRef.current;
+    handle?.scrollIntoView({
+      index: index < stagedCount ? index : index - stagedCount,
+      behavior: "auto",
+    });
+  });
+
+  // Reveal the focused row when the CURSOR moves, not whenever its index
+  // changes. Reconciliation renumbers every row below a stage, an unstage or a
+  // re-sort, so a stationary cursor takes a new index constantly; scrolling for
+  // that would drag the view off whatever the user was looking at (#11684).
+  // Keyed on the `section:path` identity the cursor already tracks, plus the
+  // "had no row, now has one" case — a restored cursor on the first commit.
+  const previousFocusKeyRef = useRef<{ key: string | null; found: boolean }>({
+    key: null,
+    found: false,
+  });
   useLayoutEffect(() => {
-    if (focusedIndex < 0 || !fileListRef.current) return;
-    const row = fileListRef.current.querySelector<HTMLElement>(
-      `[data-row-index="${focusedIndex}"]`
+    const item = focusedIndex >= 0 ? navigableItems[focusedIndex] : undefined;
+    const key = item ? `${item.section}:${item.file.path}` : null;
+    const previous = previousFocusKeyRef.current;
+    previousFocusKeyRef.current = { key, found: item !== undefined };
+    if (!item) return;
+    if (key === previous.key && previous.found) return;
+    revealRow(focusedIndex);
+  }, [focusedIndex, navigableItems]);
+
+  // A row menu requested on a row the window had scrolled past. `revealRow`
+  // above has already asked for it; this fires on the commit that mounts it.
+  // Dropped rather than retried if the row leaves the list first — a filter, a
+  // stage or a refresh means the menu no longer names anything.
+  useEffect(() => {
+    if (pendingMenuIndex === null) return;
+    // The cursor moved on, or the list changed under it. The request named a
+    // row that is no longer the one the user asked about, so it is dropped
+    // rather than left armed to open a menu on something else later.
+    if (pendingMenuIndex !== focusedIndex) {
+      setPendingMenuIndex(null);
+      return;
+    }
+    const row = fileListRef.current?.querySelector<HTMLElement>(
+      `[data-row-index="${pendingMenuIndex}"]`
     );
-    row?.scrollIntoView({ behavior: "instant", block: "nearest" });
-  }, [focusedIndex]);
+    if (!row) return;
+    setPendingMenuIndex(null);
+    openFileRowMenuFromKeyboard(row);
+  }, [pendingMenuIndex, focusedIndex, navigableItems, stagedRange, unstagedRange]);
+
+  // Sections report their mounted slice in LOCAL indices; the cursor lives in
+  // flat staged+unstaged coordinates, so shift the unstaged one by the staged
+  // count. Guarded rather than set unconditionally: Virtuoso fires
+  // `rangeChanged` on every scroll frame, and re-rendering the hub at that
+  // cadence would cost far more than the attribute it feeds is worth.
+  const stagedCount = derivedStaged.length;
+  const handleStagedRangeChange = useCallback((range: { start: number; end: number } | null) => {
+    setStagedRange((current) =>
+      current?.start === range?.start && current?.end === range?.end ? current : range
+    );
+  }, []);
+  const handleUnstagedRangeChange = useCallback(
+    (range: { start: number; end: number } | null) => {
+      const shifted =
+        range === null ? null : { start: range.start + stagedCount, end: range.end + stagedCount };
+      setUnstagedRange((current) =>
+        current?.start === shifted?.start && current?.end === shifted?.end ? current : shifted
+      );
+    },
+    [stagedCount]
+  );
+
+  // Never point `aria-activedescendant` at a row that is not in the document.
+  // On the static path every row is mounted and the answer is always yes; the
+  // windowed path mounts a slice, so a cursor the user has scrolled away from
+  // has an index in `navigableItems` and no DOM node at all.
+  const focusedRowExists = focusedIndex >= 0 && focusedIndex < navigableItems.length;
+  const focusedRowIsMounted =
+    focusedRowExists &&
+    (!workingTreeVirtualized ||
+      (focusedIndex < derivedStaged.length
+        ? stagedRange === null ||
+          (focusedIndex >= stagedRange.start && focusedIndex <= stagedRange.end)
+        : unstagedRange === null ||
+          (focusedIndex >= unstagedRange.start && focusedIndex <= unstagedRange.end)));
 
   const sortedBaseBranchFiles = useMemo(
     () =>
@@ -1342,6 +1454,15 @@ export function ReviewHubContent({
     []
   );
 
+  const handleOpenBaseBranchFile = useCallback((file: CrossWorktreeFile, trigger: HTMLElement) => {
+    diffTriggerRef.current = trigger;
+    setSelectedBaseBranchFile(file);
+  }, []);
+
+  const handleOpenDecorationUrl = useCallback((url: string) => {
+    void systemClient.openExternal(url);
+  }, []);
+
   const handleRowClick = useCallback(
     (
       section: FileStageRowSection,
@@ -1504,6 +1625,17 @@ export function ReviewHubContent({
         // the menu can't double-fire.
         e.preventDefault();
         e.stopPropagation();
+        return;
+      }
+      // No node for a cursor that DOES name a row: the windowed list has
+      // scrolled past it. Reveal it and replay the menu on the commit that
+      // mounts it, rather than dropping a key the user pressed on a row they
+      // can see the cursor on.
+      if (rowElement === null && focusedRowExists) {
+        e.preventDefault();
+        e.stopPropagation();
+        revealRow(focusedIndex);
+        setPendingMenuIndex(focusedIndex);
       }
       return;
     }
@@ -1546,6 +1678,10 @@ export function ReviewHubContent({
           item.section,
           item.file.path,
           item.file.status,
+          // Falls back to the listbox, which the windowed list makes routine
+          // rather than exceptional: a cursor the user has scrolled past has no
+          // row node to hand the dialog back to, and the listbox is the element
+          // that owns focus anyway.
           fileListRef.current?.querySelector<HTMLElement>(`[data-row-index="${focusedIndex}"]`) ??
             fileListRef.current
         );
@@ -1793,7 +1929,7 @@ export function ReviewHubContent({
 
         {/* Content */}
         <div
-          ref={scrollContainerRef}
+          ref={attachScrollContainer}
           data-testid="review-hub-scroll-container"
           className={cn(
             // `min-h-0` is load-bearing and stays alone in its Tailwind group:
@@ -1913,27 +2049,13 @@ export function ReviewHubContent({
                       </span>
                     </div>
                   </div>
-                  <div className="px-2 py-1 flex flex-col gap-0.5">
-                    {sortedBaseBranchFiles.map((file) => {
-                      const decoration = reviewDecorations[file.path];
-                      return (
-                        <BaseBranchFileRow
-                          key={`${file.status}:${file.path}`}
-                          file={file}
-                          onClick={(e) => {
-                            diffTriggerRef.current = e.currentTarget;
-                            setSelectedBaseBranchFile(file);
-                          }}
-                          unresolvedDecoration={decoration}
-                          onBadgeClick={
-                            decoration?.url
-                              ? () => void systemClient.openExternal(decoration.url as string)
-                              : undefined
-                          }
-                        />
-                      );
-                    })}
-                  </div>
+                  <BaseBranchFileList
+                    files={sortedBaseBranchFiles}
+                    decorations={reviewDecorations}
+                    onOpenFile={handleOpenBaseBranchFile}
+                    onOpenDecorationUrl={handleOpenDecorationUrl}
+                    scrollParent={scrollParent}
+                  />
                 </div>
               ) : null
             ) : (
@@ -2112,7 +2234,7 @@ export function ReviewHubContent({
                         // panel's (`useGlobalKeybindings`).
                         data-row-menu=""
                         aria-activedescendant={
-                          focusedIndex >= 0 ? `review-hub-row-${focusedIndex}` : undefined
+                          focusedRowIsMounted ? `review-hub-row-${focusedIndex}` : undefined
                         }
                         className="outline-hidden"
                       >
@@ -2148,6 +2270,10 @@ export function ReviewHubContent({
                           files={derivedStaged}
                           allFiles={status.staged}
                           indexOffset={0}
+                          virtualized={workingTreeVirtualized}
+                          scrollParent={scrollParent}
+                          listRef={stagedListRef}
+                          onRenderedRangeChange={handleStagedRangeChange}
                           focusedIndex={focusedIndex}
                           selectionSection={selectionSection}
                           selectedPaths={selectedPaths}
@@ -2179,6 +2305,10 @@ export function ReviewHubContent({
                           files={derivedUnstaged}
                           allFiles={status.unstaged}
                           indexOffset={derivedStaged.length}
+                          virtualized={workingTreeVirtualized}
+                          scrollParent={scrollParent}
+                          listRef={unstagedListRef}
+                          onRenderedRangeChange={handleUnstagedRangeChange}
                           focusedIndex={focusedIndex}
                           selectionSection={selectionSection}
                           selectedPaths={selectedPaths}

--- a/src/components/Worktree/ReviewHub/ReviewHubContent.tsx
+++ b/src/components/Worktree/ReviewHub/ReviewHubContent.tsx
@@ -309,6 +309,16 @@ export function ReviewHubContent({
   // than dropping the key.
   const [pendingMenu, setPendingMenu] = useState<{ index: number; key: string } | null>(null);
   const focusedItemKeyRef = useRef<string | null>(null);
+  // The same `section:path` value as the ref above, mirrored into state so it
+  // can drive the reveal effect — a ref cannot. The ref stays the source of
+  // truth because the reconciler reads it synchronously, before the render that
+  // would publish new state. `writeCursorKey` keeps the two in step; nothing
+  // may write one without the other.
+  const [focusedCursorKey, setFocusedCursorKey] = useState<string | null>(null);
+  const writeCursorKey = useCallback((key: string | null) => {
+    focusedItemKeyRef.current = key;
+    setFocusedCursorKey(key);
+  }, []);
   const refreshIdRef = useRef(0);
   const bgRefreshIdRef = useRef(0);
   const baseBranchRequestRef = useRef(0);
@@ -400,7 +410,7 @@ export function ReviewHubContent({
   // list, clamp to the nearest valid index so focus never points off the end.
   useEffect(() => {
     if (navigableItems.length === 0) {
-      focusedItemKeyRef.current = null;
+      writeCursorKey(null);
       setFocusedIndex((prev) => (prev === -1 ? prev : -1));
       return;
     }
@@ -410,14 +420,12 @@ export function ReviewHubContent({
     if (nextIdx === -1) {
       const clamped = Math.min(focusedIndex < 0 ? 0 : focusedIndex, navigableItems.length - 1);
       const clampedItem = navigableItems[clamped];
-      focusedItemKeyRef.current = clampedItem
-        ? `${clampedItem.section}:${clampedItem.file.path}`
-        : null;
+      writeCursorKey(clampedItem ? `${clampedItem.section}:${clampedItem.file.path}` : null);
       setFocusedIndex(clamped);
     } else if (nextIdx !== focusedIndex) {
       setFocusedIndex(nextIdx);
     }
-  }, [navigableItems, focusedIndex]);
+  }, [navigableItems, focusedIndex, writeCursorKey]);
 
   // Whether the working-tree list windows. Decided across BOTH sections: they
   // share one scroll container and one cursor, so windowing one and not the
@@ -437,6 +445,8 @@ export function ReviewHubContent({
   // An ABSENT row only the virtualizer can place, and `scrollToIndex` is the
   // right call there precisely because it skips that visibility check — the
   // destination it computes is in parent coordinates and is correct.
+  const revealCursor = useEffectEvent(() => revealRow(focusedIndex));
+
   const revealRow = useEffectEvent((index: number) => {
     const row = fileListRef.current?.querySelector<HTMLElement>(`[data-row-index="${index}"]`);
     if (row) {
@@ -448,41 +458,34 @@ export function ReviewHubContent({
     const handle = index < stagedCount ? stagedListRef.current : unstagedListRef.current;
     handle?.scrollToIndex({
       index: index < stagedCount ? index : index - stagedCount,
-      align: "center",
+      // `start`, never `center`: centring subtracts half the viewport height,
+      // and the viewport height a `customScrollParent` list is given is
+      // `parentHeight - max(0, listTop - parentTop)` — which goes NEGATIVE for a
+      // section far below the fold and sends the scroll past the row entirely.
+      // Aligning to the top needs no viewport arithmetic at all.
+      align: "start",
       behavior: "auto",
     });
   });
 
-  // Reveal the focused row when the CURSOR moves, not whenever its index
-  // changes. Reconciliation renumbers every row below a stage, an unstage or a
-  // re-sort, so a stationary cursor takes a new index constantly; scrolling for
-  // that would drag the view off whatever the user was looking at (#11684).
-  // Keyed on the `section:path` identity the cursor already tracks, plus the
-  // "had no row, now has one" case — a restored cursor on the first commit.
-  const previousFocusKeyRef = useRef<{ key: string | null; found: boolean }>({
-    key: null,
-    found: false,
-  });
+  // Reveal when the cursor lands on a DIFFERENT FILE — never merely because its
+  // index moved. Reconciliation renumbers every row below a stage, an unstage
+  // or a re-sort, so a stationary cursor takes a new index constantly, and
+  // scrolling for that drags the view off whatever the user was looking at
+  // (#11684).
+  //
+  // `focusedCursorKey` is the same `section:path` value `focusedItemKeyRef`
+  // holds, mirrored into state because a ref cannot drive an effect. Keying on
+  // it rather than on `focusedIndex` + `navigableItems` also settles the
+  // ordering: a refresh swaps the list one commit before the reconcile effect
+  // below moves the index to follow the file, and an effect that read the new
+  // list at the old index would see a different file, reveal it, and reveal
+  // again on the way back. Both writers below set the key and the index
+  // together, so this only ever fires on a settled cursor.
   useLayoutEffect(() => {
-    const item = focusedIndex >= 0 ? navigableItems[focusedIndex] : undefined;
-    const key = item ? `${item.section}:${item.file.path}` : null;
-
-    // A refresh replaces `navigableItems` one commit BEFORE the reconcile
-    // effect below moves `focusedIndex` to follow the file. On that commit the
-    // old index names a DIFFERENT file, which reads as a cursor move and
-    // scrolls — twice, once on the way in and once on the way back. So the
-    // reveal only trusts an index the cursor's own identity agrees with, and
-    // records nothing until it does: overwriting the baseline mid-reconcile
-    // would make the settled commit look like a move as well.
-    const intended = focusedItemKeyRef.current;
-    if (item && intended !== null && key !== intended) return;
-
-    const previous = previousFocusKeyRef.current;
-    previousFocusKeyRef.current = { key, found: item !== undefined };
-    if (!item) return;
-    if (key === previous.key && previous.found) return;
-    revealRow(focusedIndex);
-  }, [focusedIndex, navigableItems]);
+    if (focusedCursorKey === null) return;
+    revealCursor();
+  }, [focusedCursorKey]);
 
   // A row menu requested on a row the window had scrolled past. `revealRow`
   // above has already asked for it; this fires on the commit that mounts it.
@@ -999,7 +1002,7 @@ export function ReviewHubContent({
       setSelectionSection(null);
       selectionAnchorRef.current = null;
       setFocusedIndex(-1);
-      focusedItemKeyRef.current = null;
+      writeCursorKey(null);
       hasAutoStagedRef.current = false;
       // Filter state lives in `stagedView`/`changesView` rather than refs, so the
       // modal-shell path (which unmounts on close) never noticed leftover
@@ -1011,7 +1014,7 @@ export function ReviewHubContent({
       setStagedView(DEFAULT_SECTION_STATE);
       setChangesView(DEFAULT_SECTION_STATE);
     }
-  }, [isOpen, refresh]);
+  }, [isOpen, refresh, writeCursorKey]);
 
   useEffect(() => {
     if (!isOpen || !autoStageOnOpen) return;
@@ -1693,7 +1696,7 @@ export function ReviewHubContent({
       const item = navigableItems[index];
       if (!item) return;
       setFocusedIndex(index);
-      focusedItemKeyRef.current = `${item.section}:${item.file.path}`;
+      writeCursorKey(`${item.section}:${item.file.path}`);
       // Move DOM focus to the listbox so assistive tech announces the active
       // option via aria-activedescendant. Scroll is handled by the layout effect.
       fileListRef.current?.focus({ preventScroll: true });

--- a/src/components/Worktree/ReviewHub/__tests__/ReviewHub.virtualization.test.tsx
+++ b/src/components/Worktree/ReviewHub/__tests__/ReviewHub.virtualization.test.tsx
@@ -289,7 +289,24 @@ import { usePreferencesStore } from "@/store/preferencesStore";
  * of the `aria-activedescendant` contract.
  */
 const virtuosoRange = { current: null as { startIndex: number; endIndex: number } | null };
-const scrollIntoViewMock = vi.fn();
+/**
+ * Reveal calls, tagged with the list that received them.
+ *
+ * One spy across every instance would not be able to tell "revealed unstaged
+ * row 1" from "revealed staged row 1" — which is the whole of the flat-index
+ * to section-local arithmetic. The tag is derived from the data the instance
+ * was handed, so it identifies the real list rather than a wiring assumption.
+ */
+const scrollToIndexMock = vi.fn<(list: string, location: { index: number }) => void>();
+
+function listTag(data: unknown[]): string {
+  const first = data[0] as { path?: string } | undefined;
+  const path = first?.path ?? "";
+  if (path.startsWith("src/staged/")) return "staged";
+  if (path.startsWith("src/unstaged/")) return "unstaged";
+  if (path.startsWith("src/base/")) return "base";
+  return "unknown";
+}
 
 vi.mock("react-virtuoso", async (importOriginal) => {
   const actual = await importOriginal<typeof import("react-virtuoso")>();
@@ -304,10 +321,17 @@ vi.mock("react-virtuoso", async (importOriginal) => {
         computeItemKey?: (index: number, item: unknown, context: unknown) => string;
         rangeChanged?: (range: { startIndex: number; endIndex: number }) => void;
       },
-      ref: ForwardedRef<Pick<VirtuosoHandle, "scrollIntoView">>
+      ref: ForwardedRef<Pick<VirtuosoHandle, "scrollToIndex">>
     ) {
-      useImperativeHandle(ref, () => ({ scrollIntoView: scrollIntoViewMock }), []);
       const { rangeChanged, data } = props;
+      const tag = listTag(data);
+      useImperativeHandle(
+        ref,
+        () => ({
+          scrollToIndex: (location: { index: number }) => scrollToIndexMock(tag, location),
+        }),
+        [tag]
+      );
       const lastIndex = data.length - 1;
       useEffect(() => {
         rangeChanged?.(virtuosoRange.current ?? { startIndex: 0, endIndex: lastIndex });
@@ -381,10 +405,24 @@ const makeLargeStatus = () =>
     })),
   });
 
+/** Drives the hub's background refresh, which is what renumbers the list. */
+const makeWorktreeState = (path = WORKTREE_PATH): WorktreeState =>
+  ({
+    id: path,
+    path,
+    worktreeId: path,
+    name: "test",
+    isCurrent: true,
+    worktreeChanges: null,
+    lastActivityTimestamp: null,
+  }) as WorktreeState;
+
 describe("ReviewHub windowed file list (#12241)", () => {
+  let capturedUpdateCallback: ((state: WorktreeState) => void) | null = null;
   const mockUnsubscribe = vi.fn();
 
   beforeEach(() => {
+    capturedUpdateCallback = null;
     debounceCancelSpy.mockReset();
 
     // Clear the file-list disclosure map rather than force-expanding it: the
@@ -419,7 +457,7 @@ describe("ReviewHub windowed file list (#12241)", () => {
       // The component subscribes to the per-view worktree port; tests keep
       // driving it with a plain WorktreeState by wrapping it in the port
       // event envelope here.
-      void callback;
+      capturedUpdateCallback = (state: WorktreeState) => callback({ worktree: state });
       return mockUnsubscribe;
     });
 
@@ -499,7 +537,7 @@ describe("ReviewHub windowed file list (#12241)", () => {
 
   beforeEach(() => {
     virtuosoRange.current = null;
-    scrollIntoViewMock.mockClear();
+    scrollToIndexMock.mockClear();
     // jsdom implements neither; the static path's reveal calls the first and
     // Radix's menu machinery touches the second.
     HTMLElement.prototype.scrollIntoView = vi.fn();
@@ -508,8 +546,9 @@ describe("ReviewHub windowed file list (#12241)", () => {
   const renderLargeHub = async () => {
     getStagingStatusMock.mockResolvedValue(makeLargeStatus());
     render(<ReviewHubContent isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />);
-    await waitFor(() => screen.getByTestId("file-stage-row-src/staged/file-000.ts"));
-    return screen.getByRole("listbox", { name: "Changed files" });
+    // Waits on the listbox, not on a particular row: a narrow window may not
+    // mount row zero at all.
+    return await screen.findByRole("listbox", { name: "Changed files" });
   };
 
   it("keeps row ids, roles and the flat index space across the section split", async () => {
@@ -547,9 +586,29 @@ describe("ReviewHub windowed file list (#12241)", () => {
     // outside the mounted window, so the listbox must not claim it as its
     // active descendant.
     expect(listbox.getAttribute("aria-activedescendant")).toBeNull();
-    expect(scrollIntoViewMock).toHaveBeenCalledWith(
-      expect.objectContaining({ index: 14, behavior: "auto" })
+    expect(scrollToIndexMock).toHaveBeenCalledWith(
+      "staged",
+      expect.objectContaining({ index: 14 })
     );
+  });
+
+  it("scrolls a mounted row natively instead of asking the virtualizer", async () => {
+    // react-virtuoso cannot answer "is this row visible" correctly against a
+    // shared scroll parent — it clamps its section-local scrollTop to zero and
+    // keeps the parent's full viewport height, so a section below the fold
+    // thinks its first rows are on screen. A mounted row is scrolled through
+    // the DOM, which knows.
+    virtuosoRange.current = { startIndex: 0, endIndex: 59 };
+    const nativeScroll = vi.fn();
+    HTMLElement.prototype.scrollIntoView = nativeScroll;
+    await renderLargeHub();
+    scrollToIndexMock.mockClear();
+    nativeScroll.mockClear();
+
+    act(() => void fireEvent.keyDown(document, { key: "ArrowDown" }));
+
+    expect(nativeScroll).toHaveBeenCalled();
+    expect(scrollToIndexMock).not.toHaveBeenCalled();
   });
 
   it("names the active descendant again once the window covers the cursor", async () => {
@@ -563,39 +622,64 @@ describe("ReviewHub windowed file list (#12241)", () => {
   });
 
   it("reveals into the unstaged section using that section's own indices", async () => {
-    virtuosoRange.current = { startIndex: 0, endIndex: 59 };
+    // A window in the middle of each section, so the second unstaged row is
+    // genuinely absent and only the virtualizer can bring it back.
+    virtuosoRange.current = { startIndex: 20, endIndex: 30 };
     await renderLargeHub();
 
-    // 61 steps: 60 staged rows, then the second unstaged row.
-    for (let i = 0; i < 61; i++) {
+    // 62 steps: 60 staged rows, then the second unstaged row.
+    for (let i = 0; i < 62; i++) {
       act(() => void fireEvent.keyDown(document, { key: "ArrowDown" }));
     }
+    expect(screen.queryByTestId("file-stage-row-src/unstaged/file-001.ts")).toBeNull();
     // Flat index 60 is the unstaged section's index 0 — the reveal has to speak
     // the section's coordinates, not the cursor's.
-    expect(scrollIntoViewMock).toHaveBeenLastCalledWith(
-      expect.objectContaining({ index: 0, behavior: "auto" })
+    // Flat index 61 is the unstaged section's index 1 — the reveal has to speak
+    // the section's own coordinates, and reach the unstaged list, not the
+    // staged one that happens to have a row at index 1 too.
+    expect(scrollToIndexMock).toHaveBeenLastCalledWith(
+      "unstaged",
+      expect.objectContaining({ index: 1 })
     );
   });
 
   it("does not re-reveal a stationary cursor when the list renumbers", async () => {
     virtuosoRange.current = { startIndex: 0, endIndex: 59 };
-    await renderLargeHub();
-    act(() => void fireEvent.keyDown(document, { key: "ArrowDown" }));
-    scrollIntoViewMock.mockClear();
+    const listbox = await renderLargeHub();
+    // Park the cursor in the unstaged section, so a new STAGED file lands above
+    // it and shifts its index.
+    for (let i = 0; i < 62; i++) {
+      act(() => void fireEvent.keyDown(document, { key: "ArrowDown" }));
+    }
+    expect(listbox.getAttribute("aria-activedescendant")).toBe("review-hub-row-61");
+    scrollToIndexMock.mockClear();
 
-    // Staging a file above the cursor shifts its index without moving it. A
+    // A background refresh that adds a file above the cursor renumbers every
+    // row below it. The cursor has not moved — it is on the same file — and a
     // reveal keyed on the index alone would scroll here and drag the view off
     // whatever the user was looking at (#11684).
     const status = makeLargeStatus();
     getStagingStatusMock.mockResolvedValue({
       ...status,
       staged: [
-        { path: "src/staged/added.ts", status: "modified" as const, insertions: 1, deletions: 0 },
+        {
+          path: "src/staged/aaa-added.ts",
+          status: "modified" as const,
+          insertions: 1,
+          deletions: 0,
+        },
         ...status.staged,
       ],
     });
-    act(() => void fireEvent.keyDown(document, { key: "v" }));
-    await waitFor(() => expect(scrollIntoViewMock).not.toHaveBeenCalled());
+    await act(async () => {
+      capturedUpdateCallback!(makeWorktreeState());
+      await Promise.resolve();
+    });
+    await waitFor(() => screen.getByTestId("file-stage-row-src/staged/aaa-added.ts"));
+
+    // The renumber happened — same file, new index — and nothing scrolled.
+    expect(listbox.getAttribute("aria-activedescendant")).toBe("review-hub-row-62");
+    expect(scrollToIndexMock).not.toHaveBeenCalled();
   });
 
   it("reveals the row before opening its menu when the window has scrolled past it", async () => {
@@ -605,7 +689,7 @@ describe("ReviewHub windowed file list (#12241)", () => {
       act(() => void fireEvent.keyDown(document, { key: "ArrowDown" }));
     }
     expect(screen.queryByTestId("file-stage-row-src/staged/file-014.ts")).toBeNull();
-    scrollIntoViewMock.mockClear();
+    scrollToIndexMock.mockClear();
 
     act(() => void fireEvent.keyDown(document, { key: "F10", shiftKey: true }));
 
@@ -613,8 +697,9 @@ describe("ReviewHub windowed file list (#12241)", () => {
     // may not be, and the key must not simply evaporate: the hub asks the
     // virtualizer for the row and replays the menu on the commit that mounts
     // it.
-    expect(scrollIntoViewMock).toHaveBeenCalledWith(
-      expect.objectContaining({ index: 14, behavior: "auto" })
+    expect(scrollToIndexMock).toHaveBeenCalledWith(
+      "staged",
+      expect.objectContaining({ index: 14 })
     );
   });
 
@@ -649,13 +734,16 @@ describe("ReviewHub windowed file list (#12241)", () => {
     virtuosoRange.current = { startIndex: 0, endIndex: 59 };
     await renderLargeHub();
     act(() => void fireEvent.keyDown(document, { key: "ArrowDown" }));
-    scrollIntoViewMock.mockClear();
+    scrollToIndexMock.mockClear();
 
     act(() => void fireEvent.keyDown(document, { key: "F10", shiftKey: true }));
 
     // No reveal needed, and none requested — the deferred path is for absent
     // rows only, not a new cost on every menu.
-    expect(scrollIntoViewMock).not.toHaveBeenCalled();
-    await waitFor(() => expect(screen.getAllByRole("menu").length).toBeGreaterThan(0));
+    expect(scrollToIndexMock).not.toHaveBeenCalled();
+    // Named, not merely counted: the mocked section toolbars render dropdown
+    // menus of their own, so `getAllByRole("menu")` is satisfied whether or not
+    // the row menu ever opened.
+    await waitFor(() => screen.getByRole("menuitem", { name: /open diff/i }));
   });
 });

--- a/src/components/Worktree/ReviewHub/__tests__/ReviewHub.virtualization.test.tsx
+++ b/src/components/Worktree/ReviewHub/__tests__/ReviewHub.virtualization.test.tsx
@@ -1,0 +1,661 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, act, fireEvent } from "@testing-library/react";
+import type { ForwardedRef, ReactNode } from "react";
+import type { VirtuosoHandle } from "react-virtuoso";
+import type { StagingStatus } from "@shared/types";
+import type { WorktreeState } from "@shared/types";
+
+const {
+  getStagingStatusMock,
+  onUpdateMock,
+  debounceCancelSpy,
+  compareWorktreesMock,
+  openExternalMock,
+  classifyPushErrorMock,
+  abortRepositoryOperationMock,
+  continueRepositoryOperationMock,
+  scanConflictMarkersMock,
+  checkoutOursTheirsMock,
+  openInEditorMock,
+  stageFileMock,
+  unstageFileMock,
+  stageFilesMock,
+  unstageFilesMock,
+  stageAllMock,
+  unstageAllMock,
+  commitMock,
+  pushMock,
+  pullRebaseMock,
+  forcePushWithLeaseMock,
+  listRemoteCommitsMock,
+  listCommitsMock,
+  actionDispatchMock,
+  getDecorationsMock,
+  onDecorationsChangedMock,
+  worktreeStoreData,
+} = vi.hoisted(() => ({
+  getStagingStatusMock: vi.fn(),
+  onUpdateMock: vi.fn(),
+  debounceCancelSpy: vi.fn(),
+  compareWorktreesMock: vi.fn(),
+  openExternalMock: vi.fn().mockResolvedValue(undefined),
+  // Mirrors the real GitHub forge provider: extracts a GH### code from stderr
+  // and reports the resolved canonical provider id used to route the
+  // settings CTA.
+  classifyPushErrorMock: vi.fn(async (_cwd: string, stderr: string) => {
+    const match = /\bGH\d{3,}\b/.exec(String(stderr));
+    return {
+      providerId: "daintree.github.github",
+      classification: match ? { code: match[0] } : null,
+    };
+  }),
+  abortRepositoryOperationMock: vi.fn().mockResolvedValue(undefined),
+  continueRepositoryOperationMock: vi.fn().mockResolvedValue(undefined),
+  scanConflictMarkersMock: vi.fn().mockResolvedValue([]),
+  checkoutOursTheirsMock: vi.fn().mockResolvedValue(undefined),
+  openInEditorMock: vi.fn().mockResolvedValue(undefined),
+  stageFileMock: vi.fn().mockResolvedValue(undefined),
+  unstageFileMock: vi.fn().mockResolvedValue(undefined),
+  stageFilesMock: vi.fn().mockResolvedValue(undefined),
+  unstageFilesMock: vi.fn().mockResolvedValue(undefined),
+  stageAllMock: vi.fn().mockResolvedValue(undefined),
+  unstageAllMock: vi.fn().mockResolvedValue(undefined),
+  commitMock: vi.fn(),
+  pushMock: vi.fn(),
+  pullRebaseMock: vi.fn(),
+  forcePushWithLeaseMock: vi.fn(),
+  listRemoteCommitsMock: vi.fn(),
+  listCommitsMock: vi.fn().mockResolvedValue({ items: [], hasMore: false, total: 0 }),
+  actionDispatchMock: vi.fn().mockResolvedValue({ ok: true }),
+  getDecorationsMock: vi.fn().mockResolvedValue({}),
+  onDecorationsChangedMock: vi.fn().mockReturnValue(vi.fn()),
+  worktreeStoreData: {
+    current: new Map<string, Partial<WorktreeState>>([
+      [
+        "main-wt",
+        {
+          id: "main-wt",
+          path: "/home/user/project",
+          name: "main",
+          branch: "main",
+          isMainWorktree: true,
+          isCurrent: false,
+          worktreeId: "main-wt",
+          worktreeChanges: null,
+          lastActivityTimestamp: null,
+        },
+      ],
+    ]),
+  },
+}));
+
+vi.mock("@/utils/debounce", () => ({
+  debounce: (fn: (...args: unknown[]) => void) => {
+    const immediate = (...args: unknown[]) => fn(...args);
+    immediate.cancel = debounceCancelSpy;
+    immediate.flush = vi.fn();
+    return immediate;
+  },
+}));
+
+vi.mock("@/hooks", () => ({
+  useTruncationDetection: vi.fn(() => ({ ref: vi.fn(), isTruncated: false })),
+  // Reached only when a row menu actually renders, which only happens in this
+  // file once a windowed row has been revealed.
+  useAriaKeyshortcuts: vi.fn(() => undefined),
+}));
+
+vi.mock("@/hooks/useWorktreeStore", () => ({
+  // The hoisted fixture holds partial worktrees, which is all the hub reads —
+  // typing the selector's view to match beats asserting the narrower shape.
+  useWorktreeStore: (
+    selector: (state: { worktrees: Map<string, Partial<WorktreeState>> }) => unknown
+  ) => selector({ worktrees: worktreeStoreData.current }),
+}));
+
+vi.mock("@/clients/systemClient", () => ({
+  systemClient: { openExternal: openExternalMock },
+}));
+
+vi.mock("@/clients/forgeClient", () => ({
+  forgeClient: { classifyPushError: classifyPushErrorMock },
+}));
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: { dispatch: actionDispatchMock },
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    onClick,
+    disabled,
+    "aria-disabled": ariaDisabled,
+    "aria-label": ariaLabel,
+    "data-testid": testId,
+  }: {
+    children: ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+    "aria-disabled"?: boolean;
+    variant?: string;
+    size?: string;
+    className?: string;
+    "aria-label"?: string;
+    "data-testid"?: string;
+  }) => (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-disabled={ariaDisabled}
+      aria-label={ariaLabel}
+      data-testid={testId}
+    >
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("@/components/ui/ConfirmDialog", () => ({
+  ConfirmDialog: ({
+    isOpen,
+    title,
+    description,
+    children,
+    onConfirm,
+    onClose,
+    confirmLabel,
+    cancelLabel,
+  }: {
+    isOpen: boolean;
+    title: ReactNode;
+    description?: ReactNode;
+    children?: ReactNode;
+    onConfirm: () => void;
+    onClose?: () => void;
+    confirmLabel: string;
+    cancelLabel?: string;
+    variant: "default" | "destructive" | "info";
+  }) => {
+    if (!isOpen) return null;
+    return (
+      <div role="alertdialog" aria-label={typeof title === "string" ? title : "confirm"}>
+        <div>{title}</div>
+        {description && <div>{description}</div>}
+        {children && <div>{children}</div>}
+        <button type="button" onClick={onConfirm}>
+          {confirmLabel}
+        </button>
+        {onClose && (
+          <button type="button" onClick={onClose}>
+            {cancelLabel ?? "Cancel"}
+          </button>
+        )}
+      </div>
+    );
+  },
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DropdownMenuTrigger: ({ children, asChild }: { children: ReactNode; asChild?: boolean }) =>
+    asChild ? <>{children}</> : <button type="button">{children}</button>,
+  DropdownMenuContent: ({
+    children,
+    align: _align,
+    className: _className,
+  }: {
+    children: ReactNode;
+    align?: string;
+    className?: string;
+  }) => <div role="menu">{children}</div>,
+  DropdownMenuRadioGroup: ({
+    children,
+    value,
+    onValueChange: _onValueChange,
+  }: {
+    children: ReactNode;
+    value: string;
+    onValueChange: (v: string) => void;
+  }) => <div data-value={value}>{children}</div>,
+  DropdownMenuRadioItem: ({ children, value: _value }: { children: ReactNode; value: string }) => (
+    <div role="menuitemradio">{children}</div>
+  ),
+  DropdownMenuCheckboxItem: ({
+    children,
+    checked,
+    onCheckedChange,
+  }: {
+    children: ReactNode;
+    checked: boolean;
+    onCheckedChange: (checked: boolean) => void;
+  }) => (
+    <div
+      role="menuitemcheckbox"
+      aria-checked={checked}
+      onClick={() => onCheckedChange(!checked)}
+      className="cursor-pointer"
+    >
+      {children}
+    </div>
+  ),
+  DropdownMenuLabel: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuSeparator: () => <hr />,
+}));
+
+vi.mock("@/components/ui/EmptyState", () => ({
+  EmptyState: ({
+    variant,
+    scale,
+    title,
+    action,
+  }: {
+    variant: string;
+    scale?: string;
+    title: string;
+    action?: ReactNode;
+  }) => (
+    <div data-testid={`empty-state-${variant}`} data-scale={scale}>
+      <p>{title}</p>
+      {action && <div>{action}</div>}
+    </div>
+  ),
+}));
+
+import { ReviewHubContent } from "../ReviewHubContent";
+import { useUIStore } from "@/store/uiStore";
+import { usePreferencesStore } from "@/store/preferencesStore";
+
+/**
+ * A `Virtuoso` that mounts every row but reports an arbitrary rendered range.
+ *
+ * Copied in shape from `src/panels/file-browser/__tests__/FileTreeView.test.tsx`,
+ * for the same reason: jsdom measures nothing, so the real virtualizer's window
+ * is a function of a viewport that does not exist. Mounting everything while
+ * reporting a NARROW range is a combination the real component cannot produce,
+ * and it is exactly the one these tests need — it separates "is this row in the
+ * DOM" from "does the hub believe this row is in the DOM", which is the whole
+ * of the `aria-activedescendant` contract.
+ */
+const virtuosoRange = { current: null as { startIndex: number; endIndex: number } | null };
+const scrollIntoViewMock = vi.fn();
+
+vi.mock("react-virtuoso", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-virtuoso")>();
+  const { forwardRef, useEffect, useImperativeHandle } = await import("react");
+  return {
+    ...actual,
+    Virtuoso: forwardRef(function VirtuosoStub(
+      props: {
+        data: unknown[];
+        context: unknown;
+        itemContent: (index: number, item: unknown, context: unknown) => ReactNode;
+        computeItemKey?: (index: number, item: unknown, context: unknown) => string;
+        rangeChanged?: (range: { startIndex: number; endIndex: number }) => void;
+      },
+      ref: ForwardedRef<Pick<VirtuosoHandle, "scrollIntoView">>
+    ) {
+      useImperativeHandle(ref, () => ({ scrollIntoView: scrollIntoViewMock }), []);
+      const { rangeChanged, data } = props;
+      const lastIndex = data.length - 1;
+      useEffect(() => {
+        rangeChanged?.(virtuosoRange.current ?? { startIndex: 0, endIndex: lastIndex });
+      }, [rangeChanged, lastIndex]);
+      // Mounts only the slice it reports. `FileTreeView`'s stub renders
+      // everything because its tests only need the reported range to differ
+      // from the mounted one; these need a row that genuinely has no DOM node,
+      // which is the state every contract below is about.
+      const range = virtuosoRange.current;
+      return (
+        <div>
+          {props.data.map((item, index) => {
+            if (range && (index < range.startIndex || index > range.endIndex)) return null;
+            return (
+              <div key={props.computeItemKey?.(index, item, props.context) ?? index}>
+                {props.itemContent(index, item, props.context)}
+              </div>
+            );
+          })}
+        </div>
+      );
+    }),
+  };
+});
+
+const WORKTREE_PATH = "/home/user/project";
+
+const makeStatus = (overrides?: Partial<StagingStatus>): StagingStatus => ({
+  staged: [{ path: "src/index.ts", status: "modified", insertions: 5, deletions: 2 }],
+  unstaged: [{ path: "src/app.ts", status: "modified", insertions: 3, deletions: 1 }],
+  conflicted: [],
+  conflictedFiles: [],
+  isDetachedHead: false,
+  currentBranch: "feature/test",
+  hasRemote: false,
+  pushDestination: { remote: "origin", branch: "feature/test" },
+  pullSource: { remote: "origin", branch: "feature/test" },
+  repoState: "DIRTY",
+  rebaseStep: null,
+  rebaseTotalSteps: null,
+  rebaseSequence: null,
+  ...overrides,
+});
+
+/**
+ * `checkoutOursTheirs` now gates on a per-file `ConfirmDialog` (#8242). The
+ * row button only opens the dialog; clicking its `Take ours` / `Take theirs`
+ * confirm button is what reaches the IPC.
+ */
+
+/**
+ * `pullRebase` now gates on a `ConfirmDialog` showing the divergence preview
+ * (#8242). The push-error CTA only opens the dialog; clicking its
+ * `Pull and rebase` confirm button is what reaches the IPC.
+ */
+
+/** Past the 80-row windowing threshold, split across both sections. */
+const makeLargeStatus = () =>
+  makeStatus({
+    staged: Array.from({ length: 60 }, (_, i) => ({
+      path: `src/staged/file-${String(i).padStart(3, "0")}.ts`,
+      status: "modified" as const,
+      insertions: i,
+      deletions: 1,
+    })),
+    unstaged: Array.from({ length: 60 }, (_, i) => ({
+      path: `src/unstaged/file-${String(i).padStart(3, "0")}.ts`,
+      status: "modified" as const,
+      insertions: i,
+      deletions: 1,
+    })),
+  });
+
+describe("ReviewHub windowed file list (#12241)", () => {
+  const mockUnsubscribe = vi.fn();
+
+  beforeEach(() => {
+    debounceCancelSpy.mockReset();
+
+    // Clear the file-list disclosure map rather than force-expanding it: the
+    // disclosure now defaults to expanded, so an unset entry is what production
+    // renders, and clearing also stops a test that collapses it from leaking
+    // into the next one.
+    useUIStore.setState({ reviewHubFileListExpanded: {} });
+
+    // #8025: reset the per-worktree push-confirm opt-out so a previous test
+    // that pre-set it can't leak into the next one.
+    usePreferencesStore.getState().setSkipPushConfirmForWorktree(WORKTREE_PATH, false);
+
+    worktreeStoreData.current = new Map([
+      [
+        "main-wt",
+        {
+          id: "main-wt",
+          path: "/home/user/project",
+          name: "main",
+          branch: "main",
+          isMainWorktree: true,
+          isCurrent: false,
+          worktreeId: "main-wt",
+          worktreeChanges: null,
+          lastActivityTimestamp: null,
+        },
+      ],
+    ]);
+
+    getStagingStatusMock.mockResolvedValue(makeStatus());
+    onUpdateMock.mockImplementation((_type: string, callback: (data: unknown) => void) => {
+      // The component subscribes to the per-view worktree port; tests keep
+      // driving it with a plain WorktreeState by wrapping it in the port
+      // event envelope here.
+      void callback;
+      return mockUnsubscribe;
+    });
+
+    compareWorktreesMock.mockResolvedValue({ branch1: "main", branch2: "feature/test", files: [] });
+
+    abortRepositoryOperationMock.mockReset().mockResolvedValue(undefined);
+    continueRepositoryOperationMock.mockReset().mockResolvedValue(undefined);
+    scanConflictMarkersMock.mockReset().mockResolvedValue([]);
+    checkoutOursTheirsMock.mockReset().mockResolvedValue(undefined);
+    openInEditorMock.mockReset().mockResolvedValue(undefined);
+    stageFileMock.mockReset().mockResolvedValue(undefined);
+    unstageFileMock.mockReset().mockResolvedValue(undefined);
+    stageFilesMock.mockReset().mockResolvedValue(undefined);
+    unstageFilesMock.mockReset().mockResolvedValue(undefined);
+    stageAllMock.mockReset().mockResolvedValue(undefined);
+    unstageAllMock.mockReset().mockResolvedValue(undefined);
+    commitMock.mockReset().mockResolvedValue({ hash: "abc123", summary: "commit" });
+    pushMock.mockReset().mockResolvedValue(undefined);
+    pullRebaseMock.mockReset().mockResolvedValue(undefined);
+    forcePushWithLeaseMock.mockReset().mockResolvedValue(undefined);
+    listRemoteCommitsMock.mockReset().mockResolvedValue([]);
+    listCommitsMock.mockReset().mockResolvedValue({ items: [], hasMore: false, total: 0 });
+    actionDispatchMock.mockReset().mockResolvedValue({ ok: true });
+    openExternalMock.mockReset().mockResolvedValue(undefined);
+    classifyPushErrorMock.mockReset().mockImplementation(async (_cwd: string, stderr: string) => {
+      const match = /\bGH\d{3,}\b/.exec(String(stderr));
+      return {
+        providerId: "daintree.github.github",
+        classification: match ? { code: match[0] } : null,
+      };
+    });
+    getDecorationsMock.mockReset().mockResolvedValue({});
+    onDecorationsChangedMock.mockReset().mockReturnValue(vi.fn());
+
+    Object.defineProperty(window, "electron", {
+      value: {
+        git: {
+          getStagingStatus: getStagingStatusMock,
+          stageFile: stageFileMock,
+          unstageFile: unstageFileMock,
+          stageFiles: stageFilesMock,
+          unstageFiles: unstageFilesMock,
+          stageAll: stageAllMock,
+          unstageAll: unstageAllMock,
+          commit: commitMock,
+          push: pushMock,
+          pullRebase: pullRebaseMock,
+          forcePushWithLease: forcePushWithLeaseMock,
+          listRemoteCommits: listRemoteCommitsMock,
+          listCommits: listCommitsMock,
+          compareWorktrees: compareWorktreesMock,
+          abortRepositoryOperation: abortRepositoryOperationMock,
+          continueRepositoryOperation: continueRepositoryOperationMock,
+          scanConflictMarkers: scanConflictMarkersMock,
+          checkoutOursTheirs: checkoutOursTheirsMock,
+          onPushProgress: vi.fn().mockReturnValue(vi.fn()),
+        },
+        system: { openInEditor: openInEditorMock },
+        worktreePort: { onEvent: onUpdateMock },
+        plugin: {
+          // Default to no decorations; per-describe blocks can override via
+          // `getDecorationsMock.mockResolvedValueOnce(...)` once a worktree
+          // PR is set (the scope is empty when no PR is linked, so the
+          // hook skips the IPC anyway).
+          getDecorations: getDecorationsMock,
+          onDecorationsChanged: onDecorationsChangedMock,
+        },
+      },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  beforeEach(() => {
+    virtuosoRange.current = null;
+    scrollIntoViewMock.mockClear();
+    // jsdom implements neither; the static path's reveal calls the first and
+    // Radix's menu machinery touches the second.
+    HTMLElement.prototype.scrollIntoView = vi.fn();
+  });
+
+  const renderLargeHub = async () => {
+    getStagingStatusMock.mockResolvedValue(makeLargeStatus());
+    render(<ReviewHubContent isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />);
+    await waitFor(() => screen.getByTestId("file-stage-row-src/staged/file-000.ts"));
+    return screen.getByRole("listbox", { name: "Changed files" });
+  };
+
+  it("keeps row ids, roles and the flat index space across the section split", async () => {
+    await renderLargeHub();
+    // Row 60 is the first unstaged file: the staged section's 60 rows come
+    // first in one continuous coordinate space, exactly as before windowing.
+    const firstUnstaged = screen.getByTestId("file-stage-row-src/unstaged/file-000.ts");
+    expect(firstUnstaged.getAttribute("id")).toBe("review-hub-row-60");
+    expect(firstUnstaged.getAttribute("data-row-index")).toBe("60");
+    expect(firstUnstaged.getAttribute("role")).toBe("option");
+    expect(firstUnstaged.getAttribute("aria-selected")).toBe("false");
+  });
+
+  it("drops the content-visibility hint once the list windows", async () => {
+    await renderLargeHub();
+    // The two optimisations answer the same question with different numbers:
+    // `contain-intrinsic-size` is a guess, and a virtualizer that measures rows
+    // would cache the guess instead of the row.
+    const row = screen.getByTestId("file-stage-row-src/staged/file-000.ts");
+    expect(row.style.contentVisibility).toBe("");
+    expect(row.style.containIntrinsicSize).toBe("");
+  });
+
+  it("arrows onto an off-screen row and asks the virtualizer to reveal it", async () => {
+    // Only the first ten rows of each section are mounted, so the cursor's
+    // fifteenth step lands somewhere with no DOM node.
+    virtuosoRange.current = { startIndex: 0, endIndex: 9 };
+    const listbox = await renderLargeHub();
+
+    for (let i = 0; i < 15; i++) {
+      act(() => void fireEvent.keyDown(document, { key: "ArrowDown" }));
+    }
+
+    // The cursor moved — the hub's own state says so — but the row it names is
+    // outside the mounted window, so the listbox must not claim it as its
+    // active descendant.
+    expect(listbox.getAttribute("aria-activedescendant")).toBeNull();
+    expect(scrollIntoViewMock).toHaveBeenCalledWith(
+      expect.objectContaining({ index: 14, behavior: "auto" })
+    );
+  });
+
+  it("names the active descendant again once the window covers the cursor", async () => {
+    virtuosoRange.current = { startIndex: 0, endIndex: 40 };
+    const listbox = await renderLargeHub();
+
+    for (let i = 0; i < 15; i++) {
+      act(() => void fireEvent.keyDown(document, { key: "ArrowDown" }));
+    }
+    expect(listbox.getAttribute("aria-activedescendant")).toBe("review-hub-row-14");
+  });
+
+  it("reveals into the unstaged section using that section's own indices", async () => {
+    virtuosoRange.current = { startIndex: 0, endIndex: 59 };
+    await renderLargeHub();
+
+    // 61 steps: 60 staged rows, then the second unstaged row.
+    for (let i = 0; i < 61; i++) {
+      act(() => void fireEvent.keyDown(document, { key: "ArrowDown" }));
+    }
+    // Flat index 60 is the unstaged section's index 0 — the reveal has to speak
+    // the section's coordinates, not the cursor's.
+    expect(scrollIntoViewMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ index: 0, behavior: "auto" })
+    );
+  });
+
+  it("does not re-reveal a stationary cursor when the list renumbers", async () => {
+    virtuosoRange.current = { startIndex: 0, endIndex: 59 };
+    await renderLargeHub();
+    act(() => void fireEvent.keyDown(document, { key: "ArrowDown" }));
+    scrollIntoViewMock.mockClear();
+
+    // Staging a file above the cursor shifts its index without moving it. A
+    // reveal keyed on the index alone would scroll here and drag the view off
+    // whatever the user was looking at (#11684).
+    const status = makeLargeStatus();
+    getStagingStatusMock.mockResolvedValue({
+      ...status,
+      staged: [
+        { path: "src/staged/added.ts", status: "modified" as const, insertions: 1, deletions: 0 },
+        ...status.staged,
+      ],
+    });
+    act(() => void fireEvent.keyDown(document, { key: "v" }));
+    await waitFor(() => expect(scrollIntoViewMock).not.toHaveBeenCalled());
+  });
+
+  it("reveals the row before opening its menu when the window has scrolled past it", async () => {
+    virtuosoRange.current = { startIndex: 0, endIndex: 9 };
+    await renderLargeHub();
+    for (let i = 0; i < 15; i++) {
+      act(() => void fireEvent.keyDown(document, { key: "ArrowDown" }));
+    }
+    expect(screen.queryByTestId("file-stage-row-src/staged/file-014.ts")).toBeNull();
+    scrollIntoViewMock.mockClear();
+
+    act(() => void fireEvent.keyDown(document, { key: "F10", shiftKey: true }));
+
+    // Before windowing there was always a node to open the menu on. Now there
+    // may not be, and the key must not simply evaporate: the hub asks the
+    // virtualizer for the row and replays the menu on the commit that mounts
+    // it.
+    expect(scrollIntoViewMock).toHaveBeenCalledWith(
+      expect.objectContaining({ index: 14, behavior: "auto" })
+    );
+  });
+
+  it("windows the base-branch list without changing its rows", async () => {
+    virtuosoRange.current = { startIndex: 0, endIndex: 9 };
+    compareWorktreesMock.mockResolvedValue({
+      branch1: "main",
+      branch2: "feature/test",
+      files: Array.from({ length: 120 }, (_, i) => ({
+        path: `src/base/file-${String(i).padStart(3, "0")}.ts`,
+        status: "modified" as const,
+        insertions: i,
+        deletions: 1,
+      })),
+    });
+    getStagingStatusMock.mockResolvedValue(makeLargeStatus());
+    render(<ReviewHubContent isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />);
+    await waitFor(() => screen.getByTestId("file-stage-row-src/staged/file-000.ts"));
+
+    act(() => void fireEvent.click(screen.getByRole("button", { name: /vs main/i })));
+    await waitFor(() => screen.getByText("file-000.ts"));
+
+    // Windowed, but still the same read-only rows: a native button per file,
+    // named the way it always was. This list has no cursor and no listbox
+    // semantics, and windowing must not invent either.
+    expect(screen.queryByText("file-050.ts")).toBeNull();
+    expect(screen.getByRole("button", { name: /file-000\.ts/ })).toBeTruthy();
+    expect(screen.queryAllByRole("option", { name: /file-000\.ts/ })).toHaveLength(0);
+  });
+
+  it("opens the menu directly when the focused row is mounted", async () => {
+    virtuosoRange.current = { startIndex: 0, endIndex: 59 };
+    await renderLargeHub();
+    act(() => void fireEvent.keyDown(document, { key: "ArrowDown" }));
+    scrollIntoViewMock.mockClear();
+
+    act(() => void fireEvent.keyDown(document, { key: "F10", shiftKey: true }));
+
+    // No reveal needed, and none requested — the deferred path is for absent
+    // rows only, not a new cost on every menu.
+    expect(scrollIntoViewMock).not.toHaveBeenCalled();
+    await waitFor(() => expect(screen.getAllByRole("menu").length).toBeGreaterThan(0));
+  });
+});

--- a/src/lib/fileListWindowing.ts
+++ b/src/lib/fileListWindowing.ts
@@ -1,0 +1,27 @@
+/**
+ * When a changed-file list stops rendering every row.
+ *
+ * Below this, the Review Hub's sections, its base-branch list and the diff
+ * shelf render exactly as they always have: one DOM node per file, no
+ * virtualizer, no measurement, no windowed-range bookkeeping. Ordinary reviews
+ * are small, and windowing them would buy nothing while putting a scroll
+ * container's worth of new failure modes between the user and their files.
+ *
+ * 80 is chosen against the row, not the viewport. A comfortable-density
+ * `FileStageRow` is ~32px, so ~80 rows is roughly three screens of the tallest
+ * list — far enough past the fold that mounting the rest is waste, close enough
+ * that a reviewer who scrolls the whole list never notices the seam.
+ */
+export const FILE_LIST_VIRTUALIZATION_THRESHOLD = 80;
+
+/**
+ * Whether a list of `count` rows should window.
+ *
+ * Takes the count the surface actually renders as one scrollable body — for the
+ * Review Hub's working tree that is staged plus unstaged, because the two
+ * sections share a scroll container and a keyboard cursor, and two 79-row
+ * sections are a 158-row list wearing a hat.
+ */
+export function shouldVirtualizeFileList(count: number): boolean {
+  return count >= FILE_LIST_VIRTUALIZATION_THRESHOLD;
+}

--- a/src/lib/fileListWindowing.ts
+++ b/src/lib/fileListWindowing.ts
@@ -25,3 +25,30 @@ export const FILE_LIST_VIRTUALIZATION_THRESHOLD = 80;
 export function shouldVirtualizeFileList(count: number): boolean {
   return count >= FILE_LIST_VIRTUALIZATION_THRESHOLD;
 }
+
+/**
+ * The rows a windowed list currently has in the DOM, in that list's OWN index
+ * space.
+ *
+ * Only a windowed list reports one at all — the static path is answered by not
+ * asking. So the absence of a range means "no virtualizer has reported yet",
+ * NOT "everything is on screen": conflating those two lets
+ * `aria-activedescendant` name a row that is not in the document, which is the
+ * exact contract the gate exists to hold. Read an unreported range as
+ * {@link EMPTY_MOUNTED_RANGE}.
+ */
+export type MountedRange = { start: number; end: number } | null;
+
+/** Nothing mounted yet. Covers no index, so the gate stays closed until it does. */
+export const EMPTY_MOUNTED_RANGE: MountedRange = { start: 0, end: -1 };
+
+export function sameRange(a: MountedRange, b: MountedRange): boolean {
+  if (a === null || b === null) return a === b;
+  return a.start === b.start && a.end === b.end;
+}
+
+/** Whether `index` — local to the list that reported `range` — is mounted. */
+export function rangeCovers(range: MountedRange, index: number): boolean {
+  if (range === null) return true;
+  return index >= range.start && index <= range.end;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -40,7 +40,7 @@ export default defineConfig({
       "electron/**/*.{test,spec}.{js,ts}",
       "src/**/*.{test,spec}.{js,ts,jsx,tsx}",
       "shared/**/*.{test,spec}.{js,ts}",
-      "scripts/**/*.{test,spec}.{js,ts,mjs}",
+      "scripts/**/*.{test,spec}.{js,ts,mjs,tsx}",
       "e2e/helpers/__tests__/*.{test,spec}.{js,ts}",
       "plugins/**/*.{test,spec}.{js,ts,jsx,tsx}",
       "packages/**/*.{test,spec}.{js,ts,jsx,tsx}",


### PR DESCRIPTION
## Summary

- The Review Hub's staged and unstaged sections, its base-branch file list, and the diff workspace's file shelf each mounted one DOM row per changed file. All three now window through `react-virtuoso` above 80 rows, following the pattern `src/panels/file-browser/FileTreeView.tsx` already established.
- Below 80 rows everything renders exactly as before. The existing `ReviewHub` and `DiffFileSidebar` test suites needed no changes, which is the evidence for that.
- Along the way I found and fixed two real bugs in how the app was using `react-virtuoso` 4.18.11 (details below).

Resolves #12241

## Measurements

New scenario PERF-247 (`scripts/perf/scenarios/panels.ts`), same machine, same session, before -> after:

| surface | mountedRows | initialRenderMs | selectionChangeMs |
|---|---|---|---|
| Review Hub section, 423 files | 423 -> **27** | 616.4 -> **37.0** | 250.3 -> **21.6** (91% faster) |
| Review Hub section, 2,000 files | 2000 -> **27** | 2114.7 -> **26.0** | 1096.8 -> **23.7** (98% faster) |
| Diff shelf, 423 files | 423 -> **25** | 214.6 -> **16.9** | 100.0 -> **4.5** (95% faster) |
| Diff shelf, 2,000 files | 2000 -> **25** | 757.7 -> **16.0** | 331.1 -> **4.6** (99% faster) |

The issue's landing gate was a 50% improvement in `selectionChangeMs` at 2,000 files. Both surfaces clear it at 98-99%. `PERF-244` and `PERF-245` are untouched.

`PERF-247` carries its own negative control in every run: it measures the same lists again with windowing off, and `controlMisses` is nonzero unless that arm mounted every row. A benchmark that can't tell a windowed list from an unwindowed one can't be trusted to report either.

## Keyboard and focus behaviours

All verified by test (`src/components/Worktree/ReviewHub/__tests__/ReviewHub.virtualization.test.tsx`, 10 tests):

- Row ids, roles, and the flat staged+unstaged index space survive the section split.
- Arrow navigation onto an off-screen row, with the reveal reaching the right section's virtualizer at that section's own local index.
- `aria-activedescendant` withheld while the cursor's row is outside the mounted window, restored once the window covers it again.
- A mounted row is scrolled natively rather than through the virtualizer.
- A stationary cursor is not re-revealed when a background refresh renumbers the list (#11684).
- Shift+F10 on an off-screen row reveals it and replays the menu rather than dropping the key, and opens directly with no reveal when the row is already mounted.
- The base-branch list windows without gaining listbox semantics it never had.
- The `content-visibility` hint comes off on the windowed path.

## Why PERF-247 runs under vitest

The perf harness normally runs under plain `tsx`, but these components' real module graph reaches `import.meta.glob`, `import.meta.env`, and a Tailwind stylesheet before it reaches a single row. Vitest is the only environment in the repo that supplies that pipeline, so the scenario spawns it and reads the numbers back. It's listed in `EXPENSIVE_SCENARIOS` so `npm test` doesn't nest one vitest run inside another; its windowing oracle still runs in `npm test` every time, at a cheaper size.

## React Virtuoso fixes

Two subtle bugs in `react-virtuoso` 4.18.11 usage, both confirmed against its source:

- `computeItemKey` is called with the raw slot index, group headers included, while `itemContent` gets the file-only index. The shelf's keys are now built in slot order.
- With `customScrollParent`, a list's viewport height is `parentHeight - max(0, listTop - parentTop)`, which goes negative below the fold. Reveals now align to `start`, and mounted rows scroll natively instead of through the virtualizer.

## Limitations

Stated plainly: `PERF-247` runs in jsdom, so it measures JS-thread mount and reconcile cost, not frames. No compositor, no paint, no Chromium layout, and the child process runs development React without the compiler transform production ships. The real-UI E2E check the issue mentions is deliberately left out. The issue scopes that to "only when the user asks for it."

## Testing

- `npm run typecheck`: exit 0
- Targeted vitest across ReviewHub, FileViewer, file-browser, diff, and the perf harness: 189 files / 4191 tests pass
- `npm run lint:ratchet`: passes, warnings down one (3048 vs 3049 baseline)
- `prettier`: clean on changed files
- `npm run perf ci -- --scenario PERF-247`: exit 0, all correctness predicates at zero
- `compiler-budget:check` fails identically on `origin/develop` (same file, same 269 -> 271 Hint count). Pre-existing, not widened by this change, and the one new component compiles cleanly.
