### PR TITLE
fix(diff): render the unified gutter marker only on the owning side

### DIFF
--- a/src/components/Worktree/DiffViewer.tsx
+++ b/src/components/Worktree/DiffViewer.tsx
@@ -33,6 +33,7 @@ import type {
   HunkTokens,
   RenderGutter,
   RenderToken,
+  Side,
   TokenNode,
   ViewType,
 } from "react-diff-view";
@@ -134,33 +135,51 @@ export interface DiffViewerProps {
 }
 
 /**
+ * The marker belongs to the side that owns the change. A unified row renders an
+ * old *and* a new gutter cell from the same change object, so a marker keyed
+ * only off change.type prints in both and reads as "+ 1519 +" (#12255). Split
+ * only ever calls the gutter renderer for the side that owns the change, so the
+ * same gate is correct there too — no viewType branching needed.
+ *
+ * The empty string still renders: .diff-line-marker is a fixed 1ch inline-block
+ * in a right-aligned gutter, so dropping the span would shift that column's
+ * number out of line with its neighbour.
+ */
+function getGutterMarker(change: ChangeData, side: Side): "+" | "-" | "" {
+  if (change.type === "insert") return side === "new" ? "+" : "";
+  if (change.type === "delete") return side === "old" ? "-" : "";
+  return "";
+}
+
+/**
  * Default line number plus a textual +/- marker so insert/delete state never
  * relies on color alone (WCAG 1.4.1; survives forced-colors). Gutters are
  * user-select: none, so markers stay out of copied text.
  */
