### PR TITLE
feat(file-browser): refresh only the affected directories on a change

### DIFF
--- a/.agents/skills/optimize/metric-class.mjs
+++ b/.agents/skills/optimize/metric-class.mjs
@@ -41,7 +41,7 @@ const RULES = [
   {
     cls: "count",
     pattern:
-      /[Cc]ount|[Rr]ows|[Ss]pawns|[Ss]tarts|[Ll]aunches|[Ii]nvocations|[Rr]etries|[Cc]alls|[Hh]its|[Mm]isses|[Ee]vents|[Ff]lushes|[Rr]enders|[Mm]essages|[Tt]asks|[Hh]andles|[Dd]escriptors|[Ww]rites|[Rr]eads|[Pp]asses|[Aa]ttempts|[Cc]allbacks|[Kk]eystrokes|[Rr]oundTrips|[Ll]ines|[Pp]anels|[Gg]roups|[Hh]unks|[Tt]argets|[Ff]rames|[Ff]iles|[Tt]okens|[Dd]ecorations|[Cc]hanges|[Bb]atches|[Ii]tems|[Rr]esolved|[Rr]eloads|[Jj]obs|[Pp]osted/,
+      /[Cc]ount|[Rr]ows|[Ss]pawns|[Ss]tarts|[Ll]aunches|[Ii]nvocations|[Rr]etries|[Cc]alls|[Hh]its|[Mm]isses|[Ee]vents|[Ff]lushes|[Rr]enders|[Mm]essages|[Tt]asks|[Hh]andles|[Dd]escriptors|[Ww]rites|[Rr]eads|[Pp]asses|[Aa]ttempts|[Cc]allbacks|[Kk]eystrokes|[Rr]oundTrips|[Ll]ines|[Pp]anels|[Gg]roups|[Hh]unks|[Tt]argets|[Ff]rames|[Ff]iles|[Tt]okens|[Dd]ecorations|[Cc]hanges|[Bb]atches|[Ii]tems|[Rr]esolved|[Rr]eloads|[Jj]obs|[Pp]osted|[Rr]equests|[Cc]opies/,
   },
 ];
 

--- a/electron/utils/__tests__/gitFileWatcher.test.ts
+++ b/electron/utils/__tests__/gitFileWatcher.test.ts
@@ -1040,6 +1040,104 @@ describe("GitFileWatcher", () => {
       expect(onWorktreeFilesChanged).not.toHaveBeenCalled();
       expect(onChange).not.toHaveBeenCalled();
     });
+
+    // ---- The burst's affected directories (#12244) ----
+
+    function watcherWithPaths() {
+      const onChange = vi.fn();
+      const onWorktreeFilesChanged = vi.fn<(dirs: readonly string[] | null) => void>();
+      const mock = setupSubscribeMock();
+      const gitWatcher = new GitFileWatcher({
+        worktreePath: "/repo",
+        branch: "main",
+        debounceMs: 300,
+        onChange,
+        onWorktreeFilesChanged,
+        watchWorktree: true,
+        worktreeMinDebounceMs: 500,
+        worktreeMaxDebounceMs: 500,
+        worktreeMaxWaitMs: 2000,
+      });
+      return { gitWatcher, onChange, onWorktreeFilesChanged, mock };
+    }
+
+    /** The directories one flush reported, order-independent. */
+    function reportedDirs(fn: ReturnType<typeof vi.fn>, call = 0): string[] | null {
+      const dirs = fn.mock.calls[call]?.[0] as readonly string[] | null | undefined;
+      return dirs == null ? null : [...dirs].sort();
+    }
+
+    it("reports the parent directory of every path in the burst, deduped", async () => {
+      const { gitWatcher, onWorktreeFilesChanged, mock } = watcherWithPaths();
+      await expect(gitWatcher.start()).resolves.toBe(true);
+      mock.resolve();
+      const cb = mock.getCallback();
+
+      fireEvents(cb, [
+        { type: "update", path: pathJoin("/repo", "src", "panels", "a.ts") },
+        { type: "update", path: pathJoin("/repo", "src", "panels", "b.ts") },
+        { type: "create", path: pathJoin("/repo", "package.json") },
+      ]);
+      await vi.advanceTimersByTimeAsync(500);
+
+      // Two writes in one directory plus one at the top level: two targets, not
+      // three — which is the whole point of deduping to parents.
+      expect(reportedDirs(onWorktreeFilesChanged)).toEqual(["", "src/panels"]);
+      gitWatcher.dispose();
+    });
+
+    it("reports unknown for a burst carrying an event it cannot place", async () => {
+      const { gitWatcher, onWorktreeFilesChanged, mock } = watcherWithPaths();
+      await expect(gitWatcher.start()).resolves.toBe(true);
+      mock.resolve();
+      const cb = mock.getCallback();
+
+      fireEvents(cb, [
+        { type: "update", path: pathJoin("/repo", "src", "a.ts") },
+        // No path: an event shape the watcher cannot reason about, which makes
+        // the whole burst unscopeable rather than partially known.
+        { type: "update" },
+      ]);
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(onWorktreeFilesChanged).toHaveBeenCalledTimes(1);
+      expect(reportedDirs(onWorktreeFilesChanged)).toBeNull();
+      gitWatcher.dispose();
+    });
+
+    it("gives each flush its own burst rather than accumulating across them", async () => {
+      const { gitWatcher, onWorktreeFilesChanged, mock } = watcherWithPaths();
+      await expect(gitWatcher.start()).resolves.toBe(true);
+      mock.resolve();
+      const cb = mock.getCallback();
+
+      fireEvents(cb, [{ type: "update", path: pathJoin("/repo", "src", "a.ts") }]);
+      await vi.advanceTimersByTimeAsync(500);
+      fireEvents(cb, [{ type: "update", path: pathJoin("/repo", "electron", "b.ts") }]);
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(reportedDirs(onWorktreeFilesChanged, 0)).toEqual(["src"]);
+      // The second flush must not still be carrying `src`: a scope that grows
+      // forever converges on the full sweep it exists to avoid.
+      expect(reportedDirs(onWorktreeFilesChanged, 1)).toEqual(["electron"]);
+      gitWatcher.dispose();
+    });
+
+    it("still reports directories for a burst the ignore classifier will skip", async () => {
+      // The raw-filesystem signal fires before (and independently of) the
+      // decision to skip the git status pass, so a build writing only into an
+      // ignored folder still tells the file browser exactly where to look.
+      const { gitWatcher, onWorktreeFilesChanged, mock } = watcherWithPaths();
+      await expect(gitWatcher.start()).resolves.toBe(true);
+      mock.resolve();
+      const cb = mock.getCallback();
+
+      fireEvents(cb, [{ type: "update", path: pathJoin("/repo", "dist", "bundle.js") }]);
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(reportedDirs(onWorktreeFilesChanged)).toEqual(["dist"]);
+      gitWatcher.dispose();
+    });
   });
 
   // ---- Error handling tests (adapted to async Promise rejection) ----

--- a/electron/utils/__tests__/gitFileWatcher.test.ts
+++ b/electron/utils/__tests__/gitFileWatcher.test.ts
@@ -1101,7 +1101,10 @@ describe("GitFileWatcher", () => {
       await vi.advanceTimersByTimeAsync(500);
 
       expect(onWorktreeFilesChanged).toHaveBeenCalledTimes(1);
-      expect(reportedDirs(onWorktreeFilesChanged)).toBeNull();
+      // Explicitly null, not merely absent: the callback has to SAY "unknown"
+      // rather than leave the consumer to infer it from a missing argument.
+      expect(onWorktreeFilesChanged.mock.calls[0]).toHaveLength(1);
+      expect(onWorktreeFilesChanged.mock.calls[0][0]).toBeNull();
       gitWatcher.dispose();
     });
 
@@ -1120,22 +1123,6 @@ describe("GitFileWatcher", () => {
       // The second flush must not still be carrying `src`: a scope that grows
       // forever converges on the full sweep it exists to avoid.
       expect(reportedDirs(onWorktreeFilesChanged, 1)).toEqual(["electron"]);
-      gitWatcher.dispose();
-    });
-
-    it("still reports directories for a burst the ignore classifier will skip", async () => {
-      // The raw-filesystem signal fires before (and independently of) the
-      // decision to skip the git status pass, so a build writing only into an
-      // ignored folder still tells the file browser exactly where to look.
-      const { gitWatcher, onWorktreeFilesChanged, mock } = watcherWithPaths();
-      await expect(gitWatcher.start()).resolves.toBe(true);
-      mock.resolve();
-      const cb = mock.getCallback();
-
-      fireEvents(cb, [{ type: "update", path: pathJoin("/repo", "dist", "bundle.js") }]);
-      await vi.advanceTimersByTimeAsync(500);
-
-      expect(reportedDirs(onWorktreeFilesChanged)).toEqual(["dist"]);
       gitWatcher.dispose();
     });
   });
