### PR TITLE
fix(plugins): scrub the whole plugin diagnostics report, not just the trace

### DIFF
--- a/shared/utils/__tests__/reportScrubbers.test.ts
+++ b/shared/utils/__tests__/reportScrubbers.test.ts
@@ -162,3 +162,31 @@ describe("scrubReportText", () => {
     expect(result).not.toContain("ghp_0123456789");
   });
 });
+
+describe("scrubReportPath across a multi-section document", () => {
+  // The username classes matched every character but `/`, `"` and `\\` — which
+  // includes newlines. A home path at the end of one section therefore ate the
+  // rest of the document into the `USER` replacement, silently truncating the
+  // very report it was redacting.
+  it("stops the username match at the end of its line", () => {
+    const report = "Message: /Users/alice\n\nStack:\nkeep me\n\nComponent stack:\nand me";
+
+    const scrubbed = scrubReportPath(report);
+
+    expect(scrubbed).toContain("Message: /Users/USER");
+    expect(scrubbed).toContain("keep me");
+    expect(scrubbed).toContain("and me");
+  });
+
+  it("still redacts a username containing spaces", () => {
+    expect(scrubReportPath("/Users/john smith/notes.txt")).toBe("/Users/USER/notes.txt");
+    expect(scrubReportPath("C:\\Users\\john smith\\notes.txt")).toBe("C:\\Users\\USER\\notes.txt");
+  });
+
+  it("stops a Windows username match at the end of its line", () => {
+    const scrubbed = scrubReportPath("Path: C:\\Users\\alice\nStack:\nkeep me");
+
+    expect(scrubbed).toContain("C:\\Users\\USER");
+    expect(scrubbed).toContain("keep me");
+  });
+});

