### PR TITLE
fix(recipes): refuse in-repo writes that strip unsupported content

### DIFF
--- a/electron/ipc/handlers/__tests__/projectInRepoSettings.test.ts
+++ b/electron/ipc/handlers/__tests__/projectInRepoSettings.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const ipcHandlers = vi.hoisted(() => new Map<string, unknown>());
+const ipcMainMock = vi.hoisted(() => ({
+  handle: vi.fn((channel: string, fn: unknown) => ipcHandlers.set(channel, fn)),
+  removeHandler: vi.fn((channel: string) => ipcHandlers.delete(channel)),
+}));
+
+const projectStoreMock = vi.hoisted(() => ({
+  getAllProjects: vi.fn(() => []),
+  getProjectById: vi.fn(() => undefined as unknown),
+  getProjectSettings: vi.fn(async () => ({})),
+  getRecipes: vi.fn(async () => [] as Array<{ id: string; name: string }>),
+  assertInRepoRecipesForwardCompatible: vi.fn(async () => undefined),
+  writeInRepoProjectIdentity: vi.fn(async () => undefined),
+  writeInRepoSettings: vi.fn(async () => undefined),
+  writeInRepoRecipe: vi.fn(async () => undefined),
+  updateProject: vi.fn(async () => ({ id: "p1", inRepoSettings: true })),
+}));
+
+vi.mock("electron", () => ({ ipcMain: ipcMainMock, dialog: {} }));
+vi.mock("../../../services/ProjectStore.js", () => ({ projectStore: projectStoreMock }));
+
+import { registerProjectInRepoSettingsHandlers } from "../projectInRepoSettings.js";
+import { CHANNELS } from "../../channels.js";
+import type { HandlerDependencies } from "../../types.js";
+
+type Handler = (event: Electron.IpcMainInvokeEvent, ...args: unknown[]) => Promise<unknown>;
+
+function getHandler(channel: string): Handler {
+  const fn = ipcHandlers.get(channel);
+  if (!fn) throw new Error(`handler not registered: ${channel}`);
+  return fn as Handler;
+}
+
+function fakeEvent(): Electron.IpcMainInvokeEvent {
+  return { sender: {} as Electron.WebContents } as Electron.IpcMainInvokeEvent;
+}
+
+describe("project:enable-in-repo-settings forward-compatibility pre-flight (#12261)", () => {
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    ipcHandlers.clear();
+    vi.clearAllMocks();
+    projectStoreMock.getProjectById.mockReturnValue({
+      id: "p1",
+      name: "Repo",
+      path: "/repo",
+    } as unknown as undefined);
+    projectStoreMock.getProjectSettings.mockResolvedValue({});
+    projectStoreMock.getRecipes.mockResolvedValue([
+      { id: "r1", name: "Alpha" },
+      { id: "r2", name: "Beta" },
+    ]);
+    projectStoreMock.assertInRepoRecipesForwardCompatible.mockResolvedValue(undefined);
+    projectStoreMock.updateProject.mockResolvedValue({ id: "p1", inRepoSettings: true });
+    cleanup = registerProjectInRepoSettingsHandlers({} as HandlerDependencies);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  const enable = () =>
+    getHandler(CHANNELS.PROJECT_ENABLE_IN_REPO_SETTINGS)(fakeEvent(), "p1") as Promise<unknown>;
+
+  it("pre-flights every recipe destination before enabling", async () => {
+    await enable();
+    expect(projectStoreMock.assertInRepoRecipesForwardCompatible).toHaveBeenCalledWith("/repo", [
+      "Alpha",
+      "Beta",
+    ]);
+    expect(projectStoreMock.writeInRepoRecipe).toHaveBeenCalledTimes(2);
+    expect(projectStoreMock.updateProject).toHaveBeenCalledWith("p1", {
+      inRepoSettings: true,
+      daintreeConfigPresent: true,
+    });
+  });
+
+  it("writes nothing at all when a destination holds unsupported content", async () => {
+    // The whole point of pre-flighting: a half-written batch with the setting
+    // flipped on is worse than not enabling.
+    const refusal = Object.assign(new Error("would strip"), {
+      code: "RECIPE_FORWARD_COMPAT_CONFLICT",
+    });
+    projectStoreMock.assertInRepoRecipesForwardCompatible.mockRejectedValue(refusal);
+
+    await expect(enable()).rejects.toMatchObject({ code: "RECIPE_FORWARD_COMPAT_CONFLICT" });
+
+    expect(projectStoreMock.writeInRepoProjectIdentity).not.toHaveBeenCalled();
+    expect(projectStoreMock.writeInRepoSettings).not.toHaveBeenCalled();
+    expect(projectStoreMock.writeInRepoRecipe).not.toHaveBeenCalled();
+    expect(projectStoreMock.updateProject).not.toHaveBeenCalled();
+  });
+
+  it("runs the pre-flight ahead of the identity and settings writes", async () => {
+    const order: string[] = [];
+    projectStoreMock.assertInRepoRecipesForwardCompatible.mockImplementation(async () => {
+      order.push("preflight");
+    });
+    projectStoreMock.writeInRepoProjectIdentity.mockImplementation(async () => {
+      order.push("identity");
+    });
+    projectStoreMock.writeInRepoSettings.mockImplementation(async () => {
+      order.push("settings");
+    });
+    projectStoreMock.writeInRepoRecipe.mockImplementation(async () => {
+      order.push("recipe");
+    });
+
+    await enable();
+    expect(order).toEqual(["preflight", "identity", "settings", "recipe", "recipe"]);
+  });
+
+  it("still enables a project that has no recipes", async () => {
+    projectStoreMock.getRecipes.mockResolvedValue([]);
+    await enable();
+    expect(projectStoreMock.assertInRepoRecipesForwardCompatible).toHaveBeenCalledWith("/repo", []);
+    expect(projectStoreMock.updateProject).toHaveBeenCalled();
+  });
+});

--- a/electron/ipc/handlers/__tests__/projectRecipes.adversarial.test.ts
+++ b/electron/ipc/handlers/__tests__/projectRecipes.adversarial.test.ts
@@ -15,6 +15,7 @@ const projectStoreMock = vi.hoisted(() => ({
   deleteRecipe: vi.fn(),
   readInRepoRecipes: vi.fn(() => []),
   writeInRepoRecipe: vi.fn(),
+  assertInRepoRecipesForwardCompatible: vi.fn(),
   deleteInRepoRecipe: vi.fn(),
   reconcileProjectRecipes: vi.fn(() => []),
 }));
@@ -361,6 +362,35 @@ describe("projectRecipes IPC adversarial", () => {
         recipes: [validRecipe(), { ...validRecipe(), id: "r2", terminals: [secretTerminal()] }],
       })
     ).rejects.toThrow(/secret.*github-pat|GITHUB_TOKEN/i);
+    expect(projectStoreMock.writeInRepoRecipe).not.toHaveBeenCalled();
+  });
+
+  it("syncInRepoRecipes pre-flights forward compatibility before writing anything", async () => {
+    projectStoreMock.getProjectById.mockReturnValueOnce({ path: "/repo" } as never);
+    await getHandler(CHANNELS.PROJECT_SYNC_INREPO_RECIPES)(fakeEvent(), {
+      projectId: "p1",
+      recipes: [validRecipe(), { ...validRecipe(), id: "r2", name: "Second" }],
+    });
+    expect(projectStoreMock.assertInRepoRecipesForwardCompatible).toHaveBeenCalledWith("/repo", [
+      "My Recipe",
+      "Second",
+    ]);
+    expect(projectStoreMock.writeInRepoRecipe).toHaveBeenCalledTimes(2);
+  });
+
+  it("syncInRepoRecipes writes nothing when the pre-flight rejects", async () => {
+    // This writer is unchecked by design, so the pre-flight is the only thing
+    // standing between an automation-driven sync and the tracked files (#12261).
+    projectStoreMock.getProjectById.mockReturnValueOnce({ path: "/repo" } as never);
+    projectStoreMock.assertInRepoRecipesForwardCompatible.mockRejectedValueOnce(
+      Object.assign(new Error("would strip"), { code: "RECIPE_FORWARD_COMPAT_CONFLICT" })
+    );
+    await expect(
+      getHandler(CHANNELS.PROJECT_SYNC_INREPO_RECIPES)(fakeEvent(), {
+        projectId: "p1",
+        recipes: [validRecipe()],
+      })
+    ).rejects.toMatchObject({ code: "RECIPE_FORWARD_COMPAT_CONFLICT" });
     expect(projectStoreMock.writeInRepoRecipe).not.toHaveBeenCalled();
   });
 

--- a/electron/ipc/handlers/projectInRepoSettings.ts
+++ b/electron/ipc/handlers/projectInRepoSettings.ts
@@ -95,6 +95,18 @@ export function registerProjectInRepoSettingsHandlers(_deps: HandlerDependencies
       throw new Error(`Project not found: ${projectId}`);
     }
     const settings = await projectStore.getProjectSettings(projectId);
+
+    // Enabling rewrites every project recipe over `.daintree/recipes/`. Any
+    // destination already holding content this build can't represent would be
+    // silently stripped and committed, so check them all up front and fail the
+    // whole operation — a half-written batch with `inRepoSettings` flipped on is
+    // worse than not enabling at all (#12261).
+    const recipes = await projectStore.getRecipes(projectId);
+    await projectStore.assertInRepoRecipesForwardCompatible(
+      project.path,
+      recipes.map((recipe) => recipe.name)
+    );
+
     await projectStore.writeInRepoProjectIdentity(project.path, {
       id: project.id,
       name: project.name,
@@ -103,8 +115,7 @@ export function registerProjectInRepoSettingsHandlers(_deps: HandlerDependencies
     });
     await projectStore.writeInRepoSettings(project.path, settings);
 
-    // Sync existing project recipes to .daintree/recipes/
-    const recipes = await projectStore.getRecipes(projectId);
+    // Sync existing project recipes to .daintree/recipes/ (pre-flighted above).
     for (const recipe of recipes) {
       await projectStore.writeInRepoRecipe(project.path, recipe);
     }

--- a/electron/ipc/handlers/projectRecipes.ts
+++ b/electron/ipc/handlers/projectRecipes.ts
@@ -233,6 +233,13 @@ export function registerProjectRecipesHandlers(_deps: HandlerDependencies): () =
         assertNoSecretEnvValues(recipe.terminals);
       }
     }
+    // Same forward-compatibility pre-flight as the enable path: this writer is
+    // unchecked by design, so without it an automation-driven sync would strip
+    // newer content out of the tracked files (#12261).
+    await projectStore.assertInRepoRecipesForwardCompatible(
+      project.path,
+      recipes.map((recipe) => recipe.name)
+    );
     for (const recipe of recipes) {
       await projectStore.writeInRepoRecipe(project.path, recipe);
     }

--- a/electron/services/ProjectIdentityFiles.ts
+++ b/electron/services/ProjectIdentityFiles.ts
@@ -17,6 +17,11 @@ import {
   sanitizeRecipeTerminals,
   MAX_TERMINALS_PER_RECIPE,
 } from "../../shared/utils/recipeSanitizer.js";