@@ -1816,7 +1803,7 @@ describe("GitFileWatcher", () => {
     /** Start a watcher whose worktree bursts are eligible for classification. */
     async function startClassifyingWatcher(overrides: {
       onChange: () => void;
-      onWorktreeFilesChanged?: () => void;
+      onWorktreeFilesChanged?: (affectedDirs: readonly string[] | null) => void;
     }) {
       const mock = setupSubscribeMock();
       const gitWatcher = new GitFileWatcher({
@@ -1853,6 +1840,10 @@ describe("GitFileWatcher", () => {
       await flushClassification();
       expect(onChange).not.toHaveBeenCalled();
       expect(onWorktreeFilesChanged).toHaveBeenCalledTimes(1);
+      // And it carries the directories, so a build writing only into an ignored
+      // folder tells the file browser exactly where to look even though the
+      // status pass is skipped entirely (#12244 riding on #11330).
+      expect(onWorktreeFilesChanged.mock.calls[0]?.[0]).toEqual([".output"]);
 
       expect(checkIgnoredPaths).toHaveBeenCalledTimes(1);
       const [cwd, paths] = vi.mocked(checkIgnoredPaths).mock.calls[0];

--- a/electron/utils/__tests__/worktreeAffectedDirs.test.ts
+++ b/electron/utils/__tests__/worktreeAffectedDirs.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import { affectedDirsForBurst } from "../worktreeAffectedDirs.js";
+
+// The absolute-to-relative conversion the whole scoped-refresh feature rests on
+// (#12244). A silent mismatch here does not break anything visibly — every
+// lookup just misses, the tree falls back to the full sweep, and the feature
+// ships as a no-op that reviews clean (#11276). So these assert the exact
+// relative strings, never merely "something came back".
+
+const ROOT = "/repo";
+
+const dirsOf = (paths: string[], root = ROOT, realRoot: string | null = null) => {
+  const result = affectedDirsForBurst(new Set(paths), root, realRoot);
+  return result === null ? null : [...result].sort();
+};
+
+describe("affectedDirsForBurst", () => {
+  it("returns the worktree-relative parent of each changed path", () => {
+    expect(dirsOf(["/repo/src/panels/foo/Bar.tsx"])).toEqual(["src/panels/foo"]);
+  });
+
+  it("reports a top-level entry as the worktree root", () => {
+    expect(dirsOf(["/repo/package.json"])).toEqual([""]);
+  });
+
+  it("dedupes siblings down to their one shared parent", () => {
+    expect(dirsOf(["/repo/src/a.ts", "/repo/src/b.ts", "/repo/src/c.ts"])).toEqual(["src"]);
+  });
+
+  it("keeps distinct parents apart", () => {
+    expect(dirsOf(["/repo/src/a.ts", "/repo/electron/b.ts", "/repo/README.md"])).toEqual([
+      "",
+      "electron",
+      "src",
+    ]);
+  });
+
+  it("names the parent, never the changed path itself — a changed directory is a row in its parent", () => {
+    // The watcher cannot say whether a path is a file or a directory, and it
+    // does not need to: `src/panels` is created, deleted or renamed as an entry
+    // inside `src`, so `src` is what has to be re-read.
+    expect(dirsOf(["/repo/src/panels"])).toEqual(["src"]);
+  });
+
+  it("resolves paths under the canonical alias as well as the configured root", () => {
+    expect(dirsOf(["/private/var/repo/src/a.ts"], "/var/repo", "/private/var/repo")).toEqual([
+      "src",
+    ]);
+  });
+
+  it("rejects a sibling whose name merely extends the root rather than mangling it", () => {
+    // `/repo-other/x.ts` under `/repo` would slice into `-other/x.ts` with a
+    // raw prefix strip — a relative-looking path naming no real directory.
+    expect(dirsOf(["/repo-other/src/x.ts"])).toBeNull();
+  });
+
+  it("degrades the whole burst when any single path is unusable", () => {
+    expect(dirsOf(["/repo/src/a.ts", "/elsewhere/b.ts"])).toBeNull();
+  });
+
+  it("degrades when a path is the worktree root itself", () => {
+    // The Windows adapter collapses an unknown filename to the watch root,
+    // which means "something under here changed" — unscopeable.
+    expect(dirsOf(["/repo"])).toBeNull();
+  });
+
+  it("passes an unknown burst straight through as unknown", () => {
+    expect(affectedDirsForBurst(null, ROOT, null)).toBeNull();
+  });
+
+  it("returns an empty list for an empty burst, which is not the same as unknown", () => {
+    expect(affectedDirsForBurst(new Set(), ROOT, null)).toEqual([]);
+  });
+
+  it("normalizes backslash separators to the tree's forward-slash namespace", () => {
+    expect(dirsOf(["C:\\repo\\src\\panels\\Bar.tsx"], "C:\\repo")).toEqual(["src/panels"]);
+  });
+
+  it("tolerates a trailing separator on the configured root", () => {
+    expect(dirsOf(["/repo/src/a.ts"], "/repo/")).toEqual(["src"]);
+  });
+});

--- a/electron/utils/gitFileWatcher.ts
+++ b/electron/utils/gitFileWatcher.ts
@@ -13,6 +13,7 @@ import { checkIgnoredPaths, hasTrackedIgnoredPaths } from "./gitCheckIgnore.js";
 import { OPERATION_SENTINEL_NAMES } from "./gitRepoOperationState.js";
 import { subscribeParcelWatcher } from "./parcelWatcherBackend.js";
 import { logWarn } from "./logger.js";
+import { affectedDirsForBurst } from "./worktreeAffectedDirs.js";
 
 const LINUX_INOTIFY_LIMIT_HELP =
   "inotify watch limit reached — file watching may be incomplete. " +
@@ -125,8 +126,12 @@ export interface GitFileWatcherOptions {
    * same coalescing as `onChange`. Drives the file browser's live refresh when
    * a write lands in a gitignored path that leaves `git status` unchanged
    * (#11330).
+   *
+   * Receives the burst's affected directories, worktree-relative and deduped
+   * (`""` = the worktree root), or `null` when the burst could not be described
+   * and the subscriber must assume everything changed (#12244).
    */
-  onWorktreeFilesChanged?: () => void;
+  onWorktreeFilesChanged?: (affectedDirs: readonly string[] | null) => void;
   /** Watch the working tree recursively for file edits (macOS FSEvents). */
   watchWorktree?: boolean;
   /** Minimum debounce delay for worktree events — first event in a burst fires at this delay. */
@@ -189,7 +194,9 @@ export class GitFileWatcher {
   private readonly worktreeDebounceRampMs = 10;
   private readonly onChange: () => void;
   private readonly onGitConfigChanged: (() => void) | undefined;
-  private readonly onWorktreeFilesChanged: (() => void) | undefined;
+  private readonly onWorktreeFilesChanged:
+    | ((affectedDirs: readonly string[] | null) => void)
+    | undefined;
   /** Set when the current (unflushed) burst touched `.git/config`. */
   private gitConfigChangePending = false;
   /**
@@ -835,7 +842,13 @@ export class GitFileWatcher {
     // status pass, let alone for a classification that may decide to skip it
     // (#11330). Firing it here (not the git-internal path) keeps it scoped to
     // actual working-tree writes.
-    this.onWorktreeFilesChanged?.();
+    // The burst itself, not the supersession-adjusted `paths` below: a
+    // superseded burst only lost its *classification*, and the burst it
+    // superseded already delivered its own directories through this same
+    // callback. Nothing is unaccounted for, so the scope stays exact.
+    this.onWorktreeFilesChanged?.(
+      affectedDirsForBurst(burst, this.worktreePath, this.worktreeRealPath)
+    );
 
     // The callback above is synchronous and may dispose this watcher.
     if (this.disposed) return;

--- a/electron/utils/gitFileWatcher.ts
+++ b/electron/utils/gitFileWatcher.ts
@@ -195,8 +195,7 @@ export class GitFileWatcher {
   private readonly onChange: () => void;
   private readonly onGitConfigChanged: (() => void) | undefined;
   private readonly onWorktreeFilesChanged:
-    | ((affectedDirs: readonly string[] | null) => void)
-    | undefined;
+    ((affectedDirs: readonly string[] | null) => void) | undefined;
   /** Set when the current (unflushed) burst touched `.git/config`. */
   private gitConfigChangePending = false;
   /**

--- a/electron/utils/worktreeAffectedDirs.ts
+++ b/electron/utils/worktreeAffectedDirs.ts
@@ -1,0 +1,48 @@
+import { isPathInside, toWorktreeRelative } from "../../shared/utils/path.js";
+
+/**
+ * The worktree-relative directories a burst of absolute changed paths touched:
+ * one parent per path, deduped, `""` for the worktree root.
+ *
+ * Only parents, never the changed paths themselves — a tree discovers a child
+ * by looking it up in its parent's listing, never by iterating expansions, so
+ * re-reading the parent is what reveals a create, a delete, a rename or a
+ * changed size. That also covers the case a watcher cannot report: a path that
+ * is itself a directory carries no `isDirectory` flag in the event, and its own
+ * row lives in the parent's listing regardless.
+ *
+ * `null` is the conservative answer — "this burst cannot be described, refresh
+ * everything" — and is returned for an unknown burst and for any path that does
+ * not resolve inside the worktree. No cap of its own: one parent per path can
+ * never exceed the burst's own `WORKTREE_BURST_PATH_CAP`, which has already
+ * degraded the burst to `null` by the time it would matter.
+ *
+ * Containment goes through `isPathInside`/`toWorktreeRelative` rather than a
+ * prefix slice: a sibling whose name merely extends the root (`/repo-other/x`
+ * under `/repo`) would otherwise mangle into a plausible-looking relative path
+ * and scope the refresh to a directory that does not exist (#11276).
+ */
+export function affectedDirsForBurst(
+  burst: ReadonlySet<string> | null,
+  worktreePath: string,
+  worktreeRealPath: string | null
+): string[] | null {
+  if (burst === null) return null;
+  const dirs = new Set<string>();
+  for (const path of burst) {
+    const root = [worktreePath, worktreeRealPath].find(
+      (candidate) => candidate !== null && candidate !== "" && isPathInside(path, candidate)
+    );
+    // Collection already rejects paths outside the worktree, so this is the
+    // belt-and-braces branch: a root that changed spelling between collection
+    // and flush must degrade the burst, never silently drop one of its paths.
+    if (root === undefined || root === null) return null;
+    const relative = toWorktreeRelative(path, root);
+    // `toWorktreeRelative` hands back the input untouched when it cannot strip
+    // the root, which would put an absolute path into a relative namespace.
+    if (relative === path || relative === "") return null;
+    const slash = relative.lastIndexOf("/");
+    dirs.add(slash === -1 ? "" : relative.slice(0, slash));
+  }
+  return [...dirs];
+}

--- a/electron/workspace-host/SnapshotBuilder.ts
+++ b/electron/workspace-host/SnapshotBuilder.ts
@@ -66,6 +66,7 @@ export interface SnapshotBuilderHost {
   readonly lastFetchedAt: number | null;
   readonly lastGitStatusCheckedAt: number;
   readonly workingTreeChangedAt: number;
+  readonly workingTreeChangedDirs: readonly string[] | null | undefined;
   readonly fetchAuthFailed: boolean;
   readonly fetchNetworkFailed: boolean;
   readonly isFetchInFlight: boolean;
@@ -177,6 +178,14 @@ export class SnapshotBuilder {
       // 0 → undefined so a worktree that has never seen a raw fs write serializes
       // lean; the store side map treats absent as "no signal yet".
       workingTreeChangedAt: this.host.workingTreeChangedAt || undefined,
+      // Passed through verbatim, never `|| undefined`: `null` ("the burst could
+      // not be described — re-read everything") and `[]` ("a real burst that
+      // touched no directory") are distinct answers, and both differ from
+      // absent ("no burst has been described at all"). Suppressed only when
+      // there is no stamp for them to belong to (#12244).
+      workingTreeChangedDirs: this.host.workingTreeChangedAt
+        ? this.host.workingTreeChangedDirs
+        : undefined,
       fetchAuthFailed: this.host.fetchAuthFailed || undefined,
       fetchNetworkFailed: this.host.fetchNetworkFailed || undefined,
       // Read in-flight state authoritatively at snapshot time (lesson #1700)

--- a/electron/workspace-host/WatcherController.ts
+++ b/electron/workspace-host/WatcherController.ts
@@ -65,8 +65,12 @@ export interface WatcherControllerHost {
    * independent of whether git status changed. Lets the host stamp a
    * working-tree-changed timestamp so the file browser can refresh on writes
    * into gitignored paths that leave `git status` unmoved (#11330).
+   *
+   * `affectedDirs` names the burst's worktree-relative parent directories
+   * (`""` = the worktree root), or is `null` when the burst could not be
+   * described and every listing must be re-read (#12244).
    */
-  onWorktreeFilesChanged?(): void;
+  onWorktreeFilesChanged?(affectedDirs: readonly string[] | null): void;
 }
 
 /**
@@ -170,7 +174,7 @@ export class WatcherController {
       debounceMs: this.host.gitWatchDebounceMs,
       onChange: () => this.handleGitFileChange(),
       onGitConfigChanged: () => this.host.onGitConfigChanged?.(),
-      onWorktreeFilesChanged: () => this.handleWorktreeFilesChanged(),
+      onWorktreeFilesChanged: (affectedDirs) => this.handleWorktreeFilesChanged(affectedDirs),
       watchWorktree: mode === "recursive",
       worktreeMinDebounceMs: WATCHER_WORKTREE_MIN_DEBOUNCE_MS,
       worktreeMaxDebounceMs: WATCHER_WORKTREE_MAX_DEBOUNCE_MS,
@@ -593,9 +597,9 @@ export class WatcherController {
    * can't stamp the monitor after `stop()`. `flushWorktreeChange` already
    * checks the watcher's own disposed flag; this is the controller-level gate.
    */
-  private handleWorktreeFilesChanged(): void {
+  private handleWorktreeFilesChanged(affectedDirs: readonly string[] | null): void {
     if (this.disposed || !this.host.isRunning) return;
-    this.host.onWorktreeFilesChanged?.();
+    this.host.onWorktreeFilesChanged?.(affectedDirs);
   }
 
   private handleGitFileChange(): void {

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -184,6 +184,11 @@ export class WorktreeMonitor {
   // snapshot dedup and carried through the store's side map like the
   // git-status-checked timestamp.
   private _workingTreeChangedAt: number = 0;
+  /**
+   * Directories the burst behind `_workingTreeChangedAt` touched, or `null`
+   * when it could not be described. `undefined` until the first flush.
+   */
+  private _workingTreeChangedDirs: readonly string[] | null | undefined = undefined;
   // Stamped by the watcher's onTriggerUpdate hook before a forced refresh
   // fires. The stat pre-check compares against `lastStatBaselineAt` to know
   // whether an event arrived since the baseline was captured — if so, the
@@ -424,7 +429,7 @@ export class WorktreeMonitor {
         monitor.callbacks.onEmfileLimitReached?.(worktreeId),
       onWatcherRecovered: () => monitor.callbacks.onWatcherRecovered?.(monitor.id),
       onGitConfigChanged: () => monitor.callbacks.onGitConfigChanged?.(monitor.id),
-      onWorktreeFilesChanged: () => monitor.handleWorktreeFilesChanged(),
+      onWorktreeFilesChanged: (affectedDirs) => monitor.handleWorktreeFilesChanged(affectedDirs),
     };
     this.watcherController = new WatcherController(watcherHost);
 
@@ -587,6 +592,9 @@ export class WorktreeMonitor {
       },
       get workingTreeChangedAt() {
         return monitor._workingTreeChangedAt;
+      },
+      get workingTreeChangedDirs() {
+        return monitor._workingTreeChangedDirs;
       },
       get fetchAuthFailed() {
         return monitor._fetchAuthFailed;
@@ -1916,11 +1924,21 @@ export class WorktreeMonitor {
    * clock adjustment) still strictly increase, so each registers downstream.
    * Before the first status resolves there is no snapshot to emit — the stamp
    * is retained and the first normal snapshot carries it.
+   *
+   * `affectedDirs` rides the same stamp so a subscriber can scope its re-read
+   * to the directories that actually changed (#12244). A retained stamp cannot
+   * carry them: a second flush before the first status would overwrite the
+   * first burst's directories with the second's, and nothing would ever re-read
+   * the difference — so the retained case reports `null` (refresh everything)
+   * rather than a set it cannot prove is complete.
    */
-  private handleWorktreeFilesChanged(): void {
+  private handleWorktreeFilesChanged(affectedDirs: readonly string[] | null): void {
     this._workingTreeChangedAt = Math.max(Date.now(), this._workingTreeChangedAt + 1);
     if (this._hasInitialStatus) {
+      this._workingTreeChangedDirs = affectedDirs;
       this.emitUpdate();
+    } else {
+      this._workingTreeChangedDirs = null;
     }
   }
 

--- a/electron/workspace-host/__tests__/SnapshotBuilder.test.ts
+++ b/electron/workspace-host/__tests__/SnapshotBuilder.test.ts
@@ -56,6 +56,7 @@ function makeHost(overrides: Partial<SnapshotBuilderHost> = {}): SnapshotBuilder
     lastFetchedAt: null,
     lastGitStatusCheckedAt: 0,
     workingTreeChangedAt: 0,
+    workingTreeChangedDirs: undefined,
     fetchAuthFailed: false,
     fetchNetworkFailed: false,
     isFetchInFlight: false,
@@ -206,6 +207,29 @@ describe("SnapshotBuilder", () => {
     expect(new SnapshotBuilder(makeHost({ worktreeMode: "remote" })).build().worktreeMode).toBe(
       "remote"
     );
+  });
+
+  it("keeps the affected directories' three answers apart on the wire", () => {
+    // Absent, `null` and `[]` mean different things to the file browser — "no
+    // burst described", "burst unclassifiable, re-read everything" and "a real
+    // burst that touched nothing" — so none of them may collapse into another.
+    expect(new SnapshotBuilder(makeHost()).build().workingTreeChangedDirs).toBeUndefined();
+    // Suppressed while there is no stamp for them to belong to, even if the
+    // monitor happens to be holding a set.
+    const unstamped = makeHost({ workingTreeChangedDirs: ["src"] });
+    expect(new SnapshotBuilder(unstamped).build().workingTreeChangedDirs).toBeUndefined();
+
+    const uncertain = makeHost({ workingTreeChangedAt: 1_725_000_000_000, workingTreeChangedDirs: null });
+    expect(new SnapshotBuilder(uncertain).build().workingTreeChangedDirs).toBeNull();
+
+    const empty = makeHost({ workingTreeChangedAt: 1_725_000_000_000, workingTreeChangedDirs: [] });
+    expect(new SnapshotBuilder(empty).build().workingTreeChangedDirs).toEqual([]);
+
+    const known = makeHost({
+      workingTreeChangedAt: 1_725_000_000_000,
+      workingTreeChangedDirs: ["src/panels", ""],
+    });
+    expect(new SnapshotBuilder(known).build().workingTreeChangedDirs).toEqual(["src/panels", ""]);
   });
 
   it("omits workingTreeChangedAt until a fs write is observed, then surfaces it", () => {

--- a/electron/workspace-host/__tests__/SnapshotBuilder.test.ts
+++ b/electron/workspace-host/__tests__/SnapshotBuilder.test.ts
@@ -219,7 +219,10 @@ describe("SnapshotBuilder", () => {
     const unstamped = makeHost({ workingTreeChangedDirs: ["src"] });
     expect(new SnapshotBuilder(unstamped).build().workingTreeChangedDirs).toBeUndefined();
 
-    const uncertain = makeHost({ workingTreeChangedAt: 1_725_000_000_000, workingTreeChangedDirs: null });
+    const uncertain = makeHost({
+      workingTreeChangedAt: 1_725_000_000_000,
+      workingTreeChangedDirs: null,
+    });
     expect(new SnapshotBuilder(uncertain).build().workingTreeChangedDirs).toBeNull();
 
     const empty = makeHost({ workingTreeChangedAt: 1_725_000_000_000, workingTreeChangedDirs: [] });

--- a/electron/workspace-host/__tests__/WatcherController.test.ts
+++ b/electron/workspace-host/__tests__/WatcherController.test.ts
@@ -605,11 +605,18 @@ describe("WatcherController", () => {
     await settle();
 
     const fireWorktreeFilesChanged = capturedWatcherOptions?.onWorktreeFilesChanged as
-      (() => void) | undefined;
+      | ((affectedDirs: readonly string[] | null) => void)
+      | undefined;
     expect(fireWorktreeFilesChanged).toBeDefined();
 
-    fireWorktreeFilesChanged?.();
+    fireWorktreeFilesChanged?.(["src/panels"]);
     expect(host.onWorktreeFilesChanged).toHaveBeenCalledTimes(1);
+    // Forwarded verbatim: the controller is a disposal gate, not a place where
+    // the burst's directories get reinterpreted (#12244).
+    expect(host.onWorktreeFilesChanged).toHaveBeenCalledWith(["src/panels"]);
+
+    fireWorktreeFilesChanged?.(null);
+    expect(host.onWorktreeFilesChanged).toHaveBeenLastCalledWith(null);
   });
 
   it("drops a late onWorktreeFilesChanged once the host is no longer running", async () => {
@@ -620,14 +627,15 @@ describe("WatcherController", () => {
     await settle();
 
     const fireWorktreeFilesChanged = capturedWatcherOptions?.onWorktreeFilesChanged as
-      (() => void) | undefined;
+      | ((affectedDirs: readonly string[] | null) => void)
+      | undefined;
 
     // A watcher rotated out (or a stopped controller) can still fire its
     // debounced flush; the controller-level guard must not stamp the host
     // after teardown.
     host.isRunning = false;
     ctrl.stop();
-    fireWorktreeFilesChanged?.();
+    fireWorktreeFilesChanged?.(["src"]);
 
     expect(host.onWorktreeFilesChanged).not.toHaveBeenCalled();
   });

--- a/electron/workspace-host/__tests__/WatcherController.test.ts
+++ b/electron/workspace-host/__tests__/WatcherController.test.ts
@@ -605,8 +605,7 @@ describe("WatcherController", () => {
     await settle();
 
     const fireWorktreeFilesChanged = capturedWatcherOptions?.onWorktreeFilesChanged as
-      | ((affectedDirs: readonly string[] | null) => void)
-      | undefined;
+      ((affectedDirs: readonly string[] | null) => void) | undefined;
     expect(fireWorktreeFilesChanged).toBeDefined();
 
     fireWorktreeFilesChanged?.(["src/panels"]);
@@ -627,8 +626,7 @@ describe("WatcherController", () => {
     await settle();
 
     const fireWorktreeFilesChanged = capturedWatcherOptions?.onWorktreeFilesChanged as
-      | ((affectedDirs: readonly string[] | null) => void)
-      | undefined;
+      ((affectedDirs: readonly string[] | null) => void) | undefined;
 
     // A watcher rotated out (or a stopped controller) can still fire its
     // debounced flush; the controller-level guard must not stamp the host

--- a/electron/workspace-host/__tests__/WorktreeMonitor.watcher.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeMonitor.watcher.test.ts
@@ -924,9 +924,10 @@ describe("WorktreeMonitor", () => {
       const emitsBefore = vi.mocked(callbacks.onUpdate).mock.calls.length;
 
       const fireWorktreeFilesChanged = capturedWatcherOptions?.onWorktreeFilesChanged as
-        (() => void) | undefined;
+        | ((affectedDirs: readonly string[] | null) => void)
+        | undefined;
       expect(fireWorktreeFilesChanged).toBeDefined();
-      fireWorktreeFilesChanged?.();
+      fireWorktreeFilesChanged?.(null);
 
       // Emitted off the write alone — a fresh snapshot, no extra git status run.
       expect(vi.mocked(callbacks.onUpdate).mock.calls.length).toBe(emitsBefore + 1);
@@ -943,14 +944,16 @@ describe("WorktreeMonitor", () => {
       const monitor = new WorktreeMonitor(ACTIVE_WORKTREE, WATCH_CONFIG, callbacks, "main");
       await monitor.start();
 
-      const fireWorktreeFilesChanged = capturedWatcherOptions?.onWorktreeFilesChanged as () => void;
+      const fireWorktreeFilesChanged = capturedWatcherOptions?.onWorktreeFilesChanged as (
+        affectedDirs: readonly string[] | null
+      ) => void;
 
       // Two flushes with no timer advance between them: the monotonic guard
       // (Math.max(now, prev + 1)) must still move the stamp forward even when
       // Date.now() is unchanged.
-      fireWorktreeFilesChanged();
+      fireWorktreeFilesChanged(null);
       const first = vi.mocked(callbacks.onUpdate).mock.calls.at(-1)?.[0]?.workingTreeChangedAt;
-      fireWorktreeFilesChanged();
+      fireWorktreeFilesChanged(null);
       const second = vi.mocked(callbacks.onUpdate).mock.calls.at(-1)?.[0]?.workingTreeChangedAt;
 
       expect(first).toBeGreaterThan(0);
@@ -971,8 +974,10 @@ describe("WorktreeMonitor", () => {
       expect(monitor.hasInitialStatus).toBe(false);
       expect(callbacks.onUpdate).not.toHaveBeenCalled();
 
-      const fireWorktreeFilesChanged = capturedWatcherOptions?.onWorktreeFilesChanged as () => void;
-      fireWorktreeFilesChanged();
+      const fireWorktreeFilesChanged = capturedWatcherOptions?.onWorktreeFilesChanged as (
+        affectedDirs: readonly string[] | null
+      ) => void;
+      fireWorktreeFilesChanged(["src"]);
 
       // Stamped internally, but no incomplete snapshot emitted for it.
       expect(callbacks.onUpdate).not.toHaveBeenCalled();
@@ -985,6 +990,37 @@ describe("WorktreeMonitor", () => {
       expect(
         vi.mocked(callbacks.onUpdate).mock.calls[0]?.[0]?.workingTreeChangedAt
       ).toBeGreaterThan(0);
+      // But NOT the directories that burst named. A second flush before the
+      // first status would have overwritten them, and nothing would ever
+      // re-read the difference — so a retained stamp reports "unknown" rather
+      // than a set it cannot prove is complete (#12244).
+      expect(
+        vi.mocked(callbacks.onUpdate).mock.calls[0]?.[0]?.workingTreeChangedDirs
+      ).toBeNull();
+
+      monitor.stop();
+    });
+
+    it("carries the burst's directories on the snapshot the flush emits", async () => {
+      const callbacks = makeCallbacks();
+      const monitor = new WorktreeMonitor(ACTIVE_WORKTREE, WATCH_CONFIG, callbacks, "main");
+      await monitor.start();
+
+      const fireWorktreeFilesChanged = capturedWatcherOptions?.onWorktreeFilesChanged as (
+        affectedDirs: readonly string[] | null
+      ) => void;
+
+      fireWorktreeFilesChanged(["src/panels", ""]);
+      const emitted = vi.mocked(callbacks.onUpdate).mock.calls.at(-1)?.[0];
+      expect(emitted?.workingTreeChangedDirs).toEqual(["src/panels", ""]);
+      expect(emitted?.workingTreeChangedAt).toBeGreaterThan(0);
+
+      // An unclassifiable burst replaces them rather than leaving the previous
+      // burst's directories standing against a newer stamp.
+      fireWorktreeFilesChanged(null);
+      const next = vi.mocked(callbacks.onUpdate).mock.calls.at(-1)?.[0];
+      expect(next?.workingTreeChangedDirs).toBeNull();
+      expect(next?.workingTreeChangedAt).toBeGreaterThan(emitted?.workingTreeChangedAt ?? 0);
 
       monitor.stop();
     });

--- a/electron/workspace-host/__tests__/WorktreeMonitor.watcher.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeMonitor.watcher.test.ts
@@ -924,8 +924,7 @@ describe("WorktreeMonitor", () => {
       const emitsBefore = vi.mocked(callbacks.onUpdate).mock.calls.length;
 
       const fireWorktreeFilesChanged = capturedWatcherOptions?.onWorktreeFilesChanged as
-        | ((affectedDirs: readonly string[] | null) => void)
-        | undefined;
+        ((affectedDirs: readonly string[] | null) => void) | undefined;
       expect(fireWorktreeFilesChanged).toBeDefined();
       fireWorktreeFilesChanged?.(null);
 
@@ -994,9 +993,7 @@ describe("WorktreeMonitor", () => {
       // first status would have overwritten them, and nothing would ever
       // re-read the difference — so a retained stamp reports "unknown" rather
       // than a set it cannot prove is complete (#12244).
-      expect(
-        vi.mocked(callbacks.onUpdate).mock.calls[0]?.[0]?.workingTreeChangedDirs
-      ).toBeNull();
+      expect(vi.mocked(callbacks.onUpdate).mock.calls[0]?.[0]?.workingTreeChangedDirs).toBeNull();
 
       monitor.stop();
     });

--- a/packages/plugin-sdk/src/files/fileTree.ts
+++ b/packages/plugin-sdk/src/files/fileTree.ts
@@ -875,7 +875,12 @@ export function refreshTargets(
   // it is collapsed in the tree (#11620) — it is on screen, so leaving it out
   // would let it go stale while the tree beside it updates. Added up front and
   // guarded below so the walk can't list it twice.
-  if (keepPath !== null && keepPath !== rootPath && !expandedPaths.has(keepPath) && wanted(keepPath))
+  if (
+    keepPath !== null &&
+    keepPath !== rootPath &&
+    !expandedPaths.has(keepPath) &&
+    wanted(keepPath)
+  )
     targets.push(keepPath);
   const walk = (dirPath: string, depth: number): void => {
     if (depth > MAX_TREE_DEPTH) return;

--- a/packages/plugin-sdk/src/files/fileTree.ts
+++ b/packages/plugin-sdk/src/files/fileTree.ts
@@ -849,22 +849,34 @@ export function listingsFromSnapshot(
  * survives its directory being deleted. Without this filter a browser restored
  * onto a changed worktree would re-request every folder the user ever opened,
  * including ones that no longer exist, on every single refresh tick.
+ *
+ * `affectedDirs` narrows that answer to the directories a change actually
+ * touched (#12244). It filters what is emitted, never where the walk goes: an
+ * affected directory is only reachable through its unaffected ancestors, and
+ * reachability is exactly what this function exists to establish. Omit it (or
+ * pass `null`) for the full sweep — that is what a manual refresh, an identity
+ * reset, and any change the watcher could not describe all take.
  */
 export function refreshTargets(
   listings: DirectoryListings,
   expandedPaths: ReadonlySet<string>,
   rootPath = "",
   isVisible?: (name: string) => boolean,
-  keepPath: string | null = null
+  keepPath: string | null = null,
+  affectedDirs: ReadonlySet<string> | null = null
 ): string[] {
-  const targets = [rootPath];
+  const wanted = (dirPath: string): boolean => affectedDirs === null || affectedDirs.has(dirPath);
+  const targets: string[] = [];
+  // The root is unconditional for a full sweep, and only when a top-level entry
+  // changed for a scoped one — the affected set names a *parent*, so "" appears
+  // in it exactly when something directly inside the root moved.
+  if (wanted(rootPath)) targets.push(rootPath);
   // The folder the viewer is listing is re-read like an expanded one even when
   // it is collapsed in the tree (#11620) — it is on screen, so leaving it out
   // would let it go stale while the tree beside it updates. Added up front and
   // guarded below so the walk can't list it twice.
-  if (keepPath !== null && keepPath !== rootPath && !expandedPaths.has(keepPath)) {
+  if (keepPath !== null && keepPath !== rootPath && !expandedPaths.has(keepPath) && wanted(keepPath))
     targets.push(keepPath);
-  }
   const walk = (dirPath: string, depth: number): void => {
     if (depth > MAX_TREE_DEPTH) return;
     const children = listings.get(dirPath);
@@ -874,7 +886,7 @@ export function refreshTargets(
       // A hidden directory has no row, so re-listing it (and its subtree) every
       // tick is pure waste — skip it and everything beneath it.
       if (isVisible && !isVisible(node.name)) continue;
-      targets.push(node.path);
+      if (wanted(node.path)) targets.push(node.path);
       walk(node.path, depth + 1);
     }
   };

--- a/scripts/perf/__tests__/comparability.test.ts
+++ b/scripts/perf/__tests__/comparability.test.ts
@@ -62,6 +62,8 @@ describe("classifyMetric", () => {
   const REAL_COUNTS = [
     "executedJobs",
     "postedJobs",
+    "directoryRequests",
+    "listingsMapCopies",
     "supersededPosted",
     "gitSpawns",
     "agentCount",

--- a/scripts/perf/__tests__/panels.test.ts
+++ b/scripts/perf/__tests__/panels.test.ts
@@ -87,15 +87,49 @@ describe("panel scenarios (PERF-240..247)", () => {
       expect(metrics.refreshMisses).toBe(0);
       expect(metrics.refreshTargetCount).toBeGreaterThan(1);
       expect(metrics.relistedNodeCount).toBeGreaterThan(100);
-      // Three arms, each priced separately. The middle one is the scenario's
-      // point: a change with nothing to show still pays a full sweep, because
-      // refreshTargets is content-blind.
+      // Three unscoped arms, each priced separately. The middle one is the
+      // scenario's original point: a change with nothing to show still pays a
+      // full sweep, because refreshTargets is content-blind.
       expect(metrics.sweepMs).toBeGreaterThan(0);
       expect(metrics.ignoredOnlySweepMs).toBeGreaterThan(0);
       expect(metrics.inPlaceEditSweepMs).toBeGreaterThan(0);
       expect(sample.durationMs).toBeGreaterThanOrEqual(
         metrics.sweepMs! + metrics.ignoredOnlySweepMs! + metrics.inPlaceEditSweepMs!
       );
+      // An unscoped sweep re-lists the root plus every expanded directory, and
+      // commits one listings-map copy per response.
+      expect(metrics.fullDirectoryRequests).toBe(metrics.refreshTargetCount);
+      expect(metrics.fullDirectoryRequests).toBeGreaterThan(20);
+      expect(metrics.fullListingsMapCopies).toBe(metrics.fullDirectoryRequests);
+    }
+  );
+
+  it(
+    "PERF-242 scopes a sweep to the directories a burst actually touched",
+    { timeout: FIXTURE_TIMEOUT_MS },
+    async () => {
+      const sample = await scenarioFor("PERF-242").run(contextFor("smoke"));
+      const metrics = sample.metrics!;
+      // Exact, not "smaller than": the whole feature is that the count drops to
+      // the number of directories written to, and a near-miss here (an extra
+      // root request, or a conversion that fell back to the full sweep) is the
+      // regression the arm exists to name.
+      expect(metrics.scopedSubtreeDirectoryRequests).toBe(1);
+      expect(metrics.scopedRootDirectoryRequests).toBe(1);
+      expect(metrics.scopedMultiDirectoryRequests).toBe(3);
+      // Twenty writes over three directories cost three listings, not twenty:
+      // the affected set is deduped to parents before it reaches the tree.
+      expect(metrics.scopedMultiListingsMapCopies).toBe(3);
+      expect(metrics.scopedSubtreeListingsMapCopies).toBe(1);
+      expect(metrics.scopedRootListingsMapCopies).toBe(1);
+      // And the correctness oracle covers the scoped arms too: refreshMisses is
+      // asserted zero above over an expectation set that includes every burst
+      // file, so a scoped sweep that dropped the listings it did not re-read
+      // would score there rather than pass quietly here.
+      expect(metrics.refreshMisses).toBe(0);
+      expect(metrics.scopedSubtreeSweepMs).toBeGreaterThan(0);
+      expect(metrics.scopedRootSweepMs).toBeGreaterThan(0);
+      expect(metrics.scopedMultiSweepMs).toBeGreaterThan(0);
     }
   );
 

--- a/scripts/perf/__tests__/panels.test.ts
+++ b/scripts/perf/__tests__/panels.test.ts
@@ -111,17 +111,26 @@ describe("panel scenarios (PERF-240..247)", () => {
       const sample = await scenarioFor("PERF-242").run(contextFor("smoke"));
       const metrics = sample.metrics!;
       // Exact, not "smaller than": the whole feature is that the count drops to
-      // the number of directories written to, and a near-miss here (an extra
-      // root request, or a conversion that fell back to the full sweep) is the
-      // regression the arm exists to name.
-      expect(metrics.scopedSubtreeDirectoryRequests).toBe(1);
+      // the directories written to plus the parent each one's own row lives in,
+      // and a near-miss here (an extra request, or a conversion that fell back
+      // to the full sweep) is the regression the arm exists to name.
+      expect(metrics.scopedSubtreeDirectoryRequests).toBe(2);
+      // A top-level write's directory IS the root, and the root is its own
+      // parent — one request, not two.
       expect(metrics.scopedRootDirectoryRequests).toBe(1);
-      expect(metrics.scopedMultiDirectoryRequests).toBe(3);
-      // Twenty writes over three directories cost three listings, not twenty:
-      // the affected set is deduped to parents before it reaches the tree.
-      expect(metrics.scopedMultiListingsMapCopies).toBe(3);
-      expect(metrics.scopedSubtreeListingsMapCopies).toBe(1);
-      expect(metrics.scopedRootListingsMapCopies).toBe(1);
+      // Twenty writes over three disjoint subtrees: three directories plus the
+      // parents their rows live in, never twenty — the affected set is deduped
+      // to directories before it reaches the tree.
+      expect(metrics.scopedMultiDirectoryRequests).toBeGreaterThanOrEqual(4);
+      expect(metrics.scopedMultiDirectoryRequests).toBeLessThanOrEqual(6);
+      // Every request commits exactly one listings-map copy, as the panel does.
+      expect(metrics.scopedSubtreeListingsMapCopies).toBe(metrics.scopedSubtreeDirectoryRequests);
+      expect(metrics.scopedRootListingsMapCopies).toBe(metrics.scopedRootDirectoryRequests);
+      expect(metrics.scopedMultiListingsMapCopies).toBe(metrics.scopedMultiDirectoryRequests);
+      // And all of them stay an order of magnitude under the sweep they replace.
+      expect(metrics.scopedMultiDirectoryRequests! * 5).toBeLessThan(
+        metrics.fullDirectoryRequests!
+      );
       // And the correctness oracle covers the scoped arms too: refreshMisses is
       // asserted zero above over an expectation set that includes every burst
       // file, so a scoped sweep that dropped the listings it did not re-read

--- a/scripts/perf/lib/comparability.ts
+++ b/scripts/perf/lib/comparability.ts
@@ -156,6 +156,12 @@ const RULES: ReadonlyArray<{ cls: ComparabilityClass; pattern: RegExp }> = [
   // Tallies. Plain word matching is safe here: it runs last, so anything a
   // stronger rule wanted has already been claimed.
   //
+  // `Requests` and `Copies` joined the list with PERF-242's scoped-refresh arms
+  // (#12244): a directory listing request and a listings-map copy are both
+  // deterministic tallies of work the panel does, and without a token here they
+  // fell through to `unknown` and lost their cross-machine comparison — which
+  // is the whole point of counting them rather than only timing the sweep.
+  //
   // `Reloads` is spelled out rather than folded into a shared `[Ll]oads` token:
   // a bare "loads" finds itself inside "payload", which would take a
   // deterministic `payloadBytesPerMessage` away from `size` for the same reason
@@ -163,7 +169,7 @@ const RULES: ReadonlyArray<{ cls: ComparabilityClass; pattern: RegExp }> = [
   {
     cls: "count",
     pattern:
-      /[Cc]ount|[Rr]ows|[Ss]pawns|[Ss]tarts|[Ll]aunches|[Ii]nvocations|[Rr]etries|[Cc]alls|[Hh]its|[Mm]isses|[Ee]vents|[Ff]lushes|[Rr]enders|[Mm]essages|[Tt]asks|[Hh]andles|[Dd]escriptors|[Ww]rites|[Rr]eads|[Pp]asses|[Aa]ttempts|[Cc]allbacks|[Kk]eystrokes|[Rr]oundTrips|[Ll]ines|[Pp]anels|[Gg]roups|[Hh]unks|[Tt]argets|[Ff]rames|[Ff]iles|[Tt]okens|[Dd]ecorations|[Cc]hanges|[Bb]atches|[Ii]tems|[Rr]esolved|[Rr]eloads|[Jj]obs|[Pp]osted/,
+      /[Cc]ount|[Rr]ows|[Ss]pawns|[Ss]tarts|[Ll]aunches|[Ii]nvocations|[Rr]etries|[Cc]alls|[Hh]its|[Mm]isses|[Ee]vents|[Ff]lushes|[Rr]enders|[Mm]essages|[Tt]asks|[Hh]andles|[Dd]escriptors|[Ww]rites|[Rr]eads|[Pp]asses|[Aa]ttempts|[Cc]allbacks|[Kk]eystrokes|[Rr]oundTrips|[Ll]ines|[Pp]anels|[Gg]roups|[Hh]unks|[Tt]argets|[Ff]rames|[Ff]iles|[Tt]okens|[Dd]ecorations|[Cc]hanges|[Bb]atches|[Ii]tems|[Rr]esolved|[Rr]eloads|[Jj]obs|[Pp]osted|[Rr]equests|[Cc]opies/,
   },
 ];
 

--- a/scripts/perf/lib/panelsFixture.ts
+++ b/scripts/perf/lib/panelsFixture.ts
@@ -540,6 +540,28 @@ export function loadBrowserTreeModule(): Promise<BrowserTreeModule> {
   return browserTreePromise;
 }
 
+export type WorktreeAffectedDirsModule =
+  typeof import("../../../electron/utils/worktreeAffectedDirs");
+
+let affectedDirsPromise: Promise<WorktreeAffectedDirsModule> | null = null;
+
+/**
+ * The production absolute-path → worktree-relative-directory conversion
+ * (#12244), loaded rather than restated.
+ *
+ * The scoped-refresh arms feed it ABSOLUTE paths, exactly as the watcher
+ * reports them, so a shape mismatch between the two namespaces fails the arm
+ * instead of quietly degrading every scoped sweep to a full one — which would
+ * leave the benchmark measuring the old behaviour under the new name.
+ */
+export function loadAffectedDirsModule(): Promise<WorktreeAffectedDirsModule> {
+  if (!affectedDirsPromise) {
+    ensurePerfEnv();
+    affectedDirsPromise = import("../../../electron/utils/worktreeAffectedDirs");
+  }
+  return affectedDirsPromise;
+}
+
 let hiddenPatternsPromise: Promise<readonly string[]> | null = null;
 
 /**
@@ -625,6 +647,48 @@ export interface TreeMutation {
  * iteration cannot leak state into the next one or into another scenario
  * sharing the tree.
  */
+export interface TreeBurstMutation {
+  /** Worktree-relative paths of the files this burst adds. */
+  paths: string[];
+  /** The same paths as a watcher reports them — absolute, root-prefixed. */
+  absolutePaths: string[];
+  write: () => void;
+  revert: () => void;
+}
+
+/**
+ * Prepare a burst of `count` new files spread round-robin over `dirs`, for the
+ * arms that price a change confined to a known set of directories.
+ *
+ * Separate from {@link mutateTree} because that one models three DIFFERENT
+ * kinds of change, one per sweep; this models one kind of change landing many
+ * times before a single sweep — the shape an agent's edit pass or a build has.
+ */
+export function writeBurst(
+  tree: BrowseTree,
+  dirs: readonly string[],
+  count: number,
+  token: string
+): TreeBurstMutation {
+  const paths: string[] = [];
+  for (let i = 0; i < count; i += 1) {
+    const dir = dirs[i % dirs.length] ?? "";
+    const name = `BurstService${token}_${i}.ts`;
+    paths.push(dir === "" ? name : `${dir}/${name}`);
+  }
+  const absolutePaths = paths.map((path) => join(tree.path, path));
+  return {
+    paths,
+    absolutePaths,
+    write: () => {
+      for (const path of absolutePaths) writeFileSync(path, ORDINARY_FILE_CONTENT);
+    },
+    revert: () => {
+      for (const path of absolutePaths) rmSync(path, { force: true });
+    },
+  };
+}
+
 export function mutateTree(
   tree: BrowseTree,
   target: { visibleDir: string; junkDir: string; touchDir: string },

--- a/scripts/perf/scenarios/panels.ts
+++ b/scripts/perf/scenarios/panels.ts
@@ -17,6 +17,7 @@ import {
   getViewerFixture,
   listDirectories,
   listedSizeOf,
+  loadAffectedDirsModule,
   loadAlwaysHiddenPatterns,
   loadBrowserTreeModule,
   loadReviewModules,
@@ -28,6 +29,7 @@ import {
   sequenceMismatchCount,
   setDifferenceCount,
   stagingStatusFor,
+  writeBurst,
 } from "../lib/panelsFixture";
 
 // Panel surfaces (PERF-240..246) — the file browser, the Review Hub and the
@@ -351,16 +353,21 @@ export const panelScenarios: PerfScenario[] = [
     id: "PERF-242",
     name: "File Browser Refresh Sweep After a Change",
     description:
-      "The incremental path, as three write→sweep arms over a fully-expanded tree: a new visible " +
-      "file then a sweep (sweepMs), a new file the junk list hides then a sweep " +
-      "(ignoredOnlySweepMs), an in-place edit then a sweep (inPlaceEditSweepMs). Each write lands " +
+      "The incremental path, as six write→sweep arms over a fully-expanded tree. Three price the " +
+      "UNSCOPED sweep — a new visible file (sweepMs), a new file the junk list hides " +
+      "(ignoredOnlySweepMs), an in-place edit (inPlaceEditSweepMs) — and report what one costs in " +
+      "fullDirectoryRequests and fullListingsMapCopies. Three price the SCOPED sweep the watcher's " +
+      "affected-directory signal makes possible (#12244): one write in one expanded subtree, one " +
+      "at the root, and twenty writes across three subtrees in a single burst. Each write lands " +
       "between the preceding sweep and its own, so every arm prices a refresh over a change that " +
       "had not yet happened when the last one ran. Each sweep is the real refreshTargets → " +
-      "re-list → flattenTree/countHiddenRows path. refreshTargets is content-blind, which is what " +
-      "makes the middle arm worth its own number: a junk-only write shows nothing and still pays " +
-      "a full sweep. refreshMisses proves each arm reconciled its own write — the visible file as " +
-      "a row, the junk file as a hidden tally and never a row, and the edit as the file's new " +
-      "byte length in the re-listed nodes, which a sweep that skipped the re-read cannot produce.",
+      "re-list → flattenTree/countHiddenRows path, committing one listings-map copy per accepted " +
+      "response exactly as the panel does. The scoped arms derive their directory set by feeding " +
+      "ABSOLUTE paths through the production conversion helper, so an absolute-vs-relative " +
+      "mismatch scores as a full sweep rather than passing silently. refreshMisses proves every " +
+      "arm reconciled its own write — the visible file as a row, the junk file as a hidden tally " +
+      "and never a row, the edit as the file's new byte length, and each burst file as a row in " +
+      "the directory it landed in — which a sweep that skipped the re-read cannot produce.",
     tier: "heavy",
     modes: ["smoke", "ci", "nightly"],
     iterations: { smoke: 5, ci: 10, nightly: 14 },
@@ -371,6 +378,7 @@ export const panelScenarios: PerfScenario[] = [
       const tree = fixture.mutable;
       const alwaysHiddenPatterns = await loadAlwaysHiddenPatterns();
       const browserTree = await loadBrowserTreeModule();
+      const { affectedDirsForBurst } = await loadAffectedDirsModule();
       const expanded = new Set(tree.directories);
       const isVisible = browserTree.createVisibilityFilter({
         hideDotfiles: false,
@@ -394,15 +402,35 @@ export const panelScenarios: PerfScenario[] = [
         token
       );
 
-      let refreshTargetCount = 0;
-      let relistedNodeCount = 0;
-
-      /** One full refresh over whatever is on disk now, timed end to end. */
-      const sweep = async () => {
+      /**
+       * One refresh over whatever is on disk now, timed end to end.
+       *
+       * `affectedDirs` is the watcher's answer for the burst that preceded this
+       * sweep, or null for the unscoped sweep the panel took before #12244.
+       *
+       * Each returned listing is merged under its own fresh Map, never swapped
+       * in wholesale: that is one copy per accepted response, which is what the
+       * panel's `setListings` actually does — and a wholesale swap would also
+       * discard every directory a scoped sweep deliberately did not re-read.
+       */
+      const sweep = async (affectedDirs: ReadonlySet<string> | null = null) => {
         const startedAt = performance.now();
-        const targets = browserTree.refreshTargets(listings, expanded, "", isVisible, null);
+        const targets = browserTree.refreshTargets(
+          listings,
+          expanded,
+          "",
+          isVisible,
+          null,
+          affectedDirs
+        );
         const swept = await listDirectories(tree.path, targets);
-        listings = swept.listings;
+        let listingsMapCopies = 0;
+        for (const [dirPath, nodes] of swept.listings) {
+          const next = new Map(listings);
+          next.set(dirPath, nodes);
+          listings = next;
+          listingsMapCopies += 1;
+        }
         const rows = browserTree.flattenTree(
           listings,
           expanded,
@@ -415,16 +443,30 @@ export const panelScenarios: PerfScenario[] = [
           hideDotfiles: false,
           alwaysHiddenPatterns,
         });
-        refreshTargetCount = targets.length;
-        relistedNodeCount = swept.nodes;
         return {
           ms: performance.now() - startedAt,
+          directoryRequests: targets.length,
+          listingsMapCopies,
+          relistedNodes: swept.nodes,
           rowPaths: rowPathSet(rows),
           rowCount: rows.length,
           hiddenJunk: hidden.alwaysHidden,
           touchedSize: listedSizeOf(listings, mutation.touchedPath),
         };
       };
+
+      /**
+       * The directory scope a burst of absolute paths resolves to, through the
+       * production helper. A conversion that fails hands back null, which is
+       * the full sweep — so an arm that expected to be scoped scores its
+       * unscoped request count and the regression is visible in the number.
+       */
+      const scopeFor = (absolutePaths: readonly string[]): ReadonlySet<string> | null => {
+        const dirs = affectedDirsForBurst(new Set(absolutePaths), tree.path, null);
+        return dirs === null ? null : new Set(dirs);
+      };
+
+      const burstsToRevert: Array<{ revert: () => void }> = [];
 
       try {
         // Every arm's expectation, from the manifest: the added visible file is
@@ -444,25 +486,87 @@ export const panelScenarios: PerfScenario[] = [
         mutation.writeTouch();
         const editSweep = await sweep();
 
-        const refreshMisses =
+        // Scored before the scoped arms write anything. `expectedRows` is a
+        // live set that each arm below adds to, and an arm can only be held to
+        // the rows that existed when it ran.
+        const unscopedMisses =
           setDifferenceCount(expectedRows, visibleSweep.rowPaths) +
           setDifferenceCount(expectedRows, ignoredOnlySweep.rowPaths) +
-          setDifferenceCount(expectedRows, editSweep.rowPaths) +
+          setDifferenceCount(expectedRows, editSweep.rowPaths);
+
+        // The scoped arms, each over the same fully-listed tree the unscoped
+        // ones left behind. Every burst's expected rows accumulate, so a later
+        // arm also re-proves that an earlier arm's directories were not thrown
+        // away by a sweep that skipped them.
+        const runScopedArm = async (dirs: readonly string[], count: number, suffix: string) => {
+          const burst = writeBurst(tree, dirs, count, `${token}${suffix}`);
+          // Registered before the write so a failure mid-arm still cleans up.
+          burstsToRevert.push(burst);
+          burst.write();
+          for (const path of burst.paths) expectedRows.add(path);
+          // Snapshotted here: this arm has to account for every row expected so
+          // far, not just its own — a scoped sweep that dropped the listings it
+          // deliberately did not re-read loses the earlier arms' rows, and that
+          // is precisely the failure this arm exists to catch.
+          const expectedNow = new Set(expectedRows);
+          const swept = await sweep(scopeFor(burst.absolutePaths));
+          return { ...swept, misses: setDifferenceCount(expectedNow, swept.rowPaths) };
+        };
+
+        const subtreeSweep = await runScopedArm([targetDirs[4] ?? ""], 1, "s");
+        const rootSweep = await runScopedArm([""], 1, "r");
+        const multiSweep = await runScopedArm(
+          [targetDirs[5] ?? "", targetDirs[6] ?? "", targetDirs[7] ?? ""],
+          20,
+          "m"
+        );
+
+        const refreshMisses =
+          unscopedMisses +
           Math.abs(visibleSweep.hiddenJunk - baseHiddenJunk) +
           Math.abs(ignoredOnlySweep.hiddenJunk - (baseHiddenJunk + 1)) +
           Math.abs(editSweep.hiddenJunk - (baseHiddenJunk + 1)) +
           (visibleSweep.touchedSize === mutation.touchedBytesBefore ? 0 : 1) +
           (ignoredOnlySweep.touchedSize === mutation.touchedBytesBefore ? 0 : 1) +
-          (editSweep.touchedSize === mutation.touchedBytesAfter ? 0 : 1);
+          (editSweep.touchedSize === mutation.touchedBytesAfter ? 0 : 1) +
+          // Each scoped arm against the rows expected at its own point.
+          subtreeSweep.misses +
+          rootSweep.misses +
+          multiSweep.misses +
+          // The edited file's size has to survive the scoped arms untouched:
+          // they never re-read its directory, so a stale value here means a
+          // scoped sweep discarded a listing it was right not to re-request.
+          (multiSweep.touchedSize === mutation.touchedBytesAfter ? 0 : 1);
 
         return {
-          durationMs: visibleSweep.ms + ignoredOnlySweep.ms + editSweep.ms,
+          durationMs:
+            visibleSweep.ms +
+            ignoredOnlySweep.ms +
+            editSweep.ms +
+            subtreeSweep.ms +
+            rootSweep.ms +
+            multiSweep.ms,
           metrics: {
             sweepMs: visibleSweep.ms,
             ignoredOnlySweepMs: ignoredOnlySweep.ms,
             inPlaceEditSweepMs: editSweep.ms,
-            refreshTargetCount,
-            relistedNodeCount,
+            // The before-numbers the scoped arms are read against: one unscoped
+            // sweep over this tree, whatever moved.
+            fullDirectoryRequests: visibleSweep.directoryRequests,
+            fullListingsMapCopies: visibleSweep.listingsMapCopies,
+            scopedSubtreeSweepMs: subtreeSweep.ms,
+            scopedSubtreeDirectoryRequests: subtreeSweep.directoryRequests,
+            scopedSubtreeListingsMapCopies: subtreeSweep.listingsMapCopies,
+            scopedRootSweepMs: rootSweep.ms,
+            scopedRootDirectoryRequests: rootSweep.directoryRequests,
+            scopedRootListingsMapCopies: rootSweep.listingsMapCopies,
+            scopedMultiSweepMs: multiSweep.ms,
+            scopedMultiDirectoryRequests: multiSweep.directoryRequests,
+            scopedMultiListingsMapCopies: multiSweep.listingsMapCopies,
+            // Still the UNSCOPED sweep's shape, so the pre-existing series keeps
+            // measuring the same thing now that scoped arms follow it.
+            refreshTargetCount: editSweep.directoryRequests,
+            relistedNodeCount: editSweep.relistedNodes,
             rowCount: visibleSweep.rowCount,
             hiddenJunkCount: editSweep.hiddenJunk,
             refreshMisses,
@@ -474,6 +578,7 @@ export const panelScenarios: PerfScenario[] = [
         };
       } finally {
         mutation.revert();
+        for (const burst of burstsToRevert) burst.revert();
       }
     },
   },

--- a/scripts/perf/scenarios/panels.ts
+++ b/scripts/perf/scenarios/panels.ts
@@ -488,7 +488,18 @@ export const panelScenarios: PerfScenario[] = [
        */
       const scopeFor = (absolutePaths: readonly string[]): ReadonlySet<string> | null => {
         const dirs = affectedDirsForBurst(new Set(absolutePaths), tree.path, null);
-        return dirs === null ? null : new Set(dirs);
+        if (dirs === null) return null;
+        // Widened with each directory's parent exactly as the tree hook does:
+        // a directory's own row — its mtime, the Modified column, the sort that
+        // reads it — lives in its parent's listing. Pricing the raw burst
+        // instead would measure a scope the product never uses.
+        const scoped = new Set<string>();
+        for (const dir of dirs) {
+          scoped.add(dir);
+          const slash = dir.lastIndexOf("/");
+          scoped.add(slash === -1 ? "" : dir.slice(0, slash));
+        }
+        return scoped;
       };
 
       const burstsToRevert: Array<{ revert: () => void }> = [];

--- a/scripts/perf/scenarios/panels.ts
+++ b/scripts/perf/scenarios/panels.ts
@@ -409,9 +409,18 @@ export const panelScenarios: PerfScenario[] = [
        * sweep, or null for the unscoped sweep the panel took before #12244.
        *
        * Each returned listing is merged under its own fresh Map, never swapped
-       * in wholesale: that is one copy per accepted response, which is what the
-       * panel's `setListings` actually does — and a wholesale swap would also
-       * discard every directory a scoped sweep deliberately did not re-read.
+       * in wholesale. MERGING is what a scoped sweep requires — a wholesale
+       * swap would discard every directory it deliberately did not re-read —
+       * and ONE COPY PER RESPONSE is the fidelity choice on top of that: it is
+       * what the panel's `setListings` does, where a single merged copy would
+       * price a batching layer the panel does not have.
+       *
+       * That second half moves the three unscoped arms' durations: they now
+       * carry per-response copies they previously did not. `sweepMs`,
+       * `ignoredOnlySweepMs` and `inPlaceEditSweepMs` are therefore not
+       * comparable across this change, and neither is `durationMs` (three arms
+       * became six). Compare implementations under this harness, not against
+       * readings taken before it.
        */
       const sweep = async (affectedDirs: ReadonlySet<string> | null = null) => {
         const startedAt = performance.now();
@@ -453,6 +462,22 @@ export const panelScenarios: PerfScenario[] = [
           hiddenJunk: hidden.alwaysHidden,
           touchedSize: listedSizeOf(listings, mutation.touchedPath),
         };
+      };
+
+      /**
+       * Pick `count` directories no two of which contain each other, so a
+       * multi-directory burst really does land in separate subtrees.
+       */
+      const disjointDirs = (candidates: readonly string[], count: number): string[] => {
+        const picked: string[] = [];
+        for (const candidate of candidates) {
+          if (picked.length === count) break;
+          const nested = picked.some(
+            (chosen) => candidate.startsWith(`${chosen}/`) || chosen.startsWith(`${candidate}/`)
+          );
+          if (!nested) picked.push(candidate);
+        }
+        return picked;
       };
 
       /**
@@ -515,11 +540,10 @@ export const panelScenarios: PerfScenario[] = [
 
         const subtreeSweep = await runScopedArm([targetDirs[4] ?? ""], 1, "s");
         const rootSweep = await runScopedArm([""], 1, "r");
-        const multiSweep = await runScopedArm(
-          [targetDirs[5] ?? "", targetDirs[6] ?? "", targetDirs[7] ?? ""],
-          20,
-          "m"
-        );
+        // Three subtrees that are genuinely disjoint, not a parent and two of
+        // its children: nesting still yields three targets, but it would not
+        // demonstrate what the arm claims to.
+        const multiSweep = await runScopedArm(disjointDirs(targetDirs, 3), 20, "m");
 
         const refreshMisses =
           unscopedMisses +
@@ -529,10 +553,16 @@ export const panelScenarios: PerfScenario[] = [
           (visibleSweep.touchedSize === mutation.touchedBytesBefore ? 0 : 1) +
           (ignoredOnlySweep.touchedSize === mutation.touchedBytesBefore ? 0 : 1) +
           (editSweep.touchedSize === mutation.touchedBytesAfter ? 0 : 1) +
-          // Each scoped arm against the rows expected at its own point.
+          // Each scoped arm against the rows expected at its own point, and
+          // against the hidden tally as well: a scoped response that dropped
+          // only the hidden entries would leave every visible row, request
+          // count and file size intact and score zero on rows alone.
           subtreeSweep.misses +
           rootSweep.misses +
           multiSweep.misses +
+          Math.abs(subtreeSweep.hiddenJunk - (baseHiddenJunk + 1)) +
+          Math.abs(rootSweep.hiddenJunk - (baseHiddenJunk + 1)) +
+          Math.abs(multiSweep.hiddenJunk - (baseHiddenJunk + 1)) +
           // The edited file's size has to survive the scoped arms untouched:
           // they never re-read its directory, so a stale value here means a
           // scoped sweep discarded a listing it was right not to re-request.

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -219,6 +219,23 @@ export interface WorktreeSnapshot {
    */
   workingTreeChangedAt?: number;
 
+  /**
+   * The worktree-relative parent directories of every path in the burst behind
+   * `workingTreeChangedAt` — `""` is the worktree root. Lets the file browser
+   * re-list only what changed instead of every expanded directory (#12244).
+   *
+   * Three distinct answers, and a consumer must keep them apart: absent means
+   * no burst has been described (an older host, or a stamp retained before the
+   * first snapshot), `null` means the burst could not be classified and
+   * everything must be re-read (the pre-#12244 behaviour), and `[]` means a
+   * real burst that resolved to no directory at all.
+   *
+   * Excluded from snapshot dedup and carried in the store's side map, for the
+   * same reason `workingTreeChangedAt` is: it advances on events that change
+   * nothing else in the snapshot.
+   */
+  workingTreeChangedDirs?: readonly string[] | null;
+
   /** True when this worktree's repo is in an auth-failed fetch state. */
   fetchAuthFailed?: boolean;
 

--- a/src/components/Fleet/__tests__/fleetBroadcast.test.ts
+++ b/src/components/Fleet/__tests__/fleetBroadcast.test.ts
@@ -83,7 +83,7 @@ function installViewStore(worktrees: Map<string, WorktreeSnapshot>) {
     worktrees,
     statusCheckedAt: new Map(),
     workingTreeChangedAtById: new Map(),
-      workingTreeChangedDirsById: new Map(),
+    workingTreeChangedDirsById: new Map(),
     manualAssociations: new Map(),
     version: { epoch: "", seq: 0 },
     tombstones: new Map(),

--- a/src/components/Fleet/__tests__/fleetBroadcast.test.ts
+++ b/src/components/Fleet/__tests__/fleetBroadcast.test.ts
@@ -83,6 +83,7 @@ function installViewStore(worktrees: Map<string, WorktreeSnapshot>) {
     worktrees,
     statusCheckedAt: new Map(),
     workingTreeChangedAtById: new Map(),
+      workingTreeChangedDirsById: new Map(),
     manualAssociations: new Map(),
     version: { epoch: "", seq: 0 },
     tombstones: new Map(),

--- a/src/panels/file-browser/FileBrowserPane.tsx
+++ b/src/panels/file-browser/FileBrowserPane.tsx
@@ -395,6 +395,21 @@ export function FileBrowserPane({
   // One tick contract for `useFileBrowserTree`, whichever side supplied it.
   const changeTick = worktreeChangeTick ?? externalChangeTick;
 
+  // The directories behind the latest raw-filesystem tick (#12244). Handed over
+  // whole rather than pre-judged against `changeTick`: the record carries the
+  // stamp it describes and the one it superseded, and the tree is the only
+  // layer that knows which tick it last acted on — the test for "does this
+  // scope actually cover everything since then" belongs where that cursor
+  // lives. A workspace root gets nothing here, exactly as it gets nothing from
+  // the two tick maps (#11482), and falls back to the full refresh.
+  const changedDirs = useWorktreeStore(
+    useCallback(
+      (state) =>
+        sourceWorktreeId ? state.workingTreeChangedDirsById.get(sourceWorktreeId) : undefined,
+      [sourceWorktreeId]
+    )
+  );
+
   const {
     rows,
     isInitialLoading,
@@ -418,6 +433,7 @@ export function FileBrowserPane({
     alwaysHiddenPatterns,
     rootPath,
     changeTick,
+    changedDirs,
     treeSnapshot,
     sort,
     selectedPath,

--- a/src/panels/file-browser/FileBrowserPane.tsx
+++ b/src/panels/file-browser/FileBrowserPane.tsx
@@ -434,6 +434,7 @@ export function FileBrowserPane({
     rootPath,
     changeTick,
     changedDirs,
+    gitChangeTick,
     treeSnapshot,
     sort,
     selectedPath,

--- a/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
@@ -243,7 +243,17 @@ vi.mock("@/hooks/useWorktreeStore", () => ({
       workingTreeChangedDirsById: new Map(
         worktreeTicks.fs === undefined
           ? []
-          : [["wt-1", { at: worktreeTicks.fs, previousAt: null, dirs: worktreeTicks.dirs }]]
+          : [
+              [
+                "wt-1",
+                {
+                  at: worktreeTicks.fs,
+                  previousAt: null,
+                  dirs: worktreeTicks.dirs,
+                  run: "test-run",
+                },
+              ],
+            ]
       ),
     }),
 }));
@@ -1682,7 +1692,12 @@ describe("promoted workspace-rooted browser (#11489)", () => {
     renderPane({ worktreeId: "wt-1" });
 
     expect(treeArgs.changeTick).toBe(300);
-    expect(treeArgs.changedDirs).toEqual({ at: 300, previousAt: null, dirs: ["src/panels"] });
+    expect(treeArgs.changedDirs).toEqual({
+      at: 300,
+      previousAt: null,
+      dirs: ["src/panels"],
+      run: "test-run",
+    });
   });
 
   it("hands over an unclassifiable burst as-is rather than dropping the record", () => {
@@ -1692,7 +1707,12 @@ describe("promoted workspace-rooted browser (#11489)", () => {
     worktreeTicks.dirs = null;
     renderPane({ worktreeId: "wt-1" });
 
-    expect(treeArgs.changedDirs).toEqual({ at: 300, previousAt: null, dirs: null });
+    expect(treeArgs.changedDirs).toEqual({
+      at: 300,
+      previousAt: null,
+      dirs: null,
+      run: "test-run",
+    });
   });
 
   it("hands over nothing when the worktree has seen no filesystem write", () => {

--- a/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
@@ -123,8 +123,8 @@ const {
     treeArgs: {
       changeTick: undefined as number | undefined,
       changedDirs: undefined as
-        | { at: number; previousAt: number | null; dirs: readonly string[] | null }
-        | undefined,
+        { at: number; previousAt: number | null; dirs: readonly string[] | null } | undefined,
+      gitChangeTick: undefined as number | undefined,
       sort: undefined as { key: string; direction: string } | undefined,
       selectedPath: undefined as string | null | undefined,
     },
@@ -254,11 +254,14 @@ vi.mock("@/hooks/useWorktreeStore", () => ({
 vi.mock("../useFileBrowserTree", () => ({
   useFileBrowserTree: (args: {
     changeTick?: number;
+    changedDirs?: { at: number; previousAt: number | null; dirs: readonly string[] | null };
+    gitChangeTick?: number;
     sort?: { key: string; direction: string };
     selectedPath?: string | null;
   }) => {
     treeArgs.changeTick = args.changeTick;
     treeArgs.changedDirs = args.changedDirs;
+    treeArgs.gitChangeTick = args.gitChangeTick;
     treeArgs.sort = args.sort;
     treeArgs.selectedPath = args.selectedPath;
     // The real hook resolves this against its listings map; here the stubbed
@@ -606,6 +609,7 @@ beforeEach(() => {
   mockPanel.browserExpandedPaths = undefined;
   treeArgs.changeTick = undefined;
   treeArgs.changedDirs = undefined;
+  treeArgs.gitChangeTick = undefined;
   treeProps.onActivate = undefined;
   treeProps.onInsertFileReference = undefined;
   treeProps.canInsertFileReference = undefined;
@@ -1697,6 +1701,18 @@ describe("promoted workspace-rooted browser (#11489)", () => {
 
     expect(treeArgs.changeTick).toBe(450);
     expect(treeArgs.changedDirs).toBeUndefined();
+  });
+
+  it("hands the git half of the tick over separately", () => {
+    // `changeTick` is the max of the two, which hides a git-status pass a later
+    // filesystem burst outran inside one React batch — the tree needs the git
+    // stamp itself to notice one it never acted on.
+    worktreeTicks.git = 150;
+    worktreeTicks.fs = 300;
+    renderPane({ worktreeId: "wt-1" });
+
+    expect(treeArgs.changeTick).toBe(300);
+    expect(treeArgs.gitChangeTick).toBe(150);
   });
 
   it("ignores the placement worktree's change ticks once workspace-rooted", () => {

--- a/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
+++ b/src/panels/file-browser/__tests__/FileBrowserPane.test.tsx
@@ -122,11 +122,19 @@ const {
     // change tick rather than only what renders.
     treeArgs: {
       changeTick: undefined as number | undefined,
+      changedDirs: undefined as
+        | { at: number; previousAt: number | null; dirs: readonly string[] | null }
+        | undefined,
       sort: undefined as { key: string; direction: string } | undefined,
       selectedPath: undefined as string | null | undefined,
     },
     // Ticks the worktree store reports for wt-1; both default to "never moved".
-    worktreeTicks: { git: undefined as number | undefined, fs: undefined as number | undefined },
+    worktreeTicks: {
+      git: undefined as number | undefined,
+      fs: undefined as number | undefined,
+      // Directories the fs tick's burst touched, or null for "unknown" (#12244).
+      dirs: null as readonly string[] | null,
+    },
     // The rest of what the store reports for wt-1. `changes` stays null by
     // default so the bulk of this suite keeps the lastUpdated-only snapshot
     // shape it was written against — which is also a real runtime state (the
@@ -229,6 +237,14 @@ vi.mock("@/hooks/useWorktreeStore", () => ({
       workingTreeChangedAtById: new Map<string, number>(
         worktreeTicks.fs === undefined ? [] : [["wt-1", worktreeTicks.fs]]
       ),
+      // And the affected-directory record that rides the same stamp (#12244) —
+      // absent for a worktree that has seen no burst, which is the "re-read
+      // everything" answer the tree already took before scoping existed.
+      workingTreeChangedDirsById: new Map(
+        worktreeTicks.fs === undefined
+          ? []
+          : [["wt-1", { at: worktreeTicks.fs, previousAt: null, dirs: worktreeTicks.dirs }]]
+      ),
     }),
 }));
 
@@ -242,6 +258,7 @@ vi.mock("../useFileBrowserTree", () => ({
     selectedPath?: string | null;
   }) => {
     treeArgs.changeTick = args.changeTick;
+    treeArgs.changedDirs = args.changedDirs;
     treeArgs.sort = args.sort;
     treeArgs.selectedPath = args.selectedPath;
     // The real hook resolves this against its listings map; here the stubbed
@@ -588,6 +605,7 @@ beforeEach(() => {
   mockPanel.browserWorkspaceRooted = undefined;
   mockPanel.browserExpandedPaths = undefined;
   treeArgs.changeTick = undefined;
+  treeArgs.changedDirs = undefined;
   treeProps.onActivate = undefined;
   treeProps.onInsertFileReference = undefined;
   treeProps.canInsertFileReference = undefined;
@@ -603,6 +621,7 @@ beforeEach(() => {
   dispatchMock.mockResolvedValue({ ok: true, result: { panelId: "file-1" } });
   worktreeTicks.git = undefined;
   worktreeTicks.fs = undefined;
+  worktreeTicks.dirs = null;
   worktreeMock.path = "/repo";
   worktreeMock.changes = null;
   worktreeMock.changesRootPath = "/repo";
@@ -1651,6 +1670,33 @@ describe("promoted workspace-rooted browser (#11489)", () => {
     renderPane({ worktreeId: "wt-1" });
 
     expect(treeArgs.changeTick).toBe(300);
+  });
+
+  it("hands the tree the affected directories behind its own filesystem tick", () => {
+    worktreeTicks.fs = 300;
+    worktreeTicks.dirs = ["src/panels"];
+    renderPane({ worktreeId: "wt-1" });
+
+    expect(treeArgs.changeTick).toBe(300);
+    expect(treeArgs.changedDirs).toEqual({ at: 300, previousAt: null, dirs: ["src/panels"] });
+  });
+
+  it("hands over an unclassifiable burst as-is rather than dropping the record", () => {
+    // `null` dirs and no record at all both end in a full refresh, but they are
+    // different states and the pane is not the layer that decides between them.
+    worktreeTicks.fs = 300;
+    worktreeTicks.dirs = null;
+    renderPane({ worktreeId: "wt-1" });
+
+    expect(treeArgs.changedDirs).toEqual({ at: 300, previousAt: null, dirs: null });
+  });
+
+  it("hands over nothing when the worktree has seen no filesystem write", () => {
+    worktreeTicks.git = 450;
+    renderPane({ worktreeId: "wt-1" });
+
+    expect(treeArgs.changeTick).toBe(450);
+    expect(treeArgs.changedDirs).toBeUndefined();
   });
 
   it("ignores the placement worktree's change ticks once workspace-rooted", () => {

--- a/src/panels/file-browser/__tests__/fileBrowserTree.test.ts
+++ b/src/panels/file-browser/__tests__/fileBrowserTree.test.ts
@@ -428,6 +428,112 @@ describe("refreshTargets", () => {
       refreshTargets(listings, new Set([".cache", ".cache/inner", "src"]), "", isVisible)
     ).toEqual(["", "src"]);
   });
+
+  // ---- Scoped targets (#12244) ----
+
+  const scopedListings = () =>
+    listingsOf({
+      "": [dir("a"), dir("b"), file("top.txt")],
+      a: [dir("a/deep"), file("a/one.ts")],
+      "a/deep": [file("a/deep/two.ts")],
+      b: [file("b/three.ts")],
+    });
+  const scopedExpanded = new Set(["a", "a/deep", "b"]);
+
+  it("emits only the affected directory, and does not add the root for free", () => {
+    expect(
+      refreshTargets(scopedListings(), scopedExpanded, "", undefined, null, new Set(["a/deep"]))
+    ).toEqual(["a/deep"]);
+  });
+
+  it("emits the root exactly when a top-level entry changed", () => {
+    // The affected set names PARENTS, so "" appears in it precisely when
+    // something directly inside the root moved.
+    expect(
+      refreshTargets(scopedListings(), scopedExpanded, "", undefined, null, new Set([""]))
+    ).toEqual([""]);
+  });
+
+  it("reaches an affected descendant through unaffected ancestors", () => {
+    // `a` is not in the set and must not be re-read, but the walk still has to
+    // pass through it to establish that `a/deep` is reachable at all.
+    expect(
+      refreshTargets(scopedListings(), scopedExpanded, "", undefined, null, new Set(["a/deep"]))
+    ).toEqual(["a/deep"]);
+  });
+
+  it("still refuses an affected directory that is unreachable or hidden", () => {
+    const isVisible = createVisibilityFilter({ hideDotfiles: true, alwaysHiddenPatterns: [] });
+    const listings = listingsOf({
+      "": [dir(".cache"), dir("src")],
+      ".cache": [dir(".cache/inner")],
+      src: [file("src/a.ts")],
+    });
+
+    // Affected, expanded, and still not a target: it renders no row, and a
+    // scoped refresh narrows the full answer rather than bypassing it.
+    expect(
+      refreshTargets(
+        listings,
+        new Set([".cache", ".cache/inner", "src"]),
+        "",
+        isVisible,
+        null,
+        new Set([".cache/inner"])
+      )
+    ).toEqual([]);
+    // Same for a directory nothing has a row for at all.
+    expect(
+      refreshTargets(
+        scopedListings(),
+        scopedExpanded,
+        "",
+        undefined,
+        null,
+        new Set(["never/listed"])
+      )
+    ).toEqual([]);
+  });
+
+  it("returns nothing for a burst that resolved to no directory", () => {
+    expect(
+      refreshTargets(scopedListings(), scopedExpanded, "", undefined, null, new Set())
+    ).toEqual([]);
+  });
+
+  it("takes the full answer for a null scope, exactly as omitting it does", () => {
+    const full = refreshTargets(scopedListings(), scopedExpanded);
+    expect(refreshTargets(scopedListings(), scopedExpanded, "", undefined, null, null)).toEqual(
+      full
+    );
+    expect(full).toEqual(["", "a", "a/deep", "b"]);
+  });
+
+  it("re-reads the viewer's collapsed folder only when the change landed in it", () => {
+    const listings = scopedListings();
+    // `b` is listed for the viewer but collapsed out of the tree (#11620).
+    const expanded = new Set(["a", "a/deep"]);
+
+    expect(refreshTargets(listings, expanded, "", undefined, "b", new Set(["b"]))).toEqual(["b"]);
+    expect(refreshTargets(listings, expanded, "", undefined, "b", new Set(["a/deep"]))).toEqual([
+      "a/deep",
+    ]);
+  });
+
+  it("scopes against a browse root without re-listing it unasked", () => {
+    const listings = listingsOf({
+      "": [dir("src")],
+      src: [dir("src/lib"), file("src/a.ts")],
+      "src/lib": [file("src/lib/util.ts")],
+    });
+
+    expect(
+      refreshTargets(listings, new Set(["src/lib"]), "src", undefined, null, new Set(["src/lib"]))
+    ).toEqual(["src/lib"]);
+    expect(
+      refreshTargets(listings, new Set(["src/lib"]), "src", undefined, null, new Set(["src"]))
+    ).toEqual(["src"]);
+  });
 });
 
 describe("createVisibilityFilter", () => {

--- a/src/panels/file-browser/__tests__/useFileBrowserTree.test.tsx
+++ b/src/panels/file-browser/__tests__/useFileBrowserTree.test.tsx
@@ -2188,9 +2188,9 @@ describe("useFileBrowserTree failure recovery edge cases (#11620)", () => {
 
     const EXPANDED = ["a", "a/deep", "b"];
 
-    /** A store record for one burst. */
+    /** A store record for one burst, all from the same host run. */
     function burst(at: number, previousAt: number | null, dirs: readonly string[] | null) {
-      return { at, previousAt, dirs };
+      return { at, previousAt, dirs, run: "test-run" };
     }
 
     /** Which directories a run of the hook asked for, root as "". */
@@ -2245,7 +2245,7 @@ describe("useFileBrowserTree failure recovery edge cases (#11620)", () => {
       await act(() => settle());
     }
 
-    it("re-lists only the touched directory, leaving the rest of the tree alone", async () => {
+    it("re-lists the touched directory and its parent, leaving the rest alone", async () => {
       mockThreeBranches();
       const base: TickProps = { changeTick: 1, changedDirs: undefined };
       const { rerender } = await mountTree(base);
@@ -2255,7 +2255,10 @@ describe("useFileBrowserTree failure recovery edge cases (#11620)", () => {
       rerender({ ...base, changeTick: 200, changedDirs: burst(200, 100, ["a/deep"]) });
       await act(() => settle());
 
-      expect(requested(from)).toEqual(["a/deep"]);
+      // `a/deep` for its contents, `a` because that is where `a/deep`'s own row
+      // lives — its mtime, the Modified column and the sort that reads it. The
+      // root and `b` are untouched.
+      expect(requested(from).sort()).toEqual(["a", "a/deep"]);
     });
 
     it("re-lists only the root when a top-level entry changed", async () => {
@@ -2281,7 +2284,8 @@ describe("useFileBrowserTree failure recovery edge cases (#11620)", () => {
       rerender({ ...base, changeTick: 200, changedDirs: burst(200, 100, ["a", "b"]) });
       await act(() => settle());
 
-      expect(requested(from).sort()).toEqual(["a", "b"]);
+      // Both, plus the root they both sit in — still four short of the sweep.
+      expect(requested(from).sort()).toEqual(["", "a", "b"]);
     });
 
     it("ignores a touched directory that is not on screen", async () => {
@@ -2367,7 +2371,7 @@ describe("useFileBrowserTree failure recovery edge cases (#11620)", () => {
       const secondFrom = listDirectory.mock.calls.length;
       rerender({ ...base, changeTick: 200, changedDirs: burst(200, 100, ["a"]) });
       await act(() => settle());
-      expect(requested(secondFrom)).toEqual(["a"]);
+      expect(requested(secondFrom).sort()).toEqual(["", "a"]);
     });
 
     it("advances the cursor across a full sweep so the tick after it scopes", async () => {
@@ -2383,7 +2387,7 @@ describe("useFileBrowserTree failure recovery edge cases (#11620)", () => {
       const from = listDirectory.mock.calls.length;
       rerender({ ...base, changeTick: 300, changedDirs: burst(300, 200, ["b"]) });
       await act(() => settle());
-      expect(requested(from)).toEqual(["b"]);
+      expect(requested(from).sort()).toEqual(["", "b"]);
     });
 
     it("keeps a manual refresh a full sweep whatever the last burst said", async () => {
@@ -2469,7 +2473,7 @@ describe("useFileBrowserTree failure recovery edge cases (#11620)", () => {
       rerender({ ...base, changeTick: 200, changedDirs: burst(200, 100, ["b"]) });
       await act(() => settle());
 
-      expect(requested(from).sort()).toEqual(["a/deep", "b"]);
+      expect(requested(from).sort()).toEqual(["", "a/deep", "b"]);
       await waitFor(() =>
         expect(result.current.rows.map((row) => row.path)).toContain("a/deep/two.ts")
       );
@@ -2508,7 +2512,7 @@ describe("useFileBrowserTree failure recovery edge cases (#11620)", () => {
       // read that started before the change, so it has to be re-read after.
       rerender({ ...base, changeTick: 300, changedDirs: burst(300, 200, ["a/deep", "b"]) });
       await act(() => settle());
-      expect(requested(from)).toEqual(["b"]);
+      expect(requested(from).sort()).toEqual(["", "a", "b"]);
 
       holdDeep = false;
       await act(async () => {
@@ -2517,7 +2521,7 @@ describe("useFileBrowserTree failure recovery edge cases (#11620)", () => {
       });
 
       // The replay is the union of what collided — "a/deep" — and nothing wider.
-      expect(requested(from).sort()).toEqual(["a/deep", "b"]);
+      expect(requested(from).sort()).toEqual(["", "a", "a/deep", "b"]);
     });
 
     it("unions successive deferred scopes rather than keeping only the last", async () => {
@@ -2766,7 +2770,9 @@ describe("useFileBrowserTree failure recovery edge cases (#11620)", () => {
       rerender({ ...base, changeTick: 200, changedDirs: burst(200, 100, ["b"]) });
       await act(() => settle());
 
-      expect(requested(from)).toContain("");
+      // Exactly the root and the burst's own directory — `toContain("")` would
+      // have been satisfied by a full sweep, which is what this used to do.
+      expect(requested(from).sort()).toEqual(["", "b"]);
       await waitFor(() => expect(result.current.rootError).toBeNull());
     });
 
@@ -2835,7 +2841,7 @@ describe("useFileBrowserTree failure recovery edge cases (#11620)", () => {
         changedDirs: burst(300, 200, ["b"]),
       });
       await act(() => settle());
-      expect(requested(next)).toEqual(["b"]);
+      expect(requested(next).sort()).toEqual(["", "b"]);
     });
 
     it("asks for nothing on a burst that resolved to no directory", async () => {
@@ -2855,7 +2861,7 @@ describe("useFileBrowserTree failure recovery edge cases (#11620)", () => {
       const next = listDirectory.mock.calls.length;
       rerender({ ...base, changeTick: 300, changedDirs: burst(300, 200, ["b"]) });
       await act(() => settle());
-      expect(requested(next)).toEqual(["b"]);
+      expect(requested(next).sort()).toEqual(["", "b"]);
     });
 
     it("resets the cursor on a worktree switch so the new tree's first tick is full", async () => {
@@ -2963,12 +2969,12 @@ describe("useFileBrowserTree failure recovery edge cases (#11620)", () => {
       const from = listDirectory.mock.calls.length;
       harness.rerender({ ...base, changeTick: 200, changedDirs: burst(200, 100, ["b"]) });
       await act(() => settle());
-      expect(requested(from)).toEqual(["b"]);
+      expect(requested(from).sort()).toEqual(["", "b"]);
 
       const next = listDirectory.mock.calls.length;
       harness.rerender({ ...base, changeTick: 300, changedDirs: burst(300, 200, ["a"]) });
       await act(() => settle());
-      expect(requested(next)).toEqual(["a"]);
+      expect(requested(next).sort()).toEqual(["", "a"]);
     });
   });
 });

--- a/src/panels/file-browser/__tests__/useFileBrowserTree.test.tsx
+++ b/src/panels/file-browser/__tests__/useFileBrowserTree.test.tsx
@@ -2201,6 +2201,7 @@ describe("useFileBrowserTree failure recovery edge cases (#11620)", () => {
     interface TickProps {
       changeTick: number | undefined;
       changedDirs: ReturnType<typeof burst> | undefined;
+      gitChangeTick?: number;
       rootPath?: string;
       selectedPath?: string | null;
     }
@@ -2215,6 +2216,7 @@ describe("useFileBrowserTree failure recovery edge cases (#11620)", () => {
             alwaysHiddenPatterns: [],
             changeTick: props.changeTick,
             changedDirs: props.changedDirs,
+            gitChangeTick: props.gitChangeTick,
             rootPath: props.rootPath,
             selectedPath: props.selectedPath ?? null,
           }),
@@ -2432,9 +2434,7 @@ describe("useFileBrowserTree failure recovery edge cases (#11620)", () => {
       await primeCursor(harness.rerender, base);
 
       const from = listDirectory.mock.calls.length;
-      rerender_ancestor: {
-        harness.rerender({ ...base, changeTick: 200, changedDirs: burst(200, 100, [""]) });
-      }
+      harness.rerender({ ...base, changeTick: 200, changedDirs: burst(200, 100, [""]) });
       await act(() => settle());
 
       expect(requested(from).sort()).toEqual(["a", "a/deep"]);
@@ -2520,6 +2520,66 @@ describe("useFileBrowserTree failure recovery edge cases (#11620)", () => {
       expect(requested(from).sort()).toEqual(["a/deep", "b"]);
     });
 
+    it("unions successive deferred scopes rather than keeping only the last", async () => {
+      // Two directories held open at once, each collided by its own tick. If
+      // the merge kept only the newest scope, the first collision's directory
+      // would never be re-read — the exact "mutations arrive while a refresh is
+      // in flight get dropped" failure.
+      const deepGate = deferred<FileTreeNode[]>();
+      const bGate = deferred<FileTreeNode[]>();
+      let holdDeep = false;
+      let holdB = false;
+      listDirectory.mockImplementation(async (payload) => {
+        if (payload.dirPath === "a/deep" && holdDeep) return deepGate.promise;
+        if (payload.dirPath === "b" && holdB) return bGate.promise;
+        switch (payload.dirPath) {
+          case undefined:
+            return [dir("a"), dir("b"), file("top.txt")];
+          case "a":
+            return [dir("a/deep"), file("a/one.ts")];
+          case "a/deep":
+            return [file("a/deep/two.ts")];
+          case "b":
+            return [file("b/three.ts")];
+          default:
+            return [];
+        }
+      });
+      const base: TickProps = { changeTick: 1, changedDirs: undefined };
+      const { rerender } = await mountTree(base);
+      await primeCursor(rerender, base);
+
+      // Open a read of "a/deep" and hold it.
+      holdDeep = true;
+      rerender({ ...base, changeTick: 200, changedDirs: burst(200, 100, ["a/deep"]) });
+      await act(() => settle());
+
+      // Open a read of "b" and hold that too.
+      holdB = true;
+      rerender({ ...base, changeTick: 300, changedDirs: burst(300, 200, ["b"]) });
+      await act(() => settle());
+
+      // Now collide with BOTH, one tick at a time, so two separate deferrals
+      // accumulate.
+      rerender({ ...base, changeTick: 400, changedDirs: burst(400, 300, ["a/deep"]) });
+      await act(() => settle());
+      rerender({ ...base, changeTick: 500, changedDirs: burst(500, 400, ["b"]) });
+      await act(() => settle());
+
+      // Boundary taken immediately before the gates release, so the replay's
+      // requests are the only thing measured.
+      const from = listDirectory.mock.calls.length;
+      holdDeep = false;
+      holdB = false;
+      await act(async () => {
+        deepGate.resolve([file("a/deep/two.ts")]);
+        bGate.resolve([file("b/three.ts")]);
+        await settle();
+      });
+
+      expect(requested(from).sort()).toEqual(["a/deep", "b"]);
+    });
+
     it("widens a deferred scope to the whole tree when a manual refresh collides", async () => {
       const gate = deferred<FileTreeNode[]>();
       let holdDeep = false;
@@ -2545,23 +2605,307 @@ describe("useFileBrowserTree failure recovery edge cases (#11620)", () => {
       holdDeep = true;
       rerender({ ...base, changeTick: 200, changedDirs: burst(200, 100, ["a/deep"]) });
       await act(() => settle());
-      const from = listDirectory.mock.calls.length;
 
       await act(async () => {
         result.current.refresh({ manual: true });
         await settle();
       });
 
+      // The boundary goes AFTER the manual press: the press issues its own
+      // requests for every idle target, and counting those would let a replay
+      // of the single deferred directory masquerade as a full sweep.
+      const from = listDirectory.mock.calls.length;
       holdDeep = false;
       await act(async () => {
         gate.resolve([file("a/deep/two.ts")]);
         await settle();
       });
 
-      // The manual press promoted the deferred scope, so the replay is the full
-      // sweep rather than the one directory the tick had asked for.
-      expect(requested(from)).toContain("a/deep");
-      expect(new Set(requested(from))).toEqual(new Set(["", "a", "a/deep", "b"]));
+      // The manual press promoted the deferred scope, so the replay itself is
+      // the full sweep rather than the one directory the tick asked for.
+      expect(requested(from).sort()).toEqual(["", "a", "a/deep", "b"]);
+    });
+
+    it("re-reads a directory that was replaced in place, and cascades down it", async () => {
+      // `rm -rf b && mv b.tmp b`: the name survives, so re-reading the parent
+      // shows `b` exactly as before and the stale cache underneath would stay
+      // on screen. The directory's own mtime is what gives the swap away.
+      let bMtime = 1_000;
+      const deepMtime = 5_000;
+      let swapped = false;
+      listDirectory.mockImplementation(async (payload) => {
+        switch (payload.dirPath) {
+          case undefined:
+            return [
+              { name: "a", path: "a", isDirectory: true, mtimeMs: 100 },
+              { name: "b", path: "b", isDirectory: true, mtimeMs: bMtime },
+              file("top.txt"),
+            ];
+          case "a":
+            return [{ name: "deep", path: "a/deep", isDirectory: true, mtimeMs: deepMtime }];
+          case "a/deep":
+            return [file("a/deep/two.ts")];
+          case "b":
+            return [file(swapped ? "b/replaced.ts" : "b/three.ts")];
+          default:
+            return [];
+        }
+      });
+      const base: TickProps = { changeTick: 1, changedDirs: undefined };
+      const harness = renderHook(
+        (props: TickProps) =>
+          useFileBrowserTree({
+            source: wtSource("wt-1"),
+            expandedPaths: EXPANDED,
+            hideDotfiles: false,
+            alwaysHiddenPatterns: [],
+            changeTick: props.changeTick,
+            changedDirs: props.changedDirs,
+          }),
+        { initialProps: base }
+      );
+      await waitFor(() => expect(listDirectory.mock.calls.length).toBe(4));
+      await act(() => settle());
+      await primeCursor(harness.rerender, base);
+
+      // The swap. The watcher saw only the directory itself move, so the burst
+      // names its PARENT — the root — and nothing below.
+      swapped = true;
+      bMtime = 2_000;
+      const from = listDirectory.mock.calls.length;
+      harness.rerender({ ...base, changeTick: 200, changedDirs: burst(200, 100, [""]) });
+      await act(() => settle());
+
+      // The root re-read plus `b`, which the mtime comparison caught.
+      expect(requested(from).sort()).toEqual(["", "b"]);
+      await waitFor(() =>
+        expect(harness.result.current.rows.map((row) => row.path)).toContain("b/replaced.ts")
+      );
+      expect(harness.result.current.rows.map((row) => row.path)).not.toContain("b/three.ts");
+    });
+
+    it("leaves an unchanged sibling alone when one directory was replaced", async () => {
+      // The cascade must be driven by the mtime, not by "the parent was read".
+      listDirectory.mockImplementation(async (payload) => {
+        switch (payload.dirPath) {
+          case undefined:
+            return [
+              { name: "a", path: "a", isDirectory: true, mtimeMs: 100 },
+              { name: "b", path: "b", isDirectory: true, mtimeMs: 200 },
+              file("top.txt"),
+            ];
+          case "a":
+            return [{ name: "deep", path: "a/deep", isDirectory: true, mtimeMs: 300 }];
+          case "a/deep":
+            return [file("a/deep/two.ts")];
+          case "b":
+            return [file("b/three.ts")];
+          default:
+            return [];
+        }
+      });
+      const base: TickProps = { changeTick: 1, changedDirs: undefined };
+      const harness = renderHook(
+        (props: TickProps) =>
+          useFileBrowserTree({
+            source: wtSource("wt-1"),
+            expandedPaths: EXPANDED,
+            hideDotfiles: false,
+            alwaysHiddenPatterns: [],
+            changeTick: props.changeTick,
+            changedDirs: props.changedDirs,
+          }),
+        { initialProps: base }
+      );
+      await waitFor(() => expect(listDirectory.mock.calls.length).toBe(4));
+      await act(() => settle());
+      await primeCursor(harness.rerender, base);
+
+      const from = listDirectory.mock.calls.length;
+      harness.rerender({ ...base, changeTick: 200, changedDirs: burst(200, 100, [""]) });
+      await act(() => settle());
+
+      expect(requested(from)).toEqual([""]);
+    });
+
+    it("retries a root whose backoff budget is spent, on a tick that named something else", async () => {
+      // A root failure is deliberately kept out of `failedListings`, so once the
+      // backoff is spent the panel sits on an error banner. The full sweep
+      // re-read the root every tick and cleared it; a scoped pass naming a
+      // descendant must not lose that.
+      let failRoot = false;
+      listDirectory.mockImplementation(async (payload) => {
+        if (payload.dirPath === undefined && failRoot) throw new Error("unreadable");
+        switch (payload.dirPath) {
+          case undefined:
+            return [dir("a"), dir("b"), file("top.txt")];
+          case "a":
+            return [dir("a/deep"), file("a/one.ts")];
+          case "a/deep":
+            return [file("a/deep/two.ts")];
+          case "b":
+            return [file("b/three.ts")];
+          default:
+            return [];
+        }
+      });
+      const base: TickProps = { changeTick: 1, changedDirs: undefined };
+      const { result, rerender } = await mountTree(base);
+      await primeCursor(rerender, base);
+
+      // Spend the whole retry schedule on a failing root.
+      failRoot = true;
+      await act(async () => {
+        result.current.refresh({ manual: true });
+        await settle();
+      });
+      await waitFor(() => expect(result.current.rootError).not.toBeNull(), { timeout: 4000 });
+
+      failRoot = false;
+      const from = listDirectory.mock.calls.length;
+      rerender({ ...base, changeTick: 200, changedDirs: burst(200, 100, ["b"]) });
+      await act(() => settle());
+
+      expect(requested(from)).toContain("");
+      await waitFor(() => expect(result.current.rootError).toBeNull());
+    });
+
+    it("takes the full sweep while a directory symlink is on screen", async () => {
+      // The alias is cached under the path the tree renders; the watcher
+      // reports writes under the link's target. A scoped pass would leave the
+      // alias stale, so its mere presence disables scoping (#11939).
+      listDirectory.mockImplementation(async (payload) => {
+        switch (payload.dirPath) {
+          case undefined:
+            return [dir("a"), dir("b"), file("top.txt")];
+          case "a":
+            return [
+              {
+                name: "deep",
+                path: "a/deep",
+                isDirectory: true,
+                symlink: { target: "../generated", targetKind: "directory" as const },
+              },
+              file("a/one.ts"),
+            ];
+          case "a/deep":
+            return [file("a/deep/two.ts")];
+          case "b":
+            return [file("b/three.ts")];
+          default:
+            return [];
+        }
+      });
+      const base: TickProps = { changeTick: 1, changedDirs: undefined };
+      const { rerender } = await mountTree(base);
+      await primeCursor(rerender, base);
+
+      const from = listDirectory.mock.calls.length;
+      rerender({ ...base, changeTick: 200, changedDirs: burst(200, 100, ["b"]) });
+      await act(() => settle());
+
+      expect(requested(from).sort()).toEqual(["", "a", "a/deep", "b"]);
+    });
+
+    it("takes the full sweep when a git-status pass was batched behind a newer burst", async () => {
+      mockThreeBranches();
+      const base: TickProps = { changeTick: 1, changedDirs: undefined, gitChangeTick: undefined };
+      const { rerender } = await mountTree(base);
+      await primeCursor(rerender, base);
+
+      const from = listDirectory.mock.calls.length;
+      // git 150 then fs 200 in one commit: `Math.max` reports 200 and the burst
+      // chain is intact, but git 150's own discovery was never re-read.
+      rerender({
+        ...base,
+        changeTick: 200,
+        gitChangeTick: 150,
+        changedDirs: burst(200, 100, ["b"]),
+      });
+      await act(() => settle());
+
+      expect(requested(from).sort()).toEqual(["", "a", "a/deep", "b"]);
+
+      // And once that git tick has been accounted for, scoping resumes.
+      const next = listDirectory.mock.calls.length;
+      rerender({
+        ...base,
+        changeTick: 300,
+        gitChangeTick: 150,
+        changedDirs: burst(300, 200, ["b"]),
+      });
+      await act(() => settle());
+      expect(requested(next)).toEqual(["b"]);
+    });
+
+    it("asks for nothing on a burst that resolved to no directory", async () => {
+      mockThreeBranches();
+      const base: TickProps = { changeTick: 1, changedDirs: undefined };
+      const { rerender } = await mountTree(base);
+      await primeCursor(rerender, base);
+
+      const from = listDirectory.mock.calls.length;
+      // Known-empty is a real answer and must not be read as "unknown".
+      rerender({ ...base, changeTick: 200, changedDirs: burst(200, 100, []) });
+      await act(() => settle());
+
+      expect(requested(from)).toEqual([]);
+
+      // The cursor still advanced, so the next burst scopes.
+      const next = listDirectory.mock.calls.length;
+      rerender({ ...base, changeTick: 300, changedDirs: burst(300, 200, ["b"]) });
+      await act(() => settle());
+      expect(requested(next)).toEqual(["b"]);
+    });
+
+    it("resets the cursor on a worktree switch so the new tree's first tick is full", async () => {
+      mockThreeBranches();
+      const harness = renderHook(
+        (props: TickProps & { worktreeId: string }) =>
+          useFileBrowserTree({
+            source: wtSource(props.worktreeId),
+            expandedPaths: EXPANDED,
+            hideDotfiles: false,
+            alwaysHiddenPatterns: [],
+            changeTick: props.changeTick,
+            changedDirs: props.changedDirs,
+          }),
+        {
+          initialProps: {
+            worktreeId: "wt-1",
+            changeTick: 1,
+            changedDirs: undefined,
+          } as TickProps & { worktreeId: string },
+        }
+      );
+      await waitFor(() => expect(listDirectory.mock.calls.length).toBe(4));
+      await act(() => settle());
+      harness.rerender({
+        worktreeId: "wt-1",
+        changeTick: 100,
+        changedDirs: burst(100, null, ["a"]),
+      });
+      await act(() => settle());
+
+      // Switch worktrees; the identity reset re-lists everything for wt-2.
+      harness.rerender({
+        worktreeId: "wt-2",
+        changeTick: 100,
+        changedDirs: burst(100, null, ["a"]),
+      });
+      await waitFor(() => expect(harness.result.current.rows).toHaveLength(7));
+      await act(() => settle());
+
+      // A continuous-looking burst under the NEW identity must still be full:
+      // the cursor it would chain off belonged to the tree we left.
+      const from = listDirectory.mock.calls.length;
+      harness.rerender({
+        worktreeId: "wt-2",
+        changeTick: 200,
+        changedDirs: burst(200, 100, ["b"]),
+      });
+      await act(() => settle());
+      expect(requested(from).sort()).toEqual(["", "a", "a/deep", "b"]);
     });
 
     it("leaves selection and expansion untouched across a scoped pass", async () => {
@@ -2627,5 +2971,4 @@ describe("useFileBrowserTree failure recovery edge cases (#11620)", () => {
       expect(requested(next)).toEqual(["a"]);
     });
   });
-
 });

--- a/src/panels/file-browser/__tests__/useFileBrowserTree.test.tsx
+++ b/src/panels/file-browser/__tests__/useFileBrowserTree.test.tsx
@@ -2159,4 +2159,473 @@ describe("useFileBrowserTree failure recovery edge cases (#11620)", () => {
     await waitFor(() => expect(result.current.selectedNode?.path).toBe("src/a.ts"));
     expect(result.current.selectedNode?.isDirectory).toBe(false);
   });
+
+  // ---- Scoped refresh: re-list only the directories a change touched (#12244) ----
+
+  describe("scoped refresh", () => {
+    /**
+     * A three-directory tree, fully expanded, so a scoped tick has somewhere to
+     * NOT go. Every listing is served from the shape rather than a queue, so a
+     * re-list returns the same content and only the call log distinguishes a
+     * scoped pass from a full one.
+     */
+    function mockThreeBranches(): void {
+      listDirectory.mockImplementation(async (payload) => {
+        switch (payload.dirPath) {
+          case undefined:
+            return [dir("a"), dir("b"), file("top.txt")];
+          case "a":
+            return [dir("a/deep"), file("a/one.ts")];
+          case "a/deep":
+            return [file("a/deep/two.ts")];
+          case "b":
+            return [file("b/three.ts")];
+          default:
+            return [];
+        }
+      });
+    }
+
+    const EXPANDED = ["a", "a/deep", "b"];
+
+    /** A store record for one burst. */
+    function burst(at: number, previousAt: number | null, dirs: readonly string[] | null) {
+      return { at, previousAt, dirs };
+    }
+
+    /** Which directories a run of the hook asked for, root as "". */
+    function requested(fromCall: number): string[] {
+      return listDirectory.mock.calls.slice(fromCall).map((call) => call[0].dirPath ?? "");
+    }
+
+    interface TickProps {
+      changeTick: number | undefined;
+      changedDirs: ReturnType<typeof burst> | undefined;
+      rootPath?: string;
+      selectedPath?: string | null;
+    }
+
+    async function mountTree(initialProps: TickProps) {
+      const harness = renderHook(
+        (props: TickProps) =>
+          useFileBrowserTree({
+            source: wtSource("wt-1"),
+            expandedPaths: EXPANDED,
+            hideDotfiles: false,
+            alwaysHiddenPatterns: [],
+            changeTick: props.changeTick,
+            changedDirs: props.changedDirs,
+            rootPath: props.rootPath,
+            selectedPath: props.selectedPath ?? null,
+          }),
+        { initialProps }
+      );
+      // The root plus the three expanded directories — waiting on the request
+      // count rather than a row tally keeps the helper usable by the arm where
+      // one of those listings deliberately fails.
+      await waitFor(() => expect(listDirectory.mock.calls.length).toBe(4));
+      await act(() => settle());
+      return harness;
+    }
+
+    /**
+     * The first tick under an identity can never be scoped — there is no
+     * consumed stamp for the record to chain off — so every scoped assertion
+     * spends one full tick establishing the cursor first. That is the shipped
+     * behaviour, not a test artefact: one full sweep per panel lifetime buys a
+     * continuity proof for every tick after it.
+     */
+    async function primeCursor(
+      rerender: (props: TickProps) => void,
+      base: TickProps
+    ): Promise<void> {
+      rerender({ ...base, changeTick: 100, changedDirs: burst(100, null, ["a"]) });
+      await act(() => settle());
+    }
+
+    it("re-lists only the touched directory, leaving the rest of the tree alone", async () => {
+      mockThreeBranches();
+      const base: TickProps = { changeTick: 1, changedDirs: undefined };
+      const { rerender } = await mountTree(base);
+      await primeCursor(rerender, base);
+
+      const from = listDirectory.mock.calls.length;
+      rerender({ ...base, changeTick: 200, changedDirs: burst(200, 100, ["a/deep"]) });
+      await act(() => settle());
+
+      expect(requested(from)).toEqual(["a/deep"]);
+    });
+
+    it("re-lists only the root when a top-level entry changed", async () => {
+      mockThreeBranches();
+      const base: TickProps = { changeTick: 1, changedDirs: undefined };
+      const { rerender } = await mountTree(base);
+      await primeCursor(rerender, base);
+
+      const from = listDirectory.mock.calls.length;
+      rerender({ ...base, changeTick: 200, changedDirs: burst(200, 100, [""]) });
+      await act(() => settle());
+
+      expect(requested(from)).toEqual([""]);
+    });
+
+    it("re-lists each touched directory once when one burst spans several", async () => {
+      mockThreeBranches();
+      const base: TickProps = { changeTick: 1, changedDirs: undefined };
+      const { rerender } = await mountTree(base);
+      await primeCursor(rerender, base);
+
+      const from = listDirectory.mock.calls.length;
+      rerender({ ...base, changeTick: 200, changedDirs: burst(200, 100, ["a", "b"]) });
+      await act(() => settle());
+
+      expect(requested(from).sort()).toEqual(["a", "b"]);
+    });
+
+    it("ignores a touched directory that is not on screen", async () => {
+      mockThreeBranches();
+      const base: TickProps = { changeTick: 1, changedDirs: undefined };
+      const { rerender } = await mountTree(base);
+      await primeCursor(rerender, base);
+
+      const from = listDirectory.mock.calls.length;
+      // Nothing renders this directory, so re-reading it would buy nothing.
+      rerender({ ...base, changeTick: 200, changedDirs: burst(200, 100, ["c/unexpanded"]) });
+      await act(() => settle());
+
+      expect(requested(from)).toEqual([]);
+    });
+
+    it("falls back to the full sweep when the burst could not be described", async () => {
+      mockThreeBranches();
+      const base: TickProps = { changeTick: 1, changedDirs: undefined };
+      const { rerender } = await mountTree(base);
+      await primeCursor(rerender, base);
+
+      const from = listDirectory.mock.calls.length;
+      rerender({ ...base, changeTick: 200, changedDirs: burst(200, 100, null) });
+      await act(() => settle());
+
+      expect(requested(from).sort()).toEqual(["", "a", "a/deep", "b"]);
+    });
+
+    it("falls back to the full sweep with no record at all", async () => {
+      mockThreeBranches();
+      const base: TickProps = { changeTick: 1, changedDirs: undefined };
+      const { rerender } = await mountTree(base);
+      await primeCursor(rerender, base);
+
+      const from = listDirectory.mock.calls.length;
+      rerender({ ...base, changeTick: 200, changedDirs: undefined });
+      await act(() => settle());
+
+      expect(requested(from).sort()).toEqual(["", "a", "a/deep", "b"]);
+    });
+
+    it("falls back to the full sweep when a git-status tick outran the burst", async () => {
+      mockThreeBranches();
+      const base: TickProps = { changeTick: 1, changedDirs: undefined };
+      const { rerender } = await mountTree(base);
+      await primeCursor(rerender, base);
+
+      const from = listDirectory.mock.calls.length;
+      // The tick moved to 300 but the newest burst is still stamped 200: a git
+      // status pass moved it, and that pass describes no directories.
+      rerender({ ...base, changeTick: 300, changedDirs: burst(200, 100, ["a"]) });
+      await act(() => settle());
+
+      expect(requested(from).sort()).toEqual(["", "a", "a/deep", "b"]);
+    });
+
+    it("falls back to the full sweep when a burst went by unseen", async () => {
+      mockThreeBranches();
+      const base: TickProps = { changeTick: 1, changedDirs: undefined };
+      const { rerender } = await mountTree(base);
+      await primeCursor(rerender, base);
+
+      const from = listDirectory.mock.calls.length;
+      // Two bursts landed but React committed once: this record supersedes 150,
+      // not the 100 the tree last acted on, so 150's directories are lost.
+      rerender({ ...base, changeTick: 200, changedDirs: burst(200, 150, ["a"]) });
+      await act(() => settle());
+
+      expect(requested(from).sort()).toEqual(["", "a", "a/deep", "b"]);
+    });
+
+    it("takes the full sweep on the first tick, then scopes the next one", async () => {
+      mockThreeBranches();
+      const base: TickProps = { changeTick: 1, changedDirs: undefined };
+      const { rerender } = await mountTree(base);
+
+      const firstFrom = listDirectory.mock.calls.length;
+      rerender({ ...base, changeTick: 100, changedDirs: burst(100, null, ["a"]) });
+      await act(() => settle());
+      expect(requested(firstFrom).sort()).toEqual(["", "a", "a/deep", "b"]);
+
+      const secondFrom = listDirectory.mock.calls.length;
+      rerender({ ...base, changeTick: 200, changedDirs: burst(200, 100, ["a"]) });
+      await act(() => settle());
+      expect(requested(secondFrom)).toEqual(["a"]);
+    });
+
+    it("advances the cursor across a full sweep so the tick after it scopes", async () => {
+      mockThreeBranches();
+      const base: TickProps = { changeTick: 1, changedDirs: undefined };
+      const { rerender } = await mountTree(base);
+      await primeCursor(rerender, base);
+
+      // An unclassifiable burst — full sweep, but the cursor still moves to 200.
+      rerender({ ...base, changeTick: 200, changedDirs: burst(200, 100, null) });
+      await act(() => settle());
+
+      const from = listDirectory.mock.calls.length;
+      rerender({ ...base, changeTick: 300, changedDirs: burst(300, 200, ["b"]) });
+      await act(() => settle());
+      expect(requested(from)).toEqual(["b"]);
+    });
+
+    it("keeps a manual refresh a full sweep whatever the last burst said", async () => {
+      mockThreeBranches();
+      const base: TickProps = { changeTick: 1, changedDirs: undefined };
+      const { result, rerender } = await mountTree(base);
+      await primeCursor(rerender, base);
+      rerender({ ...base, changeTick: 200, changedDirs: burst(200, 100, ["a"]) });
+      await act(() => settle());
+
+      const from = listDirectory.mock.calls.length;
+      await act(async () => {
+        result.current.refresh({ manual: true });
+        await settle();
+      });
+
+      expect(requested(from).sort()).toEqual(["", "a", "a/deep", "b"]);
+    });
+
+    it("takes the full sweep when the change is above a browse root it cannot see", async () => {
+      // Rooted at "a": the tree holds no listing for "" , so a rename of "a"
+      // itself is only discoverable by re-reading the root.
+      listDirectory.mockImplementation(async (payload) => {
+        switch (payload.dirPath) {
+          case "a":
+            return [dir("a/deep"), file("a/one.ts")];
+          case "a/deep":
+            return [file("a/deep/two.ts")];
+          default:
+            return [];
+        }
+      });
+      const base: TickProps = { changeTick: 1, changedDirs: undefined, rootPath: "a" };
+      const harness = renderHook(
+        (props: TickProps) =>
+          useFileBrowserTree({
+            source: wtSource("wt-1"),
+            expandedPaths: ["a/deep"],
+            hideDotfiles: false,
+            alwaysHiddenPatterns: [],
+            changeTick: props.changeTick,
+            changedDirs: props.changedDirs,
+            rootPath: props.rootPath,
+          }),
+        { initialProps: base }
+      );
+      await waitFor(() => expect(harness.result.current.rows).toHaveLength(3));
+      await primeCursor(harness.rerender, base);
+
+      const from = listDirectory.mock.calls.length;
+      rerender_ancestor: {
+        harness.rerender({ ...base, changeTick: 200, changedDirs: burst(200, 100, [""]) });
+      }
+      await act(() => settle());
+
+      expect(requested(from).sort()).toEqual(["a", "a/deep"]);
+    });
+
+    it("retries a failed listing on a scoped tick that did not touch it", async () => {
+      let failDeep = true;
+      listDirectory.mockImplementation(async (payload) => {
+        if (payload.dirPath === "a/deep") {
+          if (failDeep) throw new Error("nope");
+          return [file("a/deep/two.ts")];
+        }
+        switch (payload.dirPath) {
+          case undefined:
+            return [dir("a"), dir("b"), file("top.txt")];
+          case "a":
+            return [dir("a/deep"), file("a/one.ts")];
+          case "b":
+            return [file("b/three.ts")];
+          default:
+            return [];
+        }
+      });
+      const base: TickProps = { changeTick: 1, changedDirs: undefined };
+      const { result, rerender } = await mountTree(base);
+      await primeCursor(rerender, base);
+      failDeep = false;
+
+      const from = listDirectory.mock.calls.length;
+      // The burst touched "b" only, but a full sweep used to retry every failed
+      // directory for free and scoping must not quietly end that.
+      rerender({ ...base, changeTick: 200, changedDirs: burst(200, 100, ["b"]) });
+      await act(() => settle());
+
+      expect(requested(from).sort()).toEqual(["a/deep", "b"]);
+      await waitFor(() =>
+        expect(result.current.rows.map((row) => row.path)).toContain("a/deep/two.ts")
+      );
+    });
+
+    it("defers a scoped refresh that collided with an in-flight read, then replays it", async () => {
+      const gate = deferred<FileTreeNode[]>();
+      let holdDeep = false;
+      listDirectory.mockImplementation(async (payload) => {
+        if (payload.dirPath === "a/deep" && holdDeep) return gate.promise;
+        switch (payload.dirPath) {
+          case undefined:
+            return [dir("a"), dir("b"), file("top.txt")];
+          case "a":
+            return [dir("a/deep"), file("a/one.ts")];
+          case "a/deep":
+            return [file("a/deep/two.ts")];
+          case "b":
+            return [file("b/three.ts")];
+          default:
+            return [];
+        }
+      });
+      const base: TickProps = { changeTick: 1, changedDirs: undefined };
+      const { rerender } = await mountTree(base);
+      await primeCursor(rerender, base);
+
+      // First scoped tick opens a read of "a/deep" and holds it.
+      holdDeep = true;
+      rerender({ ...base, changeTick: 200, changedDirs: burst(200, 100, ["a/deep"]) });
+      await act(() => settle());
+      const from = listDirectory.mock.calls.length;
+
+      // A second burst arrives while that read is still open. Its own directory
+      // is free, so it goes out immediately; "a/deep" cannot be trusted from the
+      // read that started before the change, so it has to be re-read after.
+      rerender({ ...base, changeTick: 300, changedDirs: burst(300, 200, ["a/deep", "b"]) });
+      await act(() => settle());
+      expect(requested(from)).toEqual(["b"]);
+
+      holdDeep = false;
+      await act(async () => {
+        gate.resolve([file("a/deep/two.ts")]);
+        await settle();
+      });
+
+      // The replay is the union of what collided — "a/deep" — and nothing wider.
+      expect(requested(from).sort()).toEqual(["a/deep", "b"]);
+    });
+
+    it("widens a deferred scope to the whole tree when a manual refresh collides", async () => {
+      const gate = deferred<FileTreeNode[]>();
+      let holdDeep = false;
+      listDirectory.mockImplementation(async (payload) => {
+        if (payload.dirPath === "a/deep" && holdDeep) return gate.promise;
+        switch (payload.dirPath) {
+          case undefined:
+            return [dir("a"), dir("b"), file("top.txt")];
+          case "a":
+            return [dir("a/deep"), file("a/one.ts")];
+          case "a/deep":
+            return [file("a/deep/two.ts")];
+          case "b":
+            return [file("b/three.ts")];
+          default:
+            return [];
+        }
+      });
+      const base: TickProps = { changeTick: 1, changedDirs: undefined };
+      const { result, rerender } = await mountTree(base);
+      await primeCursor(rerender, base);
+
+      holdDeep = true;
+      rerender({ ...base, changeTick: 200, changedDirs: burst(200, 100, ["a/deep"]) });
+      await act(() => settle());
+      const from = listDirectory.mock.calls.length;
+
+      await act(async () => {
+        result.current.refresh({ manual: true });
+        await settle();
+      });
+
+      holdDeep = false;
+      await act(async () => {
+        gate.resolve([file("a/deep/two.ts")]);
+        await settle();
+      });
+
+      // The manual press promoted the deferred scope, so the replay is the full
+      // sweep rather than the one directory the tick had asked for.
+      expect(requested(from)).toContain("a/deep");
+      expect(new Set(requested(from))).toEqual(new Set(["", "a", "a/deep", "b"]));
+    });
+
+    it("leaves selection and expansion untouched across a scoped pass", async () => {
+      mockThreeBranches();
+      const base: TickProps = {
+        changeTick: 1,
+        changedDirs: undefined,
+        selectedPath: "a/deep/two.ts",
+      };
+      const { result, rerender } = await mountTree(base);
+      await primeCursor(rerender, base);
+
+      const rowsBefore = result.current.rows.map((row) => row.path);
+      rerender({ ...base, changeTick: 200, changedDirs: burst(200, 100, ["b"]) });
+      await act(() => settle());
+
+      expect(result.current.rows.map((row) => row.path)).toEqual(rowsBefore);
+      expect(result.current.selectedNode?.path).toBe("a/deep/two.ts");
+    });
+
+    it("re-reads the collapsed folder the viewer is listing when the change lands in it", async () => {
+      listDirectory.mockImplementation(async (payload) => {
+        switch (payload.dirPath) {
+          case undefined:
+            return [dir("a"), dir("b"), file("top.txt")];
+          case "a":
+            return [dir("a/deep"), file("a/one.ts")];
+          case "a/deep":
+            return [file("a/deep/two.ts")];
+          case "b":
+            return [file("b/three.ts")];
+          default:
+            return [];
+        }
+      });
+      // "b" is selected as a folder but collapsed out of the tree, so only the
+      // viewer depends on its listing.
+      const base: TickProps = { changeTick: 1, changedDirs: undefined, selectedPath: "b" };
+      const harness = renderHook(
+        (props: TickProps) =>
+          useFileBrowserTree({
+            source: wtSource("wt-1"),
+            expandedPaths: ["a"],
+            hideDotfiles: false,
+            alwaysHiddenPatterns: [],
+            changeTick: props.changeTick,
+            changedDirs: props.changedDirs,
+            selectedPath: props.selectedPath ?? null,
+          }),
+        { initialProps: base }
+      );
+      await waitFor(() => expect(harness.result.current.listingStatus).toBe("ready"));
+      await primeCursor(harness.rerender, base);
+
+      const from = listDirectory.mock.calls.length;
+      harness.rerender({ ...base, changeTick: 200, changedDirs: burst(200, 100, ["b"]) });
+      await act(() => settle());
+      expect(requested(from)).toEqual(["b"]);
+
+      const next = listDirectory.mock.calls.length;
+      harness.rerender({ ...base, changeTick: 300, changedDirs: burst(300, 200, ["a"]) });
+      await act(() => settle());
+      expect(requested(next)).toEqual(["a"]);
+    });
+  });
+
 });

--- a/src/panels/file-browser/useFileBrowserTree.ts
+++ b/src/panels/file-browser/useFileBrowserTree.ts
@@ -85,23 +85,23 @@ type RefreshScope = { kind: "all" } | { kind: "dirs"; dirs: ReadonlySet<string> 
 const REFRESH_ALL: RefreshScope = { kind: "all" };
 
 /**
- * The set `refreshTargets` filters against, with the currently-failed listings
- * folded in.
+ * The set `refreshTargets` filters against, with the directories that need
+ * retrying folded in.
  *
- * Failed directories ride along on every scoped pass because the full sweep
- * retried them for free — a change anywhere re-requested the whole tree,
- * unreadable directories included. Scoping would silently end that and leave a
- * transiently-unreadable folder stuck until the user pressed Refresh, so the
- * retry is made explicit instead of lost.
+ * Those ride along on every scoped pass because the full sweep retried them for
+ * free — a change anywhere re-requested the whole tree, unreadable directories
+ * included. Scoping would silently end that and leave a transiently-unreadable
+ * folder stuck until the user pressed Refresh, so the retry is made explicit
+ * instead of lost.
  */
 function scopeFilter(
   scope: RefreshScope,
-  failedListings: ReadonlySet<string>
+  retryTargets: ReadonlySet<string>
 ): ReadonlySet<string> | null {
   if (scope.kind === "all") return null;
-  if (failedListings.size === 0) return scope.dirs;
+  if (retryTargets.size === 0) return scope.dirs;
   const dirs = new Set(scope.dirs);
-  for (const path of failedListings) dirs.add(path);
+  for (const path of retryTargets) dirs.add(path);
   return dirs;
 }
 
@@ -118,6 +118,9 @@ function scopeForTick(
   record: WorktreeChangedDirs | undefined,
   tick: number | undefined,
   lastConsumedAt: number | undefined,
+  gitTick: number | undefined,
+  lastConsumedGitTick: number | undefined,
+  hasSymlinkedDirectory: boolean,
   rootPath: string
 ): RefreshScope {
   // No signal at all (a source with no watcher, an older host), or a burst the
@@ -127,6 +130,18 @@ function scopeForTick(
   // this burst did not produce was produced by a git-status pass — which
   // describes no directories, and whose own writes this burst may predate.
   if (record.at !== tick) return REFRESH_ALL;
+  // And a git-status pass that moved while this burst outran it is invisible to
+  // `Math.max`: git 150 then fs 200, batched into one render, leaves the tick
+  // at 200 with a continuous burst chain while git 150's own discovery — the
+  // writes a watcher outage lost — was never re-read. The git tick needs its
+  // own cursor for the same reason the filesystem one does.
+  if (gitTick !== lastConsumedGitTick) return REFRESH_ALL;
+  // A directory symlink inside the worktree is cached under the ALIAS path the
+  // tree renders, while the watcher reports the change under the link's target.
+  // The two namespaces never meet, so a scoped pass would leave the alias's
+  // rows stale (#11939). Rare enough to answer with the full sweep rather than
+  // a canonical-identity map.
+  if (hasSymlinkedDirectory) return REFRESH_ALL;
   // A burst between the last one acted on and this one was never seen — the
   // store saw it, but React batched the render away. Its directories are gone,
   // so this scope is incomplete.
@@ -194,6 +209,13 @@ export interface UseFileBrowserTreeArgs {
    * falls back to the full refresh this hook has always done.
    */
   changedDirs?: WorktreeChangedDirs;
+  /**
+   * The git-status half of `changeTick`, so the tree can tell which source
+   * moved it. `changeTick` is the max of the two, which hides a git-status pass
+   * that a later filesystem burst outran inside one React batch — and that pass
+   * is the only signal for writes a watcher outage never saw.
+   */
+  gitChangeTick?: number;
   /**
    * Last-known tree structure from the panel record (#11367). When it matches
    * the current identity, the identity reset seeds the listings from it and
@@ -330,6 +352,7 @@ export function useFileBrowserTree({
   rootPath = "",
   changeTick,
   changedDirs,
+  gitChangeTick,
   treeSnapshot,
   sort = DEFAULT_FILE_SORT,
   selectedPath = null,
@@ -485,16 +508,56 @@ export function useFileBrowserTree({
     [listingPath, selectionParent]
   );
 
+  /**
+   * Directories a scoped refresh has to re-request whether or not the change
+   * touched them, because nothing else will ask again.
+   *
+   * The failed listings are the obvious half. The root is the half that is easy
+   * to miss: a root failure is deliberately kept out of `failedListings`
+   * (`fetchDirectory` records only non-root failures), and once its retry
+   * backoff is spent the panel sits on an error banner with `hasLoadedRoot`
+   * true. The full sweep re-requested the root on every tick, so the banner
+   * cleared itself the moment the worktree became readable again; a scoped pass
+   * naming some descendant never would.
+   */
+  const retryTargets = useMemo(() => {
+    const rootNeedsRetry = rootError !== null || !listings.has(rootPath);
+    if (failedListings.size === 0 && !rootNeedsRetry) return EMPTY_EXPANDED;
+    const targets = new Set(failedListings);
+    if (rootNeedsRetry) targets.add(rootPath);
+    return targets;
+  }, [failedListings, rootError, listings, rootPath]);
+
+  /**
+   * Whether anything the tree is showing is reached through a directory
+   * symlink (#11939).
+   *
+   * Such a directory is cached under the alias path the tree renders, while the
+   * watcher reports writes under the link's target — two namespaces that never
+   * meet, so a scoped pass would leave the alias stale. Walked over the
+   * expansions rather than every cached node: only a directory whose listing is
+   * on screen can go stale unnoticed.
+   */
+  const hasSymlinkedDirectory = useMemo(() => {
+    for (const path of expandedSet) {
+      if (findNodeInListings(listings, path)?.symlink !== undefined) return true;
+    }
+    for (const path of retainedPaths) {
+      if (findNodeInListings(listings, path)?.symlink !== undefined) return true;
+    }
+    return false;
+  }, [listings, expandedSet, retainedPaths]);
+
   // Read inside `fetchDirectory`'s completion guard and the prune, both of
   // which run outside the render that knows the current targets. Kept in sync
   // in the same layout effect as `expandedSetRef` so the two are never read at
   // different vintages.
   const listingPathRef = useRef(listingPath);
   const retainedPathsRef = useRef(retainedPaths);
-  // Read by a scoped refresh, which folds the failed directories back into its
-  // target set so a change tick still retries them — the full sweep retried
-  // them for free, and scoping must not quietly take that away.
-  const failedListingsRef = useRef(failedListings);
+  // Read by a scoped refresh, which folds these back into its target set so a
+  // change tick still retries them — the full sweep retried them for free, and
+  // scoping must not quietly take that away.
+  const retryTargetsRef = useRef<ReadonlySet<string>>(EMPTY_EXPANDED);
 
   // What a refresh could not run because its targets were already in flight,
   // and at what scope. Without it, a tick that arrives mid-flight is consumed
@@ -509,6 +572,8 @@ export function useFileBrowserTree({
   // first tick lands under this identity, which is why that first tick is
   // always a full refresh.
   const lastChangedDirsAtRef = useRef<number | undefined>(undefined);
+  /** The same cursor for the git-status half of the tick. */
+  const lastGitTickRef = useRef<number | undefined>(undefined);
 
   // `pump` and `fetchDirectory` call each other: a settled request pumps the
   // queue, and the queue starts requests. Routing one direction through a
@@ -579,6 +644,47 @@ export function useFileBrowserTree({
           !expandedSetRef.current.has(dirPath)
         )
           return;
+
+        // A child directory that is still called the same thing but is no
+        // longer the same directory (#12244).
+        //
+        // A scoped refresh only re-reads the burst's parent directories, and a
+        // parent re-read is normally enough: a child that was deleted or
+        // renamed stops appearing in it and its orphaned cache stops rendering
+        // with it. In-place replacement — `rm -rf dist && mv dist.tmp dist`, a
+        // generator swapping a prepared tree in — defeats that, because the
+        // name survives and the watcher may report only the directory's own
+        // path. The cached listing underneath would then stay on screen,
+        // wrong, until something unrelated refreshed it.
+        //
+        // A directory's mtime moves when its own entries change, so comparing
+        // it against the copy we are replacing catches exactly that, one level
+        // per pass — and the pass it triggers carries the test down the next
+        // level, as far as the stale subtree goes. Only children we actually
+        // hold a listing for: nothing else has anything to go stale.
+        const cachedChildren = listingsRef.current.get(dirPath);
+        if (cachedChildren !== undefined) {
+          const cachedMtimes = new Map<string, number | undefined>();
+          for (const node of cachedChildren) {
+            if (node.isDirectory) cachedMtimes.set(node.path, node.mtimeMs);
+          }
+          const replaced: string[] = [];
+          for (const node of nodes) {
+            if (!node.isDirectory || !listingsRef.current.has(node.path)) continue;
+            const before = cachedMtimes.get(node.path);
+            // Both sides have to be known for the comparison to mean anything,
+            // and an unknown one is NOT treated as suspicious: a live listing
+            // always carries `mtimeMs`, so the only source without it is a
+            // rehydrated snapshot — whose every listing the identity reset is
+            // already revalidating. Re-reading on unknown would turn each
+            // scoped pass into a cascade down the whole restored tree, which is
+            // the full sweep this exists to avoid.
+            if (before === undefined || node.mtimeMs === undefined) continue;
+            if (before === node.mtimeMs) continue;
+            replaced.push(node.path);
+          }
+          if (replaced.length > 0) enqueueTargets(replaced, generation);
+        }
 
         setListings((previous) => {
           const next = new Map(previous);
@@ -698,7 +804,7 @@ export function useFileBrowserTree({
         pumpRef.current();
       }
     },
-    [rootPath, clearRootRetryTimer, resetRootRetryState]
+    [rootPath, clearRootRetryTimer, resetRootRetryState, enqueueTargets]
   );
 
   const pump = useCallback((): void => {
@@ -733,7 +839,7 @@ export function useFileBrowserTree({
           rootPath,
           isVisibleRef.current,
           listingPathRef.current,
-          scopeFilter(pending, failedListingsRef.current)
+          scopeFilter(pending, retryTargetsRef.current)
         ),
         generation
       );
@@ -767,7 +873,7 @@ export function useFileBrowserTree({
     treeSnapshotRef.current = treeSnapshot;
     listingPathRef.current = listingPath;
     retainedPathsRef.current = retainedPaths;
-    failedListingsRef.current = failedListings;
+    retryTargetsRef.current = retryTargets;
   }, [
     listings,
     expandedSet,
@@ -776,7 +882,7 @@ export function useFileBrowserTree({
     treeSnapshot,
     listingPath,
     retainedPaths,
-    failedListings,
+    retryTargets,
   ]);
 
   // Cancel a pending root retry synchronously when the identity changes or the
@@ -824,7 +930,7 @@ export function useFileBrowserTree({
         rootPath,
         isVisibleRef.current,
         listingPathRef.current,
-        scopeFilter(scope, failedListingsRef.current)
+        scopeFilter(scope, retryTargetsRef.current)
       );
       // A user press should spin the toolbar icon until the re-list drains. Set
       // this before `pump` so the flag is up if fetches start synchronously; a
@@ -877,6 +983,7 @@ export function useFileBrowserTree({
     // The incoming identity has no consumed tick of its own yet, so its first
     // change tick cannot prove continuity and takes the full refresh.
     lastChangedDirsAtRef.current = undefined;
+    lastGitTickRef.current = undefined;
     // A worktree switch abandons any in-flight manual refresh; its drain will
     // never complete for this identity, so end the spin here rather than leave
     // the icon stuck.
@@ -1024,13 +1131,30 @@ export function useFileBrowserTree({
     // final. `hasLoadedRoot` is a dependency, so this re-runs when it lands.
     if (!hasLoadedRoot) return;
     lastTickRef.current = changeTick;
-    const scope = scopeForTick(changedDirs, changeTick, lastChangedDirsAtRef.current, rootPath);
-    // Advanced even when the scope came out "all": the point of the cursor is
+    const scope = scopeForTick(
+      changedDirs,
+      changeTick,
+      lastChangedDirsAtRef.current,
+      gitChangeTick,
+      lastGitTickRef.current,
+      hasSymlinkedDirectory,
+      rootPath
+    );
+    // Advanced even when the scope came out "all": the point of a cursor is
     // where the *next* tick continues from, and a full refresh has covered
     // everything up to here just as a scoped one covers its own directories.
     if (changedDirs !== undefined) lastChangedDirsAtRef.current = changedDirs.at;
+    lastGitTickRef.current = gitChangeTick;
     runRefresh(scope, false);
-  }, [changeTick, changedDirs, hasLoadedRoot, rootPath, runRefresh]);
+  }, [
+    changeTick,
+    changedDirs,
+    gitChangeTick,
+    hasLoadedRoot,
+    hasSymlinkedDirectory,
+    rootPath,
+    runRefresh,
+  ]);
 
   const rows = useMemo(
     () => flattenTree(listings, expandedSet, loadingPaths, rootPath, isVisible, sortKeyed),

--- a/src/panels/file-browser/useFileBrowserTree.ts
+++ b/src/panels/file-browser/useFileBrowserTree.ts
@@ -141,6 +141,14 @@ function scopeForTick(
   // The two namespaces never meet, so a scoped pass would leave the alias's
   // rows stale (#11939). Rare enough to answer with the full sweep rather than
   // a canonical-identity map.
+  //
+  // Known gap: this can only see a link the tree holds a NODE for, which means
+  // a link at or above the browse root is invisible — nothing above `rootPath`
+  // is ever listed. Browsing rooted inside a symlinked directory therefore
+  // keeps taking scoped refreshes that the watcher's paths never match, and
+  // that subtree goes stale until a manual refresh. Closing it needs the host
+  // to send a realpath-relative form alongside the burst, which costs a syscall
+  // per changed path — deliberately out of scope here.
   if (hasSymlinkedDirectory) return REFRESH_ALL;
   // A burst between the last one acted on and this one was never seen — the
   // store saw it, but React batched the render away. Its directories are gone,
@@ -153,7 +161,19 @@ function scopeForTick(
   if (rootPath !== "" && record.dirs.some((dir) => dir === "" || rootPath.startsWith(`${dir}/`))) {
     return REFRESH_ALL;
   }
-  return { kind: "dirs", dirs: new Set(record.dirs) };
+  const dirs = new Set<string>();
+  for (const dir of record.dirs) {
+    dirs.add(dir);
+    // And the parent, because a directory's OWN row — its name, its mtime, the
+    // Modified column and the sort that reads it — lives in its PARENT's
+    // listing, not its own. Re-reading only the directory a write landed in
+    // leaves that row describing the tree as it was, which the issue's "sort
+    // order must be unaffected" rules out. One level up and no further: a
+    // grandparent's entry for the parent did not change, and this is what keeps
+    // a scoped pass at the "1 or 2 requests" the issue budgets for.
+    dirs.add(parentDirectoryOf(dir));
+  }
+  return { kind: "dirs", dirs };
 }
 
 /**
@@ -539,11 +559,11 @@ export function useFileBrowserTree({
    * on screen can go stale unnoticed.
    */
   const hasSymlinkedDirectory = useMemo(() => {
-    for (const path of expandedSet) {
-      if (findNodeInListings(listings, path)?.symlink !== undefined) return true;
-    }
-    for (const path of retainedPaths) {
-      if (findNodeInListings(listings, path)?.symlink !== undefined) return true;
+    for (const nodes of listings.values()) {
+      for (const node of nodes) {
+        if (node.symlink === undefined || !node.isDirectory) continue;
+        if (expandedSet.has(node.path) || retainedPaths.includes(node.path)) return true;
+      }
     }
     return false;
   }, [listings, expandedSet, retainedPaths]);
@@ -671,19 +691,41 @@ export function useFileBrowserTree({
           const replaced: string[] = [];
           for (const node of nodes) {
             if (!node.isDirectory || !listingsRef.current.has(node.path)) continue;
+            // Absent from the copy we are replacing is its own answer, and a
+            // suspicious one: the directory went away and came back (a delete
+            // and a re-create landing in separate bursts) while we held its
+            // listing the whole time, so that listing describes the old one.
+            if (!cachedMtimes.has(node.path)) {
+              replaced.push(node.path);
+              continue;
+            }
             const before = cachedMtimes.get(node.path);
-            // Both sides have to be known for the comparison to mean anything,
-            // and an unknown one is NOT treated as suspicious: a live listing
-            // always carries `mtimeMs`, so the only source without it is a
-            // rehydrated snapshot — whose every listing the identity reset is
-            // already revalidating. Re-reading on unknown would turn each
-            // scoped pass into a cascade down the whole restored tree, which is
-            // the full sweep this exists to avoid.
+            // Present but with an unknown mtime on either side is NOT
+            // suspicious: a live listing always carries `mtimeMs`, so the only
+            // source without it is a rehydrated snapshot — whose every listing
+            // the identity reset is already revalidating. Re-reading on unknown
+            // would turn each scoped pass into a cascade down the whole
+            // restored tree, which is the full sweep this exists to avoid.
             if (before === undefined || node.mtimeMs === undefined) continue;
             if (before === node.mtimeMs) continue;
             replaced.push(node.path);
           }
-          if (replaced.length > 0) enqueueTargets(replaced, generation);
+          if (replaced.length > 0) {
+            // A replaced child already being read started that read before we
+            // learned it was replaced, so its answer describes the old
+            // directory. `enqueueTargets` would silently skip it as a
+            // duplicate, so the collision is deferred the same way a colliding
+            // refresh is — otherwise the stale response commits and nothing is
+            // left queued to correct it.
+            const collided = replaced.filter((path) => inFlightRef.current.has(path));
+            if (collided.length > 0) {
+              refreshPendingRef.current = mergeScopes(refreshPendingRef.current, {
+                kind: "dirs",
+                dirs: new Set(collided),
+              });
+            }
+            enqueueTargets(replaced, generation);
+          }
         }
 
         setListings((previous) => {

--- a/src/panels/file-browser/useFileBrowserTree.ts
+++ b/src/panels/file-browser/useFileBrowserTree.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { FileTreeNode } from "@shared/types";
 import type { FileBrowserTreeSnapshot } from "@shared/types/panel";
+import type { WorktreeChangedDirs } from "@/store/createWorktreeStore";
 import { fileBrowserClient } from "@/clients/fileBrowserClient";
 import { logError } from "@/utils/logger";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
@@ -63,6 +64,97 @@ const MAX_CONCURRENT_LISTINGS = 6;
  */
 const ROOT_RETRY_DELAYS_MS = [150, 400, 800] as const;
 
+/**
+ * Ceiling on directories accumulated in a deferred scope before it gives up and
+ * becomes a full refresh.
+ *
+ * Mirrors the watcher's own `WORKTREE_BURST_PATH_CAP`, which degrades a single
+ * burst to "unknown" at the same size. One burst can never exceed it (the
+ * directories are one parent per path), but a deferral spanning several bursts
+ * can, and a scope that has grown to thousands of directories is a full sweep
+ * wearing a costume — cheaper to say so than to carry the set.
+ */
+const MAX_PENDING_AFFECTED_DIRS = 2048;
+
+/**
+ * What a refresh should re-read: everything reachable, or only the directories
+ * a change actually touched.
+ */
+type RefreshScope = { kind: "all" } | { kind: "dirs"; dirs: ReadonlySet<string> };
+
+const REFRESH_ALL: RefreshScope = { kind: "all" };
+
+/**
+ * The set `refreshTargets` filters against, with the currently-failed listings
+ * folded in.
+ *
+ * Failed directories ride along on every scoped pass because the full sweep
+ * retried them for free — a change anywhere re-requested the whole tree,
+ * unreadable directories included. Scoping would silently end that and leave a
+ * transiently-unreadable folder stuck until the user pressed Refresh, so the
+ * retry is made explicit instead of lost.
+ */
+function scopeFilter(
+  scope: RefreshScope,
+  failedListings: ReadonlySet<string>
+): ReadonlySet<string> | null {
+  if (scope.kind === "all") return null;
+  if (failedListings.size === 0) return scope.dirs;
+  const dirs = new Set(scope.dirs);
+  for (const path of failedListings) dirs.add(path);
+  return dirs;
+}
+
+/**
+ * How much of the tree one change tick has to re-read.
+ *
+ * Scoping is the exception, not the rule: it needs a described burst whose
+ * stamp *is* the tick that moved, with proof that no burst went by unseen. Each
+ * bail-out below is a case where the directories on hand cannot account for
+ * everything that changed since the last pass, and the answer to that is the
+ * full refresh this hook has always done.
+ */
+function scopeForTick(
+  record: WorktreeChangedDirs | undefined,
+  tick: number | undefined,
+  lastConsumedAt: number | undefined,
+  rootPath: string
+): RefreshScope {
+  // No signal at all (a source with no watcher, an older host), or a burst the
+  // watcher could not classify.
+  if (record === undefined || record.dirs === null) return REFRESH_ALL;
+  // The tick is the newer of the git-status and filesystem stamps, so a tick
+  // this burst did not produce was produced by a git-status pass — which
+  // describes no directories, and whose own writes this burst may predate.
+  if (record.at !== tick) return REFRESH_ALL;
+  // A burst between the last one acted on and this one was never seen — the
+  // store saw it, but React batched the render away. Its directories are gone,
+  // so this scope is incomplete.
+  if (lastConsumedAt === undefined || record.previousAt !== lastConsumedAt) return REFRESH_ALL;
+  // A tree rooted below the worktree holds no listing above its own root, so a
+  // change to an ancestor — the browse root itself renamed or deleted — has no
+  // target that would reveal it. Only the full refresh re-reads the root and
+  // surfaces the failure.
+  if (rootPath !== "" && record.dirs.some((dir) => dir === "" || rootPath.startsWith(`${dir}/`))) {
+    return REFRESH_ALL;
+  }
+  return { kind: "dirs", dirs: new Set(record.dirs) };
+}
+
+/**
+ * Fold a scope into whatever a deferred refresh is already holding. "All"
+ * dominates in both directions and an over-large union collapses to it, so the
+ * merge can only ever widen what the replay re-reads — never narrow it, which
+ * is what would drop a change.
+ */
+function mergeScopes(pending: RefreshScope | null, incoming: RefreshScope): RefreshScope {
+  if (pending === null) return incoming;
+  if (pending.kind === "all" || incoming.kind === "all") return REFRESH_ALL;
+  const dirs = new Set(pending.dirs);
+  for (const dir of incoming.dirs) dirs.add(dir);
+  return dirs.size > MAX_PENDING_AFFECTED_DIRS ? REFRESH_ALL : { kind: "dirs", dirs };
+}
+
 export interface UseFileBrowserTreeArgs {
   /** What the tree is rooted at; null while nothing resolves (no tree, no fetches). */
   source: FileBrowserSource | null;
@@ -90,6 +182,18 @@ export interface UseFileBrowserTreeArgs {
    * is deliberately not in scope here.
    */
   changeTick: number | undefined;
+  /**
+   * The directories behind the latest raw-filesystem tick, when the workspace
+   * host could name them (#12244). Lets a change confined to one subtree
+   * re-list that subtree instead of the root plus every expanded directory.
+   *
+   * Only ever narrows the work, never skips it: the scope is used exactly when
+   * the record's stamp *is* the tick that bumped and its `previousAt` proves no
+   * burst went unseen. Anything else — a git-status tick, an unclassifiable
+   * burst, a batched render that swallowed a burst, a source with no watcher —
+   * falls back to the full refresh this hook has always done.
+   */
+  changedDirs?: WorktreeChangedDirs;
   /**
    * Last-known tree structure from the panel record (#11367). When it matches
    * the current identity, the identity reset seeds the listings from it and
@@ -225,6 +329,7 @@ export function useFileBrowserTree({
   alwaysHiddenPatterns,
   rootPath = "",
   changeTick,
+  changedDirs,
   treeSnapshot,
   sort = DEFAULT_FILE_SORT,
   selectedPath = null,
@@ -386,12 +491,24 @@ export function useFileBrowserTree({
   // different vintages.
   const listingPathRef = useRef(listingPath);
   const retainedPathsRef = useRef(retainedPaths);
+  // Read by a scoped refresh, which folds the failed directories back into its
+  // target set so a change tick still retries them — the full sweep retried
+  // them for free, and scoping must not quietly take that away.
+  const failedListingsRef = useRef(failedListings);
 
-  // Set when a refresh could not run because its targets were already in
-  // flight. Without it, a tick that arrives mid-flight is consumed by a request
-  // that had already read the filesystem, and the tree stays stale until the
-  // user touches it.
-  const refreshPendingRef = useRef(false);
+  // What a refresh could not run because its targets were already in flight,
+  // and at what scope. Without it, a tick that arrives mid-flight is consumed
+  // by a request that had already read the filesystem, and the tree stays stale
+  // until the user touches it. Holding the scope rather than a bare flag is
+  // what lets the replay stay narrow: a deferred single-subtree change replays
+  // as that subtree, not as the whole tree.
+  const refreshPendingRef = useRef<RefreshScope | null>(null);
+
+  // The `workingTreeChangedAt` stamp of the last burst this tree acted on, so
+  // the next one can prove nothing went by in between. Undefined until the
+  // first tick lands under this identity, which is why that first tick is
+  // always a full refresh.
+  const lastChangedDirsAtRef = useRef<number | undefined>(undefined);
 
   // `pump` and `fetchDirectory` call each other: a settled request pumps the
   // queue, and the queue starts requests. Routing one direction through a
@@ -601,13 +718,13 @@ export function useFileBrowserTree({
       void fetchDirectory(next.dirPath, next.generation);
     }
 
-    // A refresh that collided with in-flight work runs once the queue drains.
-    if (
-      refreshPendingRef.current &&
-      physicalInFlightRef.current === 0 &&
-      queueRef.current.length === 0
-    ) {
-      refreshPendingRef.current = false;
+    // A refresh that collided with in-flight work runs once the queue drains,
+    // at the union of every scope that collided — cleared before the replay so
+    // a change arriving during it forms the next pass rather than being folded
+    // into one already under way.
+    const pending = refreshPendingRef.current;
+    if (pending !== null && physicalInFlightRef.current === 0 && queueRef.current.length === 0) {
+      refreshPendingRef.current = null;
       const generation = generationRef.current;
       enqueueTargets(
         refreshTargets(
@@ -615,7 +732,8 @@ export function useFileBrowserTree({
           expandedSetRef.current,
           rootPath,
           isVisibleRef.current,
-          listingPathRef.current
+          listingPathRef.current,
+          scopeFilter(pending, failedListingsRef.current)
         ),
         generation
       );
@@ -649,7 +767,17 @@ export function useFileBrowserTree({
     treeSnapshotRef.current = treeSnapshot;
     listingPathRef.current = listingPath;
     retainedPathsRef.current = retainedPaths;
-  }, [listings, expandedSet, isVisible, pump, treeSnapshot, listingPath, retainedPaths]);
+    failedListingsRef.current = failedListings;
+  }, [
+    listings,
+    expandedSet,
+    isVisible,
+    pump,
+    treeSnapshot,
+    listingPath,
+    retainedPaths,
+    failedListings,
+  ]);
 
   // Cancel a pending root retry synchronously when the identity changes or the
   // panel unmounts. The generation bump that would invalidate the retry lives in
@@ -669,7 +797,7 @@ export function useFileBrowserTree({
     return () => {
       disposedRef.current = true;
       queueRef.current = [];
-      refreshPendingRef.current = false;
+      refreshPendingRef.current = null;
       // Drop any pending root retry so it can't fire into an unmounted panel.
       clearRootRetryTimer();
       // Invalidate everything still in the air so a late response can't commit
@@ -687,34 +815,49 @@ export function useFileBrowserTree({
     [enqueueTargets, pump]
   );
 
-  const refresh = useCallback(
-    (options?: { manual?: boolean }): void => {
+  const runRefresh = useCallback(
+    (scope: RefreshScope, manual: boolean): void => {
       const generation = generationRef.current;
       const targets = refreshTargets(
         listingsRef.current,
         expandedSetRef.current,
         rootPath,
         isVisibleRef.current,
-        listingPathRef.current
+        listingPathRef.current,
+        scopeFilter(scope, failedListingsRef.current)
       );
       // A user press should spin the toolbar icon until the re-list drains. Set
       // this before `pump` so the flag is up if fetches start synchronously; a
       // no-op refresh (no worktree, no targets) drains inside `pump` and clears
       // it again in the same batch, so the icon never flickers.
-      if (options?.manual) {
+      if (manual) {
         isRefreshingRef.current = true;
         setIsRefreshing(true);
       }
       // A target already in flight read the filesystem before this refresh was
       // asked for, so its result may not reflect the change that triggered us.
-      // Defer rather than accept that response as final.
-      if (targets.some((target) => inFlightRef.current.has(target))) {
-        refreshPendingRef.current = true;
+      // Defer rather than accept that response as final — and defer only the
+      // targets that actually collided, so a twenty-directory burst with one
+      // busy directory replays that one rather than all twenty. A full refresh
+      // still replays as a full refresh: it was never about specific targets.
+      const collided = targets.filter((target) => inFlightRef.current.has(target));
+      if (collided.length > 0) {
+        refreshPendingRef.current = mergeScopes(
+          refreshPendingRef.current,
+          scope.kind === "all" ? REFRESH_ALL : { kind: "dirs", dirs: new Set(collided) }
+        );
       }
       enqueueTargets(targets, generation);
       pump();
     },
     [enqueueTargets, pump, rootPath]
+  );
+
+  const refresh = useCallback(
+    (options?: { manual?: boolean }): void => {
+      runRefresh(REFRESH_ALL, options?.manual === true);
+    },
+    [runRefresh]
   );
 
   // Identity reset — only a worktree switch or a root change, not a visibility
@@ -730,7 +873,10 @@ export function useFileBrowserTree({
     resetRootRetryState(generationRef.current);
     inFlightRef.current.clear();
     queueRef.current = [];
-    refreshPendingRef.current = false;
+    refreshPendingRef.current = null;
+    // The incoming identity has no consumed tick of its own yet, so its first
+    // change tick cannot prove continuity and takes the full refresh.
+    lastChangedDirsAtRef.current = undefined;
     // A worktree switch abandons any in-flight manual refresh; its drain will
     // never complete for this identity, so end the spin here rather than leave
     // the icon stuck.
@@ -878,8 +1024,13 @@ export function useFileBrowserTree({
     // final. `hasLoadedRoot` is a dependency, so this re-runs when it lands.
     if (!hasLoadedRoot) return;
     lastTickRef.current = changeTick;
-    refresh();
-  }, [changeTick, hasLoadedRoot, refresh]);
+    const scope = scopeForTick(changedDirs, changeTick, lastChangedDirsAtRef.current, rootPath);
+    // Advanced even when the scope came out "all": the point of the cursor is
+    // where the *next* tick continues from, and a full refresh has covered
+    // everything up to here just as a scoped one covers its own directories.
+    if (changedDirs !== undefined) lastChangedDirsAtRef.current = changedDirs.at;
+    runRefresh(scope, false);
+  }, [changeTick, changedDirs, hasLoadedRoot, rootPath, runRefresh]);
 
   const rows = useMemo(
     () => flattenTree(listings, expandedSet, loadingPaths, rootPath, isVisible, sortKeyed),

--- a/src/services/actions/__tests__/actionDefinitions.quality.test.ts
+++ b/src/services/actions/__tests__/actionDefinitions.quality.test.ts
@@ -1145,6 +1145,7 @@ describe("destructive-action danger metadata", () => {
       ]),
       statusCheckedAt: new Map(),
       workingTreeChangedAtById: new Map(),
+      workingTreeChangedDirsById: new Map(),
       manualAssociations: new Map(),
       version: { epoch: "test", seq: 1 },
       tombstones: new Map(),

--- a/src/store/__tests__/createWorktreeStore.workingTreeChangedAt.test.ts
+++ b/src/store/__tests__/createWorktreeStore.workingTreeChangedAt.test.ts
@@ -223,16 +223,14 @@ describe("createWorktreeStore — workingTreeChangedDirs side map", () => {
     const before = store.getState().workingTreeChangedDirsById;
 
     // A git-status pass re-emits the same stamp; nothing new happened.
-    store
-      .getState()
-      .applyUpdate(
-        makeSnapshot("wt-1", {
-          workingTreeChangedAt: 1_000,
-          workingTreeChangedDirs: ["src"],
-          modifiedCount: 3,
-        }),
-        nextV()
-      );
+    store.getState().applyUpdate(
+      makeSnapshot("wt-1", {
+        workingTreeChangedAt: 1_000,
+        workingTreeChangedDirs: ["src"],
+        modifiedCount: 3,
+      }),
+      nextV()
+    );
 
     expect(store.getState().workingTreeChangedDirsById).toBe(before);
   });
@@ -249,12 +247,15 @@ describe("createWorktreeStore — workingTreeChangedDirs side map", () => {
         makeSnapshot("wt-1", { workingTreeChangedAt: 1_000, workingTreeChangedDirs: ["src"] }),
         nextV()
       );
-    store
-      .getState()
-      .applySnapshot(
-        [makeSnapshot("wt-1", { workingTreeChangedAt: 3_000, workingTreeChangedDirs: ["electron"] })],
-        nextV()
-      );
+    store.getState().applySnapshot(
+      [
+        makeSnapshot("wt-1", {
+          workingTreeChangedAt: 3_000,
+          workingTreeChangedDirs: ["electron"],
+        }),
+      ],
+      nextV()
+    );
 
     expect(store.getState().workingTreeChangedDirsById.get("wt-1")).toEqual({
       at: 3_000,

--- a/src/store/__tests__/createWorktreeStore.workingTreeChangedAt.test.ts
+++ b/src/store/__tests__/createWorktreeStore.workingTreeChangedAt.test.ts
@@ -136,3 +136,163 @@ describe("createWorktreeStore — workingTreeChangedAt side map", () => {
     expect(store.getState().worktrees.has("wt-1")).toBe(false);
   });
 });
+
+// The affected-directory side map (#12244) rides the same stamp: it lets the
+// file browser re-list only what a burst touched. Its `previousAt` chain is the
+// only thing standing between "scoped refresh" and "silently dropped a burst",
+// so these assert the chain, not just the payload.
+describe("createWorktreeStore — workingTreeChangedDirs side map", () => {
+  it("records the burst's directories alongside the stamp they belong to", () => {
+    const store = createWorktreeStore();
+    store
+      .getState()
+      .applyUpdate(
+        makeSnapshot("wt-1", { workingTreeChangedAt: 1_000, workingTreeChangedDirs: ["src"] }),
+        nextV()
+      );
+
+    expect(store.getState().workingTreeChangedDirsById.get("wt-1")).toEqual({
+      at: 1_000,
+      previousAt: null,
+      dirs: ["src"],
+    });
+  });
+
+  it("chains previousAt across consecutive updates so a consumer can prove continuity", () => {
+    const store = createWorktreeStore();
+    store
+      .getState()
+      .applyUpdate(
+        makeSnapshot("wt-1", { workingTreeChangedAt: 1_000, workingTreeChangedDirs: ["src"] }),
+        nextV()
+      );
+    store
+      .getState()
+      .applyUpdate(
+        makeSnapshot("wt-1", { workingTreeChangedAt: 2_000, workingTreeChangedDirs: ["electron"] }),
+        nextV()
+      );
+
+    expect(store.getState().workingTreeChangedDirsById.get("wt-1")).toEqual({
+      at: 2_000,
+      previousAt: 1_000,
+      dirs: ["electron"],
+    });
+  });
+
+  it("never carries a previous burst's directories forward onto a new stamp", () => {
+    // The absent field means "this host described no burst for this stamp",
+    // which is not the same as "the same directories again" — inheriting would
+    // scope a refresh to directories that had nothing to do with the change.
+    const store = createWorktreeStore();
+    store
+      .getState()
+      .applyUpdate(
+        makeSnapshot("wt-1", { workingTreeChangedAt: 1_000, workingTreeChangedDirs: ["src"] }),
+        nextV()
+      );
+    store.getState().applyUpdate(makeSnapshot("wt-1", { workingTreeChangedAt: 2_000 }), nextV());
+
+    expect(store.getState().workingTreeChangedDirsById.get("wt-1")).toEqual({
+      at: 2_000,
+      previousAt: 1_000,
+      dirs: null,
+    });
+  });
+
+  it("keeps a known-empty burst distinct from an undescribed one", () => {
+    const store = createWorktreeStore();
+    store
+      .getState()
+      .applyUpdate(
+        makeSnapshot("wt-1", { workingTreeChangedAt: 1_000, workingTreeChangedDirs: [] }),
+        nextV()
+      );
+
+    expect(store.getState().workingTreeChangedDirsById.get("wt-1")?.dirs).toEqual([]);
+  });
+
+  it("holds the map identity when a snapshot repeats the stamp it already recorded", () => {
+    const store = createWorktreeStore();
+    store
+      .getState()
+      .applyUpdate(
+        makeSnapshot("wt-1", { workingTreeChangedAt: 1_000, workingTreeChangedDirs: ["src"] }),
+        nextV()
+      );
+    const before = store.getState().workingTreeChangedDirsById;
+
+    // A git-status pass re-emits the same stamp; nothing new happened.
+    store
+      .getState()
+      .applyUpdate(
+        makeSnapshot("wt-1", {
+          workingTreeChangedAt: 1_000,
+          workingTreeChangedDirs: ["src"],
+          modifiedCount: 3,
+        }),
+        nextV()
+      );
+
+    expect(store.getState().workingTreeChangedDirsById).toBe(before);
+  });
+
+  it("refuses to claim continuity on the authoritative snapshot path", () => {
+    // A full snapshot is the host's whole state and can jump across flushes the
+    // store never saw one by one, so the record it writes must say so — the
+    // consumer then takes one full re-read rather than scoping to a set that
+    // may be missing a burst.
+    const store = createWorktreeStore();
+    store
+      .getState()
+      .applyUpdate(
+        makeSnapshot("wt-1", { workingTreeChangedAt: 1_000, workingTreeChangedDirs: ["src"] }),
+        nextV()
+      );
+    store
+      .getState()
+      .applySnapshot(
+        [makeSnapshot("wt-1", { workingTreeChangedAt: 3_000, workingTreeChangedDirs: ["electron"] })],
+        nextV()
+      );
+
+    expect(store.getState().workingTreeChangedDirsById.get("wt-1")).toEqual({
+      at: 3_000,
+      previousAt: null,
+      dirs: ["electron"],
+    });
+  });
+
+  it("carries an unchanged record through the authoritative snapshot path untouched", () => {
+    const store = createWorktreeStore();
+    store
+      .getState()
+      .applyUpdate(
+        makeSnapshot("wt-1", { workingTreeChangedAt: 1_000, workingTreeChangedDirs: ["src"] }),
+        nextV()
+      );
+    const record = store.getState().workingTreeChangedDirsById.get("wt-1");
+
+    store
+      .getState()
+      .applySnapshot(
+        [makeSnapshot("wt-1", { workingTreeChangedAt: 1_000, workingTreeChangedDirs: ["src"] })],
+        nextV()
+      );
+
+    expect(store.getState().workingTreeChangedDirsById.get("wt-1")).toBe(record);
+  });
+
+  it("prunes the record when its worktree is removed", () => {
+    const store = createWorktreeStore();
+    store
+      .getState()
+      .applyUpdate(
+        makeSnapshot("wt-1", { workingTreeChangedAt: 1_000, workingTreeChangedDirs: ["src"] }),
+        nextV()
+      );
+    store.getState().applyRemove("wt-1", nextV());
+
+    expect(store.getState().workingTreeChangedDirsById.has("wt-1")).toBe(false);
+  });
+});

--- a/src/store/__tests__/createWorktreeStore.workingTreeChangedAt.test.ts
+++ b/src/store/__tests__/createWorktreeStore.workingTreeChangedAt.test.ts
@@ -151,7 +151,7 @@ describe("createWorktreeStore — workingTreeChangedDirs side map", () => {
         nextV()
       );
 
-    expect(store.getState().workingTreeChangedDirsById.get("wt-1")).toEqual({
+    expect(store.getState().workingTreeChangedDirsById.get("wt-1")).toMatchObject({
       at: 1_000,
       previousAt: null,
       dirs: ["src"],
@@ -173,7 +173,7 @@ describe("createWorktreeStore — workingTreeChangedDirs side map", () => {
         nextV()
       );
 
-    expect(store.getState().workingTreeChangedDirsById.get("wt-1")).toEqual({
+    expect(store.getState().workingTreeChangedDirsById.get("wt-1")).toMatchObject({
       at: 2_000,
       previousAt: 1_000,
       dirs: ["electron"],
@@ -193,7 +193,7 @@ describe("createWorktreeStore — workingTreeChangedDirs side map", () => {
       );
     store.getState().applyUpdate(makeSnapshot("wt-1", { workingTreeChangedAt: 2_000 }), nextV());
 
-    expect(store.getState().workingTreeChangedDirsById.get("wt-1")).toEqual({
+    expect(store.getState().workingTreeChangedDirsById.get("wt-1")).toMatchObject({
       at: 2_000,
       previousAt: 1_000,
       dirs: null,
@@ -257,7 +257,7 @@ describe("createWorktreeStore — workingTreeChangedDirs side map", () => {
       nextV()
     );
 
-    expect(store.getState().workingTreeChangedDirsById.get("wt-1")).toEqual({
+    expect(store.getState().workingTreeChangedDirsById.get("wt-1")).toMatchObject({
       at: 3_000,
       previousAt: null,
       dirs: ["electron"],
@@ -282,6 +282,53 @@ describe("createWorktreeStore — workingTreeChangedDirs side map", () => {
       );
 
     expect(store.getState().workingTreeChangedDirsById.get("wt-1")).toBe(record);
+  });
+
+  it("breaks the chain when the worktree is re-created at the same path", () => {
+    // Same epoch, new incarnation: the stamp keeps climbing (it is clock-based)
+    // so nothing about the number says the old tree died, but its record
+    // describes a different timeline.
+    const store = createWorktreeStore();
+    store.getState().applyUpdate(
+      makeSnapshot("wt-1", {
+        generation: 1,
+        workingTreeChangedAt: 1_000,
+        workingTreeChangedDirs: ["src"],
+      }),
+      nextV()
+    );
+    store.getState().applyUpdate(
+      makeSnapshot("wt-1", {
+        generation: 2,
+        workingTreeChangedAt: 2_000,
+        workingTreeChangedDirs: ["electron"],
+      }),
+      nextV()
+    );
+
+    expect(store.getState().workingTreeChangedDirsById.get("wt-1")?.previousAt).toBeNull();
+  });
+
+  it("does not chain a later new-epoch event back onto the dead run", () => {
+    // Only the FIRST event of a new epoch sees the transition, so a guard that
+    // tests the incoming event rather than the record lets the second one
+    // reconnect. Here the first new-epoch update carries no fs stamp at all.
+    const store = createWorktreeStore();
+    store
+      .getState()
+      .applyUpdate(
+        makeSnapshot("wt-1", { workingTreeChangedAt: 1_000, workingTreeChangedDirs: ["src"] }),
+        { epoch: "epoch-a", seq: 1 }
+      );
+    store.getState().applyUpdate(makeSnapshot("wt-1"), { epoch: "epoch-b", seq: 1 });
+    store
+      .getState()
+      .applyUpdate(
+        makeSnapshot("wt-1", { workingTreeChangedAt: 2_000, workingTreeChangedDirs: ["b"] }),
+        { epoch: "epoch-b", seq: 2 }
+      );
+
+    expect(store.getState().workingTreeChangedDirsById.get("wt-1")?.previousAt).toBeNull();
   });
 
   it("prunes the record when its worktree is removed", () => {

--- a/src/store/createWorktreeStore.ts
+++ b/src/store/createWorktreeStore.ts
@@ -311,6 +311,13 @@ function mergeChangedDirs(
   if (at === undefined) return current;
   const existing = current.get(snapshot.id);
   if (existing?.at === at) return current;
+  // A strictly older stamp is never a new burst — it is a stale one being
+  // replayed. Renderer-built PR/issue overlays spread the CACHED snapshot,
+  // whose fs stamp goes stale the moment a timestamp-only update takes the
+  // `snapshotsEqual` fast path and leaves that object in place. Letting one
+  // walk the record backwards would reconnect the continuity chain across a
+  // burst that was never seen, and the consumer would scope past it.
+  if (existing !== undefined && at < existing.at) return current;
   const next = new Map(current);
   next.set(snapshot.id, {
     at,
@@ -607,7 +614,10 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
       {
         let rebuilt = new Map<string, WorktreeChangedDirs>();
         for (const s of merged) {
-          const carried = prev.workingTreeChangedDirsById.get(s.id);
+          const carried = epochChanged ? undefined : prev.workingTreeChangedDirsById.get(s.id);
+          // Carried by identity only within one host run: across an epoch the
+          // record's `previousAt` describes a chain the new host knows nothing
+          // about, and repeating the stamp would preserve it.
           if (carried !== undefined && carried.at === s.workingTreeChangedAt) {
             rebuilt.set(s.id, carried);
             continue;
@@ -761,11 +771,14 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
         workingTreeChangedAtById !== prevState.workingTreeChangedAtById;
 
       // Per-event, so continuity holds: the store sees every host update in
-      // order and each record can name the stamp it superseded (#12244).
+      // order and each record can name the stamp it superseded (#12244) — but
+      // only within one host run. An epoch transition means the host restarted,
+      // and whatever changed on disk while it was down reached nobody, so the
+      // first event of the new epoch must not chain off the old one's stamp.
       const workingTreeChangedDirsById = mergeChangedDirs(
         prevState.workingTreeChangedDirsById,
         merged,
-        true
+        !epochChanged
       );
       const workingTreeChangedDirsChanged =
         workingTreeChangedDirsById !== prevState.workingTreeChangedDirsById;

--- a/src/store/createWorktreeStore.ts
+++ b/src/store/createWorktreeStore.ts
@@ -291,6 +291,23 @@ export interface WorktreeChangedDirs {
    * the burst could not be described and everything must be re-read.
    */
   readonly dirs: readonly string[] | null;
+  /**
+   * The host run this record belongs to. Continuity is only ever claimed within
+   * one run: across a host restart (new epoch) or a re-created worktree at the
+   * same path (new generation), whatever changed on disk in between reached
+   * nobody, so the chain has to break.
+   *
+   * Carried on the record rather than tested against the incoming event,
+   * because only the FIRST event of a new epoch sees the transition — a later
+   * one in the same run would find `epochChanged` false and chain straight back
+   * onto the dead run's stamp.
+   */
+  readonly run: string;
+}
+
+/** The host run a snapshot belongs to: its epoch plus the worktree's incarnation. */
+function runKeyFor(snapshot: WorktreeSnapshot, epoch: string): string {
+  return `${epoch}\u0000${snapshot.generation ?? ""}`;
 }
 
 /**
@@ -300,32 +317,45 @@ export interface WorktreeChangedDirs {
  * snapshot notifies no subscriber.
  *
  * `continuous` is false for the authoritative full-snapshot path, which can
- * jump across host events the store never saw individually.
+ * jump across host events the store never saw individually. A run change breaks
+ * continuity regardless of what the caller claims.
  */
 function mergeChangedDirs(
   current: Map<string, WorktreeChangedDirs>,
   snapshot: WorktreeSnapshot,
+  epoch: string,
   continuous: boolean
 ): Map<string, WorktreeChangedDirs> {
   const { workingTreeChangedAt: at } = snapshot;
   if (at === undefined) return current;
+  const run = runKeyFor(snapshot, epoch);
   const existing = current.get(snapshot.id);
-  if (existing?.at === at) return current;
-  // A strictly older stamp is never a new burst — it is a stale one being
-  // replayed. Renderer-built PR/issue overlays spread the CACHED snapshot,
-  // whose fs stamp goes stale the moment a timestamp-only update takes the
-  // `snapshotsEqual` fast path and leaves that object in place. Letting one
-  // walk the record backwards would reconnect the continuity chain across a
-  // burst that was never seen, and the consumer would scope past it.
-  if (existing !== undefined && at < existing.at) return current;
+  // Only a record from the SAME host run can be compared against or chained
+  // off. One from a dead run is not "older" — it describes a different
+  // timeline, so it neither dedups nor rejects nor supplies a predecessor.
+  const previous = existing !== undefined && existing.run === run ? existing : undefined;
+  if (previous !== undefined) {
+    if (previous.at === at) return current;
+    // A strictly older stamp is never a new burst — it is a stale one being
+    // replayed. Renderer-built PR/issue overlays spread the CACHED snapshot,
+    // whose fs stamp goes stale the moment a timestamp-only update takes the
+    // `snapshotsEqual` fast path and leaves that object in place. Letting one
+    // walk the record backwards would reconnect the continuity chain across a
+    // burst that was never seen, and the consumer would scope past it.
+    if (at < previous.at) return current;
+  }
+  // A record with no same-run predecessor is written once per run transition
+  // and reports `previousAt: null`, which is what actually stops the consumer
+  // scoping off it. The directories stay faithful to what the host said.
   const next = new Map(current);
   next.set(snapshot.id, {
     at,
-    previousAt: continuous ? (existing?.at ?? null) : null,
+    previousAt: continuous ? (previous?.at ?? null) : null,
     // Absent on the wire means the host described no burst for this stamp,
     // which is not the same as a burst that touched nothing — both must reach
     // the consumer as "re-read everything".
     dirs: snapshot.workingTreeChangedDirs ?? null,
+    run,
   });
   return next;
 }
@@ -614,15 +644,20 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
       {
         let rebuilt = new Map<string, WorktreeChangedDirs>();
         for (const s of merged) {
-          const carried = epochChanged ? undefined : prev.workingTreeChangedDirsById.get(s.id);
-          // Carried by identity only within one host run: across an epoch the
-          // record's `previousAt` describes a chain the new host knows nothing
-          // about, and repeating the stamp would preserve it.
-          if (carried !== undefined && carried.at === s.workingTreeChangedAt) {
+          const carried = prev.workingTreeChangedDirsById.get(s.id);
+          // Carried by identity only within one host run: across an epoch or a
+          // re-created worktree the record's `previousAt` describes a chain the
+          // new run knows nothing about, and repeating the stamp would preserve
+          // it.
+          if (
+            carried !== undefined &&
+            carried.at === s.workingTreeChangedAt &&
+            carried.run === runKeyFor(s, version.epoch)
+          ) {
             rebuilt.set(s.id, carried);
             continue;
           }
-          rebuilt = mergeChangedDirs(rebuilt, s, false);
+          rebuilt = mergeChangedDirs(rebuilt, s, version.epoch, false);
         }
         const unchanged =
           rebuilt.size === prev.workingTreeChangedDirsById.size &&
@@ -778,7 +813,8 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
       const workingTreeChangedDirsById = mergeChangedDirs(
         prevState.workingTreeChangedDirsById,
         merged,
-        !epochChanged
+        version.epoch,
+        true
       );
       const workingTreeChangedDirsChanged =
         workingTreeChangedDirsById !== prevState.workingTreeChangedDirsById;

--- a/src/store/createWorktreeStore.ts
+++ b/src/store/createWorktreeStore.ts
@@ -266,6 +266,63 @@ function isConnectivityError(message: string): boolean {
   );
 }
 
+/**
+ * The directories behind one `workingTreeChangedAt` stamp, with enough
+ * continuity information for a consumer to tell whether it has seen every
+ * burst since the one it last acted on (#12244).
+ */
+export interface WorktreeChangedDirs {
+  /** The `workingTreeChangedAt` stamp these directories describe. */
+  readonly at: number;
+  /**
+   * The stamp this record superseded, or `null` when that is unknown — an
+   * authoritative snapshot catching up, or the first record for this worktree.
+   *
+   * This is the whole skipped-burst defence. The store sees every host event in
+   * order, but React can batch two of them into one render, and the consumer
+   * would then see only the newer record. Comparing this against the stamp it
+   * last consumed tells it a burst went by unseen, so it falls back to a full
+   * re-read instead of scoping to a set that is missing the older burst's
+   * directories.
+   */
+  readonly previousAt: number | null;
+  /**
+   * Worktree-relative directories (`""` = the worktree root), or `null` when
+   * the burst could not be described and everything must be re-read.
+   */
+  readonly dirs: readonly string[] | null;
+}
+
+/**
+ * Fold one snapshot's working-tree-change fields into the side map, chaining
+ * `previousAt` off whatever the map already held for this worktree. Returns the
+ * previous map identity unchanged when the stamp has not moved, so a quiet
+ * snapshot notifies no subscriber.
+ *
+ * `continuous` is false for the authoritative full-snapshot path, which can
+ * jump across host events the store never saw individually.
+ */
+function mergeChangedDirs(
+  current: Map<string, WorktreeChangedDirs>,
+  snapshot: WorktreeSnapshot,
+  continuous: boolean
+): Map<string, WorktreeChangedDirs> {
+  const { workingTreeChangedAt: at } = snapshot;
+  if (at === undefined) return current;
+  const existing = current.get(snapshot.id);
+  if (existing?.at === at) return current;
+  const next = new Map(current);
+  next.set(snapshot.id, {
+    at,
+    previousAt: continuous ? (existing?.at ?? null) : null,
+    // Absent on the wire means the host described no burst for this stamp,
+    // which is not the same as a burst that touched nothing — both must reach
+    // the consumer as "re-read everything".
+    dirs: snapshot.workingTreeChangedDirs ?? null,
+  });
+  return next;
+}
+
 export interface WorktreeViewState {
   worktrees: Map<string, WorktreeSnapshot>;
   /**
@@ -290,6 +347,13 @@ export interface WorktreeViewState {
    * that leave `git status` unmoved (#11330).
    */
   workingTreeChangedAtById: Map<string, number>;
+  /**
+   * `worktreeId → ` the directories behind the latest `workingTreeChangedAt`,
+   * so the file browser can re-list only what changed (#12244). A side map for
+   * the same reason as {@link workingTreeChangedAtById}, and updated in lockstep
+   * with it on both merge paths.
+   */
+  workingTreeChangedDirsById: Map<string, WorktreeChangedDirs>;
   manualAssociations: Map<string, ManualIssueAssociation>;
   /**
    * Host-minted `(epoch, seq)` stamp of the most recently applied event.
@@ -449,6 +513,7 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
     worktrees: new Map(),
     statusCheckedAt: new Map(),
     workingTreeChangedAtById: new Map(),
+    workingTreeChangedDirsById: new Map(),
     manualAssociations: new Map(),
     version: { epoch: "", seq: 0 },
     tombstones: new Map(),
@@ -533,6 +598,30 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
       const workingTreeChangedAtChanged =
         nextWorkingTreeChangedAt !== prev.workingTreeChangedAtById;
 
+      // Same rebuild for the affected-directory side map. Continuity is
+      // deliberately not claimed here: a snapshot is the host's authoritative
+      // state and can jump across flushes the store never saw one by one, so
+      // every advanced stamp lands with `previousAt: null` and the file browser
+      // takes one full re-read before scoping resumes.
+      let nextWorkingTreeChangedDirs = prev.workingTreeChangedDirsById;
+      {
+        let rebuilt = new Map<string, WorktreeChangedDirs>();
+        for (const s of merged) {
+          const carried = prev.workingTreeChangedDirsById.get(s.id);
+          if (carried !== undefined && carried.at === s.workingTreeChangedAt) {
+            rebuilt.set(s.id, carried);
+            continue;
+          }
+          rebuilt = mergeChangedDirs(rebuilt, s, false);
+        }
+        const unchanged =
+          rebuilt.size === prev.workingTreeChangedDirsById.size &&
+          [...rebuilt].every(([id, record]) => prev.workingTreeChangedDirsById.get(id) === record);
+        if (!unchanged) nextWorkingTreeChangedDirs = rebuilt;
+      }
+      const workingTreeChangedDirsChanged =
+        nextWorkingTreeChangedDirs !== prev.workingTreeChangedDirsById;
+
       // Once hydrated, suppress redundant Map identity churn when every
       // incoming snapshot is value-equal to its existing counterpart. Cold
       // starts always rebuild so `isInitialized` flips correctly even when
@@ -556,6 +645,9 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
           ...(workingTreeChangedAtChanged
             ? { workingTreeChangedAtById: nextWorkingTreeChangedAt }
             : {}),
+          ...(workingTreeChangedDirsChanged
+            ? { workingTreeChangedDirsById: nextWorkingTreeChangedDirs }
+            : {}),
           ...(tombstonesChanged ? { tombstones: nextTombstones } : {}),
           ...(associationsChanged ? { manualAssociations: manual } : {}),
         });
@@ -573,6 +665,9 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
         ...(statusCheckedAtChanged ? { statusCheckedAt: nextStatusCheckedAt } : {}),
         ...(workingTreeChangedAtChanged
           ? { workingTreeChangedAtById: nextWorkingTreeChangedAt }
+          : {}),
+        ...(workingTreeChangedDirsChanged
+          ? { workingTreeChangedDirsById: nextWorkingTreeChangedDirs }
           : {}),
         ...(tombstonesChanged ? { tombstones: nextTombstones } : {}),
         ...(associationsChanged ? { manualAssociations: manual } : {}),
@@ -665,6 +760,16 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
       const workingTreeChangedAtChanged =
         workingTreeChangedAtById !== prevState.workingTreeChangedAtById;
 
+      // Per-event, so continuity holds: the store sees every host update in
+      // order and each record can name the stamp it superseded (#12244).
+      const workingTreeChangedDirsById = mergeChangedDirs(
+        prevState.workingTreeChangedDirsById,
+        merged,
+        true
+      );
+      const workingTreeChangedDirsChanged =
+        workingTreeChangedDirsById !== prevState.workingTreeChangedDirsById;
+
       // Replace with the complete state so Zustand does not merge into a second object.
       if (existing && snapshotsEqual(existing, merged)) {
         set(
@@ -673,6 +778,7 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
             version,
             ...(statusCheckedAtChanged ? { statusCheckedAt } : {}),
             ...(workingTreeChangedAtChanged ? { workingTreeChangedAtById } : {}),
+            ...(workingTreeChangedDirsChanged ? { workingTreeChangedDirsById } : {}),
             ...(tombstonesChanged ? { tombstones } : {}),
           },
           true
@@ -688,6 +794,7 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
           version,
           ...(statusCheckedAtChanged ? { statusCheckedAt } : {}),
           ...(workingTreeChangedAtChanged ? { workingTreeChangedAtById } : {}),
+          ...(workingTreeChangedDirsChanged ? { workingTreeChangedDirsById } : {}),
           ...(tombstonesChanged ? { tombstones } : {}),
         },
         true
@@ -772,6 +879,7 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
       const hadWorktree = prevState.worktrees.has(worktreeId);
       const hadStatusCheckedAt = prevState.statusCheckedAt.has(worktreeId);
       const hadWorkingTreeChangedAt = prevState.workingTreeChangedAtById.has(worktreeId);
+      const hadWorkingTreeChangedDirs = prevState.workingTreeChangedDirsById.has(worktreeId);
       const hadDeletingId = prevState.deletingIds.has(worktreeId);
       const hadDeleteError = prevState.deleteErrors.has(worktreeId);
       const hadDeleteErrorArgs = prevState.deleteErrorArgs.has(worktreeId);
@@ -789,6 +897,10 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
         ? new Map(prevState.workingTreeChangedAtById)
         : prevState.workingTreeChangedAtById;
       if (hadWorkingTreeChangedAt) nextWorkingTreeChangedAt.delete(worktreeId);
+      const nextWorkingTreeChangedDirs = hadWorkingTreeChangedDirs
+        ? new Map(prevState.workingTreeChangedDirsById)
+        : prevState.workingTreeChangedDirsById;
+      if (hadWorkingTreeChangedDirs) nextWorkingTreeChangedDirs.delete(worktreeId);
       const nextDeletingIds = hadDeletingId
         ? new Set(prevState.deletingIds)
         : prevState.deletingIds;
@@ -825,6 +937,7 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
         worktrees: nextWorktrees,
         statusCheckedAt: nextStatusCheckedAt,
         workingTreeChangedAtById: nextWorkingTreeChangedAt,
+        workingTreeChangedDirsById: nextWorkingTreeChangedDirs,
         deletingIds: nextDeletingIds,
         deleteErrors: nextDeleteErrors,
         deleteErrorArgs: nextDeleteErrorArgs,
@@ -1987,11 +2100,12 @@ function snapshotsEqual(a: WorktreeSnapshot, b: WorktreeSnapshot): boolean {
     a.baseBehindCount === b.baseBehindCount &&
     a.baseMatchesUpstream === b.baseMatchesUpstream &&
     a.baseCompareRef === b.baseCompareRef &&
-    // lastGitStatusCheckedAt and workingTreeChangedAt are deliberately NOT
-    // compared (like `timestamp`): both advance on events that change nothing
-    // else in the snapshot, so comparing either here would force a new
-    // worktrees Map identity per quiet tick. They live in the store's
-    // `statusCheckedAt` / `workingTreeChangedAtById` side maps instead.
+    // lastGitStatusCheckedAt, workingTreeChangedAt and workingTreeChangedDirs
+    // are deliberately NOT compared (like `timestamp`): all advance on events
+    // that change nothing else in the snapshot, so comparing any of them here
+    // would force a new worktrees Map identity per quiet tick. They live in the
+    // store's `statusCheckedAt` / `workingTreeChangedAtById` /
+    // `workingTreeChangedDirsById` side maps instead.
     a.lastFetchedAt === b.lastFetchedAt &&
     a.fetchAuthFailed === b.fetchAuthFailed &&
     a.fetchNetworkFailed === b.fetchNetworkFailed &&


### PR DESCRIPTION
Any worktree write made the file browser re-list the root plus every expanded directory, because the change tick carried no information about what moved. `WorktreeMonitor.handleWorktreeFilesChanged` bumped a timestamp and emitted the whole snapshot; the burst of changed paths `gitFileWatcher` had already collected was dropped at the callback boundary. An agent editing one file with 60 folders open cost 61 directory listings, and a build writing into one ignored folder cost the same again on every flush.

This carries the burst through to the tree, so a change confined to one subtree re-lists that subtree.

## User-facing effect

Agent edits and builds no longer make a widely expanded file browser re-read the whole tree.

## How it works

- `gitFileWatcher.flushWorktreeChange` converts the burst it already holds into worktree-relative parent directories and passes them through `onWorktreeFilesChanged` instead of dropping them. `WatcherController` and `WorktreeMonitor` widen in lockstep.
- `WorktreeSnapshot.workingTreeChangedDirs` keeps three answers apart: absent (no burst described), `null` (unclassifiable, meaning re-read everything, the pre-change behaviour), and a real directory list.
- The store carries it in a `workingTreeChangedDirsById` side map beside the existing stamp map, each record naming the stamp it superseded and the host run it belongs to.
- `refreshTargets` gained an optional affected-directory filter that narrows what the walk emits without changing where it goes, so reachability, hidden directories and the viewer's collapsed folder all behave as before.
- The tree scopes a tick only when the record's stamp is the tick that bumped and its continuity holds. Everything else is the full sweep: a git-status tick, a burst that went unseen because React batched a render, an unclassifiable burst, a host restart, a directory symlink on screen, or a change above a browse root the tree holds no listing for. Manual refresh, worktree switch and root change stay full.

The scope carries one level up from each changed directory, because a directory's own row (its name, its mtime, the Modified column, and the sort that reads it) lives in its parent's listing.

## Measurements

PERF-242, same machine, same session. The scoped arms derive their directory set by feeding absolute paths through the production conversion helper, so a path-namespace mismatch fails the arm rather than quietly falling back.

| Arm | directoryRequests | listingsMapCopies | sweepMs |
| --- | --- | --- | --- |
| Full sweep (before) | 67 | 67 | 11.498 |
| One write, one subtree | 2 | 2 | 0.694 |
| One write at the root | 1 | 1 | 0.383 |
| 20 writes over 3 subtrees | 4 | 4 | 1.982 |

`refreshMisses: 0`, every arm reconciled its own write, including the hidden tallies and the sizes of files it deliberately did not re-read.

PERF-240 and PERF-241 unchanged: `directoryCount: 61`, `nodeCount: 769`, `rowCount: 744`, `largeNodeCount: 6489`, `largeRowCount: 6405`, and zero misses on both. (Absolute timings on the final run were taken under machine load and moved uniformly across all three scenarios, including the two this PR does not touch; the within-run ratios are the comparison.)

PERF-242's own duration series is not comparable across this change: each sweep now commits one listings-map copy per accepted response, as the panel does, and the scenario went from three arms to six. That is called out in the scenario description.

## Verification

Full `npm test` (56,585 tests) and `npm run check` both green. The compiler-budget baseline was not touched.

`check:sample-views` fails in my worktree, and only there: it rebuilds `plugins/sample/file-tree/view/file-tree-view.js` and the only difference is a `//#region` comment path, because this worktree's `node_modules` is a symlink to the main checkout. It reproduces identically on a pristine `develop`, so it is not from this branch and I have not committed the rebuilt artifact.

## Known limitation

The symlink guard can only see a link the tree holds a node for, so a directory symlink at or above the browse root is invisible: nothing above `rootPath` is ever listed. Browsing rooted inside a symlinked directory keeps taking scoped refreshes the watcher's paths never match, and that subtree stays stale until a manual refresh. Closing it needs the host to send a realpath-relative form alongside the burst, at a syscall per changed path. Documented where the guard lives.

Resolves #12244

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W5QCaJ6sNxA7k3wbG6Lv6s
