### PR TITLE
fix(dev-preview): keep the route when crossing the proxy origin

### DIFF
--- a/electron/services/DevPreviewProxyService.ts
+++ b/electron/services/DevPreviewProxyService.ts
@@ -29,6 +29,13 @@ const UPSTREAM_HOST = "localhost";
 // dev server mid-restart (or wedged) should surface a 502, not an indefinite spinner.
 const UPSTREAM_TIMEOUT_MS = 30_000;
 
+// Redirect statuses whose `Location` a browser will follow.
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+// Absolute (`http://host/x`) or protocol-relative (`//host/x`). Only these can carry the
+// guest off the proxy origin; a path-relative `Location` is resolved by the guest against
+// the proxy URL it asked for and is already correct.
+const ABSOLUTE_LOCATION_REGEX = /^(?:https?:)?\/\//i;
+
 // "Open in real browser" handoff token (#9101). The token is HMAC-signed,
 // single-use, bound to its issuing panel, and expires fast — it only has to
 // survive the round-trip from `shell.openExternal` to the browser's first
@@ -95,6 +102,14 @@ export interface DevPreviewProxyDiagnostic {
 export class DevPreviewProxyService {
   private server: http.Server | null = null;
   private proxy: ProxyServer | null = null;
+  // The origin pair each in-flight proxied request was dialled with, so the response
+  // hook rewrites against the upstream this request actually used. Resolving again on
+  // the response would risk a different port if the dev server restarted meanwhile.
+  // Weak keys: an aborted request is collected without an explicit delete.
+  private readonly inFlightOrigins = new WeakMap<
+    http.IncomingMessage,
+    { upstreamOrigin: string; proxyOrigin: string }
+  >();
   private actualPort = 0;
   private portFallback = false;
   private startPromise: Promise<number> | null = null;
@@ -167,6 +182,19 @@ export class DevPreviewProxyService {
       } else {
         res.destroy();
       }
+    });
+    // Keep a same-upstream absolute redirect on the panel's stable origin. Without this
+    // the guest follows `Location: http://localhost:<upstreamPort>/…` off the proxy
+    // origin, and the pane has to migrate it back — losing the route, and re-requesting
+    // a single-use callback in the process (#12297).
+    //
+    // Deliberately not httpxy's `autoRewrite`: that resolves a *relative* Location
+    // against the upstream root (so `Location: consume` from `/nested/once` becomes
+    // `/consume`) and preserves `https:` for a TLS upstream, which this plain-HTTP
+    // proxy does not serve. Emitted before the outgoing header copy, so mutating
+    // `proxyRes.headers` here is what reaches the guest.
+    proxy.on("proxyRes", (proxyRes, req) => {
+      this.rewriteSameUpstreamRedirect(proxyRes, req);
     });
     this.proxy = proxy;
 