+import {
+  detectRecipeForwardIncompat,
+  describeRecipeForwardIncompat,
+  type RecipeForwardIncompat,
+} from "../../shared/utils/recipeCompatibility.js";
 
 /**
  * Builds the exact UTF-8 byte string that `writeInRepoRecipe` lands on disk
@@ -334,6 +339,38 @@ export class ProjectIdentityFiles {
     }
   }
 
+  /**
+   * Inspects the file a write to `recipeName` would land on and reports what
+   * re-serializing this build's in-memory recipe over it would delete (#12261).
+   * Returns `null` when the write is lossless — including when the file does not
+   * exist yet, or holds content this build cannot parse at all (a malformed file
+   * is already skipped by the reader and carries nothing worth preserving).
+   *
+   * Deliberately reads the file fresh rather than consulting the load-time hash
+   * cache. The cache cannot answer this question: its entries are keyed by the
+   * recipe id the reader resolved, and the files at risk here include ones the
+   * reader dropped entirely (every terminal unsupported), which never got an
+   * entry. A cold cache must never read as "safe to overwrite".
+   */
+  async inspectInRepoRecipeForwardCompat(
+    projectPath: string,
+    recipeName: string
+  ): Promise<RecipeForwardIncompat | null> {
+    const filePath = path.join(projectPath, DAINTREE_RECIPES_DIR, safeRecipeFilename(recipeName));
+    let content: string;
+    try {
+      content = await fs.readFile(filePath, "utf-8");
+    } catch (error) {
+      if (error instanceof Error && "code" in error && error.code === "ENOENT") return null;
+      throw error;
+    }
+    try {
+      return detectRecipeForwardIncompat(JSON.parse(content));
+    } catch {
+      return null;
+    }
+  }
+
   async readInRepoRecipes(projectPath: string): Promise<TerminalRecipe[]> {
     const { recipes } = await this.readInRepoRecipesWithHashes(projectPath);
     return recipes;
@@ -427,6 +464,18 @@ export class ProjectIdentityFiles {
           continue;
         }
         seenIds.add(result.data.id);
+        // Name what this build cannot represent while the passthrough parse
+        // still carries it. Sanitization below is about to discard the
+        // evidence, and re-serializing the reduced recipe over this file would
+        // delete it from git with nothing to show for it (#12261). The write
+        // paths refuse that separately; this is the read-time half.
+        const forwardIncompat = detectRecipeForwardIncompat(result.data);
+        if (forwardIncompat) {
+          console.warn(
+            `[ProjectIdentityFiles] ${entry.name} holds content this build does not support — ` +
+              `it will not round-trip: ${describeRecipeForwardIncompat(forwardIncompat)}`
+          );
+        }
         // The schema only validates shape (and passes unknown fields through).
         // Content-validate every terminal at this trust boundary — dropping any
         // with a bad type or control-char-laden command/args/env — so an

--- a/electron/services/ProjectStore.ts
+++ b/electron/services/ProjectStore.ts
@@ -1879,6 +1879,26 @@ export class ProjectStore {
           continue;
         }
 
+        // `seenFilenames` only knows about recipes the reader returned, so a
+        // file it dropped whole — every terminal of a type this build doesn't
+        // know — records no owner and would be promoted straight over (#12261).
+        // That is the worst case of all: it needs no user action, since an
+        // ordinary project load runs reconciliation. Unlike the write paths this
+        // one cannot throw, so keep the local recipe in the mirror and leave the
+        // file alone; both survive, and neither is silently dropped.
+        const loss = await this.identityFiles.inspectInRepoRecipeForwardCompat(
+          projectPath,
+          recipe.name
+        );
+        if (loss) {
+          console.warn(
+            `[ProjectStore] Not promoting recipe "${recipe.name}" — ${filename} holds content ` +
+              `this build does not support: ${describeRecipeForwardIncompat(loss)}`
+          );
+          keptLocal.push(recipe);
+          continue;
+        }
+
         await this.writeInRepoRecipe(projectPath, recipe);
         inRepoById.set(recipe.id, recipe);
         seenFilenames.set(filename, recipe.id);

--- a/electron/services/ProjectStore.ts
+++ b/electron/services/ProjectStore.ts
@@ -53,6 +53,7 @@ import {
   cleanupUserDataRootQuarantineFiles,
 } from "./projectQuarantineCleanup.js";
 import { safeRecipeFilename } from "../utils/recipeFilename.js";
+import { describeRecipeForwardIncompat } from "../../shared/utils/recipeCompatibility.js";
 import { isInRepoRecipeId } from "../../shared/utils/recipeFilename.js";
 
 import { bumpFrecencyScore, decayFrecencyScore, FRECENCY_COLD_START } from "./frecency.js";
@@ -418,6 +419,14 @@ export class ProjectStore {
     options: { force?: boolean; previousName?: string } = {}
   ): Promise<void> {
     if (!options.force) {
+      // Checked before staleness: an unchanged file can still be one this build
+      // would strip on write-back, and that loss is invisible to a hash
+      // comparison taken from those same unchanged bytes (#12261). A rename
+      // reads both destinations, since the old-name file is deleted below.
+      await this.assertInRepoRecipesForwardCompatible(projectPath, [
+        recipe.name,
+        ...(options.previousName ? [options.previousName] : []),
+      ]);
       await this.assertRecipeFileNotStale(projectPath, recipe.id, recipe.name);
       if (
         options.previousName &&
@@ -433,6 +442,56 @@ export class ProjectStore {
     }
     const hash = await this.identityFiles.writeInRepoRecipe(projectPath, recipe);
     this.inRepoRecipeHashes.set(this.hashKey(projectPath, recipe.id), hash);
+  }
+
+  /**
+   * Refuses a write into `.daintree/recipes/` that would delete content this
+   * build cannot represent (#12261).
+   *
+   * `.daintree/recipes/*.json` is git-tracked and shared between machines on
+   * different builds. This build rebuilds every recipe from an explicit field
+   * list and drops terminals whose `type` it doesn't know, then serializes that
+   * reduced object straight back over the file — so without this guard an older
+   * build silently commits away whatever a newer one wrote. The staleness guard
+   * cannot catch it: the file hasn't changed, so its hash still matches.
+   *
+   * Each destination is read fresh rather than looked up in
+   * `inRepoRecipeHashes`. The files most at risk are the ones the reader
+   * dropped entirely, which never get a cache entry at all — a cold cache must
+   * never read as "safe to overwrite".
+   *
+   * Names are deduplicated by resolved filename so a rename whose two names
+   * collapse to one file is reported once.
+   *
+   * Public so the batch writers (enable-in-repo-settings, recipe sync) can
+   * pre-flight every destination before their first write and fail the whole
+   * operation, rather than stopping halfway with some files already rewritten.
+   */
+  async assertInRepoRecipesForwardCompatible(
+    projectPath: string,
+    recipeNames: string[]
+  ): Promise<void> {
+    const seen = new Set<string>();
+    const affected: string[] = [];
+    for (const name of recipeNames) {
+      const filename = safeRecipeFilename(name);
+      if (seen.has(filename)) continue;
+      seen.add(filename);
+      const loss = await this.identityFiles.inspectInRepoRecipeForwardCompat(projectPath, name);
+      if (loss) affected.push(`${filename} — ${describeRecipeForwardIncompat(loss)}`);
+    }
+    if (affected.length === 0) return;
+
+    // The detail has to travel in `userMessage`: `context` never crosses the
+    // contextBridge (the preload reconstructs only code/message/userMessage),
+    // and packaged builds strip it outright.
+    const detail = affected.join("\n");
+    throw new AppError({
+      code: "RECIPE_FORWARD_COMPAT_CONFLICT",
+      message: `Saving would delete unsupported content from ${affected.length} in-repo recipe file(s)`,
+      userMessage: detail,
+      context: { projectPath, affected },
+    });
   }
 
   private async assertRecipeFileNotStale(

--- a/electron/services/__tests__/ProjectStore.recipes.test.ts
+++ b/electron/services/__tests__/ProjectStore.recipes.test.ts
@@ -763,3 +763,238 @@ describe("ProjectStore.writeInRepoRecipeChecked (in-repo recipe staleness guard,
     await expect(fresh.writeInRepoRecipeChecked(projectPath, recipe)).resolves.toBeUndefined();
   });
 });
+
+describe("ProjectStore in-repo recipe forward-compatibility guard (#12261)", () => {
+  let tmpDir: string;
+  let projectPath: string;
+  let store: ProjectStore;
+  let recipesDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "daintree-recipe-fwd-"));
+    projectPath = path.join(tmpDir, "repo");
+    recipesDir = path.join(projectPath, ".daintree", "recipes");
+    store = new ProjectStore();
+    (store as unknown as { projectsConfigDir: string }).projectsConfigDir = tmpDir;
+    (store as unknown as { fileStore: { projectsConfigDir: string } }).fileStore.projectsConfigDir =
+      tmpDir;
+    await store.initialize();
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  /**
+   * Lands a file exactly as a newer build would have: content this build reads
+   * with parts dropped, and whose bytes then never change — so the staleness
+   * guard sees a matching hash and waves the write through.
+   */
+  async function seedFutureFile(name: string, body: Record<string, unknown>): Promise<string> {
+    await fs.mkdir(recipesDir, { recursive: true });
+    const filePath = path.join(recipesDir, `${name}.json`);
+    await fs.writeFile(filePath, JSON.stringify(body, null, 2) + "\n", "utf-8");
+    return filePath;
+  }
+
+  const futureBody = (name: string, extra: Record<string, unknown> = {}) => ({
+    id: stableInRepoId(name),
+    name,
+    terminals: [{ type: "terminal", command: "echo hi" }],
+    createdAt: 1,
+    scope: "inrepo",
+    ...extra,
+  });
+
+  it("refuses a save that would strip an unknown top-level field, leaving bytes untouched", async () => {
+    const filePath = await seedFutureFile("Widget", futureBody("Widget", { ritual: "nightly" }));
+    const original = await fs.readFile(filePath, "utf-8");
+
+    // Load the way the app does, so the staleness cache is warm and matching —
+    // this is precisely the state in which the old guard passes the write.
+    const [loaded] = await store.readInRepoRecipes(projectPath);
+    expect(loaded.name).toBe("Widget");
+
+    await expect(
+      store.writeInRepoRecipeChecked(projectPath, {
+        ...loaded,
+        terminals: [{ type: "terminal", command: "changed" }],
+      })
+    ).rejects.toMatchObject({ code: "RECIPE_FORWARD_COMPAT_CONFLICT" });
+
+    expect(await fs.readFile(filePath, "utf-8")).toBe(original);
+  });
+
+  it("refuses a save that would drop a terminal of an unrecognized type", async () => {
+    const filePath = await seedFutureFile("Fleet", {
+      ...futureBody("Fleet"),
+      terminals: [{ type: "terminal", command: "echo hi" }, { type: "future-agent" }],
+    });
+    const original = await fs.readFile(filePath, "utf-8");
+    const [loaded] = await store.readInRepoRecipes(projectPath);
+    // The unsupported terminal is already gone from memory — this is the loss.
+    expect(loaded.terminals).toHaveLength(1);
+
+    await expect(store.writeInRepoRecipeChecked(projectPath, loaded)).rejects.toMatchObject({
+      code: "RECIPE_FORWARD_COMPAT_CONFLICT",
+    });
+    expect(await fs.readFile(filePath, "utf-8")).toBe(original);
+  });
+
+  it("refuses a save that would strip an unknown field from a terminal", async () => {
+    await seedFutureFile("Runner", {
+      ...futureBody("Runner"),
+      terminals: [{ type: "terminal", command: "echo hi", retryPolicy: "always" }],
+    });
+    const [loaded] = await store.readInRepoRecipes(projectPath);
+    await expect(store.writeInRepoRecipeChecked(projectPath, loaded)).rejects.toMatchObject({
+      code: "RECIPE_FORWARD_COMPAT_CONFLICT",
+    });
+  });
+
+  it("names the affected file and what would be lost, without leaking values", async () => {
+    await seedFutureFile("Detail", futureBody("Detail", { secretPlan: "launch-codes" }));
+    const [loaded] = await store.readInRepoRecipes(projectPath);
+
+    await expect(store.writeInRepoRecipeChecked(projectPath, loaded)).rejects.toMatchObject({
+      code: "RECIPE_FORWARD_COMPAT_CONFLICT",
+      // Detail must ride in `userMessage`: `context` never crosses the contextBridge.
+      userMessage: expect.stringContaining("detail.json"),
+    });
+    await expect(store.writeInRepoRecipeChecked(projectPath, loaded)).rejects.toMatchObject({
+      userMessage: expect.not.stringContaining("launch-codes"),
+    });
+  });
+
+  it("fires on a cold cache, before any read has happened", async () => {
+    // The cache can't answer this question, so the guard must not depend on it.
+    await seedFutureFile("Cold", futureBody("Cold", { ritual: 1 }));
+    const fresh = new ProjectStore();
+    (fresh as unknown as { projectsConfigDir: string }).projectsConfigDir = tmpDir;
+    await fresh.initialize();
+
+    await expect(
+      fresh.writeInRepoRecipeChecked(projectPath, makeRecipe({ name: "Cold" }))
+    ).rejects.toMatchObject({ code: "RECIPE_FORWARD_COMPAT_CONFLICT" });
+  });
+
+  it("protects a file the reader dropped entirely", async () => {
+    // Every terminal unsupported → the reader skips the recipe, so it never
+    // reaches the store and has no cache entry at all. Overwriting it is the
+    // worst case: the whole file's content is destroyed.
+    const filePath = await seedFutureFile("Ghost", {
+      ...futureBody("Ghost"),
+      terminals: [{ type: "future-agent" }],
+    });
+    const original = await fs.readFile(filePath, "utf-8");
+    expect(await store.readInRepoRecipes(projectPath)).toHaveLength(0);
+
+    await expect(
+      store.writeInRepoRecipeChecked(projectPath, makeRecipe({ name: "Ghost" }))
+    ).rejects.toMatchObject({ code: "RECIPE_FORWARD_COMPAT_CONFLICT" });
+    expect(await fs.readFile(filePath, "utf-8")).toBe(original);
+  });
+
+  it("refuses a rename when the old-name file is the affected one", async () => {
+    // The rename deletes the old file, so it must be inspected too.
+    const oldPath = await seedFutureFile("Before", futureBody("Before", { ritual: 1 }));
+    const original = await fs.readFile(oldPath, "utf-8");
+    const [loaded] = await store.readInRepoRecipes(projectPath);
+
+    await expect(
+      store.writeInRepoRecipeChecked(
+        projectPath,
+        { ...loaded, name: "After" },
+        { previousName: "Before" }
+      )
+    ).rejects.toMatchObject({ code: "RECIPE_FORWARD_COMPAT_CONFLICT" });
+
+    await expect(fs.access(path.join(recipesDir, "after.json"))).rejects.toThrow();
+    expect(await fs.readFile(oldPath, "utf-8")).toBe(original);
+  });
+
+  it("force=true overwrites, because the dialog's Overwrite is the explicit resolution", async () => {
+    const filePath = await seedFutureFile("Forced", futureBody("Forced", { ritual: 1 }));
+    const [loaded] = await store.readInRepoRecipes(projectPath);
+
+    await expect(
+      store.writeInRepoRecipeChecked(
+        projectPath,
+        { ...loaded, terminals: [{ type: "terminal", command: "mine" }] },
+        { force: true }
+      )
+    ).resolves.toBeUndefined();
+
+    const written = JSON.parse(await fs.readFile(filePath, "utf-8"));
+    expect(written.ritual).toBeUndefined();
+    expect(written.terminals[0].command).toBe("mine");
+  });
+
+  it("leaves a fully-understood recipe alone on every path", async () => {
+    const recipe = makeRecipe({ id: stableInRepoId("Plain"), name: "Plain" });
+    await store.writeInRepoRecipe(projectPath, recipe);
+    await store.readInRepoRecipes(projectPath);
+
+    await expect(
+      store.writeInRepoRecipeChecked(projectPath, {
+        ...recipe,
+        terminals: [{ type: "terminal", command: "still fine" }],
+      })
+    ).resolves.toBeUndefined();
+    await expect(
+      store.assertInRepoRecipesForwardCompatible(projectPath, ["Plain"])
+    ).resolves.toBeUndefined();
+  });
+
+  it("passes for a brand-new recipe whose file does not exist yet", async () => {
+    await expect(
+      store.assertInRepoRecipesForwardCompatible(projectPath, ["Nothing Here"])
+    ).resolves.toBeUndefined();
+  });
+
+  it("ignores a malformed file, which the reader already skips and holds nothing to preserve", async () => {
+    await fs.mkdir(recipesDir, { recursive: true });
+    await fs.writeFile(path.join(recipesDir, "broken.json"), "{ not json", "utf-8");
+    await expect(
+      store.assertInRepoRecipesForwardCompatible(projectPath, ["Broken"])
+    ).resolves.toBeUndefined();
+  });
+
+  it("aggregates every affected file in one batch error and dedupes by filename", async () => {
+    await seedFutureFile("One", futureBody("One", { ritual: 1 }));
+    await seedFutureFile("Two", {
+      ...futureBody("Two"),
+      terminals: [{ type: "future-agent" }],
+    });
+    await store.writeInRepoRecipe(projectPath, makeRecipe({ name: "Three" }));
+
+    // "One" twice: a rename collapsing to the same file must be reported once.
+    await expect(
+      store.assertInRepoRecipesForwardCompatible(projectPath, ["One", "Two", "Three", "One"])
+    ).rejects.toMatchObject({ code: "RECIPE_FORWARD_COMPAT_CONFLICT" });
+
+    const error = await store
+      .assertInRepoRecipesForwardCompatible(projectPath, ["One", "Two", "Three", "One"])
+      .catch((e: Error & { userMessage?: string }) => e);
+    const lines = (error as { userMessage: string }).userMessage.split("\n");
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toContain("one.json");
+    expect(lines[1]).toContain("two.json");
+  });
+
+  it("keeps projects separate — another clone's file cannot block this one", async () => {
+    const otherPath = path.join(tmpDir, "other-repo");
+    await fs.mkdir(path.join(otherPath, ".daintree", "recipes"), { recursive: true });
+    await fs.writeFile(
+      path.join(otherPath, ".daintree", "recipes", "shared.json"),
+      JSON.stringify(futureBody("Shared", { ritual: 1 }), null, 2) + "\n",
+      "utf-8"
+    );
+    await expect(
+      store.assertInRepoRecipesForwardCompatible(projectPath, ["Shared"])
+    ).resolves.toBeUndefined();
+    await expect(
+      store.assertInRepoRecipesForwardCompatible(otherPath, ["Shared"])
+    ).rejects.toMatchObject({ code: "RECIPE_FORWARD_COMPAT_CONFLICT" });
+  });
+});

