### PR TITLE
fix(dev-preview): track navigation outcome so load failures survive the error page

### DIFF
--- a/electron/services/DevPreviewProxyService.ts
+++ b/electron/services/DevPreviewProxyService.ts
@@ -6,6 +6,7 @@ import { createProxyServer, type ProxyServer } from "httpxy";
 import {
   DEV_PREVIEW_BOOTSTRAP_PATH,
   DEV_PREVIEW_PROXY_PORT,
+  DEV_PREVIEW_PROXY_STATUS_TEXT,
   buildBootstrapUrl,
   buildDevPreviewProxyOrigin,
   buildDevPreviewSubdomain,
@@ -348,7 +349,12 @@ export class DevPreviewProxyService {
       res.end();
       return;
     }
-    res.writeHead(502, { "Content-Type": "text/plain; charset=utf-8" });
+    // The custom reason phrase is the renderer's only provenance signal for a
+    // self-generated 502 — a 502 forwarded from the developer's own app keeps its
+    // own status text and must render normally (#12296).
+    res.writeHead(502, DEV_PREVIEW_PROXY_STATUS_TEXT, {
+      "Content-Type": "text/plain; charset=utf-8",
+    });
     res.end(message);
   }
 

--- a/electron/services/__tests__/DevPreviewProxyService.test.ts
+++ b/electron/services/__tests__/DevPreviewProxyService.test.ts
@@ -7,7 +7,10 @@ import {
   DevPreviewProxyService,
   type DevPreviewProxyDiagnostic,
 } from "../DevPreviewProxyService.js";
-import { DEV_PREVIEW_PROXY_PORT } from "../../../shared/utils/devPreviewProxy.js";
+import {
+  DEV_PREVIEW_PROXY_PORT,
+  DEV_PREVIEW_PROXY_STATUS_TEXT,
+} from "../../../shared/utils/devPreviewProxy.js";
 
 // A self-signed cert/key for `localhost`, valid for 100 years, used to stand up a real TLS
 // upstream so the proxy's HTTPS path (#9974) is exercised end-to-end. The proxy dials with
