### PR TITLE
fix(agents): make mcpInjection load-bearing at the assistant admission gate

### DIFF
--- a/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
@@ -175,6 +175,21 @@ vi.mock("../../../../shared/config/agentRegistry.js", () => ({
         },
       };
     }
+    if (id === "gemini") {
+      // Declares a full wiring shape but at deprecated tier, so it is absent
+      // from `getAssistantWiredAgentIds()` above — the exact shape that used to
+      // fall through the help-token rejection (#12262).
+      return {
+        supports: {
+          mcpInjection: "project-config",
+          settingsOverlay: true,
+          permissionBypass: false,
+          trustDialog: true,
+          versionProbe: true,
+          tier: "deprecated",
+        },
+      };
+    }
     return undefined;
   }),
 }));
@@ -1654,6 +1669,68 @@ describe("terminal spawn handler - help session detection (#6524)", () => {
 
     expect(ptyClient.spawn).not.toHaveBeenCalled();
     expect(mockPreparePaneConfig).not.toHaveBeenCalled();
+  });
+
+  it("refuses a help token on an agent that declares wiring but is not admitted (#12262)", async () => {
+    // The token is VALID here — the refusal is about the agent, not the bearer.
+    // Gemini declares a wiring shape but its deprecated tier keeps it out of
+    // the wired list, so `isAssistantAgent` is false. The rejection used to be
+    // conditioned on that same flag, so this spawn sailed past it and landed on
+    // the ordinary launch path with a live help bearer still in its env and no
+    // MCP wiring of any kind. Narrowing the wired list for unimplemented
+    // injection modes would have widened that hole, so the rejection now keys
+    // off whether the agent claims assistant wiring at all.
+    mockValidateToken.mockReturnValue("action");
+    mockIsRunning.mockReturnValue(true);
+    mockCurrentPort.mockReturnValue(45454);
+    mockGetProjectSettings.mockResolvedValue({ daintreeMcpTier: "action" });
+
+    const deps = { ptyClient } as unknown as HandlerDependencies;
+    registerTerminalLifecycleHandlers(deps);
+
+    const handler = getSpawnHandler();
+    await expect(
+      handler(
+        {} as Electron.IpcMainInvokeEvent,
+        {
+          cols: 80,
+          rows: 24,
+          cwd: tmpDir,
+          command: "gemini",
+          launchAgentId: "gemini",
+          env: { DAINTREE_MCP_TOKEN: "live-help-token" },
+        } as unknown as Parameters<typeof handler>[1]
+      )
+    ).rejects.toThrow(/Daintree Assistant session token is invalid/);
+
+    expect(ptyClient.spawn).not.toHaveBeenCalled();
+    expect(mockPreparePaneConfig).not.toHaveBeenCalled();
+  });
+
+  it("leaves a plain shell carrying a stray DAINTREE_MCP_TOKEN alone (#12262)", async () => {
+    // The rejection keys off the agent declaring `supports`, so a terminal that
+    // merely inherited the var from the user's own environment still spawns.
+    mockValidateToken.mockReturnValue(false);
+    mockIsRunning.mockReturnValue(true);
+    mockCurrentPort.mockReturnValue(45454);
+    mockGetProjectSettings.mockResolvedValue({ daintreeMcpTier: "action" });
+
+    const deps = { ptyClient } as unknown as HandlerDependencies;
+    registerTerminalLifecycleHandlers(deps);
+
+    const handler = getSpawnHandler();
+    await handler(
+      {} as Electron.IpcMainInvokeEvent,
+      {
+        cols: 80,
+        rows: 24,
+        cwd: tmpDir,
+        command: "bash",
+        env: { DAINTREE_MCP_TOKEN: "inherited-from-profile" },
+      } as unknown as Parameters<typeof handler>[1]
+    );
+
+    expect(ptyClient.spawn).toHaveBeenCalled();
   });
 
   it("starts MCP on demand before injecting config for restored Claude agent spawns", async () => {

--- a/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
@@ -135,50 +135,6 @@ vi.mock("../../../utils.js", () => ({
   },
 }));
 
-vi.mock("../../../../shared/config/agentRegistry.js", () => ({
-  isRegisteredAgent: vi.fn(() => false),
-  getAssistantWiredAgentIds: vi.fn(() => ["claude", "codex", "copilot"]),
-  getEffectiveAgentConfig: vi.fn((id: string) => {
-    if (id === "claude") {
-      return {
-        supports: {
-          mcpInjection: "project-config",
-          settingsOverlay: true,
-          permissionBypass: true,
-          trustDialog: true,
-          versionProbe: true,
-          tier: "stable",
-        },
-      };
-    }
-    if (id === "codex") {
-      return {
-        supports: {
-          mcpInjection: "cli-flags",
-          settingsOverlay: false,
-          permissionBypass: true,
-          trustDialog: false,
-          versionProbe: true,
-          tier: "stable",
-        },
-      };
-    }
-    if (id === "copilot") {
-      return {
-        supports: {
-          mcpInjection: "project-config",
-          settingsOverlay: false,
-          permissionBypass: false,
-          trustDialog: false,
-          versionProbe: true,
-          tier: "experimental",
-        },
-      };
-    }
-    return undefined;
-  }),
-}));
-
 const {
   mockValidateToken,
   mockIsRunning,
@@ -217,7 +173,7 @@ const mockGetClaudeLaunchArgs = vi.hoisted(() =>
 );
 
 const mockMarkTerminalForToken = vi.hoisted(() =>
-  vi.fn<(token: string, terminalId: string) => boolean>(() => true)
+  vi.fn<(token: string, terminalId: string, expectedAgentId?: string) => boolean>(() => true)
 );
 
 const mockUnbindTerminal = vi.hoisted(() => vi.fn<(terminalId: string) => void>());

--- a/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
@@ -175,21 +175,6 @@ vi.mock("../../../../shared/config/agentRegistry.js", () => ({
         },
       };
     }
-    if (id === "gemini") {
-      // Declares a full wiring shape but at deprecated tier, so it is absent
-      // from `getAssistantWiredAgentIds()` above — the exact shape that used to
-      // fall through the help-token rejection (#12262).
-      return {
-        supports: {
-          mcpInjection: "project-config",
-          settingsOverlay: true,
-          permissionBypass: false,
-          trustDialog: true,
-          versionProbe: true,
-          tier: "deprecated",
-        },
-      };
-    }
     return undefined;
   }),
 }));
