### PR TITLE
fix(github): keep the dropdown skeleton in sync with the row

### DIFF
--- a/plugins/builtin/github/renderer/__tests__/GitHubDropdownSkeletons.test.tsx
+++ b/plugins/builtin/github/renderer/__tests__/GitHubDropdownSkeletons.test.tsx
@@ -6,7 +6,10 @@ import { render, act } from "@testing-library/react";
 import {
   GitHubResourceListSkeleton,
   CommitListSkeleton,
+  ForgeOptionRowsSkeleton,
+  FORGE_OPTION_ROW,
   RESOURCE_ITEM_HEIGHT_PX,
+  RESOURCE_RAIL_SLOTS,
   COMMIT_ITEM_HEIGHT_PX,
   MAX_SKELETON_ITEMS,
 } from "../components/GitHubDropdownSkeletons";
@@ -84,6 +87,21 @@ describe("GitHubResourceListSkeleton", () => {
     expect(status?.getAttribute("aria-label")).toBe("Loading GitHub results");
   });
 
+  it("hands the rows the type it was given, which they need to pick a rail", () => {
+    // The panel skeleton took `type` for its tabs and search copy and then
+    // dropped it, so a PR panel drew an issue's rail under a PR's header.
+    for (const type of ["issue", "pr"] as const) {
+      const { container, unmount } = render(<GitHubResourceListSkeleton count={1} type={type} />);
+      const ids = Array.from(container.querySelectorAll("[data-rail-slot]")).map((slot) =>
+        slot.getAttribute("data-rail-slot")
+      );
+      expect(ids).toEqual(
+        RESOURCE_RAIL_SLOTS[type].filter((slot) => slot.bone).map((slot) => slot.id)
+      );
+      unmount();
+    }
+  });
+
   it("reserves every header icon slot the loaded list renders", () => {
     // Refresh, sort and bulk-select. One slot short and the search field
     // jumps narrower the moment real content replaces this.
@@ -137,5 +155,35 @@ describe("CommitListSkeleton", () => {
     const status = container.querySelector('[role="status"]');
     expect(status).not.toBeNull();
     expect(status?.getAttribute("aria-label")).toBe("Loading commits");
+  });
+});
+
+describe("ForgeOptionRowsSkeleton", () => {
+  it("draws the option row's own geometry, not the 64px resource row", () => {
+    // `IssueSelector` borrowed the resource skeleton for a single-line popover
+    // option, so its list collapsed to a third the height when issues landed.
+    const { container } = render(<ForgeOptionRowsSkeleton count={3} />);
+    const rows = container.querySelectorAll('[aria-hidden="true"] > div');
+    expect(rows).toHaveLength(3);
+    for (const row of rows) {
+      for (const token of FORGE_OPTION_ROW.split(" ")) {
+        expect(row.className).toContain(token);
+      }
+      expect(row.getAttribute("style")).toBeNull();
+    }
+  });
+
+  it("clamps its count the way every other skeleton here does", () => {
+    const { container } = render(<ForgeOptionRowsSkeleton count={99} />);
+    expect(container.querySelectorAll('[aria-hidden="true"] > div')).toHaveLength(
+      MAX_SKELETON_ITEMS
+    );
+  });
+
+  it("pulses immediately when the caller already knows the wait is long", () => {
+    const { container } = render(<ForgeOptionRowsSkeleton count={1} immediate />);
+    const row = container.querySelector('[aria-hidden="true"] > div');
+    expect(row?.className).toContain("animate-pulse-immediate");
+    expect(row?.className).not.toContain("animate-pulse-delayed");
   });
 });

--- a/plugins/builtin/github/renderer/__tests__/GitHubDropdownSkeletons.test.tsx
+++ b/plugins/builtin/github/renderer/__tests__/GitHubDropdownSkeletons.test.tsx
@@ -7,9 +7,11 @@ import {
   GitHubResourceListSkeleton,
   CommitListSkeleton,
   ForgeOptionRowsSkeleton,
+  FORGE_OPTION_LINE,
   FORGE_OPTION_ROW,
   RESOURCE_ITEM_HEIGHT_PX,
-  RESOURCE_RAIL_SLOTS,
+  RESOURCE_RAIL_ORDER,
+  RESOURCE_RAIL_SLOT,
   COMMIT_ITEM_HEIGHT_PX,
   MAX_SKELETON_ITEMS,
 } from "../components/GitHubDropdownSkeletons";
@@ -95,9 +97,7 @@ describe("GitHubResourceListSkeleton", () => {
       const ids = Array.from(container.querySelectorAll("[data-rail-slot]")).map((slot) =>
         slot.getAttribute("data-rail-slot")
       );
-      expect(ids).toEqual(
-        RESOURCE_RAIL_SLOTS[type].filter((slot) => slot.bone).map((slot) => slot.id)
-      );
+      expect(ids).toEqual(RESOURCE_RAIL_ORDER[type].filter((id) => RESOURCE_RAIL_SLOT[id].bone));
       unmount();
     }
   });
@@ -166,10 +166,13 @@ describe("ForgeOptionRowsSkeleton", () => {
     const rows = container.querySelectorAll('[aria-hidden="true"] > div');
     expect(rows).toHaveLength(3);
     for (const row of rows) {
-      for (const token of FORGE_OPTION_ROW.split(" ")) {
-        expect(row.className).toContain(token);
-      }
+      expectTokens(row, FORGE_OPTION_ROW);
+      // No inline height: the option sizes to its own content, unlike the
+      // 64px resource row this used to borrow.
       expect(row.getAttribute("style")).toBeNull();
+      // The line box the loaded option gets from `text-sm` and a bone has
+      // none of. Without it every row comes up 4px short.
+      expectTokens(row.querySelector("[data-option-line]")!, FORGE_OPTION_LINE);
     }
   });
 
@@ -187,3 +190,11 @@ describe("ForgeOptionRowsSkeleton", () => {
     expect(row?.className).not.toContain("animate-pulse-delayed");
   });
 });
+
+/** Whole tokens only — a substring check would accept `w-40` for `w-4`. */
+function expectTokens(el: Element, classes: string) {
+  const present = Array.from(el.classList);
+  for (const token of classes.split(" ").filter(Boolean)) {
+    expect(present).toContain(token);
+  }
+}

--- a/plugins/builtin/github/renderer/__tests__/GitHubListItem.test.tsx
+++ b/plugins/builtin/github/renderer/__tests__/GitHubListItem.test.tsx
@@ -5,6 +5,12 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, act, cleanup } from "@testing-library/react";
 import { Activity, type ReactNode } from "react";
 import { GitHubListItem } from "../components/GitHubListItem";
+import {
+  GitHubResourceRowsSkeleton,
+  RESOURCE_RAIL_SLOTS,
+  RESOURCE_ROW_STATE_MARK,
+  RESOURCE_STATE_BONE,
+} from "../components/GitHubDropdownSkeletons";
 import type { Issue, PR } from "@shared/types/forge";
 import type { Worktree } from "@shared/types/worktree";
 import { actionService } from "@/services/ActionService";