@@ -118,6 +121,7 @@ const canBindIpv6Only = await new Promise<boolean>((resolve) => {
 
 interface ProxyResponse {
   status: number;
+  statusText: string;
   body: string;
   headers: http.IncomingHttpHeaders;
 }
@@ -136,7 +140,14 @@ function request(
       (res) => {
         let body = "";
         res.on("data", (chunk) => (body += chunk));
-        res.on("end", () => resolve({ status: res.statusCode ?? 0, body, headers: res.headers }));
+        res.on("end", () =>
+          resolve({
+            status: res.statusCode ?? 0,
+            statusText: res.statusMessage ?? "",
+            body,
+            headers: res.headers,
+          })
+        );
       }
     );
     req.on("error", reject);
@@ -391,6 +402,35 @@ describe("DevPreviewProxyService", () => {
 
     const res = await request(proxyPort, `dp-test.localhost:${proxyPort}`);
     expect(res.status).toBe(502);
+  });
+
+  it("stamps its own 502s with the provenance reason phrase (#12296)", async () => {
+    // The renderer only sees the status code and the reason phrase, so this is
+    // how a proxy-generated 502 identifies itself against one forwarded from the
+    // developer's own app.
+    proxy = new DevPreviewProxyService(() => null);
+    const proxyPort = await proxy.start();
+
+    const res = await request(proxyPort, `dp-missing.localhost:${proxyPort}`);
+    expect(res.status).toBe(502);
+    expect(res.statusText).toBe(DEV_PREVIEW_PROXY_STATUS_TEXT);
+  });
+
+  it("forwards an upstream 502 without the provenance reason phrase (#12296)", async () => {
+    upstream = http.createServer((_req, res) => {
+      res.writeHead(502, "Bad Gateway", { "Content-Type": "text/html" });
+      res.end("<h1>App error page</h1>");
+    });
+    await new Promise<void>((resolve) => upstream!.listen(0, "127.0.0.1", resolve));
+    const upstreamPort = (upstream.address() as AddressInfo).port;
+
+    proxy = new DevPreviewProxyService(() => ({ port: upstreamPort, isHttps: false }));
+    const proxyPort = await proxy.start();
+
+    const res = await request(proxyPort, `dp-test.localhost:${proxyPort}`);
+    expect(res.status).toBe(502);
+    expect(res.statusText).not.toBe(DEV_PREVIEW_PROXY_STATUS_TEXT);
+    expect(res.body).toContain("App error page");
   });
 
   it("exposes the bound port and is idempotent on start", async () => {

--- a/shared/utils/devPreviewProxy.ts
+++ b/shared/utils/devPreviewProxy.ts
@@ -26,6 +26,18 @@ const LOCALHOST_SUFFIX = ".localhost";
 export const DEV_PREVIEW_BOOTSTRAP_PATH = "/_daintree/bootstrap";
 
 /**
+ * HTTP/1.1 reason phrase the proxy stamps on the 502 it generates itself when the
+ * upstream dev server is down or unregistered (#12296). The renderer's only
+ * renderer-side view of a response status is `did-frame-navigate`, which carries
+ * `httpResponseCode` and `httpStatusText` but no headers — so the reason phrase is
+ * how a proxy-generated 502 announces its provenance. Chromium preserves an
+ * arbitrary HTTP/1.1 reason phrase verbatim, and the proxy is a plain Node `http`
+ * server, so this survives the round trip. A 502 forwarded from the developer's own
+ * app carries that app's reason phrase instead and must render normally.
+ */
+export const DEV_PREVIEW_PROXY_STATUS_TEXT = "Daintree Preview Proxy Upstream Unavailable";
+
+/**
  * Reduce an arbitrary id to a DNS-label-safe token: lowercased, every character outside
  * `[a-z0-9-]` collapsed to a hyphen, capped at 24 chars (well under the 63-char DNS label
  * limit, even combined as `dp-<a>-<b>`). Lowercasing is essential, not cosmetic — hostnames

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -343,6 +343,11 @@ export function DevPreviewPane({
       }
     };
 
+    // dom-ready as well as did-finish-load, matching the finish boundary the load
+    // overlay and its watchdog share: did-finish-load waits on the window load
+    // event, so a single hanging subresource left this spinner covering a usable
+    // document with nothing to time it out (#12296).
+    webview.addEventListener("dom-ready", handleRecoveryFinishLoad);
     webview.addEventListener("did-finish-load", handleRecoveryFinishLoad);
 
     try {
@@ -354,6 +359,7 @@ export function DevPreviewPane({
     }
 
     return () => {
+      webview.removeEventListener("dom-ready", handleRecoveryFinishLoad);
       webview.removeEventListener("did-finish-load", handleRecoveryFinishLoad);
     };
   }, [isRecoveringFromEviction, webviewElement]);
@@ -494,14 +500,22 @@ export function DevPreviewPane({
     if (!webview) return false;
     setWebviewLoadError(null);
     clearRetryState();
-    try {
-      const wcId = (webview as unknown as { getWebContentsId(): number }).getWebContentsId();
-      safeFireAndForget(window.electron.webview.reloadIgnoringCache(wcId, id), {
-        context: "Reloading dev preview ignoring cache",
-      });
-      return true;
-    } catch {
-      // No WebContents id — the guest was never attached, or is already gone.
+    // The cache-ignoring reload runs in the main process against a *registered*
+    // panel, and registration is itself gated on the guest reaching dom-ready
+    // (useWebviewDialog). For a guest that never got there the IPC resolves
+    // without reloading anything — so `isWebviewReady` routes between the two
+    // paths here rather than gating recovery altogether, which is what made
+    // crash-before-ready unrecoverable (#12296).
+    if (isWebviewReady) {
+      try {
+        const wcId = (webview as unknown as { getWebContentsId(): number }).getWebContentsId();
+        safeFireAndForget(window.electron.webview.reloadIgnoringCache(wcId, id), {
+          context: "Reloading dev preview ignoring cache",
+        });
+        return true;
+      } catch {
+        // No WebContents id — the guest is detached or already gone.
+      }
     }
     try {
       webview.reload();
@@ -511,7 +525,7 @@ export function DevPreviewPane({
     }
     remountWebview();
     return true;
-  }, [id, setWebviewLoadError, clearRetryState, remountWebview]);
+  }, [isWebviewReady, id, setWebviewLoadError, clearRetryState, remountWebview]);
 
   // Clear the crash banner only once recovery is under way — clearing first meant a
   // reload that returned early left the user with no crash state and no reload.

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -245,6 +245,10 @@ export function DevPreviewPane({
   // re-bound to navigation state — Electron's SrcAttribute observer would turn
   // each guest navigation into a redundant full reload (#9940).
   const [webviewSeedUrl, setWebviewSeedUrl] = useState(history.present);
+  // Bumped to force a fresh guest when in-place reload cannot reach the current
+  // one — a renderer that died before it was ever attached has no WebContents to
+  // reload, and recovery must not silently do nothing (#12296).
+  const [webviewInstanceKey, setWebviewInstanceKey] = useState(0);
   const [consoleTerminalId, setConsoleTerminalId] = useState<string | null>(terminalId);
   const isConsoleOpen = terminal?.devPreviewConsoleOpen ?? false;
   const activeConsoleTab = terminal?.devPreviewConsoleTab ?? "output";
@@ -470,23 +474,51 @@ export function DevPreviewPane({
     setConsoleTerminalId(terminalId);
   }, [terminalId]);
 
-  const performReload = useCallback(() => {
+  // Recreate the guest from scratch. `src` is seed-only (#9940), so re-seed it to
+  // the URL we actually want before the remount rather than letting the new element
+  // rewind to the mount-time URL.
+  const remountWebview = useCallback(() => {
+    setWebviewSeedUrl(currentUrl);
+    setIsWebviewReady(false);
+    setWebviewInstanceKey((key) => key + 1);
+  }, [currentUrl, setIsWebviewReady]);
+
+  // Returns whether a reload was actually initiated. Deliberately not gated on
+  // `isWebviewReady`: that is exactly the state of a renderer that crashed before
+  // its first dom-ready, and gating there made both auto-recovery and the manual
+  // Reload action silent no-ops (#12296). Falls back through the in-place reload
+  // paths to a full remount so the only "nothing happened" outcome is having no
+  // guest mounted at all.
+  const performReload = useCallback((): boolean => {
     const webview = webviewRef.current;
-    if (!webview || !isWebviewReady) return;
+    if (!webview) return false;
     setWebviewLoadError(null);
+    clearRetryState();
     try {
       const wcId = (webview as unknown as { getWebContentsId(): number }).getWebContentsId();
       safeFireAndForget(window.electron.webview.reloadIgnoringCache(wcId, id), {
         context: "Reloading dev preview ignoring cache",
       });
+      return true;
     } catch {
-      webview.reload();
+      // No WebContents id — the guest was never attached, or is already gone.
     }
-  }, [isWebviewReady, id, setWebviewLoadError]);
+    try {
+      webview.reload();
+      return true;
+    } catch {
+      // In-place reload is unavailable on a guest that never attached.
+    }
+    remountWebview();
+    return true;
+  }, [id, setWebviewLoadError, clearRetryState, remountWebview]);
 
+  // Clear the crash banner only once recovery is under way — clearing first meant a
+  // reload that returned early left the user with no crash state and no reload.
   const handleHardReload = useCallback(() => {
-    resetCrashHistory();
-    performReload();
+    if (performReload()) {
+      resetCrashHistory();
+    }
   }, [resetCrashHistory, performReload]);
 
   // Keep crashReloadRef in sync so onRenderProcessGone can call performReload
@@ -532,6 +564,7 @@ export function DevPreviewPane({
     setIsLoading,
     setWebviewLoadError,
     clearLoadTimers,
+    clearRetryState,
     isConsoleOpen,
     setDevPreviewConsoleOpen,
     onHardReload: handleHardReload,
@@ -1030,6 +1063,7 @@ export function DevPreviewPane({
                     }
                   >
                     <webview
+                      key={webviewInstanceKey}
                       ref={setWebviewNode}
                       // Seed-only: never re-bind to navigation state (#9940).
                       src={effectiveWebviewSeedUrl}

--- a/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
@@ -5,6 +5,7 @@ import type { DevPreviewPaneProps } from "../DevPreviewPane";
 import { DevPreviewPane } from "../DevPreviewPane";
 import { projectClient } from "@/clients";
 import { actionService } from "@/services/ActionService";
+import { DEV_PREVIEW_PROXY_STATUS_TEXT } from "@shared/utils/devPreviewProxy";
 
 const notifyMock = vi.hoisted(() => vi.fn());
 
@@ -786,8 +787,12 @@ describe("DevPreviewPane webview lifecycle regression", () => {
 
     const callsAfterFirstRetry = webview.loadURL.mock.calls.length;
 
-    // Successful load resets retry counter
+    // The retry issues its own load, so the real sequence carries a load start
+    // before the successful finish. Without it the failure latch from the first
+    // did-fail-load would still be up and did-finish-load would (correctly) refuse
+    // to treat this as a successful load.
     act(() => {
+      emitWebviewEvent(webview, "did-start-loading");
       emitWebviewEvent(webview, "did-finish-load");
     });
 
@@ -2690,6 +2695,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
         emitWebviewEvent(webview, "did-frame-navigate", {
           isMainFrame: true,
           httpResponseCode: 502,
+          httpStatusText: DEV_PREVIEW_PROXY_STATUS_TEXT,
           url: "http://localhost:5173/",
         });
         emitWebviewEvent(webview, "did-navigate", { url: "http://localhost:5173/" });
@@ -2707,6 +2713,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
         emitWebviewEvent(webview, "did-frame-navigate", {
           isMainFrame: true,
           httpResponseCode: 502,
+          httpStatusText: DEV_PREVIEW_PROXY_STATUS_TEXT,
           url: "http://localhost:5173/",
         });
       });
@@ -2764,6 +2771,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
           emitWebviewEvent(webview, "did-frame-navigate", {
             isMainFrame: true,
             httpResponseCode: 502,
+            httpStatusText: DEV_PREVIEW_PROXY_STATUS_TEXT,
             url: "http://localhost:5173/",
           });
         });
@@ -2787,6 +2795,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
         emitWebviewEvent(webview, "did-frame-navigate", {
           isMainFrame: true,
           httpResponseCode: 502,
+          httpStatusText: DEV_PREVIEW_PROXY_STATUS_TEXT,
           url: "http://localhost:5173/",
         });
       });
@@ -2807,6 +2816,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
         emitWebviewEvent(webview, "did-frame-navigate", {
           isMainFrame: false,
           httpResponseCode: 502,
+          httpStatusText: DEV_PREVIEW_PROXY_STATUS_TEXT,
           url: "http://localhost:5173/iframe",
         });
         emitWebviewEvent(webview, "did-finish-load");
@@ -2823,6 +2833,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
         emitWebviewEvent(webview, "did-frame-navigate", {
           isMainFrame: true,
           httpResponseCode: 502,
+          httpStatusText: DEV_PREVIEW_PROXY_STATUS_TEXT,
           url: "http://localhost:5173/",
         });
       });
@@ -2848,6 +2859,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
           emitWebviewEvent(webview, "did-frame-navigate", {
             isMainFrame: true,
             httpResponseCode: 502,
+            httpStatusText: DEV_PREVIEW_PROXY_STATUS_TEXT,
             url: "http://localhost:5173/",
           });
         });
@@ -2871,6 +2883,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
         emitWebviewEvent(webview, "did-frame-navigate", {
           isMainFrame: true,
           httpResponseCode: 502,
+          httpStatusText: DEV_PREVIEW_PROXY_STATUS_TEXT,
           url: "http://localhost:5173/",
         });
       });
@@ -2889,6 +2902,285 @@ describe("DevPreviewPane webview lifecycle regression", () => {
       });
 
       expect(container.textContent).not.toContain("Dev server unavailable");
+    });
+  });
+
+  describe("failed-load and early-crash recovery (#12296)", () => {
+    const REFUSED = {
+      errorCode: -102,
+      errorDescription: "ERR_CONNECTION_REFUSED",
+      isMainFrame: true,
+      validatedURL: "http://localhost:5173/",
+    };
+
+    // Render a pane whose guest reports isLoading() true from creation, so the
+    // mount-time readiness probe leaves isWebviewReady false — the state of a
+    // renderer that dies during its first load, before dom-ready ever fires.
+    const renderNeverReadyPane = () => {
+      const decorating = document.createElement;
+      document.createElement = ((tagName: string, options?: ElementCreationOptions) => {
+        const element = decorating(tagName, options);
+        if (String(tagName).toLowerCase() === "webview") {
+          (element as MockWebviewElement).setMockLoading(true);
+        }
+        return element;
+      }) as typeof document.createElement;
+      try {
+        return render(<DevPreviewPane {...baseProps} />);
+      } finally {
+        document.createElement = decorating;
+      }
+    };
+
+    // Chromium commits its own error document when a main-frame load fails and
+    // replays the whole lifecycle for it. This is the sequence captured from the
+    // real guest against a closed port.
+    const emitErrorDocumentTail = (webview: MockWebviewElement) => {
+      emitWebviewEvent(webview, "dom-ready");
+      emitWebviewEvent(webview, "did-navigate", { url: "http://localhost:5173/" });
+      emitWebviewEvent(webview, "did-finish-load");
+      emitWebviewEvent(webview, "did-stop-loading");
+    };
+
+    it("keeps a terminal load error across the error document's own lifecycle", () => {
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        emitWebviewEvent(webview, "did-start-loading");
+        emitWebviewEvent(webview, "did-fail-load", {
+          errorCode: -105,
+          errorDescription: "ERR_NAME_NOT_RESOLVED",
+          isMainFrame: true,
+          validatedURL: "http://missing.test/",
+        });
+        emitErrorDocumentTail(webview);
+      });
+
+      expect(container.textContent).toContain("Couldn't resolve address");
+      expect(container.textContent).toContain("Couldn't resolve missing.test");
+    });
+
+    it("exhausts the connection-refused budget when each retry starts its own load", () => {
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+      const loadsBefore = webview.loadURL.mock.calls.length;
+
+      // MAX_RETRIES = 5, so the 6th failure is the one that gives up. Every cycle
+      // carries the load start the scheduled retry actually issues — the event that
+      // used to refill the budget and make the cap unreachable.
+      for (let i = 0; i < 6; i++) {
+        act(() => {
+          emitWebviewEvent(webview, "did-start-loading");
+          emitWebviewEvent(webview, "did-fail-load", REFUSED);
+          emitErrorDocumentTail(webview);
+        });
+        if (i < 5) {
+          act(() => {
+            vi.advanceTimersByTime(Math.min(500 * 2 ** i, 8000));
+          });
+        }
+      }
+
+      expect(webview.loadURL.mock.calls.length - loadsBefore).toBe(5);
+      expect(container.textContent).toContain("Dev server unreachable");
+      expect(container.textContent).toContain("Unable to connect to dev server");
+    });
+
+    it("hands the retry budget back when the user reloads after exhaustion", () => {
+      let reloadCb: ((payload: { panelId: string }) => void) | undefined;
+      const electron = (window as unknown as { electron: { webview: Record<string, unknown> } })
+        .electron;
+      electron.webview.onReloadShortcut = vi.fn((cb: (payload: { panelId: string }) => void) => {
+        reloadCb = cb;
+        return vi.fn();
+      });
+
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      for (let i = 0; i < 6; i++) {
+        act(() => {
+          emitWebviewEvent(webview, "did-start-loading");
+          emitWebviewEvent(webview, "did-fail-load", REFUSED);
+          emitErrorDocumentTail(webview);
+        });
+        if (i < 5) {
+          act(() => {
+            vi.advanceTimersByTime(Math.min(500 * 2 ** i, 8000));
+          });
+        }
+      }
+      expect(container.textContent).toContain("Unable to connect to dev server");
+
+      // Manual recovery must not inherit the exhausted budget now that a load
+      // start no longer refills it.
+      act(() => {
+        reloadCb?.({ panelId: "dev-preview-panel-1" });
+      });
+
+      const loadsBefore = webview.loadURL.mock.calls.length;
+      act(() => {
+        emitWebviewEvent(webview, "did-start-loading");
+        emitWebviewEvent(webview, "did-fail-load", REFUSED);
+        emitErrorDocumentTail(webview);
+      });
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+
+      expect(webview.loadURL.mock.calls.length).toBeGreaterThan(loadsBefore);
+    });
+
+    it("lifts the blocking overlay at dom-ready while a subresource is still pending", () => {
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        webview.setMockLoading(true);
+        emitWebviewEvent(webview, "did-start-loading");
+      });
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+      expect(container.textContent).toContain("Loading preview");
+
+      // The document is committed and usable; a hanging image means
+      // did-stop-loading never arrives. dom-ready is the shared finish boundary,
+      // so the overlay lifts and the watchdog it used to silently outlive is gone.
+      act(() => {
+        emitWebviewEvent(webview, "dom-ready");
+      });
+      expect(container.textContent).not.toContain("Loading preview");
+
+      act(() => {
+        vi.advanceTimersByTime(60000);
+      });
+      expect(webview.stop).not.toHaveBeenCalled();
+      expect(container.textContent).not.toContain("Page load timed out");
+    });
+
+    it("still times out when the main document never reaches dom-ready", () => {
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        webview.setMockLoading(true);
+        emitWebviewEvent(webview, "did-start-loading");
+      });
+      act(() => {
+        vi.advanceTimersByTime(30000);
+      });
+
+      expect(webview.stop).toHaveBeenCalledTimes(1);
+      expect(container.textContent).toContain("Page load timed out");
+    });
+
+    it("renders an application 502 instead of the proxy outage overlay", () => {
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      // Same status code, different provenance: the proxy forwarded this one from
+      // the developer's app, so its error page has to stay inspectable.
+      act(() => {
+        emitWebviewEvent(webview, "did-start-loading");
+        emitWebviewEvent(webview, "did-frame-navigate", {
+          isMainFrame: true,
+          httpResponseCode: 502,
+          httpStatusText: "Bad Gateway",
+          url: "http://localhost:5173/",
+        });
+        emitWebviewEvent(webview, "did-navigate", { url: "http://localhost:5173/" });
+        emitWebviewEvent(webview, "did-finish-load");
+      });
+
+      expect(container.textContent).not.toContain("Dev server unavailable");
+      act(() => {
+        vi.advanceTimersByTime(16000);
+      });
+      expect(webview.reload).not.toHaveBeenCalled();
+    });
+
+    it("reloads a guest that crashed before its first dom-ready", () => {
+      const electron = (window as unknown as { electron: { webview: Record<string, unknown> } })
+        .electron;
+      const reloadIgnoringCache = electron.webview.reloadIgnoringCache as ReturnType<typeof vi.fn>;
+
+      const { container } = renderNeverReadyPane();
+      const webview = getWebviewElement(container);
+
+      // Auto-recovery on the first crash routes through the same reload the manual
+      // action uses; both used to return early while isWebviewReady was false.
+      act(() => {
+        emitWebviewEvent(webview, "render-process-gone", {
+          details: { reason: "crashed", exitCode: 1 },
+        });
+      });
+
+      expect(reloadIgnoringCache).toHaveBeenCalledWith(42, "dev-preview-panel-1");
+    });
+
+    it("clears the crash banner only once the reload is actually issued", () => {
+      let reloadCb: ((payload: { panelId: string }) => void) | undefined;
+      const electron = (window as unknown as { electron: { webview: Record<string, unknown> } })
+        .electron;
+      electron.webview.onReloadShortcut = vi.fn((cb: (payload: { panelId: string }) => void) => {
+        reloadCb = cb;
+        return vi.fn();
+      });
+      const reloadIgnoringCache = electron.webview.reloadIgnoringCache as ReturnType<typeof vi.fn>;
+
+      const { container } = renderNeverReadyPane();
+      const webview = getWebviewElement(container);
+
+      // Two crashes inside the 60s window: auto-recovery stops, so the banner and
+      // its manual actions are the only way out.
+      act(() => {
+        emitWebviewEvent(webview, "render-process-gone", {
+          details: { reason: "crashed", exitCode: 1 },
+        });
+        emitWebviewEvent(webview, "render-process-gone", {
+          details: { reason: "crashed", exitCode: 1 },
+        });
+      });
+      expect(container.textContent).toContain("Preview process crashed");
+
+      reloadIgnoringCache.mockClear();
+      act(() => {
+        reloadCb?.({ panelId: "dev-preview-panel-1" });
+      });
+
+      expect(reloadIgnoringCache).toHaveBeenCalledWith(42, "dev-preview-panel-1");
+      expect(container.textContent).not.toContain("Preview process crashed");
+    });
+
+    it("recreates the guest when it can no longer be reloaded in place", () => {
+      let reloadCb: ((payload: { panelId: string }) => void) | undefined;
+      const electron = (window as unknown as { electron: { webview: Record<string, unknown> } })
+        .electron;
+      electron.webview.onReloadShortcut = vi.fn((cb: (payload: { panelId: string }) => void) => {
+        reloadCb = cb;
+        return vi.fn();
+      });
+
+      const { container } = renderNeverReadyPane();
+      const webview = getWebviewElement(container);
+
+      // A renderer that died before it was ever attached has no WebContents to
+      // reach, so recovery falls through to a fresh guest rather than doing
+      // nothing.
+      webview.getWebContentsId.mockImplementation(() => {
+        throw new Error("The WebView must be attached to the DOM");
+      });
+      webview.reload.mockImplementation(() => {
+        throw new Error("The WebView must be attached to the DOM");
+      });
+
+      act(() => {
+        reloadCb?.({ panelId: "dev-preview-panel-1" });
+      });
+
+      expect(getWebviewElement(container)).not.toBe(webview);
     });
   });
 

--- a/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
@@ -2935,9 +2935,9 @@ describe("DevPreviewPane webview lifecycle regression", () => {
     // Chromium commits its own error document when a main-frame load fails and
     // replays the whole lifecycle for it. This is the sequence captured from the
     // real guest against a closed port.
-    const emitErrorDocumentTail = (webview: MockWebviewElement) => {
+    const emitErrorDocumentTail = (webview: MockWebviewElement, url = "http://localhost:5173/") => {
       emitWebviewEvent(webview, "dom-ready");
-      emitWebviewEvent(webview, "did-navigate", { url: "http://localhost:5173/" });
+      emitWebviewEvent(webview, "did-navigate", { url });
       emitWebviewEvent(webview, "did-finish-load");
       emitWebviewEvent(webview, "did-stop-loading");
     };
@@ -2954,11 +2954,36 @@ describe("DevPreviewPane webview lifecycle regression", () => {
           isMainFrame: true,
           validatedURL: "http://missing.test/",
         });
-        emitErrorDocumentTail(webview);
+        emitErrorDocumentTail(webview, "http://missing.test/");
       });
 
       expect(container.textContent).toContain("Couldn't resolve address");
       expect(container.textContent).toContain("Couldn't resolve missing.test");
+    });
+
+    it("survives the exact captured sequence, with no did-navigate at all", () => {
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      // Verbatim from the issue's real-Electron capture against a closed port:
+      // did-start-loading → did-fail-load(-102) → dom-ready → did-finish-load →
+      // did-stop-loading. Nothing in that tail may read as a successful load.
+      act(() => {
+        emitWebviewEvent(webview, "did-start-loading");
+        emitWebviewEvent(webview, "did-fail-load", REFUSED);
+        emitWebviewEvent(webview, "dom-ready");
+        emitWebviewEvent(webview, "did-finish-load");
+        emitWebviewEvent(webview, "did-stop-loading");
+      });
+
+      // The failure survived: the scheduled retry is still pending and fires with
+      // the URL that failed, rather than having been cancelled by the tail.
+      const loadsBefore = webview.loadURL.mock.calls.length;
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+      expect(webview.loadURL.mock.calls.length).toBe(loadsBefore + 1);
+      expect(webview.loadURL).toHaveBeenLastCalledWith("http://localhost:5173/");
     });
 
     it("exhausts the connection-refused budget when each retry starts its own load", () => {
@@ -2983,8 +3008,100 @@ describe("DevPreviewPane webview lifecycle regression", () => {
       }
 
       expect(webview.loadURL.mock.calls.length - loadsBefore).toBe(5);
+      expect(webview.loadURL).toHaveBeenLastCalledWith("http://localhost:5173/");
       expect(container.textContent).toContain("Dev server unreachable");
       expect(container.textContent).toContain("Unable to connect to dev server");
+
+      // Past every remaining backoff window, nothing more is scheduled: the cap
+      // stops the loop rather than merely relabelling the overlay.
+      act(() => {
+        vi.advanceTimersByTime(30000);
+      });
+      expect(webview.loadURL.mock.calls.length - loadsBefore).toBe(5);
+    });
+
+    it("recovers when the dev server comes up mid retry loop", () => {
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      for (let i = 0; i < 2; i++) {
+        act(() => {
+          emitWebviewEvent(webview, "did-start-loading");
+          emitWebviewEvent(webview, "did-fail-load", REFUSED);
+          emitErrorDocumentTail(webview);
+        });
+        act(() => {
+          vi.advanceTimersByTime(Math.min(500 * 2 ** i, 8000));
+        });
+      }
+
+      // The third attempt finds the server up.
+      act(() => {
+        emitWebviewEvent(webview, "did-start-loading");
+        emitWebviewEvent(webview, "did-frame-navigate", {
+          isMainFrame: true,
+          httpResponseCode: 200,
+          httpStatusText: "OK",
+          url: "http://localhost:5173/",
+        });
+        emitWebviewEvent(webview, "did-navigate", { url: "http://localhost:5173/" });
+        emitWebviewEvent(webview, "did-finish-load");
+        emitWebviewEvent(webview, "did-stop-loading");
+      });
+      expect(container.textContent).not.toContain("Dev server unreachable");
+
+      // A confirmed success returns the full budget: the next failure retries at
+      // the first backoff step rather than partway up the ladder.
+      const loadsBefore = webview.loadURL.mock.calls.length;
+      act(() => {
+        emitWebviewEvent(webview, "did-start-loading");
+        emitWebviewEvent(webview, "did-fail-load", REFUSED);
+        emitErrorDocumentTail(webview);
+      });
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+      expect(webview.loadURL.mock.calls.length).toBe(loadsBefore + 1);
+    });
+
+    it("cancels a pending retry when a fresh navigation starts", () => {
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        emitWebviewEvent(webview, "did-start-loading");
+        emitWebviewEvent(webview, "did-fail-load", REFUSED);
+        emitErrorDocumentTail(webview);
+      });
+
+      const loadsBefore = webview.loadURL.mock.calls.length;
+      act(() => {
+        emitWebviewEvent(webview, "did-start-loading");
+      });
+      act(() => {
+        vi.advanceTimersByTime(8000);
+      });
+
+      expect(webview.loadURL.mock.calls.length).toBe(loadsBefore);
+    });
+
+    it("cancels a pending retry when the panel closes", () => {
+      const { container, unmount } = render(<DevPreviewPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        emitWebviewEvent(webview, "did-start-loading");
+        emitWebviewEvent(webview, "did-fail-load", REFUSED);
+        emitErrorDocumentTail(webview);
+      });
+
+      const loadsBefore = webview.loadURL.mock.calls.length;
+      unmount();
+      act(() => {
+        vi.advanceTimersByTime(8000);
+      });
+
+      expect(webview.loadURL.mock.calls.length).toBe(loadsBefore);
     });
 
     it("hands the retry budget back when the user reloads after exhaustion", () => {
@@ -3117,7 +3234,32 @@ describe("DevPreviewPane webview lifecycle regression", () => {
         });
       });
 
+      // It has to reach the guest directly: the cache-ignoring IPC only acts on a
+      // panel registered at dom-ready, so for this guest it would resolve having
+      // done nothing at all.
+      expect(webview.reload).toHaveBeenCalledTimes(1);
+      expect(reloadIgnoringCache).not.toHaveBeenCalled();
+    });
+
+    it("uses the cache-ignoring reload once the guest has reached dom-ready", () => {
+      const electron = (window as unknown as { electron: { webview: Record<string, unknown> } })
+        .electron;
+      const reloadIgnoringCache = electron.webview.reloadIgnoringCache as ReturnType<typeof vi.fn>;
+
+      const { container } = renderNeverReadyPane();
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        emitWebviewEvent(webview, "dom-ready");
+      });
+      act(() => {
+        emitWebviewEvent(webview, "render-process-gone", {
+          details: { reason: "crashed", exitCode: 1 },
+        });
+      });
+
       expect(reloadIgnoringCache).toHaveBeenCalledWith(42, "dev-preview-panel-1");
+      expect(webview.reload).not.toHaveBeenCalled();
     });
 
     it("clears the crash banner only once the reload is actually issued", () => {
@@ -3128,8 +3270,6 @@ describe("DevPreviewPane webview lifecycle regression", () => {
         reloadCb = cb;
         return vi.fn();
       });
-      const reloadIgnoringCache = electron.webview.reloadIgnoringCache as ReturnType<typeof vi.fn>;
-
       const { container } = renderNeverReadyPane();
       const webview = getWebviewElement(container);
 
@@ -3145,12 +3285,12 @@ describe("DevPreviewPane webview lifecycle regression", () => {
       });
       expect(container.textContent).toContain("Preview process crashed");
 
-      reloadIgnoringCache.mockClear();
+      webview.reload.mockClear();
       act(() => {
         reloadCb?.({ panelId: "dev-preview-panel-1" });
       });
 
-      expect(reloadIgnoringCache).toHaveBeenCalledWith(42, "dev-preview-panel-1");
+      expect(webview.reload).toHaveBeenCalledTimes(1);
       expect(container.textContent).not.toContain("Preview process crashed");
     });
 

--- a/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
@@ -34,9 +34,13 @@ type MockWebviewElement = HTMLElement & {
   setMockLoading: (value: boolean) => void;
 };
 
+// Opt-in for the next guest to report a load already in flight, so the pane's
+// mount-time readiness probe leaves it unready (#12296).
+let nextWebviewStartsLoading = false;
+
 function decorateWebviewElement(element: HTMLElement): MockWebviewElement {
   let currentUrl = element.getAttribute("src") ?? "http://localhost:5173/";
-  let loading = false;
+  let loading = nextWebviewStartsLoading;
   const webview = element as MockWebviewElement;
 
   const syncUrlFromAttribute = () => {
@@ -335,6 +339,12 @@ function emitWebviewEvent(
   webview.dispatchEvent(event);
 }
 
+// The mocked `window.electron` needs a cast to be reachable at all; doing it once
+// here keeps it out of every individual test.
+function getElectronMock(): { webview: Record<string, unknown> } {
+  return (window as unknown as { electron: { webview: Record<string, unknown> } }).electron;
+}
+
 function getWebviewElement(container: HTMLElement): MockWebviewElement {
   const webview = container.querySelector("webview");
   if (!webview) {
@@ -458,8 +468,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
 
   it("hard-reloads the focused webview guest when onReloadShortcut fires for this panel (#9497)", async () => {
     let reloadCb: ((payload: { panelId: string }) => void) | undefined;
-    const electron = (window as unknown as { electron: { webview: Record<string, unknown> } })
-      .electron;
+    const electron = getElectronMock();
     electron.webview.onReloadShortcut = vi.fn((cb: (payload: { panelId: string }) => void) => {
       reloadCb = cb;
       return vi.fn();
@@ -489,8 +498,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
 
   it("unsubscribes from onReloadShortcut on unmount (#9497)", () => {
     const unsubscribe = vi.fn();
-    const electron = (window as unknown as { electron: { webview: Record<string, unknown> } })
-      .electron;
+    const electron = getElectronMock();
     electron.webview.onReloadShortcut = vi.fn(() => unsubscribe);
 
     const { unmount } = render(<DevPreviewPane {...baseProps} />);
@@ -501,8 +509,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
 
   it("closes this panel when onCloseShortcut fires for it, and ignores other panels (#10859)", async () => {
     let closeCb: ((payload: { panelId: string }) => void) | undefined;
-    const electron = (window as unknown as { electron: { webview: Record<string, unknown> } })
-      .electron;
+    const electron = getElectronMock();
     electron.webview.onCloseShortcut = vi.fn((cb: (payload: { panelId: string }) => void) => {
       closeCb = cb;
       return vi.fn();
@@ -537,8 +544,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
 
   it("unsubscribes from onCloseShortcut on unmount (#10859)", () => {
     const unsubscribe = vi.fn();
-    const electron = (window as unknown as { electron: { webview: Record<string, unknown> } })
-      .electron;
+    const electron = getElectronMock();
     electron.webview.onCloseShortcut = vi.fn(() => unsubscribe);
 
     const { unmount } = render(<DevPreviewPane {...baseProps} />);
@@ -2241,8 +2247,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
 
     it("keeps the unresponsive banner visible while the URL is unchanged", () => {
       let unresponsiveCb: ((data: { panelId: string }) => void) | undefined;
-      const electron = (window as unknown as { electron: { webview: Record<string, unknown> } })
-        .electron;
+      const electron = getElectronMock();
       electron.webview.onUnresponsive = vi.fn((cb: (data: { panelId: string }) => void) => {
         unresponsiveCb = cb;
         return vi.fn();
@@ -2263,8 +2268,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
     it("clears the unresponsive banner when the guest becomes responsive again", () => {
       let unresponsiveCb: ((data: { panelId: string }) => void) | undefined;
       let responsiveCb: ((data: { panelId: string }) => void) | undefined;
-      const electron = (window as unknown as { electron: { webview: Record<string, unknown> } })
-        .electron;
+      const electron = getElectronMock();
       electron.webview.onUnresponsive = vi.fn((cb: (data: { panelId: string }) => void) => {
         unresponsiveCb = cb;
         return vi.fn();
@@ -2290,8 +2294,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
 
     it("does not clear a crashed banner when a stale responsive event arrives", () => {
       let responsiveCb: ((data: { panelId: string }) => void) | undefined;
-      const electron = (window as unknown as { electron: { webview: Record<string, unknown> } })
-        .electron;
+      const electron = getElectronMock();
       electron.webview.onResponsive = vi.fn((cb: (data: { panelId: string }) => void) => {
         responsiveCb = cb;
         return vi.fn();
@@ -2314,8 +2317,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
 
     it("ignores unresponsive events targeting a different panel", () => {
       let unresponsiveCb: ((data: { panelId: string }) => void) | undefined;
-      const electron = (window as unknown as { electron: { webview: Record<string, unknown> } })
-        .electron;
+      const electron = getElectronMock();
       electron.webview.onUnresponsive = vi.fn((cb: (data: { panelId: string }) => void) => {
         unresponsiveCb = cb;
         return vi.fn();
@@ -2917,18 +2919,11 @@ describe("DevPreviewPane webview lifecycle regression", () => {
     // mount-time readiness probe leaves isWebviewReady false — the state of a
     // renderer that dies during its first load, before dom-ready ever fires.
     const renderNeverReadyPane = () => {
-      const decorating = document.createElement;
-      document.createElement = ((tagName: string, options?: ElementCreationOptions) => {
-        const element = decorating(tagName, options);
-        if (String(tagName).toLowerCase() === "webview") {
-          (element as MockWebviewElement).setMockLoading(true);
-        }
-        return element;
-      }) as typeof document.createElement;
+      nextWebviewStartsLoading = true;
       try {
         return render(<DevPreviewPane {...baseProps} />);
       } finally {
-        document.createElement = decorating;
+        nextWebviewStartsLoading = false;
       }
     };
 
@@ -3106,8 +3101,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
 
     it("hands the retry budget back when the user reloads after exhaustion", () => {
       let reloadCb: ((payload: { panelId: string }) => void) | undefined;
-      const electron = (window as unknown as { electron: { webview: Record<string, unknown> } })
-        .electron;
+      const electron = getElectronMock();
       electron.webview.onReloadShortcut = vi.fn((cb: (payload: { panelId: string }) => void) => {
         reloadCb = cb;
         return vi.fn();
@@ -3219,8 +3213,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
     });
 
     it("reloads a guest that crashed before its first dom-ready", () => {
-      const electron = (window as unknown as { electron: { webview: Record<string, unknown> } })
-        .electron;
+      const electron = getElectronMock();
       const reloadIgnoringCache = electron.webview.reloadIgnoringCache as ReturnType<typeof vi.fn>;
 
       const { container } = renderNeverReadyPane();
@@ -3242,8 +3235,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
     });
 
     it("uses the cache-ignoring reload once the guest has reached dom-ready", () => {
-      const electron = (window as unknown as { electron: { webview: Record<string, unknown> } })
-        .electron;
+      const electron = getElectronMock();
       const reloadIgnoringCache = electron.webview.reloadIgnoringCache as ReturnType<typeof vi.fn>;
 
       const { container } = renderNeverReadyPane();
@@ -3264,8 +3256,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
 
     it("clears the crash banner only once the reload is actually issued", () => {
       let reloadCb: ((payload: { panelId: string }) => void) | undefined;
-      const electron = (window as unknown as { electron: { webview: Record<string, unknown> } })
-        .electron;
+      const electron = getElectronMock();
       electron.webview.onReloadShortcut = vi.fn((cb: (payload: { panelId: string }) => void) => {
         reloadCb = cb;
         return vi.fn();
@@ -3296,8 +3287,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
 
     it("recreates the guest when it can no longer be reloaded in place", () => {
       let reloadCb: ((payload: { panelId: string }) => void) | undefined;
-      const electron = (window as unknown as { electron: { webview: Record<string, unknown> } })
-        .electron;
+      const electron = getElectronMock();
       electron.webview.onReloadShortcut = vi.fn((cb: (payload: { panelId: string }) => void) => {
         reloadCb = cb;
         return vi.fn();

--- a/src/components/DevPreview/__tests__/useDevPreviewNavigation.test.tsx
+++ b/src/components/DevPreview/__tests__/useDevPreviewNavigation.test.tsx
@@ -265,6 +265,51 @@ describe("useDevPreviewNavigation — history handlers", () => {
     act(() => result.current.handleForward());
     expect(setHistory).not.toHaveBeenCalled();
   });
+
+  // A load start no longer refills the connection-retry budget (#12296), so every
+  // explicit navigation has to hand it back — otherwise a target that exhausted
+  // its five retries makes the next URL's first transient failure terminal.
+  it("handleNavigate resets the retry budget for the new target", () => {
+    const clearRetryState = vi.fn();
+    const { result } = renderHook(() => useDevPreviewNavigation(baseParams({ clearRetryState })));
+    act(() => result.current.handleNavigate("localhost:5173/app"));
+    expect(clearRetryState).toHaveBeenCalledTimes(1);
+  });
+
+  it("handleNavigate leaves the retry budget alone when the URL is rejected", () => {
+    const clearRetryState = vi.fn();
+    const { result } = renderHook(() => useDevPreviewNavigation(baseParams({ clearRetryState })));
+    act(() => result.current.handleNavigate("   "));
+    expect(clearRetryState).not.toHaveBeenCalled();
+  });
+
+  it("handleBack and handleForward reset the retry budget only when they navigate", () => {
+    const clearRetryState = vi.fn();
+    const { result } = renderHook(() =>
+      useDevPreviewNavigation(
+        baseParams({ clearRetryState, canGoBack: false, canGoForward: false })
+      )
+    );
+    act(() => result.current.handleBack());
+    act(() => result.current.handleForward());
+    expect(clearRetryState).not.toHaveBeenCalled();
+
+    const { result: navigable } = renderHook(() =>
+      useDevPreviewNavigation(baseParams({ clearRetryState, canGoBack: true, canGoForward: true }))
+    );
+    act(() => navigable.current.handleBack());
+    act(() => navigable.current.handleForward());
+    expect(clearRetryState).toHaveBeenCalledTimes(2);
+  });
+
+  it("handleReload and handleRetryWebviewLoad reset the retry budget", () => {
+    const clearRetryState = vi.fn();
+    const { result } = renderHook(() => useDevPreviewNavigation(baseParams({ clearRetryState })));
+    act(() => result.current.handleReload());
+    expect(clearRetryState).toHaveBeenCalledTimes(1);
+    act(() => result.current.handleRetryWebviewLoad());
+    expect(clearRetryState).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe("useDevPreviewNavigation — reload/cancel/retry", () => {

--- a/src/components/DevPreview/__tests__/useDevPreviewNavigation.test.tsx
+++ b/src/components/DevPreview/__tests__/useDevPreviewNavigation.test.tsx
@@ -51,6 +51,7 @@ function baseParams(overrides: Partial<Parameters<typeof useDevPreviewNavigation
     setIsLoading: vi.fn(),
     setWebviewLoadError: vi.fn(),
     clearLoadTimers: vi.fn(),
+    clearRetryState: vi.fn(),
     isConsoleOpen: false,
     setDevPreviewConsoleOpen: vi.fn(),
     onHardReload: vi.fn(),

--- a/src/components/DevPreview/__tests__/useDevPreviewNavigation.test.tsx
+++ b/src/components/DevPreview/__tests__/useDevPreviewNavigation.test.tsx
@@ -276,6 +276,15 @@ describe("useDevPreviewNavigation — history handlers", () => {
     expect(clearRetryState).toHaveBeenCalledTimes(1);
   });
 
+  // Re-submitting the URL already showing starts no load, so clearing retry state
+  // there would drop an in-flight document's latches with nothing to restore them.
+  it("handleNavigate leaves the retry budget alone when re-submitting the current URL", () => {
+    const clearRetryState = vi.fn();
+    const { result } = renderHook(() => useDevPreviewNavigation(baseParams({ clearRetryState })));
+    act(() => result.current.handleNavigate("http://localhost:3000/"));
+    expect(clearRetryState).not.toHaveBeenCalled();
+  });
+
   it("handleNavigate leaves the retry budget alone when the URL is rejected", () => {
     const clearRetryState = vi.fn();
     const { result } = renderHook(() => useDevPreviewNavigation(baseParams({ clearRetryState })));

--- a/src/components/DevPreview/useDevPreviewLoadLifecycle.ts
+++ b/src/components/DevPreview/useDevPreviewLoadLifecycle.ts
@@ -3,6 +3,7 @@ import { usePanelStore } from "@/store";
 import { useUrlHistoryStore } from "@/store/urlHistoryStore";
 import type { BrowserHistory } from "@shared/types/browser";
 import { isDevPreviewPanel } from "@shared/types/panel";
+import { DEV_PREVIEW_PROXY_STATUS_TEXT } from "@shared/utils/devPreviewProxy";
 import { getViewportPreset } from "@/panels/dev-preview/viewportPresets";
 import { getDevPreviewWebContents, buildEmulationParams } from "./viewportEmulation";
 import { pushBrowserHistory } from "../Browser/historyUtils";
@@ -124,6 +125,17 @@ export function useDevPreviewLoadLifecycle({
   // the three events fire sequentially within one microtask pump.
   const pendingHttpErrorRef = useRef(false);
 
+  // Companion latch for a failed main-frame navigation. When a main-frame load
+  // fails, Chromium commits its own internal error document and replays the whole
+  // lifecycle for it — the observed sequence is
+  // did-start-loading → did-fail-load → dom-ready → did-finish-load → did-stop-loading
+  // — so those trailing events are evidence about the interstitial, not about the
+  // requested URL. did-fail-load latches the failure here and, unlike the HTTP
+  // latch, it is not consumed on did-finish-load: it describes the document
+  // currently committed, so only the next did-start-loading — a genuinely new
+  // navigation — clears it (#12296).
+  const pendingNetErrorRef = useRef(false);
+
   // Bounded auto-retry for a proxy 5xx. The dev server can restart in place
   // (e.g. config-change full reload) while Daintree still reports status
   // "running", so the webview never remounts and there's no recovery signal
@@ -180,6 +192,7 @@ export function useDevPreviewLoadLifecycle({
     failLoadRetryCountRef.current = 0;
     proxyRetryCountRef.current = 0;
     pendingHttpErrorRef.current = false;
+    pendingNetErrorRef.current = false;
     setReconnectAttempt(0);
   }, []);
 
@@ -236,6 +249,7 @@ export function useDevPreviewLoadLifecycle({
       failLoadRetryCountRef.current = 0;
       proxyRetryCountRef.current = 0;
       pendingHttpErrorRef.current = false;
+      pendingNetErrorRef.current = false;
       if (reason === "clean-exit") return;
       setWebviewLoadError(null);
       onRenderProcessGone?.({ reason, exitCode });
@@ -245,9 +259,11 @@ export function useDevPreviewLoadLifecycle({
       setIsLoading(true);
       setWebviewLoadError(null);
       setReconnectAttempt(0);
-      // Fresh navigation: drop any stale HTTP-error latch. did-frame-navigate,
-      // which fires after this for the same navigation, re-sets it if needed.
+      // Fresh navigation: drop any stale error latches. did-frame-navigate and
+      // did-fail-load, which fire after this for the same navigation, re-set them
+      // if needed.
       pendingHttpErrorRef.current = false;
+      pendingNetErrorRef.current = false;
       // Cancel a pending proxy auto-retry — this load supersedes it. The retry
       // count is intentionally preserved so a still-failing upstream keeps
       // walking up the backoff; it resets only on a genuine successful load.
@@ -262,7 +278,11 @@ export function useDevPreviewLoadLifecycle({
         clearTimeout(failLoadRetryRef.current);
         failLoadRetryRef.current = null;
       }
-      failLoadRetryCountRef.current = 0;
+      // The connection-refused retry count is deliberately preserved here, exactly
+      // like proxyRetryCountRef above: the scheduled retry issues its own loadURL,
+      // which fires this handler, so resetting made MAX_RETRIES unreachable and the
+      // backoff loop endless (#12296). It resets on a confirmed successful load, on
+      // a crash, and when a user-initiated action calls clearRetryState.
       loadTimeoutRef.current = setTimeout(() => {
         loadTimeoutRef.current = null;
         try {
@@ -301,6 +321,13 @@ export function useDevPreviewLoadLifecycle({
       // the latch so the next genuine successful load clears the overlay.
       if (pendingHttpErrorRef.current) {
         pendingHttpErrorRef.current = false;
+        return;
+      }
+
+      // The requested navigation failed: this event belongs to Chromium's error
+      // document, so it is not evidence that anything loaded. Keep the overlay and
+      // the retry budget intact (#12296).
+      if (pendingNetErrorRef.current) {
         return;
       }
 
@@ -355,6 +382,11 @@ export function useDevPreviewLoadLifecycle({
       if (e.errorCode === -3) return;
       // Ignore subframe failures — they don't affect the main-frame load state
       if (!e.isMainFrame) return;
+
+      // Everything past here either surfaces an error overlay or schedules a retry,
+      // and in both cases Chromium is about to commit its error document. Latch the
+      // failure so that document's own lifecycle events don't clear it (#12296).
+      pendingNetErrorRef.current = true;
 
       setIsLoading(false);
       if (loadTimeoutRef.current) {
@@ -502,8 +534,15 @@ export function useDevPreviewLoadLifecycle({
       // the raw text/plain 502 body. Latch a main-frame 502 here and surface the
       // styled overlay; the guards in did-navigate/did-finish-load keep it from
       // being cleared. 4xx (bootstrap 403/405) and other 5xx pass through.
+      //
+      // The status code alone is ambiguous: the proxy also forwards an upstream
+      // 502 untouched, and hiding the app's own error page behind the outage
+      // overlay costs the developer the debugging information (#12296). So match
+      // the proxy's provenance marker — the custom HTTP/1.1 reason phrase
+      // send502 stamps on the responses it generates itself — not the bare status.
       if (!e.isMainFrame) return;
       if (e.httpResponseCode !== 502) return;
+      if (e.httpStatusText !== DEV_PREVIEW_PROXY_STATUS_TEXT) return;
       pendingHttpErrorRef.current = true;
       setIsLoading(false);
       setReconnectAttempt(0);
@@ -556,9 +595,10 @@ export function useDevPreviewLoadLifecycle({
       // Suppress about:blank navigations triggered by eviction
       if (navigatedUrl === "about:blank" && evictingRef.current) return;
       setBlockedNav({ type: "DISMISS" });
-      // A main-frame 5xx (proxy 502) was just committed via did-frame-navigate;
-      // keep the overlay rather than clearing it for this "successful" load.
-      if (!pendingHttpErrorRef.current) {
+      // A main-frame 5xx (proxy 502) was just committed via did-frame-navigate, or
+      // the navigation failed and this is the error document committing; keep the
+      // overlay rather than clearing it for either "successful" load (#12296).
+      if (!pendingHttpErrorRef.current && !pendingNetErrorRef.current) {
         setWebviewLoadError(null);
         setReconnectAttempt(0);
         proxyRetryCountRef.current = 0;
@@ -566,13 +606,15 @@ export function useDevPreviewLoadLifecycle({
           clearTimeout(proxyRetryRef.current);
           proxyRetryRef.current = null;
         }
-      }
-      // A confirmed new main-frame navigation means we're past any previous failure;
-      // reset the retry budget so stale exhaustion doesn't block future attempts.
-      failLoadRetryCountRef.current = 0;
-      if (failLoadRetryRef.current) {
-        clearTimeout(failLoadRetryRef.current);
-        failLoadRetryRef.current = null;
+        // A confirmed new main-frame navigation means we're past any previous
+        // failure; reset the retry budget so stale exhaustion doesn't block future
+        // attempts. Gated on the document actually being the requested one — the
+        // error document's own commit would otherwise refill the budget forever.
+        failLoadRetryCountRef.current = 0;
+        if (failLoadRetryRef.current) {
+          clearTimeout(failLoadRetryRef.current);
+          failLoadRetryRef.current = null;
+        }
       }
       if (navigatedUrl !== lastSetUrlRef.current) {
         setHistory((prev) => pushBrowserHistory(prev, navigatedUrl));
@@ -667,10 +709,17 @@ export function useDevPreviewLoadLifecycle({
       } catch {
         // WebContents not available yet
       }
+      // The watchdog and the blocking "Loading preview" overlay share this one
+      // finish boundary. dom-ready is DOMContentLoaded: the document is committed
+      // and usable, while did-finish-load/did-stop-loading additionally wait on the
+      // window load event — so a single hung image used to clear the only timer
+      // guarding an overlay that then stayed up forever (#12296). A hung main
+      // document never reaches dom-ready and still hits the timeout.
       if (loadTimeoutRef.current) {
         clearTimeout(loadTimeoutRef.current);
         loadTimeoutRef.current = null;
       }
+      setIsLoading(false);
 
       const currentPanel = usePanelStore.getState().getTerminal(id);
       const saved =

--- a/src/components/DevPreview/useDevPreviewNavigation.ts
+++ b/src/components/DevPreview/useDevPreviewNavigation.ts
@@ -36,6 +36,7 @@ interface UseDevPreviewNavigationParams {
   setIsLoading: React.Dispatch<React.SetStateAction<boolean>>;
   setWebviewLoadError: React.Dispatch<React.SetStateAction<WebviewLoadError | null>>;
   clearLoadTimers: () => void;
+  clearRetryState: () => void;
   isConsoleOpen: boolean;
   setDevPreviewConsoleOpen: (id: string, open: boolean) => void;
   onHardReload: () => void;
@@ -72,6 +73,7 @@ export function useDevPreviewNavigation({
   setIsLoading,
   setWebviewLoadError,
   clearLoadTimers,
+  clearRetryState,
   isConsoleOpen,
   setDevPreviewConsoleOpen,
   onHardReload,
@@ -152,10 +154,14 @@ export function useDevPreviewNavigation({
     }
   }, [canGoForward, setHistory]);
 
+  // A user-initiated reload is a fresh attempt: hand back the retry budget. Load
+  // start no longer refills it on its own, so without this an exhausted panel would
+  // stay exhausted for the rest of its life (#12296).
   const handleReload = useCallback(() => {
     setWebviewLoadError(null);
+    clearRetryState();
     webviewRef.current?.reload();
-  }, [setWebviewLoadError, webviewRef]);
+  }, [clearRetryState, setWebviewLoadError, webviewRef]);
 
   const handleCancelLoad = useCallback(() => {
     clearLoadTimers();
@@ -170,6 +176,7 @@ export function useDevPreviewNavigation({
 
   const handleRetryWebviewLoad = useCallback(() => {
     setWebviewLoadError(null);
+    clearRetryState();
     setIsLoading(true);
     if (currentUrl) {
       // Swallow ERR_ABORTED-class rejections — did-fail-load is the source
@@ -181,7 +188,7 @@ export function useDevPreviewNavigation({
     } else {
       webviewRef.current?.reload();
     }
-  }, [currentUrl, setWebviewLoadError, setIsLoading, webviewRef]);
+  }, [currentUrl, clearRetryState, setWebviewLoadError, setIsLoading, webviewRef]);
 
   const handleCaptureScreenshot = useCallback(async () => {
     const webview = webviewRef.current;

--- a/src/components/DevPreview/useDevPreviewNavigation.ts
+++ b/src/components/DevPreview/useDevPreviewNavigation.ts
@@ -130,29 +130,38 @@ export function useDevPreviewNavigation({
     setBrowserZoom(id, zoomFactor);
   }, [id, zoomFactor, setBrowserZoom]);
 
+  // Every explicit navigation action hands the retry budget back. A load start no
+  // longer refills it (#12296), and the budget belongs to the target that
+  // exhausted it — carrying it into a URL the user just asked for would make that
+  // navigation's first transient failure terminal. Deliberately done in the
+  // action handlers rather than an effect on `currentUrl`: the error document's
+  // own history update must not replenish anything.
   const handleNavigate = useCallback(
     (rawUrl: string) => {
       const normalized = normalizeBrowserUrl(rawUrl);
       if (normalized.url) {
+        clearRetryState();
         // Push history only; the imperative navigation effect drives loadURL now
         // that `src` is seed-only (#9940). Mirrors handleBack/handleForward.
         setHistory((prev) => pushBrowserHistory(prev, normalized.url!));
       }
     },
-    [setHistory]
+    [clearRetryState, setHistory]
   );
 
   const handleBack = useCallback(() => {
     if (canGoBack) {
+      clearRetryState();
       setHistory((prev) => goBackBrowserHistory(prev));
     }
-  }, [canGoBack, setHistory]);
+  }, [canGoBack, clearRetryState, setHistory]);
 
   const handleForward = useCallback(() => {
     if (canGoForward) {
+      clearRetryState();
       setHistory((prev) => goForwardBrowserHistory(prev));
     }
-  }, [canGoForward, setHistory]);
+  }, [canGoForward, clearRetryState, setHistory]);
 
   // A user-initiated reload is a fresh attempt: hand back the retry budget. Load
   // start no longer refills it on its own, so without this an exhausted panel would

--- a/src/components/DevPreview/useDevPreviewNavigation.ts
+++ b/src/components/DevPreview/useDevPreviewNavigation.ts
@@ -111,9 +111,15 @@ export function useDevPreviewNavigation({
       ? computeDevServerUrl(devServerUrl, currentUrl, proxyOrigin)
       : false;
     if (nextUrl !== false) {
+      // Adopting a different dev-server target (legacy mode follows the upstream
+      // port in place). The budget belongs to the target that exhausted it, so
+      // hand it back before the imperative effect loads the new one (#12296).
+      if (nextUrl !== currentUrl) {
+        clearRetryState();
+      }
       setHistory((prev) => pushBrowserHistory(prev, nextUrl));
     }
-  }, [devServerUrl, currentUrl, isUnconfigured, proxyOrigin, setHistory]);
+  }, [devServerUrl, currentUrl, isUnconfigured, proxyOrigin, clearRetryState, setHistory]);
 
   useEffect(() => {
     if (isUnconfigured) return;
@@ -140,13 +146,19 @@ export function useDevPreviewNavigation({
     (rawUrl: string) => {
       const normalized = normalizeBrowserUrl(rawUrl);
       if (normalized.url) {
-        clearRetryState();
+        // Only when the target actually changes. Re-submitting the URL already
+        // showing pushes no history and starts no load, so resetting here would
+        // drop the in-flight document's latches with nothing to re-establish
+        // them — silently cancelling a 502's overlay and its auto-recovery.
+        if (normalized.url !== currentUrl) {
+          clearRetryState();
+        }
         // Push history only; the imperative navigation effect drives loadURL now
         // that `src` is seed-only (#9940). Mirrors handleBack/handleForward.
         setHistory((prev) => pushBrowserHistory(prev, normalized.url!));
       }
     },
-    [clearRetryState, setHistory]
+    [currentUrl, clearRetryState, setHistory]
   );
 
   const handleBack = useCallback(() => {


### PR DESCRIPTION
## Summary

This fixes four defects in the Dev Preview webview load lifecycle, all reported in issue #12296 and all traceable to the same root cause: nothing was tracking which document a lifecycle event belonged to, so events fired for Chromium's own internal error page were being read as evidence about the requested URL.

Resolves #12296

## Changes

- **Swallowed load failures.** A new `pendingNetErrorRef` latch is set in `did-fail-load` and checked in `did-finish-load` and `did-navigate`, so the error document's own `dom-ready` and `did-finish-load` events no longer clear the loading overlay. `did-start-loading` also stopped resetting `failLoadRetryCountRef`, so the retry budget of 5 attempts was never actually reachable. It now mirrors the existing `proxyRetryCountRef` pattern.
- **One finish boundary.** `dom-ready` now clears both the blocking loading overlay and the load watchdog. A hanging image or iframe still exposes the usable document, while a hanging main document, script, or stylesheet still trips the configured timeout.
- **Proxy provenance instead of a status heuristic.** `send502` stamps a custom HTTP/1.1 reason phrase (`DEV_PREVIEW_PROXY_STATUS_TEXT` in `shared/utils/devPreviewProxy.ts`) that the renderer reads from `did-frame-navigate`'s existing `httpStatusText` field, so an application's own 502 renders normally instead of hiding behind the outage overlay. Deliberately not widened to any 5xx status.
- **Recovery that can't silently no-op.** `performReload` no longer bails out when the webview isn't ready yet, which is exactly the state of a renderer that crashed before its first `dom-ready`, and now returns whether recovery was actually initiated. `handleHardReload` only clears the crash banner once recovery is confirmed initiated. Readiness now routes between the cache-ignoring reload IPC and a direct guest call, falling back to a keyed remount. Explicit navigation (toolbar URL entry, back, forward, dev server URL adoption) resets the retry budget, but only when the navigation target actually changes, so a same-URL resubmit doesn't drop a committed 502's latches.

Files touched: `src/components/DevPreview/useDevPreviewLoadLifecycle.ts`, `src/components/DevPreview/DevPreviewPane.tsx`, `src/components/DevPreview/useDevPreviewNavigation.ts`, `shared/utils/devPreviewProxy.ts`, `electron/services/DevPreviewProxyService.ts`, plus three test files.

## Testing

516 tests pass across the Dev Preview test suites plus the proxy service and shared proxy-util suites. A full TypeScript typecheck is clean. `eslint` and `prettier` are clean on all changed files.

New tests cover the issue's exact captured event sequence (with no `did-navigate` at all), retry exhaustion (including the intervening `did-start-loading` events the old tests omitted), retry destinations as well as call counts, recovery when the server comes back up mid-loop, cancellation on fresh navigation and on panel close, an application 502 staying inspectable, and reload after a crash before first `dom-ready` reaching the guest.

Also checked the lint ratchet: the changed files carry fewer `no-unsafe-type-assertion` warnings than the base branch, so no baseline update is needed.

Deliberately didn't add end-to-end coverage with real hanging-subresource fixtures. Those only run when explicitly requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014oAsAqgHQqPFb4YS8GPZhe
