### PR TITLE
fix(plugin): cancel prompts and host calls a retired worker generation left behind

### DIFF
--- a/electron/services/plugin/PluginDevWorkerHost.ts
+++ b/electron/services/plugin/PluginDevWorkerHost.ts
@@ -453,13 +453,39 @@ export class PluginDevWorkerHost extends EventEmitter {
 
     this.installLogForwarding();
 
-    this.child.on("message", (msg: PluginWorkerToHostMessage) => {
+    // Bind both listeners to THIS child so a superseded or retiring worker can
+    // never speak for the host (#12279).
+    const child = this.child;
+
+    child.on("message", (msg: PluginWorkerToHostMessage) => {
+      if (!this.hasAuthority(child)) return;
       this.handleWorkerMessage(msg);
     });
 
-    this.child.on("exit", (code) => {
+    child.on("exit", (code) => {
+      if (this.child !== child) return;
       this.handleExit(code);
     });
+  }
+
+  /**
+   * Whether messages from `child` still carry authority.
+   *
+   * A reload asks the worker to dispose cooperatively and only force-kills it
+   * after a grace period, so the outgoing worker stays alive and connected well
+   * after `reloading` announced its retirement — and its `dispose` handler runs
+   * the plugin's cleanup, which can itself call the host. Those calls must not
+   * be forwarded: the bridge stamps every host call with the CURRENT generation,
+   * which by then is the incoming one, so a late prompt, settings/storage write
+   * or delegated action from the dead generation would pass every downstream
+   * staleness check and commit with full authority.
+   *
+   * Gating on child identity is self-clearing — the replacement becomes
+   * `this.child` and is served immediately, including the host calls its
+   * `activate()` makes, so this cannot deadlock activation.
+   */
+  private hasAuthority(child: UtilityProcess): boolean {
+    return !this.isDisposed && !this.isReloading && this.child === child;
   }
 
   private handleWorkerMessage(msg: PluginWorkerToHostMessage): void {

--- a/electron/services/plugin/PluginDevWorkerHost.ts
+++ b/electron/services/plugin/PluginDevWorkerHost.ts
@@ -226,11 +226,19 @@ export class PluginDevWorkerHost extends EventEmitter {
   /** Re-arm the ready promise and fork a new worker. */
   private startFresh(): void {
     if (this.isDisposed) return;
-    this.readyPromise = new Promise((resolve, reject) => {
-      this.readyResolve = resolve;
-      this.readyReject = reject;
-    });
-    this.readyPromise.catch(() => undefined);
+    // Only re-arm once the previous wait has settled. A rebuild landing before
+    // the first `ready` retires that worker with the original `start()` caller
+    // still pending — re-arming here would orphan its resolver forever, and
+    // PluginService reads a `start()` rejection as a hard fork failure and
+    // disposes the very replacement being forked (#12279). Reusing the pending
+    // resolver lets the replacement satisfy the original waiter.
+    if (!this.readyResolve) {
+      this.readyPromise = new Promise((resolve, reject) => {
+        this.readyResolve = resolve;
+        this.readyReject = reject;
+      });
+      this.readyPromise.catch(() => undefined);
+    }
     this.startWorker();
   }
 
@@ -528,9 +536,15 @@ export class PluginDevWorkerHost extends EventEmitter {
     this.expectingExit = false;
     this.child = null;
 
-    if (this.readyReject) {
+    // A reload's deliberate kill is not an activation failure — a replacement
+    // fork is already on its way and settles this same waiter. Rejecting here
+    // would fail an activation that is about to succeed (#12279). A crash still
+    // rejects: a worker that dies on load has genuinely failed to activate.
+    const replacementComing = wasExpected && !this.isDisposed;
+    if (this.readyReject && !replacementComing) {
       this.readyReject(new Error(`Plugin dev worker exited (code ${code ?? "unknown"})`));
       this.readyReject = null;
+      this.readyResolve = null;
     }
 
     if (this.isDisposed) {

--- a/electron/services/plugin/PluginDevWorkerMainBridge.ts
+++ b/electron/services/plugin/PluginDevWorkerMainBridge.ts
@@ -278,7 +278,15 @@ export class PluginDevWorkerMainBridge {
    */
   private retireGeneration(reason: string): void {
     this.reloadGeneration++;
-    this.clearPriorRegistrations();
+    // Before the fallible steps: aborting the outgoing generation's host calls
+    // is what takes its open prompts off the user's screen, and a throw from
+    // plugin-supplied registration cleanup must not strand a visible dialog.
+    this.abortAllHostCalls();
+    try {
+      this.clearPriorRegistrations();
+    } catch {
+      // best-effort — one failed step must not skip the rest of the teardown
+    }
     for (const dispose of this.subscriptionDisposers.values()) {
       try {
         dispose();
@@ -289,7 +297,6 @@ export class PluginDevWorkerMainBridge {
     this.subscriptionDisposers.clear();
     this.disposeProviders();
     this.disposeProcessHandles();
-    this.abortAllHostCalls();
     for (const pending of this.pendingInvokes.values()) {
       pending.reject(new Error(reason));
     }
@@ -491,18 +498,20 @@ export class PluginDevWorkerMainBridge {
       }
       case "showQuickPick": {
         // Reuse the real host so validation/provenance/cancellation all match
-        // the installed-plugin path. On reload the dialog auto-resolves when the
-        // user dismisses or the plugin unloads (promptDispatcher.cancelForPlugin).
+        // the installed-plugin path. `signal` is what ties the dialog to this
+        // generation: retiring one aborts every in-flight host call, which
+        // dismisses the question rather than leaving it on screen owned by a
+        // worker that no longer exists (#12279).
         const p = params as ShowQuickPickParams;
-        return this.host.showQuickPick(p.items, p.options ?? {});
+        return this.host.showQuickPick(p.items, p.options ?? {}, { signal });
       }
       case "showInputBox": {
         const p = params as ShowInputBoxParams;
-        return this.host.showInputBox(p.options);
+        return this.host.showInputBox(p.options, { signal });
       }
       case "showConfirm": {
         const p = params as ShowConfirmParams;
-        return this.host.showConfirm(p.options);
+        return this.host.showConfirm(p.options, { signal });
       }
       case "settings.get": {
         const p = params as SettingsGetParams;

--- a/electron/services/plugin/PluginHostFactory.ts
+++ b/electron/services/plugin/PluginHostFactory.ts
@@ -70,6 +70,7 @@ import type {
   ActionHandler,
   PluginQuickPickItem,
   PluginQuickPickOptions,
+  PluginHostCallOptions,
   PluginInputBoxOptions,
   PluginConfirmOptions,
   BuiltInPluginCapability,
@@ -1399,7 +1400,8 @@ export function createHost(
     // so authoring mistakes surface loudly (mirrors showToast).
     showQuickPick: (async (
       items: PluginQuickPickItem[],
-      options?: PluginQuickPickOptions
+      options?: PluginQuickPickOptions,
+      callOptions?: PluginHostCallOptions
     ): Promise<PluginQuickPickItem | PluginQuickPickItem[] | undefined> => {
       if (!deps.plugins.has(pluginId)) return undefined;
       const validItems = validateQuickPickItems(pluginId, items);
@@ -1415,20 +1417,22 @@ export function createHost(
           items: validItems,
           options: sanitizeQuickPickOptions(options),
         },
-        boundProjectId
+        boundProjectId,
+        callOptions?.signal
       );
       return value as PluginQuickPickItem | PluginQuickPickItem[] | undefined;
     }) as PluginHostApi["showQuickPick"],
-    showInputBox: async (options) => {
+    showInputBox: async (options, callOptions) => {
       if (!deps.plugins.has(pluginId)) return undefined;
       const value = await deps.promptDispatcher.requestPrompt(
         pluginId,
         { kind: "inputBox", options: sanitizeInputBoxOptions(options) },
-        boundProjectId
+        boundProjectId,
+        callOptions?.signal
       );
       return value as string | undefined;
     },
-    showConfirm: async (options) => {
+    showConfirm: async (options, callOptions) => {
       if (!deps.plugins.has(pluginId)) return false;
       if (!options || typeof options !== "object" || typeof options.title !== "string") {
         throw new Error(`Plugin "${pluginId}" showConfirm: options.title must be a string`);
@@ -1436,7 +1440,8 @@ export function createHost(
       const value = await deps.promptDispatcher.requestPrompt(
         pluginId,
         { kind: "confirm", options: sanitizeConfirmOptions(options) },
-        boundProjectId
+        boundProjectId,
+        callOptions?.signal
       );
       return value === true;
     },

--- a/electron/services/plugin/PluginUIPromptDispatcher.ts
+++ b/electron/services/plugin/PluginUIPromptDispatcher.ts
@@ -30,8 +30,8 @@ const MAX_PENDING_PROMPTS_PER_PLUGIN = 1;
  * An imperative UI prompt awaiting its renderer response. Unlike the dispatch
  * bridge there is NO per-request timeout: a user-facing prompt has no deadline
  * racing the dialog (mirrors `pluginConfirmStore`'s no-timeout stance). It
- * settles on the renderer response, a renderer `destroyed`, a per-plugin cancel
- * (unload), or {@link PluginUIPromptDispatcher.dispose}.
+ * settles on the renderer response, a renderer `destroyed`, a caller's aborted
+ * signal, a per-plugin cancel (unload), or {@link PluginUIPromptDispatcher.dispose}.
  */
 interface PendingPrompt {
   resolve: (value: PluginUiPromptResultValue) => void;
@@ -39,7 +39,13 @@ interface PendingPrompt {
   pluginId: string;
   /** Value to resolve with when the prompt is cancelled rather than answered. */
   cancelValue: PluginUiPromptResultValue;
-  destroyedCleanup?: () => void;
+  /**
+   * Detaches every listener this prompt registered — the WebContents
+   * `destroyed` hook and the caller's `abort` hook. One combined disposer so a
+   * settlement path can never remember to drop one and leak the other; called
+   * on every terminal path.
+   */
+  cleanup?: () => void;
 }
 
 interface PluginUIPromptDispatcherDeps {
@@ -89,7 +95,7 @@ export class PluginUIPromptDispatcher {
         );
         return;
       }
-      pending.destroyedCleanup?.();
+      pending.cleanup?.();
       this.pending.delete(payload.promptId);
       pending.resolve(payload.result);
     };
@@ -108,15 +114,28 @@ export class PluginUIPromptDispatcher {
    * `projectId` binds the prompt to one project's renderer, including a cached
    * (not currently visible) view so the user finds it on switching back; it is
    * the only path that can reject, with `PROJECT_VIEW_UNAVAILABLE`.
+   *
+   * `signal` ties the prompt to the lifetime of whatever asked for it. Aborting
+   * dismisses the open dialog and resolves the cancel value — it never rejects,
+   * because a cancelled prompt is a dismissal and callers document a
+   * never-throws contract. This is what lets a dev worker's retired generation
+   * take its own questions off the user's screen (#12279).
    */
   requestPrompt(
     pluginId: string,
     params: PluginUiPromptParams,
-    projectId?: PluginTargetProjectId
+    projectId?: PluginTargetProjectId,
+    signal?: AbortSignal
   ): Promise<PluginUiPromptResultValue> {
     const cancelValue = cancelValueFor(params.kind);
     return new Promise((resolve) => {
       if (this.deps.isDisposed()) {
+        resolve(cancelValue);
+        return;
+      }
+      // Already cancelled before anything reached the renderer — never open a
+      // dialog the caller has stopped waiting for.
+      if (signal?.aborted) {
         resolve(cancelValue);
         return;
       }
@@ -148,16 +167,32 @@ export class PluginUIPromptDispatcher {
       const onDestroyed = () => {
         const pending = this.pending.get(promptId);
         if (!pending) return;
+        pending.cleanup?.();
         this.pending.delete(promptId);
         resolve(cancelValue);
       };
       webContents.once("destroyed", onDestroyed);
-      const destroyedCleanup = () => {
+
+      // Settles this one prompt when its caller goes away. Scoped by `promptId`
+      // so a late abort can only ever dismiss the request it belongs to — never
+      // a successor the same plugin opened after this one settled.
+      const onAbort = () => {
+        const pending = this.pending.get(promptId);
+        if (!pending) return;
+        pending.cleanup?.();
+        this.pending.delete(promptId);
+        this.sendCancel(webContentsId, pluginId, promptId);
+        resolve(cancelValue);
+      };
+      signal?.addEventListener("abort", onAbort, { once: true });
+
+      const cleanup = () => {
         try {
           webContents.removeListener("destroyed", onDestroyed);
         } catch {
           // best-effort; webContents may already be gone
         }
+        signal?.removeEventListener("abort", onAbort);
       };
 
       this.pending.set(promptId, {
@@ -165,13 +200,13 @@ export class PluginUIPromptDispatcher {
         webContentsId,
         pluginId,
         cancelValue,
-        destroyedCleanup,
+        cleanup,
       });
 
       try {
         webContents.send(CHANNELS.PLUGIN_UI_PROMPT_REQUEST, { promptId, pluginId, params });
       } catch {
-        destroyedCleanup();
+        cleanup();
         this.pending.delete(promptId);
         resolve(cancelValue);
       }
@@ -188,7 +223,7 @@ export class PluginUIPromptDispatcher {
     let notifiedWebContentsId: number | null = null;
     for (const [promptId, pending] of [...this.pending.entries()]) {
       if (pending.pluginId !== pluginId) continue;
-      pending.destroyedCleanup?.();
+      pending.cleanup?.();
       this.pending.delete(promptId);
       // Dismiss the visible dialog. One broadcast per affected window suffices —
       // the renderer drops every queued prompt for this plugin.
@@ -200,7 +235,11 @@ export class PluginUIPromptDispatcher {
     }
   }
 
-  private sendCancel(webContentsId: number, pluginId: string): void {
+  /**
+   * Tell a renderer to drop prompts for `pluginId`. With `promptId` only that
+   * one request is dismissed; without it every prompt for the plugin goes.
+   */
+  private sendCancel(webContentsId: number, pluginId: string, promptId?: string): void {
     // Target the window the prompt was originally sent to by id — NOT the
     // currently-focused window. In a multi-window session the user may have
     // switched projects between prompt-open and unload; resolving "active" here
@@ -208,7 +247,10 @@ export class PluginUIPromptDispatcher {
     const target = webContents.fromId(webContentsId);
     if (target && !target.isDestroyed()) {
       try {
-        target.send(CHANNELS.PLUGIN_UI_PROMPT_CANCEL, { pluginId });
+        target.send(CHANNELS.PLUGIN_UI_PROMPT_CANCEL, {
+          pluginId,
+          ...(promptId ? { promptId } : {}),
+        });
       } catch {
         // best-effort
       }
@@ -224,7 +266,7 @@ export class PluginUIPromptDispatcher {
     this.responseListenerCleanup = null;
     for (const pending of this.pending.values()) {
       try {
-        pending.destroyedCleanup?.();
+        pending.cleanup?.();
         pending.resolve(pending.cancelValue);
       } catch {
         // best-effort — one prompt's resolve must not strand the rest

--- a/electron/services/plugin/__tests__/PluginDevWorkerHost.test.ts
+++ b/electron/services/plugin/__tests__/PluginDevWorkerHost.test.ts
@@ -452,6 +452,33 @@ describe("PluginDevWorkerHost", () => {
     host.dispose();
   });
 
+  it("lets the replacement satisfy a start() that a rebuild interrupted (#12279)", async () => {
+    vi.useFakeTimers();
+    const { PluginDevWorkerHost } = await loadModule();
+    const host = new PluginDevWorkerHost(OPTS);
+    const started = host.start();
+    let rejected: unknown = null;
+    started.catch((e) => (rejected = e));
+
+    // A rebuild lands before the first worker ever reported ready.
+    const oldChild = mockChildren[0] as MockUtilityChild;
+    watchCalls[0].cb("change", "index.js");
+    vi.advanceTimersByTime(250);
+    // Its late `ready` is correctly ignored — that generation is retired.
+    oldChild.emit("message", { type: "ready" });
+    oldChild.emit("exit", 0);
+    await vi.runOnlyPendingTimersAsync();
+
+    // The deliberate kill must NOT fail the activation: PluginService reads a
+    // start() rejection as a hard fork failure and disposes the replacement.
+    expect(rejected).toBeNull();
+
+    const newChild = mockChildren[mockChildren.length - 1] as MockUtilityChild;
+    newChild.emit("message", { type: "ready" });
+    await expect(started).resolves.toBeUndefined();
+    host.dispose();
+  });
+
   it("ignores a superseded child once its replacement takes over (#12279)", async () => {
     vi.useFakeTimers();
     const { PluginDevWorkerHost } = await loadModule();

--- a/electron/services/plugin/__tests__/PluginDevWorkerHost.test.ts
+++ b/electron/services/plugin/__tests__/PluginDevWorkerHost.test.ts
@@ -418,4 +418,70 @@ describe("PluginDevWorkerHost", () => {
     expect(seen).toContainEqual({ type: "host-call", requestId: "c1", method: "getWorktrees" });
     host.dispose();
   });
+
+  // #12279: a reload asks the worker to dispose cooperatively and only
+  // force-kills it after a grace period, so the outgoing worker stays alive and
+  // connected after `reloading` has already retired its generation. Anything it
+  // says in that window would be stamped with the INCOMING generation and pass
+  // every downstream staleness check.
+  it("drops messages from a worker that is being retired (#12279)", async () => {
+    vi.useFakeTimers();
+    const { PluginDevWorkerHost } = await loadModule();
+    const host = new PluginDevWorkerHost(OPTS);
+    const seen: any[] = [];
+    host.on("worker-message", (m) => seen.push(m));
+    void host.start();
+    const child = mockChildren[0] as MockUtilityChild;
+    child.emit("message", { type: "ready" });
+
+    watchCalls[0].cb("change", "index.js");
+    vi.advanceTimersByTime(250);
+
+    // The dying worker's cleanup runs before the process exits and can still
+    // call the host — a settings write here must not be forwarded.
+    child.emit("message", {
+      type: "host-call",
+      requestId: "late",
+      method: "settings.set",
+      params: { key: "k", value: "v" },
+    });
+
+    expect(seen).toHaveLength(0);
+    // The cooperative dispose must still reach it — gating receives, not sends.
+    expect(child.postMessage).toHaveBeenCalledWith({ type: "dispose" });
+    host.dispose();
+  });
+
+  it("ignores a superseded child once its replacement takes over (#12279)", async () => {
+    vi.useFakeTimers();
+    const { PluginDevWorkerHost } = await loadModule();
+    const host = new PluginDevWorkerHost(OPTS);
+    const seen: any[] = [];
+    host.on("worker-message", (m) => seen.push(m));
+    void host.start();
+    const oldChild = mockChildren[0] as MockUtilityChild;
+    oldChild.emit("message", { type: "ready" });
+
+    watchCalls[0].cb("change", "index.js");
+    vi.advanceTimersByTime(250);
+    oldChild.emit("exit", 0);
+    await vi.runOnlyPendingTimersAsync();
+
+    const newChild = mockChildren[mockChildren.length - 1] as MockUtilityChild;
+    expect(newChild).not.toBe(oldChild);
+
+    oldChild.emit("message", { type: "host-call", requestId: "ghost", method: "getWorktrees" });
+    expect(seen).toHaveLength(0);
+
+    // The replacement is served immediately — including the host calls its
+    // activate() makes, so the guard cannot deadlock activation.
+    newChild.emit("message", { type: "ready" });
+    newChild.emit("message", { type: "host-call", requestId: "live", method: "getWorktrees" });
+    expect(seen).toContainEqual({
+      type: "host-call",
+      requestId: "live",
+      method: "getWorktrees",
+    });
+    host.dispose();
+  });
 });

--- a/electron/services/plugin/__tests__/PluginDevWorkerMainBridge.test.ts
+++ b/electron/services/plugin/__tests__/PluginDevWorkerMainBridge.test.ts
@@ -40,6 +40,9 @@ function makeHost() {
     invalidateFileDecorations: vi.fn(),
     setPanelBadge: vi.fn(async () => {}),
     showToast: vi.fn(async () => {}),
+    showQuickPick: vi.fn(async (): Promise<unknown> => undefined),
+    showInputBox: vi.fn(async (): Promise<unknown> => undefined),
+    showConfirm: vi.fn(async () => false),
     dispatch: vi.fn(async () => ({ ok: true, result: undefined })),
     actions: {
       list: vi.fn(async () => [{ id: "terminal.new", danger: "safe", requiresArgs: false }]),
@@ -768,6 +771,82 @@ describe("PluginDevWorkerMainBridge", () => {
     // The worker is gone, so the read has nowhere to deliver — cancel the I/O
     // rather than let it complete against a dead generation.
     expect(seenSignal?.aborted).toBe(true);
+  });
+
+  // #12279: a prompt is the one host call the user can SEE. Retiring the
+  // generation that asked must take the question off the screen, not just drop
+  // the answer — otherwise the user is left answering a dead worker, and the
+  // per-plugin one-prompt cap makes the successor's first prompt resolve
+  // instantly to its cancel value.
+  describe.each([
+    { method: "showQuickPick", params: { items: [{ id: "a", label: "A" }] }, signalArg: 2 },
+    { method: "showInputBox", params: { options: {} }, signalArg: 1 },
+    { method: "showConfirm", params: { options: { title: "Sure?" } }, signalArg: 1 },
+  ])("$method cancellation (#12279)", ({ method, params, signalArg }) => {
+    const openPrompt = async (host: any, workerHost: FakeWorkerHost) => {
+      let seenSignal: AbortSignal | undefined;
+      host[method].mockImplementation((...args: any[]) => {
+        seenSignal = args[signalArg]?.signal;
+        // A prompt has no deadline — it stays open until the user answers.
+        return new Promise(() => {});
+      });
+      workerHost.emit("worker-message", {
+        type: "host-call",
+        requestId: "p1",
+        method,
+        params,
+      });
+      await flush();
+      return () => seenSignal;
+    };
+
+    it("forwards a signal that the reload boundary aborts", async () => {
+      const { host, workerHost, bridge } = makeBridge();
+      bridge.waitForActivation().catch(() => {});
+      const signal = await openPrompt(host, workerHost);
+      expect(signal()).toBeDefined();
+      expect(signal()?.aborted).toBe(false);
+
+      workerHost.emit("reloading");
+
+      expect(signal()?.aborted).toBe(true);
+    });
+
+    it("aborts the prompt when the worker crashes instead", async () => {
+      const { host, workerHost, bridge } = makeBridge();
+      bridge.waitForActivation().catch(() => {});
+      const signal = await openPrompt(host, workerHost);
+
+      workerHost.emit("exit", 139, false);
+
+      expect(signal()?.aborted).toBe(true);
+    });
+  });
+
+  it("still cancels prompts when registration cleanup throws on reload (#12279)", async () => {
+    const clear = vi.fn(() => {
+      throw new Error("registration cleanup exploded");
+    });
+    const { host, workerHost, bridge } = makeBridge({ clear });
+    bridge.waitForActivation().catch(() => {});
+    let seenSignal: AbortSignal | undefined;
+    (host.showConfirm as any).mockImplementation((_o: any, call?: any) => {
+      seenSignal = call?.signal;
+      return new Promise(() => {});
+    });
+    workerHost.emit("worker-message", {
+      type: "host-call",
+      requestId: "p1",
+      method: "showConfirm",
+      params: { options: { title: "Sure?" } },
+    });
+    await flush();
+
+    // A throwing teardown step must not strand a dialog on the user's screen,
+    // nor skip the rest of the cascade (#9322).
+    expect(() => workerHost.emit("reloading")).not.toThrow();
+    expect(seenSignal?.aborted).toBe(true);
+    expect(clear).toHaveBeenCalled();
   });
 
   it("retires the crashed generation's registrations and subscriptions (#12216)", async () => {

--- a/electron/services/plugin/__tests__/PluginHostFactory.binding.test.ts
+++ b/electron/services/plugin/__tests__/PluginHostFactory.binding.test.ts
@@ -518,6 +518,35 @@ describe("createHost dispatch, catalog and prompts", () => {
     for (const call of h.requestPrompt.mock.calls) expect(call[2]).toBe(PROJECT_A);
   });
 
+  it("forwards each prompt's cancellation signal to the dispatcher (#12279)", async () => {
+    const h = makeHarness();
+    const { host } = createHost(h.deps, PLUGIN_ID, BOUND);
+    const controller = new AbortController();
+
+    await host.showQuickPick([{ id: "a", label: "A" }], {}, { signal: controller.signal });
+    await host.showInputBox({ title: "name" }, { signal: controller.signal });
+    await host.showConfirm({ title: "sure?" }, { signal: controller.signal });
+
+    // This is the link that ties a prompt to the lifetime of whatever asked for
+    // it — without it the dev worker's retired generation cannot dismiss its own
+    // question, and the signal is silently dropped at the factory boundary.
+    expect(h.requestPrompt.mock.calls).toHaveLength(3);
+    for (const call of h.requestPrompt.mock.calls) {
+      expect(call[3]).toBe(controller.signal);
+      // The binding must survive alongside the new trailing argument.
+      expect(call[2]).toBe(PROJECT_A);
+    }
+  });
+
+  it("leaves the signal undefined when a plugin passes no call options (#12279)", async () => {
+    const h = makeHarness();
+    const { host } = createHost(h.deps, PLUGIN_ID, BOUND);
+
+    await host.showConfirm({ title: "sure?" });
+
+    expect(h.requestPrompt.mock.calls[0][3]).toBeUndefined();
+  });
+
   it("passes null through when unbound so the dispatchers stay ambient", async () => {
     const h = makeHarness();
     const { host } = createHost(h.deps, PLUGIN_ID, UNBOUND_PLUGIN_HOST_BINDING);

--- a/electron/services/plugin/__tests__/PluginUIPromptDispatcher.test.ts
+++ b/electron/services/plugin/__tests__/PluginUIPromptDispatcher.test.ts
@@ -241,6 +241,81 @@ describe("PluginUIPromptDispatcher", () => {
     await expect(other).resolves.toEqual({ id: "k", label: "Kept" });
   });
 
+  it("never opens a prompt whose signal is already aborted (#12279)", async () => {
+    const wc = makeWebContents(7);
+    setActiveWebContents(wc);
+    const d = new PluginUIPromptDispatcher({ isDisposed: () => false });
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(d.requestPrompt("mine", CONFIRM, undefined, controller.signal)).resolves.toBe(
+      false
+    );
+
+    expect(
+      wc.send.mock.calls.filter((c) => c[0] === CHANNELS.PLUGIN_UI_PROMPT_REQUEST)
+    ).toHaveLength(0);
+    // The one-prompt-per-plugin cap must not have been spent on a dialog that
+    // was never shown — the next request still gets through.
+    const next = d.requestPrompt("mine", CONFIRM);
+    expect(
+      wc.send.mock.calls.filter((c) => c[0] === CHANNELS.PLUGIN_UI_PROMPT_REQUEST)
+    ).toHaveLength(1);
+    d.cancelForPlugin("mine");
+    await expect(next).resolves.toBe(false);
+  });
+
+  it("aborting a prompt dismisses that one request and settles it (#12279)", async () => {
+    const wc = makeWebContents(7);
+    setActiveWebContents(wc);
+    const d = new PluginUIPromptDispatcher({ isDisposed: () => false });
+    const controller = new AbortController();
+
+    const promise = d.requestPrompt("mine", CONFIRM, undefined, controller.signal);
+    const promptId = lastPromptId(wc);
+
+    controller.abort();
+
+    await expect(promise).resolves.toBe(false);
+    // Scoped by promptId so the renderer drops exactly this dialog.
+    expect(wc.send).toHaveBeenCalledWith(CHANNELS.PLUGIN_UI_PROMPT_CANCEL, {
+      pluginId: "mine",
+      promptId,
+    });
+  });
+
+  it("a late abort cannot dismiss a replacement prompt (#12279)", async () => {
+    const wc = makeWebContents(7);
+    setActiveWebContents(wc);
+    const d = new PluginUIPromptDispatcher({ isDisposed: () => false });
+    const controller = new AbortController();
+
+    const first = d.requestPrompt("mine", CONFIRM, undefined, controller.signal);
+    const firstId = lastPromptId(wc);
+    ipcMainMock._emit(
+      CHANNELS.PLUGIN_UI_PROMPT_RESPONSE,
+      { sender: { id: 7 } },
+      { promptId: firstId, result: true }
+    );
+    await expect(first).resolves.toBe(true);
+
+    // Same plugin asks again; the earlier caller only now gives up.
+    const second = d.requestPrompt("mine", CONFIRM);
+    const secondId = lastPromptId(wc);
+    expect(secondId).not.toBe(firstId);
+
+    controller.abort();
+
+    // The stale signal must not reach the successor's dialog.
+    expect(wc.send).not.toHaveBeenCalledWith(CHANNELS.PLUGIN_UI_PROMPT_CANCEL, expect.anything());
+    ipcMainMock._emit(
+      CHANNELS.PLUGIN_UI_PROMPT_RESPONSE,
+      { sender: { id: 7 } },
+      { promptId: secondId, result: false }
+    );
+    await expect(second).resolves.toBe(false);
+  });
+
   it("cancelForPlugin dismisses on the ORIGINAL window even after focus switches", async () => {
     const wc1 = makeWebContents(7);
     setActiveWebContents(wc1);

--- a/electron/services/plugin/__tests__/PluginUIPromptDispatcher.test.ts
+++ b/electron/services/plugin/__tests__/PluginUIPromptDispatcher.test.ts
@@ -217,10 +217,11 @@ describe("PluginUIPromptDispatcher", () => {
     d.cancelForPlugin("mine");
 
     await expect(mine).resolves.toBe(false);
-    expect(wc.send).toHaveBeenCalledWith(
-      CHANNELS.PLUGIN_UI_PROMPT_CANCEL,
-      expect.objectContaining({ pluginId: "mine" })
-    );
+    // Deliberately unscoped: the bulk drain dismisses every prompt for the
+    // plugin, so an accidental `promptId` here would narrow it to one.
+    expect(wc.send).toHaveBeenCalledWith(CHANNELS.PLUGIN_UI_PROMPT_CANCEL, {
+      pluginId: "mine",
+    });
 
     // The other plugin's prompt is untouched until it answers.
     const otherId = (
@@ -282,6 +283,18 @@ describe("PluginUIPromptDispatcher", () => {
       pluginId: "mine",
       promptId,
     });
+
+    // The abort must release the per-plugin cap, not just settle the promise —
+    // otherwise the successor generation's first prompt is answered for it.
+    const next = d.requestPrompt("mine", CONFIRM);
+    const nextId = lastPromptId(wc);
+    expect(nextId).not.toBe(promptId);
+    ipcMainMock._emit(
+      CHANNELS.PLUGIN_UI_PROMPT_RESPONSE,
+      { sender: { id: 7 } },
+      { promptId: nextId, result: true }
+    );
+    await expect(next).resolves.toBe(true);
   });
 
   it("a late abort cannot dismiss a replacement prompt (#12279)", async () => {
@@ -308,12 +321,14 @@ describe("PluginUIPromptDispatcher", () => {
 
     // The stale signal must not reach the successor's dialog.
     expect(wc.send).not.toHaveBeenCalledWith(CHANNELS.PLUGIN_UI_PROMPT_CANCEL, expect.anything());
+    // Answer affirmatively: `false` would also be the value a wrongly-delivered
+    // cancellation produces, so it could not tell the two apart.
     ipcMainMock._emit(
       CHANNELS.PLUGIN_UI_PROMPT_RESPONSE,
       { sender: { id: 7 } },
-      { promptId: secondId, result: false }
+      { promptId: secondId, result: true }
     );
-    await expect(second).resolves.toBe(false);
+    await expect(second).resolves.toBe(true);
   });
 
   it("cancelForPlugin dismisses on the ORIGINAL window even after focus switches", async () => {

--- a/electron/services/plugin/__tests__/pluginDevWorkerHostProxy.test.ts
+++ b/electron/services/plugin/__tests__/pluginDevWorkerHostProxy.test.ts
@@ -618,6 +618,57 @@ describe("PluginDevWorkerHostProxy host-call post failure (#10526)", () => {
   });
 });
 
+describe("PluginDevWorkerHostProxy prompt cancellation (#12279)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("resolves the dismiss value and posts host-cancel when the signal aborts", async () => {
+    const { proxy, sent } = makeProxy();
+    const controller = new AbortController();
+
+    const promise = proxy.host.showConfirm({ title: "Sure?" }, { signal: controller.signal });
+    const call = sent.find((m) => m.type === "host-call");
+    expect(call.method).toBe("showConfirm");
+
+    controller.abort();
+
+    // A cancelled prompt is a dismissal, not a failure.
+    await expect(promise).resolves.toBe(false);
+    expect(sent).toContainEqual({ type: "host-cancel", requestId: call.requestId });
+  });
+
+  it("never sends an already-aborted prompt", async () => {
+    const { proxy, sent } = makeProxy();
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      proxy.host.showQuickPick([{ id: "a", label: "A" }], {}, { signal: controller.signal })
+    ).resolves.toBeUndefined();
+    expect(sent.filter((m) => m.type === "host-call")).toHaveLength(0);
+  });
+
+  it("still throws a genuine error when the signal aborts after it (#12279)", async () => {
+    const { proxy, sent } = makeProxy();
+    const controller = new AbortController();
+
+    const promise = proxy.host.showConfirm({ title: "Sure?" }, { signal: controller.signal });
+    const call = sent.find((m) => m.type === "host-call");
+
+    // The host rejects for a real reason, and only then does the caller give up.
+    proxy.handleMessage({
+      type: "host-result",
+      requestId: call.requestId,
+      ok: false,
+      error: "options.title must be a string",
+    } as any);
+    controller.abort();
+
+    // Settling the grace value on signal state alone would rewrite this real
+    // validation failure into a silent dismissal.
+    await expect(promise).rejects.toThrow(/options.title must be a string/);
+  });
+});
+
 describe("PluginDevWorkerHostProxy runtime-surface validation rejects, never throws (#10617)", () => {
   beforeEach(() => vi.clearAllMocks());
 

--- a/electron/services/plugin/pluginDevWorkerHostProxy.ts
+++ b/electron/services/plugin/pluginDevWorkerHostProxy.ts
@@ -251,13 +251,9 @@ export class PluginDevWorkerHostProxy {
     if (signal?.aborted) {
       return Promise.resolve(graceValue);
     }
-    return this.call<T>(method, params, signal, { value: graceValue }).catch((err: unknown) => {
-      // A cancelled prompt is a dismissal, not a failure (#12279): settle the
-      // grace value so the never-throws contract holds. Only an abort of THIS
-      // call's signal is swallowed — validation and transport errors still throw.
-      if (signal?.aborted) return graceValue;
-      throw err;
-    });
+    // Cancellation settles the grace value inside `call`'s abort branch, so a
+    // real validation or transport error is never rewritten into a dismissal.
+    return this.call<T>(method, params, signal, { value: graceValue });
   }
 
   private call<T>(
@@ -291,9 +287,23 @@ export class PluginDevWorkerHostProxy {
           if (!pending) return;
           this.pendingCalls.delete(requestId);
           cleanup();
-          // Tell main to abort the in-flight host call (AbortSignal itself is not
-          // structured-clone-safe, so the requestId is the cancellation handle).
-          this.post({ type: "host-cancel", requestId });
+          try {
+            // Tell main to abort the in-flight host call (AbortSignal itself is not
+            // structured-clone-safe, so the requestId is the cancellation handle).
+            this.post({ type: "host-cancel", requestId });
+          } catch {
+            // best-effort — the entry is already claimed, so a failed cancel
+            // post must not leave the caller's promise unsettled forever
+          }
+          // A grace-bearing call (the imperative prompts) treats cancellation as
+          // a dismissal rather than a failure. Settling it HERE is what makes
+          // that safe: this branch only runs when the abort actually claimed the
+          // pending entry, so a genuine error that already settled the call can
+          // never be rewritten into a dismissal (#12279).
+          if (grace) {
+            resolve(grace.value as T);
+            return;
+          }
           reject(abortError(signal));
         };
         signal.addEventListener("abort", onAbort, { once: true });

--- a/electron/services/plugin/pluginDevWorkerHostProxy.ts
+++ b/electron/services/plugin/pluginDevWorkerHostProxy.ts
@@ -26,6 +26,7 @@ import type {
   PluginToastOptions,
   PluginQuickPickItem,
   PluginQuickPickOptions,
+  PluginHostCallOptions,
   PluginTypedIpcHandler,
   PluginWorktreeSnapshot,
   PluginWorktreeStatus,
@@ -241,12 +242,22 @@ export class PluginDevWorkerHostProxy {
   private callWithGrace<T>(
     method: PluginHostCallMethod,
     params: unknown,
-    graceValue: T
+    graceValue: T,
+    signal?: AbortSignal
   ): Promise<T> {
     if (this.disposed) {
       return Promise.resolve(graceValue);
     }
-    return this.call<T>(method, params, undefined, { value: graceValue });
+    if (signal?.aborted) {
+      return Promise.resolve(graceValue);
+    }
+    return this.call<T>(method, params, signal, { value: graceValue }).catch((err: unknown) => {
+      // A cancelled prompt is a dismissal, not a failure (#12279): settle the
+      // grace value so the never-throws contract holds. Only an abort of THIS
+      // call's signal is swallowed — validation and transport errors still throw.
+      if (signal?.aborted) return graceValue;
+      throw err;
+    });
   }
 
   private call<T>(
@@ -663,15 +674,26 @@ export class PluginDevWorkerHostProxy {
       // assertActivationOpen): plugins prompt from command handlers. They use
       // callWithGrace so a plugin unload mid-prompt resolves the dismiss value
       // (undefined / false) instead of rejecting — matching the host contract.
-      showQuickPick: ((items: PluginQuickPickItem[], options?: PluginQuickPickOptions) =>
+      showQuickPick: ((
+        items: PluginQuickPickItem[],
+        options?: PluginQuickPickOptions,
+        callOptions?: PluginHostCallOptions
+      ) =>
         this.callWithGrace<PluginQuickPickItem | PluginQuickPickItem[] | undefined>(
           "showQuickPick",
           { items, options },
-          undefined
+          undefined,
+          callOptions?.signal
         )) as PluginHostApi["showQuickPick"],
-      showInputBox: (options) =>
-        this.callWithGrace<string | undefined>("showInputBox", { options }, undefined),
-      showConfirm: (options) => this.callWithGrace<boolean>("showConfirm", { options }, false),
+      showInputBox: (options, callOptions) =>
+        this.callWithGrace<string | undefined>(
+          "showInputBox",
+          { options },
+          undefined,
+          callOptions?.signal
+        ),
+      showConfirm: (options, callOptions) =>
+        this.callWithGrace<boolean>("showConfirm", { options }, false, callOptions?.signal),
       logger: {
         info: (message, fields) => this.notify("logger.info", { message, fields }),
         warn: (message, fields) => this.notify("logger.warn", { message, fields }),

--- a/packages/plugin-sdk/api-report/index.d.ts
+++ b/packages/plugin-sdk/api-report/index.d.ts
@@ -3883,11 +3883,16 @@ interface PluginHostApi extends PluginActivationApi {
      * plugin is unloaded while the palette is open the pending call resolves
      * `undefined` (it never throws). Invalid items reject so authoring mistakes
      * surface loudly.
+     *
+     * Aborting `callOptions.signal` dismisses the open palette and resolves
+     * `undefined` rather than rejecting — a cancelled prompt is a dismissal, not a
+     * failure, so the never-throws contract above still holds (#12279). This is
+     * the one place {@link PluginHostCallOptions} settles instead of rejecting.
      */
     showQuickPick(items: PluginQuickPickItem[], options: PluginQuickPickOptions & {
         canSelectMany: true;
-    }): Promise<PluginQuickPickItem[] | undefined>;
-    showQuickPick(items: PluginQuickPickItem[], options?: PluginQuickPickOptions): Promise<PluginQuickPickItem | undefined>;
+    }, callOptions?: PluginHostCallOptions): Promise<PluginQuickPickItem[] | undefined>;
+    showQuickPick(items: PluginQuickPickItem[], options?: PluginQuickPickOptions, callOptions?: PluginHostCallOptions): Promise<PluginQuickPickItem | undefined>;
     /**
      * Imperatively prompt the user for a line of text, rendered through the app's
      * dialog surface. Resolves with the entered string, or `undefined` if the user
@@ -3895,19 +3900,21 @@ interface PluginHostApi extends PluginActivationApi {
      * is enforced client-side at submit time.
      *
      * Async and NOT revoke-guarded for the same reason as {@link showQuickPick};
-     * resolves `undefined` if the plugin is unloaded while the dialog is open.
+     * resolves `undefined` if the plugin is unloaded while the dialog is open, and
+     * aborting `callOptions.signal` dismisses it and resolves `undefined` too.
      */
-    showInputBox(options?: PluginInputBoxOptions): Promise<string | undefined>;
+    showInputBox(options?: PluginInputBoxOptions, callOptions?: PluginHostCallOptions): Promise<string | undefined>;
     /**
      * Imperatively ask the user to confirm an action, rendered through the app's
      * `ConfirmDialog`. Resolves `true` if confirmed, `false` if cancelled,
      * dismissed, or the plugin is unloaded while the dialog is open.
      *
      * Async and NOT revoke-guarded for the same reason as {@link showQuickPick}.
+     * Aborting `callOptions.signal` dismisses the dialog and resolves `false`.
      * For an irreversible action set {@link PluginConfirmOptions.destructive} and
      * use a verb-noun `confirmLabel`.
      */
-    showConfirm(options: PluginConfirmOptions): Promise<boolean>;
+    showConfirm(options: PluginConfirmOptions, callOptions?: PluginHostCallOptions): Promise<boolean>;
     /**
      * Persistent, plugin-scoped key/value settings. Plaintext JSON storage with
      * `chmod 0o600` on POSIX — no OS keychain (#9167). See {@link SettingsApi}.

--- a/shared/testing/createMockHost.ts
+++ b/shared/testing/createMockHost.ts
@@ -45,6 +45,7 @@ import type {
   PluginPtyProcessSpawnOptions,
   PluginQuickPickItem,
   PluginQuickPickOptions,
+  PluginHostCallOptions,
   PluginSettingsScope,
   PluginStorageScope,
   PluginToastOptions,
@@ -1192,19 +1193,29 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
     // production parity, records the call for assertions, then resolves the
     // configured `simulate*Response` value (default = the user-cancel dismiss
     // value). A shape the real host rejects now fails the mock too.
-    showQuickPick: (async (items: PluginQuickPickItem[], options?: PluginQuickPickOptions) => {
+    // An already-aborted signal dismisses without recording a call, matching
+    // production — a plugin test must not get a configured answer to a question
+    // the real host would never have asked (#12279).
+    showQuickPick: (async (
+      items: PluginQuickPickItem[],
+      options?: PluginQuickPickOptions,
+      callOptions?: PluginHostCallOptions
+    ) => {
       const validItems = validateQuickPickItems(items);
+      if (callOptions?.signal?.aborted) return undefined;
       showQuickPickCalls.push({ items: validItems, options });
       return quickPickResponse;
     }) as PluginHostApi["showQuickPick"],
-    async showInputBox(options) {
+    async showInputBox(options, callOptions) {
+      if (callOptions?.signal?.aborted) return undefined;
       showInputBoxCalls.push({ options });
       return inputBoxResponse;
     },
-    async showConfirm(options) {
+    async showConfirm(options, callOptions) {
       if (!options || typeof options !== "object" || typeof options.title !== "string") {
         throw new Error("showConfirm: options.title must be a string");
       }
+      if (callOptions?.signal?.aborted) return false;
       showConfirmCalls.push({ options });
       return confirmResponse;
     },

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -2980,14 +2980,21 @@ export interface PluginHostApi extends PluginActivationApi {
    * plugin is unloaded while the palette is open the pending call resolves
    * `undefined` (it never throws). Invalid items reject so authoring mistakes
    * surface loudly.
+   *
+   * Aborting `callOptions.signal` dismisses the open palette and resolves
+   * `undefined` rather than rejecting — a cancelled prompt is a dismissal, not a
+   * failure, so the never-throws contract above still holds (#12279). This is
+   * the one place {@link PluginHostCallOptions} settles instead of rejecting.
    */
   showQuickPick(
     items: PluginQuickPickItem[],
-    options: PluginQuickPickOptions & { canSelectMany: true }
+    options: PluginQuickPickOptions & { canSelectMany: true },
+    callOptions?: PluginHostCallOptions
   ): Promise<PluginQuickPickItem[] | undefined>;
   showQuickPick(
     items: PluginQuickPickItem[],
-    options?: PluginQuickPickOptions
+    options?: PluginQuickPickOptions,
+    callOptions?: PluginHostCallOptions
   ): Promise<PluginQuickPickItem | undefined>;
   /**
    * Imperatively prompt the user for a line of text, rendered through the app's
@@ -2996,19 +3003,24 @@ export interface PluginHostApi extends PluginActivationApi {
    * is enforced client-side at submit time.
    *
    * Async and NOT revoke-guarded for the same reason as {@link showQuickPick};
-   * resolves `undefined` if the plugin is unloaded while the dialog is open.
+   * resolves `undefined` if the plugin is unloaded while the dialog is open, and
+   * aborting `callOptions.signal` dismisses it and resolves `undefined` too.
    */
-  showInputBox(options?: PluginInputBoxOptions): Promise<string | undefined>;
+  showInputBox(
+    options?: PluginInputBoxOptions,
+    callOptions?: PluginHostCallOptions
+  ): Promise<string | undefined>;
   /**
    * Imperatively ask the user to confirm an action, rendered through the app's
    * `ConfirmDialog`. Resolves `true` if confirmed, `false` if cancelled,
    * dismissed, or the plugin is unloaded while the dialog is open.
    *
    * Async and NOT revoke-guarded for the same reason as {@link showQuickPick}.
+   * Aborting `callOptions.signal` dismisses the dialog and resolves `false`.
    * For an irreversible action set {@link PluginConfirmOptions.destructive} and
    * use a verb-noun `confirmLabel`.
    */
-  showConfirm(options: PluginConfirmOptions): Promise<boolean>;
+  showConfirm(options: PluginConfirmOptions, callOptions?: PluginHostCallOptions): Promise<boolean>;
   /**
    * Persistent, plugin-scoped key/value settings. Plaintext JSON storage with
    * `chmod 0o600` on POSIX — no OS keychain (#9167). See {@link SettingsApi}.

--- a/src/components/Plugin/__tests__/PluginViewContent.test.tsx
+++ b/src/components/Plugin/__tests__/PluginViewContent.test.tsx
@@ -352,7 +352,12 @@ describe("makePluginViewContent", () => {
 
       render(<Content panelId="panel-act" />);
 
-      await waitFor(() => expect(capturedFactory).toBeDefined());
+      // `waitFor` defaults to 1s regardless of vitest's 15s testTimeout, and
+      // capturing the lazy factory through a re-imported module lands right on
+      // that boundary on a loaded CI runner — which shard 1 hit twice, on a
+      // different one of these three waits each time. The assertion is
+      // unchanged; only the polling window is widened.
+      await waitFor(() => expect(capturedFactory).toBeDefined(), { timeout: 5000 });
       // Activation rejects, so the awaited call short-circuits before `import()`.
       // Awaiting to settlement also lets the factory's `finally` clear the 10s
       // timeout rather than leaking an open timer into the next test.
@@ -399,7 +404,7 @@ describe("makePluginViewContent", () => {
 
       render(<Content panelId="panel-act-fail" />);
 
-      await waitFor(() => expect(capturedFactory).toBeDefined());
+      await waitFor(() => expect(capturedFactory).toBeDefined(), { timeout: 5000 });
       // The factory rejects with the real activation error and never reaches the
       // `plugin://` import.
       await expect(capturedFactory!()).rejects.toThrow(/boom/);
@@ -432,7 +437,7 @@ describe("makePluginViewContent", () => {
 
       render(<Content panelId="panel-noact" />);
 
-      await waitFor(() => expect(capturedFactory).toBeDefined());
+      await waitFor(() => expect(capturedFactory).toBeDefined(), { timeout: 5000 });
 
       // The factory still rejects here — jsdom can't resolve a `plugin://` URL —
       // so "did it reject" proves nothing. What matters is the *cause*: with the

--- a/src/components/Plugin/__tests__/PluginViewContent.test.tsx
+++ b/src/components/Plugin/__tests__/PluginViewContent.test.tsx
@@ -352,12 +352,7 @@ describe("makePluginViewContent", () => {
 
       render(<Content panelId="panel-act" />);
 
-      // `waitFor` defaults to 1s regardless of vitest's 15s testTimeout, and
-      // capturing the lazy factory through a re-imported module lands right on
-      // that boundary on a loaded CI runner — which shard 1 hit twice, on a
-      // different one of these three waits each time. The assertion is
-      // unchanged; only the polling window is widened.
-      await waitFor(() => expect(capturedFactory).toBeDefined(), { timeout: 5000 });
+      await waitFor(() => expect(capturedFactory).toBeDefined());
       // Activation rejects, so the awaited call short-circuits before `import()`.
       // Awaiting to settlement also lets the factory's `finally` clear the 10s
       // timeout rather than leaking an open timer into the next test.
@@ -404,7 +399,7 @@ describe("makePluginViewContent", () => {
 
       render(<Content panelId="panel-act-fail" />);
 
-      await waitFor(() => expect(capturedFactory).toBeDefined(), { timeout: 5000 });
+      await waitFor(() => expect(capturedFactory).toBeDefined());
       // The factory rejects with the real activation error and never reaches the
       // `plugin://` import.
       await expect(capturedFactory!()).rejects.toThrow(/boom/);
@@ -437,7 +432,7 @@ describe("makePluginViewContent", () => {
 
       render(<Content panelId="panel-noact" />);
 
-      await waitFor(() => expect(capturedFactory).toBeDefined(), { timeout: 5000 });
+      await waitFor(() => expect(capturedFactory).toBeDefined());
 
       // The factory still rejects here — jsdom can't resolve a `plugin://` URL —
       // so "did it reject" proves nothing. What matters is the *cause*: with the


### PR DESCRIPTION
## Summary

- A plugin dev worker hot reload (what an author hits on every save) retired the generation and aborted host calls, but the three prompt cases never forwarded that abort signal, so a stranded dialog stayed on screen and its one-prompt-per-plugin cap silently ate the new worker's first prompt too.
- The outgoing worker also kept mutation authority during its cooperative dispose window: anything it sent (a delegated action, a settings or storage write) got stamped with the incoming generation and passed every staleness check.
- Both are closed here, plus a regression the first commit introduced that a Codex review caught before merge.

Resolves #12279

## The bug

When a plugin dev worker hot reloads, `PluginDevWorkerMainBridge.retireGeneration` bumps the generation counter and calls `abortAllHostCalls`. The three prompt cases in `dispatchHostCall` (`showQuickPick`, `showInputBox`, `showConfirm`) just forwarded to the host methods without passing the abort signal along, so nothing was listening for it and the dialog stayed on screen.

`PluginUIPromptDispatcher.cancelForPlugin` was already wired into full plugin unload and into idle deactivation, just never into the reload path. Because there's a one-prompt-per-plugin cap, the stranded dialog also caused the successor generation's first prompt to resolve instantly to its cancel value. So this silently broke the new worker's prompts too, not just the old one's.

## Mutation authority

The second half of the issue: reload asks the worker to dispose cooperatively and only force kills it after a grace period, so the outgoing worker stays alive and message connected after its generation is already retired. Anything it sent in that window, a delegated action, a settings or storage write, got stamped by the bridge with the incoming generation. It passed every existing staleness check and committed with full authority.

Closed by gating receives on worker instance identity in `PluginDevWorkerHost`.

## Changes

- Added an optional trailing `PluginHostCallOptions` on the three prompt methods, reusing the existing signal-in-a-trailing-bag convention (purely additive, `api-report` regenerated). Aborting settles the dismiss value rather than rejecting, so the never-throws contract holds.
- `PluginUIPromptDispatcher` is now signal-aware: an already-aborted fast path, promptId-scoped renderer dismissal (the payload field and renderer store support already existed and were unused), and one combined listener disposer so the abort hook can't leak on any settlement path.
- `PluginDevWorkerHost` drops messages from a retiring or superseded child. The gate self-clears on child identity, so it can't deadlock activation, and it only gates receives, the cooperative dispose still reaches the outgoing worker.
- `retireGeneration` aborts host calls before the fallible registration cleanup, which is now guarded, so a throwing disposer can't strand a visible dialog.
- The proxy settles a cancelled prompt inside `call()`'s abort branch, where the abort has provably claimed the pending entry, so a real validation or transport error that already settled never gets rewritten into a dismissal.

## Behavior change worth flagging

A plugin that issues host calls from its deactivate or cleanup hook no longer has them serviced during a hot reload. This was never a usable persistence contract: the worker proxy rejects pending calls immediately after cleanup runs and the process exits, and ordinary unload already disposes the bridge before asking the worker to clean up, so hot reload was the accidental exception. No plugin in this repo persists state from a cleanup hook. Worth a line in `docs/plugins/host-api.md` as a follow-up; docs are out of scope here.

## Deliberately out of scope

- Threading commit authorization through `electron/utils/fs.ts`'s atomic writer and `PluginSettingsStore`'s write queue. With the admission gate in place, a retired generation's mutations are never admitted, so this would only cover writes that are already committed and irreversible, at the cost of changing a writer shared repo-wide.
- Cancelling actions already handed to the renderer, and consent revocation epochs. Both need an owner-aware action execution contract.

## Testing

1383 tests across 47 files pass (every plugin-system suite in the repo plus the renderer prompt store). Typecheck is clean, and lint/format are clean on the touched files.

New regression coverage: prompt cancellation across all three prompt kinds on both the reload and crash boundaries, the retiring/superseded worker gate, factory signal forwarding, the abort releasing the per-plugin prompt cap, a late abort not dismissing a successor prompt, and a rebuild interrupting initial startup.

A Codex review caught a regression in the first commit: the receive gate stranded the initial `start()` waiter, which `PluginService` reads as a fork failure and would have disposed the replacement worker. The second commit fixes that and adds the covering test.