--- a/electron/services/__tests__/ProjectStore.recipes.test.ts
+++ b/electron/services/__tests__/ProjectStore.recipes.test.ts
@@ -3,7 +3,7 @@ import fs from "fs/promises";
 import path from "path";
 import os from "os";
 import type { TerminalRecipe } from "../../types/index.js";
-import { stableInRepoId } from "../../../shared/utils/recipeFilename.js";
+import { stableInRepoId, safeRecipeFilename } from "../../../shared/utils/recipeFilename.js";
 
 vi.mock("electron", () => ({
   app: {
@@ -792,7 +792,10 @@ describe("ProjectStore in-repo recipe forward-compatibility guard (#12261)", () 
    */
   async function seedFutureFile(name: string, body: Record<string, unknown>): Promise<string> {
     await fs.mkdir(recipesDir, { recursive: true });
-    const filePath = path.join(recipesDir, `${name}.json`);
+    // Resolve the filename the same way the reader and writer do. Spelling it
+    // `${name}.json` passes on a case-insensitive macOS volume and fails on
+    // Linux CI, where the inspector would look at a different file.
+    const filePath = path.join(recipesDir, safeRecipeFilename(name));
     await fs.writeFile(filePath, JSON.stringify(body, null, 2) + "\n", "utf-8");
     return filePath;
   }
@@ -814,6 +817,10 @@ describe("ProjectStore in-repo recipe forward-compatibility guard (#12261)", () 
     // this is precisely the state in which the old guard passes the write.
     const [loaded] = await store.readInRepoRecipes(projectPath);
     expect(loaded.name).toBe("Widget");
+    // The unknown field is genuinely gone from memory — this is the loss the
+    // write-back would commit, and the staleness guard is blind to it because
+    // the file's bytes never changed.
+    expect(loaded).not.toHaveProperty("ritual");
 
     await expect(
       store.writeInRepoRecipeChecked(projectPath, {
@@ -856,14 +863,18 @@ describe("ProjectStore in-repo recipe forward-compatibility guard (#12261)", () 
     await seedFutureFile("Detail", futureBody("Detail", { secretPlan: "launch-codes" }));
     const [loaded] = await store.readInRepoRecipes(projectPath);
 
-    await expect(store.writeInRepoRecipeChecked(projectPath, loaded)).rejects.toMatchObject({
-      code: "RECIPE_FORWARD_COMPAT_CONFLICT",
-      // Detail must ride in `userMessage`: `context` never crosses the contextBridge.
-      userMessage: expect.stringContaining("detail.json"),
-    });
-    await expect(store.writeInRepoRecipeChecked(projectPath, loaded)).rejects.toMatchObject({
-      userMessage: expect.not.stringContaining("launch-codes"),
-    });
+    // One rejection, asserted whole — `expect.not.stringContaining` would also
+    // pass against an absent field, so the presence checks have to be on the
+    // same captured value.
+    const error = await store
+      .writeInRepoRecipeChecked(projectPath, loaded)
+      .then(() => null)
+      .catch((e: Error & { code?: string; userMessage?: string }) => e);
+    expect(error?.code).toBe("RECIPE_FORWARD_COMPAT_CONFLICT");
+    // Detail must ride in `userMessage`: `context` never crosses the contextBridge.
+    expect(error?.userMessage).toContain("detail.json");
+    expect(error?.userMessage).toContain("secretPlan");
+    expect(error?.userMessage).not.toContain("launch-codes");
   });
 
   it("fires on a cold cache, before any read has happened", async () => {
@@ -968,13 +979,15 @@ describe("ProjectStore in-repo recipe forward-compatibility guard (#12261)", () 
     });
     await store.writeInRepoRecipe(projectPath, makeRecipe({ name: "Three" }));
 
-    // "One" twice: a rename collapsing to the same file must be reported once.
+    // "One" and "ONE" are distinct names resolving to the same file — dedup has
+    // to happen on the resolved filename, so a rename can't report it twice.
+    const names = ["One", "Two", "Three", "ONE"];
     await expect(
-      store.assertInRepoRecipesForwardCompatible(projectPath, ["One", "Two", "Three", "One"])
+      store.assertInRepoRecipesForwardCompatible(projectPath, names)
     ).rejects.toMatchObject({ code: "RECIPE_FORWARD_COMPAT_CONFLICT" });
 
     const error = await store
-      .assertInRepoRecipesForwardCompatible(projectPath, ["One", "Two", "Three", "One"])
+      .assertInRepoRecipesForwardCompatible(projectPath, names)
       .catch((e: Error & { userMessage?: string }) => e);
     const lines = (error as { userMessage: string }).userMessage.split("\n");
     expect(lines).toHaveLength(2);
@@ -982,11 +995,62 @@ describe("ProjectStore in-repo recipe forward-compatibility guard (#12261)", () 
     expect(lines[1]).toContain("two.json");
   });
 
+  it("reconciliation does not promote a local recipe over an unsupported file", async () => {
+    // The nastiest path: no user action at all. An ordinary project load runs
+    // reconciliation, and `seenFilenames` is built from what the reader
+    // returned — so a file it dropped whole records no owner and would be
+    // promoted straight over.
+    const filePath = await seedFutureFile("Ghost", {
+      ...futureBody("Ghost"),
+      terminals: [{ type: "future-agent" }],
+    });
+    const original = await fs.readFile(filePath, "utf-8");
+    expect(await store.readInRepoRecipes(projectPath)).toHaveLength(0);
+
+    const projectId = "a".repeat(64);
+    await store.saveRecipes(projectId, [makeRecipe({ id: "local-ghost", name: "Ghost" })]);
+    await store.reconcileProjectRecipes(projectPath, projectId);
+
+    // The in-repo file is untouched...
+    expect(await fs.readFile(filePath, "utf-8")).toBe(original);
+    // ...and the local recipe still survives in the mirror rather than being dropped.
+    expect((await store.getRecipes(projectId)).map((r) => r.id)).toContain("local-ghost");
+  });
+
+  it("reconciliation still promotes when the destination is absent or clean", async () => {
+    const projectId = "a".repeat(64);
+    await store.saveRecipes(projectId, [makeRecipe({ id: "local-new", name: "Fresh" })]);
+    await store.reconcileProjectRecipes(projectPath, projectId);
+
+    const onDisk = await fs.readFile(path.join(recipesDir, "fresh.json"), "utf-8");
+    expect(JSON.parse(onDisk).name).toBe("Fresh");
+  });
+
+  it("refuses a save that would drop terminals past the per-recipe cap", async () => {
+    // 11 ordinary terminals: the reader returns 10 and caches the 11-entry
+    // file's hash, so both the staleness guard and a key/type diff see nothing.
+    const filePath = await seedFutureFile("Crowded", {
+      ...futureBody("Crowded"),
+      terminals: Array.from({ length: 11 }, (_, i) => ({
+        type: "terminal",
+        command: `echo ${i}`,
+      })),
+    });
+    const original = await fs.readFile(filePath, "utf-8");
+    const [loaded] = await store.readInRepoRecipes(projectPath);
+    expect(loaded.terminals).toHaveLength(10);
+
+    await expect(
+      store.writeInRepoRecipeChecked(projectPath, { ...loaded, showInEmptyState: true })
+    ).rejects.toMatchObject({ code: "RECIPE_FORWARD_COMPAT_CONFLICT" });
+    expect(await fs.readFile(filePath, "utf-8")).toBe(original);
+  });
+
   it("keeps projects separate — another clone's file cannot block this one", async () => {
     const otherPath = path.join(tmpDir, "other-repo");
     await fs.mkdir(path.join(otherPath, ".daintree", "recipes"), { recursive: true });
     await fs.writeFile(
-      path.join(otherPath, ".daintree", "recipes", "shared.json"),
+      path.join(otherPath, ".daintree", "recipes", safeRecipeFilename("Shared")),
       JSON.stringify(futureBody("Shared", { ritual: 1 }), null, 2) + "\n",
       "utf-8"
     );

--- a/electron/services/__tests__/writeInRepoFiles.test.ts
+++ b/electron/services/__tests__/writeInRepoFiles.test.ts
@@ -582,6 +582,57 @@ describe("readInRepoRecipesWithHashes", () => {
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
 
+  it("names what it cannot represent, and still returns the parts it can (#12261)", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    await fs.mkdir(path.join(tmpDir, DAINTREE_RECIPES_DIR), { recursive: true });
+    await fs.writeFile(
+      path.join(tmpDir, DAINTREE_RECIPES_DIR, "future.json"),
+      JSON.stringify(
+        {
+          id: "r1",
+          name: "Future",
+          createdAt: 1,
+          ritual: "nightly",
+          terminals: [
+            { type: "terminal", command: "echo hi", retryPolicy: "always" },
+            { type: "future-agent" },
+          ],
+        },
+        null,
+        2
+      ) + "\n",
+      "utf-8"
+    );
+
+    const { recipes } = await identityFiles.readInRepoRecipesWithHashes(tmpDir);
+
+    // The supported half still loads — the guard is about writing, not reading.
+    expect(recipes).toHaveLength(1);
+    expect(recipes[0].terminals).toHaveLength(1);
+
+    const warning = warnSpy.mock.calls
+      .map((call) => String(call[0]))
+      .find((message) => message.includes("does not support"));
+    expect(warning).toBeDefined();
+    expect(warning).toContain("future.json");
+    expect(warning).toContain('terminal #2 (type "future-agent")');
+    expect(warning).toContain("retryPolicy");
+    expect(warning).toContain("ritual");
+    warnSpy.mockRestore();
+  });
+
+  it("stays quiet for a recipe it fully understands", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    await identityFiles.writeInRepoRecipe(tmpDir, makeRecipe({ id: "r1", name: "Plain" }));
+
+    await identityFiles.readInRepoRecipesWithHashes(tmpDir);
+
+    expect(
+      warnSpy.mock.calls.map((call) => String(call[0])).filter((m) => m.includes("does not support"))
+    ).toEqual([]);
+    warnSpy.mockRestore();
+  });
+
   it("returns hash matching the file bytes for each loaded recipe", async () => {
     await identityFiles.writeInRepoRecipe(tmpDir, makeRecipe({ id: "r1", name: "First" }));
     await identityFiles.writeInRepoRecipe(tmpDir, makeRecipe({ id: "r2", name: "Second" }));

--- a/electron/services/__tests__/writeInRepoFiles.test.ts
+++ b/electron/services/__tests__/writeInRepoFiles.test.ts
@@ -628,7 +628,9 @@ describe("readInRepoRecipesWithHashes", () => {
     await identityFiles.readInRepoRecipesWithHashes(tmpDir);
 
     expect(
-      warnSpy.mock.calls.map((call) => String(call[0])).filter((m) => m.includes("does not support"))
+      warnSpy.mock.calls
+        .map((call) => String(call[0]))
+        .filter((m) => m.includes("does not support"))
     ).toEqual([]);
     warnSpy.mockRestore();
   });

--- a/shared/types/appError.ts
+++ b/shared/types/appError.ts
@@ -29,6 +29,10 @@ export type AppErrorCode =
   | "ARG_COUNT_EXCEEDED"
   | "PAYLOAD_TOO_LARGE"
   | "RECIPE_STALE_CONFLICT"
+  // A write into `.daintree/recipes/` would delete content this build cannot
+  // represent — unknown fields, or terminals of an unrecognized type — that a
+  // newer build (or a plugin) put in the tracked file (#12261).
+  | "RECIPE_FORWARD_COMPAT_CONFLICT"
   | "PLUGIN_ACTIVATION_FAILED"
   // A project-bound plugin host call had no live renderer for its own project.
   // Deliberately not a fallback to the focused view: delivering it elsewhere is

--- a/shared/utils/__tests__/recipeCompatibility.test.ts
+++ b/shared/utils/__tests__/recipeCompatibility.test.ts
@@ -134,6 +134,37 @@ describe("detectRecipeForwardIncompat", () => {
     ).toBeNull();
   });
 
+  it("reports valid terminals the per-recipe cap would discard on write-back", () => {
+    // The cap is a spawn-safety limit, but the reader applies it before the
+    // recipe reaches memory — so saving deletes the overflow from the file too.
+    const terminals = Array.from({ length: 12 }, (_, i) => ({
+      type: "terminal",
+      command: `echo ${i}`,
+    }));
+    const loss = detectRecipeForwardIncompat({ ...cleanRecipe(), terminals });
+    expect(loss?.cappedTerminalCount).toBe(2);
+    expect(loss?.unknownRecipeKeys).toEqual([]);
+    expect(loss?.unsupportedTerminals).toEqual([]);
+  });
+
+  it("counts only terminals the cap discards, not ones the sanitizer rejects", () => {
+    // 11 entries, but one is rejected for a control-char command — 10 survive,
+    // which is exactly the cap, so nothing is lost to it.
+    const terminals = [
+      ...Array.from({ length: 10 }, (_, i) => ({ type: "terminal", command: `echo ${i}` })),
+      { type: "terminal", command: "echo\nrm -rf /" },
+    ];
+    expect(detectRecipeForwardIncompat({ ...cleanRecipe(), terminals })).toBeNull();
+  });
+
+  it("reports nothing for a recipe exactly at the cap", () => {
+    const terminals = Array.from({ length: 10 }, (_, i) => ({
+      type: "terminal",
+      command: `echo ${i}`,
+    }));
+    expect(detectRecipeForwardIncompat({ ...cleanRecipe(), terminals })).toBeNull();
+  });
+
   it("leaves the inspected object untouched", () => {
     const recipe = { ...cleanRecipe(), mystery: 1 };
     const snapshot = JSON.stringify(recipe);
@@ -161,6 +192,14 @@ describe("describeRecipeForwardIncompat", () => {
     expect(described).toContain('terminal #1 (type "future-agent")');
     expect(described).toContain("unknown terminal fields — #2: retryPolicy");
     expect(described).toContain("unknown recipe fields — ritual");
+  });
+
+  it("names the cap overflow", () => {
+    const loss = detectRecipeForwardIncompat({
+      ...cleanRecipe(),
+      terminals: Array.from({ length: 11 }, () => ({ type: "terminal", command: "x" })),
+    })!;
+    expect(describeRecipeForwardIncompat(loss)).toBe("1 terminal(s) past the 10-terminal limit");
   });
 
   it("never reveals values, only shape", () => {

--- a/shared/utils/__tests__/recipeCompatibility.test.ts
+++ b/shared/utils/__tests__/recipeCompatibility.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from "vitest";
+import {
+  detectRecipeForwardIncompat,
+  describeRecipeForwardIncompat,
+} from "../recipeCompatibility.js";
+
+const cleanRecipe = () => ({
+  id: "r1",
+  name: "Build",
+  terminals: [{ type: "terminal", command: "npm run dev" }],
+  createdAt: 1,
+});
+
+describe("detectRecipeForwardIncompat", () => {
+  it("returns null for a recipe this build fully understands", () => {
+    expect(detectRecipeForwardIncompat(cleanRecipe())).toBeNull();
+  });
+
+  it("returns null for non-objects rather than throwing", () => {
+    expect(detectRecipeForwardIncompat(undefined)).toBeNull();
+    expect(detectRecipeForwardIncompat(null)).toBeNull();
+    expect(detectRecipeForwardIncompat("nope")).toBeNull();
+    expect(detectRecipeForwardIncompat([1, 2])).toBeNull();
+  });
+
+  it("treats every declared field as known, including ones never written to disk", () => {
+    // agentModelId/agentLaunchFlags/location are transient and stripped before
+    // persistence — a file carrying one is ordinary data, not a newer schema (#9654).
+    const recipe = {
+      ...cleanRecipe(),
+      projectId: "p",
+      worktreeId: "w",
+      showInEmptyState: true,
+      lastUsedAt: 5,
+      usageHistory: [1],
+      autoAssign: "prompt",
+      shadowedBy: "other",
+      scope: "inrepo",
+      origin: { kind: "plugin", pluginId: "a", contributionId: "b" },
+      terminals: [
+        {
+          type: "terminal",
+          title: "t",
+          command: "c",
+          env: { A: "1" },
+          initialPrompt: "p",
+          args: "--x",
+          devCommand: "d",
+          exitBehavior: "keep",
+          agentModelId: "m",
+          agentLaunchFlags: ["--f"],
+          location: "dock",
+        },
+      ],
+    };
+    expect(detectRecipeForwardIncompat(recipe)).toBeNull();
+  });
+
+  it("reports unknown top-level recipe keys, sorted", () => {
+    const loss = detectRecipeForwardIncompat({ ...cleanRecipe(), zeta: 1, alpha: 2 });
+    expect(loss?.unknownRecipeKeys).toEqual(["alpha", "zeta"]);
+    expect(loss?.unknownTerminalKeys).toEqual([]);
+    expect(loss?.unsupportedTerminals).toEqual([]);
+  });
+
+  it("reports unknown terminal keys against the original on-disk index", () => {
+    const loss = detectRecipeForwardIncompat({
+      ...cleanRecipe(),
+      terminals: [
+        { type: "terminal" },
+        { type: "terminal", retryPolicy: "always" },
+        { type: "terminal" },
+      ],
+    });
+    expect(loss?.unknownTerminalKeys).toEqual([{ index: 1, keys: ["retryPolicy"] }]);
+  });
+
+  it("reports a well-formed but unrecognized terminal type", () => {
+    const loss = detectRecipeForwardIncompat({
+      ...cleanRecipe(),
+      terminals: [{ type: "terminal" }, { type: "future-agent" }],
+    });
+    expect(loss?.unsupportedTerminals).toEqual([{ index: 1, type: "future-agent" }]);
+  });
+
+  it("keeps original indices when an earlier terminal is itself unsupported", () => {
+    // Indices must survive filtering — they point the user at entries in a file
+    // they may go and open, not at the sanitized in-memory array.
+    const loss = detectRecipeForwardIncompat({
+      ...cleanRecipe(),
+      terminals: [{ type: "future-agent" }, { type: "terminal", extra: 1 }],
+    });
+    expect(loss?.unsupportedTerminals).toEqual([{ index: 0, type: "future-agent" }]);
+    expect(loss?.unknownTerminalKeys).toEqual([{ index: 1, keys: ["extra"] }]);
+  });
+
+  it("honours additionalAllowedTypes so plugin agent types are not flagged", () => {
+    const terminals = [{ type: "acme-agent" }];
+    expect(detectRecipeForwardIncompat({ ...cleanRecipe(), terminals })).not.toBeNull();
+    expect(
+      detectRecipeForwardIncompat(
+        { ...cleanRecipe(), terminals },
+        { additionalAllowedTypes: new Set(["acme-agent"]) }
+      )
+    ).toBeNull();
+  });
+
+  it("ignores a missing, empty or non-string type as malformed rather than newer", () => {
+    const loss = detectRecipeForwardIncompat({
+      ...cleanRecipe(),
+      terminals: [{}, { type: "" }, { type: 7 }],
+    });
+    expect(loss).toBeNull();
+  });
+
+  it("does not treat a security-rejected terminal as a compatibility problem", () => {
+    // A control-char command is dropped by the sanitizer for injection safety
+    // (#9160). That is not version skew, and flagging it here would let a
+    // crafted file permanently block saves.
+    expect(
+      detectRecipeForwardIncompat({
+        ...cleanRecipe(),
+        terminals: [{ type: "terminal", command: "echo\nrm -rf /" }],
+      })
+    ).toBeNull();
+  });
+
+  it("does not descend into env, so env keys are never read as recipe fields", () => {
+    expect(
+      detectRecipeForwardIncompat({
+        ...cleanRecipe(),
+        terminals: [{ type: "terminal", env: { SOMETHING_UNKNOWN: "x" } }],
+      })
+    ).toBeNull();
+  });
+
+  it("leaves the inspected object untouched", () => {
+    const recipe = { ...cleanRecipe(), mystery: 1 };
+    const snapshot = JSON.stringify(recipe);
+    detectRecipeForwardIncompat(recipe);
+    expect(JSON.stringify(recipe)).toBe(snapshot);
+  });
+});
+
+describe("describeRecipeForwardIncompat", () => {
+  it("renders terminal positions 1-based and names the foreign type", () => {
+    const loss = detectRecipeForwardIncompat({
+      ...cleanRecipe(),
+      terminals: [{ type: "terminal" }, { type: "future-agent" }],
+    })!;
+    expect(describeRecipeForwardIncompat(loss)).toBe('terminal #2 (type "future-agent")');
+  });
+
+  it("covers all three loss modes in one description", () => {
+    const loss = detectRecipeForwardIncompat({
+      ...cleanRecipe(),
+      ritual: true,
+      terminals: [{ type: "future-agent" }, { type: "terminal", retryPolicy: "always" }],
+    })!;
+    const described = describeRecipeForwardIncompat(loss);
+    expect(described).toContain('terminal #1 (type "future-agent")');
+    expect(described).toContain("unknown terminal fields — #2: retryPolicy");
+    expect(described).toContain("unknown recipe fields — ritual");
+  });
+
+  it("never reveals values, only shape", () => {
+    const loss = detectRecipeForwardIncompat({
+      ...cleanRecipe(),
+      secretToken: "hunter2",
+      terminals: [{ type: "terminal", futureField: "s3cret" }],
+    })!;
+    const described = describeRecipeForwardIncompat(loss);
+    expect(described).toContain("secretToken");
+    expect(described).toContain("futureField");
+    expect(described).not.toContain("hunter2");
+    expect(described).not.toContain("s3cret");
+  });
+});

--- a/shared/utils/recipeCompatibility.ts
+++ b/shared/utils/recipeCompatibility.ts
@@ -1,0 +1,178 @@
+/**
+ * Forward-compatibility detection for in-repo recipe files (#12261).
+ *
+ * `.daintree/recipes/*.json` is git-tracked and shared across machines that may
+ * run different Daintree builds. The read path in
+ * `ProjectIdentityFiles.readInRepoRecipesWithHashes` rebuilds every recipe from
+ * an explicit field list and drops terminals whose `type` this build does not
+ * know — deliberately, since those files are untrusted input (#9160). The write
+ * path then serializes that reduced in-memory recipe straight back over the
+ * file, so an older build silently deletes whatever a newer one wrote, and the
+ * staleness guard cannot see it: the cached hash is taken from the *original*
+ * bytes, which have not changed.
+ *
+ * This module names what the reduction would destroy, so the read path can warn
+ * with specifics and the write paths can refuse. It deliberately does NOT call
+ * the sanitizer: a terminal rejected for a control-char command is a security
+ * drop, not version skew, and folding it in here would both mislabel an attack
+ * and let a crafted file permanently block saves.
+ */
+import type { RecipeTerminal, TerminalRecipe } from "../types/project.js";
+import { isAllowedRecipeType, type RecipeSanitizeOptions } from "./recipeSanitizer.js";
+
+/**
+ * Every field this build knows on a `RecipeTerminal`, including the three that
+ * are *intentionally* absent from disk (`agentModelId`, `agentLaunchFlags`,
+ * `location` are transient and stripped before persistence). They must count as
+ * known: a file that happens to carry one is ordinary data this build
+ * understands, not something a newer build invented (#9654).
+ *
+ * `satisfies Record<keyof T, true>` is what makes this safe to rely on — adding
+ * a field to either interface without listing it here is a compile error, so
+ * the reference set cannot silently drift out of date and start reporting our
+ * own new fields as foreign.
+ */
+const KNOWN_TERMINAL_FIELDS = {
+  type: true,
+  title: true,
+  command: true,
+  env: true,
+  initialPrompt: true,
+  args: true,
+  devCommand: true,
+  exitBehavior: true,
+  agentModelId: true,
+  agentLaunchFlags: true,
+  location: true,
+} satisfies Record<keyof RecipeTerminal, true>;
+
+const KNOWN_RECIPE_FIELDS = {
+  id: true,
+  name: true,
+  projectId: true,
+  worktreeId: true,
+  terminals: true,
+  createdAt: true,
+  showInEmptyState: true,
+  lastUsedAt: true,
+  usageHistory: true,
+  autoAssign: true,
+  shadowedBy: true,
+  scope: true,
+  origin: true,
+} satisfies Record<keyof TerminalRecipe, true>;
+
+const KNOWN_TERMINAL_KEYS: ReadonlySet<string> = new Set(Object.keys(KNOWN_TERMINAL_FIELDS));
+const KNOWN_RECIPE_KEYS: ReadonlySet<string> = new Set(Object.keys(KNOWN_RECIPE_FIELDS));
+
+/** A terminal this build cannot represent, identified by its position on disk. */
+export interface UnsupportedTerminal {
+  /** Index into the file's original `terminals` array, before any filtering. */
+  index: number;
+  /** The unrecognized `type` string, reported verbatim so the user can place it. */
+  type: string;
+}
+
+/** Unknown keys found on one terminal, by its position on disk. */
+export interface UnsupportedTerminalKeys {
+  index: number;
+  keys: string[];
+}
+
+/**
+ * What re-serializing a recipe read by this build would delete from its file.
+ * Only ever describes *shape* — key names and the foreign `type` string. Values,
+ * commands, prompts and env contents are never captured, so this can be logged
+ * and put in front of the user without leaking anything the file holds.
+ */
+export interface RecipeForwardIncompat {
+  /** Top-level recipe keys this build does not know. */
+  unknownRecipeKeys: string[];
+  /** Unknown keys per terminal, keyed by original index. */
+  unknownTerminalKeys: UnsupportedTerminalKeys[];
+  /** Terminals whose `type` is well-formed but unknown, so the whole entry drops. */
+  unsupportedTerminals: UnsupportedTerminal[];
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function unknownKeysOf(value: Record<string, unknown>, known: ReadonlySet<string>): string[] {
+  // Sorted so warnings and error copy are stable across runs — `Object.keys`
+  // order follows insertion order in the parsed JSON, which varies by file.
+  return Object.keys(value)
+    .filter((key) => !known.has(key))
+    .sort();
+}
+
+/**
+ * Inspects a recipe parsed by the passthrough schema (so unknown keys are still
+ * attached) and reports what this build would drop. Returns `null` when nothing
+ * would be lost, which is the overwhelmingly common case — callers can treat a
+ * non-null result as "this file was written by something this build does not
+ * fully understand".
+ *
+ * Pass the same {@link RecipeSanitizeOptions} the matching sanitize call uses,
+ * or the two will disagree about which terminal types are admissible.
+ */
+export function detectRecipeForwardIncompat(
+  parsed: unknown,
+  options?: RecipeSanitizeOptions
+): RecipeForwardIncompat | null {
+  if (!isPlainObject(parsed)) return null;
+
+  const unknownRecipeKeys = unknownKeysOf(parsed, KNOWN_RECIPE_KEYS);
+  const unknownTerminalKeys: UnsupportedTerminalKeys[] = [];
+  const unsupportedTerminals: UnsupportedTerminal[] = [];
+
+  if (Array.isArray(parsed.terminals)) {
+    parsed.terminals.forEach((raw, index) => {
+      if (!isPlainObject(raw)) return;
+      const keys = unknownKeysOf(raw, KNOWN_TERMINAL_KEYS);
+      if (keys.length > 0) unknownTerminalKeys.push({ index, keys });
+      // Only a *well-formed* type that this build doesn't know counts. A missing
+      // or non-string type is malformed input, not a newer schema.
+      const type = raw.type;
+      if (typeof type === "string" && type !== "" && !isAllowedRecipeType(type, options)) {
+        unsupportedTerminals.push({ index, type });
+      }
+    });
+  }
+
+  if (
+    unknownRecipeKeys.length === 0 &&
+    unknownTerminalKeys.length === 0 &&
+    unsupportedTerminals.length === 0
+  ) {
+    return null;
+  }
+  return { unknownRecipeKeys, unknownTerminalKeys, unsupportedTerminals };
+}
+
+/**
+ * One-line, user-facing summary of what a save would delete. Terminal positions
+ * are rendered 1-based because they are pointing the user at entries in a file
+ * they may go and open.
+ */
+export function describeRecipeForwardIncompat(loss: RecipeForwardIncompat): string {
+  const parts: string[] = [];
+  if (loss.unsupportedTerminals.length > 0) {
+    const described = loss.unsupportedTerminals
+      .map((t) => `#${t.index + 1} (type "${t.type}")`)
+      .join(", ");
+    parts.push(
+      `${loss.unsupportedTerminals.length === 1 ? "terminal" : "terminals"} ${described}`
+    );
+  }
+  if (loss.unknownTerminalKeys.length > 0) {
+    const described = loss.unknownTerminalKeys
+      .map((t) => `#${t.index + 1}: ${t.keys.join(", ")}`)
+      .join("; ");
+    parts.push(`unknown terminal fields — ${described}`);
+  }
+  if (loss.unknownRecipeKeys.length > 0) {
+    parts.push(`unknown recipe fields — ${loss.unknownRecipeKeys.join(", ")}`);
+  }
+  return parts.join("; ");
+}

--- a/shared/utils/recipeCompatibility.ts
+++ b/shared/utils/recipeCompatibility.ts
@@ -18,7 +18,12 @@
  * and let a crafted file permanently block saves.
  */
 import type { RecipeTerminal, TerminalRecipe } from "../types/project.js";
-import { isAllowedRecipeType, type RecipeSanitizeOptions } from "./recipeSanitizer.js";
+import {
+  isAllowedRecipeType,
+  sanitizeRecipeTerminals,
+  MAX_TERMINALS_PER_RECIPE,
+  type RecipeSanitizeOptions,
+} from "./recipeSanitizer.js";
 
 /**
  * Every field this build knows on a `RecipeTerminal`, including the three that
@@ -92,6 +97,13 @@ export interface RecipeForwardIncompat {
   unknownTerminalKeys: UnsupportedTerminalKeys[];
   /** Terminals whose `type` is well-formed but unknown, so the whole entry drops. */
   unsupportedTerminals: UnsupportedTerminal[];
+  /**
+   * Terminals this build considers entirely valid but discards anyway, because
+   * the file holds more than {@link MAX_TERMINALS_PER_RECIPE}. The cap is a
+   * spawn-safety limit, but the reader applies it before the recipe reaches
+   * memory, so a write-back deletes the overflow from the file too.
+   */
+  cappedTerminalCount: number;
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
@@ -125,6 +137,13 @@ export function detectRecipeForwardIncompat(
   const unknownRecipeKeys = unknownKeysOf(parsed, KNOWN_RECIPE_KEYS);
   const unknownTerminalKeys: UnsupportedTerminalKeys[] = [];
   const unsupportedTerminals: UnsupportedTerminal[] = [];
+  // The sanitizer is used here only to COUNT survivors, never to report what it
+  // rejected — a terminal dropped for a control-char command is a security drop
+  // and deliberately stays out of this result. What remains is the number of
+  // entries this build considers entirely valid, so anything past the cap is
+  // content it simply refuses to carry back to disk.
+  const survivingTerminals = sanitizeRecipeTerminals(parsed.terminals, options).length;
+  const cappedTerminalCount = Math.max(0, survivingTerminals - MAX_TERMINALS_PER_RECIPE);
 
   if (Array.isArray(parsed.terminals)) {
     parsed.terminals.forEach((raw, index) => {
@@ -143,11 +162,12 @@ export function detectRecipeForwardIncompat(
   if (
     unknownRecipeKeys.length === 0 &&
     unknownTerminalKeys.length === 0 &&
-    unsupportedTerminals.length === 0
+    unsupportedTerminals.length === 0 &&
+    cappedTerminalCount === 0
   ) {
     return null;
   }
-  return { unknownRecipeKeys, unknownTerminalKeys, unsupportedTerminals };
+  return { unknownRecipeKeys, unknownTerminalKeys, unsupportedTerminals, cappedTerminalCount };
 }
 
 /**
@@ -161,9 +181,7 @@ export function describeRecipeForwardIncompat(loss: RecipeForwardIncompat): stri
     const described = loss.unsupportedTerminals
       .map((t) => `#${t.index + 1} (type "${t.type}")`)
       .join(", ");
-    parts.push(
-      `${loss.unsupportedTerminals.length === 1 ? "terminal" : "terminals"} ${described}`
-    );
+    parts.push(`${loss.unsupportedTerminals.length === 1 ? "terminal" : "terminals"} ${described}`);
   }
   if (loss.unknownTerminalKeys.length > 0) {
     const described = loss.unknownTerminalKeys
@@ -173,6 +191,11 @@ export function describeRecipeForwardIncompat(loss: RecipeForwardIncompat): stri
   }
   if (loss.unknownRecipeKeys.length > 0) {
     parts.push(`unknown recipe fields — ${loss.unknownRecipeKeys.join(", ")}`);
+  }
+  if (loss.cappedTerminalCount > 0) {
+    parts.push(
+      `${loss.cappedTerminalCount} terminal(s) past the ${MAX_TERMINALS_PER_RECIPE}-terminal limit`
+    );
   }
   return parts.join("; ");
 }

--- a/shared/utils/recipeSanitizer.ts
+++ b/shared/utils/recipeSanitizer.ts
@@ -67,10 +67,7 @@ export interface RecipeSanitizeOptions {
  * question without duplicating the allowlist — the two must never disagree
  * about which terminals this build can represent (#12261).
  */
-export function isAllowedRecipeType(
-  type: string,
-  options?: RecipeSanitizeOptions
-): boolean {
+export function isAllowedRecipeType(type: string, options?: RecipeSanitizeOptions): boolean {
   return ALLOWED_RECIPE_TYPES.has(type) || options?.additionalAllowedTypes?.has(type) === true;
 }
 

--- a/shared/utils/recipeSanitizer.ts
+++ b/shared/utils/recipeSanitizer.ts
@@ -61,7 +61,16 @@ export interface RecipeSanitizeOptions {
   additionalAllowedTypes?: ReadonlySet<string>;
 }
 
-function isAllowedRecipeType(type: string, options: RecipeSanitizeOptions | undefined): boolean {
+/**
+ * Whether `type` is admissible at this trust boundary. Exported so the
+ * forward-compatibility detector in `recipeCompatibility.ts` can ask the same
+ * question without duplicating the allowlist — the two must never disagree
+ * about which terminals this build can represent (#12261).
+ */
+export function isAllowedRecipeType(
+  type: string,
+  options?: RecipeSanitizeOptions
+): boolean {
   return ALLOWED_RECIPE_TYPES.has(type) || options?.additionalAllowedTypes?.has(type) === true;
 }
 

--- a/src/components/Project/GeneralTab.tsx
+++ b/src/components/Project/GeneralTab.tsx
@@ -23,6 +23,7 @@ import { cn } from "@/lib/utils";
 import { sanitizeSvg, svgToDataUrl } from "@/lib/svg";
 import { GITIGNORE_SNIPPET } from "./projectSettingsConstants";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
+import { isClientAppError } from "@/utils/clientAppError";
 import type { DaintreeMcpTier, Project } from "@shared/types/project";
 import { useProjectSettingsStore } from "@/store/projectSettingsStore";
 import { useProjectRelocationStore } from "@/store/projectRelocationStore";
@@ -298,7 +299,18 @@ export function GeneralTab({
         setInRepoExpanded(false);
       }
     } catch (err) {
-      setInRepoError(formatErrorMessage(err, "Failed to enable in-repo settings"));
+      // The forward-compat refusal (#12261) carries its per-file detail in
+      // `userMessage` — `context` never survives the contextBridge — so lead
+      // with why nothing was written and list the files underneath.
+      if (isClientAppError(err) && err.code === "RECIPE_FORWARD_COMPAT_CONFLICT") {
+        setInRepoError(
+          "In-repo settings weren't enabled. These recipe files hold content this version of " +
+            "Daintree doesn't understand, and enabling would delete it from them:\n" +
+            (err.userMessage ?? "")
+        );
+      } else {
+        setInRepoError(formatErrorMessage(err, "Failed to enable in-repo settings"));
+      }
     } finally {
       setInRepoEnabling(false);
     }
@@ -719,7 +731,7 @@ export function GeneralTab({
 
         {inRepoError && (
           <div
-            className="mt-2 text-xs text-status-error bg-status-error/10 border border-status-error/20 rounded p-2"
+            className="mt-2 whitespace-pre-line text-xs text-status-error bg-status-error/10 border border-status-error/20 rounded p-2"
             role="alert"
           >
             {inRepoError}

--- a/src/components/TerminalRecipe/RecipeConflictDialog.tsx
+++ b/src/components/TerminalRecipe/RecipeConflictDialog.tsx
@@ -5,14 +5,20 @@ import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { useRecipeConflictStore } from "@/store/recipeConflictStore";
 
 /**
- * Stale-write conflict surface for in-repo recipes (#9186). When
- * `.daintree/recipes/<name>.json` was changed externally (git pull, branch
- * switch, stash pop) between load and save, the main process refuses the
- * write with `RECIPE_STALE_CONFLICT` and `recipeStore.updateRecipe` parks
- * the failed update here. The user picks:
+ * Refused-write surface for in-repo recipes. Covers both reasons the main
+ * process declines to overwrite `.daintree/recipes/<name>.json`:
+ *
+ * - `"stale"` (#9186) — the file changed externally (git pull, branch switch,
+ *   stash pop) between load and save.
+ * - `"forward-compat"` (#12261) — the file is unchanged, but holds fields or
+ *   terminal types this build cannot represent. It was read with those parts
+ *   dropped, so saving would delete them from the tracked file. `detail` names
+ *   exactly what, so Overwrite is a decision rather than a guess.
+ *
+ * `recipeStore.updateRecipe` parks the failed update here. The user picks:
  *
  * - "Reload from disk" — discard the in-flight edit, refresh state to match disk.
- * - "Overwrite" — re-apply the edit with `force: true`, replacing newer disk content.
+ * - "Overwrite" — re-apply the edit with `force: true`, replacing disk content.
  * - Dismiss (close button / Esc) — leave the rolled-back state; user can retry later.
  *
  * Tier D1 per CLAUDE.md: local irreversible, no typed-name gate. The destructive
@@ -35,17 +41,31 @@ function RecipeConflictDialogInner() {
 
   if (!pendingConflict) return null;
 
+  const isForwardCompat = pendingConflict.reason === "forward-compat";
+  const title = isForwardCompat
+    ? `Recipe '${pendingConflict.recipeName}' uses unsupported content`
+    : `Recipe '${pendingConflict.recipeName}' changed on disk`;
+
   return (
     <AppDialog isOpen={true} onClose={() => resolveConflict("cancel")} size="sm">
       <AppDialog.Header>
-        <AppDialog.Title>{`Recipe '${pendingConflict.recipeName}' changed on disk`}</AppDialog.Title>
+        <AppDialog.Title>{title}</AppDialog.Title>
         <AppDialog.CloseButton />
       </AppDialog.Header>
       <AppDialog.Body className="space-y-3">
         <AppDialog.Description>
-          Another tool changed this recipe's file since it was loaded — usually a git pull, branch
-          switch, or stash pop. Your unsaved edit hasn't been written. Choose how to reconcile.
+          {isForwardCompat
+            ? "This recipe's file holds content this version of Daintree doesn't understand — most likely written by a newer build or a plugin that isn't loaded. It was read without those parts, so saving would delete them from the file. Your unsaved edit hasn't been written."
+            : "Another tool changed this recipe's file since it was loaded — usually a git pull, branch switch, or stash pop. Your unsaved edit hasn't been written. Choose how to reconcile."}
         </AppDialog.Description>
+        {isForwardCompat && pendingConflict.detail && (
+          <pre
+            className="max-h-32 overflow-auto whitespace-pre-wrap rounded border border-border-default bg-surface-canvas p-2 font-mono text-xs text-text-secondary"
+            data-testid="recipe-conflict-detail"
+          >
+            {pendingConflict.detail}
+          </pre>
+        )}
       </AppDialog.Body>
       <AppDialog.Footer>
         <div className="flex items-center gap-3">
@@ -54,7 +74,7 @@ function RecipeConflictDialogInner() {
             onClick={() => resolveConflict("overwrite")}
             data-testid="recipe-conflict-overwrite"
           >
-            Overwrite recipe
+            {isForwardCompat ? "Overwrite and discard" : "Overwrite recipe"}
           </Button>
           <Button
             variant="contrast"

--- a/src/components/TerminalRecipe/RecipeConflictDialog.tsx
+++ b/src/components/TerminalRecipe/RecipeConflictDialog.tsx
@@ -55,12 +55,12 @@ function RecipeConflictDialogInner() {
       <AppDialog.Body className="space-y-3">
         <AppDialog.Description>
           {isForwardCompat
-            ? "This recipe's file holds content this version of Daintree doesn't understand — most likely written by a newer build or a plugin that isn't loaded. It was read without those parts, so saving would delete them from the file. Your unsaved edit hasn't been written."
+            ? "This recipe's file holds content this version of Daintree can't represent — most likely written by a newer build. It was read without those parts, so saving would delete them from the file. Your unsaved edit hasn't been written."
             : "Another tool changed this recipe's file since it was loaded — usually a git pull, branch switch, or stash pop. Your unsaved edit hasn't been written. Choose how to reconcile."}
         </AppDialog.Description>
         {isForwardCompat && pendingConflict.detail && (
           <pre
-            className="max-h-32 overflow-auto whitespace-pre-wrap rounded border border-border-default bg-surface-canvas p-2 font-mono text-xs text-text-secondary"
+            className="max-h-32 overflow-auto whitespace-pre-wrap rounded-[var(--radius-md)] border border-border-default bg-surface-canvas p-2 font-mono text-xs text-text-secondary"
             data-testid="recipe-conflict-detail"
           >
             {pendingConflict.detail}

--- a/src/components/TerminalRecipe/__tests__/RecipeConflictDialog.test.tsx
+++ b/src/components/TerminalRecipe/__tests__/RecipeConflictDialog.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup, act } from "@testing-library/react";
+import { RecipeConflictDialog } from "../RecipeConflictDialog";
+import { useRecipeConflictStore, type RecipeConflictRequest } from "@/store/recipeConflictStore";
+
+// No jest-dom in this repo — plain DOM reads only.
+
+function park(overrides: Partial<RecipeConflictRequest> = {}) {
+  const request: RecipeConflictRequest = {
+    recipeId: "inrepo-1",
+    recipeName: "Build",
+    updates: { name: "Build" },
+    reason: "stale",
+    ...overrides,
+  };
+  let resolution: string | undefined;
+  act(() => {
+    void useRecipeConflictStore
+      .getState()
+      .requestConflict(request)
+      .then((r) => {
+        resolution = r;
+      });
+  });
+  return () => resolution;
+}
+
+afterEach(() => {
+  act(() => {
+    if (useRecipeConflictStore.getState().pendingConflict) {
+      useRecipeConflictStore.getState().resolveConflict("cancel");
+    }
+  });
+  useRecipeConflictStore.setState({ pendingConflict: null });
+  cleanup();
+});
+
+describe("RecipeConflictDialog", () => {
+  it("renders nothing when no conflict is pending", () => {
+    const { container } = render(<RecipeConflictDialog />);
+    expect(container.textContent).toBe("");
+  });
+
+  it("explains an external change for the stale reason", () => {
+    park({ reason: "stale" });
+    render(<RecipeConflictDialog />);
+
+    const text = document.body.textContent ?? "";
+    expect(text).toContain("changed on disk");
+    expect(text).toContain("git pull");
+    expect(text).not.toContain("can't represent");
+    expect(screen.getByTestId("recipe-conflict-overwrite").textContent).toBe("Overwrite recipe");
+    expect(document.querySelector('[data-testid="recipe-conflict-detail"]')).toBeNull();
+  });
+
+  it("explains unsupported content and shows the detail for the forward-compat reason", () => {
+    park({
+      reason: "forward-compat",
+      detail: 'build.json — terminal #2 (type "future-agent")',
+    });
+    render(<RecipeConflictDialog />);
+
+    const text = document.body.textContent ?? "";
+    expect(text).toContain("uses unsupported content");
+    expect(text).toContain("can't represent");
+    // The stale explanation must not leak into this branch — it would send the
+    // user looking for someone else's edit that never happened.
+    expect(text).not.toContain("git pull");
+    expect(screen.getByTestId("recipe-conflict-detail").textContent).toBe(
+      'build.json — terminal #2 (type "future-agent")'
+    );
+    // Overwrite is relabelled, because here it discards content rather than
+    // just losing a race.
+    expect(screen.getByTestId("recipe-conflict-overwrite").textContent).toBe(
+      "Overwrite and discard"
+    );
+  });
+
+  it("omits the detail block when the main process sent none", () => {
+    park({ reason: "forward-compat" });
+    render(<RecipeConflictDialog />);
+    expect(document.querySelector('[data-testid="recipe-conflict-detail"]')).toBeNull();
+    expect(document.body.textContent).toContain("uses unsupported content");
+  });
+
+  it("resolves the awaiting promise from either button, in both reasons", async () => {
+    for (const reason of ["stale", "forward-compat"] as const) {
+      const read = park({ reason });
+      render(<RecipeConflictDialog />);
+
+      act(() => {
+        screen.getByTestId("recipe-conflict-overwrite").click();
+      });
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(read()).toBe("overwrite");
+      cleanup();
+    }
+  });
+
+  it("resolves as reload from the reload button", async () => {
+    const read = park({ reason: "forward-compat", detail: "x" });
+    render(<RecipeConflictDialog />);
+
+    act(() => {
+      screen.getByTestId("recipe-conflict-reload").click();
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(read()).toBe("reload");
+  });
+});

--- a/src/hooks/app/__tests__/useE2EBridges.test.tsx
+++ b/src/hooks/app/__tests__/useE2EBridges.test.tsx
@@ -178,6 +178,7 @@ describe("useE2EBridges", () => {
       recipeId: "inrepo-my-recipe",
       recipeName: "my-recipe",
       updates: { name: "my-recipe" },
+      reason: "stale",
     });
   });
 

--- a/src/hooks/app/useE2EBridges.ts
+++ b/src/hooks/app/useE2EBridges.ts
@@ -62,6 +62,7 @@ export function useE2EBridges(): void {
           recipeId: `inrepo-${recipeName}`,
           recipeName,
           updates: { name: recipeName },
+          reason: "stale",
         });
       };
 

--- a/src/store/__tests__/recipeConflictStore.test.ts
+++ b/src/store/__tests__/recipeConflictStore.test.ts
@@ -5,6 +5,7 @@ const baseRequest = (recipeId: string): RecipeConflictRequest => ({
   recipeId,
   recipeName: `Recipe ${recipeId}`,
   updates: { name: `Recipe ${recipeId}` },
+  reason: "stale",
 });
 
 afterEach(() => {

--- a/src/store/__tests__/recipeStore.test.ts
+++ b/src/store/__tests__/recipeStore.test.ts
@@ -2937,7 +2937,11 @@ describe("recipeStore", () => {
 
       async function importConflictStore() {
         const mod = await import("../recipeConflictStore");
-        mod.useRecipeConflictStore.setState({ pendingConflict: null });
+        // Release rather than drop: clearing the field alone would leave an
+        // earlier failed test's awaiter hanging forever.
+        if (mod.useRecipeConflictStore.getState().pendingConflict) {
+          mod.useRecipeConflictStore.getState().resolveConflict("cancel");
+        }
         return mod.useRecipeConflictStore;
       }
 

--- a/src/store/__tests__/recipeStore.test.ts
+++ b/src/store/__tests__/recipeStore.test.ts
@@ -2921,6 +2921,93 @@ describe("recipeStore", () => {
       });
     });
 
+    describe("RECIPE_FORWARD_COMPAT_CONFLICT handling (#12261)", () => {
+      // A refusal because the tracked file holds content this build can't
+      // represent. Routed through the same conflict gate as the stale case —
+      // the resolution (reload, or overwrite with force) is identical — but
+      // tagged so the dialog can explain a different problem.
+      function makeForwardCompatError(detail: string) {
+        const err = new Error(
+          `[AppError|RECIPE_FORWARD_COMPAT_CONFLICT|${encodeURIComponent(detail)}] ` +
+            "Saving would delete unsupported content from 1 in-repo recipe file(s)"
+        );
+        err.name = "Error";
+        return err;
+      }
+
+      async function importConflictStore() {
+        const mod = await import("../recipeConflictStore");
+        mod.useRecipeConflictStore.setState({ pendingConflict: null });
+        return mod.useRecipeConflictStore;
+      }
+
+      const inRepoRecipe = {
+        id: "inrepo-fwd",
+        name: "Future Recipe",
+        terminals: [{ type: "terminal" as const, title: "Shell", env: {} }],
+        createdAt: 500,
+      };
+
+      function seedStore() {
+        useRecipeStore.setState({
+          inRepoRecipes: [inRepoRecipe],
+          globalRecipes: [],
+          projectRecipes: [],
+          recipes: [inRepoRecipe],
+          currentProjectId: "project-1",
+        });
+      }
+
+      it("parks a forward-compat conflict carrying the main process's detail", async () => {
+        seedStore();
+        const store = await importConflictStore();
+        const detail = 'future-recipe.json — terminal #2 (type "future-agent")';
+        updateInRepoRecipeMock.mockRejectedValueOnce(makeForwardCompatError(detail));
+
+        const promise = useRecipeStore.getState().updateRecipe("inrepo-fwd", { name: "Mine" });
+        await Promise.resolve();
+        await Promise.resolve();
+
+        const pending = store.getState().pendingConflict;
+        expect(pending?.reason).toBe("forward-compat");
+        expect(pending?.detail).toBe(detail);
+
+        store.getState().resolveConflict("cancel");
+        await expect(promise).resolves.toBeUndefined();
+        // Rolled back — the rejected edit must not linger in memory.
+        expect(useRecipeStore.getState().inRepoRecipes[0]?.name).toBe("Future Recipe");
+      });
+
+      it("'overwrite' retries with force:true, which is the guard's explicit resolution", async () => {
+        seedStore();
+        const store = await importConflictStore();
+        updateInRepoRecipeMock.mockRejectedValueOnce(makeForwardCompatError("detail"));
+        updateInRepoRecipeMock.mockResolvedValueOnce(undefined);
+
+        const promise = useRecipeStore.getState().updateRecipe("inrepo-fwd", { name: "Mine" });
+        await Promise.resolve();
+        await Promise.resolve();
+        store.getState().resolveConflict("overwrite");
+        await expect(promise).resolves.toBeUndefined();
+
+        expect(updateInRepoRecipeMock).toHaveBeenCalledTimes(2);
+        expect(updateInRepoRecipeMock.mock.calls[1]?.[3]).toEqual({ force: true });
+      });
+
+      it("leaves unrelated AppErrors to propagate rather than opening the dialog", async () => {
+        seedStore();
+        const store = await importConflictStore();
+        const err = new Error("[AppError|VALIDATION|nope] Invalid recipe");
+        err.name = "Error";
+        updateInRepoRecipeMock.mockRejectedValueOnce(err);
+
+        await expect(
+          useRecipeStore.getState().updateRecipe("inrepo-fwd", { name: "Mine" })
+        ).rejects.toThrow();
+        expect(store.getState().pendingConflict).toBeNull();
+      });
+    });
+
     it("updateRecipe rolls back inRepoRecipes on failure", async () => {
       const inRepoRecipe = {
         id: "inrepo-test",

--- a/src/store/recipeConflictStore.ts
+++ b/src/store/recipeConflictStore.ts
@@ -15,12 +15,29 @@ import type { TerminalRecipe } from "@/types";
 
 export type RecipeConflictResolution = "reload" | "overwrite" | "cancel";
 
+/**
+ * Why the write was refused. `"stale"` is the original case (#9186): the file
+ * changed on disk since load. `"forward-compat"` is #12261: the file is
+ * unchanged, but holds fields or terminal types this build cannot represent, so
+ * saving would delete them. The two need different copy — one is about someone
+ * else's edit, the other about this build's own blind spot — but the same
+ * reload/overwrite resolution.
+ */
+export type RecipeConflictReason = "stale" | "forward-compat";
+
 export interface RecipeConflictRequest {
   recipeId: string;
   recipeName: string;
   updates: Partial<Omit<TerminalRecipe, "id" | "projectId" | "createdAt">>;
   /** Original name when the failed save was a rename — passed back to the retry. */
   previousName?: string;
+  reason: RecipeConflictReason;
+  /**
+   * For `"forward-compat"`, the main process's description of exactly what
+   * would be deleted (one line per affected file). Shown verbatim so the user
+   * can weigh Overwrite against a specific loss rather than a vague warning.
+   */
+  detail?: string;
 }
 
 interface PendingRecipeConflict extends RecipeConflictRequest {

--- a/src/store/recipeStore.ts
+++ b/src/store/recipeStore.ts
@@ -657,7 +657,19 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
         inRepoRecipes: prevInRepo,
         recipes: mergeRecipes(prevGlobal, prevProject, prevInRepo, get().pluginRecipes),
       });
-      if (isInRepo && isClientAppError(error) && error.code === "RECIPE_STALE_CONFLICT") {
+      // Both refusals resolve the same way — reload from disk, or overwrite with
+      // `force: true` — so they share this gate and differ only in the dialog's
+      // copy. `force` is the explicit resolution the guards hold out for; it is
+      // reachable only from the dialog's Overwrite button (#9186, #12261).
+      const conflictReason =
+        isInRepo && isClientAppError(error)
+          ? error.code === "RECIPE_STALE_CONFLICT"
+            ? "stale"
+            : error.code === "RECIPE_FORWARD_COMPAT_CONFLICT"
+              ? "forward-compat"
+              : undefined
+          : undefined;
+      if (conflictReason) {
         const projectId = get().currentProjectId;
         const previousName = updates.name && updates.name !== recipe.name ? recipe.name : undefined;
         const resolution = await useRecipeConflictStore.getState().requestConflict({
@@ -665,6 +677,11 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
           recipeName: updatedRecipe.name,
           updates: sanitizedUpdates,
           previousName,
+          reason: conflictReason,
+          detail:
+            conflictReason === "forward-compat" && isClientAppError(error)
+              ? error.userMessage
+              : undefined,
         });
         if (resolution === "reload" && projectId) {
           void get().loadRecipes(projectId);


### PR DESCRIPTION
## Summary

`.daintree/recipes/*.json` files are git tracked and shared across machines running different builds. The read path (`ProjectIdentityFiles.readInRepoRecipesWithHashes`) rebuilds every recipe from an explicit field allowlist and drops any terminal whose `type` it doesn't recognize, which is deliberate since these files are untrusted input (#9160). The write path then serializes that reduced in-memory recipe straight back over the file, so an older build silently deletes whatever a newer build wrote and commits the loss. The staleness guard from #9186 can't catch this, because its cached hash comes from the original, unchanged bytes.

This fix detects what the current build can't represent and refuses to overwrite it without an explicit decision.

Resolves #12261

## Changes

- New `shared/utils/recipeCompatibility.ts` reports unknown recipe/terminal keys, well formed but unrecognized terminal types, and valid terminals discarded by the 10-terminal cap. Its known field sets are declared with `satisfies Record<keyof RecipeTerminal, true>` / `Record<keyof TerminalRecipe, true>`, so adding a field to the interface without listing it here is a compile error. That's what keeps the reference set from drifting and misreporting our own new fields as foreign, the #9654 class of bug.
- The read path now warns naming the specific keys and foreign types it drops, instead of a generic drop count.
- A new `writeInRepoRecipeChecked` refuses the write. The enable-in-repo-settings and sync handlers pre-flight the whole batch before their first write, so a rejected enable doesn't leave anything half written.
- Reconciliation's promotion loop is guarded too: its filename-ownership map is now built only from recipes the reader actually returned, so a file the reader dropped entirely no longer records no owner and gets silently promoted over. This path needs no user action since an ordinary project load reconciles, and it can't throw there, so it keeps the recipe local and leaves the file alone. Both survive.
- The refusal routes through the existing `RecipeConflictDialog` with its own copy listing exactly what would be deleted. `force: true` still overwrites, reachable only from the dialog's Overwrite button, the explicit resolution the guard is holding out for.
- Destinations are inspected fresh rather than through the load-time hash cache, which has no entry for files the reader dropped entirely. A cold cache must never read as safe to overwrite.

The sanitizer's strictness is untouched on purpose. A terminal rejected for control characters is a security drop from #9160, not version skew, so it's not reported by the new detector. Folding it in would mislabel an attack and let a crafted file permanently block saves. The detector never calls the sanitizer to classify, only to count survivors for the cap check.

Two things are deliberately left out as possible follow-ups: a low-priority inbox notification at read time (it would mean reshaping the `project:get-inrepo-recipes` IPC response and regenerating the IPC contracts, to surface something the user already sees at the moment it matters), and a `_schemaVersion` envelope for in-repo recipe files mirroring `ProjectFileStore`'s, the highest-cost option and the one the issue deprioritizes.

## Testing

685 tests pass across the 15 affected files, plus a clean `tsc --noEmit`, plus clean `prettier --check` / `eslint` on all 21 changed files.

New coverage: the detector's field sets and all four loss modes; the write guard with unchanged bytes and a warm matching hash cache (proving the staleness guard would have passed); byte-for-byte file preservation after every refusal; a cold cache; a file the reader dropped entirely; the rename path's old-name destination; the `force: true` bypass; batch pre-flight ordering and aggregation for both the enable and sync handlers; the reconcile promotion hole; and both branches of the dialog.

No new IPC channels, so no codegen. No docs touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C4BYSrd6136qEiWN7nyGXT
