### PR TITLE
feat(launcher): tell plugin panel kinds apart from built-in ones

### DIFF
--- a/shared/config/__tests__/panelKindRegistry.test.ts
+++ b/shared/config/__tests__/panelKindRegistry.test.ts
@@ -5,6 +5,7 @@ import {
   getPanelKindConfig,
   getExtensionFallbackDefaults,
   getPanelKindIds,
+  getPanelKindOrigin,
   getPluginPanelKinds,
   onPanelKindRegistered,
   onPanelKindUnregistered,
@@ -910,5 +911,56 @@ describe("panel kind identity split", () => {
     );
     expect(registered).toBe("project.dashboard.overview");
     expect(isProjectQualifiedPanelKindId(registered as string)).toBe(false);
+  });
+});
+
+describe("getPanelKindOrigin", () => {
+  it("classifies a built-in kind as builtin", () => {
+    expect(getPanelKindOrigin({})).toBe("builtin");
+    for (const kind of BUILT_IN_PANEL_KINDS) {
+      const config = getPanelKindConfig(kind);
+      if (!config) continue;
+      expect(getPanelKindOrigin(config)).toBe("builtin");
+    }
+  });
+
+  it("classifies a globally installed plugin's kind as plugin", () => {
+    expect(getPanelKindOrigin({ extensionId: "acme.dashboard" })).toBe("plugin");
+  });
+
+  it("treats an absent and a null projectId the same", () => {
+    // `PanelKindConfig` documents both as "not project-owned", and PluginService
+    // writes null where the registration has no project.
+    expect(getPanelKindOrigin({ extensionId: "acme.dashboard", projectId: null })).toBe("plugin");
+    expect(getPanelKindOrigin({ extensionId: "acme.dashboard", projectId: undefined })).toBe(
+      "plugin"
+    );
+  });
+
+  it("lets project ownership win over the extension id", () => {
+    // A project-local kind always carries an extensionId too, so testing that
+    // first would collapse the tier this issue exists to surface.
+    expect(getPanelKindOrigin({ extensionId: "acme.dashboard", projectId: "project-7" })).toBe(
+      "project-plugin"
+    );
+  });
+
+  it("reads the same tier off a registered config as off the literal", () => {
+    registerPanelKind({
+      id: "project:project-7/acme.dashboard/overview",
+      name: "Overview",
+      iconId: "package",
+      color: "#fff",
+      hasPty: false,
+      canRestart: false,
+      canConvert: false,
+      extensionId: "acme.dashboard",
+      projectId: "project-7",
+      pluginManifestId: "acme.dashboard",
+    });
+    const config = getPanelKindConfig("project:project-7/acme.dashboard/overview");
+    expect(config).toBeDefined();
+    expect(getPanelKindOrigin(config!)).toBe("project-plugin");
+    unregisterPanelKind("project:project-7/acme.dashboard/overview");
   });
 });