--- a/shared/utils/reportScrubbers.ts
+++ b/shared/utils/reportScrubbers.ts
@@ -19,6 +19,13 @@ export { scrubSecrets };
  * `USER` placeholder. Username-agnostic — uses only static patterns, so it is
  * safe in the renderer where `os.homedir()` is unavailable. Handles both
  * forward-slash and backslash Windows paths (lesson #4979).
+ *
+ * Every "rest of the segment" class excludes CR and LF. A username cannot
+ * contain either, and without that bound a home path sitting at the end of one
+ * section of a multi-section report consumes every following section into the
+ * replacement — silently truncating the document it was meant to redact.
+ * Spaces stay inside the classes: usernames and directories can contain them,
+ * and stopping at one would leak the remainder of the name.
  */
 export function scrubReportPath(str: string): string {
   return (
@@ -30,22 +37,22 @@ export function scrubReportPath(str: string): string {
       // `wsl.localhost` prefixes without `$` acting as an end-of-line anchor.
       // Handle the JSON-doubled backslash form before the raw form. The distro
       // is kept (useful WSL signal); only the username is redacted.
-      .replace(/(\\\\\\\\wsl[$.][^\\"]*\\\\[^\\"]+\\\\home\\\\)[^\\"]+/gi, "$1USER")
-      .replace(/(\\\\wsl[$.][^\\"]*\\[^\\"]+\\home\\)[^\\"]+/gi, "$1USER")
+      .replace(/(\\\\\\\\wsl[$.][^\\"\r\n]*\\\\[^\\"\r\n]+\\\\home\\\\)[^\\"\r\n]+/gi, "$1USER")
+      .replace(/(\\\\wsl[$.][^\\"\r\n]*\\[^\\"\r\n]+\\home\\)[^\\"\r\n]+/gi, "$1USER")
       // macOS / Linux — the username is the segment after /Users/ or /home/,
       // ending at a path separator, JSON-string quote, or end of string. Matching
       // only the username (not requiring a trailing slash) also catches paths that
       // appear at the end of a JSON value, e.g. `{"cwd":"/Users/alice"}`.
-      .replace(/(\/Users\/)[^/"\\]+/g, "$1USER")
-      .replace(/(\/home\/)[^/"\\]+/g, "$1USER")
+      .replace(/(\/Users\/)[^/"\\\r\n]+/g, "$1USER")
+      .replace(/(\/home\/)[^/"\\\r\n]+/g, "$1USER")
       // Windows backslash — JSON.stringify doubles backslashes, so handle the
       // double-backslash form before the single-backslash (raw path) form. The
       // drive letter is generalized to any letter so non-`C:` profiles
       // (e.g. `D:\Users\alice`) are scrubbed too.
-      .replace(/([A-Za-z]:\\\\Users\\\\)[^\\"]+/gi, "$1USER")
-      .replace(/([A-Za-z]:\\Users\\)[^\\"]+/gi, "$1USER")
+      .replace(/([A-Za-z]:\\\\Users\\\\)[^\\"\r\n]+/gi, "$1USER")
+      .replace(/([A-Za-z]:\\Users\\)[^\\"\r\n]+/gi, "$1USER")
       // Windows forward-slash form (e.g. from a posix-normalized path).
-      .replace(/([A-Za-z]:\/Users\/)[^/"\\]+/gi, "$1USER")
+      .replace(/([A-Za-z]:\/Users\/)[^/"\\\r\n]+/gi, "$1USER")
       // Git remotes — the org/repo segment names private projects. The host is
       // kept (useful signal, same rationale as keeping the WSL distro). SSH
       // form first (a `.git` suffix folds into the redaction — repo names may

--- a/src/components/Plugin/PluginViewDiagnosticsFallback.tsx
+++ b/src/components/Plugin/PluginViewDiagnosticsFallback.tsx
@@ -71,13 +71,6 @@ export function PluginViewDiagnosticsFallback({
 }: PluginViewDiagnosticsFallbackProps) {
   const { copied, copy } = useCopyWithFeedback({ announcement: "Diagnostics copied" });
 
-  const announcedRef = useRef(false);
-  useEffect(() => {
-    if (announcedRef.current) return;
-    announcedRef.current = true;
-    useAnnouncerStore.getState().announce(`${panelDisplayName} error`, "polite");
-  }, [panelDisplayName]);
-
   // Built once, here, so the rendered pane and the copied report can never
   // diverge — the label claiming redaction has to describe both.
   const diagnostics = useMemo(
@@ -105,7 +98,17 @@ export function PluginViewDiagnosticsFallback({
       incidentId,
     ]
   );
-  const { message, trace, report } = diagnostics;
+  // Destructured from the builder rather than read off the props: the manifest
+  // supplies these, so they are author-controlled text like the message, and a
+  // pane labelled redacted must not print them raw beside that label.
+  const { message, trace, report, panelDisplayName: panelName } = diagnostics;
+
+  const announcedRef = useRef(false);
+  useEffect(() => {
+    if (announcedRef.current) return;
+    announcedRef.current = true;
+    useAnnouncerStore.getState().announce(`${panelName} error`, "polite");
+  }, [panelName]);
 
   const handleCopy = useCallback(() => {
     void copy(report);
@@ -118,7 +121,7 @@ export function PluginViewDiagnosticsFallback({
   return (
     <div
       role="region"
-      aria-label={`${panelDisplayName} render error`}
+      aria-label={`${panelName} render error`}
       data-testid="plugin-view-diagnostics"
       className="flex h-full min-h-0 w-full flex-col gap-4 overflow-auto bg-surface-panel p-6"
     >
@@ -128,7 +131,7 @@ export function PluginViewDiagnosticsFallback({
           className="text-sm font-semibold text-status-error"
           data-testid="plugin-view-diagnostics-title"
         >
-          Couldn&apos;t render {panelDisplayName}
+          Couldn&apos;t render {panelName}
         </h2>
       </div>
 
@@ -144,18 +147,18 @@ export function PluginViewDiagnosticsFallback({
       <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-xs">
         <dt className="text-text-muted">Plugin</dt>
         <dd className="font-mono break-all text-text-primary">
-          {pluginDisplayName} ({pluginId})
+          {diagnostics.pluginDisplayName} ({diagnostics.pluginId})
         </dd>
         <dt className="text-text-muted">Panel</dt>
         <dd className="font-mono break-all text-text-primary">
-          {panelDisplayName} ({kindId})
+          {panelName} ({diagnostics.kindId})
         </dd>
         <dt className="text-text-muted">Module</dt>
-        <dd className="font-mono break-all text-text-primary">{componentPath}</dd>
-        {incidentId && (
+        <dd className="font-mono break-all text-text-primary">{diagnostics.componentPath}</dd>
+        {diagnostics.incidentId && (
           <>
             <dt className="text-text-muted">Error ID</dt>
-            <dd className="font-mono break-all text-text-primary">{incidentId}</dd>
+            <dd className="font-mono break-all text-text-primary">{diagnostics.incidentId}</dd>
           </>
         )}
         {diagnostics.code && (

--- a/src/components/Plugin/PluginViewDiagnosticsFallback.tsx
+++ b/src/components/Plugin/PluginViewDiagnosticsFallback.tsx
@@ -1,13 +1,18 @@
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { TriangleAlert } from "lucide-react";
-import { scrubReportText } from "@shared/utils/reportScrubbers";
+import { buildPluginViewDiagnostics } from "@/components/Plugin/buildPluginViewDiagnostics";
 import { cn } from "@/lib/utils";
 import { actionService } from "@/services/ActionService";
 import { useCopyWithFeedback } from "@/hooks/useCopyWithFeedback";
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 
 export interface PluginViewDiagnosticsFallbackProps {
-  error: Error;
+  /**
+   * Whatever the view threw. Typed `unknown` rather than `Error` because React
+   * stores the thrown value unnormalized — `getDerivedStateFromError`'s `Error`
+   * annotation is the type system's claim, not the runtime's.
+   */
+  error: unknown;
   errorInfo?: React.ErrorInfo;
   resetError: () => void;
   incidentId?: string | null;
@@ -34,16 +39,6 @@ export interface PluginViewDiagnosticsFallbackProps {
 const BUTTON_BASE = "rounded px-3 py-1.5 text-xs transition-colors";
 const NEUTRAL_BUTTON = "bg-border-default text-text-primary hover:bg-daintree-border/80";
 
-function buildTrace(error: Error, errorInfo: React.ErrorInfo | undefined): string {
-  return [
-    "Stack:",
-    error.stack || "No stack trace available",
-    "",
-    "Component stack:",
-    errorInfo?.componentStack || "No component stack available",
-  ].join("\n");
-}
-
 /**
  * Diagnostics pane for a plugin view that threw during render. Replaces the
  * shared `component` ErrorFallback at the plugin boundary only — that variant
@@ -52,9 +47,14 @@ function buildTrace(error: Error, errorInfo: React.ErrorInfo | undefined): strin
  *
  * Detail depth keys off the plugin's own `devMode`, never `import.meta.env.DEV`:
  * plugin authors build against a *production* Daintree, so a build-mode gate
- * blinds the exact audience the trace exists for. The trace is redacted rather
+ * blinds the exact audience the trace exists for. Content is redacted rather
  * than hidden for installed plugins — visibility isn't the risk, leaking the
  * user's paths and secrets into a pasted report is (#9427).
+ *
+ * Redaction covers the whole document — message and cause chain included, not
+ * just the stacks — because the plugin author decides what goes in them
+ * (#12281). See `buildPluginViewDiagnostics` for why that differs from the
+ * sibling `ErrorFallback`, which keeps its first-party message raw.
  */
 export function PluginViewDiagnosticsFallback({
   error,
@@ -70,7 +70,6 @@ export function PluginViewDiagnosticsFallback({
   onRequestClose,
 }: PluginViewDiagnosticsFallbackProps) {
   const { copied, copy } = useCopyWithFeedback({ announcement: "Diagnostics copied" });
-  const message = error.message || "Unknown render error";
 
   const announcedRef = useRef(false);
   useEffect(() => {
@@ -79,41 +78,34 @@ export function PluginViewDiagnosticsFallback({
     useAnnouncerStore.getState().announce(`${panelDisplayName} error`, "polite");
   }, [panelDisplayName]);
 
-  // Scrubbed once, here, so the rendered trace and the copied report can never
-  // diverge. A dev-mode plugin's paths are the author's own — redacting them
-  // would strip the file references they need to find the throw.
-  const trace = useMemo(() => {
-    const raw = buildTrace(error, errorInfo);
-    return devMode ? raw : scrubReportText(raw);
-  }, [error, errorInfo, devMode]);
-
-  // Identity and message stay raw in both surfaces: they name the plugin, not
-  // the user, and redacting them costs signal for no leak benefit.
-  const report = useMemo(
+  // Built once, here, so the rendered pane and the copied report can never
+  // diverge — the label claiming redaction has to describe both.
+  const diagnostics = useMemo(
     () =>
-      [
-        `Plugin: ${pluginDisplayName} (${pluginId})`,
-        `Panel: ${panelDisplayName} (${kindId})`,
-        `Module: ${componentPath}`,
-        ...(incidentId ? [`Error ID: ${incidentId}`] : []),
-        `Trace: ${devMode ? "raw (dev mode)" : "redacted"}`,
-        "",
-        `Message: ${message}`,
-        "",
-        trace,
-      ].join("\n"),
+      buildPluginViewDiagnostics({
+        error,
+        componentStack: errorInfo?.componentStack,
+        devMode,
+        pluginId,
+        pluginDisplayName,
+        kindId,
+        panelDisplayName,
+        componentPath,
+        incidentId,
+      }),
     [
-      pluginDisplayName,
+      error,
+      errorInfo,
+      devMode,
       pluginId,
-      panelDisplayName,
+      pluginDisplayName,
       kindId,
+      panelDisplayName,
       componentPath,
       incidentId,
-      devMode,
-      message,
-      trace,
     ]
   );
+  const { message, trace, report } = diagnostics;
 
   const handleCopy = useCallback(() => {
     void copy(report);
@@ -140,7 +132,12 @@ export function PluginViewDiagnosticsFallback({
         </h2>
       </div>
 
-      <p className="text-xs text-text-primary" data-testid="plugin-view-diagnostics-message">
+      {/* Wraps and keeps newlines: a thrown non-Error renders as formatted JSON
+          here, and a plugin's message is routinely multi-line. */}
+      <p
+        className="text-xs break-words whitespace-pre-wrap text-text-primary"
+        data-testid="plugin-view-diagnostics-message"
+      >
         {message}
       </p>
 
@@ -161,6 +158,18 @@ export function PluginViewDiagnosticsFallback({
             <dd className="font-mono break-all text-text-primary">{incidentId}</dd>
           </>
         )}
+        {diagnostics.code && (
+          <>
+            <dt className="text-text-muted">Code</dt>
+            <dd className="font-mono break-all text-text-primary">{diagnostics.code}</dd>
+          </>
+        )}
+        {/* The pane makes a claim about its own contents, so it has to state
+            which claim — an unlabelled raw view is how #12281 happened. */}
+        <dt className="text-text-muted">Report</dt>
+        <dd className="text-text-primary" data-testid="plugin-view-diagnostics-mode">
+          {diagnostics.mode}
+        </dd>
       </dl>
 
       <div className="flex flex-wrap gap-2">

--- a/src/components/Plugin/__tests__/PluginViewDiagnosticsFallback.test.tsx
+++ b/src/components/Plugin/__tests__/PluginViewDiagnosticsFallback.test.tsx
@@ -24,10 +24,15 @@ const writeTextMock = vi.fn<(text: string) => Promise<void>>();
 // which would keep every path assertion green while leaking credentials.
 const ALICE_TOKEN = `ghp_${"a".repeat(36)}`;
 const BOB_TOKEN = `ghp_${"b".repeat(36)}`;
+const CAROL_TOKEN = `ghp_${"c".repeat(36)}`;
+/** Carries a path and a token in the one field #12281 shipped raw. */
+const LEAKY_MESSAGE = `Failed to load /Users/carol/config.json ${CAROL_TOKEN}`;
 const STACK = `Error: boom (${ALICE_TOKEN})\n    at Widget (/Users/alice/plugins/acme/dashboard.js:10:5)`;
 const COMPONENT_STACK = `\n    at Widget (/Users/bob/plugins/acme/dashboard.js:10:5) ${BOB_TOKEN}`;
 /** Everything that must never survive redaction for an installed plugin. */
 const SENSITIVE = ["/Users/alice", "/Users/bob", ALICE_TOKEN, BOB_TOKEN];
+/** Only the cases that actually render a leaky message or cause assert these. */
+const CAROL_SENSITIVE = ["/Users/carol", CAROL_TOKEN];
 
 function makeError(message: string, stack?: string): Error {
   const error = new Error(message);
@@ -112,21 +117,53 @@ describe("PluginViewDiagnosticsFallback", () => {
     for (const secret of SENSITIVE) expect(trace()).toContain(secret);
   });
 
-  // Redaction is about the user's data, not the plugin's. Scrubbing the message
-  // would cost diagnostic signal for no leak benefit (#9427).
-  it("never redacts the message", () => {
-    renderFallback({
-      devMode: false,
-      error: makeError("Failed to load /Users/alice/config.json", STACK),
-    });
+  // The message is plugin-authored, untrusted text: the author decides whether
+  // it carries a path or a token, so a report labelled redacted must scrub it
+  // too (#12281). Not a reversal of #9427 — that keeps the *first-party*
+  // ErrorFallback's message raw, where scrubbing costs signal and prevents no
+  // leak. The trust boundary differs, so the policy does.
+  it("redacts the message an installed plugin threw", () => {
+    renderFallback({ devMode: false, error: makeError(LEAKY_MESSAGE, STACK) });
 
     expect(screen.getByTestId("plugin-view-diagnostics-message").textContent).toBe(
-      "Failed to load /Users/alice/config.json"
+      "Failed to load /Users/USER/config.json [REDACTED]"
     );
   });
 
+  it("leaves a dev-mode plugin's message raw", () => {
+    renderFallback({ devMode: true, error: makeError(LEAKY_MESSAGE, STACK) });
+
+    expect(screen.getByTestId("plugin-view-diagnostics-message").textContent).toBe(LEAKY_MESSAGE);
+  });
+
+  // An unlabelled raw view is how #12281 happened: the pane claimed redaction
+  // for the trace while the message beside it was untouched.
+  it("says which document it is showing", () => {
+    const { unmount } = renderFallback({ devMode: false });
+    expect(screen.getByTestId("plugin-view-diagnostics-mode").textContent).toBe("redacted");
+    unmount();
+
+    renderFallback({ devMode: true });
+    expect(screen.getByTestId("plugin-view-diagnostics-mode").textContent).toBe("raw (dev mode)");
+  });
+
+  it("renders the cause chain the stack alone cannot show", () => {
+    const cause = makeError(
+      `inner /Users/carol/x ${CAROL_TOKEN}`,
+      "Error: inner\n    at f (a.js:1:1)"
+    );
+    const error = makeError("outer", STACK);
+    Object.assign(error, { cause });
+
+    renderFallback({ devMode: false, error });
+
+    expect(trace()).toContain("Caused by: Error: inner");
+    expect(trace()).toContain("a.js:1:1");
+    for (const secret of [...SENSITIVE, ...CAROL_SENSITIVE]) expect(trace()).not.toContain(secret);
+  });
+
   it("copies the trace it renders and nothing sensitive beyond it", async () => {
-    renderFallback({ devMode: false });
+    renderFallback({ devMode: false, error: makeError(LEAKY_MESSAGE, STACK) });
 
     fireEvent.click(screen.getByTestId("plugin-view-diagnostics-copy"));
 
@@ -135,7 +172,7 @@ describe("PluginViewDiagnosticsFallback", () => {
     expect(copied).toContain(trace());
     // Containment alone would still pass if the report appended a *raw* second
     // copy of either stack, so assert every sensitive value is absent outright.
-    for (const secret of SENSITIVE) expect(copied).not.toContain(secret);
+    for (const secret of [...SENSITIVE, ...CAROL_SENSITIVE]) expect(copied).not.toContain(secret);
     expect(copied).toContain("plugin://acme/dashboard.js");
   });
 

--- a/src/components/Plugin/__tests__/PluginViewDiagnosticsFallback.test.tsx
+++ b/src/components/Plugin/__tests__/PluginViewDiagnosticsFallback.test.tsx
@@ -28,7 +28,7 @@ const CAROL_TOKEN = `ghp_${"c".repeat(36)}`;
 /** Carries a path and a token in the one field #12281 shipped raw. */
 const LEAKY_MESSAGE = `Failed to load /Users/carol/config.json ${CAROL_TOKEN}`;
 const STACK = `Error: boom (${ALICE_TOKEN})\n    at Widget (/Users/alice/plugins/acme/dashboard.js:10:5)`;
-const COMPONENT_STACK = `\n    at Widget (/Users/bob/plugins/acme/dashboard.js:10:5) ${BOB_TOKEN}`;
+const COMPONENT_STACK = `\n    at Widget (/Users/bob/plugins/acme/panel.js:20:7) ${BOB_TOKEN}`;
 /** Everything that must never survive redaction for an installed plugin. */
 const SENSITIVE = ["/Users/alice", "/Users/bob", ALICE_TOKEN, BOB_TOKEN];
 /** Only the cases that actually render a leaky message or cause assert these. */
@@ -105,8 +105,10 @@ describe("PluginViewDiagnosticsFallback", () => {
 
     for (const secret of SENSITIVE) expect(trace()).not.toContain(secret);
     // Redaction must not cost the frame itself — the author still needs to see
-    // which module and line threw.
+    // which module and line threw. Both stacks, with distinct locations, so
+    // one surviving cannot stand in for the other.
     expect(trace()).toContain("dashboard.js:10:5");
+    expect(trace()).toContain("panel.js:20:7");
   });
 
   it("leaves a dev-mode plugin's paths and secrets raw even though the app build is not DEV", () => {
@@ -119,9 +121,10 @@ describe("PluginViewDiagnosticsFallback", () => {
 
   // The message is plugin-authored, untrusted text: the author decides whether
   // it carries a path or a token, so a report labelled redacted must scrub it
-  // too (#12281). Not a reversal of #9427 — that keeps the *first-party*
-  // ErrorFallback's message raw, where scrubbing costs signal and prevents no
-  // leak. The trust boundary differs, so the policy does.
+  // too (#12281). Not a reversal of #9427 — the sibling ErrorFallback shows
+  // fixed first-party copy in production and the raw message only under
+  // `import.meta.env.DEV`, so it has no untrusted message to redact. This pane
+  // deliberately shows plugin text to a production user, which is why it must.
   it("redacts the message an installed plugin threw", () => {
     renderFallback({ devMode: false, error: makeError(LEAKY_MESSAGE, STACK) });
 
@@ -160,6 +163,23 @@ describe("PluginViewDiagnosticsFallback", () => {
     expect(trace()).toContain("Caused by: Error: inner");
     expect(trace()).toContain("a.js:1:1");
     for (const secret of [...SENSITIVE, ...CAROL_SENSITIVE]) expect(trace()).not.toContain(secret);
+  });
+
+  // The manifest supplies the identity, so the plugin author controls it — a
+  // pane that prints it raw under "Report: redacted" is #12281 again in a
+  // different field.
+  it("redacts the manifest identity it prints beside the redacted label", () => {
+    renderFallback({
+      devMode: false,
+      pluginDisplayName: `Acme ${CAROL_TOKEN}`,
+      componentPath: "plugin:///Users/carol/dev/acme/dashboard.js",
+    });
+
+    const pane = screen.getByTestId("plugin-view-diagnostics").textContent ?? "";
+    for (const secret of CAROL_SENSITIVE) expect(pane).not.toContain(secret);
+    // The identity still has to identify something.
+    expect(pane).toContain("Acme");
+    expect(pane).toContain("dashboard.js");
   });
 
   it("copies the trace it renders and nothing sensitive beyond it", async () => {

--- a/src/components/Plugin/__tests__/buildPluginViewDiagnostics.test.ts
+++ b/src/components/Plugin/__tests__/buildPluginViewDiagnostics.test.ts
@@ -1,0 +1,276 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildPluginViewDiagnostics,
+  type PluginViewDiagnosticsInput,
+} from "../buildPluginViewDiagnostics";
+
+// A distinct token per field, so an assertion can prove *which* field leaked
+// rather than only that something did.
+const MSG_TOKEN = `ghp_${"m".repeat(36)}`;
+const STACK_TOKEN = `ghp_${"s".repeat(36)}`;
+const CAUSE_TOKEN = `ghp_${"c".repeat(36)}`;
+const PATH_TOKEN = `ghp_${"p".repeat(36)}`;
+
+function build(overrides: Partial<PluginViewDiagnosticsInput> = {}) {
+  return buildPluginViewDiagnostics({
+    error: new Error("boom"),
+    componentStack: "    at View",
+    devMode: false,
+    pluginId: "acme",
+    pluginDisplayName: "Acme Tools",
+    kindId: "acme.dashboard",
+    panelDisplayName: "Dashboard",
+    componentPath: "plugin://acme/dashboard.js",
+    incidentId: null,
+    ...overrides,
+  });
+}
+
+function errorWith(message: string, stack?: string, extra: Record<string, unknown> = {}): Error {
+  const error = new Error(message);
+  error.stack = stack;
+  return Object.assign(error, extra);
+}
+
+describe("buildPluginViewDiagnostics", () => {
+  describe("redaction", () => {
+    it("scrubs the message, not just the trace", () => {
+      const { message, report } = build({
+        error: errorWith(`Failed to load /Users/alice/config.json ${MSG_TOKEN}`),
+      });
+
+      expect(message).toBe("Failed to load /Users/USER/config.json [REDACTED]");
+      expect(report).not.toContain(MSG_TOKEN);
+      expect(report).not.toContain("/Users/alice");
+    });
+
+    it("leaves the message raw for a dev-mode plugin", () => {
+      const { message, mode } = build({
+        devMode: true,
+        error: errorWith(`Failed to load /Users/alice/config.json ${MSG_TOKEN}`),
+      });
+
+      expect(message).toContain(MSG_TOKEN);
+      expect(message).toContain("/Users/alice");
+      expect(mode).toBe("raw (dev mode)");
+    });
+
+    // The whole-document pass is what stops the next field added to the report
+    // from shipping raw the way `Message:` did. Only the metadata carries this
+    // token, so nothing but that final pass can remove it.
+    it("scrubs metadata the per-field passes never see", () => {
+      const { report } = build({
+        componentPath: `plugin:///Users/alice/dev/acme/dashboard.js?t=${PATH_TOKEN}`,
+      });
+
+      expect(report).not.toContain(PATH_TOKEN);
+      expect(report).not.toContain("/Users/alice");
+    });
+
+    it("keeps the code location and the structured code through redaction", () => {
+      const { code, report } = build({
+        error: errorWith(
+          "boom",
+          `Error: boom ${STACK_TOKEN}\n    at Widget (/Users/alice/plugins/acme/dashboard.js:10:5)`,
+          { code: "E_PLUGIN_RENDER" }
+        ),
+      });
+
+      expect(report).toContain("dashboard.js:10:5");
+      expect(report).toContain("Code: E_PLUGIN_RENDER");
+      expect(code).toBe("E_PLUGIN_RENDER");
+      expect(report).not.toContain(STACK_TOKEN);
+    });
+
+    it("keeps a numeric zero code rather than dropping it as falsy", () => {
+      expect(build({ error: errorWith("boom", undefined, { code: 0 }) }).code).toBe("0");
+    });
+
+    it("omits the code line entirely when the error carries none", () => {
+      expect(build().report).not.toContain("Code:");
+    });
+
+    it("is stable across a devMode round trip", () => {
+      const error = errorWith(`boom ${MSG_TOKEN}`, `Error: boom\n    at V (/Users/alice/a.js:1:1)`);
+
+      const first = build({ error }).report;
+      build({ error, devMode: true });
+
+      expect(build({ error }).report).toBe(first);
+    });
+  });
+
+  describe("cause chain", () => {
+    it("surfaces an Error cause with its name, message, code and frames", () => {
+      const cause = errorWith(
+        "fetch failed",
+        "TypeError: fetch failed\n    at fetch (net.js:2:1)",
+        {
+          code: "ECONNRESET",
+        }
+      );
+      cause.name = "TypeError";
+      const { trace } = build({ error: errorWith("boom", "Error: boom", { cause }) });
+
+      expect(trace).toContain("Caused by: TypeError: fetch failed (code: ECONNRESET)");
+      expect(trace).toContain("at fetch (net.js:2:1)");
+      // The header already names the error; repeating the stack's own header
+      // would print it twice per cause.
+      expect(trace).not.toContain("TypeError: fetch failed\nTypeError");
+    });
+
+    it("scrubs a cause the same way it scrubs the root", () => {
+      const cause = errorWith(
+        `token is ${CAUSE_TOKEN}`,
+        `Error: x\n    at f (/Users/bob/a.js:1:1)`
+      );
+      const { trace, report } = build({ error: errorWith("boom", "Error: boom", { cause }) });
+
+      expect(trace).not.toContain(CAUSE_TOKEN);
+      expect(trace).not.toContain("/Users/bob");
+      expect(report).not.toContain(CAUSE_TOKEN);
+    });
+
+    it("renders non-Error causes with their type intact", () => {
+      const q = (cause: unknown) => build({ error: errorWith("boom", "s", { cause }) }).trace;
+
+      // Quoted, so an empty-string cause reads as one rather than as nothing.
+      expect(q("socket hang up")).toContain('Caused by: "socket hang up"');
+      expect(q("")).toContain('Caused by: ""');
+      expect(q(null)).toContain("Caused by: null");
+      expect(q(undefined)).toContain("Caused by: undefined");
+      expect(q(42)).toContain("Caused by: 42");
+      expect(q(false)).toContain("Caused by: false");
+    });
+
+    it("renders an object cause as readable JSON, keeping nested Errors legible", () => {
+      const { trace } = build({
+        error: errorWith("boom", "s", { cause: { step: "fetch", err: new Error("inner") } }),
+      });
+
+      expect(trace).toContain('"step": "fetch"');
+      expect(trace).toContain('"message": "inner"');
+      expect(trace).not.toContain("[object Object]");
+    });
+
+    it("stops at a cycle instead of hanging", () => {
+      const outer = errorWith("outer", "s");
+      const inner = errorWith("inner", "s");
+      Object.assign(outer, { cause: inner });
+      Object.assign(inner, { cause: outer });
+
+      const { trace } = build({ error: outer });
+
+      expect(trace).toContain("Caused by: Error: inner");
+      expect(trace).toContain("Caused by: [Circular]");
+    });
+
+    it("stops at a depth cap instead of walking an unbounded chain", () => {
+      let error = errorWith("deepest", "s");
+      for (let i = 9; i >= 1; i -= 1) error = errorWith(`level ${i}`, "s", { cause: error });
+
+      const { trace } = build({ error });
+
+      // Root is `level 1`, so the eight walked links are `level 2`..`level 9`.
+      expect(trace).toContain("Caused by: Error: level 9");
+      expect(trace).not.toContain("deepest");
+      expect(trace).toContain("Caused by: [MaxDepth]");
+    });
+
+    it("omits the cause section when there is no cause property", () => {
+      expect(build().trace).not.toContain("Caused by:");
+    });
+  });
+
+  describe("hostile and malformed input", () => {
+    it("survives throwing accessors rather than becoming the second failure", () => {
+      const hostile = new Error("outer");
+      Object.defineProperty(hostile, "stack", {
+        get() {
+          throw new Error("stack getter");
+        },
+      });
+      Object.defineProperty(hostile, "cause", {
+        get() {
+          throw new Error("cause getter");
+        },
+      });
+
+      const { trace } = build({ error: hostile });
+
+      expect(trace).toContain("No stack trace available");
+      expect(trace).toContain("Caused by: undefined");
+    });
+
+    it("describes a cause that cannot be serialized", () => {
+      const cause: Record<string, unknown> = {};
+      cause.self = {
+        get boom(): never {
+          throw new Error("nope");
+        },
+      };
+
+      expect(build({ error: errorWith("boom", "s", { cause }) }).trace).toContain(
+        "Caused by: [Unserializable]"
+      );
+    });
+
+    it("accepts a thrown value that is not an Error", () => {
+      expect(build({ error: "just a string" }).message).toBe("just a string");
+      expect(build({ error: { reason: "nope" } }).message).toContain('"reason": "nope"');
+      expect(build({ error: null }).message).toBe("Unknown render error");
+      expect(build({ error: undefined }).message).toBe("Unknown render error");
+      expect(build({ error: errorWith("") }).message).toBe("Unknown render error");
+    });
+
+    it("never writes the scrubbed text back onto the error", () => {
+      const stack = `Error: boom ${STACK_TOKEN}\n    at V (/Users/alice/a.js:1:1)`;
+      const cause = errorWith(`inner ${CAUSE_TOKEN}`, "Error: inner");
+      const error = errorWith(`boom ${MSG_TOKEN}`, stack, { cause });
+      // Read first: V8 caches the formatted stack on first access, so a
+      // implementation that mutated `message` afterwards would desync the two.
+      void error.stack;
+
+      build({ error });
+
+      expect(error.message).toBe(`boom ${MSG_TOKEN}`);
+      expect(error.stack).toBe(stack);
+      expect(cause.message).toBe(`inner ${CAUSE_TOKEN}`);
+    });
+  });
+
+  it("lays the report out with metadata, mode, message and trace in order", () => {
+    const { report } = build({
+      devMode: true,
+      incidentId: "abc-123",
+      error: errorWith("boom", "Error: boom\n    at View (dashboard.js:3:1)", { code: "E_RENDER" }),
+    });
+
+    expect(report).toBe(
+      [
+        "Plugin: Acme Tools (acme)",
+        "Panel: Dashboard (acme.dashboard)",
+        "Module: plugin://acme/dashboard.js",
+        "Error ID: abc-123",
+        "Code: E_RENDER",
+        "Report: raw (dev mode)",
+        "",
+        "Message: boom",
+        "",
+        "Stack:",
+        "Error: boom",
+        "    at View (dashboard.js:3:1)",
+        "",
+        "Component stack:",
+        "    at View",
+      ].join("\n")
+    );
+  });
+
+  it("substitutes placeholders when the value carries no stacks", () => {
+    const { trace } = build({ error: errorWith("boom", undefined), componentStack: undefined });
+
+    expect(trace).toContain("No stack trace available");
+    expect(trace).toContain("No component stack available");
+  });
+});

--- a/src/components/Plugin/__tests__/buildPluginViewDiagnostics.test.ts
+++ b/src/components/Plugin/__tests__/buildPluginViewDiagnostics.test.ts
@@ -413,3 +413,92 @@ describe("buildPluginViewDiagnostics — value shapes", () => {
     expect(report).toContain("Module: plugin://acme/dashboard.js");
   });
 });
+
+describe("buildPluginViewDiagnostics — secrets the leaf pass alone cannot see", () => {
+  // Scrubbing each leaf in isolation is necessary but not sufficient: some
+  // patterns match a key and its value together, and some values are objects
+  // that would otherwise be walked apart character by character.
+
+  it("catches a secret only recognizable from its key and value together", () => {
+    const secret = "Q".repeat(40);
+    const { trace, report } = build({
+      error: errorWith("boom", "s", { cause: { SecretAccessKey: secret } }),
+    });
+
+    expect(trace).not.toContain(secret);
+    expect(report).not.toContain(secret);
+  });
+
+  it("redacts before truncating, so a cut cannot expose a secret's prefix", () => {
+    const secret = "Q".repeat(40);
+    // Padded so the secret straddles the output cap: truncating the raw text
+    // first would leave a handful of its characters behind. No `[Truncated]`
+    // assertion — redacting first shrinks the payload back under the cap, which
+    // is the point.
+    const { trace } = build({
+      error: errorWith("boom", "s", {
+        cause: { padding: "p".repeat(3960), SecretAccessKey: secret },
+      }),
+    });
+
+    // A partial survivor at the cut is the dangerous case, not the whole value.
+    expect(trace).not.toContain(secret.slice(0, 10));
+    expect(trace).toContain("ppp");
+  });
+
+  it("unboxes a boxed string instead of spelling it out one property per character", () => {
+    const { trace } = build({
+      // A boxed string is exactly what a plugin can hand us as a cause.
+      error: errorWith("boom", "s", { cause: new String(CAUSE_TOKEN) }),
+    });
+
+    expect(trace).not.toContain(CAUSE_TOKEN);
+    expect(trace).not.toContain('"0":');
+  });
+
+  it("keeps only the frames of an Error nested inside an object cause", () => {
+    // The stack's `Name: message` header carries a second copy of the message
+    // that is no longer at a line start, so the line-anchored patterns miss it.
+    const nested = errorWith(
+      "access_token=opaque-secret-value",
+      "Error: access_token=opaque-secret-value\n    at f (nested.js:7:7)"
+    );
+    const { trace, report } = build({ error: errorWith("boom", "s", { cause: { err: nested } }) });
+
+    expect(trace).not.toContain("opaque-secret-value");
+    expect(report).not.toContain("opaque-secret-value");
+    // Stripping the header must not cost the location.
+    expect(trace).toContain("nested.js:7:7");
+  });
+
+  it("scrubs a symbol's description before the Symbol() wrapper unanchors it", () => {
+    const { trace } = build({
+      error: errorWith("boom", "s", { cause: Symbol("access_token=opaque-secret-value") }),
+    });
+
+    expect(trace).not.toContain("opaque-secret-value");
+  });
+
+  it("keeps distinct entries whose keys redact to the same text", () => {
+    const { trace } = build({
+      error: errorWith("boom", "s", {
+        cause: { "/Users/alice/f": "ENOENT", "/Users/bob/f": "EACCES" },
+      }),
+    });
+
+    // Rewriting keys in place collapsed these two onto one entry.
+    expect(trace).toContain("ENOENT");
+    expect(trace).toContain("EACCES");
+    expect(trace).not.toContain("/Users/alice");
+    expect(trace).not.toContain("/Users/bob");
+  });
+
+  it("bounds an object too wide to serialize whole", () => {
+    const wide: Record<string, string> = {};
+    for (let i = 0; i < 5_000; i += 1) wide[`k${i}`] = "v".repeat(100);
+    const { trace } = build({ error: errorWith("boom", "s", { cause: wide }) });
+
+    expect(trace).toContain("[Truncated]");
+    expect(trace.length).toBeLessThan(20_000);
+  });
+});

--- a/src/components/Plugin/__tests__/buildPluginViewDiagnostics.test.ts
+++ b/src/components/Plugin/__tests__/buildPluginViewDiagnostics.test.ts
@@ -114,9 +114,10 @@ describe("buildPluginViewDiagnostics", () => {
 
       expect(trace).toContain("Caused by: TypeError: fetch failed (code: ECONNRESET)");
       expect(trace).toContain("at fetch (net.js:2:1)");
-      // The header already names the error; repeating the stack's own header
-      // would print it twice per cause.
-      expect(trace).not.toContain("TypeError: fetch failed\nTypeError");
+      // Counted, not pattern-matched: a `stackFrames` that stopped stripping
+      // the header would print the name twice, and a forbidden-substring
+      // assertion misses that as soon as the header gains a suffix.
+      expect(trace.match(/TypeError: fetch failed/g)).toHaveLength(1);
     });
 
     it("scrubs a cause the same way it scrubs the root", () => {
@@ -272,5 +273,143 @@ describe("buildPluginViewDiagnostics", () => {
 
     expect(trace).toContain("No stack trace available");
     expect(trace).toContain("No component stack available");
+  });
+});
+
+describe("buildPluginViewDiagnostics — redaction survives formatting", () => {
+  // Each of these plants a secret in a position where the *shape* of the
+  // finished document, not the scrubber's patterns, decides whether it is
+  // caught. Scrubbing the assembled text alone leaks every one of them.
+
+  it("scrubs a leaf before a label can move it off its line anchor", () => {
+    // `oauth-query-param` anchors on `(^|[?&])`. Prefixing `Caused by: Error: `
+    // moves it off the line start, so the credential only dies if the cause
+    // message is scrubbed before the label is attached.
+    const cause = errorWith("access_token=opaque-secret-value&other=1", undefined);
+    const { trace, report } = build({ error: errorWith("boom", "s", { cause }) });
+
+    expect(trace).not.toContain("opaque-secret-value");
+    expect(report).not.toContain("opaque-secret-value");
+    expect(trace).toContain("Caused by: Error:");
+  });
+
+  it("scrubs a string cause before quoting escapes its anchors", () => {
+    const { trace } = build({
+      error: errorWith("boom", "s", { cause: "access_token=opaque-secret-value" }),
+    });
+
+    expect(trace).not.toContain("opaque-secret-value");
+  });
+
+  it("scrubs an object cause before JSON encoding breaks the sigil boundary", () => {
+    // JSON turns the newline into the two characters `\` and `n`, putting a
+    // word character against `ghp_` and defeating the `\b` every secret
+    // pattern anchors on. Only scrubbing before encoding catches it.
+    const { trace, report } = build({
+      error: errorWith("boom", "s", { cause: { detail: `\n${CAUSE_TOKEN}` } }),
+    });
+
+    expect(trace).not.toContain(CAUSE_TOKEN);
+    expect(report).not.toContain(CAUSE_TOKEN);
+  });
+
+  it("scrubs object keys, which JSON never offers to a replacer", () => {
+    const { trace } = build({ error: errorWith("boom", "s", { cause: { [CAUSE_TOKEN]: 1 } }) });
+
+    expect(trace).not.toContain(CAUSE_TOKEN);
+  });
+
+  it("scrubs the manifest identity the pane prints beside its redacted label", () => {
+    const built = build({
+      pluginDisplayName: `Tools ${MSG_TOKEN}`,
+      componentPath: "plugin:///Users/alice/dev/acme/dashboard.js",
+      kindId: `acme.${STACK_TOKEN}`,
+      incidentId: `id-${PATH_TOKEN}`,
+    });
+
+    for (const value of [MSG_TOKEN, STACK_TOKEN, PATH_TOKEN, "/Users/alice"]) {
+      expect(built.report).not.toContain(value);
+      expect(built.pluginDisplayName + built.componentPath + built.kindId).not.toContain(value);
+      expect(built.incidentId ?? "").not.toContain(value);
+    }
+    // Redaction must not cost the identity itself.
+    expect(built.pluginDisplayName).toContain("Tools");
+    expect(built.componentPath).toContain("dashboard.js");
+  });
+
+  it("keeps every report section when a home path ends a field", () => {
+    // `/Users/USER` is idempotent alone, but the username class used to run past
+    // the newline and swallow the rest of the document into the replacement.
+    const { report } = build({ error: "/Users/alice", componentStack: undefined });
+
+    expect(report).toContain("Message: /Users/USER");
+    expect(report).toContain("Stack:");
+    expect(report).toContain("No stack trace available");
+    expect(report).toContain("Component stack:");
+    expect(report).toContain("Report: redacted");
+  });
+
+  it("bounds a cause that would otherwise park JSON.stringify", () => {
+    // Cheap to construct, ruinous to serialize: the outer depth cap bounds the
+    // chain, not the width of a single link.
+    const { trace } = build({ error: errorWith("boom", "s", { cause: new Array(0xffffffff) }) });
+
+    expect(trace).toContain("[Truncated]");
+    expect(trace.length).toBeLessThan(10_000);
+  });
+});
+
+describe("buildPluginViewDiagnostics — value shapes", () => {
+  it("falls back rather than showing a blank pane for a whitespace-only message", () => {
+    expect(build({ error: errorWith("   \n  ") }).message).toBe("Unknown render error");
+  });
+
+  it("keeps a literal [REDACTED] in the input while still removing a fresh secret", () => {
+    const { message } = build({ error: errorWith(`saw [REDACTED] then ${MSG_TOKEN}`) });
+
+    expect(message).toBe("saw [REDACTED] then [REDACTED]");
+  });
+
+  it("renders symbol and function causes readably, scrubbing the description", () => {
+    const symbol = build({ error: errorWith("b", "s", { cause: Symbol(`k ${CAUSE_TOKEN}`) }) });
+    expect(symbol.trace).toContain("Caused by: Symbol(");
+    expect(symbol.trace).not.toContain(CAUSE_TOKEN);
+
+    expect(build({ error: errorWith("b", "s", { cause: () => 1 }) }).trace).toContain(
+      "Caused by: [Function]"
+    );
+  });
+
+  it("serializes a null-prototype cause rather than failing on it", () => {
+    const cause: Record<string, unknown> = Object.create(null);
+    cause.step = "fetch";
+    cause.token = CAUSE_TOKEN;
+    const { trace } = build({ error: errorWith("boom", "s", { cause }) });
+
+    expect(trace).toContain('"step": "fetch"');
+    expect(trace).not.toContain(CAUSE_TOKEN);
+  });
+
+  it("puts a scrubbed code in the report and keeps a zero one visible", () => {
+    const coded = build({ error: errorWith("b", "s", { code: `/Users/alice/${PATH_TOKEN}` }) });
+    expect(coded.report).not.toContain(PATH_TOKEN);
+    expect(coded.code).not.toContain("/Users/alice");
+    expect(build({ error: errorWith("b", "s", { code: 0 }) }).report).toContain("Code: 0");
+  });
+
+  it("keeps the report's own structure present, not merely free of secrets", () => {
+    const { report } = build({
+      error: errorWith(`boom ${MSG_TOKEN}`, `Error: boom\n    at V (/Users/alice/a.js:9:9)`, {
+        cause: errorWith("inner", "Error: inner\n    at C (nested.js:4:4)"),
+      }),
+    });
+
+    // Negative assertions alone stay green if a section goes missing entirely.
+    expect(report).toContain("Message: boom [REDACTED]");
+    expect(report).toContain("Report: redacted");
+    expect(report).toContain("Caused by: Error: inner");
+    expect(report).toContain("a.js:9:9");
+    expect(report).toContain("nested.js:4:4");
+    expect(report).toContain("Module: plugin://acme/dashboard.js");
   });
 });

--- a/src/components/Plugin/buildPluginViewDiagnostics.ts
+++ b/src/components/Plugin/buildPluginViewDiagnostics.ts
@@ -14,6 +14,7 @@ const MAX_CAUSE_DEPTH = 8;
  * park `JSON.stringify` on billions of holes during render.
  */
 const MAX_ARRAY_ENTRIES = 50;
+const MAX_OBJECT_KEYS = 50;
 const MAX_VALUE_CHARS = 4000;
 
 /** Sentinels, spelled as `logErrorNormalization` and `ipcErrorSerialization` spell them. */
@@ -104,9 +105,17 @@ function stringifyObject(value: object, scrub: Scrub): string {
           return {
             name: readString(item, "name") ?? "Error",
             message: readString(item, "message") ?? "",
-            stack: readString(item, "stack"),
+            // Frames only. A stack's `Name: message` header carries a second,
+            // unanchored copy of the message, which the line-anchored patterns
+            // then miss — and the `message` field above already has it.
+            stack: stackFrames(readString(item, "stack")),
           };
         }
+        // A boxed primitive is an object with indexed own properties, so the
+        // record branch below would explode `new String(token)` into one
+        // property per character and scrub none of them.
+        const boxed = unboxPrimitive(item);
+        if (boxed !== undefined) return typeof boxed === "string" ? scrub(boxed) : boxed;
         if (!isRecord(item)) return item;
         if (seen.has(item)) return CIRCULAR;
         seen.add(item);
@@ -115,12 +124,17 @@ function stringifyObject(value: object, scrub: Scrub): string {
             ? [...item.slice(0, MAX_ARRAY_ENTRIES), TRUNCATED]
             : item;
         }
-        // Rebuilt so the keys are scrubbed too — `JSON.stringify` writes a key
-        // verbatim and never offers it to the replacer. Cycle detection stays
-        // on the original object, which is already in `seen`.
-        const scrubbed: Record<string, unknown> = {};
-        for (const [key, child] of Object.entries(item)) scrubbed[scrub(key)] = child;
-        return scrubbed;
+        const entries = Object.entries(item);
+        if (entries.length <= MAX_OBJECT_KEYS) return item;
+        // Only the over-wide case is rebuilt, and it keeps the original keys:
+        // rewriting them collapses `/Users/alice/f` and `/Users/bob/f` onto one
+        // entry, silently dropping a diagnostic. Keys are covered by the text
+        // pass below instead. Null-prototype so an own `__proto__` entry lands
+        // as data rather than hitting the setter.
+        const capped: Record<string, unknown> = Object.create(null);
+        for (const [key, child] of entries.slice(0, MAX_OBJECT_KEYS)) capped[key] = child;
+        capped[TRUNCATED] = entries.length - MAX_OBJECT_KEYS;
+        return capped;
       },
       2
     );
@@ -128,9 +142,32 @@ function stringifyObject(value: object, scrub: Scrub): string {
     return UNSERIALIZABLE;
   }
   if (json === undefined) return UNSERIALIZABLE;
-  // Safe to cut: every string inside was scrubbed on the way in, so a slice
-  // cannot expose the leading bytes of a secret that straddled the boundary.
-  return json.length > MAX_VALUE_CHARS ? `${json.slice(0, MAX_VALUE_CHARS)}\n${TRUNCATED}` : json;
+  // A second pass over the encoded text, because some patterns match a key and
+  // its value together (`"SecretAccessKey": "…"`) and so can never fire while
+  // each leaf is scrubbed in isolation. This also covers the keys.
+  const scrubbed = scrub(json);
+  // Safe to cut only after both passes: a slice through raw text would leave
+  // the leading bytes of a secret that straddled the boundary.
+  return scrubbed.length > MAX_VALUE_CHARS
+    ? `${scrubbed.slice(0, MAX_VALUE_CHARS)}\n${TRUNCATED}`
+    : scrubbed;
+}
+
+/** The primitive inside a boxed `String`/`Number`/`Boolean`, else undefined. */
+function unboxPrimitive(value: unknown): string | number | boolean | undefined {
+  if (!isRecord(value)) return undefined;
+  // Tag rather than `instanceof`: a value from another realm has its own
+  // constructors, and these arrive from plugin code.
+  switch (Object.prototype.toString.call(value)) {
+    case "[object String]":
+      return String(value);
+    case "[object Number]":
+      return Number(value);
+    case "[object Boolean]":
+      return value.valueOf() === true;
+    default:
+      return undefined;
+  }
 }
 
 /** Render a cause that is not an Error, keeping its type legible. */
@@ -142,8 +179,10 @@ function formatValue(value: unknown, scrub: Scrub): string {
   if (typeof value === "string") return JSON.stringify(scrub(value));
   if (typeof value === "object") return stringifyObject(value, scrub);
   if (typeof value === "function") return "[Function]";
+  // The description alone, then wrapped: scrubbing `Symbol(access_token=…)`
+  // would already have moved the value off the anchor its pattern needs.
+  if (typeof value === "symbol") return `Symbol(${scrub(value.description ?? "")})`;
   try {
-    // A symbol's description is author-supplied text like any other.
     return scrub(String(value));
   } catch {
     return UNSERIALIZABLE;
@@ -331,7 +370,7 @@ export function buildPluginViewDiagnostics({
   const message = extractMessage(error, scrub);
   const rawCode = extractCode(error);
   const code = rawCode === undefined ? undefined : scrub(rawCode);
-  const trace = buildTrace(error, componentStack, scrub);
+  const trace = scrub(buildTrace(error, componentStack, scrub));
   const mode = devMode ? "raw (dev mode)" : "redacted";
 
   const report = [

--- a/src/components/Plugin/buildPluginViewDiagnostics.ts
+++ b/src/components/Plugin/buildPluginViewDiagnostics.ts
@@ -1,0 +1,272 @@
+import { isErrorLike } from "@shared/utils/ipcErrorSerialization";
+import { scrubReportText } from "@shared/utils/reportScrubbers";
+
+/**
+ * Depth bound for the `.cause` walk. Spelled independently of the log walk's
+ * `MAX_ERROR_SCAN_DEPTH`, but the same size: past this many links the chain is
+ * describing a wrapper stack no reader follows, and an unbounded walk is a
+ * denial-of-service surface handed to plugin authors.
+ */
+const MAX_CAUSE_DEPTH = 8;
+
+/** Sentinels, spelled as `logErrorNormalization` and `ipcErrorSerialization` spell them. */
+const MAX_DEPTH = "[MaxDepth]";
+const CIRCULAR = "[Circular]";
+const UNSERIALIZABLE = "[Unserializable]";
+
+const FALLBACK_MESSAGE = "Unknown render error";
+
+/**
+ * Read one property without ever throwing. Every field here comes off a value a
+ * plugin threw, which may be a Proxy or expose a throwing getter — the
+ * diagnostics pane must not become the second failure.
+ */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function readUnknown(source: unknown, key: string): unknown {
+  if (!isRecord(source)) return undefined;
+  try {
+    return source[key];
+  } catch {
+    return undefined;
+  }
+}
+
+function readString(source: unknown, key: string): string | undefined {
+  const value = readUnknown(source, key);
+  return typeof value === "string" ? value : undefined;
+}
+
+/**
+ * Own-or-inherited `cause`, tested by presence rather than truthiness so an
+ * explicit `{ cause: null }` is still reported as a link in the chain.
+ */
+function hasCause(value: unknown): boolean {
+  if (typeof value !== "object" || value === null) return false;
+  try {
+    return "cause" in value;
+  } catch {
+    return false;
+  }
+}
+
+/** A structured error code, kept through redaction — it names a failure, not a user. */
+function extractCode(value: unknown): string | undefined {
+  const code = readUnknown(value, "code");
+  if (typeof code === "string") return code.length > 0 ? code : undefined;
+  // Not a truthiness test: `code: 0` is a real errno-style code.
+  if (typeof code === "number" && Number.isFinite(code)) return String(code);
+  return undefined;
+}
+
+/**
+ * Readable JSON for an object that is not an Error. `JSON.stringify` throws on
+ * cycles, BigInt, and a hostile `toJSON`, and overflows the stack on a
+ * pathologically deep graph — all of which land in the `catch`. The `seen` set
+ * is never unwound, so a value referenced twice reads `[Circular]` the second
+ * time even without a true cycle; `ipcErrorSerialization` makes the same
+ * trade for the same reason.
+ */
+function stringifyObject(value: object): string {
+  const seen = new WeakSet<object>();
+  try {
+    const json = JSON.stringify(
+      value,
+      (_key, item: unknown) => {
+        if (isErrorLike(item)) {
+          return {
+            name: readString(item, "name") ?? "Error",
+            message: readString(item, "message") ?? "",
+            stack: readString(item, "stack"),
+          };
+        }
+        if (typeof item === "bigint") return String(item);
+        if (typeof item !== "object" || item === null) return item;
+        if (seen.has(item)) return CIRCULAR;
+        seen.add(item);
+        return item;
+      },
+      2
+    );
+    return json ?? UNSERIALIZABLE;
+  } catch {
+    return UNSERIALIZABLE;
+  }
+}
+
+/** Render a cause that is not an Error, keeping its type legible. */
+function formatValue(value: unknown): string {
+  if (value === null) return "null";
+  if (value === undefined) return "undefined";
+  // Quoted, so an empty-string cause is distinguishable from a missing one.
+  if (typeof value === "string") return JSON.stringify(value);
+  if (typeof value === "object") return stringifyObject(value);
+  if (typeof value === "function") return "[Function]";
+  try {
+    return String(value);
+  } catch {
+    return UNSERIALIZABLE;
+  }
+}
+
+/**
+ * The frame lines of a stack, without the `Name: message` header V8 prepends —
+ * the caller has already printed that, and repeating it doubles every cause.
+ */
+function stackFrames(stack: string | undefined): string | undefined {
+  if (!stack) return undefined;
+  const lines = stack.split("\n");
+  const firstFrame = lines.findIndex((line) => /^\s+at\s/.test(line));
+  const frames = firstFrame === -1 ? lines : lines.slice(firstFrame);
+  const joined = frames.join("\n");
+  return joined.trim().length > 0 ? joined : undefined;
+}
+
+/**
+ * The `.cause` chain as `Caused by:` blocks, in the shape a chained traceback
+ * takes everywhere else. Walked iteratively — a cause chain is a list, not a
+ * tree — with a `seen` set against cycles, mirroring
+ * `gitOperationErrors.isMissingGitExecutableError`.
+ */
+function formatCauses(root: unknown): string[] {
+  const blocks: string[] = [];
+  const seen = new Set<unknown>();
+  if (typeof root === "object" && root !== null) seen.add(root);
+
+  let current: unknown = root;
+  for (let depth = 0; hasCause(current); depth += 1) {
+    if (depth >= MAX_CAUSE_DEPTH) {
+      blocks.push(`Caused by: ${MAX_DEPTH}`);
+      break;
+    }
+    const cause = readUnknown(current, "cause");
+    if (typeof cause === "object" && cause !== null) {
+      if (seen.has(cause)) {
+        blocks.push(`Caused by: ${CIRCULAR}`);
+        break;
+      }
+      seen.add(cause);
+    }
+
+    if (isErrorLike(cause)) {
+      const name = readString(cause, "name") ?? "Error";
+      const message = readString(cause, "message") ?? "";
+      const code = extractCode(cause);
+      const header =
+        `Caused by: ${name}${message ? `: ${message}` : ""}` + (code ? ` (code: ${code})` : "");
+      const frames = stackFrames(readString(cause, "stack"));
+      blocks.push(frames ? `${header}\n${frames}` : header);
+    } else {
+      blocks.push(`Caused by: ${formatValue(cause)}`);
+    }
+
+    current = cause;
+  }
+
+  return blocks;
+}
+
+/** The message a plugin's thrown value carries, whatever kind of value it is. */
+function extractMessage(error: unknown): string {
+  if (isErrorLike(error)) return readString(error, "message") || FALLBACK_MESSAGE;
+  if (typeof error === "string") return error || FALLBACK_MESSAGE;
+  if (error === null || error === undefined) return FALLBACK_MESSAGE;
+  // A thrown plain object reads `[object Object]` through `String`, which tells
+  // the author nothing about what threw.
+  return formatValue(error) || FALLBACK_MESSAGE;
+}
+
+function buildTrace(error: unknown, componentStack: string | null | undefined): string {
+  return [
+    "Stack:",
+    readString(error, "stack") || "No stack trace available",
+    ...formatCauses(error).flatMap((block) => ["", block]),
+    "",
+    "Component stack:",
+    componentStack || "No component stack available",
+  ].join("\n");
+}
+
+export interface PluginViewDiagnosticsInput {
+  /** Whatever the view threw — React stores it unnormalized, so not always an Error. */
+  error: unknown;
+  componentStack: string | null | undefined;
+  /** The owning plugin loads from a dir outside the managed plugins dir. */
+  devMode: boolean;
+  pluginId: string;
+  pluginDisplayName: string;
+  kindId: string;
+  panelDisplayName: string;
+  componentPath: string;
+  incidentId: string | null | undefined;
+}
+
+export interface PluginViewDiagnostics {
+  /** Redaction policy already applied — safe to render as-is. */
+  message: string;
+  /** Structured error code, when the thrown value carried one. */
+  code: string | undefined;
+  /** Stack, cause chain and component stack, redaction policy already applied. */
+  trace: string;
+  /** How this document was produced: `redacted` or `raw (dev mode)`. */
+  mode: string;
+  /** The copyable report. */
+  report: string;
+}
+
+/**
+ * Build the diagnostics an errored plugin view shows and copies.
+ *
+ * Everything a plugin author controls — the message, the cause chain, the
+ * stacks — is untrusted text: the author decides what goes in it, and it
+ * routinely carries absolute paths, credentialed URLs, request payloads and
+ * tokens. So the *whole* document is scrubbed for an installed plugin, not just
+ * the trace, and the report says which of the two it is (#12281). This is not a
+ * reversal of #9427, which keeps the sibling `ErrorFallback`'s message raw: that
+ * message is first-party Daintree text, where scrubbing costs signal and
+ * prevents no leak. The trust boundary differs, so the policy does.
+ *
+ * A dev-mode plugin's paths are the author's own, so raw output is the useful
+ * output there — labelled as raw rather than silently different.
+ *
+ * The assembled report is scrubbed a second time. `scrubReportText` is
+ * idempotent, so this costs nothing on the fields already scrubbed above, and
+ * it means a field added to the report later cannot ship raw the way `Message:`
+ * did — which is the bug this function exists to close.
+ */
+export function buildPluginViewDiagnostics({
+  error,
+  componentStack,
+  devMode,
+  pluginId,
+  pluginDisplayName,
+  kindId,
+  panelDisplayName,
+  componentPath,
+  incidentId,
+}: PluginViewDiagnosticsInput): PluginViewDiagnostics {
+  const scrub = (text: string): string => (devMode ? text : scrubReportText(text));
+
+  const message = scrub(extractMessage(error));
+  const rawCode = extractCode(error);
+  const code = rawCode === undefined ? undefined : scrub(rawCode);
+  const trace = scrub(buildTrace(error, componentStack));
+  const mode = devMode ? "raw (dev mode)" : "redacted";
+
+  const report = [
+    `Plugin: ${pluginDisplayName} (${pluginId})`,
+    `Panel: ${panelDisplayName} (${kindId})`,
+    `Module: ${componentPath}`,
+    ...(incidentId ? [`Error ID: ${incidentId}`] : []),
+    ...(code ? [`Code: ${code}`] : []),
+    `Report: ${mode}`,
+    "",
+    `Message: ${message}`,
+    "",
+    trace,
+  ].join("\n");
+
+  return { message, code, trace, mode, report: scrub(report) };
+}

--- a/src/components/Plugin/buildPluginViewDiagnostics.ts
+++ b/src/components/Plugin/buildPluginViewDiagnostics.ts
@@ -2,29 +2,50 @@ import { isErrorLike } from "@shared/utils/ipcErrorSerialization";
 import { scrubReportText } from "@shared/utils/reportScrubbers";
 
 /**
- * Depth bound for the `.cause` walk. Spelled independently of the log walk's
- * `MAX_ERROR_SCAN_DEPTH`, but the same size: past this many links the chain is
+ * Depth bound for the `.cause` walk. Past this many links the chain is
  * describing a wrapper stack no reader follows, and an unbounded walk is a
  * denial-of-service surface handed to plugin authors.
  */
 const MAX_CAUSE_DEPTH = 8;
 
+/**
+ * Bounds on serializing a non-Error cause. `new Error("x", { cause: new
+ * Array(0xffffffff) })` costs the author nothing to build and would otherwise
+ * park `JSON.stringify` on billions of holes during render.
+ */
+const MAX_ARRAY_ENTRIES = 50;
+const MAX_VALUE_CHARS = 4000;
+
 /** Sentinels, spelled as `logErrorNormalization` and `ipcErrorSerialization` spell them. */
 const MAX_DEPTH = "[MaxDepth]";
 const CIRCULAR = "[Circular]";
 const UNSERIALIZABLE = "[Unserializable]";
+const TRUNCATED = "[Truncated]";
 
 const FALLBACK_MESSAGE = "Unknown render error";
+
+/**
+ * Applies the redaction policy to one leaf string.
+ *
+ * Threaded down to every leaf rather than run once over the finished document,
+ * because both the label and the encoding a leaf ends up inside destroy the
+ * anchors the scrubber matches on: `Caused by: Error: access_token=…` is no
+ * longer at a line start for `oauth-query-param`'s `(^|[?&])`, and JSON's
+ * `"\nghp_…"` puts a literal `n` against the sigil `\bghp_` needs. Scrubbing
+ * first and labelling after keeps every pattern anchored where it was written
+ * to match.
+ */
+type Scrub = (text: string) => string;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
 
 /**
  * Read one property without ever throwing. Every field here comes off a value a
  * plugin threw, which may be a Proxy or expose a throwing getter — the
  * diagnostics pane must not become the second failure.
  */
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
-
 function readUnknown(source: unknown, key: string): unknown {
   if (!isRecord(source)) return undefined;
   try {
@@ -44,7 +65,7 @@ function readString(source: unknown, key: string): string | undefined {
  * explicit `{ cause: null }` is still reported as a link in the chain.
  */
 function hasCause(value: unknown): boolean {
-  if (typeof value !== "object" || value === null) return false;
+  if (!isRecord(value)) return false;
   try {
     return "cause" in value;
   } catch {
@@ -62,19 +83,23 @@ function extractCode(value: unknown): string | undefined {
 }
 
 /**
- * Readable JSON for an object that is not an Error. `JSON.stringify` throws on
- * cycles, BigInt, and a hostile `toJSON`, and overflows the stack on a
- * pathologically deep graph — all of which land in the `catch`. The `seen` set
- * is never unwound, so a value referenced twice reads `[Circular]` the second
- * time even without a true cycle; `ipcErrorSerialization` makes the same
- * trade for the same reason.
+ * Readable JSON for an object that is not an Error, scrubbed as it is walked.
+ *
+ * `JSON.stringify` throws on cycles, BigInt and a hostile `toJSON`, and
+ * overflows the stack on a pathologically deep graph — all of which land in the
+ * `catch`. The `seen` set is never unwound, so a value referenced twice reads
+ * `[Circular]` the second time even without a true cycle;
+ * `ipcErrorSerialization` makes the same trade for the same reason.
  */
-function stringifyObject(value: object): string {
+function stringifyObject(value: object, scrub: Scrub): string {
   const seen = new WeakSet<object>();
+  let json: string | undefined;
   try {
-    const json = JSON.stringify(
+    json = JSON.stringify(
       value,
       (_key, item: unknown) => {
+        if (typeof item === "string") return scrub(item);
+        if (typeof item === "bigint") return String(item);
         if (isErrorLike(item)) {
           return {
             name: readString(item, "name") ?? "Error",
@@ -82,30 +107,44 @@ function stringifyObject(value: object): string {
             stack: readString(item, "stack"),
           };
         }
-        if (typeof item === "bigint") return String(item);
-        if (typeof item !== "object" || item === null) return item;
+        if (!isRecord(item)) return item;
         if (seen.has(item)) return CIRCULAR;
         seen.add(item);
-        return item;
+        if (Array.isArray(item)) {
+          return item.length > MAX_ARRAY_ENTRIES
+            ? [...item.slice(0, MAX_ARRAY_ENTRIES), TRUNCATED]
+            : item;
+        }
+        // Rebuilt so the keys are scrubbed too — `JSON.stringify` writes a key
+        // verbatim and never offers it to the replacer. Cycle detection stays
+        // on the original object, which is already in `seen`.
+        const scrubbed: Record<string, unknown> = {};
+        for (const [key, child] of Object.entries(item)) scrubbed[scrub(key)] = child;
+        return scrubbed;
       },
       2
     );
-    return json ?? UNSERIALIZABLE;
   } catch {
     return UNSERIALIZABLE;
   }
+  if (json === undefined) return UNSERIALIZABLE;
+  // Safe to cut: every string inside was scrubbed on the way in, so a slice
+  // cannot expose the leading bytes of a secret that straddled the boundary.
+  return json.length > MAX_VALUE_CHARS ? `${json.slice(0, MAX_VALUE_CHARS)}\n${TRUNCATED}` : json;
 }
 
 /** Render a cause that is not an Error, keeping its type legible. */
-function formatValue(value: unknown): string {
+function formatValue(value: unknown, scrub: Scrub): string {
   if (value === null) return "null";
   if (value === undefined) return "undefined";
-  // Quoted, so an empty-string cause is distinguishable from a missing one.
-  if (typeof value === "string") return JSON.stringify(value);
-  if (typeof value === "object") return stringifyObject(value);
+  // Scrubbed before quoting, not after: `JSON.stringify` escapes the very
+  // characters the secret patterns anchor against.
+  if (typeof value === "string") return JSON.stringify(scrub(value));
+  if (typeof value === "object") return stringifyObject(value, scrub);
   if (typeof value === "function") return "[Function]";
   try {
-    return String(value);
+    // A symbol's description is author-supplied text like any other.
+    return scrub(String(value));
   } catch {
     return UNSERIALIZABLE;
   }
@@ -114,6 +153,8 @@ function formatValue(value: unknown): string {
 /**
  * The frame lines of a stack, without the `Name: message` header V8 prepends —
  * the caller has already printed that, and repeating it doubles every cause.
+ * A stack with no `at` frames at all (Safari and Firefox spell them
+ * `fn@file:line`) is kept whole rather than guessed at.
  */
 function stackFrames(stack: string | undefined): string | undefined {
   if (!stack) return undefined;
@@ -130,10 +171,10 @@ function stackFrames(stack: string | undefined): string | undefined {
  * tree — with a `seen` set against cycles, mirroring
  * `gitOperationErrors.isMissingGitExecutableError`.
  */
-function formatCauses(root: unknown): string[] {
+function formatCauses(root: unknown, scrub: Scrub): string[] {
   const blocks: string[] = [];
   const seen = new Set<unknown>();
-  if (typeof root === "object" && root !== null) seen.add(root);
+  if (isRecord(root)) seen.add(root);
 
   let current: unknown = root;
   for (let depth = 0; hasCause(current); depth += 1) {
@@ -142,7 +183,7 @@ function formatCauses(root: unknown): string[] {
       break;
     }
     const cause = readUnknown(current, "cause");
-    if (typeof cause === "object" && cause !== null) {
+    if (isRecord(cause)) {
       if (seen.has(cause)) {
         blocks.push(`Caused by: ${CIRCULAR}`);
         break;
@@ -151,15 +192,16 @@ function formatCauses(root: unknown): string[] {
     }
 
     if (isErrorLike(cause)) {
-      const name = readString(cause, "name") ?? "Error";
-      const message = readString(cause, "message") ?? "";
+      const name = scrub(readString(cause, "name") ?? "Error");
+      const message = scrub(readString(cause, "message") ?? "");
       const code = extractCode(cause);
       const header =
-        `Caused by: ${name}${message ? `: ${message}` : ""}` + (code ? ` (code: ${code})` : "");
+        `Caused by: ${name}${message ? `: ${message}` : ""}` +
+        (code ? ` (code: ${scrub(code)})` : "");
       const frames = stackFrames(readString(cause, "stack"));
-      blocks.push(frames ? `${header}\n${frames}` : header);
+      blocks.push(frames ? `${header}\n${scrub(frames)}` : header);
     } else {
-      blocks.push(`Caused by: ${formatValue(cause)}`);
+      blocks.push(`Caused by: ${formatValue(cause, scrub)}`);
     }
 
     current = cause;
@@ -169,23 +211,34 @@ function formatCauses(root: unknown): string[] {
 }
 
 /** The message a plugin's thrown value carries, whatever kind of value it is. */
-function extractMessage(error: unknown): string {
-  if (isErrorLike(error)) return readString(error, "message") || FALLBACK_MESSAGE;
-  if (typeof error === "string") return error || FALLBACK_MESSAGE;
-  if (error === null || error === undefined) return FALLBACK_MESSAGE;
-  // A thrown plain object reads `[object Object]` through `String`, which tells
-  // the author nothing about what threw.
-  return formatValue(error) || FALLBACK_MESSAGE;
+function extractMessage(error: unknown, scrub: Scrub): string {
+  const raw = isErrorLike(error)
+    ? readString(error, "message")
+    : typeof error === "string"
+      ? error
+      : error === null || error === undefined
+        ? undefined
+        : // A thrown plain object reads `[object Object]` through `String`,
+          // which tells the author nothing about what threw.
+          formatValue(error, scrub);
+  if (raw === undefined) return FALLBACK_MESSAGE;
+  // Whitespace-only would render as an empty pane saying nothing at all.
+  const scrubbed = scrub(raw);
+  return scrubbed.trim().length > 0 ? scrubbed : FALLBACK_MESSAGE;
 }
 
-function buildTrace(error: unknown, componentStack: string | null | undefined): string {
+function buildTrace(
+  error: unknown,
+  componentStack: string | null | undefined,
+  scrub: Scrub
+): string {
   return [
     "Stack:",
-    readString(error, "stack") || "No stack trace available",
-    ...formatCauses(error).flatMap((block) => ["", block]),
+    scrub(readString(error, "stack") || "No stack trace available"),
+    ...formatCauses(error, scrub).flatMap((block) => ["", block]),
     "",
     "Component stack:",
-    componentStack || "No component stack available",
+    scrub(componentStack || "No component stack available"),
   ].join("\n");
 }
 
@@ -204,36 +257,53 @@ export interface PluginViewDiagnosticsInput {
 }
 
 export interface PluginViewDiagnostics {
-  /** Redaction policy already applied — safe to render as-is. */
   message: string;
   /** Structured error code, when the thrown value carried one. */
   code: string | undefined;
-  /** Stack, cause chain and component stack, redaction policy already applied. */
+  /** Stack, cause chain and component stack. */
   trace: string;
   /** How this document was produced: `redacted` or `raw (dev mode)`. */
   mode: string;
   /** The copyable report. */
   report: string;
+  /**
+   * Identity as the pane should display it. Manifest-supplied, so it is
+   * author-controlled text like every other field here — the pane renders
+   * these rather than its own props so a screenshot and a copy say the same
+   * thing.
+   */
+  pluginId: string;
+  pluginDisplayName: string;
+  kindId: string;
+  panelDisplayName: string;
+  componentPath: string;
+  incidentId: string | undefined;
 }
 
 /**
- * Build the diagnostics an errored plugin view shows and copies.
+ * Build the diagnostics an errored plugin view shows and copies. Every string
+ * on the returned object has the redaction policy already applied.
  *
  * Everything a plugin author controls — the message, the cause chain, the
- * stacks — is untrusted text: the author decides what goes in it, and it
- * routinely carries absolute paths, credentialed URLs, request payloads and
- * tokens. So the *whole* document is scrubbed for an installed plugin, not just
- * the trace, and the report says which of the two it is (#12281). This is not a
- * reversal of #9427, which keeps the sibling `ErrorFallback`'s message raw: that
- * message is first-party Daintree text, where scrubbing costs signal and
- * prevents no leak. The trust boundary differs, so the policy does.
+ * stacks, and the manifest identity — is untrusted text: the author decides
+ * what goes in it, and it routinely carries absolute paths, credentialed URLs,
+ * request payloads and tokens. So the *whole* document is scrubbed for an
+ * installed plugin, not just the trace, and it says which of the two it is
+ * (#12281).
+ *
+ * This is not a reversal of #9427. That issue was about the sibling
+ * `ErrorBoundary/ErrorFallback`, which shows fixed first-party copy in
+ * production and the raw message only under `import.meta.env.DEV` — so it has
+ * no untrusted message to redact in the first place. This pane deliberately
+ * shows plugin-authored text to a production user, which is exactly why it has
+ * to scrub it.
  *
  * A dev-mode plugin's paths are the author's own, so raw output is the useful
  * output there — labelled as raw rather than silently different.
  *
- * The assembled report is scrubbed a second time. `scrubReportText` is
- * idempotent, so this costs nothing on the fields already scrubbed above, and
- * it means a field added to the report later cannot ship raw the way `Message:`
+ * The assembled report is scrubbed once more at the end. `scrubReportText` is
+ * idempotent, so this costs nothing on fields already scrubbed above, and it
+ * means a field added to the report later cannot ship raw the way `Message:`
  * did — which is the bug this function exists to close.
  */
 export function buildPluginViewDiagnostics({
@@ -247,19 +317,28 @@ export function buildPluginViewDiagnostics({
   componentPath,
   incidentId,
 }: PluginViewDiagnosticsInput): PluginViewDiagnostics {
-  const scrub = (text: string): string => (devMode ? text : scrubReportText(text));
+  const scrub: Scrub = (text) => (devMode ? text : scrubReportText(text));
 
-  const message = scrub(extractMessage(error));
+  const identity = {
+    pluginId: scrub(pluginId),
+    pluginDisplayName: scrub(pluginDisplayName),
+    kindId: scrub(kindId),
+    panelDisplayName: scrub(panelDisplayName),
+    componentPath: scrub(componentPath),
+    incidentId: incidentId ? scrub(incidentId) : undefined,
+  };
+
+  const message = extractMessage(error, scrub);
   const rawCode = extractCode(error);
   const code = rawCode === undefined ? undefined : scrub(rawCode);
-  const trace = scrub(buildTrace(error, componentStack));
+  const trace = buildTrace(error, componentStack, scrub);
   const mode = devMode ? "raw (dev mode)" : "redacted";
 
   const report = [
-    `Plugin: ${pluginDisplayName} (${pluginId})`,
-    `Panel: ${panelDisplayName} (${kindId})`,
-    `Module: ${componentPath}`,
-    ...(incidentId ? [`Error ID: ${incidentId}`] : []),
+    `Plugin: ${identity.pluginDisplayName} (${identity.pluginId})`,
+    `Panel: ${identity.panelDisplayName} (${identity.kindId})`,
+    `Module: ${identity.componentPath}`,
+    ...(identity.incidentId ? [`Error ID: ${identity.incidentId}`] : []),
     ...(code ? [`Code: ${code}`] : []),
     `Report: ${mode}`,
     "",
@@ -268,5 +347,5 @@ export function buildPluginViewDiagnostics({
     trace,
   ].join("\n");
 
-  return { message, code, trace, mode, report: scrub(report) };
+  return { ...identity, message, code, trace, mode, report: scrub(report) };
 }


### PR DESCRIPTION
## The bug
`PluginViewDiagnosticsFallback` scrubbed the stack and component trace through `scrubReportText`, then built the copied report with `Trace: redacted` sitting directly above `Message: ${message}` raw. The old comment justified it as "they name the plugin, not the user" — true of the plugin id and panel kind, not of `error.message`, which the plugin author controls and which routinely carries absolute paths, credentialed URLs, request payloads and tokens. A user copying a report the UI called redacted could paste a token into an issue thread.

## What changed
- Report building moves into a new `src/components/Plugin/buildPluginViewDiagnostics.ts`, which applies the redaction policy to the message, the structured `code`, the manifest identity and the `.cause` chain — not just the stacks. The pane renders what the builder returns, so a screenshot and a copy say the same thing.
- The `.cause` chain is now surfaced at all. V8 stacks never include it, so causes were previously invisible. Walked iteratively with a seen-set and a depth cap of 8, mirroring `gitOperationErrors.isMissingGitExecutableError`; non-Error causes (string, number, null, plain object, symbol, boxed primitive) each render with their type intact.
- The label is now `Report: redacted` / `Report: raw (dev mode)` and appears in the pane as well as the copied report — an unlabelled raw view is how this happened.
- `error` is typed `unknown`. React's `getDerivedStateFromError(error: Error)` annotation is the type system's claim, not the runtime's — it stores whatever was thrown.

## Redaction is layered, deliberately
Scrubbing the assembled document alone is not enough, and neither is scrubbing each leaf. Both are needed, for opposite reasons:
- **Leaves first**, because a label or an encoding destroys the anchor a pattern matches on. `Caused by: Error: access_token=…` is no longer at a line start for `oauth-query-param`'s `(^|[?&])`, and JSON's `"\nghp_…"` puts a literal `n` against the `\b` that every token pattern needs.
- **Assembled text after**, because some patterns match a key and its value together — `aws-secret-key` wants `"SecretAccessKey": "…"` — and can never fire while each half is scrubbed in isolation. This pass also covers object keys, which `JSON.stringify` never offers to a replacer.

## One shared fix
`scrubReportPath`'s username classes matched every character but `/`, `"` and `\` — including newlines. A home path at the end of one section swallowed every following section into the `USER` replacement: `Message: /Users/alice` followed by a trace collapsed the whole report to `Message: /Users/USER`. The classes now stop at CR/LF. Spaces stay inside them, since usernames and directories can contain them and stopping at one would leak the rest of the name. This also fixes the same latent truncation in `buildReportIssueUrl`'s plugin diagnostics section.

## Not in this PR
- **"View logs" scoping** (the issue's secondary ask). It still opens the unfiltered application log. `PluginLogsSection` already reads per-plugin lines through `pluginClient.getDiagnosticsSnapshot()`, so this needs no new main-process plumbing — but it does need a new action and a scoped surface, which is its own change rather than a rider on a redaction fix.
- **`ghr_`** (GitHub App refresh tokens) is not matched by `secretScrubber`'s `gh[sou]_`. Real gap, but it is a shared pattern behind twelve outbound call sites and belongs in its own PR.
- **Cascade re-reveal in `scrubSecrets`**: one pattern's replacement can create a word boundary exposing a token an earlier pattern already skipped, so a fixed number of passes is not a fixpoint. Pre-existing and equally true of every call site; noted rather than fixed here.
- The root error's `stack` still embeds its own `Name: message` header, which is a second copy of the message that the line-anchored patterns do not see. Pre-existing; nested cause stacks, which this PR newly exposes, are stripped to their frames precisely so they do not add another instance.

## Verification
- 522 tests across 9 files pass, including `secretScrubber` and `buildReportIssueUrl`, which share `scrubReportText`.
- The test that asserted `"never redacts the message"` is deliberately inverted. Its old rationale cited #9427; that reasoning was wrong and is corrected in place — the sibling `ErrorFallback` shows the raw message only under `import.meta.env.DEV`, so it has no untrusted message to redact, rather than scrubbing costing it signal.
- prettier and eslint clean on all six changed files (two pre-existing warnings remain on an untouched `<pre>` block).

Resolves #12281