@@ -251,8 +279,10 @@ export class DevPreviewProxyService {
       // cert (Vite/Next dev TLS); the upstream is always `localhost`, so this stays loopback-only
       // and never disables verification for a remote host (#9974).
       const scheme = resolution.isHttps ? "https" : "http";
+      const target = `${scheme}://${UPSTREAM_HOST}:${resolution.port}`;
+      this.rememberRequestOrigins(req, target);
       await this.proxy!.web(req, res, {
-        target: `${scheme}://${UPSTREAM_HOST}:${resolution.port}`,
+        target,
         ...(resolution.isHttps ? { secure: false } : {}),
       });
     } catch (err) {
@@ -260,6 +290,54 @@ export class DevPreviewProxyService {
       this.reportFailure(subdomain, "http", classified.cause, classified.code);
       this.send502(res, "The dev server isn't responding.");
     }
+  }
+
+  /** Snapshot the origins this request is being proxied between, for the response hook. */
+  private rememberRequestOrigins(req: http.IncomingMessage, target: string): void {
+    const host = req.headers.host;
+    if (!host) return;
+    let proxyOrigin: string;
+    let upstreamOrigin: string;
+    try {
+      // The proxy serves plain HTTP only, so the guest-facing origin is always http:.
+      proxyOrigin = new URL(`http://${host}`).origin;
+      upstreamOrigin = new URL(target).origin;
+    } catch {
+      return;
+    }
+    this.inFlightOrigins.set(req, { upstreamOrigin, proxyOrigin });
+  }
+
+  /**
+   * Rewrite a redirect that points back at the upstream this very request was dialled
+   * with, so it lands on the panel's stable origin instead. Scoped deliberately tight:
+   * only redirect statuses, only an absolute or protocol-relative `Location`, and only
+   * when its origin matches the recorded upstream exactly. A relative Location, a
+   * different port, or any external destination is forwarded byte-for-byte.
+   */
+  private rewriteSameUpstreamRedirect(
+    proxyRes: http.IncomingMessage,
+    req: http.IncomingMessage
+  ): void {
+    const origins = this.inFlightOrigins.get(req);
+    this.inFlightOrigins.delete(req);
+    if (!origins) return;
+    if (!REDIRECT_STATUSES.has(proxyRes.statusCode ?? 0)) return;
+
+    const location = proxyRes.headers.location;
+    if (typeof location !== "string" || !ABSOLUTE_LOCATION_REGEX.test(location)) return;
+
+    let destination: URL;
+    try {
+      // Base supplies the scheme for a protocol-relative `//host/path`, matching how a
+      // guest on the upstream origin would resolve it.
+      destination = new URL(location, origins.upstreamOrigin);
+    } catch {
+      return;
+    }
+    if (destination.origin !== origins.upstreamOrigin) return;
+
+    proxyRes.headers.location = `${origins.proxyOrigin}${destination.pathname}${destination.search}${destination.hash}`;
   }
 
   private async handleUpgrade(

--- a/electron/services/DevPreviewProxyService.ts
+++ b/electron/services/DevPreviewProxyService.ts
@@ -35,6 +35,13 @@ const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
 // guest off the proxy origin; a path-relative `Location` is resolved by the guest against
 // the proxy URL it asked for and is already correct.
 const ABSOLUTE_LOCATION_REGEX = /^(?:https?:)?\/\//i;
+// Hostnames that name this machine. The proxy dials `localhost` and lets Node's Happy
+// Eyeballs pick the family (#9747), so we cannot know whether we reached IPv4 or IPv6 —
+// which means an upstream that answers `Location: http://127.0.0.1:<port>/…` is naming
+// the very server we just called. Matching on scheme + port + any loopback alias keeps
+// those redirects on the proxy origin; a literal origin comparison would let them
+// through and re-run the callback on the remount (#12297).
+const LOOPBACK_HOSTNAMES = new Set(["localhost", "127.0.0.1", "[::1]", "::1"]);
 
 // "Open in real browser" handoff token (#9101). The token is HMAC-signed,
 // single-use, bound to its issuing panel, and expires fast — it only has to
@@ -108,7 +115,7 @@ export class DevPreviewProxyService {
   // Weak keys: an aborted request is collected without an explicit delete.
   private readonly inFlightOrigins = new WeakMap<
     http.IncomingMessage,
-    { upstreamOrigin: string; proxyOrigin: string }
+    { upstreamOrigin: string; upstreamProtocol: string; upstreamPort: string; proxyOrigin: URL }
   >();
   private actualPort = 0;
   private portFallback = false;
@@ -292,20 +299,32 @@ export class DevPreviewProxyService {
     }
   }
 
-  /** Snapshot the origins this request is being proxied between, for the response hook. */
+  /** Snapshot the endpoints this request is being proxied between, for the response hook. */
   private rememberRequestOrigins(req: http.IncomingMessage, target: string): void {
     const host = req.headers.host;
     if (!host) return;
-    let proxyOrigin: string;
-    let upstreamOrigin: string;
+    let proxyOrigin: URL;
+    let upstream: URL;
     try {
       // The proxy serves plain HTTP only, so the guest-facing origin is always http:.
-      proxyOrigin = new URL(`http://${host}`).origin;
-      upstreamOrigin = new URL(target).origin;
+      proxyOrigin = new URL(`http://${host}`);
+      upstream = new URL(target);
     } catch {
       return;
     }
-    this.inFlightOrigins.set(req, { upstreamOrigin, proxyOrigin });
+    // `parseDevPreviewProxyHost` splits the Host at its first colon, so a crafted
+    // `dp-x.localhost:1@evil.example` satisfies routing while the URL parser reads
+    // `evil.example` as the authority and the rest as userinfo. Re-validate the parsed
+    // authority, and fail closed — a redirect must never be rewritten onto a host the
+    // proxy does not itself serve.
+    if (proxyOrigin.username || proxyOrigin.password) return;
+    if (!parseDevPreviewProxyHost(proxyOrigin.host)) return;
+    this.inFlightOrigins.set(req, {
+      upstreamOrigin: upstream.origin,
+      upstreamProtocol: upstream.protocol,
+      upstreamPort: upstream.port,
+      proxyOrigin,
+    });
   }
 
   /**
@@ -335,9 +354,17 @@ export class DevPreviewProxyService {
     } catch {
       return;
     }
-    if (destination.origin !== origins.upstreamOrigin) return;
+    if (destination.protocol !== origins.upstreamProtocol) return;
+    if (destination.port !== origins.upstreamPort) return;
+    if (!LOOPBACK_HOSTNAMES.has(destination.hostname.toLowerCase())) return;
 
-    proxyRes.headers.location = `${origins.proxyOrigin}${destination.pathname}${destination.search}${destination.hash}`;
+    // Retarget the parsed URL rather than rebuilding the string: `${pathname}${search}${hash}`
+    // silently drops an explicitly empty fragment, and a `Location` ending in a bare `#`
+    // means "clear the fragment", not "inherit the current one".
+    const rewritten = new URL(destination.toString());
+    rewritten.protocol = origins.proxyOrigin.protocol;
+    rewritten.host = origins.proxyOrigin.host;
+    proxyRes.headers.location = rewritten.toString();
   }
 
   private async handleUpgrade(

--- a/electron/services/__tests__/DevPreviewProxyService.test.ts
+++ b/electron/services/__tests__/DevPreviewProxyService.test.ts
@@ -684,6 +684,233 @@ describe("DevPreviewProxyService", () => {
     });
   });
 
+  // The dev preview sits on a stable `dp-*.localhost` proxy origin. An upstream that answers
+  // with an absolute `Location` on its own `localhost:<port>` origin would carry the guest off
+  // that origin, forcing the pane to migrate back — which is how the route was lost, and how a
+  // single-use callback ended up at risk of being requested twice (#12297).
+  describe("same-upstream redirect rewriting (#12297)", () => {
+    // A fixture that logs every path it serves, so each test can assert *counts* and prove no
+    // replay was introduced — the issue's first (disproved) hypothesis was a double redemption.
+    function redirectFixture(locationFor: (upstreamPort: number) => string) {
+      const seen: string[] = [];
+      let port = 0;
+      const server = http.createServer((req, res) => {
+        seen.push(req.url ?? "");
+        if (req.url?.startsWith("/once")) {
+          res.writeHead(302, { Location: locationFor(port) });
+          res.end();
+          return;
+        }
+        res.writeHead(200, { "Content-Type": "text/plain" });
+        res.end(`served ${req.url}`);
+      });
+      return {
+        server,
+        seen,
+        async listen() {
+          port = await listen(server);
+          return port;
+        },
+      };
+    }
+
+    function countOf(seen: string[], prefix: string): number {
+      return seen.filter((p) => p === prefix || p.startsWith(`${prefix}?`)).length;
+    }
+
+    it("rewrites an absolute same-upstream redirect onto the panel's origin and never replays the callback", async () => {
+      const fixture = redirectFixture(
+        (port) => `http://localhost:${port}/consume?token=audit-single-use`
+      );
+      upstream = fixture.server;
+      const upstreamPort = await fixture.listen();
+
+      proxy = new DevPreviewProxyService((sub) =>
+        sub === "dp-test" ? { port: upstreamPort, isHttps: false } : null
+      );
+      const proxyPort = await proxy.start();
+      const host = `dp-test.localhost:${proxyPort}`;
+
+      const redirect = await request(proxyPort, host, "/once");
+
+      expect(redirect.status).toBe(302);
+      // The guest stays on its own origin instead of being sent to the raw upstream.
+      expect(redirect.headers.location).toBe(`http://${host}/consume?token=audit-single-use`);
+      expect(countOf(fixture.seen, "/once")).toBe(1);
+      expect(countOf(fixture.seen, "/consume")).toBe(0);
+
+      // Follow it exactly once, the way the guest would.
+      const followed = await request(proxyPort, host, "/consume?token=audit-single-use");
+
+      expect(followed.status).toBe(200);
+      expect(followed.body).toBe("served /consume?token=audit-single-use");
+      expect(countOf(fixture.seen, "/once")).toBe(1);
+      expect(countOf(fixture.seen, "/consume")).toBe(1);
+      expect(countOf(fixture.seen, "/")).toBe(0);
+    });
+
+    it("preserves the fragment on a rewritten redirect", async () => {
+      const fixture = redirectFixture((port) => `http://localhost:${port}/deep/route?a=1#frag`);
+      upstream = fixture.server;
+      const upstreamPort = await fixture.listen();
+
+      proxy = new DevPreviewProxyService((sub) =>
+        sub === "dp-test" ? { port: upstreamPort, isHttps: false } : null
+      );
+      const proxyPort = await proxy.start();
+      const host = `dp-test.localhost:${proxyPort}`;
+
+      const res = await request(proxyPort, host, "/once");
+
+      expect(res.headers.location).toBe(`http://${host}/deep/route?a=1#frag`);
+    });
+
+    it("rewrites a protocol-relative same-upstream redirect", async () => {
+      const fixture = redirectFixture((port) => `//localhost:${port}/consume`);
+      upstream = fixture.server;
+      const upstreamPort = await fixture.listen();
+
+      proxy = new DevPreviewProxyService((sub) =>
+        sub === "dp-test" ? { port: upstreamPort, isHttps: false } : null
+      );
+      const proxyPort = await proxy.start();
+      const host = `dp-test.localhost:${proxyPort}`;
+
+      const res = await request(proxyPort, host, "/once");
+
+      expect(res.headers.location).toBe(`http://${host}/consume`);
+    });
+
+    it("downgrades a TLS upstream's absolute redirect to the plain-HTTP proxy origin", async () => {
+      // The proxy is an http.Server; leaving `https:` on the rewritten Location would send the
+      // guest to a scheme this proxy never serves.
+      const seen: string[] = [];
+      let upstreamPort = 0;
+      tlsUpstream = https.createServer({ cert: TLS_CERT, key: TLS_KEY }, (req, res) => {
+        seen.push(req.url ?? "");
+        if (req.url === "/once") {
+          res.writeHead(302, { Location: `https://localhost:${upstreamPort}/consume` });
+          res.end();
+          return;
+        }
+        res.writeHead(200, { "Content-Type": "text/plain" });
+        res.end(`served ${req.url}`);
+      });
+      upstreamPort = await listenTls(tlsUpstream);
+
+      proxy = new DevPreviewProxyService((sub) =>
+        sub === "dp-test" ? { port: upstreamPort, isHttps: true } : null
+      );
+      const proxyPort = await proxy.start();
+      const host = `dp-test.localhost:${proxyPort}`;
+
+      const res = await request(proxyPort, host, "/once");
+
+      expect(res.status).toBe(302);
+      expect(res.headers.location).toBe(`http://${host}/consume`);
+      expect(seen.filter((p) => p === "/consume")).toHaveLength(0);
+    });
+
+    it.each([301, 302, 303, 307, 308])("rewrites a %i redirect", async (status) => {
+      let upstreamPort = 0;
+      upstream = http.createServer((_req, res) => {
+        res.writeHead(status, { Location: `http://localhost:${upstreamPort}/moved` });
+        res.end();
+      });
+      upstreamPort = await listen(upstream);
+
+      proxy = new DevPreviewProxyService((sub) =>
+        sub === "dp-test" ? { port: upstreamPort, isHttps: false } : null
+      );
+      const proxyPort = await proxy.start();
+      const host = `dp-test.localhost:${proxyPort}`;
+
+      const res = await request(proxyPort, host, "/once");
+
+      expect(res.headers.location).toBe(`http://${host}/moved`);
+    });
+
+    it.each([
+      ["a path-relative Location", "consume"],
+      ["a root-relative Location", "/consume"],
+      ["a query-only Location", "?token=x"],
+    ])(
+      "leaves %s untouched — the guest resolves it against the proxy URL",
+      async (_l, location) => {
+        upstream = http.createServer((_req, res) => {
+          res.writeHead(302, { Location: location });
+          res.end();
+        });
+        const upstreamPort = await listen(upstream);
+
+        proxy = new DevPreviewProxyService((sub) =>
+          sub === "dp-test" ? { port: upstreamPort, isHttps: false } : null
+        );
+        const proxyPort = await proxy.start();
+
+        const res = await request(proxyPort, `dp-test.localhost:${proxyPort}`, "/nested/once");
+
+        // Rewriting these would resolve them against the upstream *root*, turning
+        // `/nested/consume` into `/consume` — the reason httpxy's autoRewrite is not used.
+        expect(res.headers.location).toBe(location);
+      }
+    );
+
+    it("leaves an external redirect untouched", async () => {
+      upstream = http.createServer((_req, res) => {
+        res.writeHead(302, { Location: "https://accounts.example.com/oauth?client_id=abc" });
+        res.end();
+      });
+      const upstreamPort = await listen(upstream);
+
+      proxy = new DevPreviewProxyService((sub) =>
+        sub === "dp-test" ? { port: upstreamPort, isHttps: false } : null
+      );
+      const proxyPort = await proxy.start();
+
+      const res = await request(proxyPort, `dp-test.localhost:${proxyPort}`, "/once");
+
+      expect(res.headers.location).toBe("https://accounts.example.com/oauth?client_id=abc");
+    });
+
+    it("leaves a redirect to a different loopback port untouched", async () => {
+      // Only the upstream this request was actually dialled with may be rewritten; another
+      // port is a different server, not this panel's dev server.
+      upstream = http.createServer((_req, res) => {
+        res.writeHead(302, { Location: "http://localhost:1/elsewhere" });
+        res.end();
+      });
+      const upstreamPort = await listen(upstream);
+
+      proxy = new DevPreviewProxyService((sub) =>
+        sub === "dp-test" ? { port: upstreamPort, isHttps: false } : null
+      );
+      const proxyPort = await proxy.start();
+
+      const res = await request(proxyPort, `dp-test.localhost:${proxyPort}`, "/once");
+
+      expect(res.headers.location).toBe("http://localhost:1/elsewhere");
+    });
+
+    it("leaves a non-redirect response's Location header untouched", async () => {
+      let upstreamPort = 0;
+      upstream = http.createServer((_req, res) => {
+        res.writeHead(200, { Location: `http://localhost:${upstreamPort}/not-a-redirect` });
+        res.end("ok");
+      });
+      upstreamPort = await listen(upstream);
+
+      proxy = new DevPreviewProxyService((sub) =>
+        sub === "dp-test" ? { port: upstreamPort, isHttps: false } : null
+      );
+      const proxyPort = await proxy.start();
+
+      const res = await request(proxyPort, `dp-test.localhost:${proxyPort}`, "/x");
+
+      expect(res.headers.location).toBe(`http://localhost:${upstreamPort}/not-a-redirect`);
+    });
+  });
+
   describe("failure classification and diagnostics", () => {
     it("502s a not-running session with distinct copy and reports the cause", async () => {
       const onDiagnostic = vi.fn<(event: DevPreviewProxyDiagnostic) => void>();

--- a/electron/services/__tests__/DevPreviewProxyService.test.ts
+++ b/electron/services/__tests__/DevPreviewProxyService.test.ts
@@ -827,6 +827,9 @@ describe("DevPreviewProxyService", () => {
 
       const res = await request(proxyPort, host, "/once");
 
+      // The status must survive the rewrite: collapsing 307/308 to 302 would silently drop
+      // their method-preserving semantics.
+      expect(res.status).toBe(status);
       expect(res.headers.location).toBe(`http://${host}/moved`);
     });
 
@@ -855,6 +858,117 @@ describe("DevPreviewProxyService", () => {
         expect(res.headers.location).toBe(location);
       }
     );
+
+    it.each(["127.0.0.1", "[::1]"])(
+      "rewrites a redirect naming the upstream by its %s loopback address",
+      async (hostname) => {
+        // The proxy dials `localhost` and lets Node pick the address family (#9747), so an
+        // upstream that answers with its own IP is still naming the server we just called.
+        // A literal origin comparison would let this through, the guest would cross off the
+        // proxy origin, and the remount would request the callback a second time.
+        const fixture = redirectFixture((port) => `http://${hostname}:${port}/consume`);
+        upstream = fixture.server;
+        const upstreamPort = await fixture.listen();
+
+        proxy = new DevPreviewProxyService((sub) =>
+          sub === "dp-test" ? { port: upstreamPort, isHttps: false } : null
+        );
+        const proxyPort = await proxy.start();
+        const host = `dp-test.localhost:${proxyPort}`;
+
+        const res = await request(proxyPort, host, "/once");
+
+        expect(res.headers.location).toBe(`http://${host}/consume`);
+        expect(countOf(fixture.seen, "/consume")).toBe(0);
+      }
+    );
+
+    it("preserves an explicitly emptied fragment", async () => {
+      // `Location: …/consume#` means "clear the fragment". Rebuilding the URL from
+      // pathname+search+hash drops the `#`, and the guest then inherits the fragment of the
+      // page it is leaving — a hash router would land on the wrong route.
+      const fixture = redirectFixture((port) => `http://localhost:${port}/consume#`);
+      upstream = fixture.server;
+      const upstreamPort = await fixture.listen();
+
+      proxy = new DevPreviewProxyService((sub) =>
+        sub === "dp-test" ? { port: upstreamPort, isHttps: false } : null
+      );
+      const proxyPort = await proxy.start();
+      const host = `dp-test.localhost:${proxyPort}`;
+
+      const res = await request(proxyPort, host, "/once");
+
+      expect(res.headers.location).toBe(`http://${host}/consume#`);
+    });
+
+    it("refuses to rewrite onto a host smuggled through the Host header as userinfo", async () => {
+      // `parseDevPreviewProxyHost` splits at the first colon, so this Host routes as `dp-test`
+      // while the URL parser reads `evil.example` as the authority. The rewrite must fail
+      // closed rather than hand the client a redirect to an external origin.
+      let upstreamPort = 0;
+      upstream = http.createServer((_req, res) => {
+        res.writeHead(302, { Location: `http://localhost:${upstreamPort}/consume` });
+        res.end();
+      });
+      upstreamPort = await listen(upstream);
+
+      proxy = new DevPreviewProxyService((sub) =>
+        sub === "dp-test" ? { port: upstreamPort, isHttps: false } : null
+      );
+      const proxyPort = await proxy.start();
+
+      const res = await request(proxyPort, `dp-test.localhost:${proxyPort}@evil.example`, "/once");
+
+      expect(res.headers.location).not.toContain("evil.example");
+      expect(res.headers.location).toBe(`http://localhost:${upstreamPort}/consume`);
+    });
+
+    it("rewrites against the upstream the request was dialled with, not the current one", async () => {
+      // The origins are snapshotted per request. If the response hook re-resolved the
+      // upstream instead, a dev-server restart landing mid-flight would move the port out
+      // from under an in-flight redirect and the rewrite would silently stop matching.
+      let releaseRedirect: (() => void) | undefined;
+      const held = new Promise<void>((resolve) => {
+        releaseRedirect = resolve;
+      });
+      let markDialled: (() => void) | undefined;
+      const dialled = new Promise<void>((resolve) => {
+        markDialled = resolve;
+      });
+      let upstreamPort = 0;
+      upstream = http.createServer((req, res) => {
+        void (async () => {
+          if (req.url === "/once") {
+            markDialled!();
+            await held;
+          }
+          res.writeHead(302, { Location: `http://localhost:${upstreamPort}/consume` });
+          res.end();
+        })();
+      });
+      upstreamPort = await listen(upstream);
+
+      let currentPort = upstreamPort;
+      proxy = new DevPreviewProxyService((sub) =>
+        sub === "dp-test" ? { port: currentPort, isHttps: false } : null
+      );
+      const proxyPort = await proxy.start();
+      const host = `dp-test.localhost:${proxyPort}`;
+
+      const inFlight = request(proxyPort, host, "/once");
+      // Wait until the upstream has the request, so the origins are already snapshotted;
+      // moving the port before that would just make the dial itself fail.
+      await dialled;
+      // The dev server "restarts" onto a different port while the response is outstanding.
+      currentPort = upstreamPort + 1;
+      releaseRedirect!();
+      const res = await inFlight;
+
+      // Re-resolving on the response would compare against the NEW port, the Location would
+      // no longer match, and the redirect would escape the rewrite entirely.
+      expect(res.headers.location).toBe(`http://${host}/consume`);
+    });
 
     it("leaves an external redirect untouched", async () => {
       upstream = http.createServer((_req, res) => {

--- a/src/components/Browser/historyUtils.ts
+++ b/src/components/Browser/historyUtils.ts
@@ -62,6 +62,25 @@ export function pushBrowserHistory(history: BrowserHistory, nextUrl: string): Br
   };
 }
 
+/**
+ * Retarget the current entry in place, keeping `past` and `future` intact.
+ *
+ * Distinct from `pushBrowserHistory`: an origin migration is a correction of *where
+ * we already are* (the dev-preview pane moving a route onto its stable proxy origin),
+ * not a new stop. Pushing one would strand the pre-migration URL in the back stack
+ * and drop every forward entry (#12297).
+ */
+export function replaceBrowserHistoryPresent(
+  history: BrowserHistory,
+  nextUrl: string
+): BrowserHistory {
+  const normalizedUrl = nextUrl.trim();
+  if (!normalizedUrl || normalizedUrl === history.present) {
+    return history;
+  }
+  return { ...history, present: normalizedUrl };
+}
+
 export function goBackBrowserHistory(history: BrowserHistory): BrowserHistory {
   const past = normalizeEntryList(history.past);
   if (past.length === 0) {

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -862,20 +862,19 @@ export function DevPreviewPane({
     !hasBeenVisible ||
     isEvicted;
 
-  // Re-seed the `src` for a *replacement* guest, at render time, before the JSX below
-  // reads it. Every branch of `showEmptyState` unmounts the webview, so flipping back
-  // to false mounts a brand-new guest; without this it would start from the URL
-  // captured when the panel first mounted — typically the proxy root — and its
-  // did-navigate would then overwrite the route we actually intended (#12297).
-  // Only ever written on the unmounted→mounted edge, so a mounted guest's `src`
-  // still never changes underneath it (#9940).
-  const isWebviewMounted = !showEmptyState;
-  const wasWebviewMountedRef = useRef(isWebviewMounted);
-  if (wasWebviewMountedRef.current !== isWebviewMounted) {
-    wasWebviewMountedRef.current = isWebviewMounted;
-    if (isWebviewMounted && currentUrl) {
-      webviewSeedUrlRef.current = currentUrl;
-    }
+  // Track the destination a *replacement* guest should start from, at render time so the
+  // JSX below reads it in the same pass that mounts the guest. Every branch of
+  // `showEmptyState` unmounts the webview, so a fresh guest would otherwise start from the
+  // URL captured when the panel first mounted — typically the proxy root — and its
+  // did-navigate would overwrite the route we actually intended (#12297).
+  //
+  // Gated on `webviewElement` rather than on `showEmptyState`: the ref callback only runs
+  // on commit, so this reflects whether a guest is *actually* live. That keeps the write
+  // impossible while one is mounted (re-binding `src` would trigger Electron's
+  // SrcAttribute observer into a redundant reload, #9940) and immune to a render that
+  // React starts and throws away, which a previous/next flag comparison is not.
+  if (!webviewElement && currentUrl) {
+    webviewSeedUrlRef.current = currentUrl;
   }
 
   return (

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -34,6 +34,7 @@ import { getViewportPreset } from "@/panels/dev-preview/viewportPresets";
 import { isDevPreviewPanel } from "@shared/types/panel";
 import { logError } from "@/utils/logger";
 import { loadWebviewUrl } from "./loadWebviewUrl";
+import { isOnOrigin } from "./urlSync";
 import { useDevPreviewLoadLifecycle, type SessionStorageEntry } from "./useDevPreviewLoadLifecycle";
 
 import { blockedNavReducer } from "./BlockedNavBanner";
@@ -241,10 +242,15 @@ export function DevPreviewPane({
   // effect does not fire a redundant loadURL on first ready (#9940). The
   // hard-restart path resets this to "" explicitly when unconfigured.
   const lastSetUrlRef = useRef<string>(history.present);
-  // Seed value for the webview `src` attribute, captured once at mount. Never
-  // re-bound to navigation state — Electron's SrcAttribute observer would turn
-  // each guest navigation into a redundant full reload (#9940).
-  const [webviewSeedUrl, setWebviewSeedUrl] = useState(history.present);
+  // Seed value for the webview `src` attribute, fixed for the lifetime of each guest.
+  // Never re-bound to navigation state while a guest is mounted — Electron's
+  // SrcAttribute observer would turn each guest navigation into a redundant full
+  // reload (#9940). A ref rather than state because a *replacement* guest has to be
+  // re-seeded synchronously, before the JSX below reads it: an effect lands after the
+  // fresh guest has already begun loading the stale value, which is how the intended
+  // route was lost across an origin migration (#12297). See the re-seed just above the
+  // webview JSX, and BrowserPane's `initialUrlRef` for the same pattern (#10185).
+  const webviewSeedUrlRef = useRef(history.present);
   // Bumped to force a fresh guest when in-place reload cannot reach the current
   // one — a renderer that died before it was ever attached has no WebContents to
   // reload, and recovery must not silently do nothing (#12296).
@@ -265,7 +271,6 @@ export function DevPreviewPane({
   const hasBeenVisible = useHasBeenVisible(id, location);
 
   const currentUrl = history.present;
-  const effectiveWebviewSeedUrl = webviewSeedUrl || currentUrl;
   const canGoBack = history.past.length > 0;
   const canGoForward = history.future.length > 0;
   const isUnconfigured =
@@ -304,13 +309,7 @@ export function DevPreviewPane({
   const isProxyUrlPending =
     status === "running" &&
     (proxyOrigin === undefined ||
-      (typeof proxyOrigin === "string" && !!currentUrl && !currentUrl.startsWith(proxyOrigin)));
-
-  useEffect(() => {
-    if (!webviewSeedUrl && currentUrl) {
-      setWebviewSeedUrl(currentUrl);
-    }
-  }, [currentUrl, webviewSeedUrl]);
+      (typeof proxyOrigin === "string" && !!currentUrl && !isOnOrigin(currentUrl, proxyOrigin)));
 
   const { isEvicted, evictingRef } = useWebviewEviction(id, location);
 
@@ -440,7 +439,7 @@ export function DevPreviewPane({
     if (!isUnconfigured) return;
     setHistory(initializeBrowserHistory(undefined, ""));
     setBrowserUrl(id, "");
-    setWebviewSeedUrl("");
+    webviewSeedUrlRef.current = "";
     lastSetUrlRef.current = "";
     setWebviewLoadError(null);
     clearRetryState();
@@ -461,12 +460,12 @@ export function DevPreviewPane({
         // Match the `src` seed so the isWebviewReady navigation effect does not
         // re-load the same URL on first ready (#9940). The isUnconfigured effect
         // resets this to "" afterward when there is no dev command.
-        lastSetUrlRef.current = effectiveWebviewSeedUrl;
+        lastSetUrlRef.current = webviewSeedUrlRef.current;
         clearRetryState();
       }
       setWebviewElement(node);
     },
-    [captureScrollViaCdp, clearRetryState, effectiveWebviewSeedUrl]
+    [captureScrollViaCdp, clearRetryState]
   );
 
   useEffect(() => {
@@ -484,7 +483,10 @@ export function DevPreviewPane({
   // the URL we actually want before the remount rather than letting the new element
   // rewind to the mount-time URL.
   const remountWebview = useCallback(() => {
-    setWebviewSeedUrl(currentUrl);
+    // Imperative, not the render-time re-seed below: a key bump keeps `showEmptyState`
+    // false, so that mount-edge guard never fires and the replacement guest would boot
+    // from the mount-time seed (#12297).
+    webviewSeedUrlRef.current = currentUrl;
     setIsWebviewReady(false);
     setWebviewInstanceKey((key) => key + 1);
   }, [currentUrl, setIsWebviewReady]);
@@ -542,6 +544,7 @@ export function DevPreviewPane({
   }, [performReload]);
 
   const {
+    validateUrl,
     handleNavigate,
     handleBack,
     handleForward,
@@ -594,7 +597,7 @@ export function DevPreviewPane({
     clearLoadTimers();
     setHistory(initializeBrowserHistory(undefined, ""));
     setBrowserUrl(id, "");
-    setWebviewSeedUrl("");
+    webviewSeedUrlRef.current = "";
     lastSetUrlRef.current = "";
     setIsLoading(false);
     setIsWebviewReady(false);
@@ -859,6 +862,22 @@ export function DevPreviewPane({
     !hasBeenVisible ||
     isEvicted;
 
+  // Re-seed the `src` for a *replacement* guest, at render time, before the JSX below
+  // reads it. Every branch of `showEmptyState` unmounts the webview, so flipping back
+  // to false mounts a brand-new guest; without this it would start from the URL
+  // captured when the panel first mounted — typically the proxy root — and its
+  // did-navigate would then overwrite the route we actually intended (#12297).
+  // Only ever written on the unmounted→mounted edge, so a mounted guest's `src`
+  // still never changes underneath it (#9940).
+  const isWebviewMounted = !showEmptyState;
+  const wasWebviewMountedRef = useRef(isWebviewMounted);
+  if (wasWebviewMountedRef.current !== isWebviewMounted) {
+    wasWebviewMountedRef.current = isWebviewMounted;
+    if (isWebviewMounted && currentUrl) {
+      webviewSeedUrlRef.current = currentUrl;
+    }
+  }
+
   return (
     <ContentPanel
       id={id}
@@ -900,6 +919,7 @@ export function DevPreviewPane({
           viewportDpr={viewportDpr}
           viewportFit={viewportFit}
           onNavigate={handleNavigate}
+          validateUrl={validateUrl}
           onBack={handleBack}
           onForward={handleForward}
           onReload={handleReload}
@@ -1080,7 +1100,7 @@ export function DevPreviewPane({
                       key={webviewInstanceKey}
                       ref={setWebviewNode}
                       // Seed-only: never re-bind to navigation state (#9940).
-                      src={effectiveWebviewSeedUrl}
+                      src={webviewSeedUrlRef.current}
                       partition={webviewPartition}
                       // @ts-expect-error React 19 requires "" to emit the attribute; boolean true is silently dropped
                       allowpopups=""

--- a/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
@@ -3520,17 +3520,86 @@ describe("DevPreviewPane webview lifecycle regression", () => {
       });
 
       expect(webview.getAttribute("src")).toBe(`${PROXY}/once`);
+      // Both halves matter: no corrective load, and no second guest seeded with the same
+      // route — either one would be a second request for the destination.
       expect(loadsAcrossGuests()).toEqual([]);
+      expect(seedsAcrossGuests()).toEqual([`${PROXY}/once`]);
+      expect(webview.reload).not.toHaveBeenCalled();
     });
 
-    it("mounts exactly one guest per destination while migrating", async () => {
+    it("creates exactly one guest, seeded once, while migrating", async () => {
       setSavedHistory({ past: [], present: "http://localhost:5173/deep/route?a=1", future: [] });
       render(<DevPreviewPane {...baseProps} />);
       await settle();
 
-      // One gated mount is expected; what must not happen is a guest per intermediate state.
-      expect(guestLog.length).toBeLessThanOrEqual(2);
-      expect(seedsAcrossGuests().at(-1)).toBe(`${PROXY}/deep/route?a=1`);
+      // Exact, not "at most": two guests each seeded with the destination would request it
+      // twice while still satisfying a loadURL-only assertion.
+      expect(guestLog).toHaveLength(1);
+      expect(seedsAcrossGuests()).toEqual([`${PROXY}/deep/route?a=1`]);
+      expect(loadsAcrossGuests()).toEqual([]);
+    });
+
+    it("re-seeds a genuine replacement guest when a redirect crosses off the proxy origin", async () => {
+      // The reported sequence, end to end, against an ALREADY-MOUNTED guest — the case the
+      // gated-first-mount tests above cannot reach. The guest is on the proxy origin, follows
+      // an absolute upstream redirect off it, which gates the webview out; the pane migrates
+      // the route back onto the proxy origin and mounts a REPLACEMENT guest. That guest must
+      // start from the callback route, not from the origin's root.
+      setSavedHistory({ past: [], present: `${PROXY}/once`, future: [] });
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      await settle();
+
+      const firstGuest = getWebviewElement(container);
+      await act(async () => {
+        emitWebviewEvent(firstGuest, "dom-ready");
+        await Promise.resolve();
+      });
+      expect(guestLog).toHaveLength(1);
+      expect(seedsAcrossGuests()).toEqual([`${PROXY}/once`]);
+
+      // The guest followed the upstream's absolute redirect and committed off-origin.
+      await act(async () => {
+        emitWebviewEvent(firstGuest, "did-navigate", {
+          url: "http://localhost:5173/consume?token=audit-single-use#done",
+        });
+        await Promise.resolve();
+      });
+      await settle();
+
+      const expected = `${PROXY}/consume?token=audit-single-use#done`;
+      // A replacement guest was created, and it starts from the callback route with its
+      // query and fragment intact — before the fix it started from the frozen session seed.
+      expect(guestLog.length).toBeGreaterThan(1);
+      expect(seedsAcrossGuests().at(-1)).toBe(expected);
+      expect(seedsAcrossGuests()).not.toContain(`${PROXY}/`);
+      // The seed navigates the replacement guest by itself; a corrective load on top would
+      // be a second request for a single-use callback.
+      expect(loadsAcrossGuests()).toEqual([]);
+      expect(getWebviewElement(container).getAttribute("src")).toBe(expected);
+    });
+
+    it("keeps a replacement guest's seed current across repeated origin crossings", async () => {
+      // Guards specifically against a fix that refreshes the seed once and then re-freezes:
+      // the second crossing must be seeded from the second destination, not the first.
+      setSavedHistory({ past: [], present: `${PROXY}/start`, future: [] });
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      await settle();
+
+      for (const route of ["/first?n=1", "/second?n=2"]) {
+        const guest = getWebviewElement(container);
+        await act(async () => {
+          emitWebviewEvent(guest, "dom-ready");
+          await Promise.resolve();
+        });
+        await act(async () => {
+          emitWebviewEvent(guest, "did-navigate", { url: `http://localhost:5173${route}` });
+          await Promise.resolve();
+        });
+        await settle();
+        expect(seedsAcrossGuests().at(-1)).toBe(`${PROXY}${route}`);
+      }
+
+      expect(loadsAcrossGuests()).toEqual([]);
     });
 
     it("hands the toolbar a validator that accepts the panel's own origin", async () => {
@@ -3572,9 +3641,11 @@ describe("DevPreviewPane webview lifecycle regression", () => {
         await Promise.resolve();
       });
 
-      // Same guest, one imperative load, and `src` was not re-bound (#9940).
+      // Same guest, one imperative load, and `src` genuinely was not re-bound (#9940) —
+      // the seed write count must not have grown.
       expect(guestLog.length).toBe(guestsBefore);
       expect(guestLog.at(-1)!.loadURLs).toEqual([`${PROXY}/typed?x=1#s`]);
+      expect(guestLog.at(-1)!.srcWrites).toEqual([`${PROXY}/`]);
     });
 
     it("retargets a raw upstream address onto the proxy origin, requesting it once", async () => {
@@ -3600,6 +3671,9 @@ describe("DevPreviewPane webview lifecycle regression", () => {
       // re-requests the route from a replacement guest.
       expect(loadsAcrossGuests()).toEqual([`${PROXY}/once`]);
       expect(loadsAcrossGuests()).not.toContain("http://localhost:5173/once");
+      // One guest throughout, seeded once — the destination is requested exactly once.
+      expect(guestLog).toHaveLength(1);
+      expect(seedsAcrossGuests()).toEqual([`${PROXY}/`]);
     });
 
     it("ignores a rejected address entirely — no load, no mount, no history entry", async () => {
@@ -3628,17 +3702,20 @@ describe("DevPreviewPane webview lifecycle regression", () => {
     });
 
     it("does not treat a prefix-matching port as the proxy origin", async () => {
-      // `startsWith` accepted `…localhost:43000` as sitting on `…localhost:4300`, which would
-      // leave the pane displaying an origin it never proxied.
-      setSavedHistory({
-        past: [],
-        present: buildDevPreviewProxyOrigin(4300, "project-1", "dev-preview-panel-1") + "/x",
-        future: [],
-      });
+      // The ports must be this way round: `"…:43000/x".startsWith("…:4300")` is TRUE, so the
+      // old check called the pane settled and left the guest on an origin it never proxied.
+      // (The reverse arrangement is rejected by `startsWith` too, and proves nothing.)
+      const shortPortProxy = buildDevPreviewProxyOrigin(4300, "project-1", "dev-preview-panel-1");
+      const electron = (window as unknown as { electron: Record<string, unknown> }).electron;
+      electron.devPreview = { getProxyPort: vi.fn().mockResolvedValue({ port: 4300 }) };
+      setSavedHistory({ past: [], present: `${PROXY}/x`, future: [] });
+
       render(<DevPreviewPane {...baseProps} />);
       await settle();
 
-      expect(seedsAcrossGuests().at(-1)).toBe(`${PROXY}/x`);
+      expect(seedsAcrossGuests().at(-1)).toBe(`${shortPortProxy}/x`);
+      // Never seeded on the longer-port origin that merely has the real one as a prefix.
+      expect(seedsAcrossGuests()).not.toContain(`${PROXY}/x`);
     });
   });
 });

--- a/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
@@ -5,7 +5,10 @@ import type { DevPreviewPaneProps } from "../DevPreviewPane";
 import { DevPreviewPane } from "../DevPreviewPane";
 import { projectClient } from "@/clients";
 import { actionService } from "@/services/ActionService";
-import { DEV_PREVIEW_PROXY_STATUS_TEXT } from "@shared/utils/devPreviewProxy";
+import {
+  buildDevPreviewProxyOrigin,
+  DEV_PREVIEW_PROXY_STATUS_TEXT,
+} from "@shared/utils/devPreviewProxy";
 
 const notifyMock = vi.hoisted(() => vi.fn());
 
@@ -19,6 +22,16 @@ type MockWebContents = {
   enableDeviceEmulation: ReturnType<typeof vi.fn>;
   disableDeviceEmulation: ReturnType<typeof vi.fn>;
 };
+
+/**
+ * One entry per `<webview>` element React actually created. `srcWrites` are seed writes
+ * (React setting the attribute); `loadURLs` are imperative navigations. The mock's
+ * `loadURL` also writes `src`, so without separating the two by origin a test cannot
+ * tell a fresh guest's seed from a corrective load — which is the exact distinction
+ * #12297 turns on.
+ */
+type GuestRecord = { srcWrites: string[]; loadURLs: string[] };
+const guestLog: GuestRecord[] = [];
 
 type MockWebviewElement = HTMLElement & {
   reload: ReturnType<typeof vi.fn>;
@@ -43,6 +56,15 @@ function decorateWebviewElement(element: HTMLElement): MockWebviewElement {
   let loading = nextWebviewStartsLoading;
   const webview = element as MockWebviewElement;
 
+  const record: GuestRecord = { srcWrites: [], loadURLs: [] };
+  guestLog.push(record);
+  let inLoadURL = false;
+  const setAttributeDirect = element.setAttribute.bind(element);
+  element.setAttribute = (name: string, value: string) => {
+    if (name === "src" && !inLoadURL) record.srcWrites.push(value);
+    setAttributeDirect(name, value);
+  };
+
   const syncUrlFromAttribute = () => {
     const src = element.getAttribute("src");
     if (typeof src === "string" && src.length > 0) {
@@ -53,8 +75,14 @@ function decorateWebviewElement(element: HTMLElement): MockWebviewElement {
   webview.reload = vi.fn();
   webview.stop = vi.fn();
   webview.loadURL = vi.fn((url: string) => {
+    record.loadURLs.push(url);
     currentUrl = url;
-    element.setAttribute("src", url);
+    inLoadURL = true;
+    try {
+      element.setAttribute("src", url);
+    } finally {
+      inLoadURL = false;
+    }
   });
   webview.setZoomFactor = vi.fn();
   webview.getURL = vi.fn(() => {
@@ -379,6 +407,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
       dispatchEvent: vi.fn(),
     }));
     scrollPositionRef.current = undefined;
+    guestLog.length = 0;
     originalCreateElement = document.createElement.bind(document);
     document.createElement = ((tagName: string, options?: ElementCreationOptions) => {
       const element = originalCreateElement(tagName, options);
@@ -3402,6 +3431,214 @@ describe("DevPreviewPane webview lifecycle regression", () => {
       });
 
       expect(webview.loadURL).toHaveBeenCalledWith("http://localhost:5174/");
+    });
+  });
+
+  // #12297 — crossing onto the stable proxy origin used to lose the route. `showEmptyState`
+  // unmounts the `<webview>` while `isProxyUrlPending` is true, and the replacement guest was
+  // seeded from `webviewSeedUrl`, which is captured once per session. These tests run the
+  // *configured proxy* path the existing coverage never reached, and assert call counts so a
+  // fix that re-requests a consumed callback would fail here.
+  describe("proxy-origin route preservation (#12297)", () => {
+    const PROXY_PORT = 43000;
+    const PROXY = buildDevPreviewProxyOrigin(PROXY_PORT, "project-1", "dev-preview-panel-1");
+
+    function enableProxyMode() {
+      const electron = (window as unknown as { electron: Record<string, unknown> }).electron;
+      electron.devPreview = {
+        getProxyPort: vi.fn().mockResolvedValue({ port: PROXY_PORT }),
+        mintBrowserToken: vi
+          .fn()
+          .mockResolvedValue({ bootstrapUrl: `${PROXY}/_daintree/bootstrap` }),
+      };
+    }
+
+    function setSavedHistory(history: { past: string[]; present: string; future: string[] }) {
+      terminalStoreState.getTerminal.mockImplementation(() => ({
+        kind: "dev-preview",
+        id: "dev-preview-panel-1",
+        browserHistory: history,
+        browserZoom: 1.4,
+        devPreviewConsoleOpen: false,
+        devCommand: "npm run dev",
+        devPreviewScrollPosition: scrollPositionRef.current,
+      }));
+    }
+
+    // Let the proxy-port promise resolve and every dependent effect flush.
+    async function settle() {
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+    }
+
+    function seedsAcrossGuests(): string[] {
+      return guestLog.flatMap((g) => g.srcWrites);
+    }
+
+    function loadsAcrossGuests(): string[] {
+      return guestLog.flatMap((g) => g.loadURLs);
+    }
+
+    beforeEach(() => {
+      enableProxyMode();
+    });
+
+    it("seeds a replacement guest from the migrated route, not the session's first URL", async () => {
+      // A session that persisted a raw upstream URL: the pane gates the webview out while it
+      // migrates onto the proxy origin, then mounts a fresh guest. Before the fix that guest
+      // was seeded with the stale `webviewSeedUrl` and landed on "/".
+      setSavedHistory({
+        past: [],
+        present: "http://localhost:5173/consume?token=audit-single-use#done",
+        future: [],
+      });
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      await settle();
+
+      const webview = getWebviewElement(container);
+      const expected = `${PROXY}/consume?token=audit-single-use#done`;
+
+      expect(webview.getAttribute("src")).toBe(expected);
+      // Path, query and fragment all survive the origin change.
+      expect(seedsAcrossGuests()).not.toContain(`${PROXY}/`);
+      expect(seedsAcrossGuests().at(-1)).toBe(expected);
+    });
+
+    it("does not re-request the destination after seeding a replacement guest", async () => {
+      // The seed navigates the guest by itself, so a corrective loadURL on top of it would be
+      // a second request — exactly the callback replay the issue rules out.
+      setSavedHistory({ past: [], present: "http://localhost:5173/once", future: [] });
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      await settle();
+
+      const webview = getWebviewElement(container);
+      await act(async () => {
+        emitWebviewEvent(webview, "dom-ready");
+        await Promise.resolve();
+      });
+
+      expect(webview.getAttribute("src")).toBe(`${PROXY}/once`);
+      expect(loadsAcrossGuests()).toEqual([]);
+    });
+
+    it("mounts exactly one guest per destination while migrating", async () => {
+      setSavedHistory({ past: [], present: "http://localhost:5173/deep/route?a=1", future: [] });
+      render(<DevPreviewPane {...baseProps} />);
+      await settle();
+
+      // One gated mount is expected; what must not happen is a guest per intermediate state.
+      expect(guestLog.length).toBeLessThanOrEqual(2);
+      expect(seedsAcrossGuests().at(-1)).toBe(`${PROXY}/deep/route?a=1`);
+    });
+
+    it("hands the toolbar a validator that accepts the panel's own origin", async () => {
+      setSavedHistory({ past: [], present: `${PROXY}/`, future: [] });
+      render(<DevPreviewPane {...baseProps} />);
+      await settle();
+
+      const props = browserToolbarPropsSpy.mock.calls.at(-1)![0] as {
+        validateUrl?: (url: string) => { url?: string; error?: string };
+      };
+      expect(props.validateUrl).toBeTypeOf("function");
+      // The reported failure: this returned "Only localhost URLs are allowed".
+      expect(props.validateUrl!(`${PROXY}/typed-route`)).toEqual({ url: `${PROXY}/typed-route` });
+      // A raw upstream address is retargeted rather than pushed off-origin.
+      expect(props.validateUrl!("http://localhost:5173/typed-route").url).toBe(
+        `${PROXY}/typed-route`
+      );
+      // Still no blanket acceptance of external hosts.
+      expect(props.validateUrl!("http://example.com/x").url).toBeUndefined();
+    });
+
+    it("navigates the live guest to a submitted route without remounting it", async () => {
+      setSavedHistory({ past: [], present: `${PROXY}/`, future: [] });
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      await settle();
+
+      const webview = getWebviewElement(container);
+      await act(async () => {
+        emitWebviewEvent(webview, "dom-ready");
+        await Promise.resolve();
+      });
+      const guestsBefore = guestLog.length;
+      const props = browserToolbarPropsSpy.mock.calls.at(-1)![0] as {
+        onNavigate: (url: string) => void;
+      };
+
+      await act(async () => {
+        props.onNavigate(`${PROXY}/typed?x=1#s`);
+        await Promise.resolve();
+      });
+
+      // Same guest, one imperative load, and `src` was not re-bound (#9940).
+      expect(guestLog.length).toBe(guestsBefore);
+      expect(guestLog.at(-1)!.loadURLs).toEqual([`${PROXY}/typed?x=1#s`]);
+    });
+
+    it("retargets a raw upstream address onto the proxy origin, requesting it once", async () => {
+      setSavedHistory({ past: [], present: `${PROXY}/`, future: [] });
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      await settle();
+
+      const webview = getWebviewElement(container);
+      await act(async () => {
+        emitWebviewEvent(webview, "dom-ready");
+        await Promise.resolve();
+      });
+      const props = browserToolbarPropsSpy.mock.calls.at(-1)![0] as {
+        onNavigate: (url: string) => void;
+      };
+
+      await act(async () => {
+        props.onNavigate("http://localhost:5173/once");
+        await Promise.resolve();
+      });
+
+      // Never lands on the raw origin, so the pane never gates the guest out and never
+      // re-requests the route from a replacement guest.
+      expect(loadsAcrossGuests()).toEqual([`${PROXY}/once`]);
+      expect(loadsAcrossGuests()).not.toContain("http://localhost:5173/once");
+    });
+
+    it("ignores a rejected address entirely — no load, no mount, no history entry", async () => {
+      setSavedHistory({ past: [], present: `${PROXY}/`, future: [] });
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      await settle();
+
+      const webview = getWebviewElement(container);
+      await act(async () => {
+        emitWebviewEvent(webview, "dom-ready");
+        await Promise.resolve();
+      });
+      const guestsBefore = guestLog.length;
+      const loadsBefore = loadsAcrossGuests().length;
+      const props = browserToolbarPropsSpy.mock.calls.at(-1)![0] as {
+        onNavigate: (url: string) => void;
+      };
+
+      await act(async () => {
+        props.onNavigate("http://evil.localhost:43000/x");
+        await Promise.resolve();
+      });
+
+      expect(guestLog.length).toBe(guestsBefore);
+      expect(loadsAcrossGuests()).toHaveLength(loadsBefore);
+    });
+
+    it("does not treat a prefix-matching port as the proxy origin", async () => {
+      // `startsWith` accepted `…localhost:43000` as sitting on `…localhost:4300`, which would
+      // leave the pane displaying an origin it never proxied.
+      setSavedHistory({
+        past: [],
+        present: buildDevPreviewProxyOrigin(4300, "project-1", "dev-preview-panel-1") + "/x",
+        future: [],
+      });
+      render(<DevPreviewPane {...baseProps} />);
+      await settle();
+
+      expect(seedsAcrossGuests().at(-1)).toBe(`${PROXY}/x`);
     });
   });
 });

--- a/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
@@ -9,6 +9,7 @@ import {
   buildDevPreviewProxyOrigin,
   DEV_PREVIEW_PROXY_STATUS_TEXT,
 } from "@shared/utils/devPreviewProxy";
+import type { NormalizeResult } from "@shared/utils/urlUtils";
 
 const notifyMock = vi.hoisted(() => vi.fn());
 
@@ -288,15 +289,30 @@ vi.mock("@/hooks/useFindInPage", () => ({
   }),
 }));
 
+// The props the tests actually read, named so recording them needs no type assertion.
+// The index signature keeps every other prop flowing through untyped, as before.
+type MockToolbarProps = {
+  onNavigate: (url: string) => void;
+  validateUrl?: (url: string) => NormalizeResult;
+  onPromoteToPortal?: () => void;
+  onCaptureScreenshot: () => Promise<boolean>;
+} & Record<string, unknown>;
+
 const { browserToolbarPropsSpy } = vi.hoisted(() => ({
-  browserToolbarPropsSpy: vi.fn(),
+  browserToolbarPropsSpy: vi.fn<(props: MockToolbarProps) => void>(),
 }));
 vi.mock("@/components/Browser/BrowserToolbar", () => ({
-  BrowserToolbar: (props: Record<string, unknown>) => {
+  BrowserToolbar: (props: MockToolbarProps) => {
     browserToolbarPropsSpy(props);
     return <div data-testid="browser-toolbar" />;
   },
 }));
+
+function latestToolbarProps(): MockToolbarProps {
+  const call = browserToolbarPropsSpy.mock.calls.at(-1);
+  if (!call) throw new Error("Expected BrowserToolbar to have rendered");
+  return call[0];
+}
 
 const headerContentPointerDownSpy = vi.hoisted(() => vi.fn());
 
@@ -1955,12 +1971,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
       error: { code: "EXECUTION_ERROR", message },
     });
 
-    const getPromoteHandler = () => {
-      const props = browserToolbarPropsSpy.mock.calls.at(-1)?.[0] as {
-        onPromoteToPortal?: () => void;
-      };
-      return props.onPromoteToPortal;
-    };
+    const getPromoteHandler = () => latestToolbarProps().onPromoteToPortal;
 
     it("renders the dispatch failure reason inline, without a global toast", async () => {
       const message = "Portal is already showing this URL";
@@ -2011,12 +2022,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
   });
 
   describe("screenshot capture", () => {
-    const getToolbarCapture = () => {
-      const props = browserToolbarPropsSpy.mock.calls.at(-1)?.[0] as {
-        onCaptureScreenshot: () => Promise<boolean>;
-      };
-      return props.onCaptureScreenshot;
-    };
+    const getToolbarCapture = () => latestToolbarProps().onCaptureScreenshot;
 
     const getWriteImageMock = () => {
       const electron = (window as unknown as { electron: { clipboard: Record<string, unknown> } })
@@ -3443,14 +3449,15 @@ describe("DevPreviewPane webview lifecycle regression", () => {
     const PROXY_PORT = 43000;
     const PROXY = buildDevPreviewProxyOrigin(PROXY_PORT, "project-1", "dev-preview-panel-1");
 
-    function enableProxyMode() {
-      const electron = (window as unknown as { electron: Record<string, unknown> }).electron;
-      electron.devPreview = {
-        getProxyPort: vi.fn().mockResolvedValue({ port: PROXY_PORT }),
-        mintBrowserToken: vi
-          .fn()
-          .mockResolvedValue({ bootstrapUrl: `${PROXY}/_daintree/bootstrap` }),
-      };
+    function enableProxyMode(port = PROXY_PORT) {
+      Object.assign(window.electron, {
+        devPreview: {
+          getProxyPort: vi.fn().mockResolvedValue({ port }),
+          mintBrowserToken: vi
+            .fn()
+            .mockResolvedValue({ bootstrapUrl: `${PROXY}/_daintree/bootstrap` }),
+        },
+      });
     }
 
     function setSavedHistory(history: { past: string[]; present: string; future: string[] }) {
@@ -3607,9 +3614,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
       render(<DevPreviewPane {...baseProps} />);
       await settle();
 
-      const props = browserToolbarPropsSpy.mock.calls.at(-1)![0] as {
-        validateUrl?: (url: string) => { url?: string; error?: string };
-      };
+      const props = latestToolbarProps();
       expect(props.validateUrl).toBeTypeOf("function");
       // The reported failure: this returned "Only localhost URLs are allowed".
       expect(props.validateUrl!(`${PROXY}/typed-route`)).toEqual({ url: `${PROXY}/typed-route` });
@@ -3632,9 +3637,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
         await Promise.resolve();
       });
       const guestsBefore = guestLog.length;
-      const props = browserToolbarPropsSpy.mock.calls.at(-1)![0] as {
-        onNavigate: (url: string) => void;
-      };
+      const props = latestToolbarProps();
 
       await act(async () => {
         props.onNavigate(`${PROXY}/typed?x=1#s`);
@@ -3658,9 +3661,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
         emitWebviewEvent(webview, "dom-ready");
         await Promise.resolve();
       });
-      const props = browserToolbarPropsSpy.mock.calls.at(-1)![0] as {
-        onNavigate: (url: string) => void;
-      };
+      const props = latestToolbarProps();
 
       await act(async () => {
         props.onNavigate("http://localhost:5173/once");
@@ -3688,9 +3689,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
       });
       const guestsBefore = guestLog.length;
       const loadsBefore = loadsAcrossGuests().length;
-      const props = browserToolbarPropsSpy.mock.calls.at(-1)![0] as {
-        onNavigate: (url: string) => void;
-      };
+      const props = latestToolbarProps();
 
       await act(async () => {
         props.onNavigate("http://evil.localhost:43000/x");
@@ -3706,8 +3705,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
       // old check called the pane settled and left the guest on an origin it never proxied.
       // (The reverse arrangement is rejected by `startsWith` too, and proves nothing.)
       const shortPortProxy = buildDevPreviewProxyOrigin(4300, "project-1", "dev-preview-panel-1");
-      const electron = (window as unknown as { electron: Record<string, unknown> }).electron;
-      electron.devPreview = { getProxyPort: vi.fn().mockResolvedValue({ port: 4300 }) };
+      enableProxyMode(4300);
       setSavedHistory({ past: [], present: `${PROXY}/x`, future: [] });
 
       render(<DevPreviewPane {...baseProps} />);

--- a/src/components/DevPreview/__tests__/urlSync.test.ts
+++ b/src/components/DevPreview/__tests__/urlSync.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { computeDevServerUrl } from "../urlSync";
+import { computeDevServerUrl, isOnOrigin, normalizeDevPreviewUrl } from "../urlSync";
 
 describe("computeDevServerUrl", () => {
   it("returns false when there is no detected URL", () => {
@@ -104,6 +104,171 @@ describe("computeDevServerUrl", () => {
 
     it("returns false when the proxy origin string cannot be parsed", () => {
       expect(computeDevServerUrl("http://localhost:3000/", "", "not-a-url")).toBe(false);
+    });
+
+    it("keeps the pane's own route when the dev server also advertises a base path (#12297)", () => {
+      // The advertised base wins on *first* adoption (covered above), but on a migration
+      // the pane already holds the route the user or the app asked for.
+      expect(
+        computeDevServerUrl("http://localhost:5174/app/", "http://localhost:5174/once", PROXY)
+      ).toBe(`${PROXY}/once`);
+    });
+
+    it("preserves query and fragment when migrating an upstream callback (#12297)", () => {
+      expect(
+        computeDevServerUrl(
+          "http://localhost:5173/",
+          "http://localhost:5173/consume?token=audit-single-use#done",
+          PROXY
+        )
+      ).toBe(`${PROXY}/consume?token=audit-single-use#done`);
+    });
+
+    it("treats a root URL carrying only a query as a route worth preserving", () => {
+      expect(
+        computeDevServerUrl("http://localhost:5174/app/", "http://localhost:5173/?code=abc", PROXY)
+      ).toBe(`${PROXY}/?code=abc`);
+    });
+
+    it("keeps a hash-router route across the migration", () => {
+      expect(
+        computeDevServerUrl("http://localhost:5173/", "http://localhost:5173/#/settings", PROXY)
+      ).toBe(`${PROXY}/#/settings`);
+    });
+  });
+});
+
+describe("isOnOrigin", () => {
+  it("matches a URL sitting on exactly that origin", () => {
+    expect(isOnOrigin("http://dp-a-b.localhost:43000/x?y#z", "http://dp-a-b.localhost:43000")).toBe(
+      true
+    );
+  });
+
+  it("rejects a port that merely shares a prefix", () => {
+    // `startsWith` would accept this — 43000 begins with 4300.
+    expect(isOnOrigin("http://dp-a-b.localhost:43000/", "http://dp-a-b.localhost:4300")).toBe(
+      false
+    );
+  });
+
+  it("rejects a different subdomain and a different scheme", () => {
+    expect(isOnOrigin("http://dp-a-c.localhost:43000/", "http://dp-a-b.localhost:43000")).toBe(
+      false
+    );
+    expect(isOnOrigin("https://dp-a-b.localhost:43000/", "http://dp-a-b.localhost:43000")).toBe(
+      false
+    );
+  });
+
+  it("rejects unparseable input on either side", () => {
+    expect(isOnOrigin("not-a-url", "http://dp-a-b.localhost:43000")).toBe(false);
+    expect(isOnOrigin("http://dp-a-b.localhost:43000/", "not-a-url")).toBe(false);
+  });
+});
+
+describe("normalizeDevPreviewUrl (#12297)", () => {
+  const PROXY = "http://dp-proj-panel.localhost:43000";
+
+  describe("configured proxy mode", () => {
+    it("accepts the panel's own proxy origin — the bug that made the address bar unusable", () => {
+      expect(normalizeDevPreviewUrl(`${PROXY}/typed-route`, PROXY)).toEqual({
+        url: `${PROXY}/typed-route`,
+      });
+    });
+
+    it("accepts the panel's own origin typed without a scheme", () => {
+      expect(normalizeDevPreviewUrl("dp-proj-panel.localhost:43000/typed-route", PROXY)).toEqual({
+        url: `${PROXY}/typed-route`,
+      });
+    });
+
+    it("keeps query and fragment on the panel's own origin", () => {
+      expect(normalizeDevPreviewUrl(`${PROXY}/a/b?x=1&x=2#frag`, PROXY)).toEqual({
+        url: `${PROXY}/a/b?x=1&x=2#frag`,
+      });
+    });
+
+    it("retargets a raw upstream URL onto the proxy origin, preserving the whole route", () => {
+      expect(normalizeDevPreviewUrl("http://localhost:5173/once?a=1#b", PROXY)).toEqual({
+        url: `${PROXY}/once?a=1#b`,
+      });
+    });
+
+    it("retargets regardless of which upstream port was typed", () => {
+      expect(normalizeDevPreviewUrl("http://127.0.0.1:9999/deep/route", PROXY)).toEqual({
+        url: `${PROXY}/deep/route`,
+      });
+    });
+
+    it("preserves percent-encoded path segments through the retarget", () => {
+      expect(normalizeDevPreviewUrl("http://localhost:5173/a%2Fb/c%20d", PROXY)).toEqual({
+        url: `${PROXY}/a%2Fb/c%20d`,
+      });
+    });
+
+    it("is idempotent — re-normalizing its own output changes nothing", () => {
+      const once = normalizeDevPreviewUrl("http://localhost:5173/once?a=1#b", PROXY);
+      expect(normalizeDevPreviewUrl(once.url!, PROXY)).toEqual(once);
+    });
+
+    it("rejects another panel's proxy origin (same shape, different owner)", () => {
+      const result = normalizeDevPreviewUrl("http://dp-proj-other.localhost:43000/x", PROXY);
+      expect(result.url).toBeUndefined();
+      expect(result.error).toContain("Only localhost URLs are allowed");
+    });
+
+    it("rejects the panel's own host on a different port", () => {
+      expect(normalizeDevPreviewUrl("http://dp-proj-panel.localhost:43001/x", PROXY).url).toBe(
+        undefined
+      );
+    });
+
+    it("rejects https on the panel's own host — the proxy serves plain HTTP", () => {
+      expect(normalizeDevPreviewUrl("https://dp-proj-panel.localhost:43000/x", PROXY).url).toBe(
+        undefined
+      );
+    });
+
+    it.each([
+      ["an arbitrary .localhost name", "http://evil.localhost:43000/x"],
+      ["a private LAN address", "http://192.168.1.7:3000/x"],
+      ["a public host", "http://example.com/x"],
+      ["a .test name", "http://app.test/x"],
+    ])("rejects %s without offering confirmation", (_label, input) => {
+      const result = normalizeDevPreviewUrl(input, PROXY);
+      expect(result.url).toBeUndefined();
+      expect(result.requiresConfirmation).toBeUndefined();
+      expect(result.error).toBeTruthy();
+    });
+
+    it("rejects a non-http(s) protocol", () => {
+      expect(normalizeDevPreviewUrl("file:///etc/passwd", PROXY).url).toBeUndefined();
+      expect(normalizeDevPreviewUrl("javascript:alert(1)", PROXY).url).toBeUndefined();
+    });
+
+    it("rejects empty input", () => {
+      expect(normalizeDevPreviewUrl("   ", PROXY).error).toBeTruthy();
+    });
+  });
+
+  describe("legacy / unresolved proxy", () => {
+    it("keeps a loopback URL untouched in legacy mode", () => {
+      expect(normalizeDevPreviewUrl("http://localhost:5173/once", null)).toEqual({
+        url: "http://localhost:5173/once",
+      });
+    });
+
+    it("keeps a loopback URL untouched while the proxy port is still resolving", () => {
+      expect(normalizeDevPreviewUrl("http://localhost:5173/once", undefined)).toEqual({
+        url: "http://localhost:5173/once",
+      });
+    });
+
+    it("still rejects a proxy-shaped origin when this panel has none", () => {
+      expect(normalizeDevPreviewUrl("http://dp-proj-panel.localhost:43000/x", null).url).toBe(
+        undefined
+      );
     });
   });
 });

--- a/src/components/DevPreview/__tests__/useDevPreviewNavigation.test.tsx
+++ b/src/components/DevPreview/__tests__/useDevPreviewNavigation.test.tsx
@@ -2,6 +2,7 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useState } from "react";
 import { renderHook, act } from "@testing-library/react";
 import { useDevPreviewNavigation } from "../useDevPreviewNavigation";
 import { initializeBrowserHistory } from "../../Browser/historyUtils";
@@ -561,6 +562,141 @@ describe("useDevPreviewNavigation — persistence effects", () => {
     );
     const updaterCalls = setHistory.mock.calls.filter((call) => typeof call[0] === "function");
     expect(updaterCalls.length).toBeGreaterThan(0);
+  });
+});
+
+// #12297 — the pane must never lose the route when it crosses onto the proxy origin,
+// and its address bar must accept the origin it is itself displaying. These need a
+// harness that actually owns history state, so the migration effect converges instead
+// of being observed one updater at a time.
+describe("useDevPreviewNavigation — proxy-origin routing (#12297)", () => {
+  const PROXY = "http://dp-proj-panel.localhost:43000";
+  const UPSTREAM = "http://localhost:5173";
+
+  function renderStateful(init: {
+    present: string;
+    past?: string[];
+    future?: string[];
+    devServerUrl?: string | null;
+    proxyOrigin?: string | null;
+  }) {
+    const initial: BrowserHistory = {
+      past: init.past ?? [],
+      present: init.present,
+      future: init.future ?? [],
+    };
+    const seen = { history: initial };
+    const rendered = renderHook(() => {
+      const [history, setHistory] = useState<BrowserHistory>(initial);
+      seen.history = history;
+      return useDevPreviewNavigation(
+        baseParams({
+          history,
+          setHistory,
+          currentUrl: history.present,
+          canGoBack: history.past.length > 0,
+          canGoForward: history.future.length > 0,
+          devServerUrl: init.devServerUrl ?? null,
+          proxyOrigin: init.proxyOrigin ?? null,
+        })
+      );
+    });
+    return { ...rendered, seen };
+  }
+
+  it("accepts the panel's own proxy origin from the address bar", () => {
+    // The reported bug: this returned "Only localhost URLs are allowed" and never navigated.
+    const { result, seen } = renderStateful({ present: `${PROXY}/`, proxyOrigin: PROXY });
+    act(() => result.current.handleNavigate(`${PROXY}/typed-route?x=1#f`));
+    expect(seen.history.present).toBe(`${PROXY}/typed-route?x=1#f`);
+    expect(result.current.validateUrl(`${PROXY}/typed-route`).error).toBeUndefined();
+  });
+
+  it("retargets a typed raw upstream URL onto the proxy origin in one commit", () => {
+    const { result, seen } = renderStateful({
+      present: `${PROXY}/`,
+      devServerUrl: `${UPSTREAM}/`,
+      proxyOrigin: PROXY,
+    });
+    act(() => result.current.handleNavigate(`${UPSTREAM}/once?a=1#b`));
+
+    // The route survives, and history never holds the raw upstream origin — so the pane
+    // never gates the webview out and never remounts it against a stale seed.
+    expect(seen.history.present).toBe(`${PROXY}/once?a=1#b`);
+    expect(seen.history.past).toEqual([`${PROXY}/`]);
+    expect(seen.history.past).not.toContain(`${UPSTREAM}/once?a=1#b`);
+  });
+
+  it("refuses a foreign host without touching history", () => {
+    const { result, seen } = renderStateful({ present: `${PROXY}/`, proxyOrigin: PROXY });
+    act(() => result.current.handleNavigate("http://example.com/x"));
+    act(() => result.current.handleNavigate("http://dp-proj-other.localhost:43000/x"));
+    expect(seen.history.present).toBe(`${PROXY}/`);
+    expect(seen.history.past).toEqual([]);
+  });
+
+  it("exposes a validator that tracks the panel's own proxy origin", () => {
+    const { result } = renderStateful({ present: `${PROXY}/`, proxyOrigin: PROXY });
+    expect(result.current.validateUrl(`${PROXY}/x`).url).toBe(`${PROXY}/x`);
+    expect(
+      result.current.validateUrl("http://dp-proj-other.localhost:43000/x").url
+    ).toBeUndefined();
+    // Same policy the toolbar submits through, so the two can never disagree.
+    expect(result.current.validateUrl(`${UPSTREAM}/x`).url).toBe(`${PROXY}/x`);
+  });
+
+  it("migrates a stale raw-upstream entry onto the proxy origin without stranding it in the back stack", () => {
+    const { seen } = renderStateful({
+      present: `${UPSTREAM}/consume?token=audit-single-use#done`,
+      past: [`${PROXY}/start`],
+      future: [`${PROXY}/ahead`],
+      devServerUrl: `${UPSTREAM}/`,
+      proxyOrigin: PROXY,
+    });
+
+    expect(seen.history.present).toBe(`${PROXY}/consume?token=audit-single-use#done`);
+    // Replacement, not a push: Back still returns to /start and Forward still works.
+    expect(seen.history.past).toEqual([`${PROXY}/start`]);
+    expect(seen.history.future).toEqual([`${PROXY}/ahead`]);
+  });
+
+  it("settles once on the proxy origin instead of re-migrating", () => {
+    const { seen, rerender } = renderStateful({
+      present: `${UPSTREAM}/settings`,
+      devServerUrl: `${UPSTREAM}/`,
+      proxyOrigin: PROXY,
+    });
+    const settled = seen.history;
+    rerender();
+    expect(seen.history.present).toBe(`${PROXY}/settings`);
+    expect(seen.history).toBe(settled);
+  });
+
+  it("still pushes in legacy mode, where a port shift is a genuine new origin", () => {
+    const { seen } = renderStateful({
+      present: "http://localhost:3000/dashboard",
+      devServerUrl: "http://localhost:3001/",
+      proxyOrigin: null,
+    });
+    expect(seen.history.present).toBe("http://localhost:3001/dashboard");
+    expect(seen.history.past).toEqual(["http://localhost:3000/dashboard"]);
+  });
+
+  it("keeps back/forward on the proxy origin after a retargeted navigation", () => {
+    const { result, seen } = renderStateful({
+      present: `${PROXY}/start`,
+      devServerUrl: `${UPSTREAM}/`,
+      proxyOrigin: PROXY,
+    });
+    act(() => result.current.handleNavigate(`${UPSTREAM}/once`));
+    expect(seen.history.present).toBe(`${PROXY}/once`);
+
+    act(() => result.current.handleBack());
+    expect(seen.history.present).toBe(`${PROXY}/start`);
+    expect(seen.history.future).toEqual([`${PROXY}/once`]);
+
+    act(() => result.current.handleForward());
+    expect(seen.history.present).toBe(`${PROXY}/once`);
   });
 });
 

--- a/src/components/DevPreview/__tests__/useDevPreviewNavigation.test.tsx
+++ b/src/components/DevPreview/__tests__/useDevPreviewNavigation.test.tsx
@@ -585,10 +585,14 @@ describe("useDevPreviewNavigation — proxy-origin routing (#12297)", () => {
       present: init.present,
       future: init.future ?? [],
     };
-    const seen = { history: initial };
+    // Every rendered history, not just the converged one: asserting on final state alone
+    // cannot tell "never committed the raw upstream URL" from "committed it, then the
+    // migration effect quietly replaced it".
+    const seen = { history: initial, commits: [] as string[] };
     const rendered = renderHook(() => {
       const [history, setHistory] = useState<BrowserHistory>(initial);
       seen.history = history;
+      if (seen.commits.at(-1) !== history.present) seen.commits.push(history.present);
       return useDevPreviewNavigation(
         baseParams({
           history,
@@ -624,7 +628,9 @@ describe("useDevPreviewNavigation — proxy-origin routing (#12297)", () => {
     // never gates the webview out and never remounts it against a stale seed.
     expect(seen.history.present).toBe(`${PROXY}/once?a=1#b`);
     expect(seen.history.past).toEqual([`${PROXY}/`]);
-    expect(seen.history.past).not.toContain(`${UPSTREAM}/once?a=1#b`);
+    // The raw URL was never committed even transiently. Without this, a strict-normalizing
+    // handleNavigate followed by a repairing migration would satisfy the assertions above.
+    expect(seen.commits).toEqual([`${PROXY}/`, `${PROXY}/once?a=1#b`]);
   });
 
   it("refuses a foreign host without touching history", () => {
@@ -670,6 +676,8 @@ describe("useDevPreviewNavigation — proxy-origin routing (#12297)", () => {
     rerender();
     expect(seen.history.present).toBe(`${PROXY}/settings`);
     expect(seen.history).toBe(settled);
+    // Exactly one migration commit: the stale entry, then the migrated one, and no loop.
+    expect(seen.commits).toEqual([`${UPSTREAM}/settings`, `${PROXY}/settings`]);
   });
 
   it("still pushes in legacy mode, where a port shift is a genuine new origin", () => {

--- a/src/components/DevPreview/urlSync.ts
+++ b/src/components/DevPreview/urlSync.ts
@@ -1,3 +1,82 @@
+import { normalizeBrowserUrl, isLocalhostUrl, type NormalizeResult } from "../Browser/browserUtils";
+
+/**
+ * Copy the route (path + query + fragment) of `from` onto `origin`, returning the
+ * absolute URL. Field assignment rather than string concatenation so an encoded
+ * path or a `//`-prefixed pathname can never be reparsed as a new authority.
+ */
+function graftRouteOntoOrigin(origin: URL, from: URL): string {
+  const target = new URL(origin.toString());
+  target.pathname = from.pathname;
+  target.search = from.search;
+  target.hash = from.hash;
+  return target.toString();
+}
+
+function parseOrNull(url: string): URL | null {
+  try {
+    return new URL(url);
+  } catch {
+    return null;
+  }
+}
+
+/** True when `url` sits on exactly `origin`. Parsed comparison, not `startsWith`: a
+ * prefix test would accept `…localhost:43000` as a match for `…localhost:4300`. */
+export function isOnOrigin(url: string, origin: string): boolean {
+  const parsed = parseOrNull(url);
+  const parsedOrigin = parseOrNull(origin);
+  return !!parsed && !!parsedOrigin && parsed.origin === parsedOrigin.origin;
+}
+
+/**
+ * Address-bar/navigation policy for a dev-preview panel (#12297).
+ *
+ * Dev Preview used to normalize with no options, which takes `normalizeBrowserUrl`'s
+ * strict branch and accepts only the bare loopback hosts — so the panel rejected the
+ * very `dp-*.localhost` origin it was itself displaying. The fix is a policy that
+ * accepts exactly two things and nothing else:
+ *
+ *  - a bare loopback URL (what already worked), and
+ *  - **this panel's own** proxy origin. `isDevPreviewProxyUrl` is deliberately not
+ *    used here: it is a shape check that passes any `*.localhost` subdomain, which
+ *    would let one panel drive another panel's origin.
+ *
+ * Everything else — LAN/private hosts, arbitrary `.localhost`/`.test` names, public
+ * hosts, non-HTTP protocols — is rejected outright rather than returned with
+ * `requiresConfirmation`, since a dev preview has no host-approval flow to fall into.
+ *
+ * In configured proxy mode a loopback URL is retargeted onto the proxy origin,
+ * preserving path, query and fragment, so a typed raw-upstream address never lands
+ * the pane off-origin and back through the migration/remount dance.
+ */
+export function normalizeDevPreviewUrl(
+  rawUrl: string,
+  proxyOrigin: string | null | undefined
+): NormalizeResult {
+  // Extended mode (empty allow-list) parses `*.localhost` instead of erroring on it;
+  // the allow-list below, not this call, is what authorizes the result.
+  const normalized = normalizeBrowserUrl(rawUrl, { allowedHosts: [] });
+  if (normalized.error || !normalized.url) {
+    return { error: normalized.error ?? "Invalid URL format" };
+  }
+
+  const parsed = parseOrNull(normalized.url);
+  if (!parsed) return { error: "Invalid URL format" };
+
+  const proxy = typeof proxyOrigin === "string" ? parseOrNull(proxyOrigin) : null;
+
+  if (isLocalhostUrl(normalized.url)) {
+    return proxy ? { url: graftRouteOntoOrigin(proxy, parsed) } : { url: normalized.url };
+  }
+
+  if (proxy && parsed.origin === proxy.origin) {
+    return { url: normalized.url };
+  }
+
+  return { error: `Only localhost URLs are allowed (got "${parsed.hostname}")` };
+}
+
 /**
  * Decides whether a freshly detected dev-server URL should replace the URL the
  * pane is currently showing, and if so, what URL to navigate to.
@@ -10,8 +89,12 @@
  * restart only shifts the upstream port — which the proxy resolves live — so once
  * the pane is on the proxy origin there is nothing to navigate (returns `false`).
  * The only navigation is the first one onto the proxy origin (and any migration
- * off a stale direct-localhost URL), where the route is taken from the detected
- * URL's non-root path, else the pane's current route, else `/`.
+ * off a stale direct-localhost URL), where the route is taken from the pane's own
+ * current route, else the detected URL's non-root path, else `/`. A route the pane
+ * already holds outranks an advertised base: on a *migration* that route is where
+ * the user or the app asked to be, and overwriting it with the dev server's base
+ * is how the destination got lost (#12297). The base still wins on first adoption,
+ * when there is no current route to defend.
  *
  * **Legacy mode (no proxy):** when the dev server restarts on a different origin
  * (typically a port shift, e.g. 3000 → 3001), the detected URL is the bare server
@@ -46,25 +129,14 @@ export function computeDevServerUrl(
     if (current && current.origin === proxy.origin) return false;
 
     // First navigation onto the proxy origin (or migrating off a stale localhost
-    // URL). Choose the route: honor a non-root path the dev server advertises
-    // (Vite `base`), else preserve the pane's current route, else land on root.
-    let detected: URL | null;
-    try {
-      detected = new URL(detectedUrl);
-    } catch {
-      detected = null;
+    // URL). Choose the route: preserve the pane's current route, else honor a
+    // non-root path the dev server advertises (Vite `base`), else land on root.
+    if (current && (current.pathname !== "/" || !!current.search || !!current.hash)) {
+      return graftRouteOntoOrigin(proxy, current);
     }
-    const target = new URL(proxy.toString());
-    if (detected && detected.pathname !== "/") {
-      target.pathname = detected.pathname;
-      target.search = detected.search;
-      target.hash = detected.hash;
-    } else if (current) {
-      target.pathname = current.pathname;
-      target.search = current.search;
-      target.hash = current.hash;
-    }
-    return target.toString();
+    const detected = parseOrNull(detectedUrl);
+    if (detected && detected.pathname !== "/") return graftRouteOntoOrigin(proxy, detected);
+    return proxy.toString();
   }
 
   if (!currentUrl) return detectedUrl;

--- a/src/components/DevPreview/useDevPreviewNavigation.ts
+++ b/src/components/DevPreview/useDevPreviewNavigation.ts
@@ -1,13 +1,14 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useBrowserActionListeners } from "@/hooks/useBrowserActionListeners";
 import type { BrowserHistory } from "@shared/types/browser";
-import { normalizeBrowserUrl } from "../Browser/browserUtils";
+import type { NormalizeResult } from "../Browser/browserUtils";
 import {
   goBackBrowserHistory,
   goForwardBrowserHistory,
   pushBrowserHistory,
+  replaceBrowserHistoryPresent,
 } from "../Browser/historyUtils";
-import { computeDevServerUrl } from "./urlSync";
+import { computeDevServerUrl, normalizeDevPreviewUrl } from "./urlSync";
 import { loadWebviewUrl } from "./loadWebviewUrl";
 import { actionService } from "@/services/ActionService";
 import { safeFireAndForget } from "@/utils/safeFireAndForget";
@@ -107,18 +108,29 @@ export function useDevPreviewNavigation({
     // Hold navigation until the proxy port resolution settles, otherwise the pane would
     // briefly adopt the unstable direct-localhost origin before the proxy origin is known (#9100).
     if (proxyOrigin === undefined) return;
-    const nextUrl = devServerUrl
-      ? computeDevServerUrl(devServerUrl, currentUrl, proxyOrigin)
-      : false;
-    if (nextUrl !== false) {
-      // Adopting a different dev-server target (legacy mode follows the upstream
-      // port in place). The budget belongs to the target that exhausted it, so
-      // hand it back before the imperative effect loads the new one (#12296).
-      if (nextUrl !== currentUrl) {
-        clearRetryState();
-      }
-      setHistory((prev) => pushBrowserHistory(prev, nextUrl));
+    if (!devServerUrl) return;
+    // Adopting a different dev-server target hands the retry budget back: it belongs
+    // to the target that exhausted it, so the imperative effect loads the new one with
+    // a full budget (#12296). Decided against `currentUrl` — the URL this effect was
+    // scheduled with — because a state setter cannot run inside a state updater.
+    const adopted = computeDevServerUrl(devServerUrl, currentUrl, proxyOrigin);
+    if (adopted !== false && adopted !== currentUrl) {
+      clearRetryState();
     }
+    // Recompute against `prev.present` inside the updater: `currentUrl` is the trigger,
+    // but a migration queued behind a newer navigation must retarget that newer intent,
+    // not resurrect the URL this effect was scheduled with.
+    setHistory((prev) => {
+      const nextUrl = computeDevServerUrl(devServerUrl, prev.present, proxyOrigin);
+      if (nextUrl === false) return prev;
+      // In proxy mode this is a retarget of the entry we are on, not a new stop —
+      // pushing would leave the pre-migration origin sitting in the back stack and
+      // wipe the forward entries (#12297). Legacy mode keeps its push: there the
+      // dev server genuinely moved to a different origin.
+      return typeof proxyOrigin === "string"
+        ? replaceBrowserHistoryPresent(prev, nextUrl)
+        : pushBrowserHistory(prev, nextUrl);
+    });
   }, [devServerUrl, currentUrl, isUnconfigured, proxyOrigin, clearRetryState, setHistory]);
 
   useEffect(() => {
@@ -136,6 +148,14 @@ export function useDevPreviewNavigation({
     setBrowserZoom(id, zoomFactor);
   }, [id, zoomFactor, setBrowserZoom]);
 
+  // One policy for the address bar and for action-driven navigation, so the toolbar
+  // can never accept a URL the hook would reject (or vice versa). It is idempotent:
+  // re-normalizing an already-approved proxy URL returns it unchanged (#12297).
+  const validateUrl = useCallback(
+    (rawUrl: string): NormalizeResult => normalizeDevPreviewUrl(rawUrl, proxyOrigin),
+    [proxyOrigin]
+  );
+
   // Every explicit navigation action hands the retry budget back. A load start no
   // longer refills it (#12296), and the budget belongs to the target that
   // exhausted it — carrying it into a URL the user just asked for would make that
@@ -144,7 +164,7 @@ export function useDevPreviewNavigation({
   // own history update must not replenish anything.
   const handleNavigate = useCallback(
     (rawUrl: string) => {
-      const normalized = normalizeBrowserUrl(rawUrl);
+      const normalized = validateUrl(rawUrl);
       if (normalized.url) {
         // Only when the target actually changes. Re-submitting the URL already
         // showing pushes no history and starts no load, so resetting here would
@@ -158,7 +178,7 @@ export function useDevPreviewNavigation({
         setHistory((prev) => pushBrowserHistory(prev, normalized.url!));
       }
     },
-    [currentUrl, clearRetryState, setHistory]
+    [currentUrl, clearRetryState, setHistory, validateUrl]
   );
 
   const handleBack = useCallback(() => {
@@ -382,6 +402,7 @@ export function useDevPreviewNavigation({
   }, [id, onHardReload]);
 
   return {
+    validateUrl,
     handleNavigate,
     handleBack,
     handleForward,


### PR DESCRIPTION
## Summary
- Two coupled bugs in the Dev Preview panel, both reproduced in the built app: an absolute upstream redirect (or a typed raw upstream URL) briefly took the pane off its stable `dp-*.localhost` proxy origin, which tore down the webview guest and let a freshly seeded replacement guest overwrite the intended route with the proxy root.
- Separately, the address bar rejected the panel's own current URL, because `handleNavigate` and `BrowserToolbar`'s fallback both normalized through `normalizeBrowserUrl`'s strict loopback-only branch with no `validateUrl` policy carrying the panel's own proxy origin.
- Both are fixed at the root: the guest's seed is now correctly re-pointed to the intended destination, and address bar entry is backed by a policy that recognizes the panel's own origin.

Resolves #12297

## Changes
- The `src` seed is now a ref, re-pointed at render time whenever no guest is live, gated on the committed `webviewElement` so it can never re-bind a mounted guest's `src` (which would reintroduce the reload regression from #9940), and immune to corruption from a discarded render. A replacement guest now starts from the current intended destination.
- A shared `normalizeDevPreviewUrl` function backs both `handleNavigate` and a new `validateUrl` prop passed to `BrowserToolbar`. It accepts bare loopback plus this panel's own proxy origin (a full origin comparison, not the `isDevPreviewProxyUrl` shape check, which passes any `*.localhost`), rejects everything else outright rather than returning `requiresConfirmation`, and retargets raw upstream input onto the proxy origin while preserving path, query, and fragment.
- The proxy now rewrites same-upstream redirect `Location` headers onto the panel's origin, scoped to the upstream each request was dialled with and snapshotted per request so a dev-server restart mid-flight can't move it. It matches on scheme, port, and any loopback alias, since the proxy dials `localhost` and Node picks the address family (#9747), so an upstream answering on `127.0.0.1` is naming the same server.
- `httpxy`'s `autoRewrite` was deliberately skipped: it resolves a relative `Location` header against the upstream root (turning `/nested/once` into `/consume`), and it keeps the `https` scheme for a TLS upstream this plain HTTP proxy never serves.
- A `Host` header carrying userinfo (`dp-x.localhost:1@evil.example`) used to route as a valid panel but parse to an external authority. The rewrite now fails closed on that.
- `computeDevServerUrl` now prefers the pane's own route over an advertised Vite `base` when migrating; the `base` still wins on first adoption.
- An origin migration now replaces the history entry instead of pushing, so back/forward keep working and no raw-upstream entry gets stranded in the back stack.
- `isProxyUrlPending` now compares origins instead of using `startsWith`, which was incorrectly accepting `:43000` as sitting on `:4300`.

## Testing
768 targeted tests pass across the DevPreview, Browser, and DevPreviewProxyService suites, with request and call counts asserted throughout so a replayed single-use callback fails the suite. The seed fix was verified to actually matter by reverting it: 4 tests failed, one showing the old code issuing a corrective `loadURL` call on top of the seed navigation. New coverage includes a live guest driven through the real redirect sequence into a replacement guest, address bar entry in configured-proxy mode, and real HTTP/TLS proxy redirect fixtures. Typecheck is clean, and lint/formatting are clean on the touched files.

### Not covered
No end-to-end spec was added. E2E isn't run in this workflow, and shipping an unrunnable spec isn't worth it, so configured-proxy-mode coverage sits at the component level instead, and real toolbar form submission remains mocked in the tests.
