### PR TITLE
docs(curation): retire the deleted workflow engine and Notes panel

### DIFF
--- a/docs/feature-curation.md
+++ b/docs/feature-curation.md
@@ -116,7 +116,7 @@ Ask yourself:
 
 If the answer is **Workshop**, we don't build the feature. At most, we build a **button that opens the Workshop** to the right place (like the existing "Open in Editor" integration).
 
-**The grey area:** Read-only viewing and lightweight interaction (staging files, reviewing diffs) belong in the Orchestration Layer. Editing code, running linters, resolving merge conflicts belong in the Workshop.
+**The grey area:** Read-only viewing, annotation, and lightweight interaction (staging files, reviewing diffs) belong in the Orchestration Layer. Editing code, running linters, resolving merge conflicts belong in the Workshop.
 
 ## Decision Examples
 
@@ -133,7 +133,7 @@ If the answer is **Workshop**, we don't build the feature. At most, we build a *
 | Voice Input | **APPROVE** | Bridges gap. Hands-free delegation while monitoring other agents. Accessibility value. |
 | Integrated Browser | **APPROVE** | Localhost preview, console capture, and agent-app debugging. Bridges gap. Not a general-purpose browser. |
 | Daintree Assistant | **APPROVE** | Wraps AI with orchestration context (panels, worktrees, actions). Not a generic chat — it's orchestration-aware. |
-| Notes Panel | **REJECT** | Daintree is a terminal manager, not a document store. Removed in #5616: the save path was architectural, not a fixable defect, and the agent-facing copy link never resolved. Markdown files in the worktree cover this. |
+| Notes Panel | **REJECT** | Daintree is a terminal manager, not a document store. Removed in #5616: the save bug was architectural, not a tractable defect, and the agent-facing copy link never resolved. Markdown files in the worktree cover this. |
 | Terminal Recipes | **APPROVE** | Enables automation. Repeatable multi-agent setups reduce manual panel configuration. |
 | Portal (Web Agent Dock) | **APPROVE** | Bridges gap between CLI agents and web agent UIs. Manages multiplicity across agent interfaces. |
 | Reintroducing the DAG Workflow Engine | **REJECT** | Removed in #4118: zero usage, ~8,000 lines of maintenance, and it bypassed the action system entirely. Scoped to the old DAG engine only — terminal recipes and worktree actions like `workflow.startWorkOnIssue` stay core. |

--- a/docs/feature-curation.md
+++ b/docs/feature-curation.md
@@ -23,13 +23,12 @@ It is the orchestration layer where you direct agent work, monitor agent fleets,
 5. **Review & Intervention** — Review agent output, stage changes, diff across worktrees, and push — without leaving Daintree
 6. **Dev Server Management** — Auto-detect and manage dev servers per worktree with embedded preview
 7. **Visual Identity & Comfort** — A rich theme system that makes Daintree feel like a native app, reduces eye strain during long sessions, and supports accessibility needs
-8. **Automation & Recipes** — Terminal recipes for repeatable multi-agent setups, and workflow engine for reactive automation
+8. **Automation & Recipes** — Terminal recipes for repeatable multi-agent setups, and actions that automate worktree creation, agent launch, and context injection
 
 **Strategic Features** (not pillars, but significant capabilities):
 
 - **Daintree Assistant** — Built-in AI assistant with orchestration-layer context (sees all panels, worktrees, actions)
 - **Voice Input** — Hands-free delegation while monitoring other agents
-- **Notes** — Annotation and note-taking alongside agent work
 - **Portal** — Tabbed dock for web-based AI agent UIs alongside terminal agents
 
 **Brand Voice:** "Calm partner" — helpful, not flashy. Reduces cognitive load. Opinionated defaults.
@@ -117,7 +116,7 @@ Ask yourself:
 
 If the answer is **Workshop**, we don't build the feature. At most, we build a **button that opens the Workshop** to the right place (like the existing "Open in Editor" integration).
 