@@ -256,8 +241,8 @@ vi.mock("../../../../services/HelpSessionService.js", () => ({
     getAssistantScratchEnv: (token: string) => mockGetAssistantScratchEnv(token),
     getBypassPermissions: (token: string) => mockGetBypassPermissions(token),
     getDebugLogging: (token: string) => mockGetDebugLogging(token),
-    markTerminalForToken: (token: string, terminalId: string) =>
-      mockMarkTerminalForToken(token, terminalId),
+    markTerminalForToken: (token: string, terminalId: string, expectedAgentId?: string) =>
+      mockMarkTerminalForToken(token, terminalId, expectedAgentId),
     unbindTerminal: (terminalId: string) => mockUnbindTerminal(terminalId),
     isHelpTerminal: (terminalId: string) => mockIsHelpTerminal(terminalId),
   },
@@ -310,6 +295,7 @@ import {
   registerPluginAgents,
   clearPluginAgentRegistryForTests,
 } from "../../../../../shared/config/pluginAgentRegistry.js";
+import { setUserRegistry } from "../../../../../shared/config/agentRegistry.js";
 import { CHANNELS } from "../../../channels.js";
 import { registerTerminalLifecycleHandlers } from "../lifecycle.js";
 import type { HandlerDependencies } from "../../../types.js";
@@ -1671,15 +1657,31 @@ describe("terminal spawn handler - help session detection (#6524)", () => {
     expect(mockPreparePaneConfig).not.toHaveBeenCalled();
   });
 
-  it("refuses a help token on an agent that declares wiring but is not admitted (#12262)", async () => {
+  it("refuses a help token on a stable agent excluded for its injection mode (#12262)", async () => {
     // The token is VALID here — the refusal is about the agent, not the bearer.
-    // Gemini declares a wiring shape but its deprecated tier keeps it out of
-    // the wired list, so `isAssistantAgent` is false. The rejection used to be
-    // conditioned on that same flag, so this spawn sailed past it and landed on
-    // the ordinary launch path with a live help bearer still in its env and no
-    // MCP wiring of any kind. Narrowing the wired list for unimplemented
-    // injection modes would have widened that hole, so the rejection now keys
-    // off whether the agent claims assistant wiring at all.
+    // This agent clears the tier gate but declares a mode Daintree implements
+    // for no third party, so narrowing `getAssistantWiredAgentIds` drops it and
+    // `isAssistantAgent` goes false. The rejection used to hang off that same
+    // flag, which would have let this spawn land on the ordinary launch path
+    // with a live help bearer in its env and no MCP wiring of any kind.
+    setUserRegistry({
+      "byo-agent": {
+        id: "byo-agent",
+        name: "BYO Agent",
+        command: "byo",
+        color: "#FF8800",
+        iconId: "custom",
+        supportsContextInjection: true,
+        supports: {
+          mcpInjection: "cli-flags",
+          settingsOverlay: false,
+          permissionBypass: false,
+          trustDialog: false,
+          versionProbe: true,
+          tier: "stable",
+        },
+      },
+    });
     mockValidateToken.mockReturnValue("action");
     mockIsRunning.mockReturnValue(true);
     mockCurrentPort.mockReturnValue(45454);
@@ -1689,27 +1691,60 @@ describe("terminal spawn handler - help session detection (#6524)", () => {
     registerTerminalLifecycleHandlers(deps);
 
     const handler = getSpawnHandler();
-    await expect(
-      handler(
-        {} as Electron.IpcMainInvokeEvent,
-        {
-          cols: 80,
-          rows: 24,
-          cwd: tmpDir,
-          command: "gemini",
-          launchAgentId: "gemini",
-          env: { DAINTREE_MCP_TOKEN: "live-help-token" },
-        } as unknown as Parameters<typeof handler>[1]
-      )
-    ).rejects.toThrow(/Daintree Assistant session token is invalid/);
+    try {
+      await expect(
+        handler(
+          {} as Electron.IpcMainInvokeEvent,
+          {
+            cols: 80,
+            rows: 24,
+            cwd: tmpDir,
+            command: "byo",
+            launchAgentId: "byo-agent",
+            env: { DAINTREE_MCP_TOKEN: "live-help-token" },
+          } as unknown as Parameters<typeof handler>[1]
+        )
+      ).rejects.toThrow(/Daintree Assistant session token is invalid/);
+    } finally {
+      setUserRegistry({});
+    }
 
     expect(ptyClient.spawn).not.toHaveBeenCalled();
     expect(mockPreparePaneConfig).not.toHaveBeenCalled();
   });
 
+  it("still launches a deprecated-tier agent carrying a user's own DAINTREE_MCP_TOKEN (#12262)", async () => {
+    // Gemini could never provision a help session, so it must keep launching
+    // even when the user has that variable in a preset or project env. Keying
+    // the rejection off "declares any supports" instead of the pre-#12262
+    // admission set would have broken this ordinary launch.
+    mockValidateToken.mockReturnValue(false);
+    mockIsRunning.mockReturnValue(true);
+    mockCurrentPort.mockReturnValue(45454);
+    mockGetProjectSettings.mockResolvedValue({ daintreeMcpTier: "action" });
+
+    const deps = { ptyClient } as unknown as HandlerDependencies;
+    registerTerminalLifecycleHandlers(deps);
+
+    const handler = getSpawnHandler();
+    await handler(
+      {} as Electron.IpcMainInvokeEvent,
+      {
+        cols: 80,
+        rows: 24,
+        cwd: tmpDir,
+        command: "gemini",
+        launchAgentId: "gemini",
+        env: { DAINTREE_MCP_TOKEN: "users-own-external-key" },
+      } as unknown as Parameters<typeof handler>[1]
+    );
+
+    expect(ptyClient.spawn).toHaveBeenCalled();
+  });
+
   it("leaves a plain shell carrying a stray DAINTREE_MCP_TOKEN alone (#12262)", async () => {
-    // The rejection keys off the agent declaring `supports`, so a terminal that
-    // merely inherited the var from the user's own environment still spawns.
+    // A terminal with no launch agent declares no `supports` at all, so it is
+    // outside the rejection either way.
     mockValidateToken.mockReturnValue(false);
     mockIsRunning.mockReturnValue(true);
     mockCurrentPort.mockReturnValue(45454);
@@ -2131,7 +2166,9 @@ describe("terminal spawn handler - help session detection (#6524)", () => {
       } as unknown as Parameters<typeof handler>[1]
     );
 
-    expect(mockMarkTerminalForToken).toHaveBeenCalledWith("help-token", id);
+    // The third argument is the cross-agent token-reuse guard for env-only
+    // agents, which have no launch-arg getter to supply one (#12262).
+    expect(mockMarkTerminalForToken).toHaveBeenCalledWith("help-token", id, "claude");
     expect(ptyClient.spawn).toHaveBeenCalledTimes(1);
   });
 

--- a/electron/ipc/handlers/terminal/lifecycle.ts
+++ b/electron/ipc/handlers/terminal/lifecycle.ts
@@ -36,6 +36,7 @@ import {
   supportsExactSessionCapture,
 } from "../../../../shared/types/agentSettings.js";
 import {
+  declaresActiveAssistantTier,
   getAssistantWiredAgentIds,
   getEffectiveAgentConfig,
 } from "../../../../shared/config/agentRegistry.js";
@@ -433,16 +434,16 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
     const isAssistantAgent =
       typeof launchAgentId === "string" && getAssistantWiredAgentIds().includes(launchAgentId);
     const isHelpLaunch = helpTier !== false && isAssistantAgent && safeCommand.length > 0;
-    // Whether the agent claims assistant wiring at all, independent of whether
-    // that wiring is admissible. The rejection below has to key off this rather
-    // than `isAssistantAgent`: an agent excluded from the wired list (deprecated
-    // tier, or an injection mode Daintree implements for no such agent) would
-    // otherwise sail past the throw and fall through to the ordinary launch
-    // path with a help bearer still in its env (#12262). A plain shell that
-    // merely inherited DAINTREE_MCP_TOKEN from the user's own environment
-    // declares no `supports` and is left alone.
-    const claimsAssistantWiring = typeof launchAgentId === "string" &&
-      Boolean(getEffectiveAgentConfig(launchAgentId)?.supports);
+    // The rejection below keys off this rather than `isAssistantAgent`, which
+    // now also requires an implemented `mcpInjection` mode: an agent excluded
+    // on that new ground would otherwise sail past the throw and fall through
+    // to the ordinary launch path with a help bearer still in its env (#12262).
+    // Deliberately the pre-#12262 admission set and no wider — a deprecated-tier
+    // agent could never provision a help session, so a user who carries their
+    // own DAINTREE_MCP_TOKEN in a preset or project env must still be able to
+    // launch it, exactly as before.
+    const couldProvisionHelpSession =
+      typeof launchAgentId === "string" && declaresActiveAssistantTier(launchAgentId);
 
     // If a help-session token was supplied but is invalid (revoked between
     // provision and spawn — typically because a sibling provision displaced
@@ -451,7 +452,7 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
     // renderer must always provision a fresh session before spawning the
     // assistant; falling through would resurrect the orphan-backend failure
     // mode (#7509) by spawning an unmanaged Claude in the assistant slot.
-    if (!isHelpLaunch && helpToken && claimsAssistantWiring && safeCommand.length > 0) {
+    if (!isHelpLaunch && helpToken && couldProvisionHelpSession && safeCommand.length > 0) {
       throw new Error(
         "Daintree Assistant session token is invalid or already displaced; refusing to spawn"
       );

--- a/electron/ipc/handlers/terminal/lifecycle.ts
+++ b/electron/ipc/handlers/terminal/lifecycle.ts
@@ -433,6 +433,16 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
     const isAssistantAgent =
       typeof launchAgentId === "string" && getAssistantWiredAgentIds().includes(launchAgentId);
     const isHelpLaunch = helpTier !== false && isAssistantAgent && safeCommand.length > 0;
+    // Whether the agent claims assistant wiring at all, independent of whether
+    // that wiring is admissible. The rejection below has to key off this rather
+    // than `isAssistantAgent`: an agent excluded from the wired list (deprecated
+    // tier, or an injection mode Daintree implements for no such agent) would
+    // otherwise sail past the throw and fall through to the ordinary launch
+    // path with a help bearer still in its env (#12262). A plain shell that
+    // merely inherited DAINTREE_MCP_TOKEN from the user's own environment
+    // declares no `supports` and is left alone.
+    const claimsAssistantWiring = typeof launchAgentId === "string" &&
+      Boolean(getEffectiveAgentConfig(launchAgentId)?.supports);
 
     // If a help-session token was supplied but is invalid (revoked between
     // provision and spawn — typically because a sibling provision displaced
@@ -441,7 +451,7 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
     // renderer must always provision a fresh session before spawning the
     // assistant; falling through would resurrect the orphan-backend failure
     // mode (#7509) by spawning an unmanaged Claude in the assistant slot.
-    if (!isHelpLaunch && helpToken && isAssistantAgent && safeCommand.length > 0) {
+    if (!isHelpLaunch && helpToken && claimsAssistantWiring && safeCommand.length > 0) {
       throw new Error(
         "Daintree Assistant session token is invalid or already displaced; refusing to spawn"
       );
@@ -621,7 +631,7 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
       // spawn (e.g. a stale resume against a session a sibling provision
       // already displaced) — refuse to launch as a help session rather
       // than silently degrading to a non-help Claude.
-      if (!helpSessionService.markTerminalForToken(helpToken, id)) {
+      if (!helpSessionService.markTerminalForToken(helpToken, id, launchAgentId)) {
         throw new Error(
           "Daintree Assistant session token is invalid or already displaced; refusing to spawn"
         );

--- a/electron/services/HelpSessionService.ts
+++ b/electron/services/HelpSessionService.ts
@@ -9,7 +9,11 @@ import { getHelpFolderPath } from "./HelpService.js";
 import { resilientAtomicWriteFile } from "../utils/fs.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 import { probeMcpServer, probeMcpSseServer } from "./mcp-server/readinessProbe.js";
-import { getAssistantWiredAgentIds } from "../../shared/config/agentRegistry.js";
+import {
+  getAssistantWiredAgentIds,
+  getEffectiveAgentConfig,
+  hasAssistantMcpImplementation,
+} from "../../shared/config/agentRegistry.js";
 import type { HelpAssistantTier } from "../../shared/types/ipc/maps.js";
 import type { ActionContext } from "../../shared/types/actions.js";
 import type { PtyClient } from "./PtyClient.js";
@@ -289,13 +293,20 @@ async function readTemplateHashStamp(sessionPath: string): Promise<string | null
  * state unprovable) or a stale managed skill could not be removed. Launching
  * anyway would run the session with outdated or unowned skill instructions,
  * so provisioning fails closed and the renderer shows a retryable error.
+ *
+ * `UNSUPPORTED_ASSISTANT_AGENT` is a refusal rather than a failure: the agent
+ * declares an `mcpInjection` mode Daintree has no implementation for, so a
+ * session provisioned under it would launch with no MCP wiring at all. The
+ * renderer has no dedicated copy for it yet and degrades to the generic
+ * spawn-failed shape.
  */
 export type HelpSessionErrorCode =
   | "MCP_NOT_READY"
   | "MCP_SERVER_NOT_STARTED"
   | "MCP_PROBE_FAILED"
   | "USER_CONTENT_SYNC_FAILED"
-  | "MIXED_AGENT_LANES";
+  | "MIXED_AGENT_LANES"
+  | "UNSUPPORTED_ASSISTANT_AGENT";
 
 export class HelpSessionError extends Error {
   readonly code: HelpSessionErrorCode;
@@ -486,11 +497,18 @@ export class HelpSessionService {
    * here too. This is the second line of defense behind the displacement in
    * `doProvision`: covers the renderer race where a new spawn arrives before
    * a prior provision's terminal binding was recorded.
+   *
+   * `expectedAgentId` is the cross-agent token-reuse check. Claude, Codex and
+   * Copilot each get it for free from their launch-arg getters, which return
+   * `null` when the token belongs to another agent's session; an `env-only`
+   * agent has no such getter, so without this a token minted for one env-only
+   * session could bind a terminal running a different one (#12262).
    */
-  markTerminalForToken(token: string, terminalId: string): boolean {
+  markTerminalForToken(token: string, terminalId: string, expectedAgentId?: string): boolean {
     if (!token || !terminalId) return false;
     const record = this.sessionsByToken.get(token);
     if (!record || record.revoked) return false;
+    if (expectedAgentId !== undefined && record.agentId !== expectedAgentId) return false;
 
     // The lane comes from the authenticated record, never from the caller — a
     // renderer-supplied slot here could evict a sibling lane's PTY using a
@@ -1827,6 +1845,20 @@ export class HelpSessionService {
     // list) keeps it hidden until promoted. Deprecated-tier agents (e.g.
     // gemini) are excluded here and cannot provision a help session.
     if (!getAssistantWiredAgentIds().includes(input.agentId)) {
+      // Separate the two refusals. A tier or registration miss is a
+      // configuration choice, but an agent whose declared injection mode has no
+      // implementation used to clear this gate and then match none of the
+      // literal-id branches below — provisioning a real session dir, bearer and
+      // probed port for an agent that would launch entirely unwired (#12262).
+      // Both messages keep the "not assistant-supported" wording the renderer
+      // and existing callers already match on.
+      const supports = getEffectiveAgentConfig(input.agentId)?.supports;
+      if (supports && !hasAssistantMcpImplementation(input.agentId)) {
+        throw new HelpSessionError(
+          "UNSUPPORTED_ASSISTANT_AGENT",
+          `agentId "${input.agentId}" is not assistant-supported: Daintree implements no "${supports.mcpInjection}" MCP wiring for it`
+        );
+      }
       throw new Error(`agentId "${input.agentId}" is not assistant-supported`);
     }
   }
@@ -2144,12 +2176,18 @@ export class HelpSessionService {
   }
 
   /**
-   * Writes `<sessionPath>/.mcp.json` for a Copilot help session. Copilot's
-   * MCP discovery is CWD-only and the file shape is `{ mcpServers: { name: {
-   * type: "http", url, headers } } }`. Auth uses Copilot's native env-var
-   * substitution (`$VAR`, single-dollar form) so the literal session token
-   * never lands on disk — the bearer is delivered through
-   * `DAINTREE_MCP_TOKEN` in PTY spawn env.
+   * Writes `<sessionPath>/.mcp.json` for a Copilot help session. Daintree wires
+   * Copilot through discovery in the managed session directory it already sets
+   * as cwd, so the file shape is `{ mcpServers: { name: { type: "http", url,
+   * headers } } }`. Auth uses Copilot's native env-var substitution (`$VAR`,
+   * single-dollar form) so the literal session token never lands on disk — the
+   * bearer is delivered through `DAINTREE_MCP_TOKEN` in PTY spawn env.
+   *
+   * Recent Copilot CLIs also accept a session-scoped `--additional-mcp-config`
+   * flag, so cwd discovery is Daintree's choice rather than the CLI's only
+   * option; the previous "discovery is CWD-only" note here was wrong about that.
+   * Switching would mean re-verifying the flag against the pinned CLI and
+   * moving the bearer into argv, so it stays as-is.
    */
   private async writeCopilotMcpConfig(
     sessionPath: string,

--- a/electron/services/__tests__/HelpSessionService.test.ts
+++ b/electron/services/__tests__/HelpSessionService.test.ts
@@ -5,6 +5,11 @@ import path from "node:path";
 import fs from "node:fs/promises";
 import type { McpRuntimeSnapshot } from "../../../shared/types/ipc/mcpServer.js";
 import { assistantSlotKey as slotKey } from "../../../shared/config/assistantSlots.js";
+import {
+  setUserRegistry,
+  type AgentConfig,
+  type AssistantSupports,
+} from "../../../shared/config/agentRegistry.js";
 
 const {
   mockUserDataDir,
@@ -2749,6 +2754,87 @@ describe("HelpSessionService", () => {
       await expect(
         service.provisionSession({ ...provisionInput(), agentId: "not-an-agent" })
       ).rejects.toThrow(/not assistant-supported/);
+    });
+  });
+
+  describe("unimplemented mcpInjection modes (#12262)", () => {
+    const baseSupports: AssistantSupports = {
+      mcpInjection: "env-only",
+      settingsOverlay: false,
+      permissionBypass: false,
+      trustDialog: false,
+      versionProbe: true,
+      tier: "stable",
+    };
+
+    function userAgent(supports: AssistantSupports): AgentConfig {
+      return {
+        id: "byo-agent",
+        name: "BYO Agent",
+        command: "byo",
+        color: "#FF8800",
+        iconId: "custom",
+        supportsContextInjection: true,
+        supports,
+      };
+    }
+
+    afterEach(() => {
+      setUserRegistry({});
+    });
+
+    it.each(["project-config", "cli-flags"] as const)(
+      "refuses a user-defined agent declaring %s before any side effect",
+      async (mcpInjection) => {
+        setUserRegistry({ "byo-agent": userAgent({ ...baseSupports, mcpInjection }) });
+        await expect(
+          service.provisionSession({ ...provisionInput(), agentId: "byo-agent" })
+        ).rejects.toThrow(
+          new RegExp(`not assistant-supported.*no "${mcpInjection}" MCP wiring`)
+        );
+        // Refused at the gate, so nothing was minted or probed: before the fix
+        // this agent got a session dir, a bearer and a live probe, then matched
+        // no wiring branch and launched with nothing.
+        expect(mockProbeMcpServer).not.toHaveBeenCalled();
+        expect(mockProbeMcpSseServer).not.toHaveBeenCalled();
+      }
+    );
+
+    it("admits a user-defined agent declaring env-only and gives it no provider wiring", async () => {
+      setUserRegistry({ "byo-agent": userAgent(baseSupports) });
+      const result = await service.provisionSession({
+        ...provisionInput(),
+        agentId: "byo-agent",
+      });
+      if (!result) throw new Error("expected result");
+      // Streamable HTTP at /mcp, the non-Claude route — the token and this URL
+      // are the entire contract an env-only agent gets.
+      expect(result.mcpUrl).toBe("http://127.0.0.1:45454/mcp");
+      expect(service.validateToken(result.token)).not.toBe(false);
+      // No provider-specific files or flags: every literal-id getter reports
+      // the cross-agent mismatch rather than handing over another agent's args.
+      expect(service.getClaudeLaunchArgs(result.token)).toBeNull();
+      expect(service.getCodexLaunchArgs(result.token)).toBeNull();
+      expect(service.getCopilotLaunchArgs(result.token)).toBeNull();
+      const shared = await readSharedMcp(result.sessionPath);
+      expect(shared.mcpServers.daintree).toBeUndefined();
+    });
+
+    it("markTerminalForToken refuses a token minted for a different agent", async () => {
+      setUserRegistry({ "byo-agent": userAgent(baseSupports) });
+      const result = await service.provisionSession({
+        ...provisionInput(),
+        agentId: "byo-agent",
+      });
+      if (!result) throw new Error("expected result");
+      // Claude/Codex/Copilot get this check from their launch-arg getters;
+      // env-only agents have none, so the binding itself has to enforce it.
+      expect(service.markTerminalForToken(result.token, "term-1", "some-other-agent")).toBe(
+        false
+      );
+      expect(service.markTerminalForToken(result.token, "term-1", "byo-agent")).toBe(true);
+      // Omitting the expected agent keeps the pre-existing call shape working.
+      expect(service.markTerminalForToken(result.token, "term-1")).toBe(true);
     });
   });
 

--- a/electron/services/__tests__/HelpSessionService.test.ts
+++ b/electron/services/__tests__/HelpSessionService.test.ts
@@ -2840,9 +2840,7 @@ describe("HelpSessionService", () => {
       if (!result) throw new Error("expected result");
       // Claude/Codex/Copilot get this check from their launch-arg getters;
       // env-only agents have none, so the binding itself has to enforce it.
-      expect(service.markTerminalForToken(result.token, "term-1", "some-other-agent")).toBe(
-        false
-      );
+      expect(service.markTerminalForToken(result.token, "term-1", "some-other-agent")).toBe(false);
       expect(service.markTerminalForToken(result.token, "term-1", "byo-agent")).toBe(true);
       // Omitting the expected agent keeps the pre-existing call shape working.
       expect(service.markTerminalForToken(result.token, "term-1")).toBe(true);

--- a/electron/services/__tests__/HelpSessionService.test.ts
+++ b/electron/services/__tests__/HelpSessionService.test.ts
@@ -2787,14 +2787,25 @@ describe("HelpSessionService", () => {
       "refuses a user-defined agent declaring %s before any side effect",
       async (mcpInjection) => {
         setUserRegistry({ "byo-agent": userAgent({ ...baseSupports, mcpInjection }) });
-        await expect(
-          service.provisionSession({ ...provisionInput(), agentId: "byo-agent" })
-        ).rejects.toThrow(
+        const before = await fs.readdir(userData, { recursive: true });
+
+        const rejection = service
+          .provisionSession({ ...provisionInput(), agentId: "byo-agent" })
+          .catch((err: unknown) => err);
+        const err = (await rejection) as Error & { code?: string };
+
+        // A plain Error carrying the same message would satisfy a message-only
+        // assertion, so pin the typed refusal the renderer decodes.
+        expect(err).toBeInstanceOf(Error);
+        expect(err.name).toBe("HelpSessionError");
+        expect(err.code).toBe("UNSUPPORTED_ASSISTANT_AGENT");
+        expect(err.message).toMatch(
           new RegExp(`not assistant-supported.*no "${mcpInjection}" MCP wiring`)
         );
-        // Refused at the gate, so nothing was minted or probed: before the fix
-        // this agent got a session dir, a bearer and a live probe, then matched
-        // no wiring branch and launched with nothing.
+        // Refused at the gate, so nothing was written, minted or probed: before
+        // the fix this agent got a session dir, a bearer and a live probe, then
+        // matched no wiring branch and launched with nothing.
+        expect(await fs.readdir(userData, { recursive: true })).toEqual(before);
         expect(mockProbeMcpServer).not.toHaveBeenCalled();
         expect(mockProbeMcpSseServer).not.toHaveBeenCalled();
       }

--- a/shared/config/__tests__/agentRegistry.test.ts
+++ b/shared/config/__tests__/agentRegistry.test.ts
@@ -558,17 +558,36 @@ describe("agentRegistry", () => {
     });
 
     it("does not treat an inherited Object.prototype key as a native implementation", () => {
+      // `env-only` is the sensitive case: a bare `TABLE[id]` lookup resolves
+      // `constructor` off the prototype, finds a function rather than
+      // `undefined`, and compares it against the declared mode — wrongly
+      // rejecting an agent the open contract should admit.
       const constructorAgent: AgentConfig = {
         ...userDefinedWithStable,
         id: "constructor",
         name: "Constructor Agent",
         command: "ctor",
-        supports: cliFlagsSupports,
       };
       setUserRegistry({ constructor: constructorAgent });
       try {
-        // A bare `TABLE[id]` lookup would resolve `constructor` off the
-        // prototype and compare against a function, not a mode.
+        expect(hasAssistantMcpImplementation("constructor")).toBe(true);
+        expect(getAssistantWiredAgentIds()).toContain("constructor");
+      } finally {
+        setUserRegistry({});
+      }
+    });
+
+    it("still rejects an inherited-key agent declaring an unimplemented mode", () => {
+      setUserRegistry({
+        constructor: {
+          ...userDefinedWithStable,
+          id: "constructor",
+          name: "Constructor Agent",
+          command: "ctor",
+          supports: cliFlagsSupports,
+        },
+      });
+      try {
         expect(hasAssistantMcpImplementation("constructor")).toBe(false);
         expect(getAssistantWiredAgentIds()).not.toContain("constructor");
       } finally {
@@ -592,15 +611,6 @@ describe("agentRegistry", () => {
       }
     });
 
-    it.each([
-      ["claude", "project-config"],
-      ["copilot", "project-config"],
-      ["codex", "cli-flags"],
-      ["daintree-assistant", "env-only"],
-    ] as const)("%s declares the mode its own wiring branch implements", (id, mode) => {
-      expect(getAgentConfig(id)?.supports).toMatchObject({ mcpInjection: mode });
-    });
-
     it("rejects a built-in whose declared mode drifts from its implementation", () => {
       // Claude's literal-id branches write project config regardless of what it
       // declares, so an `env-only` claim must not be admitted on the open
@@ -621,10 +631,51 @@ describe("agentRegistry", () => {
       }
     });
 
-    it("the stable list is a subset of the wired list", () => {
-      const wired = new Set(getAssistantWiredAgentIds());
-      for (const id of getAssistantSupportedAgentIds()) {
-        expect({ id, wired: wired.has(id) }).toEqual({ id, wired: true });
+    it("the stable list is a subset of the wired list, custom agents included", () => {
+      setUserRegistry({
+        "byo-ok": {
+          id: "byo-ok",
+          name: "BYO OK",
+          command: "byo-ok",
+          color: "#FF8800",
+          iconId: "custom",
+          supportsContextInjection: true,
+          supports: {
+            mcpInjection: "env-only",
+            settingsOverlay: false,
+            permissionBypass: false,
+            trustDialog: false,
+            versionProbe: true,
+            tier: "stable",
+          },
+        },
+        "byo-bad": {
+          id: "byo-bad",
+          name: "BYO Bad",
+          command: "byo-bad",
+          color: "#FF8800",
+          iconId: "custom",
+          supportsContextInjection: true,
+          supports: {
+            mcpInjection: "cli-flags",
+            settingsOverlay: false,
+            permissionBypass: false,
+            trustDialog: false,
+            versionProbe: true,
+            tier: "stable",
+          },
+        },
+      });
+      try {
+        const wired = new Set(getAssistantWiredAgentIds());
+        const supported = getAssistantSupportedAgentIds();
+        expect(supported).toContain("byo-ok");
+        expect(supported).not.toContain("byo-bad");
+        for (const id of supported) {
+          expect({ id, wired: wired.has(id) }).toEqual({ id, wired: true });
+        }
+      } finally {
+        setUserRegistry({});
       }
     });
 

--- a/shared/config/__tests__/agentRegistry.test.ts
+++ b/shared/config/__tests__/agentRegistry.test.ts
@@ -13,6 +13,7 @@ import {
   setAgentPresets,
   getAssistantSupportedAgentIds,
   getAssistantWiredAgentIds,
+  hasAssistantMcpImplementation,
   invalidateEffectiveRegistryCache,
   AGENT_REGISTRY,
   type AgentConfig,
@@ -348,8 +349,11 @@ describe("agentRegistry", () => {
   });
 
   describe("user-defined agents in assistant lists", () => {
+    // `env-only` is the sole mode a third-party agent can be admitted under:
+    // it needs no host-side writer or arg-builder, only the DAINTREE_MCP_* env
+    // every help launch already carries (#12262).
     const stableSupports: AssistantSupports = {
-      mcpInjection: "cli-flags",
+      mcpInjection: "env-only",
       settingsOverlay: false,
       permissionBypass: true,
       trustDialog: false,
@@ -360,6 +364,16 @@ describe("agentRegistry", () => {
     const experimentalSupports: AssistantSupports = {
       ...stableSupports,
       tier: "experimental",
+    };
+
+    const cliFlagsSupports: AssistantSupports = {
+      ...stableSupports,
+      mcpInjection: "cli-flags",
+    };
+
+    const projectConfigSupports: AssistantSupports = {
+      ...stableSupports,
+      mcpInjection: "project-config",
     };
 
     const userDefinedWithStable: AgentConfig = {
@@ -511,6 +525,113 @@ describe("agentRegistry", () => {
       } finally {
         setUserRegistry({});
       }
+    });
+
+    it.each([
+      ["cli-flags", cliFlagsSupports],
+      ["project-config", projectConfigSupports],
+    ])(
+      "excludes a stable user-defined agent declaring %s — Daintree implements neither for a third party (#12262)",
+      (_mode, supports) => {
+        setUserRegistry({
+          "byo-agent": { ...userDefinedWithStable, id: "byo-agent", supports },
+        });
+        try {
+          expect(getAssistantWiredAgentIds()).not.toContain("byo-agent");
+          expect(getAssistantSupportedAgentIds()).not.toContain("byo-agent");
+          expect(hasAssistantMcpImplementation("byo-agent")).toBe(false);
+        } finally {
+          setUserRegistry({});
+        }
+      }
+    );
+
+    it("admits a user-defined agent declaring env-only — the spawn env is the whole contract (#12262)", () => {
+      setUserRegistry({ "my-cli-agent": userDefinedWithStable });
+      try {
+        expect(getAssistantWiredAgentIds()).toContain("my-cli-agent");
+        expect(getAssistantSupportedAgentIds()).toContain("my-cli-agent");
+        expect(hasAssistantMcpImplementation("my-cli-agent")).toBe(true);
+      } finally {
+        setUserRegistry({});
+      }
+    });
+
+    it("does not treat an inherited Object.prototype key as a native implementation", () => {
+      const constructorAgent: AgentConfig = {
+        ...userDefinedWithStable,
+        id: "constructor",
+        name: "Constructor Agent",
+        command: "ctor",
+        supports: cliFlagsSupports,
+      };
+      setUserRegistry({ constructor: constructorAgent });
+      try {
+        // A bare `TABLE[id]` lookup would resolve `constructor` off the
+        // prototype and compare against a function, not a mode.
+        expect(hasAssistantMcpImplementation("constructor")).toBe(false);
+        expect(getAssistantWiredAgentIds()).not.toContain("constructor");
+      } finally {
+        setUserRegistry({});
+      }
+    });
+  });
+
+  describe("mcpInjection is load-bearing (#12262)", () => {
+    it("every active built-in declares a mode Daintree implements for it", () => {
+      // The coverage guard: read the declarations directly rather than through
+      // the wired list, or a built-in whose mode drifted would quietly drop out
+      // of both the list and this assertion.
+      for (const id of BUILT_IN_AGENT_IDS) {
+        const supports = getAgentConfig(id)?.supports;
+        if (!supports || supports.tier === "deprecated") continue;
+        expect({ id, implemented: hasAssistantMcpImplementation(id) }).toEqual({
+          id,
+          implemented: true,
+        });
+      }
+    });
+
+    it.each([
+      ["claude", "project-config"],
+      ["copilot", "project-config"],
+      ["codex", "cli-flags"],
+      ["daintree-assistant", "env-only"],
+    ] as const)("%s declares the mode its own wiring branch implements", (id, mode) => {
+      expect(getAgentConfig(id)?.supports).toMatchObject({ mcpInjection: mode });
+    });
+
+    it("rejects a built-in whose declared mode drifts from its implementation", () => {
+      // Claude's literal-id branches write project config regardless of what it
+      // declares, so an `env-only` claim must not be admitted on the open
+      // third-party contract.
+      const original = AGENT_REGISTRY.claude as AgentConfig;
+      const drifted: AssistantSupports = {
+        ...(original.supports as AssistantSupports),
+        mcpInjection: "env-only",
+      };
+      AGENT_REGISTRY.claude = { ...original, supports: drifted } as AgentConfig;
+      invalidateEffectiveRegistryCache();
+      try {
+        expect(hasAssistantMcpImplementation("claude")).toBe(false);
+        expect(getAssistantWiredAgentIds()).not.toContain("claude");
+      } finally {
+        AGENT_REGISTRY.claude = original;
+        invalidateEffectiveRegistryCache();
+      }
+    });
+
+    it("the stable list is a subset of the wired list", () => {
+      const wired = new Set(getAssistantWiredAgentIds());
+      for (const id of getAssistantSupportedAgentIds()) {
+        expect({ id, wired: wired.has(id) }).toEqual({ id, wired: true });
+      }
+    });
+
+    it("returns false for an agent with no supports declaration", () => {
+      expect(hasAssistantMcpImplementation("grok")).toBe(false);
+      expect(hasAssistantMcpImplementation("aider")).toBe(false);
+      expect(hasAssistantMcpImplementation("not-an-agent")).toBe(false);
     });
   });
 });

--- a/shared/config/agentRegistry.ts
+++ b/shared/config/agentRegistry.ts
@@ -472,6 +472,15 @@ export interface AgentContinuity {
  * assistant overlay. Each field captures a distinct wiring concern; the older
  * `supportsAssistant: boolean` collapsed all of them into one bit and
  * couldn't represent partial wiring.
+ *
+ * Three fields gate behaviour at runtime: `tier` and `mcpInjection` decide
+ * admission (`getAssistantWiredAgentIds`), and `permissionBypass` decides
+ * whether the help-session launch path appends the agent's dangerous flag. The
+ * remaining three — `settingsOverlay`, `trustDialog`, `versionProbe` — are
+ * descriptive: nothing dispatches on them, and they are pinned against the
+ * wiring the code really performs by the assistant-support tests rather than
+ * consulted at runtime. Keep that distinction when adding a field; a
+ * declaration nobody reads and nothing checks silently rots (#12262).
  */
 export interface AssistantSupports {
   /**
@@ -483,12 +492,21 @@ export interface AssistantSupports {
    * - `"env-only"`: connection details are passed purely through PTY env vars
    *   the agent reads itself (`DAINTREE_MCP_URL`, `DAINTREE_MCP_TOKEN`, …) —
    *   no config file written, no CLI flags (e.g. Daintree Assistant).
+   *
+   * Read by `hasAssistantMcpImplementation` as an admission precondition, not
+   * as a strategy selector: Claude and Copilot both declare `"project-config"`
+   * yet write different files, so the mode alone cannot choose an
+   * implementation. Declaring a mode Daintree implements for no such agent is
+   * refused at provision instead of silently launching unwired.
    */
   mcpInjection: "project-config" | "cli-flags" | "env-only";
   /**
    * Whether the agent reads a session-dir settings overlay that bakes in
    * permissions / project-MCP trust (e.g. Claude's `.claude/settings.json`
    * with `enableAllProjectMcpServers: true`).
+   *
+   * Descriptive: the overlay is written from the agent's own branch in
+   * `HelpSessionService`, not gated on this field.
    */
   settingsOverlay: boolean;
   /**
@@ -503,10 +521,15 @@ export interface AssistantSupports {
    * Whether the agent's workspace-trust dialog is fully handled by the
    * session-dir overlay (so the user is never re-prompted inside the agent
    * after Daintree has launched it).
+   *
+   * Descriptive: a property of what that overlay contains, not a switch.
    */
   trustDialog: boolean;
   /**
    * Whether version-probe data is wired up for this agent's CLI.
+   *
+   * Descriptive: `AgentVersionService` probes off the agent's own `version`
+   * block, so this mirrors that block rather than enabling anything.
    */
   versionProbe: boolean;
   /**
@@ -936,6 +959,58 @@ export function getAgentModelConfig(
 }
 
 /**
+ * The MCP injection mode Daintree has actually written host-side wiring for,
+ * per agent id. `claude` and `copilot` each get a config writer in
+ * `HelpSessionService` plus a launch-arg getter that `lifecycle.ts` appends;
+ * `codex` gets `-c` args built at provision time. Any other id can only be
+ * wired through the env contract described in `supportsImplementedMcpInjection`.
+ *
+ * An id listed here must declare the mode its branch implements — a `claude`
+ * claiming `"env-only"` would be admitted on the open contract while its
+ * literal-id branches went on writing project config, which is exactly the
+ * drift this table exists to catch. Add an entry in the same commit as its
+ * branch (#12262).
+ */
+const NATIVE_MCP_IMPLEMENTATIONS: Readonly<Record<string, AssistantSupports["mcpInjection"]>> = {
+  claude: "project-config",
+  copilot: "project-config",
+  codex: "cli-flags",
+  "daintree-assistant": "env-only",
+};
+
+function supportsImplementedMcpInjection(
+  agentId: string,
+  supports: AgentConfig["supports"]
+): boolean {
+  if (!supports) return false;
+  // Own-property check: a user-defined id is free-form, so a plain `[]` lookup
+  // would inherit `constructor` and friends off Object.prototype.
+  const native = Object.prototype.hasOwnProperty.call(NATIVE_MCP_IMPLEMENTATIONS, agentId)
+    ? NATIVE_MCP_IMPLEMENTATIONS[agentId]
+    : undefined;
+  if (native !== undefined) return supports.mcpInjection === native;
+  // `env-only` is the one open mode: every help launch already carries
+  // `DAINTREE_MCP_URL` and `DAINTREE_MCP_TOKEN` in its spawn env (see
+  // `HelpSessionProvisioner.buildHelpEnv`), so an agent that reads them is
+  // wired with no host-side code at all. `project-config` and `cli-flags` both
+  // need a writer or an arg-builder that exists for no id but the three above.
+  return supports.mcpInjection === "env-only";
+}
+
+/**
+ * Whether Daintree can deliver the MCP wiring an agent's `supports.mcpInjection`
+ * asks for. This is the one place that field is load-bearing.
+ *
+ * Without it an agent could clear the tier gate, provision a session directory,
+ * a bearer and a probed MCP port, then match none of the literal-id branches in
+ * `HelpSessionService` and `lifecycle.ts` and launch with no wiring whatsoever
+ * while `provisionSession` still handed the caller an `mcpUrl` (#12262).
+ */
+export function hasAssistantMcpImplementation(agentId: string): boolean {
+  return supportsImplementedMcpInjection(agentId, getEffectiveAgentConfig(agentId)?.supports);
+}
+
+/**
  * IDs of agents (built-in and user-defined) whose assistant wiring is at the
  * `"stable"` tier. Used by the HelpPanel agent picker to filter the visible
  * options and by the `helpPanelStore` rehydration guard to drop stale
@@ -948,26 +1023,17 @@ export function getAgentModelConfig(
  * Excludes agents marked `supports: false` (structurally ineligible),
  * `supports: undefined` (not yet wired), `tier: "experimental"`, and
  * `tier: "deprecated"`.
+ *
+ * Derived from `getAssistantWiredAgentIds` rather than re-deriving eligibility,
+ * so the picker can never offer an agent the provision gate will refuse — the
+ * ordering is identical because both walk built-ins before user-defined ones.
  */
 export function getAssistantSupportedAgentIds(): string[] {
   const effective = getEffectiveRegistry();
-  const supported = new Set<string>();
-  // Built-in first (preserves existing order and tests)
-  for (const id of BUILT_IN_AGENT_IDS) {
+  return getAssistantWiredAgentIds().filter((id) => {
     const supports = effective[id]?.supports;
-    if (supports !== false && supports?.tier === "stable") {
-      supported.add(id);
-    }
-  }
-  // Then user-defined agents not already covered
-  for (const id of Object.keys(effective)) {
-    if (supported.has(id)) continue;
-    const supports = effective[id]?.supports;
-    if (supports !== false && supports?.tier === "stable") {
-      supported.add(id);
-    }
-  }
-  return [...supported];
+    return supports !== false && supports?.tier === "stable";
+  });
 }
 
 /**
@@ -985,22 +1051,29 @@ export function getAssistantSupportedAgentIds(): string[] {
  * excludes `supports: false` (structurally ineligible), `supports: undefined`
  * (not yet wired), and `tier: "deprecated"` (retired from the overlay). Any
  * future tier addition is excluded by default until explicitly allow-listed.
+ *
+ * Tier alone is not enough: it admitted any agent that merely claimed a wiring
+ * shape, so a user-defined `"stable"` entry declaring `"project-config"` used
+ * to provision a full session and then launch with nothing written for it. The
+ * declared `mcpInjection` mode must also be one Daintree implements for that
+ * agent (#12262).
  */
 export function getAssistantWiredAgentIds(): string[] {
   const effective = getEffectiveRegistry();
   const wired = new Set<string>();
-  const isWired = (supports: AgentConfig["supports"]): boolean =>
+  const isWired = (id: string, supports: AgentConfig["supports"]): boolean =>
     supports !== false &&
     supports !== undefined &&
-    (supports.tier === "stable" || supports.tier === "experimental");
+    (supports.tier === "stable" || supports.tier === "experimental") &&
+    supportsImplementedMcpInjection(id, supports);
   for (const id of BUILT_IN_AGENT_IDS) {
-    if (isWired(effective[id]?.supports)) {
+    if (isWired(id, effective[id]?.supports)) {
       wired.add(id);
     }
   }
   for (const id of Object.keys(effective)) {
     if (wired.has(id)) continue;
-    if (isWired(effective[id]?.supports)) {
+    if (isWired(id, effective[id]?.supports)) {
       wired.add(id);
     }
   }

--- a/shared/config/agentRegistry.ts
+++ b/shared/config/agentRegistry.ts
@@ -1011,6 +1011,23 @@ export function hasAssistantMcpImplementation(agentId: string): boolean {
 }
 
 /**
+ * Whether the agent declares assistant wiring at a tier that is still active —
+ * the admission set as it stood before `mcpInjection` became a precondition.
+ *
+ * `lifecycle.ts` needs this rather than `getAssistantWiredAgentIds` for its
+ * help-token rejection: an agent newly excluded for an unimplemented injection
+ * mode must still be refused rather than falling through to the ordinary launch
+ * path, but a `deprecated`-tier agent was never admitted in the first place and
+ * must keep launching normally even if the user happens to carry a
+ * `DAINTREE_MCP_TOKEN` in their own environment.
+ */
+export function declaresActiveAssistantTier(agentId: string): boolean {
+  const supports = getEffectiveAgentConfig(agentId)?.supports;
+  if (!supports) return false;
+  return supports.tier === "stable" || supports.tier === "experimental";
+}
+
+/**
  * IDs of agents (built-in and user-defined) whose assistant wiring is at the
  * `"stable"` tier. Used by the HelpPanel agent picker to filter the visible
  * options and by the `helpPanelStore` rehydration guard to drop stale

--- a/src/services/actions/definitions/__tests__/helpLaunchAgent.test.ts
+++ b/src/services/actions/definitions/__tests__/helpLaunchAgent.test.ts
@@ -233,7 +233,7 @@ describe("help.launchAgent", () => {
     );
     expect(mockDispatch).toHaveBeenCalledWith(
       "agent.launch",
-      expect.objectContaining({ cwd: "/mock/help", location: "overlay" }),
+      expect.objectContaining({ agentId: "claude", cwd: "/mock/help", location: "overlay" }),
       { source: "user" }
     );
   });
@@ -242,9 +242,9 @@ describe("help.launchAgent", () => {
     (window.electron.help.getFolderPath as ReturnType<typeof vi.fn>).mockResolvedValue(
       "/mock/help"
     );
-    mockGetAgentPrefsState.mockReturnValue({ defaultAgent: "gemini" });
+    mockGetAgentPrefsState.mockReturnValue({ defaultAgent: "codex" });
     mockGetCliAvailabilityState.mockReturnValue({
-      availability: allAvailability({ gemini: "missing" }),
+      availability: allAvailability({ codex: "missing" }),
       isInitialized: true,
     });
 

--- a/src/services/actions/definitions/__tests__/helpLaunchAgent.test.ts
+++ b/src/services/actions/definitions/__tests__/helpLaunchAgent.test.ts
@@ -195,7 +195,7 @@ describe("help.launchAgent", () => {
     (window.electron.help.getFolderPath as ReturnType<typeof vi.fn>).mockResolvedValue(
       "/mock/help"
     );
-    mockGetAgentPrefsState.mockReturnValue({ defaultAgent: "gemini" });
+    mockGetAgentPrefsState.mockReturnValue({ defaultAgent: "codex" });
     mockGetCliAvailabilityState.mockReturnValue({
       availability: allAvailability(),
       isInitialized: true,
@@ -205,7 +205,35 @@ describe("help.launchAgent", () => {
 
     expect(mockDispatch).toHaveBeenCalledWith(
       "agent.launch",
-      expect.objectContaining({ agentId: "gemini", cwd: "/mock/help", location: "overlay" }),
+      expect.objectContaining({ agentId: "codex", cwd: "/mock/help", location: "overlay" }),
+      { source: "user" }
+    );
+  });
+
+  it("skips a preferred default the assistant gate would refuse (#12262)", async () => {
+    (window.electron.help.getFolderPath as ReturnType<typeof vi.fn>).mockResolvedValue(
+      "/mock/help"
+    );
+    // Gemini is installed and launchable from the toolbar, but its supports
+    // block sits at `tier: "deprecated"`, so `provisionSession` refuses it.
+    // The implicit default has to skip it rather than resolve into that
+    // refusal — this suite mocks provisioning, so nothing else would notice.
+    mockGetAgentPrefsState.mockReturnValue({ defaultAgent: "gemini" });
+    mockGetCliAvailabilityState.mockReturnValue({
+      availability: allAvailability(),
+      isInitialized: true,
+    });
+
+    await action.run(undefined, stubCtx);
+
+    expect(mockDispatch).not.toHaveBeenCalledWith(
+      "agent.launch",
+      expect.objectContaining({ agentId: "gemini" }),
+      { source: "user" }
+    );
+    expect(mockDispatch).toHaveBeenCalledWith(
+      "agent.launch",
+      expect.objectContaining({ cwd: "/mock/help", location: "overlay" }),
       { source: "user" }
     );
   });

--- a/src/services/actions/definitions/helpActions.ts
+++ b/src/services/actions/definitions/helpActions.ts
@@ -21,6 +21,7 @@ import { logError } from "@/utils/logger";
 import { extractHelpSessionErrorCode } from "@/utils/clientHelpSessionError";
 import { getDefaultAgentId } from "@/lib/resolveAgentId";
 import { isAssistantOnlyAgentId } from "@shared/config/agentIds";
+import { getAssistantSupportedAgentIds } from "@shared/config/agentRegistry";
 
 export function registerHelpActions(actions: ActionRegistry, callbacks: ActionCallbacks): void {
   actions.set("help.shortcuts", () => ({
@@ -163,8 +164,19 @@ export function registerHelpActions(actions: ActionRegistry, callbacks: ActionCa
       } else {
         const { defaultAgent } = useAgentPreferencesStore.getState();
         const { availability, isInitialized } = useCliAvailabilityStore.getState();
+        // Constrain the implicit default to agents the assistant gate will
+        // actually admit — `getDefaultAgentId` otherwise answers with general
+        // launch eligibility and can name one `provisionSession` refuses (a
+        // deprecated tier, or an unimplemented injection mode). An explicit
+        // `args.agentId` still goes straight to that gate, so an experimental
+        // agent stays launchable by name.
         const resolved = isInitialized
-          ? getDefaultAgentId(defaultAgent, undefined, availability)
+          ? getDefaultAgentId(
+              defaultAgent,
+              undefined,
+              availability,
+              new Set(getAssistantSupportedAgentIds())
+            )
           : null;
         agentId = resolved ?? "claude";
       }


### PR DESCRIPTION
**The problem.** `AssistantSupports.mcpInjection` documented how each agent's MCP servers get wired in (`project-config` / `cli-flags` / `env-only`), but nothing read it. Every wiring branch in `HelpSessionService` and `lifecycle.ts` dispatches on literal agent-id strings. The declarations happened to be accurate, but nothing kept them that way, and nothing consulted them.

That had a real consequence, not just a cosmetic one. `getAssistantWiredAgentIds()` gated purely on `tier`, and it walks the *effective* registry — which includes user-defined agents. So a user-defined agent declaring `tier: "stable"` + `mcpInjection: "project-config"` passed provision validation, got a session directory, a minted bearer, an MCP port and a successful probe, then matched none of the literal-id branches and launched with no wiring at all — while `provisionSession()` handed the caller a non-null `mcpUrl` saying it was connected.

**The fix.** `mcpInjection` is now load-bearing at exactly one place: the admission gate. It is a precondition, not a strategy selector — Claude and Copilot both declare `project-config` yet write different files, so the mode alone can't pick an implementation. `NATIVE_MCP_IMPLEMENTATIONS` maps each agent id to the one mode Daintree actually implements for it; everything else is admissible only under `env-only`, which needs no host-side code at all because every help launch already carries `DAINTREE_MCP_URL` and `DAINTREE_MCP_TOKEN` in its spawn env. An agent declaring a mode with no implementation is refused at provision with `UNSUPPORTED_ASSISTANT_AGENT`, before any directory, bearer or probe.

**What changed:**
- `getAssistantWiredAgentIds()` requires an implementation for the declared mode, not just an active tier. `getAssistantSupportedAgentIds()` now derives from it, so the picker can never offer an agent provision will refuse.
- `lifecycle.ts`'s help-token rejection was keyed off `isAssistantAgent` — the same list being narrowed. Left alone, a newly-excluded agent would have fallen straight through to the ordinary launch path carrying a live help bearer. It now keys off `declaresActiveAssistantTier`, which is exactly the pre-change admission set: deprecated-tier agents keep launching normally even if the user has `DAINTREE_MCP_TOKEN` in their own preset or project env.
- `markTerminalForToken` takes the expected agent id. Claude, Codex and Copilot get the cross-agent token-reuse refusal free from their launch-arg getters; an `env-only` agent has none, so admitting third-party `env-only` agents needed its own guard.
- `help.launchAgent`'s implicit default now passes the assistant-supported set to `getDefaultAgentId`, which previously answered with general launch eligibility and could name an agent provision refuses.
- The `AssistantSupports` doc comment now states which fields dispatch (`tier`, `mcpInjection`, `permissionBypass`) and which are descriptive (`settingsOverlay`, `trustDialog`, `versionProbe`). Kept rather than deleted — they document real behavior, and removing them would churn the persisted `UserAgentConfigSchema` without fixing anything.
- Corrected the Copilot comment claiming its MCP discovery is CWD-only. It isn't — `--additional-mcp-config` exists; cwd discovery in our managed session directory is our choice, not the CLI's only option.

**Gemini and Grok stay unwired, and that's unchanged.** Gemini is deprecated-tier with its wiring shape kept for history; Grok has no `supports` block at all.

**Verification:** 747 tests across the 8 affected files, typecheck clean, prettier + eslint clean on the changed files, lint ratchet one warning *below* baseline (deleting an inert mock).

**Notes for review** (two things found during review, deliberately left out of scope):
- `NATIVE_MCP_IMPLEMENTATIONS` catches a declaration that drifts from its branch, but cannot detect a branch being *deleted* while the entry remains. The behavioral tests asserting Copilot's `.mcp.json` and Codex's `-c` args do cover that; deriving admission from the dispatch implementations themselves would be the structural fix, and is a bigger change than this issue warrants.
- The renderer has no dedicated copy for `UNSUPPORTED_ASSISTANT_AGENT` — it degrades to the generic `spawn-failed` shape via `ProvisionFailureCode`'s `default`. That path is rare now that both pickers filter on implementability, so the banner/toast work is worth its own issue rather than riding along here.
- `lifecycle.spawn.test.ts` had a `vi.mock` of the agent registry whose specifier was one directory short, so it had never applied. Removed it; the tests run against the real registry, which is why they pass. Worth a sweep for the same pattern elsewhere.

Resolves #12262

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017f2emfqZgfxHG6rbDyRvsL