@@ -887,5 +893,94 @@ describe("GitHubListItem", () => {
   it("names a draft pull request's state, which only its glyph carried", () => {
     render(<GitHubListItem item={{ ...basePR, isDraft: true }} type="pr" />);
     expect(screen.getAllByLabelText("Draft pull request").length).toBeGreaterThan(0);
+  });
+});
+
+/**
+ * The skeleton and the row are two drawings of one layout, and for three
+ * releases only one of them was maintained: #12294. `RESOURCE_RAIL_SLOTS` is
+ * now the single list of what the rail holds, so these read it rather than
+ * restating it — a test that pastes its own copy of the answer is just a third
+ * copy that drifts.
+ */
+describe("skeleton/row parity (#12294)", () => {
+  const railSlotIds = (root: HTMLElement): (string | null)[] =>
+    Array.from(root.querySelector("[data-rail]")?.children ?? []).map((child) =>
+      child.getAttribute("data-rail-slot")
+    );
+
+  const railSlotClasses = (root: HTMLElement): Record<string, string> =>
+    Object.fromEntries(
+      Array.from(root.querySelectorAll("[data-rail-slot]")).map((slot) => [
+        slot.getAttribute("data-rail-slot"),
+        slot.className,
+      ])
+    );
+
+  /** A row of each type carrying every slot its rail can draw. */
+  const maximal = {
+    issue: (
+      <GitHubListItem
+        item={{
+          ...baseIssue,
+          assignees: [
+            { login: "alice", avatarUrl: "a.png", rawData: null },
+            { login: "bob", avatarUrl: "b.png", rawData: null },
+          ],
+        }}
+        type="issue"
+      />
+    ),
+    pr: <GitHubListItem item={{ ...basePR, ciStatus: "success" }} type="pr" />,
+  } as const;
+
+  for (const type of ["issue", "pr"] as const) {
+    it(`renders every ${type} rail slot the shared list names, in that order`, () => {
+      const { container } = render(maximal[type]);
+      expect(railSlotIds(container)).toEqual(RESOURCE_RAIL_SLOTS[type].map((slot) => slot.id));
+    });
+
+    it(`reserves the ${type} slots the loading row can reserve, at the row's own widths`, () => {
+      const row = render(maximal[type]);
+      const rowClasses = railSlotClasses(row.container);
+      row.unmount();
+
+      const { container } = render(<GitHubResourceRowsSkeleton count={1} type={type} />);
+      const reserved = RESOURCE_RAIL_SLOTS[type].filter((slot) => slot.bone);
+
+      expect(railSlotIds(container)).toEqual(reserved.map((slot) => slot.id));
+      for (const slot of reserved) {
+        // The box the row holds open, drawn by the loading row too — not a
+        // literal either file gets to change on its own.
+        for (const token of slot.box.split(" ")) {
+          expect(rowClasses[slot.id]).toContain(token);
+          expect(railSlotClasses(container)[slot.id]).toContain(token);
+        }
+      }
+    });
+
+    it(`places the ${type} state mark where the loaded row places it`, () => {
+      const row = render(maximal[type]);
+      const mark =
+        row.container.querySelector('[role="img"][aria-label$="request"]') ??
+        row.container.querySelector('[role="img"][aria-label$="issue"]');
+      for (const token of RESOURCE_ROW_STATE_MARK.split(" ")) {
+        expect(mark?.className).toContain(token);
+      }
+      row.unmount();
+
+      const { container } = render(<GitHubResourceRowsSkeleton count={1} type={type} />);
+      const bone = container.querySelector(".bg-muted")!;
+      for (const token of RESOURCE_ROW_STATE_MARK.split(" ")) {
+        expect(bone.className).toContain(token);
+      }
+      // An issue's mark is a circle and a PR's never is, so the loading mark
+      // must not draw the other one's shape.
+      expect(bone.className).toContain(RESOURCE_STATE_BONE[type]);
+    });
+  }
+
+  it("draws a different state-mark shape for each type", () => {
+    expect(RESOURCE_STATE_BONE.issue).not.toBe(RESOURCE_STATE_BONE.pr);
   });
 });

--- a/plugins/builtin/github/renderer/__tests__/GitHubListItem.test.tsx
+++ b/plugins/builtin/github/renderer/__tests__/GitHubListItem.test.tsx
@@ -7,7 +7,11 @@ import { Activity, type ReactNode } from "react";
 import { GitHubListItem } from "../components/GitHubListItem";
 import {
   GitHubResourceRowsSkeleton,
-  RESOURCE_RAIL_SLOTS,
+  RAIL_SLOT,
+  RESOURCE_ITEM_HEIGHT_PX,
+  RESOURCE_RAIL,
+  RESOURCE_RAIL_ORDER,
+  RESOURCE_RAIL_SLOT,
   RESOURCE_ROW_STATE_MARK,
   RESOURCE_STATE_BONE,
 } from "../components/GitHubDropdownSkeletons";
