### PR TITLE
fix(diagnostics): reflow the panel grid when the dock takes its height

### DIFF
--- a/src/components/Diagnostics/DiagnosticsDock.tsx
+++ b/src/components/Diagnostics/DiagnosticsDock.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState, useEffect } from "react";
+import { useCallback, useRef, useState, useEffect, useLayoutEffect } from "react";
 import { useShallow } from "zustand/react/shallow";
 import { X } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -27,6 +27,8 @@ import {
 import type { RetryAction } from "@/store";
 import { appClient } from "@/clients";
 import { logError } from "@/utils/logger";
+
+import { signalDiagnosticsDockLayoutChange } from "@/lib/diagnosticsDockLayout";
 
 import { DIAGNOSTICS_DOCK_REGION_ID } from "./regionIds";
 
@@ -248,6 +250,18 @@ export function DiagnosticsDock({ onRetry, onCancelRetry, className }: Diagnosti
     observer.observe(parent);
     return () => observer.disconnect();
   }, [isOpen, setMaxHeight]);
+
+  // #12264: the dock claims (or releases) its height from the same flex column
+  // that holds the panel grid, so every commit that changes it is a reflow of
+  // `<main>` and owes the grid the same protocol a sidebar transition does.
+  // Published from a layout effect, not the store, for two reasons: the first
+  // open resolves a lazy chunk, so `isOpen` flips a frame or more before any
+  // dock DOM exists to measure against; and running post-commit means
+  // subscribers read the settled box rather than the one before it. `activeTab`
+  // is deliberately not a dependency — switching tabs moves nothing.
+  useLayoutEffect(() => {
+    signalDiagnosticsDockLayoutChange();
+  }, [isOpen, height]);
 
   useEffect(() => {
     if (!isResizing && isOpen) {

--- a/src/components/Diagnostics/__tests__/DiagnosticsDock.reflow.test.tsx
+++ b/src/components/Diagnostics/__tests__/DiagnosticsDock.reflow.test.tsx
@@ -1,0 +1,181 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, act } from "@testing-library/react";
+import { DiagnosticsDock, DIAGNOSTICS_DOCK_REGION_ID } from "../DiagnosticsDock";
+import { useDiagnosticsStore } from "@/store/diagnosticsStore";
+import { useErrorStore } from "@/store";
+
+const signalMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/diagnosticsDockLayout", () => ({
+  signalDiagnosticsDockLayoutChange: signalMock,
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: () => null,
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("../ProblemsContent", () => ({ ProblemsContent: () => <div /> }));
+vi.mock("../LogsContent", () => ({ LogsContent: () => <div /> }));
+vi.mock("../EventsContent", () => ({ EventsContent: () => <div /> }));
+vi.mock("../TelemetryContent", () => ({ TelemetryContent: () => <div /> }));
+vi.mock("../PerfContent", () => ({ PerfContent: () => <div /> }));
+vi.mock("../WhySlowContent", () => ({ WhySlowContent: () => <div /> }));
+vi.mock("../DiagnosticsActions", () => ({
+  ProblemsActions: () => null,
+  LogsActions: () => null,
+  EventsActions: () => null,
+  TelemetryActions: () => null,
+  PerfActions: () => null,
+}));
+
+vi.mock("@/store/perfMetricsStore", () => {
+  const state = { outsideReferenceCount: 0 };
+  return {
+    usePerfMetricsStore: (selector: (s: typeof state) => unknown) => selector(state),
+  };
+});
+
+vi.mock("@/clients", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    appClient: {
+      setState: vi.fn().mockResolvedValue(undefined),
+      getState: vi.fn().mockResolvedValue({}),
+    },
+  };
+});
+
+vi.mock("@/utils/logger", () => ({ logError: vi.fn() }));
+
+vi.stubGlobal(
+  "ResizeObserver",
+  class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+);
+
+function resetStores() {
+  useDiagnosticsStore.setState({
+    isOpen: true,
+    activeTab: "problems",
+    height: 256,
+    maxHeight: 600,
+  });
+  useErrorStore.setState({ errors: [] });
+}
+
+// Issue #12264 — opening the dock takes its height out of the flex column that
+// holds the panel grid, but nothing told the grid to remeasure or told the
+// terminals to refit, so the bottom strip of every agent panel stayed hidden.
+// The dock now publishes each committed geometry change; the grid subscribes.
+describe("DiagnosticsDock layout signal (issue #12264)", () => {
+  let rectSpy: ReturnType<typeof vi.spyOn> | undefined;
+
+  beforeEach(() => {
+    // jsdom reports a zero-height rect for every element, which drives the
+    // dock's own maxHeight observer to clamp the store height down to the 128px
+    // floor on mount — a real height change that would publish a second,
+    // fixture-induced signal. Give the dock a plausible container so the clamp
+    // is the no-op it is in the app.
+    rectSpy = vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue({
+      x: 0,
+      y: 0,
+      top: 0,
+      left: 0,
+      right: 1000,
+      bottom: 1200,
+      width: 1000,
+      height: 1200,
+      toJSON: () => ({}),
+    } as DOMRect);
+    resetStores();
+    signalMock.mockClear();
+  });
+
+  afterEach(() => {
+    rectSpy?.mockRestore();
+    rectSpy = undefined;
+  });
+
+  it("publishes once the opened dock is in the DOM, not when the store flips", () => {
+    // The mount IS the open: the dock is lazy-loaded behind a first-open gate,
+    // so `isOpen` flips a frame or more before any dock DOM exists to measure.
+    const { container } = render(<DiagnosticsDock />);
+
+    expect(signalMock).toHaveBeenCalledTimes(1);
+    // Published from a layout effect, so the dock's box is already committed
+    // by the time a subscriber measures.
+    expect(container.querySelector(`#${DIAGNOSTICS_DOCK_REGION_ID}`)).not.toBeNull();
+  });
+
+  it("publishes when the dock closes and gives the space back", () => {
+    const { container } = render(<DiagnosticsDock />);
+    signalMock.mockClear();
+
+    act(() => {
+      useDiagnosticsStore.getState().closeDock();
+    });
+
+    expect(signalMock).toHaveBeenCalledTimes(1);
+    expect(container.querySelector(`#${DIAGNOSTICS_DOCK_REGION_ID}`)).toBeNull();
+  });
+
+  it("publishes on a height change so a drag- or keyboard-resize reflows the grid", () => {
+    render(<DiagnosticsDock />);
+    signalMock.mockClear();
+
+    act(() => {
+      useDiagnosticsStore.getState().setHeight(400);
+    });
+
+    expect(signalMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays quiet for a tab switch, which moves nothing", () => {
+    render(<DiagnosticsDock />);
+    signalMock.mockClear();
+
+    act(() => {
+      useDiagnosticsStore.getState().setActiveTab("logs");
+    });
+
+    expect(signalMock).not.toHaveBeenCalled();
+  });
+
+  it("stays quiet when a clamped setHeight leaves the height where it was", () => {
+    // setHeight clamps to [MIN, maxHeight]; a no-op clamp must not re-arm the
+    // resize suppression on every keystroke at the limit.
+    render(<DiagnosticsDock />);
+    act(() => {
+      useDiagnosticsStore.getState().setHeight(600);
+    });
+    signalMock.mockClear();
+
+    act(() => {
+      useDiagnosticsStore.getState().setHeight(900);
+    });
+
+    expect(signalMock).not.toHaveBeenCalled();
+  });
+
+  it("publishes again on reopen after a close", () => {
+    render(<DiagnosticsDock />);
+    act(() => {
+      useDiagnosticsStore.getState().closeDock();
+    });
+    signalMock.mockClear();
+
+    act(() => {
+      useDiagnosticsStore.getState().openDock("problems");
+    });
+
+    expect(signalMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/Diagnostics/__tests__/DiagnosticsDock.reflow.test.tsx
+++ b/src/components/Diagnostics/__tests__/DiagnosticsDock.reflow.test.tsx
@@ -6,6 +6,12 @@ import { useDiagnosticsStore } from "@/store/diagnosticsStore";
 import { useErrorStore } from "@/store";
 
 const signalMock = vi.hoisted(() => vi.fn());
+/**
+ * What the DOM looked like at the moment each signal fired. Asserting after
+ * `render()` returns would pass for an implementation that published during
+ * render — the whole point is that subscribers measure a committed box.
+ */
+const observations = vi.hoisted((): Array<{ present: boolean; height: string }> => []);
 
 vi.mock("@/lib/diagnosticsDockLayout", () => ({
   signalDiagnosticsDockLayoutChange: signalMock,
@@ -84,19 +90,16 @@ describe("DiagnosticsDock layout signal (issue #12264)", () => {
     // floor on mount — a real height change that would publish a second,
     // fixture-induced signal. Give the dock a plausible container so the clamp
     // is the no-op it is in the app.
-    rectSpy = vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue({
-      x: 0,
-      y: 0,
-      top: 0,
-      left: 0,
-      right: 1000,
-      bottom: 1200,
-      width: 1000,
-      height: 1200,
-      toJSON: () => ({}),
-    } as DOMRect);
+    rectSpy = vi
+      .spyOn(HTMLElement.prototype, "getBoundingClientRect")
+      .mockReturnValue(new DOMRect(0, 0, 1000, 1200));
     resetStores();
     signalMock.mockClear();
+    observations.length = 0;
+    signalMock.mockImplementation(() => {
+      const el = document.getElementById(DIAGNOSTICS_DOCK_REGION_ID);
+      observations.push({ present: el !== null, height: el?.style.height ?? "" });
+    });
   });
 
   afterEach(() => {
@@ -107,35 +110,39 @@ describe("DiagnosticsDock layout signal (issue #12264)", () => {
   it("publishes once the opened dock is in the DOM, not when the store flips", () => {
     // The mount IS the open: the dock is lazy-loaded behind a first-open gate,
     // so `isOpen` flips a frame or more before any dock DOM exists to measure.
-    const { container } = render(<DiagnosticsDock />);
+    render(<DiagnosticsDock />);
 
     expect(signalMock).toHaveBeenCalledTimes(1);
-    // Published from a layout effect, so the dock's box is already committed
-    // by the time a subscriber measures.
-    expect(container.querySelector(`#${DIAGNOSTICS_DOCK_REGION_ID}`)).not.toBeNull();
+    // Recorded inside the signal: a publish during render, or before the dock's
+    // height landed on the element, would not see this.
+    expect(observations).toEqual([{ present: true, height: "256px" }]);
   });
 
   it("publishes when the dock closes and gives the space back", () => {
-    const { container } = render(<DiagnosticsDock />);
+    render(<DiagnosticsDock />);
     signalMock.mockClear();
+    observations.length = 0;
 
     act(() => {
       useDiagnosticsStore.getState().closeDock();
     });
 
     expect(signalMock).toHaveBeenCalledTimes(1);
-    expect(container.querySelector(`#${DIAGNOSTICS_DOCK_REGION_ID}`)).toBeNull();
+    // The space is already returned when the grid is told to remeasure.
+    expect(observations).toEqual([{ present: false, height: "" }]);
   });
 
   it("publishes on a height change so a drag- or keyboard-resize reflows the grid", () => {
     render(<DiagnosticsDock />);
     signalMock.mockClear();
+    observations.length = 0;
 
     act(() => {
       useDiagnosticsStore.getState().setHeight(400);
     });
 
     expect(signalMock).toHaveBeenCalledTimes(1);
+    expect(observations).toEqual([{ present: true, height: "400px" }]);
   });
 
   it("stays quiet for a tab switch, which moves nothing", () => {

--- a/src/components/Terminal/__tests__/useContentGridContext.diagnosticsDock.test.ts
+++ b/src/components/Terminal/__tests__/useContentGridContext.diagnosticsDock.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { readFile } from "fs/promises";
+import { resolve } from "path";
+
+const HOOK_PATH = resolve(__dirname, "../useContentGridContext.tsx");
+
+// Issue #12264 — the diagnostics dock takes its height out of the same flex
+// column as the panel grid, but a height-only reflow moves none of this
+// effect's dependencies, and when it leaves `scrollRowHeight` untouched it
+// schedules no terminal correction either. The grid now remeasures on the
+// dock's committed geometry signal, through the same lock-guarded path the
+// sidebar transition and startup hydration already use.
+//
+// The wiring lives inside the grid hook, whose dependency surface makes it
+// unrenderable in isolation — the same reason the #10827 hydration coverage
+// next door asserts on source. The signal's own behaviour (subscribe, notify,
+// dispose, resize suppression) is covered for real in
+// src/lib/__tests__/diagnosticsDockLayout.test.ts, and the publishing side in
+// src/components/Diagnostics/__tests__/DiagnosticsDock.reflow.test.tsx.
+describe("useContentGridContext diagnostics dock remeasure (issue #12264)", () => {
+  it("imports the dock layout signal subscription", async () => {
+    const content = await readFile(HOOK_PATH, "utf-8");
+    expect(content).toContain("subscribeDiagnosticsDockLayoutChange");
+    expect(content).toContain("@/lib/diagnosticsDockLayout");
+  });
+
+  it("reuses the lock-guarded remeasure rather than a second measurement path", async () => {
+    // remeasureAfterUnlock re-checks isSidebarMeasurementLocked and reads
+    // gridContainerRef.current, so the dock path inherits both the #6979 jitter
+    // guard and the #10827 hydration gate for free.
+    const content = await readFile(HOOK_PATH, "utf-8");
+    expect(content).toContain("subscribeDiagnosticsDockLayoutChange(remeasureAfterUnlock)");
+  });
+
+  it("unsubscribes the dock signal alongside the sidebar subscriptions", async () => {
+    const content = await readFile(HOOK_PATH, "utf-8");
+    expect(content).toContain("unsubscribeDock()");
+    // All three disposals must live in the same cleanup as the observer, or a
+    // remount leaks a listener that measures a detached container.
+    const cleanupIndex = content.indexOf("observer.disconnect();");
+    const dockDisposeIndex = content.indexOf("unsubscribeDock()");
+    expect(cleanupIndex).toBeGreaterThan(-1);
+    expect(dockDisposeIndex).toBeGreaterThan(cleanupIndex);
+  });
+
+  it("subscribes in the same effect that owns the ResizeObserver", async () => {
+    const content = await readFile(HOOK_PATH, "utf-8");
+    const subscribeIndex = content.indexOf("subscribeDiagnosticsDockLayoutChange(");
+    const observeIndex = content.indexOf("observer.observe(container)");
+    const disposeIndex = content.indexOf("unsubscribeDock()");
+    expect(observeIndex).toBeGreaterThan(-1);
+    expect(subscribeIndex).toBeGreaterThan(observeIndex);
+    expect(disposeIndex).toBeGreaterThan(subscribeIndex);
+  });
+});

--- a/src/components/Terminal/useContentGridContext.tsx
+++ b/src/components/Terminal/useContentGridContext.tsx
@@ -47,6 +47,7 @@ import {
   subscribeSidebarLayoutTransitionUnlock,
   subscribeSidebarHydrationUnlock,
 } from "@/lib/layoutTransitionLock";
+import { subscribeDiagnosticsDockLayoutChange } from "@/lib/diagnosticsDockLayout";
 import { useWorktrees } from "@/hooks/useWorktrees";
 import { useProjectBranding } from "@/hooks";
 import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
@@ -641,6 +642,14 @@ export function useContentGridContext({
     // #10827: remeasure once the persisted sidebar width is restored. Fires
     // synchronously if hydration already completed before this effect mounted.
     const unsubscribeHydration = subscribeSidebarHydrationUnlock(remeasureAfterUnlock);
+    // #12264: the diagnostics dock takes its height out of the same flex column
+    // as the grid, but a height-only change moves none of the deps of this
+    // effect and — when it leaves `scrollRowHeight` alone — schedules no
+    // terminal correction either. The signal fires post-commit, and
+    // `remeasureAfterUnlock` reads `gridContainerRef.current` rather than the
+    // element this effect captured, so it also picks up a grid container that
+    // was replaced by a branch switch since the observer was attached.
+    const unsubscribeDock = subscribeDiagnosticsDockLayoutChange(remeasureAfterUnlock);
 
     return () => {
       observer.disconnect();
@@ -648,6 +657,7 @@ export function useContentGridContext({
       if (finalRafId !== null) cancelAnimationFrame(finalRafId);
       unsubscribeTransition();
       unsubscribeHydration();
+      unsubscribeDock();
       setGridDimensions(null);
     };
   }, [setGridDimensions, gridTerminals.length, maximizedId, twoPaneSplitEnabled, showPlaceholder]);

--- a/src/lib/__tests__/diagnosticsDockLayout.test.ts
+++ b/src/lib/__tests__/diagnosticsDockLayout.test.ts
@@ -1,0 +1,130 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const suppressMock = vi.hoisted(() => vi.fn());
+const getPanelStateMock = vi.hoisted(() => vi.fn());
+const getWorktreeSelectionStateMock = vi.hoisted(() => vi.fn());
+const getHelpPanelStateMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/services/terminal/TerminalInstanceService", () => ({
+  terminalInstanceService: {
+    suppressResizesDuringLayoutTransition: suppressMock,
+  },
+}));
+
+vi.mock("@/store/panelStore", () => ({
+  usePanelStore: { getState: getPanelStateMock },
+}));
+
+vi.mock("@/store/worktreeStore", () => ({
+  useWorktreeSelectionStore: { getState: getWorktreeSelectionStateMock },
+}));
+
+vi.mock("@/store/helpPanelStore", () => ({
+  useHelpPanelStore: { getState: getHelpPanelStateMock },
+  selectActiveSlot: (s: { terminalId: string | null }) => s,
+  selectSlotTerminalIds: (s: { terminalId: string | null }) =>
+    s.terminalId ? [s.terminalId] : [],
+}));
+
+import {
+  signalDiagnosticsDockLayoutChange,
+  subscribeDiagnosticsDockLayoutChange,
+  __resetDiagnosticsDockLayoutForTests,
+} from "../diagnosticsDockLayout";
+import { DIAGNOSTICS_DOCK_TRANSITION_MS } from "../terminalLayout";
+
+describe("diagnostics dock layout signal (issue #12264)", () => {
+  beforeEach(() => {
+    __resetDiagnosticsDockLayoutForTests();
+    suppressMock.mockClear();
+    getWorktreeSelectionStateMock.mockReturnValue({ activeWorktreeId: "wt-active" });
+    getHelpPanelStateMock.mockReturnValue({ terminalId: null });
+    getPanelStateMock.mockReturnValue({
+      panelIds: ["grid-a", "grid-b", "grid-other", "docked"],
+      panelsById: {
+        "grid-a": { id: "grid-a", location: "grid", worktreeId: "wt-active" },
+        "grid-b": { id: "grid-b", location: "grid", worktreeId: "wt-active" },
+        "grid-other": { id: "grid-other", location: "grid", worktreeId: "wt-background" },
+        docked: { id: "docked", location: "dock", worktreeId: "wt-active" },
+        // The assistant is only picked up once its panel is registered.
+        "assistant-1": { id: "assistant-1", location: "dock", worktreeId: "wt-active" },
+      },
+    });
+  });
+
+  afterEach(() => {
+    __resetDiagnosticsDockLayoutForTests();
+  });
+
+  it("notifies every subscriber when the dock geometry commits", () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    subscribeDiagnosticsDockLayoutChange(first);
+    subscribeDiagnosticsDockLayoutChange(second);
+
+    signalDiagnosticsDockLayoutChange();
+
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops notifying once a subscriber disposes", () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeDiagnosticsDockLayoutChange(listener);
+
+    signalDiagnosticsDockLayoutChange();
+    unsubscribe();
+    signalDiagnosticsDockLayoutChange();
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("suppresses PTY resizes for the dock transition window on the affected panes", () => {
+    // The corrective refit for the reflow is this lock's unlock pass — a resize
+    // dropped while it is armed is skipped, not deferred, so the pass is the
+    // only thing that gives every terminal its settled post-dock size.
+    getHelpPanelStateMock.mockReturnValue({ terminalId: "assistant-1" });
+
+    signalDiagnosticsDockLayoutChange();
+
+    expect(suppressMock).toHaveBeenCalledTimes(1);
+    const [ids, durationMs] = suppressMock.mock.calls[0]!;
+    // Grid panes on the active worktree plus the assistant — the same set a
+    // sidebar transition covers, because the same `<main>` row reflows.
+    expect(ids).toEqual(["grid-a", "grid-b", "assistant-1"]);
+    expect(durationMs).toBe(DIAGNOSTICS_DOCK_TRANSITION_MS);
+  });
+
+  it("keeps the transition window pegged to the dock's CSS height transition", () => {
+    // index.css `.diagnostics-dock { transition: height 200ms }` — a corrective
+    // pass shorter than the animation would measure a mid-transition box.
+    expect(DIAGNOSTICS_DOCK_TRANSITION_MS).toBe(200);
+  });
+
+  it("isolates subscribers from each other's failures", () => {
+    const failing = vi.fn(() => {
+      throw new Error("subscriber blew up");
+    });
+    const healthy = vi.fn();
+    subscribeDiagnosticsDockLayoutChange(failing);
+    subscribeDiagnosticsDockLayoutChange(healthy);
+
+    expect(() => signalDiagnosticsDockLayoutChange()).not.toThrow();
+    expect(healthy).toHaveBeenCalledTimes(1);
+  });
+
+  it("tolerates a subscriber unsubscribing during the notification pass", () => {
+    const later = vi.fn();
+    let disposeLater: (() => void) | undefined;
+    subscribeDiagnosticsDockLayoutChange(() => disposeLater?.());
+    disposeLater = subscribeDiagnosticsDockLayoutChange(later);
+
+    expect(() => signalDiagnosticsDockLayoutChange()).not.toThrow();
+    // The snapshot means the already-queued listener still runs this pass, but
+    // it must be gone from the next one.
+    later.mockClear();
+    signalDiagnosticsDockLayoutChange();
+    expect(later).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/__tests__/diagnosticsDockLayout.test.ts
+++ b/src/lib/__tests__/diagnosticsDockLayout.test.ts
@@ -1,5 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { readFile } from "fs/promises";
+import { resolve } from "path";
 
 const suppressMock = vi.hoisted(() => vi.fn());
 const getPanelStateMock = vi.hoisted(() => vi.fn());
@@ -23,8 +25,7 @@ vi.mock("@/store/worktreeStore", () => ({
 vi.mock("@/store/helpPanelStore", () => ({
   useHelpPanelStore: { getState: getHelpPanelStateMock },
   selectActiveSlot: (s: { terminalId: string | null }) => s,
-  selectSlotTerminalIds: (s: { terminalId: string | null }) =>
-    s.terminalId ? [s.terminalId] : [],
+  selectSlotTerminalIds: (s: { terminalId: string | null }) => (s.terminalId ? [s.terminalId] : []),
 }));
 
 import {
@@ -96,10 +97,14 @@ describe("diagnostics dock layout signal (issue #12264)", () => {
     expect(durationMs).toBe(DIAGNOSTICS_DOCK_TRANSITION_MS);
   });
 
-  it("keeps the transition window pegged to the dock's CSS height transition", () => {
-    // index.css `.diagnostics-dock { transition: height 200ms }` — a corrective
-    // pass shorter than the animation would measure a mid-transition box.
-    expect(DIAGNOSTICS_DOCK_TRANSITION_MS).toBe(200);
+  it("keeps the transition window pegged to the dock's CSS height transition", async () => {
+    // Read the duration out of the stylesheet rather than restating it: a
+    // corrective pass shorter than the animation measures a mid-transition box,
+    // and the two values drifting apart is exactly how that regresses.
+    const css = await readFile(resolve(__dirname, "../../index.css"), "utf-8");
+    const rule = /\.diagnostics-dock\s*\{[^}]*transition:\s*height\s+(\d+)ms/.exec(css);
+    expect(rule).not.toBeNull();
+    expect(Number(rule![1])).toBe(DIAGNOSTICS_DOCK_TRANSITION_MS);
   });
 
   it("isolates subscribers from each other's failures", () => {
@@ -116,13 +121,20 @@ describe("diagnostics dock layout signal (issue #12264)", () => {
 
   it("tolerates a subscriber unsubscribing during the notification pass", () => {
     const later = vi.fn();
-    let disposeLater: (() => void) | undefined;
-    subscribeDiagnosticsDockLayoutChange(() => disposeLater?.());
-    disposeLater = subscribeDiagnosticsDockLayoutChange(later);
+    // Held in a list so the earlier subscriber can dispose the later one it
+    // cannot yet name — the notify pass must survive the Set mutating under it.
+    const disposers: Array<() => void> = [];
+    subscribeDiagnosticsDockLayoutChange(() => {
+      for (const dispose of disposers) dispose();
+    });
+    disposers.push(subscribeDiagnosticsDockLayoutChange(later));
 
     expect(() => signalDiagnosticsDockLayoutChange()).not.toThrow();
-    // The snapshot means the already-queued listener still runs this pass, but
-    // it must be gone from the next one.
+    // Iterating a snapshot rather than the live Set is what keeps the
+    // already-queued listener running this pass; dropping that would make this
+    // assertion fail rather than merely change ordering.
+    expect(later).toHaveBeenCalledTimes(1);
+
     later.mockClear();
     signalDiagnosticsDockLayoutChange();
     expect(later).not.toHaveBeenCalled();

--- a/src/lib/diagnosticsDockLayout.ts
+++ b/src/lib/diagnosticsDockLayout.ts
@@ -1,0 +1,68 @@
+import { terminalInstanceService } from "@/services/terminal/TerminalInstanceService";
+import { getSidebarAffectedTerminalIds } from "./sidebarToggle";
+import { DIAGNOSTICS_DOCK_TRANSITION_MS } from "./terminalLayout";
+
+/**
+ * The diagnostics dock's half of the layout-transition protocol every other
+ * piece of layout-changing chrome already implements.
+ *
+ * The dock is a flex sibling of the sidebar/main row, so opening it shrinks
+ * `<main>` and every panel in the grid. CSS alone gets the boxes right; what
+ * the dock was missing is the two JS obligations that come with any reflow of
+ * that row (issue #12264):
+ *
+ *  1. Suppress PTY resize propagation for the transition window, exactly as
+ *     `suppressSidebarResizes` does. Without it a dock drag-resize delivers one
+ *     SIGWINCH per mousemove to every agent pane. More importantly the
+ *     suppression's unlock pass is the corrective refit: a resize dropped while
+ *     the lock is armed is SKIPPED, not deferred (see
+ *     `TerminalResizePassScheduler.batchResize`), and ResizeObserver does not
+ *     retroactively fire when a lock releases.
+ *  2. Tell the grid to remeasure. `useContentGridContext`'s ResizeObserver
+ *     already covers most of this, but a height-only change that leaves
+ *     `isScrollMode`/`scrollRowHeight` untouched schedules no grid-level
+ *     terminal correction at all, and the first open resolves a lazy chunk —
+ *     the store flips before any dock DOM exists.
+ *
+ * Single renderer = single signal, mirroring `layoutTransitionLock`: each
+ * project view is its own WebContentsView with its own V8 context, so there is
+ * exactly one grid per module scope.
+ *
+ * This is deliberately NOT a measurement lock. The dock's height transition is
+ * a user-visible resize the grid should track live; only the PTY traffic needs
+ * gating.
+ */
+
+const listeners = new Set<() => void>();
+
+/**
+ * Publish a committed dock geometry change: open, close, or a new height. Call
+ * this AFTER React has committed the dock's DOM, so subscribers measure the
+ * settled layout rather than the frame before it.
+ */
+export function signalDiagnosticsDockLayoutChange(): void {
+  const ids = getSidebarAffectedTerminalIds();
+  terminalInstanceService.suppressResizesDuringLayoutTransition(
+    ids,
+    DIAGNOSTICS_DOCK_TRANSITION_MS
+  );
+  // Snapshot — a callback may unsubscribe during iteration.
+  for (const listener of Array.from(listeners)) {
+    try {
+      listener();
+    } catch {
+      // Swallow per-listener errors so one bad subscriber can't block others.
+    }
+  }
+}
+
+export function subscribeDiagnosticsDockLayoutChange(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function __resetDiagnosticsDockLayoutForTests(): void {
+  listeners.clear();
+}

--- a/src/lib/sidebarToggle.ts
+++ b/src/lib/sidebarToggle.ts
@@ -23,9 +23,11 @@ import { SIDEBAR_TOGGLE_LOCK_MS } from "./terminalLayout";
  * Terminal ids affected by a sidebar/assistant-panel width change on the active
  * worktree: every grid panel on the active worktree plus the assistant's dock
  * terminal. Shared by the toggle-time suppression (suppressSidebarResizes,
- * TTL-based) and the drag-time resize lock (AppLayout's sidebar/assistant
- * divider drag, boolean lockResize). Both reflow `<main flex:1>`, which holds
- * the grid.
+ * TTL-based), the drag-time resize lock (AppLayout's sidebar/assistant divider
+ * drag, boolean lockResize), and the diagnostics dock's height transition
+ * (signalDiagnosticsDockLayoutChange, #12264). All of them reflow
+ * `<main flex:1>`, which holds the grid — the affected set is the same whether
+ * the row loses width or height.
  */
 export function getSidebarAffectedTerminalIds(): string[] {
   const activeWorktreeId = useWorktreeSelectionStore.getState().activeWorktreeId;

--- a/src/lib/terminalLayout.ts
+++ b/src/lib/terminalLayout.ts
@@ -80,6 +80,14 @@ export const SIDEBAR_TRANSITION_MS = 250;
  */
 export const SIDEBAR_TOGGLE_LOCK_MS = SIDEBAR_TRANSITION_MS;
 
+/**
+ * Dead-man TTL for the resize-suppression lock armed when the diagnostics dock
+ * changes height (#12264). Pegged to the `.diagnostics-dock` height transition
+ * in index.css — keep the two in step, or the corrective resize pass lands
+ * mid-animation.
+ */
+export const DIAGNOSTICS_DOCK_TRANSITION_MS = 200;
+
 // ---------------------------------------------------------------------------
 // Measured-readability model
 //

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -660,13 +660,11 @@ class TerminalInstanceService {
   }
 
   private layoutTransitionTimer: number | undefined;
+  private layoutTransitionDeadline = 0;
+  private readonly layoutTransitionPendingIds = new Set<string>();
 
   suppressResizesDuringLayoutTransition(panelIds: string[], durationMs: number): void {
     if (panelIds.length === 0) return;
-
-    if (this.layoutTransitionTimer !== undefined) {
-      clearTimeout(this.layoutTransitionTimer);
-    }
 
     // Dead-man fallback that outlives the timer-driven unlock below. The +150
     // margin (vs the +100 it covered before) spans XtermAdapter's ~50ms
@@ -677,11 +675,29 @@ class TerminalInstanceService {
     const safetyTtl = durationMs + 150;
     for (const id of panelIds) {
       this.resizeController.lockResize(id, true, safetyTtl);
+      this.layoutTransitionPendingIds.add(id);
     }
+
+    // One service-wide timer serves every overlapping transition, so a second
+    // arm must not simply replace the first: the ids it doesn't name would be
+    // unlocked by their TTL and never corrected, because the TTL only stops
+    // `isResizeLocked` reporting — it schedules nothing (#12264). The pending
+    // set is therefore the union of every arm still owed a pass, and the
+    // deadline is the latest of them, so a short transition layered on a long
+    // one can't cut the long one's window short.
+    const deadline = Date.now() + durationMs;
+    if (this.layoutTransitionTimer !== undefined) {
+      if (deadline <= this.layoutTransitionDeadline) return;
+      clearTimeout(this.layoutTransitionTimer);
+    }
+    this.layoutTransitionDeadline = deadline;
 
     this.layoutTransitionTimer = window.setTimeout(() => {
       this.layoutTransitionTimer = undefined;
-      for (const id of panelIds) {
+      this.layoutTransitionDeadline = 0;
+      const ids = [...this.layoutTransitionPendingIds];
+      this.layoutTransitionPendingIds.clear();
+      for (const id of ids) {
         if (!this.instances.has(id)) continue;
         this.resizeController.lockResize(id, false);
       }
@@ -692,7 +708,7 @@ class TerminalInstanceService {
       // close/open supersedes it cleanly (#8597). The grid hook
       // (useContentGridContext) also schedules a pass ~50ms later when grid
       // deps change; the resize() dedup guard absorbs the overlap.
-      this.runResizePass(panelIds);
+      this.runResizePass(ids);
     }, durationMs);
   }
 

--- a/src/services/terminal/__tests__/TerminalInstanceService.batchResize.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.batchResize.test.ts
@@ -51,7 +51,10 @@ vi.mock("../TerminalAddonManager", () => ({
 
 type BatchTestService = {
   instances: Map<string, ManagedTerminal>;
-  resizePassScheduler: { batchResize: (ids: string[]) => void };
+  resizePassScheduler: {
+    batchResize: (ids: string[]) => void;
+    runResizePass: (ids: string[]) => void;
+  };
   suppressResizesDuringLayoutTransition: (ids: string[], durationMs: number) => void;
   resizeController: {
     resize: (id: string, width: number, height: number) => { cols: number; rows: number } | null;
@@ -341,5 +344,49 @@ describe("TerminalInstanceService suppressResizesDuringLayoutTransition", () => 
     expect(service.resizeController.isResizeLocked("a")).toBe(false);
     expect(resizeSpy).toHaveBeenCalledTimes(1);
     expect(resizeSpy).toHaveBeenCalledWith("a", 800, 600);
+  });
+
+  // #12264: one service-wide timer serves every overlapping transition. A later
+  // arm used to replace the earlier one wholesale, so ids only the earlier call
+  // named were unlocked by their dead-man TTL and never corrected — the TTL
+  // stops `isResizeLocked` reporting, it schedules nothing. Opening the
+  // diagnostics dock arms the broad set, and the grid's own scroll-geometry
+  // effect immediately arms a narrower one, so this overlap is the common case.
+  it("corrects every id still owed a pass when a narrower transition overlaps a broader one", () => {
+    service.instances.set("a", makeManaged({ id: "a" }));
+    service.instances.set("b", makeManaged({ id: "b" }));
+    // Asserted on the pass rather than on resize(): runResizePass chunks and
+    // yields, so only the first chunk lands synchronously here.
+    const passSpy = vi
+      .spyOn(service.resizePassScheduler, "runResizePass")
+      .mockImplementation(() => {});
+
+    service.suppressResizesDuringLayoutTransition(["a", "b"], 200);
+    service.suppressResizesDuringLayoutTransition(["a"], 200);
+
+    vi.advanceTimersByTime(200);
+
+    expect(service.resizeController.isResizeLocked("a")).toBe(false);
+    expect(service.resizeController.isResizeLocked("b")).toBe(false);
+    expect(passSpy).toHaveBeenCalledTimes(1);
+    expect([...passSpy.mock.calls[0]![0]].sort()).toEqual(["a", "b"]);
+  });
+
+  it("holds the longer window when a shorter transition layers on top of it", () => {
+    service.instances.set("a", makeManaged({ id: "a" }));
+    const passSpy = vi
+      .spyOn(service.resizePassScheduler, "runResizePass")
+      .mockImplementation(() => {});
+
+    service.suppressResizesDuringLayoutTransition(["a"], 250);
+    service.suppressResizesDuringLayoutTransition(["a"], 200);
+
+    // The 200ms dock window must not cut the 250ms sidebar window short — a
+    // corrective pass at 200ms would measure a mid-animation box.
+    vi.advanceTimersByTime(200);
+    expect(passSpy).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(50);
+    expect(passSpy).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## What was wrong

The diagnostics dock is the only piece of layout-changing chrome in the app that participates in none of the layout-transition protocol. Every other surface that reflows the `<main flex:1>` row (the sidebar toggle at `src/lib/sidebarToggle.ts:48-55`, the sidebar/assistant divider drag at `AppLayout.tsx:745-761`, the two-pane divider, and grid column changes at `useContentGridContext.tsx:988-996`) does two things: suppresses PTY resize propagation for the transition window, and takes an explicit corrective remeasure and resize pass on settle.

That second half isn't optional. As the comment at `TerminalInstanceService.ts:687` puts it, ResizeObserver doesn't retroactively fire when a lock releases.

The dock has a 200ms CSS height transition (`index.css:1424`) and armed none of this. Worse, when its height change moved `scrollRowHeight`, the grid's own effect armed `suppressResizesDuringLayoutTransition`, and `TerminalResizePassScheduler.batchResize` skips (doesn't defer) every resize-locked id, so the dock path could cancel the very refit it triggered. A height-only change that left `isScrollMode`/`scrollRowHeight` equal scheduled no grid-level terminal correction at all.

Worth being straight about: the CSS flex/height chain from the app root down to `#panel-grid` was checked link by link in all three grid branches and is sound, so this isn't a missing `min-h-0` fix. Without an Electron repro I couldn't pin down the exact failing link statically, so the fix is deliberately the protocol the dock should have had all along, rather than a guess at one line.

## What changed

- New `src/lib/diagnosticsDockLayout.ts`: a module-level signal shaped like `layoutTransitionLock`, whose `signalDiagnosticsDockLayoutChange()` also arms `suppressResizesDuringLayoutTransition` on the same terminal set a sidebar transition covers.
- `DiagnosticsDock` publishes it from a `useLayoutEffect` keyed on `[isOpen, height]`, so it fires after the DOM commit. That matters because the dock is lazy-loaded behind a first-open gate, so the store flips before any dock DOM exists to measure. Tab switches deliberately publish nothing.
- `useContentGridContext` subscribes its existing lock-guarded, rAF-deferred `remeasureAfterUnlock` to that signal inside the `ResizeObserver` effect, and disposes it in the same cleanup. Because it lives in the shared hook, all three grid branches (default, fleet-scope, two-pane) get covered at once, following the precedent set in #7826. It reads `gridContainerRef.current` rather than a captured element, so it also picks up a container replaced by a branch switch.
- Both open routes, `useDiagnosticsAutoOpen` and the toolbar Problems button via `handleToggleProblems`, converge on the diagnostics store, so keying off the dock covers both for free. Auto-open behavior is unchanged.

## Second commit: a real bug found in review

`suppressResizesDuringLayoutTransition` keeps one service-wide timer, and it was letting a later arm replace an earlier one wholesale. The ids that only the earlier call had named were then released by their dead-man TTL and never corrected, since the TTL only stops `isResizeLocked` from reporting locked, it doesn't schedule anything.

Opening the dock arms a broad set of ids, and the grid's scroll-geometry effect immediately arms a narrower one, so this overlap is the common case, not a corner case. Now the pending ids are a union that the unlock pass drains, and the deadline used is the latest of the overlapping arms, so a 200ms dock window can't cut a 250ms sidebar window short.

## Testing

- `src/lib/__tests__/diagnosticsDockLayout.test.ts`: behavioral tests for dispatch, disposal, snapshot iteration, listener-error isolation, and the affected terminal set. The transition window is asserted against the `.diagnostics-dock` rule parsed out of `index.css`, not a copied literal.
- `src/components/Diagnostics/__tests__/DiagnosticsDock.reflow.test.tsx`: renders the dock and records DOM presence plus the element's inline height inside the signal, so a render-phase publish fails the assertion. Covers open, close, height change, reopen, and the two cases that must stay quiet (tab switch, no-op clamp).
- `src/services/terminal/__tests__/TerminalInstanceService.batchResize.test.ts`: regressions for the overlapping-arm stranding and the deadline.
- `src/components/Terminal/__tests__/useContentGridContext.diagnosticsDock.test.ts`: a source-level wiring guard, following the sibling `useContentGridContext.hydration.test.ts` precedent, since the hook's dependency surface makes it unrenderable in isolation.

388 targeted tests pass on the rebased branch, and prettier and tsc are clean on the touched files. Full suite and build are CI's job.

## Known gaps

Calling these out honestly as follow-ups, not as things this PR fixes.

1. `TerminalResizeController.resize()` records `lastWidth`/`lastHeight` before its deferred commit, and `lockResize(true)` cancels that job without invalidating the pixel cache, so a corrective pass measuring the same box can be dropped as redundant. Pre-existing, and equally reachable today via the sidebar toggle. Patching the core resize dedup path inside a dock-reflow fix is a bad trade, this deserves its own issue.
2. `getSidebarAffectedTerminalIds()` filters by active worktree, so fleet scope's cross-worktree armed panels get no dock suppression or corrective pass. Those panels keep their normal per-panel `ResizeObserver` path, so this is missing coverage rather than a regression. Widening the shared helper would change sidebar behavior too.

Resolves #12264