-const renderGutterWithMarker: RenderGutter = ({ change, renderDefault, wrapInAnchor }) => (
+const renderGutterWithMarker: RenderGutter = ({ change, side, renderDefault, wrapInAnchor }) => (
   <>
     <span className="diff-line-number">{wrapInAnchor(renderDefault())}</span>
-    <span className="diff-line-marker">
-      {change.type === "insert" ? "+" : change.type === "delete" ? "-" : ""}
-    </span>
+    <span className="diff-line-marker">{getGutterMarker(change, side)}</span>
   </>
 );
 
 /** Moved-aware variant: adds screen-reader text so relocation isn't styling-only. */
 function makeGutterRenderer(movedKeys: ReadonlySet<string>): RenderGutter {
   if (movedKeys.size === 0) return renderGutterWithMarker;
-  const render: RenderGutter = ({ change, renderDefault, wrapInAnchor }) => (
-    <>
-      <span className="diff-line-number">{wrapInAnchor(renderDefault())}</span>
-      <span className="diff-line-marker">
-        {change.type === "insert" ? "+" : change.type === "delete" ? "-" : ""}
-      </span>
-      {change.type !== "normal" && movedKeys.has(getChangeKey(change)) && (
-        <span className="sr-only">moved</span>
-      )}
-    </>
-  );
+  const render: RenderGutter = ({ change, side, renderDefault, wrapInAnchor }) => {
+    // A non-empty marker means this cell owns the change, which is also the one
+    // cell that should announce the relocation — otherwise both gutters say it.
+    const marker = getGutterMarker(change, side);
+    return (
+      <>
+        <span className="diff-line-number">{wrapInAnchor(renderDefault())}</span>
+        <span className="diff-line-marker">{marker}</span>
+        {marker !== "" && movedKeys.has(getChangeKey(change)) && (
+          <span className="sr-only">moved</span>
+        )}
+      </>
+    );
+  };
   return render;
 }
 

--- a/src/components/Worktree/DiffViewer.tsx
+++ b/src/components/Worktree/DiffViewer.tsx
@@ -141,9 +141,9 @@ export interface DiffViewerProps {
  * only ever calls the gutter renderer for the side that owns the change, so the
  * same gate is correct there too — no viewType branching needed.
  *
- * The empty string still renders: .diff-line-marker is a fixed 1ch inline-block
- * in a right-aligned gutter, so dropping the span would shift that column's
- * number out of line with its neighbour.
+ * Returns "" rather than null so the span still renders: .diff-line-marker is a
+ * fixed 1ch inline-block in a right-aligned gutter, so every cell has to reserve
+ * the slot or numbered context rows would sit 1ch+4px right of changed ones.
  */
 function getGutterMarker(change: ChangeData, side: Side): "+" | "-" | "" {
   if (change.type === "insert") return side === "new" ? "+" : "";

--- a/src/components/Worktree/DiffViewer.tsx
+++ b/src/components/Worktree/DiffViewer.tsx
@@ -141,9 +141,10 @@ export interface DiffViewerProps {
  * only ever calls the gutter renderer for the side that owns the change, so the
  * same gate is correct there too — no viewType branching needed.
  *
- * Returns "" rather than null so the span still renders: .diff-line-marker is a
- * fixed 1ch inline-block in a right-aligned gutter, so every cell has to reserve
- * the slot or numbered context rows would sit 1ch+4px right of changed ones.
+ * Both callers render the .diff-line-marker span unconditionally, so a
+ * suppressed side still reserves its slot: the span is a fixed 1ch inline-block
+ * in a right-aligned gutter, and without it numbered context rows would sit
+ * 1ch+4px right of changed ones.
  */
 function getGutterMarker(change: ChangeData, side: Side): "+" | "-" | "" {
   if (change.type === "insert") return side === "new" ? "+" : "";

--- a/src/components/Worktree/__tests__/DiffViewer.test.tsx
+++ b/src/components/Worktree/__tests__/DiffViewer.test.tsx
@@ -800,9 +800,12 @@ describe("DiffViewer gutter side ownership (#12255)", () => {
     const hunks = capturedDiffProps.hunks as HunkData[];
     const ins = hunks[1]!.changes.find((c) => c.type === "insert")!;
 
-    const { markers, movedLabels } = renderGutterPair(renderGutter, ins, { new: "19" });
+    const { markers, markerCounts, movedLabels } = renderGutterPair(renderGutter, ins, {
+      new: "19",
+    });
 
     expect(markers).toEqual(["", "+"]);
+    expect(markerCounts).toEqual([1, 1]);
     expect(movedLabels).toEqual([[], ["moved"]]);
   });
 
@@ -811,9 +814,12 @@ describe("DiffViewer gutter side ownership (#12255)", () => {
     const hunks = capturedDiffProps.hunks as HunkData[];
     const del = hunks[0]!.changes.find((c) => c.type === "delete")!;
 
-    const { markers, movedLabels } = renderGutterPair(renderGutter, del, { old: "2" });
+    const { markers, markerCounts, movedLabels } = renderGutterPair(renderGutter, del, {
+      old: "2",
+    });
 
     expect(markers).toEqual(["-", ""]);
+    expect(markerCounts).toEqual([1, 1]);
     expect(movedLabels).toEqual([["moved"], []]);
   });
 
@@ -826,9 +832,12 @@ describe("DiffViewer gutter side ownership (#12255)", () => {
       isInsert: true,
     };
 
-    const { markers, movedLabels } = renderGutterPair(renderGutter, change, { new: "9999" });
+    const { markers, markerCounts, movedLabels } = renderGutterPair(renderGutter, change, {
+      new: "9999",
+    });
 
     expect(markers).toEqual(["", "+"]);
+    expect(markerCounts).toEqual([1, 1]);
     expect(movedLabels).toEqual([[], []]);
   });
 });
@@ -921,6 +930,10 @@ describe("DiffViewer real gutter rows (#12255)", () => {
     ]);
     expect(labelsFollowMarkers(rows)).toBe(true);
     expect(rows.every((row) => row.markers.length <= 1)).toBe(true);
+    // Guards labelsFollowMarkers against passing vacuously on a row with no
+    // gutter cells at all.
+    expect(rows.every((row) => row.cells.length === 2)).toBe(true);
+    expect(rows.every((row) => row.cells.every((cell) => cell.markerSpans === 1))).toBe(true);
   });
 
   it("leaves split gutters marking only the owning side", () => {
@@ -931,6 +944,10 @@ describe("DiffViewer real gutter rows (#12255)", () => {
     const moved = renderRealDiff(MOVED_DIFF, "split");
     expect(moved.flatMap((row) => row.movedLabels)).toHaveLength(6);
     expect(labelsFollowMarkers(moved)).toBe(true);
+    expect(moved.every((row) => row.cells.length === 2)).toBe(true);
+    // <=1 not ===1: the non-owning side is the library's own empty placeholder,
+    // which our renderer never touches.
+    expect(moved.every((row) => row.cells.every((cell) => cell.markerSpans <= 1))).toBe(true);
   });
 
   it("keeps both markers when a split row pairs a delete with an insert", () => {

--- a/src/components/Worktree/__tests__/DiffViewer.test.tsx
+++ b/src/components/Worktree/__tests__/DiffViewer.test.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { render, screen, waitFor, fireEvent, act } from "@testing-library/react";
-import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { describe, expect, it, vi, beforeAll, beforeEach, afterEach } from "vitest";
 import type { ChangeData, HunkData, RenderGutter, RenderToken, ViewType } from "react-diff-view";
 import type { InsertChange, DeleteChange, NormalChange } from "gitdiff-parser";
 import { DiffViewer, _resetLangStateForTests, _flushLangLoadsForTests } from "../DiffViewer";
@@ -624,10 +624,16 @@ function renderGutterPair(
     </table>
   );
   const cells = [...container.querySelectorAll("td.diff-gutter")];
+  const markerSpans = cells.map((cell) => [...cell.querySelectorAll(".diff-line-marker")]);
   return {
-    markers: cells.map((cell) => cell.querySelector(".diff-line-marker")?.textContent ?? null),
+    // Counted, not just read: a cell rendering two marker spans is its own bug.
+    markerCounts: markerSpans.map((spans) => spans.length),
+    markers: markerSpans.map((spans) => spans[0]?.textContent ?? null),
     numbers: cells.map((cell) => cell.querySelector(".diff-line-number")?.textContent ?? null),
-    movedLabels: cells.map((cell) => cell.querySelectorAll(".sr-only").length),
+    // Label text, so an empty <span class="sr-only"> can't pass as an announcement.
+    movedLabels: cells.map((cell) =>
+      [...cell.querySelectorAll(".sr-only")].map((label) => label.textContent ?? "")
+    ),
   };
 }
 
@@ -720,8 +726,8 @@ describe("DiffViewer gutter marker never wraps (#10422)", () => {
 
 // A unified row renders an old AND a new gutter cell from the same change, so a
 // marker keyed only off change.type printed in both ("+  1519 +"). Split calls
-// the renderer once per row, for the owning side only, so one side-gate serves
-// both view types.
+// the renderer once per insert/delete change, for its owning side only, so one
+// side-gate serves both view types.
 describe("DiffViewer gutter side ownership (#12255)", () => {
   beforeEach(() => {
     _resetLangStateForTests();
@@ -737,13 +743,14 @@ describe("DiffViewer gutter side ownership (#12255)", () => {
       isInsert: true,
     };
 
-    const { markers, numbers, movedLabels } = renderGutterPair(renderGutter, change, {
+    const { markers, numbers, markerCounts, movedLabels } = renderGutterPair(renderGutter, change, {
       new: "1519",
     });
 
     expect(markers).toEqual(["", "+"]);
     expect(numbers).toEqual(["", "1519"]);
-    expect(movedLabels).toEqual([0, 0]);
+    expect(markerCounts).toEqual([1, 1]);
+    expect(movedLabels).toEqual([[], []]);
   });
 
   it("marks a delete only in the old gutter", () => {
@@ -755,13 +762,14 @@ describe("DiffViewer gutter side ownership (#12255)", () => {
       isDelete: true,
     };
 
-    const { markers, numbers, movedLabels } = renderGutterPair(renderGutter, change, {
+    const { markers, numbers, markerCounts, movedLabels } = renderGutterPair(renderGutter, change, {
       old: "1519",
     });
 
     expect(markers).toEqual(["-", ""]);
     expect(numbers).toEqual(["1519", ""]);
-    expect(movedLabels).toEqual([0, 0]);
+    expect(markerCounts).toEqual([1, 1]);
+    expect(movedLabels).toEqual([[], []]);
   });
 
   it("leaves context rows unmarked while keeping both line numbers", () => {
@@ -774,7 +782,7 @@ describe("DiffViewer gutter side ownership (#12255)", () => {
       isNormal: true,
     };
 
-    const { markers, numbers, movedLabels } = renderGutterPair(renderGutter, change, {
+    const { markers, numbers, markerCounts, movedLabels } = renderGutterPair(renderGutter, change, {
       old: "12",
       new: "14",
     });
@@ -783,7 +791,8 @@ describe("DiffViewer gutter side ownership (#12255)", () => {
     // neither cell earns a marker.
     expect(markers).toEqual(["", ""]);
     expect(numbers).toEqual(["12", "14"]);
-    expect(movedLabels).toEqual([0, 0]);
+    expect(markerCounts).toEqual([1, 1]);
+    expect(movedLabels).toEqual([[], []]);
   });
 
   it("announces a moved insert once, in the new gutter", () => {
@@ -794,7 +803,7 @@ describe("DiffViewer gutter side ownership (#12255)", () => {
     const { markers, movedLabels } = renderGutterPair(renderGutter, ins, { new: "19" });
 
     expect(markers).toEqual(["", "+"]);
-    expect(movedLabels).toEqual([0, 1]);
+    expect(movedLabels).toEqual([[], ["moved"]]);
   });
 
   it("announces a moved delete once, in the old gutter", () => {
@@ -805,7 +814,7 @@ describe("DiffViewer gutter side ownership (#12255)", () => {
     const { markers, movedLabels } = renderGutterPair(renderGutter, del, { old: "2" });
 
     expect(markers).toEqual(["-", ""]);
-    expect(movedLabels).toEqual([1, 0]);
+    expect(movedLabels).toEqual([["moved"], []]);
   });
 
   it("keeps the moved label off changes that did not move", () => {
@@ -820,29 +829,36 @@ describe("DiffViewer gutter side ownership (#12255)", () => {
     const { markers, movedLabels } = renderGutterPair(renderGutter, change, { new: "9999" });
 
     expect(markers).toEqual(["", "+"]);
-    expect(movedLabels).toEqual([0, 0]);
+    expect(movedLabels).toEqual([[], []]);
   });
 });
 
-// The file-level mock replaces <Hunk> with a placeholder that renders no gutter
-// cells at all, so the callback tests above never see the two-<td> layout that
-// produced #12255. These pull the real Diff/Hunk in and assert against genuine
-// unified and split markup.
+// The callback tests above simulate the library's two calls; the file-level mock
+// swaps <Hunk> for a placeholder with no gutter cells, so nothing there proves
+// react-diff-view actually invokes the renderer that way. These pull the real
+// Diff/Hunk in and assert against genuine unified and split markup.
 describe("DiffViewer real gutter rows (#12255)", () => {
   beforeEach(() => {
     _resetLangStateForTests();
     clearCapturedDiffProps();
   });
 
-  type GutterRow = { markers: string[]; numbers: string[]; moved: number };
+  type GutterCell = { marker: string; markerSpans: number; number: string; movedLabels: string[] };
+  type GutterRow = { cells: GutterCell[]; markers: string[]; movedLabels: string[] };
 
-  async function renderRealDiff(diff: string, viewType: ViewType): Promise<GutterRow[]> {
-    // Imported before the capture render so no await sits between the two
-    // renders, where a late tokenize pass would land outside act().
+  let RealDiff: typeof import("react-diff-view").Diff;
+  let RealHunk: typeof import("react-diff-view").Hunk;
+
+  // Resolved once up front so renderRealDiff stays synchronous: an await between
+  // the capture render and the real one would leave a mounted DiffViewer
+  // tokenizing across the gap, landing its setState outside act().
+  beforeAll(async () => {
     const actual = await vi.importActual<typeof import("react-diff-view")>("react-diff-view");
-    const RealDiff = actual.Diff;
-    const RealHunk = actual.Hunk;
+    RealDiff = actual.Diff;
+    RealHunk = actual.Hunk;
+  });
 
+  function renderRealDiff(diff: string, viewType: ViewType): GutterRow[] {
     const renderGutter = getRenderGutter({ diff, viewType });
     const hunks = capturedDiffProps.hunks as HunkData[];
 
@@ -853,21 +869,32 @@ describe("DiffViewer real gutter rows (#12255)", () => {
     );
 
     return [...container.querySelectorAll("tr")].map((row) => {
-      const cells = [...row.querySelectorAll("td.diff-gutter")];
+      const cells: GutterCell[] = [...row.querySelectorAll("td.diff-gutter")].map((cell) => ({
+        marker: cell.querySelector(".diff-line-marker")?.textContent ?? "",
+        markerSpans: cell.querySelectorAll(".diff-line-marker").length,
+        number: cell.querySelector(".diff-line-number")?.textContent ?? "",
+        movedLabels: [...cell.querySelectorAll(".sr-only")].map((label) => label.textContent ?? ""),
+      }));
       return {
-        markers: cells
-          .map((cell) => cell.querySelector(".diff-line-marker")?.textContent ?? "")
-          .filter((text) => text !== ""),
-        numbers: cells.map((cell) => cell.querySelector(".diff-line-number")?.textContent ?? ""),
-        moved: cells.reduce((total, cell) => total + cell.querySelectorAll(".sr-only").length, 0),
+        cells,
+        markers: cells.map((cell) => cell.marker).filter((marker) => marker !== ""),
+        movedLabels: cells.flatMap((cell) => cell.movedLabels),
       };
     });
   }
 
-  it("gives a unified row one marker and keeps both context numbers", async () => {
-    const rows = await renderRealDiff(SMALL_DIFF, "unified");
+  /** The label belongs to the cell that owns the change — the one with a marker. */
+  function labelsFollowMarkers(rows: GutterRow[]): boolean {
+    return rows.every((row) =>
+      row.cells.every((cell) => cell.movedLabels.length === (cell.marker === "" ? 0 : 1))
+    );
+  }
 
-    expect(rows.every((row) => row.markers.length <= 1)).toBe(true);
+  it("gives a unified row one marker and keeps both context numbers", () => {
+    const rows = renderRealDiff(SMALL_DIFF, "unified");
+
+    expect(rows.every((row) => row.cells.length === 2)).toBe(true);
+    expect(rows.every((row) => row.cells.every((cell) => cell.markerSpans === 1))).toBe(true);
     expect(rows.filter((row) => row.markers.length > 0).map((row) => row.markers)).toEqual([
       ["+"],
       ["-"],
@@ -875,27 +902,44 @@ describe("DiffViewer real gutter rows (#12255)", () => {
 
     const context = rows.filter((row) => row.markers.length === 0);
     expect(context.length).toBeGreaterThan(0);
-    expect(context.every((row) => row.numbers.every((n) => n !== ""))).toBe(true);
+    expect(context.every((row) => row.cells.every((cell) => cell.number !== ""))).toBe(true);
   });
 
-  it("announces each moved unified row exactly once", async () => {
-    const rows = await renderRealDiff(MOVED_DIFF, "unified");
+  it("announces every moved unified row exactly once", () => {
+    const rows = renderRealDiff(MOVED_DIFF, "unified");
 
+    // MOVED_DIFF relocates a 3-line function and detectMovedLines marks every
+    // line of a matched block, so all 3 deletes and all 3 inserts announce.
+    const announced = rows.filter((row) => row.movedLabels.length > 0);
+    expect(announced.map((row) => row.movedLabels)).toEqual([
+      ["moved"],
+      ["moved"],
+      ["moved"],
+      ["moved"],
+      ["moved"],
+      ["moved"],
+    ]);
+    expect(labelsFollowMarkers(rows)).toBe(true);
     expect(rows.every((row) => row.markers.length <= 1)).toBe(true);
-    expect(rows.every((row) => row.moved <= 1)).toBe(true);
-    expect(rows.filter((row) => row.moved === 1).length).toBeGreaterThan(0);
   });
 
-  it("leaves split gutters marking only the owning side", async () => {
-    const rows = await renderRealDiff(SMALL_DIFF, "split");
-    expect([...rows.flatMap((row) => row.markers)].sort()).toEqual(["+", "-"]);
+  it("leaves split gutters marking only the owning side", () => {
+    const rows = renderRealDiff(SMALL_DIFF, "split");
+    expect(rows.flatMap((row) => row.markers).sort()).toEqual(["+", "-"]);
+    expect(rows.every((row) => row.cells.every((cell) => cell.markerSpans <= 1))).toBe(true);
 
-    const moved = await renderRealDiff(MOVED_DIFF, "split");
-    // A split row can hold two markers legitimately (a delete paired with an
-    // insert), so the invariant is per owning cell: never more moved labels
-    // than markers.
-    expect(moved.every((row) => row.moved <= row.markers.length)).toBe(true);
-    expect(moved.some((row) => row.moved > 0)).toBe(true);
+    const moved = renderRealDiff(MOVED_DIFF, "split");
+    expect(moved.flatMap((row) => row.movedLabels)).toHaveLength(6);
+    expect(labelsFollowMarkers(moved)).toBe(true);
+  });
+
+  it("keeps both markers when a split row pairs a delete with an insert", () => {
+    // Two markers on one row is correct here — they are two different changes,
+    // so the invariant is one marker per owning cell, not per row.
+    const paired = renderRealDiff(jsDiff, "split").filter((row) => row.markers.length === 2);
+
+    expect(paired).toHaveLength(1);
+    expect(paired[0]!.cells.map((cell) => cell.marker)).toEqual(["-", "+"]);
   });
 });
 

--- a/src/components/Worktree/__tests__/DiffViewer.test.tsx
+++ b/src/components/Worktree/__tests__/DiffViewer.test.tsx
@@ -4,8 +4,8 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { render, screen, waitFor, fireEvent, act } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
-import type { ChangeData, HunkData, RenderToken } from "react-diff-view";
-import type { InsertChange, DeleteChange } from "gitdiff-parser";
+import type { ChangeData, HunkData, RenderGutter, RenderToken, ViewType } from "react-diff-view";
+import type { InsertChange, DeleteChange, NormalChange } from "gitdiff-parser";
 import { DiffViewer, _resetLangStateForTests, _flushLangLoadsForTests } from "../DiffViewer";
 import { TooltipProvider } from "@/components/ui/tooltip";
 
@@ -585,22 +585,57 @@ describe("DiffViewer hunk copy", () => {
 // .diff-line-number), so the test asserts the static DOM/CSS contract:
 // renderGutter always wraps the line number in a .diff-line-number span and
 // always emits a sibling .diff-line-marker span carrying the +/- glyph.
+// Typed as the library's own RenderGutter rather than a local shape: the
+// hand-rolled params type used here previously had no `side` field, which is
+// exactly how #12255 slipped past these tests.
+function getRenderGutter({ diff = SMALL_DIFF, viewType = "split" as ViewType } = {}): RenderGutter {
+  render(wrap(<DiffViewer diff={diff} viewType={viewType} />));
+  return capturedDiffProps.renderGutter as RenderGutter;
+}
+
+/**
+ * Mirrors react-diff-view's UnifiedChange: two gutter cells built from ONE
+ * change object, differing only by `side`. Numbers are supplied per side because
+ * the library's renderDefaultBy yields undefined for the side a change doesn't
+ * belong to.
+ */
+function renderGutterPair(
+  renderGutter: RenderGutter,
+  change: ChangeData,
+  numbers: { old?: string; new?: string } = {}
+) {
+  const { container } = render(
+    <table>
+      <tbody>
+        <tr>
+          {(["old", "new"] as const).map((side) => (
+            <td key={side} className="diff-gutter">
+              {renderGutter({
+                change,
+                side,
+                inHoverState: false,
+                renderDefault: () => numbers[side],
+                wrapInAnchor: (node) => node,
+              })}
+            </td>
+          ))}
+        </tr>
+      </tbody>
+    </table>
+  );
+  const cells = [...container.querySelectorAll("td.diff-gutter")];
+  return {
+    markers: cells.map((cell) => cell.querySelector(".diff-line-marker")?.textContent ?? null),
+    numbers: cells.map((cell) => cell.querySelector(".diff-line-number")?.textContent ?? null),
+    movedLabels: cells.map((cell) => cell.querySelectorAll(".sr-only").length),
+  };
+}
+
 describe("DiffViewer gutter marker never wraps (#10422)", () => {
   beforeEach(() => {
     _resetLangStateForTests();
     clearCapturedDiffProps();
   });
-
-  type RenderGutterParams = {
-    change: ChangeData;
-    renderDefault: () => React.ReactNode;
-    wrapInAnchor: (node: React.ReactNode) => React.ReactNode;
-  };
-  type RenderGutterFn = (params: RenderGutterParams) => React.ReactNode;
-  function getRenderGutter(): RenderGutterFn {
-    render(wrap(<DiffViewer diff={SMALL_DIFF} viewType="split" />));
-    return capturedDiffProps.renderGutter as RenderGutterFn;
-  }
 
   it("wraps the line number in a .diff-line-number span for insert rows", () => {
     const renderGutter = getRenderGutter();
@@ -612,6 +647,8 @@ describe("DiffViewer gutter marker never wraps (#10422)", () => {
     };
     const result = renderGutter({
       change,
+      side: "new",
+      inHoverState: false,
       renderDefault: () => "2",
       wrapInAnchor: (n) => <a href="#L2">{n}</a>,
     });
@@ -636,6 +673,8 @@ describe("DiffViewer gutter marker never wraps (#10422)", () => {
     };
     const result = renderGutter({
       change,
+      side: "old",
+      inHoverState: false,
       renderDefault: () => "1",
       wrapInAnchor: (n) => <a href="#L1">{n}</a>,
     });
@@ -660,6 +699,8 @@ describe("DiffViewer gutter marker never wraps (#10422)", () => {
     };
     const result = renderGutter({
       change,
+      side: "new",
+      inHoverState: false,
       renderDefault: () => "2",
       wrapInAnchor: (n) => <a href="#L2">{n}</a>,
     });
@@ -674,6 +715,187 @@ describe("DiffViewer gutter marker never wraps (#10422)", () => {
     // gutter cell is what enforces nowrap; the marker span itself is the
     // element that would wrap if the cell allowed it.
     expect(lineNumberSpans[0]!.querySelector(".diff-line-marker")).toBeNull();
+  });
+});
+
+// A unified row renders an old AND a new gutter cell from the same change, so a
+// marker keyed only off change.type printed in both ("+  1519 +"). Split calls
+// the renderer once per row, for the owning side only, so one side-gate serves
+// both view types.
+describe("DiffViewer gutter side ownership (#12255)", () => {
+  beforeEach(() => {
+    _resetLangStateForTests();
+    clearCapturedDiffProps();
+  });
+
+  it("marks an insert only in the new gutter", () => {
+    const renderGutter = getRenderGutter({ viewType: "unified" });
+    const change: InsertChange = {
+      type: "insert",
+      content: "added",
+      lineNumber: 1519,
+      isInsert: true,
+    };
+
+    const { markers, numbers, movedLabels } = renderGutterPair(renderGutter, change, {
+      new: "1519",
+    });
+
+    expect(markers).toEqual(["", "+"]);
+    expect(numbers).toEqual(["", "1519"]);
+    expect(movedLabels).toEqual([0, 0]);
+  });
+
+  it("marks a delete only in the old gutter", () => {
+    const renderGutter = getRenderGutter({ viewType: "unified" });
+    const change: DeleteChange = {
+      type: "delete",
+      content: "removed",
+      lineNumber: 1519,
+      isDelete: true,
+    };
+
+    const { markers, numbers, movedLabels } = renderGutterPair(renderGutter, change, {
+      old: "1519",
+    });
+
+    expect(markers).toEqual(["-", ""]);
+    expect(numbers).toEqual(["1519", ""]);
+    expect(movedLabels).toEqual([0, 0]);
+  });
+
+  it("leaves context rows unmarked while keeping both line numbers", () => {
+    const renderGutter = getRenderGutter({ viewType: "unified" });
+    const change: NormalChange = {
+      type: "normal",
+      content: " context",
+      oldLineNumber: 12,
+      newLineNumber: 14,
+      isNormal: true,
+    };
+
+    const { markers, numbers, movedLabels } = renderGutterPair(renderGutter, change, {
+      old: "12",
+      new: "14",
+    });
+
+    // Both numbers are real and may differ once earlier edits shift the file;
+    // neither cell earns a marker.
+    expect(markers).toEqual(["", ""]);
+    expect(numbers).toEqual(["12", "14"]);
+    expect(movedLabels).toEqual([0, 0]);
+  });
+
+  it("announces a moved insert once, in the new gutter", () => {
+    const renderGutter = getRenderGutter({ diff: MOVED_DIFF, viewType: "unified" });
+    const hunks = capturedDiffProps.hunks as HunkData[];
+    const ins = hunks[1]!.changes.find((c) => c.type === "insert")!;
+
+    const { markers, movedLabels } = renderGutterPair(renderGutter, ins, { new: "19" });
+
+    expect(markers).toEqual(["", "+"]);
+    expect(movedLabels).toEqual([0, 1]);
+  });
+
+  it("announces a moved delete once, in the old gutter", () => {
+    const renderGutter = getRenderGutter({ diff: MOVED_DIFF, viewType: "unified" });
+    const hunks = capturedDiffProps.hunks as HunkData[];
+    const del = hunks[0]!.changes.find((c) => c.type === "delete")!;
+
+    const { markers, movedLabels } = renderGutterPair(renderGutter, del, { old: "2" });
+
+    expect(markers).toEqual(["-", ""]);
+    expect(movedLabels).toEqual([1, 0]);
+  });
+
+  it("keeps the moved label off changes that did not move", () => {
+    const renderGutter = getRenderGutter({ diff: MOVED_DIFF, viewType: "unified" });
+    const change: InsertChange = {
+      type: "insert",
+      content: "unrelated",
+      lineNumber: 9999,
+      isInsert: true,
+    };
+
+    const { markers, movedLabels } = renderGutterPair(renderGutter, change, { new: "9999" });
+
+    expect(markers).toEqual(["", "+"]);
+    expect(movedLabels).toEqual([0, 0]);
+  });
+});
+
+// The file-level mock replaces <Hunk> with a placeholder that renders no gutter
+// cells at all, so the callback tests above never see the two-<td> layout that
+// produced #12255. These pull the real Diff/Hunk in and assert against genuine
+// unified and split markup.
+describe("DiffViewer real gutter rows (#12255)", () => {
+  beforeEach(() => {
+    _resetLangStateForTests();
+    clearCapturedDiffProps();
+  });
+
+  type GutterRow = { markers: string[]; numbers: string[]; moved: number };
+
+  async function renderRealDiff(diff: string, viewType: ViewType): Promise<GutterRow[]> {
+    // Imported before the capture render so no await sits between the two
+    // renders, where a late tokenize pass would land outside act().
+    const actual = await vi.importActual<typeof import("react-diff-view")>("react-diff-view");
+    const RealDiff = actual.Diff;
+    const RealHunk = actual.Hunk;
+
+    const renderGutter = getRenderGutter({ diff, viewType });
+    const hunks = capturedDiffProps.hunks as HunkData[];
+
+    const { container } = render(
+      <RealDiff viewType={viewType} diffType="modify" hunks={hunks} renderGutter={renderGutter}>
+        {(rendered) => rendered.map((hunk) => <RealHunk key={hunk.content} hunk={hunk} />)}
+      </RealDiff>
+    );
+
+    return [...container.querySelectorAll("tr")].map((row) => {
+      const cells = [...row.querySelectorAll("td.diff-gutter")];
+      return {
+        markers: cells
+          .map((cell) => cell.querySelector(".diff-line-marker")?.textContent ?? "")
+          .filter((text) => text !== ""),
+        numbers: cells.map((cell) => cell.querySelector(".diff-line-number")?.textContent ?? ""),
+        moved: cells.reduce((total, cell) => total + cell.querySelectorAll(".sr-only").length, 0),
+      };
+    });
+  }
+
+  it("gives a unified row one marker and keeps both context numbers", async () => {
+    const rows = await renderRealDiff(SMALL_DIFF, "unified");
+
+    expect(rows.every((row) => row.markers.length <= 1)).toBe(true);
+    expect(rows.filter((row) => row.markers.length > 0).map((row) => row.markers)).toEqual([
+      ["+"],
+      ["-"],
+    ]);
+
+    const context = rows.filter((row) => row.markers.length === 0);
+    expect(context.length).toBeGreaterThan(0);
+    expect(context.every((row) => row.numbers.every((n) => n !== ""))).toBe(true);
+  });
+
+  it("announces each moved unified row exactly once", async () => {
+    const rows = await renderRealDiff(MOVED_DIFF, "unified");
+
+    expect(rows.every((row) => row.markers.length <= 1)).toBe(true);
+    expect(rows.every((row) => row.moved <= 1)).toBe(true);
+    expect(rows.filter((row) => row.moved === 1).length).toBeGreaterThan(0);
+  });
+
+  it("leaves split gutters marking only the owning side", async () => {
+    const rows = await renderRealDiff(SMALL_DIFF, "split");
+    expect([...rows.flatMap((row) => row.markers)].sort()).toEqual(["+", "-"]);
+
+    const moved = await renderRealDiff(MOVED_DIFF, "split");
+    // A split row can hold two markers legitimately (a delete paired with an
+    // insert), so the invariant is per owning cell: never more moved labels
+    // than markers.
+    expect(moved.every((row) => row.moved <= row.markers.length)).toBe(true);
+    expect(moved.some((row) => row.moved > 0)).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

In unified diff view, react-diff-view renders two gutter `<td>` cells per row (an old-number column and a new-number column) by calling our `renderGutter` callback twice with the same change object, differing only in `side`. `renderGutterWithMarker` and `makeGutterRenderer` in `src/components/Worktree/DiffViewer.tsx` keyed the +/- marker purely off `change.type` and ignored `side`, so the marker printed in both cells. A row read as:

```
+   1519 +
```

The moved-line screen-reader "moved" label doubled the same way.

Worth noting the issue title is a bit generous to us: the line number itself was never actually doubled. react-diff-view's own `renderDefaultBy` already blanks the number on the side a change doesn't belong to. Only our custom marker and our sr-only label doubled.

Resolves #12255

## The fix

A shared `getGutterMarker(change, side)` helper gates the marker on ownership: insert marks the new gutter, delete marks the old one, context rows get neither. The moved sr-only label uses the same gate, so a relocated line gets announced once per occurrence instead of twice.

No `viewType` branching needed. Split view was already correct, because react-diff-view only invokes the gutter renderer for the side that owns the change there (`SplitChange` renders an `EmptyGutter` placeholder for the other side, with no callback at all). So the same side-gate is satisfied exactly once in split too. One rule covers both view types.

## What deliberately didn't change

No CSS, no change to the `gutterWidth` calc. The empty marker span still renders on the suppressed side. It's a fixed 1ch inline-block in a right-aligned gutter, and that reserved slot is what keeps numbered context rows aligned with changed rows. Both gutter columns still legitimately need marker room (old column on delete rows, new on insert rows), so the width formula isn't over-budgeted.

On the issue's open design question, whether the unified gutter should be redesigned entirely: kept the two line-number columns. GitHub and GitLab both keep two number columns in unified view, they just put the marker as the first glyph of the code cell instead. Moving the marker into the code column would touch `CodeCell` rendering, make split and unified inconsistent, and force a rework of the width formula. Bigger than this defect warrants, so leaving it as a possible follow-up.

## Testing

The existing gutter tests never caught this because the test file mocks react-diff-view's `<Hunk>` into a placeholder that renders no gutter cells, and the tests invoked the captured `renderGutter` exactly once, against a hand-written params type with no `side` field at all. That type is now the library's own `RenderGutter`, so a missing `side` is a compile error going forward.

Added a `describe` block that invokes the renderer twice per row (side `"old"` then `"new"`), mirroring `UnifiedChange`, plus a second block that pulls in the real, un-mocked `Diff`/`Hunk` to assert against genuine unified and split markup, including a split row that pairs a delete with an insert, where two markers on one row is correct.

Reverting the production fix makes exactly the new tests fail (75 passed, 7 failed), so they're actually catching the regression rather than just passing alongside it. All 11 test files covering `DiffViewer` pass, 397 tests total. Two Codex review rounds turned up no functional defect.

## Files changed

- `src/components/Worktree/DiffViewer.tsx`
- `src/components/Worktree/__tests__/DiffViewer.test.tsx`