-**The grey area:** Read-only viewing, annotation, and lightweight interaction (staging files, reviewing diffs, writing notes) belong in the Orchestration Layer. Editing code, running linters, resolving merge conflicts belong in the Workshop.
+**The grey area:** Read-only viewing and lightweight interaction (staging files, reviewing diffs) belong in the Orchestration Layer. Editing code, running linters, resolving merge conflicts belong in the Workshop.
 
 ## Decision Examples
 
@@ -134,10 +133,10 @@ If the answer is **Workshop**, we don't build the feature. At most, we build a *
 | Voice Input | **APPROVE** | Bridges gap. Hands-free delegation while monitoring other agents. Accessibility value. |
 | Integrated Browser | **APPROVE** | Localhost preview, console capture, and agent-app debugging. Bridges gap. Not a general-purpose browser. |
 | Daintree Assistant | **APPROVE** | Wraps AI with orchestration context (panels, worktrees, actions). Not a generic chat — it's orchestration-aware. |
-| Notes Panel | **APPROVE** | Annotation alongside agent work. Markdown editing for note-taking, not code editing. Bridges gap. |
+| Notes Panel | **REJECT** | Daintree is a terminal manager, not a document store. Removed in #5616: the save path was architectural, not a fixable defect, and the agent-facing copy link never resolved. Markdown files in the worktree cover this. |
 | Terminal Recipes | **APPROVE** | Enables automation. Repeatable multi-agent setups reduce manual panel configuration. |
 | Portal (Web Agent Dock) | **APPROVE** | Bridges gap between CLI agents and web agent UIs. Manages multiplicity across agent interfaces. |
-| Workflow Engine | **APPROVE** | Enables automation. DAG-based reactive workflows with approval gates. Core orchestration. |
+| Reintroducing the DAG Workflow Engine | **REJECT** | Removed in #4118: zero usage, ~8,000 lines of maintenance, and it bypassed the action system entirely. Scoped to the old DAG engine only — terminal recipes and worktree actions like `workflow.startWorkOnIssue` stay core. |
 | Chat History Search | **APPROVE** | Manages multiplicity. Essential for auditing agent work across sessions. |
 | npm Script Runner | **APPROVE (Simplified)** | Only start/stop via Dev Preview. Not editing package.json. |
 | Random Theme Cycler | **APPROVE** | Habitat principle: helps users discover the theme that feels right. Reinforces identity through exploration. |

--- a/help/AGENTS.md
+++ b/help/AGENTS.md
@@ -62,7 +62,6 @@ Signals that depend on forge data report as `unknown` when that data hasn't arri
 - Terminal recipes for repeatable setups
 - Themes and visual customization
 - Embedded browser and dev server preview
-- Workflow engine and automation
 
 ## Spotting Good Ideas
 

--- a/help/CLAUDE.md
+++ b/help/CLAUDE.md
@@ -141,7 +141,6 @@ Signals that depend on forge data report as `unknown` when that data hasn't arri
 - Terminal recipes for repeatable setups
 - Themes and visual customization
 - Embedded browser and dev server preview
-- Workflow engine and automation
 
 ## Spotting Good Ideas
 

--- a/help/README.md
+++ b/help/README.md
@@ -68,7 +68,7 @@ Both share:
 - **Tone:** Concise, actionable, grounded in documentation
 - **Scope boundary:** If a question is outside docs, search GitHub issues or offer to file one
 - **Forge access:** Search/view issues without confirmation, never write through a forge CLI. Creating an issue requires user approval of the exact draft; because `forge.createIssue` has no repository argument and targets the active worktree's repo, Daintree feedback is handed to the user to file by default and filed directly only when the active worktree is itself a `daintreehq/daintree` checkout