--- a/shared/config/panelKindRegistry.ts
+++ b/shared/config/panelKindRegistry.ts
@@ -566,6 +566,32 @@ export function getPanelKindConfig(kind: PanelKind): PanelKindConfig | undefined
 }
 
 /**
+ * Where a panel kind came from, as three tiers a launcher can speak about.
+ * Ordered by how much the distinction costs the user: a `project-plugin` kind
+ * exists only inside the project that ships it and is gone in the next one,
+ * which is the surprise this classification exists to prevent (#12272).
+ */
+export type PanelKindOrigin = "builtin" | "plugin" | "project-plugin";
+
+/**
+ * Classify a kind's origin from the ownership fields the registry already
+ * carries. Project ownership wins: a project-local kind always has an
+ * `extensionId` too, so testing `projectId` second would collapse tier 3 into
+ * tier 2.
+ *
+ * Takes the config rather than the id on purpose. The id is enough to derive
+ * this (see {@link toPersistedPanelKindRef}), but every caller that needs the
+ * tier is already projecting a `PanelKindConfig` into a row model, and parsing
+ * it back out of the id at each render site is how the surfaces drift apart.
+ */
+export function getPanelKindOrigin(
+  config: Pick<PanelKindConfig, "extensionId" | "projectId">
+): PanelKindOrigin {
+  if (config.projectId != null) return "project-plugin";
+  return config.extensionId !== undefined ? "plugin" : "builtin";
+}
+
+/**
  * Resolve a panel kind's policy, layering its declared `policy` block over
  * `DEFAULT_PANEL_KIND_POLICY`. Returns a fully-populated `Required<PanelKindPolicy>`
  * so callers can read fields without an undefined check.

--- a/src/components/Layout/DockLaunchButton.tsx
+++ b/src/components/Layout/DockLaunchButton.tsx
@@ -75,6 +75,7 @@ import {
   type DockLaunchRow,
 } from "./dockLaunchItems";
 import { unavailableAgentHint } from "@/utils/agentAvailabilityCopy";
+import { PANEL_KIND_ORIGIN_LABELS } from "@/utils/panelKindOriginCopy";
 import type { RecipeContext } from "@/utils/recipeVariables";
 
 // Same weighting as the ⌘⇧P panel palette so a name match outranks an alias or
@@ -1156,6 +1157,10 @@ function DockLaunchOption({
   // ordinary.
   const unavailableAgent = agent && !isAgentLaunchable(agent.availability) ? agent : null;
   const disabledReason = item?.disabled?.reason;
+  // Undefined on every built-in panel and on every non-panel row, so the marker
+  // only ever appears on the minority it is about.
+  const originLabel =
+    item?.category === "panel" ? PANEL_KIND_ORIGIN_LABELS[item.origin] : undefined;
   const isDimmed =
     unavailableAgent !== null ||
     disabledReason !== undefined ||
@@ -1243,18 +1248,30 @@ function DockLaunchOption({
                 isSearchResult
                 ? "Setup"
                 : undefined
-              : isSearchResult
-                ? // One axis for the whole result list. Giving the recipe its
-                  // scope and the panel its category put two different kinds of
-                  // answer in one column, so the two rows a query for "re"
-                  // returns — a recipe named Review and a panel named Review —
-                  // still had to be compared across "Team" and "Panel". Scope is
-                  // a browsing nicety; which of the two things this IS is the
-                  // question search has to answer.
-                  DOCK_LAUNCH_CATEGORY_LABELS[item!.category]
-                : item!.category === "recipe"
-                  ? item!.scopeLabel
-                  : undefined;
+              : item!.category === "panel"
+                ? // Provenance is the panel row's only metadata, and in browse it
+                  // has the column to itself — the band heading already said
+                  // "Open in dock", so nothing else is competing for it. In
+                  // search the category still has to come first (a query for
+                  // "re" returns a recipe named Review and a panel named
+                  // Review), so the two stack rather than one displacing the
+                  // other. Built-in contributes nothing to either mode, which
+                  // is what leaves the browse slot empty on most rows.
+                  [isSearchResult ? DOCK_LAUNCH_CATEGORY_LABELS.panel : undefined, originLabel]
+                    .filter(Boolean)
+                    .join(" · ") || undefined
+                : isSearchResult
+                  ? // One axis for the whole result list. Giving the recipe its
+                    // scope and the panel its category put two different kinds of
+                    // answer in one column, so the two rows a query for "re"
+                    // returns — a recipe named Review and a panel named Review —
+                    // still had to be compared across "Team" and "Panel". Scope is
+                    // a browsing nicety; which of the two things this IS is the
+                    // question search has to answer.
+                    DOCK_LAUNCH_CATEGORY_LABELS[item!.category]
+                  : item!.category === "recipe"
+                    ? item!.scopeLabel
+                    : undefined;
 
   // What the row conveys visually, in one string — the option is what
   // `aria-activedescendant` points at, and its children (the trailing qualifier,
@@ -1268,6 +1285,12 @@ function DockLaunchOption({
   // description, so repeating it here would announce it twice.
   const optionLabel = [
     spokenQualifier ? `${displayName}, ${spokenQualifier}` : displayName,
+    // Its own clause rather than folded into `spokenQualifier`, which for a
+    // panel is always the destination and for a disabled one is the reason it
+    // cannot launch. Appending keeps the `Name,` prefix that
+    // `e2e/helpers/panels.ts` matches rows by, and states provenance for a
+    // listener who never sees the trailing span.
+    originLabel,
     agent?.isNew ? "New" : undefined,
     // Stated only where it applies, so the phrase never advertises a key that
     // would do nothing on this row.

--- a/src/components/Layout/DockLaunchMenuItems.tsx
+++ b/src/components/Layout/DockLaunchMenuItems.tsx
@@ -17,6 +17,7 @@ import {
   type DockLaunchSurface,
 } from "./dockLaunchItems";
 import { unavailableAgentHint } from "@/utils/agentAvailabilityCopy";
+import { PANEL_KIND_ORIGIN_LABELS } from "@/utils/panelKindOriginCopy";
 
 export type { DockLaunchAgent } from "./dockLaunchItems";
 
@@ -114,12 +115,25 @@ export function DockLaunchMenuItems({
     );
   };
 
-  const renderPanelItem = (item: DockLaunchPanelItem) => (
-    <C.Item key={item.key} onSelect={() => activate(item)}>
-      <PanelKindIcon iconId={item.iconId} color={item.color} size={14} className="mr-2" />
-      {item.name}
-    </C.Item>
-  );
+  const renderPanelItem = (item: DockLaunchPanelItem) => {
+    // The menu has no qualifier column of its own, so this is a new slot rather
+    // than a filled one. It follows the recipe row below — trailing, dimmed,
+    // shrink-proof — except on the colour: that row is on `text-muted`, which
+    // has no dark-theme contrast floor here, and provenance is not decoration.
+    // `role="menuitem"` takes its accessible name from its text content, so the
+    // marker reaches a screen reader by being rendered; an `aria-label` would
+    // only be a second copy to keep in sync.
+    const originLabel = PANEL_KIND_ORIGIN_LABELS[item.origin];
+    return (
+      <C.Item key={item.key} onSelect={() => activate(item)}>
+        <PanelKindIcon iconId={item.iconId} color={item.color} size={14} className="mr-2" />
+        <span className="truncate">{item.name}</span>
+        {originLabel && (
+          <span className="ml-auto pl-2 text-2xs text-text-secondary shrink-0">{originLabel}</span>
+        )}
+      </C.Item>
+    );
+  };
 
   const renderRecipeItem = (item: DockLaunchRecipeItem) => (
     <C.Item

--- a/src/components/Layout/__tests__/DockLaunchButton.test.tsx
+++ b/src/components/Layout/__tests__/DockLaunchButton.test.tsx
@@ -5,6 +5,8 @@ import type { ReactNode } from "react";
 import {
   getPanelKindIds,
   getPanelKindConfig,
+  registerPanelKind,
+  unregisterPanelKind,
   type PanelKindConfig,
 } from "@shared/config/panelKindRegistry";
 
@@ -3010,5 +3012,104 @@ describe("DockLaunchButton — migrated toolbar affordances (#11691)", () => {
       // One launcher, two placements, same inventory — the issue's end state.
       expect(new Set(toolbar)).toEqual(new Set(dock));
     });
+  });
+});
+
+describe("panel origin marker", () => {
+  const GLOBAL_KIND = "acme.dashboard.overview";
+  const PROJECT_KIND = "project:proj-1/acme.notes/scratch";
+
+  function registerKind(id: string, name: string, over: Partial<PanelKindConfig> = {}) {
+    registerPanelKind({
+      id,
+      name,
+      iconId: "package",
+      color: "#fff",
+      hasPty: false,
+      canRestart: false,
+      canConvert: false,
+      dockable: false,
+      extensionId: "acme.dashboard",
+      ...over,
+    });
+  }
+
+  afterEach(() => {
+    unregisterPanelKind(GLOBAL_KIND);
+    unregisterPanelKind(PROJECT_KIND);
+  });
+
+  /** The row for a named item, found the way a screen reader would place it. */
+  function rowNamed(container: HTMLElement, name: string): HTMLElement {
+    const row = options(container).find((el) =>
+      (el.getAttribute("aria-label") ?? "").startsWith(`${name},`)
+    );
+    if (!row) throw new Error(`no row named ${name}`);
+    return row;
+  }
+
+  it("marks both plugin tiers in browse and leaves built-ins unmarked", () => {
+    registerKind(GLOBAL_KIND, "Dashboard");
+    registerKind(PROJECT_KIND, "Scratch", { projectId: "proj-1" });
+    const { container } = renderButton();
+
+    expect(qualifierTextOf(rowNamed(container, "Dashboard"))).toBe("Plugin");
+    expect(qualifierTextOf(rowNamed(container, "Scratch"))).toBe("Project plugin");
+    // The rule this follows: provenance earns a marker only where it differs
+    // from the default, so the majority of rows stay exactly as they were.
+    expect(qualifierTextOf(rowNamed(container, "Review"))).toBe("");
+  });
+
+  it("stacks origin behind the category in search rather than displacing it", () => {
+    // Search is the one mode where the row has to say what it IS — a query can
+    // return a recipe and a panel with the same name — so the category keeps
+    // the front of the slot.
+    registerKind(GLOBAL_KIND, "Dashboard");
+    registerKind(PROJECT_KIND, "Dashnotes", { projectId: "proj-1" });
+    const { container } = renderButton();
+
+    fireEvent.change(searchInput(container), { target: { value: "dash" } });
+
+    expect(qualifierTextOf(rowNamed(container, "Dashboard"))).toBe("Panel · Plugin");
+    expect(qualifierTextOf(rowNamed(container, "Dashnotes"))).toBe("Panel · Project plugin");
+  });
+
+  it("keeps a built-in row's search qualifier at the bare category", () => {
+    const { container } = renderButton();
+
+    fireEvent.change(searchInput(container), { target: { value: "review" } });
+
+    expect(qualifierTextOf(rowNamed(container, "Review"))).toBe("Panel");
+  });
+
+  it("speaks the origin without disturbing the accessible-name prefix", () => {
+    // `e2e/helpers/panels.ts` matches rows by `[aria-label^="Name,"]`, and a
+    // listener has no trailing span to read — so origin is appended as its own
+    // clause after the destination rather than folded into it.
+    registerKind(PROJECT_KIND, "Scratch", { projectId: "proj-1" });
+    const { container } = renderButton();
+
+    const label = rowNamed(container, "Scratch").getAttribute("aria-label") ?? "";
+    expect(label.startsWith("Scratch, Grid")).toBe(true);
+    expect(label).toContain("Project plugin");
+  });
+
+  it("adds nothing to a built-in row's accessible name", () => {
+    const { container } = renderButton();
+
+    const label = rowNamed(container, "Review").getAttribute("aria-label") ?? "";
+    expect(label.startsWith("Review, Grid")).toBe(true);
+    expect(label).not.toContain("Plugin");
+    expect(label).not.toContain("Built-in");
+  });
+
+  it("lets a disabled reason outrank the origin in the visible slot", () => {
+    // State changes what Enter does; provenance does not. The reason still
+    // shares the accessible name with the origin, where there is room for both.
+    registerKind(PROJECT_KIND, "Scratch", { projectId: "proj-1" });
+    const { container } = renderButton({ hasProject: false });
+
+    const row = rowNamed(container, "Dev Preview");
+    expect(qualifierTextOf(row)).toBe("Needs a project");
   });
 });