@@ -898,89 +902,137 @@ describe("GitHubListItem", () => {
 
 /**
  * The skeleton and the row are two drawings of one layout, and for three
- * releases only one of them was maintained: #12294. `RESOURCE_RAIL_SLOTS` is
- * now the single list of what the rail holds, so these read it rather than
- * restating it — a test that pastes its own copy of the answer is just a third
- * copy that drifts.
+ * releases only one of them was maintained: #12294. `RESOURCE_RAIL_SLOT` and
+ * `RESOURCE_RAIL_ORDER` are now the single answer to what the rail holds, so
+ * these read them rather than restating them — a test that pastes its own copy
+ * of the answer is just a third copy that drifts.
  */
 describe("skeleton/row parity (#12294)", () => {
-  const railSlotIds = (root: HTMLElement): (string | null)[] =>
-    Array.from(root.querySelector("[data-rail]")?.children ?? []).map((child) =>
-      child.getAttribute("data-rail-slot")
-    );
+  const railOf = (root: HTMLElement): HTMLElement => {
+    const rails = root.querySelectorAll("[data-rail]");
+    // One rail per row. Scoping to it keeps a nested marker from standing in
+    // for the real slot and masking a wrong box on the one that lays out.
+    expect(rails).toHaveLength(1);
+    return rails[0] as HTMLElement;
+  };
 
-  const railSlotClasses = (root: HTMLElement): Record<string, string> =>
-    Object.fromEntries(
-      Array.from(root.querySelectorAll("[data-rail-slot]")).map((slot) => [
-        slot.getAttribute("data-rail-slot"),
-        slot.className,
-      ])
+  /** The rail's DIRECT children — anything deeper is content, not a slot. */
+  const slotsOf = (root: HTMLElement): Map<string | null, Element> => {
+    const entries = Array.from(railOf(root).children).map(
+      (child) => [child.getAttribute("data-rail-slot"), child] as const
     );
+    expect(new Set(entries.map(([id]) => id)).size).toBe(entries.length);
+    return new Map(entries);
+  };
+
+  const slotIds = (root: HTMLElement): (string | null)[] =>
+    Array.from(railOf(root).children).map((child) => child.getAttribute("data-rail-slot"));
+
+  /** Whole tokens only — `toContain` on the string would accept `w-40` for `w-4`. */
+  const expectTokens = (el: Element, classes: string) => {
+    const present = Array.from(el.classList);
+    for (const token of classes.split(" ").filter(Boolean)) {
+      expect(present).toContain(token);
+    }
+  };
+
+  const skeleton = (type: "issue" | "pr") =>
+    render(<GitHubResourceRowsSkeleton count={1} type={type} />);
 
   /** A row of each type carrying every slot its rail can draw. */
-  const maximal = {
-    issue: (
+  const maximal: { issue: Issue; pr: PR } = {
+    issue: {
+      ...baseIssue,
+      assignees: [
+        { login: "alice", avatarUrl: "a.png", rawData: null },
+        { login: "bob", avatarUrl: "b.png", rawData: null },
+      ],
+    },
+    pr: { ...basePR, ciStatus: "success" },
+  };
+
+  const loaded = (type: "issue" | "pr", extra: Record<string, unknown> = {}) =>
+    render(
       <GitHubListItem
-        item={{
-          ...baseIssue,
-          assignees: [
-            { login: "alice", avatarUrl: "a.png", rawData: null },
-            { login: "bob", avatarUrl: "b.png", rawData: null },
-          ],
-        }}
-        type="issue"
+        item={maximal[type]}
+        type={type}
+        worktree={makeWorktree({ [type === "issue" ? "issueNumber" : "prNumber"]: 1 })}
+        {...extra}
       />
-    ),
-    pr: <GitHubListItem item={{ ...basePR, ciStatus: "success" }} type="pr" />,
-  } as const;
+    );
 
   for (const type of ["issue", "pr"] as const) {
-    it(`renders every ${type} rail slot the shared list names, in that order`, () => {
-      const { container } = render(maximal[type]);
-      expect(railSlotIds(container)).toEqual(RESOURCE_RAIL_SLOTS[type].map((slot) => slot.id));
+    const order = RESOURCE_RAIL_ORDER[type];
+
+    it(`renders every ${type} rail slot the shared order names, and nothing else`, () => {
+      expect(slotIds(loaded(type).container)).toEqual([...order]);
     });
 
-    it(`reserves the ${type} slots the loading row can reserve, at the row's own widths`, () => {
-      const row = render(maximal[type]);
-      const rowClasses = railSlotClasses(row.container);
-      row.unmount();
+    it(`keeps the ${type} menu last, so the identity column cannot slide`, () => {
+      // Everything of variable width sits to the LEFT of the identity slot,
+      // which sits immediately before the always-present menu. Reordering the
+      // count past the menu keeps the old adjacency test green but moves the
+      // avatar column the moment a count appears.
+      expect(order[order.length - 1]).toBe("menu");
+      expect(order.indexOf("menu")).toBe(order.length - 1);
+    });
 
-      const { container } = render(<GitHubResourceRowsSkeleton count={1} type={type} />);
-      const reserved = RESOURCE_RAIL_SLOTS[type].filter((slot) => slot.bone);
+    it(`reserves every fixed-width ${type} slot at the row's own box`, () => {
+      const rowSlots = slotsOf(loaded(type).container);
+      const boneSlots = slotsOf(skeleton(type).container);
 
-      expect(railSlotIds(container)).toEqual(reserved.map((slot) => slot.id));
-      for (const slot of reserved) {
-        // The box the row holds open, drawn by the loading row too — not a
-        // literal either file gets to change on its own.
-        for (const token of slot.box.split(" ")) {
-          expect(rowClasses[slot.id]).toContain(token);
-          expect(railSlotClasses(container)[slot.id]).toContain(token);
+      for (const id of order) {
+        const slot = RESOURCE_RAIL_SLOT[id];
+        if (!slot.box) {
+          // Nothing to hold open: its width is whatever it ends up carrying.
+          expect(slot.bone).toBeNull();
+          expect(boneSlots.has(id)).toBe(false);
+          continue;
         }
+        // A slot with a fixed width MUST be reserved. Deriving this from the
+        // box rather than from `bone` is the point — reading `bone` on both
+        // sides would let deleting one delete the expectation that caught it.
+        expect(slot.bone).not.toBeNull();
+        expectTokens(rowSlots.get(id)!, `${RAIL_SLOT} ${slot.box}`);
+        expectTokens(boneSlots.get(id)!, `${RAIL_SLOT} ${slot.box}`);
       }
     });
 
-    it(`places the ${type} state mark where the loaded row places it`, () => {
-      const row = render(maximal[type]);
-      const mark =
-        row.container.querySelector('[role="img"][aria-label$="request"]') ??
-        row.container.querySelector('[role="img"][aria-label$="issue"]');
-      for (const token of RESOURCE_ROW_STATE_MARK.split(" ")) {
-        expect(mark?.className).toContain(token);
-      }
-      row.unmount();
+    it(`spaces the ${type} rail identically on both sides`, () => {
+      expectTokens(railOf(loaded(type).container), RESOURCE_RAIL);
+      expectTokens(railOf(skeleton(type).container), RESOURCE_RAIL);
+    });
 
-      const { container } = render(<GitHubResourceRowsSkeleton count={1} type={type} />);
-      const bone = container.querySelector(".bg-muted")!;
-      for (const token of RESOURCE_ROW_STATE_MARK.split(" ")) {
-        expect(bone.className).toContain(token);
+    it(`places the ${type} state mark where every loaded branch places it`, () => {
+      // The dropdown always passes `onToggleSelect`, so the selection wrapper
+      // is the branch that actually ships — testing only the other one would
+      // have missed the offset this issue was filed for.
+      for (const extra of [{}, { onToggleSelect: vi.fn() }]) {
+        const row = loaded(type, extra);
+        expectTokens(row.container.querySelector("[data-state-mark]")!, RESOURCE_ROW_STATE_MARK);
+        row.unmount();
       }
-      // An issue's mark is a circle and a PR's never is, so the loading mark
-      // must not draw the other one's shape.
-      expect(bone.className).toContain(RESOURCE_STATE_BONE[type]);
+
+      const bone = skeleton(type).container.querySelector("[data-state-mark]")!;
+      expectTokens(bone, RESOURCE_ROW_STATE_MARK);
+      expectTokens(bone, RESOURCE_STATE_BONE[type]);
+    });
+
+    it(`draws both ${type} rows to the height Virtuoso lays them out on`, () => {
+      const row = loaded(type).container.querySelector("[role='row']") as HTMLElement;
+      expect(row.style.height).toBe(`${RESOURCE_ITEM_HEIGHT_PX}px`);
+      const bone = skeleton(type).container.querySelector(
+        '[aria-hidden="true"] > div'
+      ) as HTMLElement;
+      expect(bone.style.height).toBe(`${RESOURCE_ITEM_HEIGHT_PX}px`);
     });
   }
 
-  it("draws a different state-mark shape for each type", () => {
-    expect(RESOURCE_STATE_BONE.issue).not.toBe(RESOURCE_STATE_BONE.pr);
+  it("draws the loading mark round only for the type whose glyph is round", () => {
+    // Anchored to the glyphs, not to each other: `CircleDot`/`CheckCircle2`
+    // are circles and none of `getPrStateGlyph`'s four are, so asserting only
+    // that the two differ would be satisfied by swapping them.
+    expect(RESOURCE_STATE_BONE.issue).toBe("rounded-full");
+    expect(RESOURCE_STATE_BONE.pr).not.toBe("rounded-full");
   });
 });

--- a/plugins/builtin/github/renderer/__tests__/GitHubResourceList.swr.test.tsx
+++ b/plugins/builtin/github/renderer/__tests__/GitHubResourceList.swr.test.tsx
@@ -186,11 +186,22 @@ vi.mock("framer-motion", () => {
   };
 });
 
-vi.mock("../components/GitHubDropdownSkeletons", () => ({
-  GitHubResourceRowsSkeleton: () => <div data-testid="skeleton">Loading...</div>,
-  MAX_SKELETON_ITEMS: 6,
-  RESOURCE_ITEM_HEIGHT_PX: 68,
-}));
+vi.mock("../components/GitHubDropdownSkeletons", async () => {
+  const actual = await vi.importActual<typeof import("../components/GitHubDropdownSkeletons")>(
+    "../components/GitHubDropdownSkeletons"
+  );
+  return {
+    ...actual,
+    // Flattened to a marker: these tests are about when the list loads, not
+    // what a row looks like. The real constants stay — a mocked copy of the
+    // row height is one more thing to drift, and this one already had.
+    GitHubResourceRowsSkeleton: ({ type }: { type: "issue" | "pr" }) => (
+      <div data-testid="skeleton" data-type={type}>
+        Loading...
+      </div>
+    ),
+  };
+});
 
 vi.mock("react-virtuoso", () => ({
   Virtuoso: ({
@@ -520,6 +531,18 @@ describe("GitHubResourceList SWR behavior", () => {
     render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
 
     expect(screen.getByTestId("skeleton")).toBeTruthy();
+  });
+
+  it("tells the skeleton which resource it is loading (#12294)", async () => {
+    // The rail an issue reserves is not the one a PR reserves, so a skeleton
+    // that is not told the type cannot reserve either of them correctly.
+    mockListIssues.mockImplementation(
+      () => new Promise((resolve) => setTimeout(() => resolve(makeResponse([makeIssue(1)])), 100))
+    );
+
+    render(<GitHubResourceList type="pr" projectPath="/test/proj" />);
+
+    expect(screen.getByTestId("skeleton").getAttribute("data-type")).toBe("pr");
   });
 
   it("shows cached data immediately on warm remount (no skeleton)", async () => {

--- a/plugins/builtin/github/renderer/__tests__/GitHubResourceList.swr.test.tsx
+++ b/plugins/builtin/github/renderer/__tests__/GitHubResourceList.swr.test.tsx
@@ -533,17 +533,32 @@ describe("GitHubResourceList SWR behavior", () => {
     expect(screen.getByTestId("skeleton")).toBeTruthy();
   });
 
-  it("tells the skeleton which resource it is loading (#12294)", async () => {
-    // The rail an issue reserves is not the one a PR reserves, so a skeleton
-    // that is not told the type cannot reserve either of them correctly.
-    mockListIssues.mockImplementation(
-      () => new Promise((resolve) => setTimeout(() => resolve(makeResponse([makeIssue(1)])), 100))
-    );
+  it.each(["issue", "pr"] as const)(
+    "tells the skeleton it is loading %s (#12294)",
+    async (type) => {
+      // The rail an issue reserves is not the one a PR reserves, so a skeleton
+      // that is not told the type cannot reserve either of them correctly.
+      // Both types run: hardcoding one at the call site would pass a test that
+      // only ever asked for the other.
+      const fetcher = type === "issue" ? mockListIssues : mockListPRs;
+      let release!: (page: Page<Issue>) => void;
+      fetcher.mockImplementation(
+        () =>
+          new Promise<Page<Issue>>((resolve) => {
+            release = resolve;
+          })
+      );
 
-    render(<GitHubResourceList type="pr" projectPath="/test/proj" />);
+      render(<GitHubResourceList type={type} projectPath="/test/proj" />);
 
-    expect(screen.getByTestId("skeleton").getAttribute("data-type")).toBe("pr");
-  });
+      await waitFor(() => expect(fetcher).toHaveBeenCalled());
+      expect(screen.getByTestId("skeleton").getAttribute("data-type")).toBe(type);
+
+      // Settle it: a request left pending outlives the test and surfaces as an
+      // unhandled rejection in whichever file happens to run next.
+      await act(async () => release(makeResponse([makeIssue(1)])));
+    }
+  );
 
   it("shows cached data immediately on warm remount (no skeleton)", async () => {
     const cacheKey = buildCacheKey("/test/proj", "issue", "open", "created");

--- a/plugins/builtin/github/renderer/__tests__/IssueSelector.test.tsx
+++ b/plugins/builtin/github/renderer/__tests__/IssueSelector.test.tsx
@@ -5,6 +5,7 @@ import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from "vite
 import { render, screen, waitFor, act, fireEvent } from "@testing-library/react";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { IssueSelector } from "../components/IssueSelector";
+import { FORGE_OPTION_ROW } from "../components/GitHubDropdownSkeletons";
 import type { Issue } from "@shared/types/forge";
 
 const mockListIssues = vi.fn();
@@ -86,7 +87,16 @@ describe("IssueSelector", () => {
     });
     // Skeleton rows are aria-hidden, should be present
     const listbox = screen.getByRole("listbox");
-    expect(listbox.querySelectorAll('[aria-hidden="true"] > div').length).toBeGreaterThan(0);
+    const skeletonRows = listbox.querySelectorAll('[aria-hidden="true"] > div');
+    expect(skeletonRows.length).toBeGreaterThan(0);
+    // And they are this popover's single-line option, not the dropdown's 64px
+    // two-line resource row this used to borrow (#12294).
+    for (const row of skeletonRows) {
+      for (const token of FORGE_OPTION_ROW.split(" ")) {
+        expect(row.className).toContain(token);
+      }
+      expect(row.getAttribute("style")).toBeNull();
+    }
 
     // Resolve the promise
     await act(async () => resolvePromise({ items: [mockIssue()] }));

--- a/plugins/builtin/github/renderer/__tests__/IssueSelector.test.tsx
+++ b/plugins/builtin/github/renderer/__tests__/IssueSelector.test.tsx
@@ -91,9 +91,11 @@ describe("IssueSelector", () => {
     expect(skeletonRows.length).toBeGreaterThan(0);
     // And they are this popover's single-line option, not the dropdown's 64px
     // two-line resource row this used to borrow (#12294).
+    expect(skeletonRows).toHaveLength(3);
     for (const row of skeletonRows) {
-      for (const token of FORGE_OPTION_ROW.split(" ")) {
-        expect(row.className).toContain(token);
+      const present = Array.from(row.classList);
+      for (const token of FORGE_OPTION_ROW.split(" ").filter(Boolean)) {
+        expect(present).toContain(token);
       }
       expect(row.getAttribute("style")).toBeNull();
     }

--- a/plugins/builtin/github/renderer/components/GitHubDropdownSkeletons.tsx
+++ b/plugins/builtin/github/renderer/components/GitHubDropdownSkeletons.tsx
@@ -22,50 +22,52 @@ export const MAX_SKELETON_ITEMS = 6;
  */
 export const RESOURCE_ROW_STATE_MARK = "shrink-0 mt-1";
 
+/** The trailing rail itself, so neither side can respace it on its own. */
+export const RESOURCE_RAIL = "flex items-center gap-1.5 shrink-0";
+
 /** The trailing rail's shared slot frame, so rows share a right edge. */
 export const RAIL_SLOT = "shrink-0 flex items-center justify-center";
 
-export interface ResourceRailSlot {
-  id: "count" | "assignee" | "ci" | "menu";
-  /** The box the slot holds open. Empty when its width is its own content. */
-  box: string;
-  /** The bone the skeleton draws, absent for a slot it cannot reserve. */
-  bone?: string;
-}
+/**
+ * Every slot the trailing rail can hold, and the only definition of each.
+ *
+ * `box` is the width the slot holds open; `bone` is what the loading row draws
+ * inside it. A slot whose width is whatever it happens to contain carries an
+ * empty `box` and no `bone` — there is no fixed width there to reserve.
+ */
+export const RESOURCE_RAIL_SLOT = {
+  count: { box: "", bone: null },
+  assignee: { box: "w-4", bone: "w-4 h-4 rounded-full" },
+  ci: { box: "w-4 h-3.5", bone: "w-3.5 h-3.5 rounded-full" },
+  // `rounded-lg` is what a bare `rounded` already renders here — the design
+  // contract overrides `--radius` — named so the step is legible, and so the
+  // class stays visible to `component-contract/no-raw-radius`, which does not
+  // resolve identifiers and so cannot see into this table.
+  menu: { box: "w-6 h-6 -me-1", bone: "w-6 h-6 rounded-lg" },
+} as const satisfies Record<string, { box: string; bone: string | null }>;
+
+export type ResourceRailSlotId = keyof typeof RESOURCE_RAIL_SLOT;
 
 /**
- * The trailing rail, in render order, per resource type — every slot the row
- * can draw, whether or not the skeleton reserves it.
+ * The rail in render order, per resource type — every slot the row can draw,
+ * whether or not the loading row reserves it.
  *
  * The rail is strictly type-partitioned: `GitHubListItem` empties `assignees`
  * for a PR and gates the check glyph on the item being one, so neither type
  * ever draws the other's slots.
  *
- * `count` carries no bone. It has no fixed width and needs a second assignee
- * to appear at all, so reserving it would cost every title the space of a
- * count most rows never show. It stays in the list because its position is the
- * invariant that keeps avatars in one column — variable width to the LEFT of
- * the fixed identity slot — and because a rail child registered nowhere is
- * exactly how this drifted before.
+ * `count` is listed but never reserved. It has no fixed width and needs a
+ * second assignee to appear at all, so holding a box open for it would cost
+ * every title the space of a count most rows never show. It stays in the order
+ * because its position is the invariant that keeps avatars in one column —
+ * variable width to the LEFT of the fixed identity slot, which is itself
+ * immediately before the always-present menu — and because a rail child
+ * registered nowhere is exactly how this drifted in the first place.
  */
-export const RESOURCE_RAIL_SLOTS: Record<"issue" | "pr", readonly ResourceRailSlot[]> = {
-  issue: [
-    { id: "count", box: "" },
-    { id: "assignee", box: "w-4", bone: "w-4 h-4 rounded-full" },
-    { id: "menu", box: "w-6 h-6 -me-1", bone: "w-6 h-6 rounded" },
-  ],
-  pr: [
-    { id: "ci", box: "w-4 h-3.5", bone: "w-3.5 h-3.5 rounded-full" },
-    { id: "menu", box: "w-6 h-6 -me-1", bone: "w-6 h-6 rounded" },
-  ],
-};
-
-/** Each slot's box by id, for the row that draws one slot at a time. */
-export const RESOURCE_RAIL_SLOT_BOX = {
-  assignee: "w-4",
-  ci: "w-4 h-3.5",
-  menu: "w-6 h-6 -me-1",
-} as const;
+export const RESOURCE_RAIL_ORDER = {
+  issue: ["count", "assignee", "menu"],
+  pr: ["ci", "menu"],
+} as const satisfies Record<"issue" | "pr", readonly ResourceRailSlotId[]>;
 
 /**
  * An issue's state mark is a circle (`CircleDot`/`CheckCircle2`); a PR's never
@@ -84,6 +86,13 @@ export const RESOURCE_STATE_BONE = {
  */
 export const FORGE_OPTION_ROW =
   "flex items-center gap-2 px-2 py-1.5 text-sm rounded-[var(--radius-sm)] border border-transparent";
+
+/**
+ * The 20px line box `text-sm` gives the loaded option's text. A bone has no
+ * line box of its own, so the loading row has to stand one up or every row
+ * comes up 4px short of the option it stands in for.
+ */
+export const FORGE_OPTION_LINE = "h-5 flex items-center flex-1 min-w-0";
 
 function normalizeCount(count?: number | null): number {
   if (count == null || !Number.isFinite(count)) return MAX_SKELETON_ITEMS;
@@ -221,27 +230,26 @@ export function GitHubResourceRowsSkeleton({ count, immediate, type }: ResourceR
           style={{ height: `${RESOURCE_ITEM_HEIGHT_PX}px` }}
         >
           <div
+            data-state-mark
             className={cn("w-4 h-4 bg-muted", RESOURCE_ROW_STATE_MARK, RESOURCE_STATE_BONE[type])}
           />
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-2 h-6">
               <div className="h-4 bg-muted rounded flex-1" />
-              {/* Every rail slot the loaded row reserves, from the one list
+              {/* Every rail slot the loaded row reserves, from the one order
                   that names them. One short and the title bar jumps the
                   moment data lands — which is the bug this row shipped for
                   three releases. */}
-              <div data-rail className="flex items-center gap-1.5 shrink-0">
-                {RESOURCE_RAIL_SLOTS[type]
-                  .filter((slot) => slot.bone)
-                  .map((slot) => (
-                    <span
-                      key={slot.id}
-                      data-rail-slot={slot.id}
-                      className={cn(RAIL_SLOT, slot.box)}
-                    >
+              <div data-rail className={RESOURCE_RAIL}>
+                {RESOURCE_RAIL_ORDER[type].map((id) => {
+                  const slot = RESOURCE_RAIL_SLOT[id];
+                  if (!slot.bone) return null;
+                  return (
+                    <span key={id} data-rail-slot={id} className={cn(RAIL_SLOT, slot.box)}>
                       <span className={cn("bg-muted", slot.bone)} />
                     </span>
-                  ))}
+                  );
+                })}
               </div>
             </div>
             <div className="flex items-center gap-1.5 mt-1 h-4">
@@ -273,12 +281,10 @@ export function ForgeOptionRowsSkeleton({ count, immediate }: SkeletonProps) {
       {Array.from({ length: renderCount }).map((_, i) => (
         <div key={i} className={cn(FORGE_OPTION_ROW, pulseClass)}>
           <div className="w-3 h-3 rounded-full bg-muted shrink-0" />
-          {/* An empty bone has no line box, so without the loaded row's own
-              20px one to sit in, every row would come up short. */}
-          <div className="h-5 flex items-center flex-1 min-w-0">
+          <div data-option-line className={FORGE_OPTION_LINE}>
             <div
               className={cn(
-                "h-4 bg-muted rounded",
+                "h-4 bg-muted rounded-lg",
                 OPTION_BONE_WIDTHS[i % OPTION_BONE_WIDTHS.length]
               )}
             />

--- a/plugins/builtin/github/renderer/components/GitHubDropdownSkeletons.tsx
+++ b/plugins/builtin/github/renderer/components/GitHubDropdownSkeletons.tsx
@@ -14,6 +14,77 @@ export const RESOURCE_ITEM_HEIGHT_PX = 64;
 export const COMMIT_ITEM_HEIGHT_PX = 64;
 export const MAX_SKELETON_ITEMS = 6;
 
+/**
+ * The state mark's placement in a forge row. Height was not the only thing the
+ * two files each held their own copy of: the mark's offset and the trailing
+ * rail drifted apart across three unrelated PRs to `GitHubListItem`, because
+ * nothing linked them. Anything the loading row has to mirror lives here now.
+ */
+export const RESOURCE_ROW_STATE_MARK = "shrink-0 mt-1";
+
+/** The trailing rail's shared slot frame, so rows share a right edge. */
+export const RAIL_SLOT = "shrink-0 flex items-center justify-center";
+
+export interface ResourceRailSlot {
+  id: "count" | "assignee" | "ci" | "menu";
+  /** The box the slot holds open. Empty when its width is its own content. */
+  box: string;
+  /** The bone the skeleton draws, absent for a slot it cannot reserve. */
+  bone?: string;
+}
+
+/**
+ * The trailing rail, in render order, per resource type — every slot the row
+ * can draw, whether or not the skeleton reserves it.
+ *
+ * The rail is strictly type-partitioned: `GitHubListItem` empties `assignees`
+ * for a PR and gates the check glyph on the item being one, so neither type
+ * ever draws the other's slots.
+ *
+ * `count` carries no bone. It has no fixed width and needs a second assignee
+ * to appear at all, so reserving it would cost every title the space of a
+ * count most rows never show. It stays in the list because its position is the
+ * invariant that keeps avatars in one column — variable width to the LEFT of
+ * the fixed identity slot — and because a rail child registered nowhere is
+ * exactly how this drifted before.
+ */
+export const RESOURCE_RAIL_SLOTS: Record<"issue" | "pr", readonly ResourceRailSlot[]> = {
+  issue: [
+    { id: "count", box: "" },
+    { id: "assignee", box: "w-4", bone: "w-4 h-4 rounded-full" },
+    { id: "menu", box: "w-6 h-6 -me-1", bone: "w-6 h-6 rounded" },
+  ],
+  pr: [
+    { id: "ci", box: "w-4 h-3.5", bone: "w-3.5 h-3.5 rounded-full" },
+    { id: "menu", box: "w-6 h-6 -me-1", bone: "w-6 h-6 rounded" },
+  ],
+};
+
+/** Each slot's box by id, for the row that draws one slot at a time. */
+export const RESOURCE_RAIL_SLOT_BOX = {
+  assignee: "w-4",
+  ci: "w-4 h-3.5",
+  menu: "w-6 h-6 -me-1",
+} as const;
+
+/**
+ * An issue's state mark is a circle (`CircleDot`/`CheckCircle2`); a PR's never
+ * is (`getPrStateGlyph` returns four non-round glyphs). Loading cannot know
+ * which state, but it can stop claiming the wrong shape.
+ */
+export const RESOURCE_STATE_BONE = {
+  issue: "rounded-full",
+  pr: "rounded-sm",
+} as const;
+
+/**
+ * The geometry of `IssueSelector`'s option row, shared with its skeleton. The
+ * transparent border comes from `PALETTE_ROW_CLASS` on the loaded row; the
+ * skeleton takes it from here rather than the whole interactive class.
+ */
+export const FORGE_OPTION_ROW =
+  "flex items-center gap-2 px-2 py-1.5 text-sm rounded-[var(--radius-sm)] border border-transparent";
+
 function normalizeCount(count?: number | null): number {
   if (count == null || !Number.isFinite(count)) return MAX_SKELETON_ITEMS;
   return Math.min(Math.max(1, Math.floor(count)), MAX_SKELETON_ITEMS);
@@ -26,6 +97,11 @@ interface SkeletonProps {
 
 interface ResourceListSkeletonProps extends SkeletonProps {
   type?: "issue" | "pr";
+}
+
+/** Required, not defaulted: the rows cannot pick a rail without knowing. */
+interface ResourceRowsSkeletonProps extends SkeletonProps {
+  type: "issue" | "pr";
 }
 
 export function GitHubResourceListSkeleton({
@@ -108,7 +184,7 @@ export function GitHubResourceListSkeleton({
 
       {/* List skeleton rows */}
       <div className="relative overflow-hidden flex-1 min-h-0">
-        <GitHubResourceRowsSkeleton count={renderCount} immediate={showImmediate} />
+        <GitHubResourceRowsSkeleton count={renderCount} immediate={showImmediate} type={type} />
         {/* Same fade the loaded list uses, so a skeleton row cut by the panel
             edge dissolves instead of being guillotined. */}
         <div
@@ -132,7 +208,7 @@ export function GitHubResourceListSkeleton({
   );
 }
 
-export function GitHubResourceRowsSkeleton({ count, immediate }: SkeletonProps) {
+export function GitHubResourceRowsSkeleton({ count, immediate, type }: ResourceRowsSkeletonProps) {
   const renderCount = normalizeCount(count);
   const pulseClass = immediate ? "animate-pulse-immediate" : "animate-pulse-delayed";
 
@@ -144,19 +220,68 @@ export function GitHubResourceRowsSkeleton({ count, immediate }: SkeletonProps) 
           className={`${pulseClass} box-border px-3 py-2.5 flex items-start gap-2.5`}
           style={{ height: `${RESOURCE_ITEM_HEIGHT_PX}px` }}
         >
-          <div className="w-4 h-4 rounded-full bg-muted shrink-0 mt-px" />
+          <div
+            className={cn("w-4 h-4 bg-muted", RESOURCE_ROW_STATE_MARK, RESOURCE_STATE_BONE[type])}
+          />
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-2 h-6">
               <div className="h-4 bg-muted rounded flex-1" />
-              {/* The loaded row's persistent 24×24 actions slot — reserve the
-                  same box or the title bar shrinks the moment data lands. */}
-              <div className="h-6 w-6 -me-1 bg-muted rounded shrink-0" />
+              {/* Every rail slot the loaded row reserves, from the one list
+                  that names them. One short and the title bar jumps the
+                  moment data lands — which is the bug this row shipped for
+                  three releases. */}
+              <div data-rail className="flex items-center gap-1.5 shrink-0">
+                {RESOURCE_RAIL_SLOTS[type]
+                  .filter((slot) => slot.bone)
+                  .map((slot) => (
+                    <span
+                      key={slot.id}
+                      data-rail-slot={slot.id}
+                      className={cn(RAIL_SLOT, slot.box)}
+                    >
+                      <span className={cn("bg-muted", slot.bone)} />
+                    </span>
+                  ))}
+              </div>
             </div>
             <div className="flex items-center gap-1.5 mt-1 h-4">
               <div className="h-3 bg-muted rounded w-12" />
               <div className="h-3 bg-muted rounded w-16" />
               <div className="h-3 bg-muted rounded w-10" />
             </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/** Three widths, so a short stack of bars reads as titles and not as a grid. */
+const OPTION_BONE_WIDTHS = ["w-3/5", "w-4/5", "w-2/3"];
+
+/**
+ * `IssueSelector`'s loading state. It used to borrow the resource skeleton
+ * above — a 64px two-line row for a single-line option a third that height, so
+ * the popover collapsed as the issues arrived.
+ */
+export function ForgeOptionRowsSkeleton({ count, immediate }: SkeletonProps) {
+  const renderCount = normalizeCount(count);
+  const pulseClass = immediate ? "animate-pulse-immediate" : "animate-pulse-delayed";
+
+  return (
+    <div aria-hidden="true">
+      {Array.from({ length: renderCount }).map((_, i) => (
+        <div key={i} className={cn(FORGE_OPTION_ROW, pulseClass)}>
+          <div className="w-3 h-3 rounded-full bg-muted shrink-0" />
+          {/* An empty bone has no line box, so without the loaded row's own
+              20px one to sit in, every row would come up short. */}
+          <div className="h-5 flex items-center flex-1 min-w-0">
+            <div
+              className={cn(
+                "h-4 bg-muted rounded",
+                OPTION_BONE_WIDTHS[i % OPTION_BONE_WIDTHS.length]
+              )}
+            />
           </div>
         </div>
       ))}

--- a/plugins/builtin/github/renderer/components/GitHubListItem.tsx
+++ b/plugins/builtin/github/renderer/components/GitHubListItem.tsx
@@ -31,7 +31,12 @@ import {
   DropdownMenuSeparator,
 } from "@/components/ui/dropdown-menu";
 import { UI_ACTION_SUCCESS_DWELL_MS } from "@/lib/animationUtils";
-import { RESOURCE_ITEM_HEIGHT_PX } from "./GitHubDropdownSkeletons";
+import {
+  RAIL_SLOT,
+  RESOURCE_ITEM_HEIGHT_PX,
+  RESOURCE_RAIL_SLOT_BOX,
+  RESOURCE_ROW_STATE_MARK,
+} from "./GitHubDropdownSkeletons";
 import { deriveRowModel, describeWorktree, type ForgeRowPrimaryAction } from "./forgeRowModel";
 
 interface GitHubListItemProps {
@@ -93,9 +98,6 @@ function getStateLabel(state: string, type: "issue" | "pr", isDraft?: boolean): 
 function isPR(item: Issue | PR): item is PR {
   return "isDraft" in item;
 }
-
-/** The trailing rail's only always-present slot, so rows share a right edge. */
-const RAIL_SLOT = "shrink-0 flex items-center justify-center";
 
 export function GitHubListItem({
   item,
@@ -321,7 +323,7 @@ export function GitHubListItem({
             repeating them here made the row announce each of them twice. */}
         <span className="sr-only">{primaryActionHint}</span>
         {onToggleSelect ? (
-          <span className="group/icon shrink-0 relative w-4 h-4 mt-1">
+          <span className={cn("group/icon relative w-4 h-4", RESOURCE_ROW_STATE_MARK)}>
             {/* State icon: visible by default, hidden on hover or when selection active */}
             <span
               className={cn(
@@ -356,7 +358,11 @@ export function GitHubListItem({
             </span>
           </span>
         ) : (
-          <span className={cn("shrink-0 mt-1", stateColor)} role="img" aria-label={stateLabel}>
+          <span
+            className={cn(RESOURCE_ROW_STATE_MARK, stateColor)}
+            role="img"
+            aria-label={stateLabel}
+          >
             <StateIcon className="h-4 w-4" />
           </span>
         )}
@@ -408,9 +414,10 @@ export function GitHubListItem({
                 fixed identity slot, which sits immediately before the always-present
                 menu. That is what keeps avatars (and CI glyphs) in one column down
                 the list instead of sliding left whenever a neighbour appears. */}
-            <div className="flex items-center gap-1.5 shrink-0">
+            <div data-rail className="flex items-center gap-1.5 shrink-0">
               {restAssignees.length > 0 && (
                 <span
+                  data-rail-slot="count"
                   className="shrink-0 text-3xs text-text-secondary tabular-nums"
                   aria-hidden="true"
                 >
@@ -429,7 +436,8 @@ export function GitHubListItem({
                     <Tooltip>
                       <TooltipTrigger asChild>
                         <span
-                          className={cn(RAIL_SLOT, "w-4 h-3.5")}
+                          data-rail-slot="ci"
+                          className={cn(RAIL_SLOT, RESOURCE_RAIL_SLOT_BOX.ci)}
                           role="img"
                           aria-label={ciTooltip}
                         >
@@ -453,7 +461,12 @@ export function GitHubListItem({
               {firstAssignee && assigneeLabel && (
                 <Tooltip>
                   <TooltipTrigger asChild>
-                    <span className={cn(RAIL_SLOT, "w-4")} role="img" aria-label={assigneeLabel}>
+                    <span
+                      data-rail-slot="assignee"
+                      className={cn(RAIL_SLOT, RESOURCE_RAIL_SLOT_BOX.assignee)}
+                      role="img"
+                      aria-label={assigneeLabel}
+                    >
                       <Avatar src={firstAssignee.avatarUrl ?? ""} alt="" className="w-4 h-4" />
                     </span>
                   </TooltipTrigger>
@@ -470,6 +483,7 @@ export function GitHubListItem({
                        keyboard (Shift+F10) while DOM focus stays in the search
                        input — otherwise these commands would be pointer-only. */
                     id={menuTriggerId}
+                    data-rail-slot="menu"
                     onClick={(e) => e.stopPropagation()}
                     className={cn(
                       RAIL_SLOT,
@@ -478,7 +492,8 @@ export function GitHubListItem({
                       // Emphasis comes from the secondary ink, not from an
                       // opacity wash: 55% put it under the 3:1 floor a
                       // graphical control has to clear.
-                      "w-6 h-6 -me-1 rounded text-text-secondary",
+                      RESOURCE_RAIL_SLOT_BOX.menu,
+                      "rounded text-text-secondary",
                       "hover:bg-overlay-medium hover:text-text-primary",
                       "transition-[background-color,color] duration-150 ease-out",
                       "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"

--- a/plugins/builtin/github/renderer/components/GitHubListItem.tsx
+++ b/plugins/builtin/github/renderer/components/GitHubListItem.tsx
@@ -34,7 +34,8 @@ import { UI_ACTION_SUCCESS_DWELL_MS } from "@/lib/animationUtils";
 import {
   RAIL_SLOT,
   RESOURCE_ITEM_HEIGHT_PX,
-  RESOURCE_RAIL_SLOT_BOX,
+  RESOURCE_RAIL,
+  RESOURCE_RAIL_SLOT,
   RESOURCE_ROW_STATE_MARK,
 } from "./GitHubDropdownSkeletons";
 import { deriveRowModel, describeWorktree, type ForgeRowPrimaryAction } from "./forgeRowModel";
@@ -323,7 +324,10 @@ export function GitHubListItem({
             repeating them here made the row announce each of them twice. */}
         <span className="sr-only">{primaryActionHint}</span>
         {onToggleSelect ? (
-          <span className={cn("group/icon relative w-4 h-4", RESOURCE_ROW_STATE_MARK)}>
+          <span
+            data-state-mark
+            className={cn("group/icon relative w-4 h-4", RESOURCE_ROW_STATE_MARK)}
+          >
             {/* State icon: visible by default, hidden on hover or when selection active */}
             <span
               className={cn(
@@ -359,6 +363,7 @@ export function GitHubListItem({
           </span>
         ) : (
           <span
+            data-state-mark
             className={cn(RESOURCE_ROW_STATE_MARK, stateColor)}
             role="img"
             aria-label={stateLabel}
@@ -414,7 +419,7 @@ export function GitHubListItem({
                 fixed identity slot, which sits immediately before the always-present
                 menu. That is what keeps avatars (and CI glyphs) in one column down
                 the list instead of sliding left whenever a neighbour appears. */}
-            <div data-rail className="flex items-center gap-1.5 shrink-0">
+            <div data-rail className={RESOURCE_RAIL}>
               {restAssignees.length > 0 && (
                 <span
                   data-rail-slot="count"
@@ -437,7 +442,7 @@ export function GitHubListItem({
                       <TooltipTrigger asChild>
                         <span
                           data-rail-slot="ci"
-                          className={cn(RAIL_SLOT, RESOURCE_RAIL_SLOT_BOX.ci)}
+                          className={cn(RAIL_SLOT, RESOURCE_RAIL_SLOT.ci.box)}
                           role="img"
                           aria-label={ciTooltip}
                         >
@@ -463,7 +468,7 @@ export function GitHubListItem({
                   <TooltipTrigger asChild>
                     <span
                       data-rail-slot="assignee"
-                      className={cn(RAIL_SLOT, RESOURCE_RAIL_SLOT_BOX.assignee)}
+                      className={cn(RAIL_SLOT, RESOURCE_RAIL_SLOT.assignee.box)}
                       role="img"
                       aria-label={assigneeLabel}
                     >
@@ -492,7 +497,7 @@ export function GitHubListItem({
                       // Emphasis comes from the secondary ink, not from an
                       // opacity wash: 55% put it under the 3:1 floor a
                       // graphical control has to clear.
-                      RESOURCE_RAIL_SLOT_BOX.menu,
+                      RESOURCE_RAIL_SLOT.menu.box,
                       "rounded text-text-secondary",
                       "hover:bg-overlay-medium hover:text-text-primary",
                       "transition-[background-color,color] duration-150 ease-out",

--- a/plugins/builtin/github/renderer/components/GitHubResourceList.tsx
+++ b/plugins/builtin/github/renderer/components/GitHubResourceList.tsx
@@ -1531,6 +1531,7 @@ export function GitHubResourceList({
           <div key="github-skeleton" className="overflow-y-auto flex-1 min-h-0">
             <GitHubResourceRowsSkeleton
               count={initialCount && initialCount > 0 ? initialCount : MAX_SKELETON_ITEMS}
+              type={type}
             />
           </div>
         ) : data.length > 0 ? (

--- a/plugins/builtin/github/renderer/components/IssueSelector.tsx
+++ b/plugins/builtin/github/renderer/components/IssueSelector.tsx
@@ -14,7 +14,7 @@ import { ScrollShadow } from "@/components/ui/ScrollShadow";
 import { InlineStatusBanner } from "@/components/Terminal/InlineStatusBanner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { FIELD_SURFACE } from "@/components/Worktree/views/WorktreeFormLayout";
-import { GitHubResourceRowsSkeleton } from "./GitHubDropdownSkeletons";
+import { FORGE_OPTION_ROW, ForgeOptionRowsSkeleton } from "./GitHubDropdownSkeletons";
 import { logError } from "@/utils/logger";
 
 /** Conforms to the host's issue-selector slot contract (forge-normalized shapes). */
@@ -255,7 +255,7 @@ export function IssueSelector({
           aria-busy={loading || undefined}
         >
           {loading && issues.length === 0 ? (
-            <GitHubResourceRowsSkeleton count={3} immediate />
+            <ForgeOptionRowsSkeleton count={3} immediate />
           ) : issues.length === 0 ? (
             loadFailed ? null : trimmedQuery ? (
               <EmptyState
@@ -291,10 +291,7 @@ export function IssueSelector({
                 aria-current={selectedIssue?.number === issue.number ? "true" : undefined}
                 onPointerMove={() => setActiveIndex(index)}
                 onClick={() => handleSelect(issue)}
-                className={cn(
-                  PALETTE_ROW_CLASS,
-                  "flex items-center gap-2 px-2 py-1.5 text-sm rounded-[var(--radius-sm)] cursor-pointer"
-                )}
+                className={cn(PALETTE_ROW_CLASS, FORGE_OPTION_ROW, "cursor-pointer")}
               >
                 <CircleDot className="w-3 h-3 text-pr-open shrink-0" aria-hidden="true" />
                 <span className="truncate flex-1 min-w-0">


### PR DESCRIPTION
## Summary

- The dropdown loading skeleton had drifted out of sync with the row it stands in for, in three ways, each introduced by a separate, legitimate PR that never touched the skeleton: the state mark sat at `mt-px` against the row's `mt-1` (a 3px jump on load), the skeleton always drew a circle even for PR rows whose four glyphs from `getPrStateGlyph` (`GitPullRequest`, `GitMerge`, `GitPullRequestClosed`, `GitPullRequestDraft`) are never round, and it only reserved the 24x24 actions box while the loaded rail also holds a CI check glyph and an assignee avatar, so the title bar visibly narrowed the moment data landed.
- Nothing linked the two files, which is the same shape of problem `RESOURCE_ITEM_HEIGHT_PX` already solved once for row height (its own comment says "the two cannot drift"). Git history shows the mechanism: `02b84c46d` added the rail slots and bumped the mark to `mt-1`, `bee36d002` added the PR glyphs. Neither was obligated to touch the skeleton.
- Fixed it with a shared source of truth instead of a one-time re-measure, so the next unrelated row change can't quietly break the skeleton again.

Resolves #12294

## Changes

- Added one keyed table, `RESOURCE_RAIL_SLOT` (box and bone per slot), plus `RESOURCE_RAIL_ORDER` naming each resource type's slots in render order. Both the loaded row and the skeleton draw from it, so a slot's width has exactly one home.
- Shared the rail container as `RESOURCE_RAIL`, the state mark's placement as `RESOURCE_ROW_STATE_MARK`, and the mark's per-type shape as `RESOURCE_STATE_BONE` (round for an issue, not for a pull request).
- Made `type` a required prop on `GitHubResourceRowsSkeleton`. The panel skeleton was already receiving it and silently dropping it, so a PR panel was drawing an issue's rail.
- Gave `IssueSelector` its own single-line `ForgeOptionRowsSkeleton`. It had been borrowing the 64px two-line resource skeleton for a popover option a third that height.
- The skeleton reserves the assignee and CI boxes but deliberately not the `+N` overflow count, which has no fixed width and only shows up with a second assignee.
- Added a parity test in `GitHubListItem.test.tsx` that renders both the real row and skeleton components and reads the shared table rather than restating it. It checks that rail children match the shared order exactly, every fixed-size slot is reserved identically on both sides, both rails share a container class, both state-mark branches sit at the same offset, and both rows resolve to the same height. Verified it actually catches regressions: removing a bone, hardcoding a width in the row, adding an unregistered rail child, and reverting the state-mark offset each independently failed the test.

## Testing

- 298 tests pass across `GitHubDropdownSkeletons`, `GitHubListItem`, `GitHubResourceList.swr`, `IssueSelector`, `CommitList`, `BulkActionBar`, and `Toolbar.forgeDropdowns`.
- `npm run typecheck`: clean.
- `prettier --check` and eslint on all 8 changed files: clean, 0 errors. eslint warnings on these files went from 21 to 20 (a bare `rounded` tightened to `rounded-lg`, which is what it already rendered as).
- No new E2E specs: jsdom can't measure geometry, and `e2e/full/panels/core-github-panels.spec.ts` already covers pixel alignment for these rows.