-- **Topic coverage:** 11 documentation areas (getting started, panels, agents, worktrees, keybindings, actions, context injection, recipes, themes, browser/devpreview, workflows)
+- **Topic coverage:** 10 documentation areas (getting started, panels, agents, worktrees, keybindings, actions, context injection, recipes, themes, browser/devpreview)
 
 ### Editing the prompts
 

--- a/scripts/build-help-prompts.test.mjs
+++ b/scripts/build-help-prompts.test.mjs
@@ -43,7 +43,8 @@ describe("help prompt outputs", () => {
     it.each(ALL_GENERATED)("%s lists the canonical topics", (_name, body) => {
       expect(body).toContain("## Topics You Can Help With");
       expect(body).toContain("Getting started and first-run setup");
-      expect(body).toContain("Workflow engine and automation");
+      expect(body).toContain("Terminal recipes for repeatable setups");
+      expect(body).not.toContain("Workflow engine");
     });
   });
 

--- a/scripts/help-src/SHARED.md
+++ b/scripts/help-src/SHARED.md
@@ -46,7 +46,6 @@ Signals that depend on forge data report as `unknown` when that data hasn't arri
 - Terminal recipes for repeatable setups
 - Themes and visual customization
 - Embedded browser and dev server preview
-- Workflow engine and automation
 
 ## Spotting Good Ideas
 


### PR DESCRIPTION
## Summary

- `docs/feature-curation.md` is the rubric maintainers use to decide what to build, and it still listed two removed features as current and approved: the DAG workflow engine (removed in #4118, tracked in #4580, commit `9b662c91e`) and the Notes panel (removed in #5616).
- The same stale workflow-engine claim was also in the in-app assistant's help prompts, so the Assistant was advertising a topic it can't actually help with.

Resolves #12260

## Changes

Six files:

- `docs/feature-curation.md`: pillar 8 now describes the automation that actually exists (terminal recipes, plus actions that automate worktree creation, agent launch, and context injection) instead of the deleted engine. Notes is dropped from the Strategic Features list. "Writing notes" is dropped from the grey-area sentence about the Orchestration Layer. Both rows in the Decision Examples table are inverted to **REJECT**.
- Per a maintainer's review instruction, the workflow row is scoped rather than blanket: the proposal cell is renamed to "Reintroducing the DAG Workflow Engine" and the reasoning explicitly says the rejection covers only the old DAG engine, since terminal recipes and worktree actions like `workflow.startWorkOnIssue` stay core. A bare "Workflow Engine | REJECT" would have read as ruling out orchestration generally.
- `scripts/help-src/SHARED.md`: the stale "Workflow engine and automation" topic bullet is removed. The remaining live topics ("Worktree orchestration and monitoring", "The action system and command palette", "Terminal recipes for repeatable setups") already cover what's left, so no replacement bullet was added.
- `help/CLAUDE.md`, `help/AGENTS.md`: regenerated via `npm run build:help`, never hand-edited.
- `help/README.md`: topic count corrected from 11 to 10 to match the regenerated prompts.
- `scripts/build-help-prompts.test.mjs`: the assertion pinning the stale bullet now asserts a live one, plus a `not.toContain("Workflow engine")` guard so the claim can't come back, matching the existing `not.toMatch(/share them prominently/)` precedent in the same file.

**Reviewer note:** the grey-area sentence (formerly line 120) wasn't one of the four lines named in the issue. It said annotation and "writing notes" belong in the Orchestration Layer; only "writing notes" was removed. "Annotation" was deliberately kept, because the Red Light Test table already says read-only viewing and annotation are fine, and #5616 rejected a document store rather than annotation in general. Easy to drop this hunk if you'd rather keep the change scoped to the four enumerated lines.

## Testing

- `npx vitest run scripts/build-help-prompts.test.mjs` (29 tests pass)
- `node scripts/build-help-prompts.mjs --check` (generated prompts match their sources)
- `npx prettier --check` on all six changed files (pass)
- Repo-wide `grep "Workflow engine and automation"` returns zero hits