--- a/src/components/Layout/__tests__/DockLaunchButton.test.tsx
+++ b/src/components/Layout/__tests__/DockLaunchButton.test.tsx
@@ -3082,6 +3082,29 @@ describe("panel origin marker", () => {
     expect(qualifierTextOf(rowNamed(container, "Review"))).toBe("Panel");
   });
 
+  it("speaks both tiers while searching, not just in browse", () => {
+    // `rowNamed` only needs the name prefix, so the visual-qualifier cases
+    // above would still pass if search dropped origin from the spoken name.
+    registerKind(GLOBAL_KIND, "Dashboard");
+    registerKind(PROJECT_KIND, "Dashnotes", { projectId: "proj-1" });
+    const { container } = renderButton();
+
+    fireEvent.change(searchInput(container), { target: { value: "dash" } });
+
+    expect(rowNamed(container, "Dashboard").getAttribute("aria-label")).toContain("Plugin");
+    expect(rowNamed(container, "Dashnotes").getAttribute("aria-label")).toContain("Project plugin");
+  });
+
+  it("speaks a global plugin's tier in browse too", () => {
+    registerKind(GLOBAL_KIND, "Dashboard");
+    const { container } = renderButton();
+
+    const label = rowNamed(container, "Dashboard").getAttribute("aria-label") ?? "";
+    expect(label.startsWith("Dashboard, Grid")).toBe(true);
+    expect(label).toContain("Plugin");
+    expect(label).not.toContain("Project plugin");
+  });
+
   it("speaks the origin without disturbing the accessible-name prefix", () => {
     // `e2e/helpers/panels.ts` matches rows by `[aria-label^="Name,"]`, and a
     // listener has no trailing span to read — so origin is appended as its own
@@ -3097,19 +3120,19 @@ describe("panel origin marker", () => {
   it("adds nothing to a built-in row's accessible name", () => {
     const { container } = renderButton();
 
+    // Case-insensitive: `toContain("Plugin")` alone would let a stray
+    // "Project plugin" through on the row that is meant to carry neither.
     const label = rowNamed(container, "Review").getAttribute("aria-label") ?? "";
     expect(label.startsWith("Review, Grid")).toBe(true);
-    expect(label).not.toContain("Plugin");
-    expect(label).not.toContain("Built-in");
+    expect(label).not.toMatch(/plugin|built-in/i);
   });
 
-  it("lets a disabled reason outrank the origin in the visible slot", () => {
-    // State changes what Enter does; provenance does not. The reason still
-    // shares the accessible name with the origin, where there is room for both.
-    registerKind(PROJECT_KIND, "Scratch", { projectId: "proj-1" });
+  it("keeps a disabled reason ahead of the panel branch in the slot", () => {
+    // State changes what Enter does; provenance does not. Guards the branch
+    // ordering: a panel branch inserted above the disabled one would blank this
+    // row's reason, and only a panel can reach either.
     const { container } = renderButton({ hasProject: false });
 
-    const row = rowNamed(container, "Dev Preview");
-    expect(qualifierTextOf(row)).toBe("Needs a project");
+    expect(qualifierTextOf(rowNamed(container, "Dev Preview"))).toBe("Needs a project");
   });
 });

--- a/src/components/Layout/__tests__/DockLaunchMenuItems.test.tsx
+++ b/src/components/Layout/__tests__/DockLaunchMenuItems.test.tsx
@@ -254,20 +254,24 @@ describe("DockLaunchMenuItems — panel origin", () => {
     return node;
   }
 
-  it("names both plugin tiers on the item itself", () => {
-    // The menu has no aria-label of its own — a menuitem's accessible name is
-    // its text content, so rendering the marker is what makes it spoken.
+  it("names both plugin tiers in the item's computed accessible name", () => {
+    // The menu item has no label of its own — its name IS its content — so this
+    // queries by role rather than reading textContent: an `aria-hidden` on the
+    // marker would keep the text and lose the announcement.
     registerKind(GLOBAL_KIND, "Dashboard");
     registerKind(PROJECT_KIND, "Scratch", { projectId: "proj-1" });
-    const { container } = renderItems();
+    const { getByRole } = renderItems();
 
-    expect(itemNamed(container, "Dashboard").textContent).toContain("Plugin");
-    expect(itemNamed(container, "Scratch").textContent).toContain("Project plugin");
+    // Whitespace-tolerant: adjacent spans concatenate without a separator, and
+    // the assertion is about the marker reaching the name, not its spacing.
+    expect(getByRole("button", { name: /^Dashboard\s*Plugin$/ })).toBeTruthy();
+    expect(getByRole("button", { name: /^Scratch\s*Project plugin$/ })).toBeTruthy();
   });
 
-  it("leaves a built-in item's text as just its name", () => {
-    const { container } = renderItems();
+  it("leaves a built-in item's name as just its name", () => {
+    const { getByRole, container } = renderItems();
 
+    expect(getByRole("button", { name: "Review" })).toBeTruthy();
     expect(itemNamed(container, "Review").textContent).toBe("Review");
   });
 

--- a/src/components/Layout/__tests__/DockLaunchMenuItems.test.tsx
+++ b/src/components/Layout/__tests__/DockLaunchMenuItems.test.tsx
@@ -1,10 +1,12 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, fireEvent } from "@testing-library/react";
 import type { ReactNode } from "react";
 import {
   getPanelKindIds,
   getPanelKindConfig,
+  registerPanelKind,
+  unregisterPanelKind,
   type PanelKindConfig,
 } from "@shared/config/panelKindRegistry";
 
@@ -216,5 +218,66 @@ describe("DockLaunchMenuItems", () => {
 
     fireEvent.click(getByText("Review"));
     expect(addPanelMock).toHaveBeenCalledWith(expect.objectContaining({ location: "grid" }));
+  });
+});
+
+describe("DockLaunchMenuItems — panel origin", () => {
+  const GLOBAL_KIND = "acme.dashboard.overview";
+  const PROJECT_KIND = "project:proj-1/acme.notes/scratch";
+
+  function registerKind(id: string, name: string, over: Partial<PanelKindConfig> = {}) {
+    registerPanelKind({
+      id,
+      name,
+      iconId: "package",
+      color: "#fff",
+      hasPty: false,
+      canRestart: false,
+      canConvert: false,
+      dockable: false,
+      extensionId: "acme.dashboard",
+      ...over,
+    });
+  }
+
+  afterEach(() => {
+    unregisterPanelKind(GLOBAL_KIND);
+    unregisterPanelKind(PROJECT_KIND);
+  });
+
+  /** The menu item carrying a name, by the text a reader gets from it. */
+  function itemNamed(container: HTMLElement, name: string): HTMLElement {
+    const node = Array.from(container.querySelectorAll<HTMLElement>("button")).find((el) =>
+      Array.from(el.querySelectorAll("span")).some((s) => s.textContent === name)
+    );
+    if (!node) throw new Error(`no menu item named ${name}`);
+    return node;
+  }
+
+  it("names both plugin tiers on the item itself", () => {
+    // The menu has no aria-label of its own — a menuitem's accessible name is
+    // its text content, so rendering the marker is what makes it spoken.
+    registerKind(GLOBAL_KIND, "Dashboard");
+    registerKind(PROJECT_KIND, "Scratch", { projectId: "proj-1" });
+    const { container } = renderItems();
+
+    expect(itemNamed(container, "Dashboard").textContent).toContain("Plugin");
+    expect(itemNamed(container, "Scratch").textContent).toContain("Project plugin");
+  });
+
+  it("leaves a built-in item's text as just its name", () => {
+    const { container } = renderItems();
+
+    expect(itemNamed(container, "Review").textContent).toBe("Review");
+  });
+
+  it("still launches the kind the marked row names", () => {
+    registerKind(PROJECT_KIND, "Scratch", { projectId: "proj-1" });
+    const { container } = renderItems();
+
+    fireEvent.click(itemNamed(container, "Scratch"));
+    expect(addPanelMock).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: PROJECT_KIND, location: "grid" })
+    );
   });
 });

--- a/src/components/Layout/__tests__/dockLaunchItems.test.ts
+++ b/src/components/Layout/__tests__/dockLaunchItems.test.ts
@@ -120,6 +120,7 @@ const PANEL_LIMIT_MESSAGE = `Can't open another panel: ${PANEL_LIMIT_ERROR_SUFFI
 const PLUGIN_DOCKABLE = "test-plugin-dockable";
 const PLUGIN_GRID_ONLY = "test-plugin-grid-only";
 const PLUGIN_HIDDEN = "test-plugin-hidden";
+const PLUGIN_PROJECT_LOCAL = "project:proj-1/test-plugin/local";
 
 beforeEach(() => {
   addPanelMock.mockReset().mockResolvedValue("panel-1");
@@ -132,7 +133,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  for (const id of [PLUGIN_DOCKABLE, PLUGIN_GRID_ONLY, PLUGIN_HIDDEN]) {
+  for (const id of [PLUGIN_DOCKABLE, PLUGIN_GRID_ONLY, PLUGIN_HIDDEN, PLUGIN_PROJECT_LOCAL]) {
     unregisterPanelKind(id);
   }
 });
@@ -205,6 +206,42 @@ describe("buildDockLaunchModel — panel offering", () => {
 
     expect(model.dockPanels.map((p) => p.kindId)).toContain(PLUGIN_DOCKABLE);
     expect(model.gridPanels.map((p) => p.kindId)).toContain(PLUGIN_GRID_ONLY);
+  });
+
+  it("carries each kind's origin tier onto its row", () => {
+    // The whole gap this closes: the registry knows all three tiers and the row
+    // model used to flatten them into one.
+    registerPluginKind(PLUGIN_DOCKABLE);
+    registerPluginKind(PLUGIN_PROJECT_LOCAL, { projectId: "proj-1", dockable: false });
+    const model = build();
+    const byKind = new Map(
+      [...model.dockPanels, ...model.gridPanels].map((p) => [p.kindId, p.origin])
+    );
+
+    expect(byKind.get("file")).toBe("builtin");
+    expect(byKind.get(PLUGIN_DOCKABLE)).toBe("plugin");
+    expect(byKind.get(PLUGIN_PROJECT_LOCAL)).toBe("project-plugin");
+  });
+
+  it("keeps origin on the rows search actually ranks", () => {
+    // browseRows and searchItems are built separately; a marker present in one
+    // and missing in the other is the drift this asserts against.
+    registerPluginKind(PLUGIN_PROJECT_LOCAL, { projectId: "proj-1", dockable: false });
+    const model = build();
+
+    const searched = model.searchItems.find(
+      (item) => item.category === "panel" && item.kindId === PLUGIN_PROJECT_LOCAL
+    );
+    expect(searched).toBeDefined();
+    expect(searched).toMatchObject({ origin: "project-plugin" });
+
+    const browsed = model.browseRows.find(
+      (row) =>
+        row.kind === "item" &&
+        row.item.category === "panel" &&
+        row.item.kindId === PLUGIN_PROJECT_LOCAL
+    );
+    expect(browsed).toBeDefined();
   });
 
   it("honours a plugin kind's showInPalette opt-out", () => {

--- a/src/components/Layout/__tests__/launcherToolbarCatalog.test.ts
+++ b/src/components/Layout/__tests__/launcherToolbarCatalog.test.ts
@@ -43,6 +43,7 @@ function panelItem(kindId: string, name = kindId): DockLaunchItem {
     iconId: "terminal",
     color: "#000000",
     location: "grid",
+    origin: "builtin",
   };
 }
 

--- a/src/components/Layout/dockLaunchItems.ts
+++ b/src/components/Layout/dockLaunchItems.ts
@@ -7,8 +7,10 @@ import {
 import {
   panelKindIsDockable,
   getPanelKindConfig,
+  getPanelKindOrigin,
   subscribeToPanelKindRegistry,
   getPanelKindRegistrySnapshot,
+  type PanelKindOrigin,
 } from "@shared/config/panelKindRegistry";
 import { useRecipeStore } from "@/store/recipeStore";
 import { useActionMruStore } from "@/store/actionMruStore";
@@ -120,6 +122,10 @@ export interface DockLaunchPanelItem extends DockLaunchItemBase {
   /** Where selecting this item actually lands the panel. Derived from
    * `panelKindIsDockable`, so the label can never contradict `addPanel`. */
   location: "dock" | "grid";
+  /** Which tier contributed the kind. Classified once here rather than at each
+   * render site so the launcher, its context menu and the palette cannot
+   * disagree about the same kind (#12272). */
+  origin: PanelKindOrigin;
 }
 
 export interface DockLaunchRecipeItem extends DockLaunchItemBase {
@@ -425,6 +431,8 @@ function toPanelItem(
     iconId: string;
     color: string;
     searchAliases?: string[];
+    extensionId?: string;
+    projectId?: string | null;
   },
   surface: DockLaunchSurface,
   preconditions: DockLaunchPreconditions
@@ -444,6 +452,7 @@ function toPanelItem(
     // to this group without the registry aliases having to spell it out.
     searchAliases: [...(config.searchAliases ?? []), "panel", location],
     location,
+    origin: getPanelKindOrigin(config),
     disabled: panelPrecondition(config.id, preconditions),
   };
 }

--- a/src/components/PanelPalette/PanelPalette.tsx
+++ b/src/components/PanelPalette/PanelPalette.tsx
@@ -5,6 +5,7 @@ import { AppPaletteDialog, PaletteFooterHints } from "@/components/ui/AppPalette
 import { PaletteOverflowNotice } from "@/components/ui/PaletteOverflowNotice";
 import { HighlightedText, findMatchIndices } from "@/components/ui/HighlightedText";
 import type { PanelKindOption } from "@/hooks/usePanelPalette";
+import { PANEL_KIND_ORIGIN_LABELS } from "@/utils/panelKindOriginCopy";
 import type { FuseResultMatch } from "@/hooks/useSearchablePalette";
 import { PanelKindIcon } from "./PanelKindIcon";
 import { usePanelStore } from "@/store/panelStore";
@@ -114,6 +115,16 @@ export function PanelPalette({
       : kind.installed === false
         ? "Not installed"
         : null;
+    // The palette already has a second line, so provenance goes there rather
+    // than into the trailing badge, which is reserved for state ("Not
+    // installed", "Worktree removed") — what a row IS never outranks whether it
+    // can be launched. Origin leads the line so it is the half that survives
+    // truncation; the shortcut stays in `description` alone, out of the Fuse
+    // index, so typing "plugin" doesn't start matching rows on their tier.
+    const secondaryText =
+      [kind.origin ? PANEL_KIND_ORIGIN_LABELS[kind.origin] : undefined, kind.description]
+        .filter(Boolean)
+        .join(" · ") || null;
     return (
       <button
         key={kind.id}
@@ -144,8 +155,8 @@ export function PanelPalette({
               indices={findMatchIndices(matchesById.get(kind.id), "name")}
             />
           </div>
-          {kind.description && (
-            <div className="text-xs text-text-secondary truncate">{kind.description}</div>
+          {secondaryText && (
+            <div className="text-xs text-text-secondary truncate">{secondaryText}</div>
           )}
         </div>
         {badgeLabel && (

--- a/src/components/PanelPalette/__tests__/PanelPalette.test.tsx
+++ b/src/components/PanelPalette/__tests__/PanelPalette.test.tsx
@@ -126,3 +126,83 @@ describe("PanelPalette results region (#11431)", () => {
     expect(document.getElementById(activeDescendant!)).not.toBeNull();
   });
 });
+
+describe("PanelPalette panel origin (#12272)", () => {
+  const toolResults: PanelKindOption[] = [
+    {
+      id: "browser",
+      name: "Browser",
+      iconId: "browser",
+      color: "#aaa",
+      category: "tool",
+      description: "Cmd+B",
+      origin: "builtin",
+    },
+    {
+      id: "vendor.kind",
+      name: "Vendor",
+      iconId: "package",
+      color: "#aaa",
+      category: "tool",
+      origin: "plugin",
+    },
+    {
+      id: "project:proj-1/vendor/local",
+      name: "Local",
+      iconId: "package",
+      color: "#aaa",
+      category: "tool",
+      description: "Cmd+L",
+      origin: "project-plugin",
+    },
+  ];
+
+  function optionNamed(name: string): HTMLElement {
+    const node = Array.from(document.body.querySelectorAll<HTMLElement>('[role="option"]')).find(
+      (el) => el.textContent?.startsWith(name)
+    );
+    if (!node) throw new Error(`no option named ${name}`);
+    return node;
+  }
+
+  it("names a plugin tier on its own, and beside a shortcut when there is one", () => {
+    render(<PanelPalette {...baseProps} query="" results={toolResults} />);
+
+    expect(optionNamed("Vendor").textContent).toContain("Plugin");
+    // Origin leads, so it is the half that survives a truncated line.
+    expect(optionNamed("Local").textContent).toContain("Project plugin · Cmd+L");
+  });
+
+  it("leaves a built-in row showing only its shortcut", () => {
+    render(<PanelPalette {...baseProps} query="" results={toolResults} />);
+
+    const browser = optionNamed("Browser");
+    expect(browser.textContent).toContain("Cmd+B");
+    expect(browser.textContent).not.toContain("Plugin");
+  });
+
+  it("puts the origin in the option's accessible name, which is its content", () => {
+    // The row is a <button role="option"> with no aria-label, so what the row
+    // renders is exactly what is announced.
+    render(<PanelPalette {...baseProps} query="" results={toolResults} />);
+
+    expect(optionNamed("Local").getAttribute("aria-label")).toBeNull();
+    expect(optionNamed("Local").textContent).toContain("Project plugin");
+  });
+
+  it("keeps the trailing badge for state, which outranks provenance", () => {
+    render(
+      <PanelPalette {...baseProps} query="" results={[{ ...toolResults[2]!, installed: false }]} />
+    );
+
+    const row = optionNamed("Local");
+    expect(row.textContent).toContain("Not installed");
+    expect(row.textContent).toContain("Project plugin");
+  });
+
+  it("still names the origin while searching", () => {
+    render(<PanelPalette {...baseProps} query="loc" results={toolResults} />);
+
+    expect(optionNamed("Local").textContent).toContain("Project plugin");
+  });
+});

--- a/src/components/PanelPalette/__tests__/PanelPalette.test.tsx
+++ b/src/components/PanelPalette/__tests__/PanelPalette.test.tsx
@@ -176,18 +176,21 @@ describe("PanelPalette panel origin (#12272)", () => {
   it("leaves a built-in row showing only its shortcut", () => {
     render(<PanelPalette {...baseProps} query="" results={toolResults} />);
 
+    // Exactly the shortcut, not merely containing it: a "Built-in · Cmd+B"
+    // regression is the shape this has to reject, and it is the one the rule
+    // against marking the default exists to prevent.
     const browser = optionNamed("Browser");
-    expect(browser.textContent).toContain("Cmd+B");
-    expect(browser.textContent).not.toContain("Plugin");
+    expect(browser.textContent).toBe("BrowserCmd+B");
   });
 
-  it("puts the origin in the option's accessible name, which is its content", () => {
-    // The row is a <button role="option"> with no aria-label, so what the row
-    // renders is exactly what is announced.
+  it("puts the origin in the option's computed accessible name", () => {
+    // Through the role query, not textContent: an `aria-hidden` on the marker
+    // would leave the text intact and silently take the origin away from the
+    // only users who cannot see it.
     render(<PanelPalette {...baseProps} query="" results={toolResults} />);
 
-    expect(optionNamed("Local").getAttribute("aria-label")).toBeNull();
-    expect(optionNamed("Local").textContent).toContain("Project plugin");
+    expect(screen.getByRole("option", { name: /Project plugin/ })).toBeTruthy();
+    expect(screen.getByRole("option", { name: /\bPlugin\b/ })).toBeTruthy();
   });
 
   it("keeps the trailing badge for state, which outranks provenance", () => {

--- a/src/hooks/__tests__/usePanelPalette.test.tsx
+++ b/src/hooks/__tests__/usePanelPalette.test.tsx
@@ -188,20 +188,18 @@ describe("usePanelPalette", () => {
       canRestart: false,
       canConvert: false,
     };
-    getPanelKindConfigMock.mockImplementation((kind: string) => {
-      if (kind === "browser") return { ...base, id: "browser", name: "Browser", shortcut: "Cmd+B" };
-      if (kind === "vendor.kind")
-        return { ...base, id: "vendor.kind", name: "Vendor", extensionId: "vendor" };
-      if (kind === "project:proj-1/vendor/local")
-        return {
-          ...base,
-          id: "project:proj-1/vendor/local",
-          name: "Local",
-          extensionId: "vendor",
-          projectId: "proj-1",
-        };
-      return undefined;
-    });
+    const configs: Record<string, object> = {
+      browser: { ...base, id: "browser", name: "Browser", shortcut: "Cmd+B" },
+      "vendor.kind": { ...base, id: "vendor.kind", name: "Vendor", extensionId: "vendor" },
+      "project:proj-1/vendor/local": {
+        ...base,
+        id: "project:proj-1/vendor/local",
+        name: "Local",
+        extensionId: "vendor",
+        projectId: "proj-1",
+      },
+    };
+    getPanelKindConfigMock.mockImplementation((kind: string) => configs[kind]);
     getPanelKindDefinitionMock.mockImplementation((kind: string) => ({
       id: kind,
       component: () => null,
@@ -238,12 +236,16 @@ describe("usePanelPalette", () => {
       canConvert: false,
       extensionId: "vendor",
     };
-    getPanelKindConfigMock.mockImplementation((kind: string) => {
-      if (kind === "vendor.kind") return { ...base, id: "vendor.kind", name: "Zephyr" };
-      if (kind === "project:proj-1/vendor/local")
-        return { ...base, id: "project:proj-1/vendor/local", name: "Quartz", projectId: "proj-1" };
-      return undefined;
-    });
+    const configs: Record<string, object> = {
+      "vendor.kind": { ...base, id: "vendor.kind", name: "Zephyr" },
+      "project:proj-1/vendor/local": {
+        ...base,
+        id: "project:proj-1/vendor/local",
+        name: "Quartz",
+        projectId: "proj-1",
+      },
+    };
+    getPanelKindConfigMock.mockImplementation((kind: string) => configs[kind]);
     getPanelKindDefinitionMock.mockImplementation((kind: string) => ({
       id: kind,
       component: () => null,

--- a/src/hooks/__tests__/usePanelPalette.test.tsx
+++ b/src/hooks/__tests__/usePanelPalette.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { renderHook } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MORE_AGENTS_PANEL_ID } from "../usePanelPalette";
 
@@ -222,6 +222,50 @@ describe("usePanelPalette", () => {
 
     const browser = result.current.results.find((item) => item.id === "browser");
     expect(browser?.description).toBe("Cmd+B");
+  });
+
+  it("keeps origin out of the search index", async () => {
+    // The tier is a marker, not a keyword: typing "plugin" must not silently
+    // become a way to filter the palette by provenance, which would make the
+    // result list mean something different from what the query says.
+    getPanelKindIdsMock.mockReturnValue(["vendor.kind", "project:proj-1/vendor/local"]);
+    const base = {
+      iconId: "package",
+      color: "#aaa",
+      showInPalette: true,
+      hasPty: false,
+      canRestart: false,
+      canConvert: false,
+      extensionId: "vendor",
+    };
+    getPanelKindConfigMock.mockImplementation((kind: string) => {
+      if (kind === "vendor.kind") return { ...base, id: "vendor.kind", name: "Zephyr" };
+      if (kind === "project:proj-1/vendor/local")
+        return { ...base, id: "project:proj-1/vendor/local", name: "Quartz", projectId: "proj-1" };
+      return undefined;
+    });
+    getPanelKindDefinitionMock.mockImplementation((kind: string) => ({
+      id: kind,
+      component: () => null,
+    }));
+
+    const { result } = renderHook(() => usePanelPalette());
+
+    act(() => result.current.setQuery("plugin"));
+    await waitFor(() => expect(result.current.query).toBe("plugin"));
+    await waitFor(() => {
+      const ids = result.current.results.map((item) => item.id);
+      expect(ids).not.toContain("vendor.kind");
+      expect(ids).not.toContain("project:proj-1/vendor/local");
+    });
+
+    // The control: both are still findable by the thing the user actually sees.
+    act(() => result.current.setQuery("quartz"));
+    await waitFor(() => {
+      expect(result.current.results.map((item) => item.id)).toContain(
+        "project:proj-1/vendor/local"
+      );
+    });
   });
 
   it("leaves agent options without an origin, which is a panel-kind notion", () => {

--- a/src/hooks/__tests__/usePanelPalette.test.tsx
+++ b/src/hooks/__tests__/usePanelPalette.test.tsx
@@ -32,7 +32,8 @@ const {
   projectState: { currentProject: { id: "proj-1" } as { id: string } | null },
 }));
 
-vi.mock("@shared/config/panelKindRegistry", () => ({
+vi.mock("@shared/config/panelKindRegistry", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@shared/config/panelKindRegistry")>()),
   getPanelKindIds: getPanelKindIdsMock,
   getPanelKindConfig: getPanelKindConfigMock,
 }));
@@ -175,6 +176,60 @@ describe("usePanelPalette", () => {
 
     const browser = result.current.results.find((item) => item.id === "browser");
     expect(browser?.category).toBe("tool");
+  });
+
+  it("classifies each tool option's origin from the registry's ownership fields", () => {
+    getPanelKindIdsMock.mockReturnValue(["browser", "vendor.kind", "project:proj-1/vendor/local"]);
+    const base = {
+      iconId: "package",
+      color: "#aaa",
+      showInPalette: true,
+      hasPty: false,
+      canRestart: false,
+      canConvert: false,
+    };
+    getPanelKindConfigMock.mockImplementation((kind: string) => {
+      if (kind === "browser") return { ...base, id: "browser", name: "Browser", shortcut: "Cmd+B" };
+      if (kind === "vendor.kind")
+        return { ...base, id: "vendor.kind", name: "Vendor", extensionId: "vendor" };
+      if (kind === "project:proj-1/vendor/local")
+        return {
+          ...base,
+          id: "project:proj-1/vendor/local",
+          name: "Local",
+          extensionId: "vendor",
+          projectId: "proj-1",
+        };
+      return undefined;
+    });
+    getPanelKindDefinitionMock.mockImplementation((kind: string) => ({
+      id: kind,
+      component: () => null,
+    }));
+
+    const { result } = renderHook(() => usePanelPalette());
+    const originOf = (id: string) => result.current.results.find((item) => item.id === id)?.origin;
+
+    expect(originOf("browser")).toBe("builtin");
+    expect(originOf("vendor.kind")).toBe("plugin");
+    expect(originOf("project:proj-1/vendor/local")).toBe("project-plugin");
+  });
+
+  it("keeps the shortcut in description rather than spending it on origin", () => {
+    // The palette's second line is composed at render time; `description` stays
+    // the shortcut alone so Fuse never starts matching rows on their tier.
+    const { result } = renderHook(() => usePanelPalette());
+
+    const browser = result.current.results.find((item) => item.id === "browser");
+    expect(browser?.description).toBe("Cmd+B");
+  });
+
+  it("leaves agent options without an origin, which is a panel-kind notion", () => {
+    const { result } = renderHook(() => usePanelPalette());
+
+    const claude = result.current.results.find((item) => item.id === "agent:claude");
+    expect(claude?.category).toBe("agent");
+    expect(claude?.origin).toBeUndefined();
   });
 
   it("assigns category 'agent' to the MORE_AGENTS_PANEL_ID entry", () => {

--- a/src/hooks/usePanelPalette.ts
+++ b/src/hooks/usePanelPalette.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState, useSyncExternalStore } from "react";
 import type { IFuseOptions } from "fuse.js";
 import { getSpawnablePanelKinds } from "@/registry";
+import { getPanelKindOrigin, type PanelKindOrigin } from "@shared/config/panelKindRegistry";
 import { getEffectiveAgentIds, getEffectiveAgentConfig } from "@shared/config/agentRegistry";
 import {
   subscribeToPluginAgentRegistry,
@@ -27,6 +28,11 @@ export interface PanelKindOption {
   description?: string;
   searchAliases?: string[];
   category: "agent" | "tool" | "resume";
+  /**
+   * Which tier contributed a `tool` option's panel kind. Absent on agent and
+   * resume options, which are not panel kinds and have no such tier.
+   */
+  origin?: PanelKindOrigin;
   installed?: boolean;
   resumeSession?: AgentSessionRecord;
   /**
@@ -124,6 +130,7 @@ export function usePanelPalette(): UsePanelPaletteReturn {
       description: config.shortcut,
       searchAliases: config.searchAliases,
       category: "tool" as const,
+      origin: getPanelKindOrigin(config),
     }));
 
     const isAgentHidden = (agentId: string): boolean => {

--- a/src/utils/panelKindOriginCopy.ts
+++ b/src/utils/panelKindOriginCopy.ts
@@ -1,0 +1,22 @@
+import type { PanelKindOrigin } from "@shared/config/panelKindRegistry";
+
+/**
+ * How each origin tier is named to the user, in the launcher, the launcher's
+ * context menu and the panel palette.
+ *
+ * Built-in is deliberately `undefined`. It is the launcher's default and the
+ * overwhelming majority of rows, and the plugin manager already settled the
+ * rule this follows: provenance only earns a marker when it differs from the
+ * default (`PluginManagerView.tsx`). Tagging five rows "Built-in" to explain
+ * one is the trade that rule exists to refuse.
+ *
+ * Both plugin tiers are marked. "Plugin" alone answers where the kind came
+ * from; "Project plugin" also answers how long it will be there, borrowing the
+ * plugin manager's own `Project` scope word (`ProjectPluginSection.tsx`) so the
+ * two surfaces name the same thing the same way.
+ */
+export const PANEL_KIND_ORIGIN_LABELS: Record<PanelKindOrigin, string | undefined> = {
+  builtin: undefined,
+  plugin: "Plugin",
+  "project-plugin": "Project plugin",
+};


### PR DESCRIPTION
## Summary

- The launcher popover, its right-click context menu, and the panel palette (`Cmd+Shift+P`) all rendered built-in, globally-installed-plugin, and project-local-plugin panel kinds through the identical row template. A row like `Videos` gave no sign it came from a plugin, let alone one that's project-local and gone the moment you open a different project. That's the exact failure this issue is about: pin a kind, build a habit around it, then find it missing elsewhere.
- The origin data already existed on `PanelKindConfig` as `extensionId`, `projectId`, and `pluginManifestId`. `toPanelItem()` just dropped it before it reached any row.

Resolves #12272

## Changes

- Added `getPanelKindOrigin()` in `shared/config/panelKindRegistry.ts`, classifying a kind into one of three tiers from the ownership fields the registry already carried. Project ownership wins over extension id, since a project-local kind always has both.
- That tier now rides on a new required `origin` field on `DockLaunchPanelItem` and `PanelKindOption`, so all three surfaces read one shared classification instead of each re-deriving it from the kind id.
- Both plugin tiers get a text marker ("Plugin", "Project plugin"); built-in stays unmarked, following the rule the plugin manager UI already set: provenance earns a marker only when it differs from the default. Tagging "Built-in" on five rows to explain one row is the worse trade.
- Each surface fills a slot it already had: the launcher's `visualQualifier` (shown alone when browsing, behind the category label when searching, since search still has to say what a row IS first), and the palette's second line, ahead of the keyboard shortcut. Only the context menu needed a new slot, styled with `text-text-secondary` rather than `text-muted` like its neighboring recipe row, since `text-muted` has no dark-theme contrast floor in this codebase.
- The origin is appended as its own clause onto the row's accessible name, so screen readers get it too, without disturbing the `Name,` prefix that `e2e/helpers/panels.ts` matches rows by.
- Origin is deliberately left out of the palette's fuzzy-search index, so typing "plugin" doesn't quietly turn into a provenance filter.

Deliberately out of scope: `usePanelPalette`'s inventory memo only recomputes on plugin agent-registry changes, so a plugin that contributes only panels (no agents) won't refresh the palette at all. That's a pre-existing bug, unrelated to this change. Fixing it properly means live panel-registry subscriptions in a hook that's always mounted, which is exactly the app-wide re-render this file's own comments say to avoid. Leaving it alone here.

## Testing

- 412 tests pass across 8 targeted test files: `panelKindRegistry`, `dockLaunchItems`, `launcherToolbarCatalog`, `DockLaunchButton`, `DockLaunchMenuItems`, `usePanelPalette`, `PanelPalette`, `spawnablePanelKinds`.
- `prettier --check` and `eslint` both pass clean on all 14 changed files, no new lint-ratchet warnings.
- Ran three rounds of automated code review: a branch-by-branch correctness pass confirming no pre-existing `visualQualifier` rendering path changed, a tests/design pass that found and fixed five assertions that weren't actually testing anything, and a confirmation pass.
- Didn't run the full suite, a full build, or e2e locally. Relying on CI for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016qUzsRQ2kRNUNq3DzyBrp7
