### PR TITLE
fix(dev-preview): observe the dev command's own exit, not the shell's

### DIFF
--- a/electron/ipc/handlers/terminal/__tests__/commandLaunch.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/commandLaunch.test.ts
@@ -149,6 +149,91 @@ describe("buildCommandLaunchShell", () => {
     });
   });
 
+  describe("shell support allowlist", () => {
+    it("rejects fish, which ends in 'sh' but has neither trap nor $?", () => {
+      setPlatform("linux");
+
+      expect(buildCommandLaunchShell("claude", "/usr/bin/fish")).toBeNull();
+      expect(buildCommandLaunchShell("npm run dev", "/usr/bin/fish", "exit")).toBeNull();
+    });
+
+    it("accepts dash and ash through the non-login -i -c form", () => {
+      setPlatform("linux");
+
+      for (const shell of ["/bin/dash", "/bin/ash"]) {
+        const result = buildCommandLaunchShell("claude", shell);
+        expect(result?.args.slice(0, 2)).toEqual(["-i", "-c"]);
+        expect(result?.args[2]).not.toContain("-l");
+      }
+    });
+  });
+
+  // The dev-preview pane owns its whole terminal and needs the PTY to end when
+  // its command does, carrying the command's own status out (#12295).
+  describe("exit mode", () => {
+    it("ends a zsh wrapper with a bare exit instead of exec'ing a new shell", () => {
+      setPlatform("linux");
+
+      const result = buildCommandLaunchShell("npm run dev", "/bin/zsh", "exit");
+
+      expect(result?.args[0]).toBe("-lic");
+      expect(result?.args[1]).toBe("trap : INT\nnpm run dev\nexit");
+      expect(result?.args[1]).not.toContain("exec");
+    });
+
+    it("keeps the interactive -i -c form for plain sh", () => {
+      setPlatform("linux");
+
+      const result = buildCommandLaunchShell("npm run dev", "/bin/sh", "exit");
+
+      expect(result?.args.slice(0, 2)).toEqual(["-i", "-c"]);
+      expect(result?.args[2]).toBe("trap : INT\nnpm run dev\nexit");
+    });
+
+    it("preserves compound shell syntax verbatim", () => {
+      setPlatform("linux");
+
+      const result = buildCommandLaunchShell(
+        "PORT=3000 npm run dev && echo up",
+        "/bin/bash",
+        "exit"
+      );
+
+      expect(result?.args[1]).toContain("PORT=3000 npm run dev && echo up");
+    });
+
+    it("defaults to keep-open so agent launches are unaffected", () => {
+      setPlatform("linux");
+
+      expect(buildCommandLaunchShell("claude", "/bin/zsh")?.args[1]).toContain(
+        "exec '/bin/zsh' -l"
+      );
+    });
+
+    it("drops -NoExit and maps PowerShell status onto the exit code", () => {
+      setPlatform("win32");
+
+      const result = buildCommandLaunchShell("npm run dev", "pwsh.exe", "exit");
+
+      expect(result?.args).not.toContain("-NoExit");
+      const script = decodePowerShellEncodedCommand(result?.args[2] ?? "");
+      expect(script).toContain("npm run dev");
+      // $LASTEXITCODE alone is stale for cmdlet failures, so $? gates it.
+      expect(script).toContain("if ($?) { exit 0 }");
+      expect(script).toContain("if ($LASTEXITCODE) { exit $LASTEXITCODE }");
+      expect(script).toContain("OutputEncoding");
+    });
+
+    it("uses cmd /C so the shell exits with ERRORLEVEL, keeping the UTF-8 codepage", () => {
+      setPlatform("win32");
+
+      const result = buildCommandLaunchShell("npm run dev", "cmd.exe", "exit");
+
+      expect(result?.args[0]).toBe("/C");
+      expect(result?.args[1]).toBe("chcp 65001 >NUL & npm run dev");
+    });
+  });
+
   describe("common edge cases", () => {
     it("returns null for empty commands on all platforms", () => {
       setPlatform("win32");

--- a/electron/ipc/handlers/terminal/commandLaunch.ts
+++ b/electron/ipc/handlers/terminal/commandLaunch.ts
@@ -27,23 +27,28 @@
  * this layer.
  */
 
-import { getDefaultShell } from "../../../services/pty/terminalShell.js";
+import { getDefaultShell, WINDOWS_PS_UTF8_BOOTSTRAP } from "../../../services/pty/terminalShell.js";
 import { isCmdShell, isPowerShellShell } from "../../../../shared/utils/shellEscape.js";
 
 function shellQuote(value: string): string {
   return `'${value.replace(/'/g, "'\\''")}'`;
 }
 
-function supportsPosixCommandLaunchShell(shell: string): boolean {
+// Explicit allowlist, not a `endsWith("sh")` test: fish ends in "sh" but has
+// neither `trap` nor `$?`, so suffix matching handed it a bourne script it
+// silently mis-executed instead of falling back to typed input.
+const POSIX_COMMAND_LAUNCH_SHELLS: ReadonlySet<string> = new Set([
+  "sh",
+  "bash",
+  "zsh",
+  "dash",
+  "ash",
+  "ksh",
+]);
+
+function posixCommandLaunchShellName(shell: string): string | null {
   const name = shell.split(/[\\/]/).pop()?.toLowerCase() ?? "";
-  return (
-    name === "zsh" ||
-    name === "bash" ||
-    name === "sh" ||
-    name.endsWith("zsh") ||
-    name.endsWith("bash") ||
-    name.endsWith("sh")
-  );
+  return POSIX_COMMAND_LAUNCH_SHELLS.has(name) ? name : null;
 }
 
 /**
@@ -57,9 +62,40 @@ function encodePowerShellCommand(script: string): string {
   return Buffer.from(script, "utf16le").toString("base64");
 }
 
+/**
+ * `keep-open` (the default, used by agent launches) hands the pane back to an
+ * interactive shell once the command finishes. `exit` ends the PTY with the
+ * command's status instead, so a caller that owns the whole terminal — dev
+ * preview — learns that its command finished and with what code. Without it
+ * the surviving shell makes child-command exit indistinguishable from a
+ * still-running server (#12295).
+ */
+export type CommandLaunchMode = "keep-open" | "exit";
+
+// PowerShell's $LASTEXITCODE is only set by native executables and persists
+// across statements, so on its own it reports a stale code for a cmdlet
+// failure. $? covers cmdlets, $LASTEXITCODE preserves a real native code
+// (a dev server exiting 7), and the catch maps a terminating error to 1.
+function buildPowerShellExitScript(command: string): string {
+  return [
+    WINDOWS_PS_UTF8_BOOTSTRAP,
+    "$global:LASTEXITCODE = 0",
+    "try {",
+    command,
+    "  if ($?) { exit 0 }",
+    "  if ($LASTEXITCODE) { exit $LASTEXITCODE }",
+    "  exit 1",
+    "} catch {",
+    "  Write-Error -ErrorRecord $_ -ErrorAction Continue",
+    "  exit 1",
+    "}",
+  ].join("\n");
+}
+
 export function buildCommandLaunchShell(
   command: string,
-  configuredShell: string | undefined
+  configuredShell: string | undefined,
+  mode: CommandLaunchMode = "keep-open"
 ): { shell: string; args: string[] } | null {
   if (command.length === 0) {
     return null;
@@ -69,38 +105,59 @@ export function buildCommandLaunchShell(
 
   if (process.platform === "win32") {
     if (isPowerShellShell(shell)) {
+      // -EncodedCommand takes a UTF-16LE-Base64 payload, completely bypassing
+      // PowerShell's argument parser and CommandLineToArgvW — quoting inside
+      // `command` (paths with spaces, embedded quotes) survives intact.
+      // -NoLogo matches the banner-free spawn behaviour we use elsewhere;
       // -NoExit keeps the shell interactive after the command finishes so the
-      // user can keep working in the same pane. -EncodedCommand takes a
-      // UTF-16LE-Base64 payload, completely bypassing PowerShell's argument
-      // parser and CommandLineToArgvW — quoting inside `command` (paths with
-      // spaces, embedded quotes) survives intact. -NoLogo matches the
-      // banner-free spawn behaviour we use elsewhere.
+      // user can keep working in the same pane.
+      if (mode === "exit") {
+        return {
+          shell,
+          args: [
+            "-NoLogo",
+            "-EncodedCommand",
+            encodePowerShellCommand(buildPowerShellExitScript(command)),
+          ],
+        };
+      }
       return {
         shell,
         args: ["-NoLogo", "-NoExit", "-EncodedCommand", encodePowerShellCommand(command)],
       };
     }
     if (isCmdShell(shell)) {
-      // cmd /K runs <command> and then returns to an interactive prompt.
-      // node-pty's Windows agent joins the args array into a command-line
-      // string for CreateProcess, and cmd.exe then parses everything after
-      // `/K` — `%VAR%` expansion and `^` escape sequences apply. Upstream
-      // is responsible for embedding only cmd-safe values via
-      // `quoteCommandArg` (double-quote escaping); we do not re-quote here.
+      // cmd /K runs <command> and then returns to an interactive prompt; /C
+      // exits with the command's ERRORLEVEL instead. node-pty's Windows agent
+      // joins the args array into a command-line string for CreateProcess, and
+      // cmd.exe then parses everything after the switch — `%VAR%` expansion and
+      // `^` escape sequences apply. Upstream is responsible for embedding only
+      // cmd-safe values via `quoteCommandArg` (double-quote escaping); we do
+      // not re-quote here. The `/C` form carries the UTF-8 codepage the
+      // interactive default args would otherwise have set.
+      if (mode === "exit") {
+        return { shell, args: ["/C", `chcp 65001 >NUL & ${command}`] };
+      }
       return { shell, args: ["/K", command] };
     }
     return null;
   }
 
-  if (!supportsPosixCommandLaunchShell(shell)) {
+  const name = posixCommandLaunchShellName(shell);
+  if (!name) {
     return null;
   }
 
-  const name = shell.split(/[\\/]/).pop()?.toLowerCase() ?? "";
-  const execInteractiveShell =
-    name.includes("zsh") || name.includes("bash")
-      ? `exec ${shellQuote(shell)} -l`
-      : `exec ${shellQuote(shell)}`;
+  const isLoginCapable = name === "zsh" || name === "bash";
+  // `exit` with no argument carries the preceding command's status, so the
+  // wrapper reports the dev server's own exit code. A command that backgrounds
+  // itself (`vite &`) ends the wrapper immediately; a bare `wait` would fix
+  // that case but can block on jobs the shell's own rc files started, so
+  // self-backgrounding stays outside the foreground-command contract.
+  const tail =
+    mode === "exit"
+      ? "exit"
+      : `trap - INT\nexec ${shellQuote(shell)}${isLoginCapable ? " -l" : ""}`;
 
   // Run the command as interactive shell startup work instead of typing it into
   // the PTY. This prevents the tail of long absolute launch commands from being
@@ -111,15 +168,14 @@ export function buildCommandLaunchShell(
   // agent without killing the wrapper before it can exec the follow-up shell.
   // Use a no-op trap rather than SIG_IGN so child CLIs don't inherit ignored
   // SIGINT.
-  const script = `trap : INT\n${command}\ntrap - INT\n${execInteractiveShell}`;
+  const script = `trap : INT\n${command}\n${tail}`;
   // The historical macOS `sleep 0.05` deferral wrapper (added when early
   // shell/agent bytes could race the PTY data listeners) is gone: fresh
   // spawns attach a BufferedPtyDataHandoff synchronously with pty.spawn and
   // the renderer registers its data callback at prewarm, before the spawn
   // IPC is even sent — no consumer attaches late any more, and the wrapper
   // taxed every agent launch 50ms plus an extra shell exec.
-  const args =
-    name.includes("zsh") || name.includes("bash") ? ["-lic", script] : ["-i", "-c", script];
+  const args = isLoginCapable ? ["-lic", script] : ["-i", "-c", script];
 
   return { shell, args };
 }

--- a/electron/services/DevPreviewCommandNormalizer.ts
+++ b/electron/services/DevPreviewCommandNormalizer.ts
@@ -6,6 +6,7 @@ export { getInvalidCommandMessage } from "../../shared/utils/devCommandValidatio
 
 export const NEXT_DEV_DIRECT_RE = /\bnext\s+dev\b/;
 export const TURBOPACK_FLAG_RE = /--turbo(?:pack)?\b/;
+export const WEBPACK_FLAG_RE = /--webpack\b/;
 export const PKG_SCRIPT_RE =
   /^(?:npm\s+run|pnpm(?:\s+run)?|yarn(?:\s+run)?|bun(?:\s+run)?)\s+(\S+)$/;
 // Compound/piped/commented commands can't be safely rewritten -- appending
@@ -88,39 +89,92 @@ export function stripTurbopackFlag(command: string): string {
     .trim();
 }
 
-export async function normalizeNextjsDevCommand(
-  command: string,
-  cwd: string,
-  turbopackEnabled = true
-): Promise<string> {
-  if (!turbopackEnabled) return stripTurbopackFlag(command);
-  const nextMajor = await resolveNextMajorVersion(cwd);
-  if (nextMajor === null || nextMajor < 15) return stripTurbopackFlag(command);
-
-  if (TURBOPACK_FLAG_RE.test(command)) return command;
-  if (SHELL_CONTROL_RE.test(command)) return command;
-
-  if (NEXT_DEV_DIRECT_RE.test(command)) {
-    return `${command} --turbopack`;
-  }
-
-  const scriptMatch = PKG_SCRIPT_RE.exec(command);
-  if (!scriptMatch) return command;
-
-  const scriptName = scriptMatch[1];
+async function readPackageScript(cwd: string, scriptName: string): Promise<string | null> {
   try {
     const pkgRaw = await fs.readFile(path.join(cwd, "package.json"), "utf-8");
     const pkg = JSON.parse(pkgRaw);
     const scriptBody = pkg?.scripts?.[scriptName];
-    if (typeof scriptBody === "string" && NEXT_DEV_DIRECT_RE.test(scriptBody)) {
-      if (TURBOPACK_FLAG_RE.test(scriptBody)) return command;
-      return `${command}${scriptFlagSeparator(command)}--turbopack`;
-    }
+    return typeof scriptBody === "string" ? scriptBody : null;
   } catch {
-    // No package.json or invalid — leave command unchanged
+    return null;
+  }
+}
+
+/** Emitted when the user's command already names a bundler the preference contradicts. */
+export interface DevCommandBundlerConflict {
+  type: "bundler-conflict";
+  message: string;
+}
+
+/**
+ * Reconcile the project's Turbopack preference with whatever bundler flags the
+ * command already carries, across three Next.js eras: pre-15 has no
+ * `--turbopack` flag at all, 15 accepts it as an opt-in, and 16 makes Turbopack
+ * the default so opting *out* is what needs a flag (`--webpack`). Next 16 also
+ * exits 1 on `--webpack --turbopack` ("Pass either `webpack` or `turbopack`,
+ * not both"), so an explicit bundler flag always wins over the preference —
+ * emitting the fatal pair would be worse than ignoring a toggle.
+ */
+export async function normalizeNextjsDevCommand(
+  command: string,
+  cwd: string,
+  turbopackEnabled = true,
+  onConflict?: (conflict: DevCommandBundlerConflict) => void
+): Promise<string> {
+  // The renderer pre-injects --turbopack with no version awareness
+  // (src/utils/devServerDetection.ts), so a disabled preference has to strip
+  // the flag on every exit path, not merely decline to add one.
+  const applyPreference = (value: string) => (turbopackEnabled ? value : stripTurbopackFlag(value));
+
+  const nextMajor = await resolveNextMajorVersion(cwd);
+  const supportsTurbopackFlag = nextMajor !== null && nextMajor >= 15;
+  const turbopackIsDefault = nextMajor !== null && nextMajor >= 16;
+  if (!supportsTurbopackFlag) return stripTurbopackFlag(command);
+  if (SHELL_CONTROL_RE.test(command)) return applyPreference(command);
+
+  // PKG_SCRIPT_RE is anchored, so `npm run dev -- --turbopack` — what the
+  // renderer produces — matches no script. Retry without the turbo flag so the
+  // script body can still be inspected for a conflicting `--webpack`.
+  const scriptMatch =
+    PKG_SCRIPT_RE.exec(command) ?? PKG_SCRIPT_RE.exec(stripTurbopackFlag(command));
+  let resolved = command;
+  if (scriptMatch) {
+    const scriptBody = await readPackageScript(cwd, scriptMatch[1]);
+    if (scriptBody === null) return applyPreference(command);
+    // Mirrors normalizeViteDevCommand: appending to `npm run dev` puts the flag
+    // on the last command of a compound body, not on `next dev`.
+    if (SHELL_CONTROL_RE.test(scriptBody)) return applyPreference(command);
+    resolved = scriptBody;
+  }
+  if (!NEXT_DEV_DIRECT_RE.test(resolved)) return applyPreference(command);
+
+  const outerHasTurbopack = TURBOPACK_FLAG_RE.test(command);
+  const hasTurbopack = outerHasTurbopack || TURBOPACK_FLAG_RE.test(resolved);
+  const hasWebpack = WEBPACK_FLAG_RE.test(command) || WEBPACK_FLAG_RE.test(resolved);
+  const separator = scriptMatch !== null ? scriptFlagSeparator(command) : " ";
+
+  if (hasWebpack) {
+    if (turbopackEnabled) {
+      onConflict?.({
+        type: "bundler-conflict",
+        message: "Command already sets --webpack; the Turbopack preference was not applied.",
+      });
+    }
+    // Only the outer flag is ours to remove — rewriting a package script's own
+    // flags would change what every other consumer of that script runs.
+    return outerHasTurbopack ? stripTurbopackFlag(command) : command;
   }
 
-  return command;
+  if (!turbopackEnabled) {
+    const stripped = stripTurbopackFlag(command);
+    // Stripping alone stopped opting out in Next 16: Turbopack runs by default
+    // there, so honouring the preference means naming the other bundler.
+    if (!turbopackIsDefault) return stripped;
+    return `${stripped}${separator}--webpack`;
+  }
+
+  if (hasTurbopack || turbopackIsDefault) return command;
+  return `${command}${separator}--turbopack`;
 }
 
 // Vite, SvelteKit, Astro, and Nuxt all ignore process.env.PORT — the only

--- a/electron/services/DevPreviewCommandNormalizer.ts
+++ b/electron/services/DevPreviewCommandNormalizer.ts
@@ -5,8 +5,8 @@ import { scriptFlagSeparator } from "../../shared/utils/devCommandValidation.js"
 export { getInvalidCommandMessage } from "../../shared/utils/devCommandValidation.js";
 
 export const NEXT_DEV_DIRECT_RE = /\bnext\s+dev\b/;
-export const TURBOPACK_FLAG_RE = /--turbo(?:pack)?\b/;
-export const WEBPACK_FLAG_RE = /--webpack\b/;
+export const TURBOPACK_FLAG_RE = /--turbo(?:pack)?(?![\w-])/;
+export const WEBPACK_FLAG_RE = /--webpack(?![\w-])/;
 export const PKG_SCRIPT_RE =
   /^(?:npm\s+run|pnpm(?:\s+run)?|yarn(?:\s+run)?|bun(?:\s+run)?)\s+(\S+)$/;
 // Compound/piped/commented commands can't be safely rewritten -- appending
@@ -83,10 +83,15 @@ export async function extractPort(command: string, cwd: string): Promise<number 
 }
 
 export function stripTurbopackFlag(command: string): string {
-  return command
-    .replace(/\s+--\s+--turbo(?:pack)?\b/, "") // " -- --turbopack" (pkg manager form)
-    .replace(/\s+--turbo(?:pack)?\b/, "") // " --turbopack" (direct form)
-    .trim();
+  return (
+    command
+      // `\b` also matched a longer flag that merely starts with the same
+      // letters — stripping it turned `--turbopack-root` into `-root`.
+      .replace(/\s+--turbo(?:pack)?(?![\w-])/g, "")
+      // Drop npm's forwarding separator only when nothing is left to forward.
+      .replace(/\s+--\s*$/, "")
+      .trim()
+  );
 }
 
 async function readPackageScript(cwd: string, scriptName: string): Promise<string | null> {
@@ -170,6 +175,19 @@ export async function normalizeNextjsDevCommand(
     // Stripping alone stopped opting out in Next 16: Turbopack runs by default
     // there, so honouring the preference means naming the other bundler.
     if (!turbopackIsDefault) return stripped;
+    // ...but only when nothing else still asks for Turbopack. A flag inside the
+    // package script survives the strip, and adding --webpack beside it is the
+    // fatal pair. Rewriting package.json to resolve it is not ours to do.
+    if (
+      TURBOPACK_FLAG_RE.test(stripped) ||
+      (scriptMatch !== null && TURBOPACK_FLAG_RE.test(resolved))
+    ) {
+      onConflict?.({
+        type: "bundler-conflict",
+        message: `The "${scriptMatch?.[1] ?? "dev"}" script sets Turbopack itself; the preference was not applied.`,
+      });
+      return stripped;
+    }
     return `${stripped}${separator}--webpack`;
   }
 

--- a/electron/services/DevPreviewCommandNormalizer.ts
+++ b/electron/services/DevPreviewCommandNormalizer.ts
@@ -86,8 +86,9 @@ export function stripTurbopackFlag(command: string): string {
   return (
     command
       // `\b` also matched a longer flag that merely starts with the same
-      // letters — stripping it turned `--turbopack-root` into `-root`.
-      .replace(/\s+--turbo(?:pack)?(?![\w-])/g, "")
+      // letters — stripping it turned `--turbopack-root` into `-root`. Not
+      // global: a second pass reaches inside quoted argument values.
+      .replace(/\s+--turbo(?:pack)?(?![\w-])/, "")
       // Drop npm's forwarding separator only when nothing is left to forward.
       .replace(/\s+--\s*$/, "")
       .trim()
@@ -139,9 +140,13 @@ export async function normalizeNextjsDevCommand(
 
   // PKG_SCRIPT_RE is anchored, so `npm run dev -- --turbopack` — what the
   // renderer produces — matches no script. Retry without the turbo flag so the
-  // script body can still be inspected for a conflicting `--webpack`.
-  const scriptMatch =
-    PKG_SCRIPT_RE.exec(command) ?? PKG_SCRIPT_RE.exec(stripTurbopackFlag(command));
+  // script body can still be inspected for a conflicting `--webpack`. Anything
+  // appended goes onto the stripped form, or `npm run dev --` would grow a
+  // second forwarding separator.
+  const directMatch = PKG_SCRIPT_RE.exec(command);
+  const strippedCommand = stripTurbopackFlag(command);
+  const scriptMatch = directMatch ?? PKG_SCRIPT_RE.exec(strippedCommand);
+  const appendBase = directMatch !== null ? command : strippedCommand;
   let resolved = command;
   if (scriptMatch) {
     const scriptBody = await readPackageScript(cwd, scriptMatch[1]);
@@ -171,7 +176,7 @@ export async function normalizeNextjsDevCommand(
   }
 
   if (!turbopackEnabled) {
-    const stripped = stripTurbopackFlag(command);
+    const stripped = strippedCommand;
     // Stripping alone stopped opting out in Next 16: Turbopack runs by default
     // there, so honouring the preference means naming the other bundler.
     if (!turbopackIsDefault) return stripped;
@@ -192,7 +197,7 @@ export async function normalizeNextjsDevCommand(
   }
 
   if (hasTurbopack || turbopackIsDefault) return command;
-  return `${command}${separator}--turbopack`;
+  return `${appendBase}${separator}--turbopack`;
 }
 
 // Vite, SvelteKit, Astro, and Nuxt all ignore process.env.PORT — the only

--- a/electron/services/DevPreviewOutputProcessor.ts
+++ b/electron/services/DevPreviewOutputProcessor.ts
@@ -189,9 +189,12 @@ export function processDevPreviewOutput<TSession extends OutputProcessorSession>
   deps.clearCompiling(session);
 
   if (result.error.type === "missing-dependencies") {
+    // Arm the install the next terminal exit will run — but stay honest about
+    // what has actually happened. `installing` belongs to runInstall; claiming
+    // it here showed users an install that had not begun (#12295).
     session.needsInstall = true;
     deps.updateSession(session, {
-      status: "installing",
+      status: "starting",
       error: result.error,
       isRestarting: false,
     });

--- a/electron/services/DevPreviewPortAllocator.ts
+++ b/electron/services/DevPreviewPortAllocator.ts
@@ -3,6 +3,104 @@ import net from "node:net";
 export const PORT_FREE_POLL_INTERVAL_MS = 200;
 export const PORT_FREE_TIMEOUT_MS = 15_000;
 
+const MAX_OS_ASSIGNED_ATTEMPTS = 10;
+
+type FamilyProbeResult = "free" | "busy" | "unavailable" | "error";
+
+// A bind failure is only evidence the port is taken when the kernel says so.
+// Everything else on the IPv6 leg means "this host has no usable IPv6", which
+// must not make an otherwise-free port look occupied.
+const IPV6_UNAVAILABLE_CODES: ReadonlySet<string> = new Set([
+  "EAFNOSUPPORT",
+  "EADDRNOTAVAIL",
+  "ENOPROTOOPT",
+  "EINVAL",
+]);
+
+function classifyBindError(err: NodeJS.ErrnoException, ipv6Only: boolean): FamilyProbeResult {
+  if (err.code === "EADDRINUSE") return "busy";
+  if (ipv6Only && err.code && IPV6_UNAVAILABLE_CODES.has(err.code)) return "unavailable";
+  return "error";
+}
+
+/**
+ * Try to bind one address family and report what the kernel said. Binding
+ * `0.0.0.0` never also claims `::` (and whether `::` claims IPv4 depends on
+ * IPV6_V6ONLY), so the two families need independent probes — `ipv6Only` keeps
+ * the IPv6 leg from dual-claiming and confusing the two answers.
+ */
+function probeFamily(
+  port: number,
+  host: string,
+  ipv6Only: boolean,
+  signal?: AbortSignal
+): Promise<FamilyProbeResult> {
+  return new Promise<FamilyProbeResult>((resolve) => {
+    let settled = false;
+    let onAbort: () => void = () => {};
+    const settle = (value: FamilyProbeResult) => {
+      if (settled) return;
+      settled = true;
+      signal?.removeEventListener("abort", onAbort);
+      resolve(value);
+    };
+    if (signal?.aborted) {
+      settle("error");
+      return;
+    }
+    const srv = net.createServer();
+    srv.unref();
+    srv.once("error", (err) => settle(classifyBindError(err as NodeJS.ErrnoException, ipv6Only)));
+    onAbort = () => {
+      try {
+        srv.close();
+      } catch {
+        // server may already be closing
+      }
+      settle("error");
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+    try {
+      srv.listen({ port, host, ipv6Only }, () => srv.close(() => settle("free")));
+    } catch {
+      settle("error");
+    }
+  });
+}
+
+/**
+ * Every address a local dev server might take. Node sets SO_REUSEADDR, so a
+ * wildcard bind succeeds while a *loopback* listener holds the same port —
+ * measured, not assumed: with `::1` held, both `0.0.0.0` and `::` still bind.
+ * The wildcards alone therefore miss exactly the servers that matter here
+ * (Vite binds `[::1]` on macOS — see #9752), so each address is probed.
+ */
+const PROBE_ADDRESSES: ReadonlyArray<{ host: string; ipv6: boolean }> = [
+  { host: "0.0.0.0", ipv6: false },
+  { host: "127.0.0.1", ipv6: false },
+  { host: "::", ipv6: true },
+  { host: "::1", ipv6: true },
+];
+
+/**
+ * True only when the port is bindable at every address this host can actually
+ * use. The IPv4-only check that shipped in #12295 handed out a port an
+ * `ipv6Only` `::1` listener was holding. A host with no usable IPv6 answers
+ * "unavailable" there, which is not the same as "occupied" and must not block
+ * allocation. Gap between close() and the dev server's eventual bind() is an
+ * intrinsic TOCTOU we accept.
+ */
+export async function probePortFree(port: number, signal?: AbortSignal): Promise<boolean> {
+  const results = await Promise.all(
+    PROBE_ADDRESSES.map(({ host, ipv6 }) => probeFamily(port, host, ipv6, signal))
+  );
+  if (signal?.aborted) return false;
+  return results.every(
+    (result, index) =>
+      result === "free" || (PROBE_ADDRESSES[index].ipv6 && result === "unavailable")
+  );
+}
+
 export async function allocatePort(
   portRegistry: Map<string, number>,
   sessionKey: string
@@ -17,32 +115,44 @@ export async function allocatePort(
     // Reserve before the async probe so concurrent allocatePort() calls for
     // different session keys can't pick the same candidate between probe and registration.
     portRegistry.set(sessionKey, candidate);
-    const available = await new Promise<boolean>((resolve) => {
-      const srv = net.createServer();
-      srv.unref();
-      srv.once("error", () => resolve(false));
-      // Gap between close() and the dev server's eventual bind() is an intrinsic TOCTOU we accept.
-      srv.listen(candidate, "0.0.0.0", () => srv.close(() => resolve(true)));
-    });
-    if (available) return candidate;
+    if (await probePortFree(candidate)) return candidate;
     releasePort(portRegistry, sessionKey);
   }
-  return new Promise<number>((resolve, reject) => {
+
+  // Fall back to an OS-assigned port. It is only IPv4-assigned, so it still
+  // needs the IPv6 leg checked, and another session may have reserved the same
+  // number while we were binding.
+  for (let attempt = 0; attempt < MAX_OS_ASSIGNED_ATTEMPTS; attempt++) {
+    const port = await requestOsAssignedPort();
+    if (port === null) continue;
+    if (new Set(portRegistry.values()).has(port)) continue;
+    portRegistry.set(sessionKey, port);
+    if (await probePortFree(port)) return port;
+    releasePort(portRegistry, sessionKey);
+  }
+  throw new Error("Failed to allocate port");
+}
+
+function requestOsAssignedPort(): Promise<number | null> {
+  return new Promise<number | null>((resolve) => {
+    let settled = false;
+    const settle = (value: number | null) => {
+      if (settled) return;
+      settled = true;
+      resolve(value);
+    };
     const srv = net.createServer();
     srv.unref();
-    srv.once("error", (err) => reject(err));
-    srv.listen(0, "0.0.0.0", () => {
-      const addr = srv.address();
-      const port = typeof addr === "object" && addr ? addr.port : 0;
-      srv.close(() => {
-        if (port) {
-          portRegistry.set(sessionKey, port);
-          resolve(port);
-        } else {
-          reject(new Error("Failed to allocate port"));
-        }
+    srv.once("error", () => settle(null));
+    try {
+      srv.listen({ port: 0, host: "0.0.0.0" }, () => {
+        const addr = srv.address();
+        const port = typeof addr === "object" && addr ? addr.port : 0;
+        srv.close(() => settle(port > 0 ? port : null));
       });
-    });
+    } catch {
+      settle(null);
+    }
   });
 }
 
@@ -55,7 +165,7 @@ export function releasePort(portRegistry: Map<string, number>, sessionKey: strin
  * on timeout or abort. Primarily addresses Windows TIME_WAIT after a force-kill
  * of a dev server — the kernel can hold the socket for up to ~240s, which
  * causes the next allocatePort/spawn to fail with EADDRINUSE on the same port.
- * Probes with the same listen() call allocatePort uses, so a "free" answer
+ * Probes with the same dual-family check allocatePort uses, so a "free" answer
  * here implies the allocator will also succeed (TOCTOU window aside).
  */
 export async function waitForPortFree(
@@ -75,40 +185,6 @@ export async function waitForPortFree(
     }
   }
   return false;
-}
-
-function probePortFree(port: number, signal: AbortSignal): Promise<boolean> {
-  return new Promise<boolean>((resolve) => {
-    let settled = false;
-    let onAbort: () => void = () => {};
-    const settle = (value: boolean) => {
-      if (settled) return;
-      settled = true;
-      signal.removeEventListener("abort", onAbort);
-      resolve(value);
-    };
-    if (signal.aborted) {
-      settle(false);
-      return;
-    }
-    const srv = net.createServer();
-    srv.unref();
-    srv.once("error", () => settle(false));
-    onAbort = () => {
-      try {
-        srv.close();
-      } catch {
-        // server may already be closing
-      }
-      settle(false);
-    };
-    signal.addEventListener("abort", onAbort, { once: true });
-    try {
-      srv.listen(port, "0.0.0.0", () => srv.close(() => settle(true)));
-    } catch {
-      settle(false);
-    }
-  });
 }
 
 function sleepWithAbort(ms: number, signal: AbortSignal): Promise<void> {

--- a/electron/services/DevPreviewPortAllocator.ts
+++ b/electron/services/DevPreviewPortAllocator.ts
@@ -91,14 +91,18 @@ const PROBE_ADDRESSES: ReadonlyArray<{ host: string; ipv6: boolean }> = [
  * intrinsic TOCTOU we accept.
  */
 export async function probePortFree(port: number, signal?: AbortSignal): Promise<boolean> {
-  const results = await Promise.all(
-    PROBE_ADDRESSES.map(({ host, ipv6 }) => probeFamily(port, host, ipv6, signal))
-  );
-  if (signal?.aborted) return false;
-  return results.every(
-    (result, index) =>
-      result === "free" || (PROBE_ADDRESSES[index].ipv6 && result === "unavailable")
-  );
+  // Strictly sequential, each socket closed before the next opens. Running
+  // them together would have the wildcard probe hold the port while its own
+  // loopback probe binds, and Linux refuses that overlap — the allocator
+  // would then reject every port as busy, including ones nothing is using.
+  for (const { host, ipv6 } of PROBE_ADDRESSES) {
+    const result = await probeFamily(port, host, ipv6, signal);
+    if (signal?.aborted) return false;
+    if (result === "free") continue;
+    if (ipv6 && result === "unavailable") continue;
+    return false;
+  }
+  return true;
 }
 
 export async function allocatePort(

--- a/electron/services/DevPreviewSessionService.ts
+++ b/electron/services/DevPreviewSessionService.ts
@@ -76,6 +76,8 @@ interface DevPreviewSession extends DevPreviewSessionState {
   needsInstall: boolean;
   isRunningInstall: boolean;
   installAttemptedGeneration: number | null;
+  /** See TerminalControllerSession.launchEpoch — bumped by every stop. */
+  launchEpoch: number;
   startupReplayTimer: ReturnType<typeof setTimeout> | null;
   updatedAtPerformanceMs: number;
   phaseLabel?: "Compiling";
@@ -1099,6 +1101,7 @@ export class DevPreviewSessionService {
       needsInstall: false,
       isRunningInstall: false,
       installAttemptedGeneration: null,
+      launchEpoch: 0,
       startupReplayTimer: null,
       compiling: false,
       compilingTimer: null,

--- a/electron/services/DevPreviewSessionService.ts
+++ b/electron/services/DevPreviewSessionService.ts
@@ -34,6 +34,7 @@ import {
   waitForRegisteredPortFree,
   runInstall,
   handleDevPreviewTerminalExit,
+  invalidatePendingLaunch,
   clearStartupReplay,
   isBenignMissingTerminalError,
   type TerminalControllerDeps,
@@ -439,6 +440,7 @@ export class DevPreviewSessionService {
           type: "command-invalid",
           message: capDiagnosticText(commandError),
         });
+        invalidatePendingLaunch(session);
         if (configChanged && session.terminalId) {
           await this.stopSessionTerminal(session, "invalid-command");
         }
@@ -453,8 +455,11 @@ export class DevPreviewSessionService {
         return;
       }
 
-      if (configChanged && session.terminalId) {
-        await this.stopSessionTerminal(session, "config-change");
+      if (configChanged) {
+        invalidatePendingLaunch(session);
+        if (session.terminalId) {
+          await this.stopSessionTerminal(session, "config-change");
+        }
       }
 
       await this.ensureSessionTerminal(session);
@@ -668,6 +673,10 @@ export class DevPreviewSessionService {
       // branch routes through stopSessionTerminal, but a stop arriving mid
       // backoff has no live terminal and would otherwise skip the abort.
       resetCrashLoopGuard(session);
+      // Unconditional: a post-install respawn still resolving its command has
+      // no terminal yet, so the branch below would not reach stopSessionTerminal
+      // and the launch would outlive the stop.
+      invalidatePendingLaunch(session);
 
       this.recordSessionDiagnostic(session, { type: "stop-requested", context: "stop" });
 

--- a/electron/services/DevPreviewTerminalController.ts
+++ b/electron/services/DevPreviewTerminalController.ts
@@ -427,10 +427,15 @@ async function prepareAndSpawnSessionTerminal<TSession extends TerminalControlle
   // dispose() can fire while allocatePort awaits its net probe. Guard here
   // so we don't spawn a terminal on a disposed service; roll back the
   // reservation to avoid a stale portRegistry entry after disposal cleared it.
-  if (deps.isDisposed() || session.launchEpoch !== startEpoch) {
+  if (deps.isDisposed()) {
     releasePort(deps.portRegistry, sessionKey);
     return;
   }
+  // Stopped or superseded while we allocated. The registry entry is sticky per
+  // sessionKey — stopSessionTerminal leaves it in place so a restart reuses the
+  // port — so a newer launch may already own this reservation. Releasing it here
+  // would hand its live port out again and skip the next stop's TIME_WAIT wait.
+  if (session.launchEpoch !== startEpoch) return;
   // Recorded with the generation this spawn is about to become, so the whole
   // spawn lifecycle (port-allocated → spawned → …) shares one generation.
   deps.recordDiagnostic(sessionKey, nextGeneration, { type: "port-allocated", port });

--- a/electron/services/DevPreviewTerminalController.ts
+++ b/electron/services/DevPreviewTerminalController.ts
@@ -3,11 +3,13 @@ import type { DevServerError } from "../../shared/utils/devServerErrors.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 import { PERF_MARKS } from "../../shared/perf/marks.js";
 import { markPerformance } from "../utils/performance.js";
-import { CRASH_SIGNALS, EXPECTED_TERMINATION_SIGNALS } from "./pty/terminalForensics.js";
+import { EXPECTED_TERMINATION_SIGNALS } from "./pty/terminalForensics.js";
 import {
   normalizeNextjsDevCommand,
   normalizeViteDevCommand,
+  type DevCommandBundlerConflict,
 } from "./DevPreviewCommandNormalizer.js";
+import { buildCommandLaunchShell } from "../ipc/handlers/terminal/commandLaunch.js";
 import { guardedReinstall, type CrashLoopGuardSession } from "./DevPreviewCrashLoopGuard.js";
 import { classifyDevPreviewExit } from "./DevPreviewOutputProcessor.js";
 import { capDiagnosticText, type DevPreviewDiagnosticInput } from "./DevPreviewDiagnosticsRing.js";
@@ -359,6 +361,7 @@ export async function spawnSessionTerminal<TSession extends TerminalControllerSe
   deps: TerminalControllerDeps<TSession>
 ): Promise<void> {
   const terminalId = createTerminalId(session);
+  const startGeneration = session.generation;
   const nextGeneration = session.generation + 1;
 
   const sessionKey = createSessionKey(session.projectId, session.panelId);
@@ -376,6 +379,26 @@ export async function spawnSessionTerminal<TSession extends TerminalControllerSe
   const predictedUrl = `http://localhost:${port}`;
 
   const spawnEnv: Record<string, string> = { ...session.env, PORT: String(port) };
+
+  // Resolved before the spawn, not after: the command has to ride in the
+  // shell's own arguments so the PTY ends when it does. Both normalizers read
+  // package.json, so this is the second await in this function — re-check the
+  // guards a concurrent stop/restart or dispose could have tripped.
+  const normalizedCommand = await normalizeDevCommand(session, port, (conflict) =>
+    deps.recordDiagnostic(sessionKey, nextGeneration, {
+      type: "bundler-conflict",
+      message: capDiagnosticText(conflict.message),
+    })
+  );
+  if (deps.isDisposed()) {
+    releasePort(deps.portRegistry, sessionKey);
+    return;
+  }
+  // A newer spawn won the race; its reservation is the live one, so leave the
+  // registry alone and let it own the session.
+  if (session.generation !== startGeneration) return;
+
+  const launch = buildCommandLaunchShell(normalizedCommand, undefined, "exit");
 
   // Mark the dev-server spawn time for the crash-loop graduation check. Set
   // only here (the dev server), never in runInstall — an install is part of
@@ -408,6 +431,7 @@ export async function spawnSessionTerminal<TSession extends TerminalControllerSe
       restore: false,
       env: spawnEnv,
       isEphemeral: true,
+      ...(launch ? { shell: launch.shell, args: launch.args } : {}),
     });
     markPerformance(PERF_MARKS.DEVPREVIEW_TERMINAL_SPAWNED, {
       panelId: session.panelId,
@@ -448,30 +472,49 @@ export async function spawnSessionTerminal<TSession extends TerminalControllerSe
     return;
   }
 
-  const trimmedCommand = session.devCommand.trim();
-
-  const submitCommand = (cmd: string) => {
-    setTimeout(() => {
-      try {
-        if (deps.ptyClient.hasTerminal(terminalId)) {
-          deps.ptyClient.submit(terminalId, cmd);
-        }
-      } catch (err) {
-        console.warn("[DevPreviewSessionService] Failed to submit dev command:", err);
-      }
-    }, PTY_SUBMIT_AFTER_SPAWN_MS);
-  };
-
-  void normalizeNextjsDevCommand(trimmedCommand, session.cwd, session.turbopackEnabled)
-    .then((nextNormalized) => normalizeViteDevCommand(nextNormalized, session.cwd, port))
-    .then((normalizedCommand) => {
-      submitCommand(normalizedCommand);
-    })
-    .catch(() => {
-      submitCommand(trimmedCommand);
-    });
+  if (!launch) submitFallbackCommand(terminalId, normalizedCommand, deps);
 
   scheduleStartupReplay(session, deps);
+}
+
+/**
+ * Shells that can't host a startup wrapper (fish, nushell, an unrecognised
+ * Windows shell) launch bare and get the command typed in. They keep the
+ * pre-#12295 behaviour, including its blindness to the command's own exit.
+ */
+function submitFallbackCommand<TSession extends TerminalControllerSession>(
+  terminalId: string,
+  command: string,
+  deps: Pick<TerminalControllerDeps<TSession>, "ptyClient">
+): void {
+  setTimeout(() => {
+    try {
+      if (deps.ptyClient.hasTerminal(terminalId)) {
+        deps.ptyClient.submit(terminalId, command);
+      }
+    } catch (err) {
+      console.warn("[DevPreviewSessionService] Failed to submit dev command:", err);
+    }
+  }, PTY_SUBMIT_AFTER_SPAWN_MS);
+}
+
+async function normalizeDevCommand(
+  session: TerminalControllerSession,
+  port: number,
+  onConflict: (conflict: DevCommandBundlerConflict) => void
+): Promise<string> {
+  const trimmedCommand = session.devCommand.trim();
+  try {
+    const nextNormalized = await normalizeNextjsDevCommand(
+      trimmedCommand,
+      session.cwd,
+      session.turbopackEnabled,
+      onConflict
+    );
+    return await normalizeViteDevCommand(nextNormalized, session.cwd, port);
+  } catch {
+    return trimmedCommand;
+  }
 }
 
 export async function runInstall<TSession extends TerminalControllerSession>(
@@ -488,6 +531,7 @@ export async function runInstall<TSession extends TerminalControllerSession>(
   });
 
   const terminalId = createTerminalId(session);
+  const launch = buildCommandLaunchShell(installCommand, undefined, "exit");
   session.buffer = "";
   session.lastErrorKey = null;
   attachTerminal(session, terminalId, deps);
@@ -510,6 +554,7 @@ export async function runInstall<TSession extends TerminalControllerSession>(
       restore: false,
       env: session.env,
       isEphemeral: true,
+      ...(launch ? { shell: launch.shell, args: launch.args } : {}),
     });
   } catch (error) {
     session.isRunningInstall = false;
@@ -530,15 +575,7 @@ export async function runInstall<TSession extends TerminalControllerSession>(
     return;
   }
 
-  setTimeout(() => {
-    try {
-      if (deps.ptyClient.hasTerminal(terminalId)) {
-        deps.ptyClient.submit(terminalId, installCommand);
-      }
-    } catch (err) {
-      console.warn("[DevPreviewSessionService] Failed to submit install command:", err);
-    }
-  }, PTY_SUBMIT_AFTER_SPAWN_MS);
+  if (!launch) submitFallbackCommand(terminalId, installCommand, deps);
 }
 
 /**
@@ -549,6 +586,19 @@ export async function runInstall<TSession extends TerminalControllerSession>(
  * callers are expected to have already checked disposal/session-lookup/
  * terminal-id-match.
  */
+/**
+ * The wrapper shell exits normally with `128 + n` when the dev command it ran
+ * was killed by signal n, so the raw signal is gone by the time the PTY exit
+ * reaches us. Decode that POSIX convention — otherwise a user's Ctrl-C on the
+ * dev server reads as "exited with code 130" rather than a clean stop. Windows
+ * has no such encoding, so the raw signal stays the only source there.
+ */
+function isExpectedTermination(exitCode: number, signal: number | undefined): boolean {
+  if (signal !== undefined) return EXPECTED_TERMINATION_SIGNALS.has(signal);
+  if (process.platform === "win32") return false;
+  return exitCode > 128 && EXPECTED_TERMINATION_SIGNALS.has(exitCode - 128);
+}
+
 export function handleDevPreviewTerminalExit<TSession extends TerminalControllerSession>(
   session: TSession,
   exitCode: number,
@@ -617,7 +667,7 @@ export function handleDevPreviewTerminalExit<TSession extends TerminalController
     session.status === "error"
   ) {
     // Expected termination signals during startup/error = clean stop (user interrupted it)
-    if (signal !== undefined && EXPECTED_TERMINATION_SIGNALS.has(signal)) {
+    if (isExpectedTermination(exitCode, signal)) {
       deps.updateSession(session, {
         status: "stopped",
         url: null,
@@ -645,16 +695,18 @@ export function handleDevPreviewTerminalExit<TSession extends TerminalController
     return;
   }
 
-  const crashError =
-    signal !== undefined && CRASH_SIGNALS.has(signal)
-      ? classifyDevPreviewExit(exitCode, signal, recentOutput)
-      : null;
+  // A server that was serving and then died is now observable (#12295). Only a
+  // clean or expected termination is a plain stop — anything else keeps the
+  // exit evidence so the pane doesn't quietly read as "stopped" after a crash.
+  const exitError = isExpectedTermination(exitCode, signal)
+    ? null
+    : classifyDevPreviewExit(exitCode, signal, recentOutput);
 
   deps.updateSession(session, {
-    status: "stopped",
+    status: exitError ? "error" : "stopped",
     url: null,
     predictedUrl: null,
-    error: crashError,
+    error: exitError,
     terminalId: null,
     isRestarting: false,
     phaseLabel: undefined,

--- a/electron/services/DevPreviewTerminalController.ts
+++ b/electron/services/DevPreviewTerminalController.ts
@@ -138,6 +138,15 @@ export function detachTerminal<TSession extends TerminalControllerSession>(
   session.terminalId = null;
 }
 
+/**
+ * Cancel any launch still resolving its port or command. Every path that stops,
+ * replaces, or removes a session must call this — a launch with no terminal yet
+ * is invisible to the `terminalId` checks those paths otherwise rely on.
+ */
+export function invalidatePendingLaunch(session: TerminalControllerSession): void {
+  session.launchEpoch += 1;
+}
+
 export function clearStartupReplay(session: TerminalControllerSession): void {
   if (session.startupReplayTimer !== null) {
     clearTimeout(session.startupReplayTimer);
@@ -245,7 +254,7 @@ export async function stopSessionTerminal<TSession extends TerminalControllerSes
   // Before the no-terminal early return: a post-install respawn that is still
   // resolving its command has no terminal yet, and is exactly what must not
   // survive this stop.
-  session.launchEpoch += 1;
+  invalidatePendingLaunch(session);
 
   const terminalId = session.terminalId;
   if (!terminalId) return;
@@ -377,10 +386,15 @@ export async function spawnSessionTerminal<TSession extends TerminalControllerSe
   session: TSession,
   deps: TerminalControllerDeps<TSession>
 ): Promise<void> {
+  const startEpoch = session.launchEpoch;
+  const startGeneration = session.generation;
   try {
     await prepareAndSpawnSessionTerminal(session, deps);
   } catch (error) {
     if (deps.isDisposed()) return;
+    // Stopped or superseded while preparing — the owner of that transition has
+    // already published the state it wants.
+    if (session.launchEpoch !== startEpoch || session.generation !== startGeneration) return;
     const message = formatErrorMessage(error, "Failed to start dev server");
     deps.recordSessionDiagnostic(session, {
       type: "spawn-failed",
@@ -413,7 +427,7 @@ async function prepareAndSpawnSessionTerminal<TSession extends TerminalControlle
   // dispose() can fire while allocatePort awaits its net probe. Guard here
   // so we don't spawn a terminal on a disposed service; roll back the
   // reservation to avoid a stale portRegistry entry after disposal cleared it.
-  if (deps.isDisposed()) {
+  if (deps.isDisposed() || session.launchEpoch !== startEpoch) {
     releasePort(deps.portRegistry, sessionKey);
     return;
   }

--- a/electron/services/DevPreviewTerminalController.ts
+++ b/electron/services/DevPreviewTerminalController.ts
@@ -56,6 +56,13 @@ export interface TerminalControllerSession extends CrashLoopGuardSession {
   needsInstall: boolean;
   isRunningInstall: boolean;
   installAttemptedGeneration: number | null;
+  /**
+   * Bumped by every stop, so a launch that is still awaiting port allocation or
+   * command normalization can tell that the session was stopped or deleted out
+   * from under it. `generation` cannot serve here: a stop leaves it untouched,
+   * and the post-install respawn runs outside the session lock.
+   */
+  launchEpoch: number;
   startupReplayTimer: ReturnType<typeof setTimeout> | null;
   updatedAtPerformanceMs: number;
   compiling: boolean;
@@ -235,6 +242,10 @@ export async function stopSessionTerminal<TSession extends TerminalControllerSes
   deps.clearCompiling(session);
   session.needsInstall = false;
   session.isRunningInstall = false;
+  // Before the no-terminal early return: a post-install respawn that is still
+  // resolving its command has no terminal yet, and is exactly what must not
+  // survive this stop.
+  session.launchEpoch += 1;
 
   const terminalId = session.terminalId;
   if (!terminalId) return;
@@ -356,12 +367,45 @@ export async function ensureSessionTerminal<TSession extends TerminalControllerS
   await spawnSessionTerminal(session, deps);
 }
 
+/**
+ * Port allocation can now fail outright (every candidate busy on some address
+ * family), and the automatic post-install respawn calls this without a catch.
+ * Land a terminal error state instead of leaving an `installing` session with
+ * no terminal and an unhandled rejection.
+ */
 export async function spawnSessionTerminal<TSession extends TerminalControllerSession>(
+  session: TSession,
+  deps: TerminalControllerDeps<TSession>
+): Promise<void> {
+  try {
+    await prepareAndSpawnSessionTerminal(session, deps);
+  } catch (error) {
+    if (deps.isDisposed()) return;
+    const message = formatErrorMessage(error, "Failed to start dev server");
+    deps.recordSessionDiagnostic(session, {
+      type: "spawn-failed",
+      message: capDiagnosticText(message),
+    });
+    detachTerminal(session, deps);
+    deps.updateSession(session, {
+      status: "error",
+      url: null,
+      predictedUrl: null,
+      error: { type: "unknown", message: `Failed to start dev server: ${message}` },
+      terminalId: null,
+      isRestarting: false,
+      phaseLabel: undefined,
+    });
+  }
+}
+
+async function prepareAndSpawnSessionTerminal<TSession extends TerminalControllerSession>(
   session: TSession,
   deps: TerminalControllerDeps<TSession>
 ): Promise<void> {
   const terminalId = createTerminalId(session);
   const startGeneration = session.generation;
+  const startEpoch = session.launchEpoch;
   const nextGeneration = session.generation + 1;
 
   const sessionKey = createSessionKey(session.projectId, session.panelId);
@@ -397,6 +441,9 @@ export async function spawnSessionTerminal<TSession extends TerminalControllerSe
   // A newer spawn won the race; its reservation is the live one, so leave the
   // registry alone and let it own the session.
   if (session.generation !== startGeneration) return;
+  // Stopped or deleted while we resolved the command — the stop already
+  // released whatever it owned, so just abandon this launch.
+  if (session.launchEpoch !== startEpoch) return;
 
   const launch = buildCommandLaunchShell(normalizedCommand, undefined, "exit");
 
@@ -587,16 +634,23 @@ export async function runInstall<TSession extends TerminalControllerSession>(
  * terminal-id-match.
  */
 /**
- * The wrapper shell exits normally with `128 + n` when the dev command it ran
- * was killed by signal n, so the raw signal is gone by the time the PTY exit
- * reaches us. Decode that POSIX convention — otherwise a user's Ctrl-C on the
- * dev server reads as "exited with code 130" rather than a clean stop. Windows
- * has no such encoding, so the raw signal stays the only source there.
+ * What killed the dev command, as a signal number. The wrapper shell exits
+ * normally with `128 + n` when its child took signal n, so by the time the PTY
+ * exit arrives the raw signal is gone and only the encoded status is left —
+ * without decoding it, a Ctrl-C reads as "exited with code 130" and a segfault
+ * loses its crash classification. node-pty reports signal 0 for an ordinary
+ * exit and that zero survives the whole exit path, so "no signal" has to mean
+ * falsy rather than undefined. Windows has no such encoding.
  */
+function decodeExitSignal(exitCode: number, signal: number | undefined): number | undefined {
+  if (signal) return signal;
+  if (process.platform === "win32") return undefined;
+  return exitCode > 128 && exitCode < 192 ? exitCode - 128 : undefined;
+}
+
 function isExpectedTermination(exitCode: number, signal: number | undefined): boolean {
-  if (signal !== undefined) return EXPECTED_TERMINATION_SIGNALS.has(signal);
-  if (process.platform === "win32") return false;
-  return exitCode > 128 && EXPECTED_TERMINATION_SIGNALS.has(exitCode - 128);
+  const decoded = decodeExitSignal(exitCode, signal);
+  return decoded !== undefined && EXPECTED_TERMINATION_SIGNALS.has(decoded);
 }
 
 export function handleDevPreviewTerminalExit<TSession extends TerminalControllerSession>(
@@ -646,7 +700,7 @@ export function handleDevPreviewTerminalExit<TSession extends TerminalController
   deps.recordSessionDiagnostic(session, {
     type: "terminal-exited",
     exitCode,
-    ...(signal !== undefined ? { signal } : {}),
+    ...(signal ? { signal } : {}),
   });
 
   if (session.needsInstall && session.installAttemptedGeneration !== session.generation) {
@@ -679,7 +733,11 @@ export function handleDevPreviewTerminalExit<TSession extends TerminalController
       });
       return;
     }
-    const error = classifyDevPreviewExit(exitCode, signal, recentOutput) ?? {
+    const error = classifyDevPreviewExit(
+      exitCode,
+      decodeExitSignal(exitCode, signal),
+      recentOutput
+    ) ?? {
       type: "unknown",
       message: `Dev server exited with code ${exitCode}`,
     };
@@ -700,7 +758,7 @@ export function handleDevPreviewTerminalExit<TSession extends TerminalController
   // exit evidence so the pane doesn't quietly read as "stopped" after a crash.
   const exitError = isExpectedTermination(exitCode, signal)
     ? null
-    : classifyDevPreviewExit(exitCode, signal, recentOutput);
+    : classifyDevPreviewExit(exitCode, decodeExitSignal(exitCode, signal), recentOutput);
 
   deps.updateSession(session, {
     status: exitError ? "error" : "stopped",

--- a/electron/services/__tests__/DevPreviewPortAllocator.sockets.test.ts
+++ b/electron/services/__tests__/DevPreviewPortAllocator.sockets.test.ts
@@ -10,25 +10,31 @@ import { probePortFree, waitForPortFree } from "../DevPreviewPortAllocator.js";
 
 const servers: net.Server[] = [];
 
-function listen(options: net.ListenOptions): Promise<net.Server | null> {
+const IPV6_CAPABILITY_CODES = new Set(["EAFNOSUPPORT", "EADDRNOTAVAIL", "ENOPROTOOPT", "EINVAL"]);
+
+function listen(options: net.ListenOptions): Promise<net.Server | { code?: string }> {
   return new Promise((resolve) => {
     const server = net.createServer();
     server.unref();
-    server.once("error", () => resolve(null));
+    server.once("error", (err) => resolve({ code: (err as NodeJS.ErrnoException).code }));
     try {
       server.listen(options, () => {
         servers.push(server);
         resolve(server);
       });
-    } catch {
-      resolve(null);
+    } catch (err) {
+      resolve({ code: (err as NodeJS.ErrnoException).code });
     }
   });
 }
 
+function isServer(value: net.Server | { code?: string }): value is net.Server {
+  return value instanceof net.Server;
+}
+
 async function freePort(): Promise<number> {
   const server = await listen({ port: 0, host: "127.0.0.1" });
-  if (!server) throw new Error("could not reserve a probe port");
+  if (!isServer(server)) throw new Error(`could not reserve a probe port: ${server.code}`);
   const address = server.address();
   const port = typeof address === "object" && address ? address.port : 0;
   await new Promise<void>((resolve) => server.close(() => resolve()));
@@ -38,7 +44,12 @@ async function freePort(): Promise<number> {
 
 async function hasUsableIpv6(): Promise<boolean> {
   const server = await listen({ port: 0, host: "::1", ipv6Only: true });
-  if (!server) return false;
+  if (!isServer(server)) {
+    // Only a genuine capability failure disables the IPv6 cases; anything else
+    // (a permission or resource error) should surface as a real failure.
+    if (server.code && IPV6_CAPABILITY_CODES.has(server.code)) return false;
+    throw new Error(`unexpected IPv6 probe failure: ${server.code}`);
+  }
   await new Promise<void>((resolve) => server.close(() => resolve()));
   servers.splice(servers.indexOf(server), 1);
   return true;
@@ -61,7 +72,7 @@ describe("probePortFree against real sockets", () => {
 
   it("reports a port held on IPv4 as busy", async () => {
     const port = await freePort();
-    expect(await listen({ port, host: "0.0.0.0" })).toBeTruthy();
+    expect(isServer(await listen({ port, host: "0.0.0.0" }))).toBe(true);
     expect(await probePortFree(port)).toBe(false);
   });
 
@@ -69,13 +80,19 @@ describe("probePortFree against real sockets", () => {
   // free and the port was handed out.
   it.skipIf(!ipv6Available)("reports a port held only on IPv6 as busy", async () => {
     const port = await freePort();
-    expect(await listen({ port, host: "::1", ipv6Only: true })).toBeTruthy();
+    expect(isServer(await listen({ port, host: "::1", ipv6Only: true }))).toBe(true);
+    expect(await probePortFree(port)).toBe(false);
+  });
+
+  it("reports a port held only on the IPv4 loopback as busy", async () => {
+    const port = await freePort();
+    expect(isServer(await listen({ port, host: "127.0.0.1" }))).toBe(true);
     expect(await probePortFree(port)).toBe(false);
   });
 
   it.skipIf(!ipv6Available)("reports a dual-stack listener's port as busy", async () => {
     const port = await freePort();
-    expect(await listen({ port, host: "::", ipv6Only: false })).toBeTruthy();
+    expect(isServer(await listen({ port, host: "::", ipv6Only: false }))).toBe(true);
     expect(await probePortFree(port)).toBe(false);
   });
 
@@ -84,11 +101,12 @@ describe("probePortFree against real sockets", () => {
     async () => {
       const port = await freePort();
       const server = await listen({ port, host: "::1", ipv6Only: true });
-      expect(server).toBeTruthy();
+      expect(isServer(server)).toBe(true);
       expect(await probePortFree(port)).toBe(false);
 
-      await new Promise<void>((resolve) => server!.close(() => resolve()));
-      servers.splice(servers.indexOf(server!), 1);
+      const held = server as net.Server;
+      await new Promise<void>((resolve) => held.close(() => resolve()));
+      servers.splice(servers.indexOf(held), 1);
 
       expect(await waitForPortFree(port, new AbortController().signal, 5000)).toBe(true);
     }

--- a/electron/services/__tests__/DevPreviewPortAllocator.sockets.test.ts
+++ b/electron/services/__tests__/DevPreviewPortAllocator.sockets.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Real sockets, no `node:net` mock. The IPv4-only probe that shipped in
+ * #12295 handed out a port an `ipv6Only` `::1` listener was holding, and a
+ * mocked bind can't catch that class of bug — only the kernel can say whether
+ * `0.0.0.0` and `::` are actually independent.
+ */
+import net from "node:net";
+import { afterEach, describe, expect, it } from "vitest";
+import { probePortFree, waitForPortFree } from "../DevPreviewPortAllocator.js";
+
+const servers: net.Server[] = [];
+
+function listen(options: net.ListenOptions): Promise<net.Server | null> {
+  return new Promise((resolve) => {
+    const server = net.createServer();
+    server.unref();
+    server.once("error", () => resolve(null));
+    try {
+      server.listen(options, () => {
+        servers.push(server);
+        resolve(server);
+      });
+    } catch {
+      resolve(null);
+    }
+  });
+}
+
+async function freePort(): Promise<number> {
+  const server = await listen({ port: 0, host: "127.0.0.1" });
+  if (!server) throw new Error("could not reserve a probe port");
+  const address = server.address();
+  const port = typeof address === "object" && address ? address.port : 0;
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  servers.splice(servers.indexOf(server), 1);
+  return port;
+}
+
+async function hasUsableIpv6(): Promise<boolean> {
+  const server = await listen({ port: 0, host: "::1", ipv6Only: true });
+  if (!server) return false;
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  servers.splice(servers.indexOf(server), 1);
+  return true;
+}
+
+const ipv6Available = await hasUsableIpv6();
+
+afterEach(async () => {
+  while (servers.length > 0) {
+    const server = servers.pop();
+    if (!server) continue;
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+});
+
+describe("probePortFree against real sockets", () => {
+  it("reports a genuinely unused port as free", async () => {
+    expect(await probePortFree(await freePort())).toBe(true);
+  });
+
+  it("reports a port held on IPv4 as busy", async () => {
+    const port = await freePort();
+    expect(await listen({ port, host: "0.0.0.0" })).toBeTruthy();
+    expect(await probePortFree(port)).toBe(false);
+  });
+
+  // The audit's exact repro: a fixture bound `::1` with ipv6Only was reported
+  // free and the port was handed out.
+  it.skipIf(!ipv6Available)("reports a port held only on IPv6 as busy", async () => {
+    const port = await freePort();
+    expect(await listen({ port, host: "::1", ipv6Only: true })).toBeTruthy();
+    expect(await probePortFree(port)).toBe(false);
+  });
+
+  it.skipIf(!ipv6Available)("reports a dual-stack listener's port as busy", async () => {
+    const port = await freePort();
+    expect(await listen({ port, host: "::", ipv6Only: false })).toBeTruthy();
+    expect(await probePortFree(port)).toBe(false);
+  });
+
+  it.skipIf(!ipv6Available)(
+    "reports the port free again once the IPv6 listener closes",
+    async () => {
+      const port = await freePort();
+      const server = await listen({ port, host: "::1", ipv6Only: true });
+      expect(server).toBeTruthy();
+      expect(await probePortFree(port)).toBe(false);
+
+      await new Promise<void>((resolve) => server!.close(() => resolve()));
+      servers.splice(servers.indexOf(server!), 1);
+
+      expect(await waitForPortFree(port, new AbortController().signal, 5000)).toBe(true);
+    }
+  );
+});

--- a/electron/services/__tests__/DevPreviewPortAllocator.test.ts
+++ b/electron/services/__tests__/DevPreviewPortAllocator.test.ts
@@ -1,11 +1,19 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const netMock = vi.hoisted(() => ({
-  // Ports that should fail to bind (simulating EADDRINUSE).
-  busyPorts: new Set<number>(),
-  // Per-port: number of remaining failures before the port becomes free.
-  busyForCalls: new Map<number, number>(),
+  // `${host}|${port}` entries that should fail to bind, mapped to the errno the
+  // kernel would report. Host is the literal wildcard the allocator binds.
+  busy: new Map<string, string>(),
+  // Per-key: number of remaining failures before the address becomes free.
+  busyForCalls: new Map<string, number>(),
+  listens: [] as Array<{ port: number; host: string; ipv6Only: boolean }>,
 }));
+
+function bindError(code: string): NodeJS.ErrnoException {
+  const err = new Error(code) as NodeJS.ErrnoException;
+  err.code = code;
+  return err;
+}
 
 vi.mock("node:net", () => {
   const createServer = vi.fn(() => {
@@ -20,18 +28,28 @@ vi.mock("node:net", () => {
         if (event === "error") errorHandlers.push(cb as (err: Error) => void);
         return this;
       },
-      listen(this: unknown, port: number, _host: string, cb?: () => void) {
-        listenPort = port;
+      listen(
+        this: unknown,
+        options: { port: number; host: string; ipv6Only?: boolean },
+        cb?: () => void
+      ) {
+        listenPort = options.port;
+        const key = `${options.host}|${options.port}`;
+        netMock.listens.push({
+          port: options.port,
+          host: options.host,
+          ipv6Only: options.ipv6Only === true,
+        });
         queueMicrotask(() => {
           if (closed) return;
-          let isBusy = netMock.busyPorts.has(port);
-          const remaining = netMock.busyForCalls.get(port);
+          let code = netMock.busy.get(key);
+          const remaining = netMock.busyForCalls.get(key);
           if (remaining !== undefined && remaining > 0) {
-            isBusy = true;
-            netMock.busyForCalls.set(port, remaining - 1);
+            code = code ?? "EADDRINUSE";
+            netMock.busyForCalls.set(key, remaining - 1);
           }
-          if (isBusy) {
-            for (const h of errorHandlers) h(new Error("EADDRINUSE"));
+          if (code) {
+            for (const h of errorHandlers) h(bindError(code));
           } else {
             cb?.();
           }
@@ -53,18 +71,84 @@ vi.mock("node:net", () => {
 
 import {
   allocatePort,
+  probePortFree,
   releasePort,
   waitForPortFree,
   PORT_FREE_POLL_INTERVAL_MS,
 } from "../DevPreviewPortAllocator.js";
 
 beforeEach(() => {
-  netMock.busyPorts.clear();
+  netMock.busy.clear();
   netMock.busyForCalls.clear();
+  netMock.listens.length = 0;
 });
 
 afterEach(() => {
   vi.useRealTimers();
+});
+
+describe("probePortFree", () => {
+  it("probes every address a dev server could bind, ipv6Only on the IPv6 legs", async () => {
+    await probePortFree(4100);
+
+    expect(netMock.listens).toEqual([
+      { port: 4100, host: "0.0.0.0", ipv6Only: false },
+      { port: 4100, host: "127.0.0.1", ipv6Only: false },
+      { port: 4100, host: "::", ipv6Only: true },
+      { port: 4100, host: "::1", ipv6Only: true },
+    ]);
+  });
+
+  it("reports busy when only the IPv6 loopback is occupied", async () => {
+    // SO_REUSEADDR lets both wildcards bind while ::1 is held, so the
+    // loopback leg is the only one that sees a localhost-bound dev server.
+    netMock.busy.set("::1|4108", "EADDRINUSE");
+    expect(await probePortFree(4108)).toBe(false);
+  });
+
+  it("reports busy when only the IPv4 loopback is occupied", async () => {
+    netMock.busy.set("127.0.0.1|4109", "EADDRINUSE");
+    expect(await probePortFree(4109)).toBe(false);
+  });
+
+  it("reports busy when only the IPv6 wildcard is occupied", async () => {
+    netMock.busy.set("::|4101", "EADDRINUSE");
+    expect(await probePortFree(4101)).toBe(false);
+  });
+
+  it("reports busy when only IPv4 is occupied", async () => {
+    netMock.busy.set("0.0.0.0|4102", "EADDRINUSE");
+    expect(await probePortFree(4102)).toBe(false);
+  });
+
+  it("reports free when every address binds", async () => {
+    expect(await probePortFree(4103)).toBe(true);
+  });
+
+  it.each(["EAFNOSUPPORT", "EADDRNOTAVAIL", "ENOPROTOOPT", "EINVAL"])(
+    "treats IPv6 %s as unsupported rather than occupied",
+    async (code) => {
+      netMock.busy.set("::|4104", code);
+      netMock.busy.set("::1|4104", code);
+      expect(await probePortFree(4104)).toBe(true);
+    }
+  );
+
+  it("does not report free when the IPv6 leg fails for an unrecognised reason", async () => {
+    netMock.busy.set("::|4105", "EACCES");
+    expect(await probePortFree(4105)).toBe(false);
+  });
+
+  it("does not treat an unsupported-family errno on the IPv4 leg as free", async () => {
+    netMock.busy.set("0.0.0.0|4106", "EAFNOSUPPORT");
+    expect(await probePortFree(4106)).toBe(false);
+  });
+
+  it("returns false once the signal aborts", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    expect(await probePortFree(4107, controller.signal)).toBe(false);
+  });
 });
 
 describe("allocatePort", () => {
@@ -80,6 +164,43 @@ describe("allocatePort", () => {
     const port = await allocatePort(registry, "session-new");
     expect(port).toBeGreaterThan(0);
     expect(registry.get("session-new")).toBe(port);
+  });
+
+  it("rejects a candidate whose IPv6 wildcard is taken", async () => {
+    const registry = new Map<string, number>();
+    // Every candidate is IPv6-busy, so the random loop exhausts and the
+    // OS-assigned fallback (5678 from the mock) is checked too.
+    for (let port = 3000; port < 10_000; port++) netMock.busy.set(`::|${port}`, "EADDRINUSE");
+    netMock.busy.set("::|5678", "EADDRINUSE");
+
+    await expect(allocatePort(registry, "session-v6")).rejects.toThrow("Failed to allocate port");
+    expect(registry.has("session-v6")).toBe(false);
+  });
+
+  it("still allocates on a host with no usable IPv6", async () => {
+    const registry = new Map<string, number>();
+    for (let port = 3000; port < 10_000; port++) {
+      netMock.busy.set(`::|${port}`, "EAFNOSUPPORT");
+      netMock.busy.set(`::1|${port}`, "EAFNOSUPPORT");
+    }
+    netMock.busy.set("::|5678", "EAFNOSUPPORT");
+    netMock.busy.set("::1|5678", "EAFNOSUPPORT");
+
+    const port = await allocatePort(registry, "session-v4only");
+    expect(port).toBeGreaterThan(0);
+    expect(registry.get("session-v4only")).toBe(port);
+  });
+
+  it("does not hand the OS-assigned fallback port to a session that already holds it", async () => {
+    const registry = new Map<string, number>();
+    registry.set("other-session", 5678);
+    for (let port = 3000; port < 10_000; port++) netMock.busy.set(`0.0.0.0|${port}`, "EADDRINUSE");
+
+    await expect(allocatePort(registry, "session-collide")).rejects.toThrow(
+      "Failed to allocate port"
+    );
+    expect(registry.get("other-session")).toBe(5678);
+    expect(registry.has("session-collide")).toBe(false);
   });
 });
 
@@ -104,13 +225,19 @@ describe("waitForPortFree", () => {
   });
 
   it("resolves true once the port becomes free after several probes", async () => {
-    netMock.busyForCalls.set(6000, 3);
+    netMock.busyForCalls.set("0.0.0.0|6000", 3);
     const free = await waitForPortFree(6000, new AbortController().signal, 5000);
     expect(free).toBe(true);
   });
 
+  it("keeps waiting while only the IPv6 wildcard is held", async () => {
+    netMock.busy.set("::|4444", "EADDRINUSE");
+    const free = await waitForPortFree(4444, new AbortController().signal, 50);
+    expect(free).toBe(false);
+  });
+
   it("resolves false on timeout when port stays busy", async () => {
-    netMock.busyPorts.add(4444);
+    netMock.busy.set("0.0.0.0|4444", "EADDRINUSE");
     const free = await waitForPortFree(4444, new AbortController().signal, 50);
     expect(free).toBe(false);
   });
@@ -123,7 +250,7 @@ describe("waitForPortFree", () => {
   });
 
   it("resolves false when aborted mid-poll", async () => {
-    netMock.busyPorts.add(4445);
+    netMock.busy.set("0.0.0.0|4445", "EADDRINUSE");
     const controller = new AbortController();
     const promise = waitForPortFree(4445, controller.signal, 5000);
     // Wait long enough for the first probe failure + sleep to start

--- a/electron/services/__tests__/DevPreviewPortRegistry.test.ts
+++ b/electron/services/__tests__/DevPreviewPortRegistry.test.ts
@@ -41,7 +41,7 @@ vi.mock("node:net", () => {
         handlers[event].push(cb);
         return srv;
       }),
-      listen: vi.fn((_port: number, _host: string, cb: Cb) => {
+      listen: vi.fn((_options: { port: number; host: string; ipv6Only?: boolean }, cb: Cb) => {
         cb();
         return srv;
       }),
@@ -289,11 +289,11 @@ describe("DevPreviewSessionService — port registry (adversarial)", () => {
     // The same port should be reused after restart.
     expect(second.predictedUrl).toBe(portBefore);
     // allocatePort returned early from registry (no allocation probe), but
-    // restart now also calls waitForPortFree which probes once to confirm the
-    // old PTY released the port before respawning. One additional probe call
-    // is expected; allocatePort itself still does no extra work.
+    // restart now also calls waitForPortFree, which confirms the old PTY
+    // released the port on every address a dev server could hold it — one
+    // socket per PROBE_ADDRESSES entry. allocatePort itself does no extra work.
     const callsAfterRestart = vi.mocked(net.createServer).mock.calls.length;
-    expect(callsAfterRestart).toBe(callsAfterEnsure + 1);
+    expect(callsAfterRestart).toBe(callsAfterEnsure + 4);
   });
 
   // ── Positive baseline ──────────────────────────────────────────────────────

--- a/electron/services/__tests__/DevPreviewPortRegistry2.test.ts
+++ b/electron/services/__tests__/DevPreviewPortRegistry2.test.ts
@@ -27,7 +27,7 @@ vi.mock("node:net", () => {
     const srv = {
       unref: vi.fn(() => srv),
       once: vi.fn((_event: string, _cb: Cb) => srv),
-      listen: vi.fn((_port: number, _host: string, cb: Cb) => {
+      listen: vi.fn((_options: { port: number; host: string; ipv6Only?: boolean }, cb: Cb) => {
         cb();
         return srv;
       }),

--- a/electron/services/__tests__/DevPreviewPortRegistry3.test.ts
+++ b/electron/services/__tests__/DevPreviewPortRegistry3.test.ts
@@ -28,7 +28,7 @@ vi.mock("node:net", () => {
     const srv = {
       unref: vi.fn(() => srv),
       once: vi.fn((_event: string, _cb: Cb) => srv),
-      listen: vi.fn((_port: number, _host: string, cb: Cb) => {
+      listen: vi.fn((_options: { port: number; host: string; ipv6Only?: boolean }, cb: Cb) => {
         cb();
         return srv;
       }),

--- a/electron/services/__tests__/DevPreviewPortRegistry4.test.ts
+++ b/electron/services/__tests__/DevPreviewPortRegistry4.test.ts
@@ -28,7 +28,7 @@ vi.mock("node:net", () => {
     const srv = {
       unref: vi.fn(() => srv),
       once: vi.fn((_event: string, _cb: Cb) => srv),
-      listen: vi.fn((_port: number, _host: string, cb: Cb) => {
+      listen: vi.fn((_options: { port: number; host: string; ipv6Only?: boolean }, cb: Cb) => {
         cb();
         return srv;
       }),

--- a/electron/services/__tests__/DevPreviewPortRegistry5.test.ts
+++ b/electron/services/__tests__/DevPreviewPortRegistry5.test.ts
@@ -43,7 +43,7 @@ vi.mock("node:net", () => {
     const srv = {
       unref: vi.fn(() => srv),
       once: vi.fn((_event: string, _cb: Cb) => srv),
-      listen: vi.fn((_port: number, _host: string, cb: Cb) => {
+      listen: vi.fn((_options: { port: number; host: string; ipv6Only?: boolean }, cb: Cb) => {
         cb();
         return srv;
       }),
@@ -188,12 +188,16 @@ describe("DevPreviewSessionService — real-life robustness invariants (adversar
     const probeGate = new Promise<void>((resolve) => {
       releaseProbe = resolve;
     });
-    vi.mocked(net.createServer).mockImplementationOnce(() => {
+    // probePortFree opens one socket per probed address, so every socket this
+    // allocation attempt makes must be gated — a single mockImplementationOnce
+    // would leave the rest ungated and leak into the next test's first probe.
+    const defaultCreateServer = vi.mocked(net.createServer).getMockImplementation();
+    vi.mocked(net.createServer).mockImplementation(() => {
       type Cb = () => void;
       const srv = {
         unref: vi.fn(() => srv),
         once: vi.fn((_event: string, _cb: Cb) => srv),
-        listen: vi.fn((_port: number, _host: string, cb: Cb) => {
+        listen: vi.fn((_options: { port: number; host: string; ipv6Only?: boolean }, cb: Cb) => {
           probeGate.then(() => cb());
           return srv;
         }),
@@ -221,6 +225,7 @@ describe("DevPreviewSessionService — real-life robustness invariants (adversar
 
     // No spawn should have fired for this disposed service.
     expect(ptyClient.spawn).not.toHaveBeenCalled();
+    if (defaultCreateServer) vi.mocked(net.createServer).mockImplementation(defaultCreateServer);
   });
 
   it("BUG-Y3: restart() after dispose() does not spawn a terminal", async () => {

--- a/electron/services/__tests__/DevPreviewSessionService.adversarial.test.ts
+++ b/electron/services/__tests__/DevPreviewSessionService.adversarial.test.ts
@@ -462,7 +462,10 @@ describe("DevPreviewSessionService adversarial", () => {
       panelId: baseRequest.panelId,
       projectId: baseRequest.projectId,
     });
-    expect(state.status).toBe("installing");
+    // Missing dependencies are observed, not yet acted on — the install only
+    // starts once the command exits, so the session is still "starting".
+    expect(state.status).toBe("starting");
+    expect(state.error?.type).toBe("missing-dependencies");
   });
 
   it("lets a fresh URL's readiness marker accelerate again after a prior marker", async () => {

--- a/electron/services/__tests__/DevPreviewSessionService.allSessions.test.ts
+++ b/electron/services/__tests__/DevPreviewSessionService.allSessions.test.ts
@@ -44,6 +44,23 @@ function mockHttpResponse(statusCode: number) {
   vi.mocked(https.request).mockImplementation(impl);
 }
 
+function mockHttpError() {
+  const impl = ((_: unknown, __: unknown, ___: unknown) => {
+    let errorHandler: ((error: Error) => void) | undefined;
+    const req: MockRequest = {
+      on: (event, handler) => {
+        if (event === "error") errorHandler = handler as (error: Error) => void;
+        return req;
+      },
+      end: () => errorHandler?.(new Error("ECONNREFUSED")),
+      destroy: () => {},
+    };
+    return req;
+  }) as unknown as typeof http.request;
+  vi.mocked(http.request).mockImplementation(impl);
+  vi.mocked(https.request).mockImplementation(impl);
+}
+
 function createPtyClientMock() {
   const dataListeners = new Set<DataListener>();
   const exitListeners = new Set<ExitListener>();
@@ -58,7 +75,7 @@ function createPtyClientMock() {
       if (event === "data") dataListeners.delete(callback as DataListener);
       if (event === "exit") exitListeners.delete(callback as ExitListener);
     }),
-    spawn: vi.fn((id: string, spawnOptions: { projectId?: string }) => {
+    spawn: vi.fn((id: string, spawnOptions: { projectId?: string; args?: string[] }) => {
       terminals.set(id, { projectId: spawnOptions.projectId, hasPty: true });
     }),
     kill: vi.fn((id: string) => {
@@ -135,6 +152,9 @@ describe("DevPreviewSessionService — cross-worktree snapshot", () => {
   });
 
   it("getAllSessions returns every live session", async () => {
+    // No server answers, so nothing can graduate out of "starting" while the
+    // second ensure awaits command normalization.
+    mockHttpError();
     await service.ensure(baseRequest);
     await service.ensure({ ...baseRequest, panelId: "panel-2", worktreeId: "wt-2" });
 

--- a/electron/services/__tests__/DevPreviewSessionService.commandCompletion.test.ts
+++ b/electron/services/__tests__/DevPreviewSessionService.commandCompletion.test.ts
@@ -1,0 +1,359 @@
+/**
+ * The rest of the dev-preview suite drives state transitions from a mocked
+ * `emitExit`, which is exactly why #12295 shipped: a mock exit stands in for
+ * child-command completion, so nothing ever checked that a real command
+ * finishing produces one. These cases spawn real node-pty shells running real
+ * commands and assert on what the kernel actually reports.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import * as pty from "node-pty";
+import { afterEach, describe, expect, it } from "vitest";
+import { DevPreviewSessionService } from "../DevPreviewSessionService.js";
+import type { PtyClient } from "../PtyClient.js";
+import type { PtyHostSpawnOptions } from "../../../shared/types/pty-host.js";
+import type { DevPreviewSessionState } from "../../../shared/types/ipc/devPreview.js";
+
+const describePosix = process.platform === "win32" ? describe.skip : describe;
+
+type DataListener = (id: string, data: string | Uint8Array) => void;
+type ExitListener = (id: string, exitCode: number, signal?: number) => void;
+
+/**
+ * A PtyClient that really spawns what it is handed. `spawn` honours the
+ * `shell`/`args` the controller supplies, so the wrapper under test is the
+ * thing being executed — not a stand-in for it.
+ */
+class RealPtyClient {
+  readonly spawns: Array<{ id: string; options: PtyHostSpawnOptions }> = [];
+  private readonly dataListeners = new Set<DataListener>();
+  private readonly exitListeners = new Set<ExitListener>();
+  private readonly terminals = new Map<string, { proc: pty.IPty; alive: boolean }>();
+
+  on(event: string, cb: DataListener | ExitListener): void {
+    if (event === "data") this.dataListeners.add(cb as DataListener);
+    if (event === "exit") this.exitListeners.add(cb as ExitListener);
+  }
+
+  off(event: string, cb: DataListener | ExitListener): void {
+    if (event === "data") this.dataListeners.delete(cb as DataListener);
+    if (event === "exit") this.exitListeners.delete(cb as ExitListener);
+  }
+
+  spawn(id: string, options: PtyHostSpawnOptions): void {
+    this.spawns.push({ id, options });
+    const shell = options.shell ?? process.env.SHELL ?? "/bin/sh";
+    const proc = pty.spawn(shell, options.args ?? [], {
+      name: "xterm-256color",
+      cols: options.cols,
+      rows: options.rows,
+      cwd: options.cwd,
+      env: {
+        ...(process.env as Record<string, string>),
+        ...(options.env ?? {}),
+        TERM: "xterm-256color",
+        NO_COLOR: "1",
+      },
+    });
+    const entry = { proc, alive: true };
+    this.terminals.set(id, entry);
+    proc.onData((chunk) => {
+      for (const listener of this.dataListeners) listener(id, chunk);
+    });
+    proc.onExit(({ exitCode, signal }) => {
+      entry.alive = false;
+      for (const listener of this.exitListeners) listener(id, exitCode, signal || undefined);
+    });
+  }
+
+  kill(id: string): void {
+    const entry = this.terminals.get(id);
+    if (!entry?.alive) return;
+    try {
+      entry.proc.kill();
+    } catch {
+      // already gone
+    }
+  }
+
+  submit(id: string, command: string): void {
+    this.terminals.get(id)?.proc.write(`${command}\r`);
+  }
+
+  hasTerminal(id: string): boolean {
+    return this.terminals.get(id)?.alive ?? false;
+  }
+
+  setIpcDataMirror(): void {}
+
+  async replayHistoryAsync(): Promise<number> {
+    return 0;
+  }
+
+  async getTerminalAsync(id: string): Promise<{ id: string; hasPty: boolean } | null> {
+    const entry = this.terminals.get(id);
+    return entry ? { id, hasPty: entry.alive } : null;
+  }
+
+  pidFor(id: string): number | undefined {
+    return this.terminals.get(id)?.proc.pid;
+  }
+
+  killAll(): void {
+    for (const id of this.terminals.keys()) this.kill(id);
+    this.terminals.clear();
+  }
+}
+
+const tempDirs: string[] = [];
+const clients: RealPtyClient[] = [];
+const services: DevPreviewSessionService[] = [];
+
+function makeProject(files: Record<string, string> = {}): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "daintree-devpreview-"));
+  tempDirs.push(dir);
+  fs.writeFileSync(path.join(dir, "package.json"), JSON.stringify({ name: "fixture" }));
+  for (const [name, contents] of Object.entries(files)) {
+    const target = path.join(dir, name);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, contents);
+  }
+  return dir;
+}
+
+/**
+ * `detectInstallCommand` emits `npm install`, and the login shell rebuilds PATH
+ * (macOS `path_helper`), so a stub binary on PATH is not reachable. These
+ * fixtures run the real npm instead: no dependencies plus an offline `.npmrc`
+ * keeps it fast and off the network, and a failing `preinstall` script is a
+ * genuine install failure.
+ */
+function writeNpmFixture(dir: string, options: { failing?: boolean } = {}): void {
+  fs.writeFileSync(
+    path.join(dir, ".npmrc"),
+    "audit=false\nfund=false\noffline=true\nupdate-notifier=false\nprogress=false\n"
+  );
+  fs.writeFileSync(
+    path.join(dir, "package.json"),
+    JSON.stringify({
+      name: "fixture",
+      version: "1.0.0",
+      private: true,
+      ...(options.failing ? { scripts: { preinstall: "exit 3" } } : {}),
+    })
+  );
+}
+
+function startService(): { client: RealPtyClient; service: DevPreviewSessionService } {
+  const client = new RealPtyClient();
+  const service = new DevPreviewSessionService(client as unknown as PtyClient, () => {});
+  clients.push(client);
+  services.push(service);
+  return { client, service };
+}
+
+async function waitForStatus(
+  service: DevPreviewSessionService,
+  request: { panelId: string; projectId: string },
+  predicate: (state: DevPreviewSessionState) => boolean,
+  timeoutMs = 20_000
+): Promise<DevPreviewSessionState> {
+  const deadline = Date.now() + timeoutMs;
+  let last = service.getState(request);
+  while (Date.now() < deadline) {
+    last = service.getState(request);
+    if (predicate(last)) return last;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(`Timed out waiting for dev-preview state. Last: ${JSON.stringify(last)}`);
+}
+
+function readPgids(pid: number): { shellPgid: number; foregroundPgid: number } | null {
+  const result = spawnSync("ps", ["-o", "pgid=,tpgid=", "-p", String(pid)], {
+    encoding: "utf8",
+    timeout: 750,
+  });
+  if (result.status !== 0 || result.error) return null;
+  const [pgidText, tpgidText] = result.stdout.trim().split(/\s+/);
+  const shellPgid = Number.parseInt(pgidText ?? "", 10);
+  const foregroundPgid = Number.parseInt(tpgidText ?? "", 10);
+  if (!Number.isFinite(shellPgid) || !Number.isFinite(foregroundPgid)) return null;
+  return { shellPgid, foregroundPgid };
+}
+
+afterEach(() => {
+  while (services.length > 0) services.pop()?.dispose();
+  while (clients.length > 0) clients.pop()?.killAll();
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describePosix("dev preview command completion (real PTY)", () => {
+  it("reports the dev command's own nonzero exit instead of waiting on the shell", async () => {
+    const cwd = makeProject({
+      "dev.js": `require("fs").writeFileSync("marker", "done"); process.exit(7);`,
+    });
+    const { service } = startService();
+    const request = { panelId: "panel-1", projectId: "project-1" };
+
+    const initial = await service.ensure({ ...request, cwd, devCommand: "node dev.js" });
+    expect(initial.status).toBe("starting");
+
+    const final = await waitForStatus(service, request, (state) => state.status === "error");
+    // The command really ran: only the child writes this file.
+    expect(fs.existsSync(path.join(cwd, "marker"))).toBe(true);
+    expect(final.error?.message).toContain("7");
+    expect(final.terminalId).toBeNull();
+  }, 30_000);
+
+  it("treats a dev command that exits 0 before serving as a failure to start", async () => {
+    const cwd = makeProject({ "dev.js": `process.exit(0);` });
+    const { service } = startService();
+    const request = { panelId: "panel-2", projectId: "project-1" };
+
+    await service.ensure({ ...request, cwd, devCommand: "node dev.js" });
+
+    const final = await waitForStatus(service, request, (state) => state.status === "error");
+    expect(final.url).toBeNull();
+  }, 30_000);
+
+  it("keeps a real interactive parent shell that hands the foreground to the dev command", async () => {
+    const cwd = makeProject({ "dev.js": `setTimeout(() => process.exit(0), 8000);` });
+    const { client, service } = startService();
+    const request = { panelId: "panel-3", projectId: "project-1" };
+
+    const state = await service.ensure({ ...request, cwd, devCommand: "node dev.js" });
+    const pid = client.pidFor(state.terminalId ?? "");
+    expect(pid).toBeGreaterThan(0);
+
+    let snapshot: ReturnType<typeof readPgids> = null;
+    const deadline = Date.now() + 8_000;
+    while (Date.now() < deadline) {
+      snapshot = readPgids(pid!);
+      if (snapshot && snapshot.shellPgid > 0 && snapshot.foregroundPgid > 0) {
+        if (snapshot.shellPgid !== snapshot.foregroundPgid) break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+
+    // Job control is on, so the shell is genuinely interactive and the dev
+    // command owns its own foreground process group — Ctrl-C reaches the
+    // server, not the wrapper.
+    expect(snapshot).toBeTruthy();
+    expect(snapshot?.foregroundPgid).not.toBe(snapshot?.shellPgid);
+  }, 30_000);
+
+  it("detects a serving dev server exiting nonzero after it was already running", async () => {
+    const cwd = makeProject({
+      "dev.js": `
+const http = require("http");
+const server = http.createServer((_, res) => res.end("ok"));
+server.listen(Number(process.env.PORT), () => console.log("ready on " + process.env.PORT));
+setTimeout(() => { server.close(); process.exit(7); }, 3000);
+`,
+    });
+    const { service } = startService();
+    const request = { panelId: "panel-4", projectId: "project-1" };
+
+    await service.ensure({ ...request, cwd, devCommand: "node dev.js" });
+    await waitForStatus(service, request, (state) => state.status === "running");
+
+    const final = await waitForStatus(service, request, (state) => state.status === "error");
+    expect(final.error?.message).toContain("7");
+    expect(final.url).toBeNull();
+  }, 40_000);
+
+  it("runs a real install after a missing-dependency exit and restarts the dev server", async () => {
+    const cwd = makeProject({
+      "dev.js": `
+const fs = require("fs");
+// package-lock.json only exists once npm install has really run.
+if (fs.existsSync("package-lock.json")) {
+  const http = require("http");
+  const server = http.createServer((_, res) => res.end("ok"));
+  server.listen(Number(process.env.PORT), () => console.log("ready"));
+} else {
+  console.error("Error: Cannot find module 'react'");
+  process.exit(1);
+}
+`,
+    });
+    writeNpmFixture(cwd);
+    const { service } = startService();
+    const request = { panelId: "panel-5", projectId: "project-1" };
+
+    await service.ensure({ ...request, cwd, devCommand: "node dev.js" });
+
+    const running = await waitForStatus(
+      service,
+      request,
+      (state) => state.status === "running",
+      60_000
+    );
+    expect(running.url).toBeTruthy();
+    expect(fs.existsSync(path.join(cwd, "package-lock.json"))).toBe(true);
+
+    const events = service.getDiagnostics(request).events.map((event) => event.type);
+    expect(events).toContain("install-started");
+    expect(events).toContain("install-completed");
+  }, 90_000);
+
+  it("surfaces a failing install instead of leaving the session in installing", async () => {
+    const cwd = makeProject({
+      "dev.js": `console.error("Error: Cannot find module 'react'"); process.exit(1);`,
+    });
+    writeNpmFixture(cwd, { failing: true });
+    const { service } = startService();
+    const request = { panelId: "panel-6", projectId: "project-1" };
+
+    await service.ensure({ ...request, cwd, devCommand: "node dev.js" });
+
+    const final = await waitForStatus(
+      service,
+      request,
+      (state) => state.status === "error" && state.error?.type === "missing-dependencies",
+      60_000
+    );
+    expect(final.error?.message).toContain("Dependency installation failed");
+    expect(service.getDiagnostics(request).events.map((event) => event.type)).toContain(
+      "install-failed"
+    );
+  }, 90_000);
+
+  it("reports a clean stop when the user interrupts the dev command", async () => {
+    const cwd = makeProject({ "dev.js": `setInterval(() => {}, 1000);` });
+    const { client, service } = startService();
+    const request = { panelId: "panel-7", projectId: "project-1" };
+
+    const state = await service.ensure({ ...request, cwd, devCommand: "node dev.js" });
+    const pid = client.pidFor(state.terminalId ?? "");
+
+    // Wait for the child to own the foreground, then deliver a real SIGINT to
+    // it exactly as the TTY line discipline would on Ctrl-C.
+    let foreground = 0;
+    const deadline = Date.now() + 8_000;
+    while (Date.now() < deadline) {
+      const snapshot = readPgids(pid!);
+      if (
+        snapshot &&
+        snapshot.foregroundPgid > 0 &&
+        snapshot.foregroundPgid !== snapshot.shellPgid
+      ) {
+        foreground = snapshot.foregroundPgid;
+        break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+    expect(foreground).toBeGreaterThan(0);
+    process.kill(-foreground, "SIGINT");
+
+    // The wrapper survives the interrupt and exits 128+SIGINT, which must read
+    // as a stop rather than a crash.
+    const final = await waitForStatus(service, request, (state) => state.status === "stopped");
+    expect(final.error).toBeNull();
+  }, 30_000);
+});

--- a/electron/services/__tests__/DevPreviewSessionService.commandCompletion.test.ts
+++ b/electron/services/__tests__/DevPreviewSessionService.commandCompletion.test.ts
@@ -64,7 +64,10 @@ class RealPtyClient {
     });
     proc.onExit(({ exitCode, signal }) => {
       entry.alive = false;
-      for (const listener of this.exitListeners) listener(id, exitCode, signal || undefined);
+      // Forwarded exactly as production does (TerminalExitHandler: `signal ??
+      // undefined`), so node-pty's `signal: 0` for a normal exit reaches the
+      // service. Collapsing it to undefined here hid the Ctrl-C bug.
+      for (const listener of this.exitListeners) listener(id, exitCode, signal ?? undefined);
     });
   }
 
@@ -101,8 +104,20 @@ class RealPtyClient {
     return this.terminals.get(id)?.proc.pid;
   }
 
-  killAll(): void {
+  async killAll(): Promise<void> {
+    const pending = [...this.terminals.values()].filter((entry) => entry.alive);
+    const exits = pending.map(
+      (entry) =>
+        new Promise<void>((resolve) => {
+          const timer = setTimeout(resolve, 3000);
+          entry.proc.onExit(() => {
+            clearTimeout(timer);
+            resolve();
+          });
+        })
+    );
     for (const id of this.terminals.keys()) this.kill(id);
+    await Promise.all(exits);
     this.terminals.clear();
   }
 }
@@ -141,7 +156,13 @@ function writeNpmFixture(dir: string, options: { failing?: boolean } = {}): void
       name: "fixture",
       version: "1.0.0",
       private: true,
-      ...(options.failing ? { scripts: { preinstall: "exit 3" } } : {}),
+      ...(options.failing
+        ? {
+            scripts: {
+              preinstall: `node -e "require('fs').writeFileSync('preinstall-ran','1')" && exit 3`,
+            },
+          }
+        : {}),
     })
   );
 }
@@ -170,6 +191,29 @@ async function waitForStatus(
   throw new Error(`Timed out waiting for dev-preview state. Last: ${JSON.stringify(last)}`);
 }
 
+function readPgid(pid: number): number | null {
+  const result = spawnSync("ps", ["-o", "pgid=", "-p", String(pid)], {
+    encoding: "utf8",
+    timeout: 750,
+  });
+  if (result.status !== 0 || result.error) return null;
+  const pgid = Number.parseInt(result.stdout.trim(), 10);
+  return Number.isFinite(pgid) && pgid > 0 ? pgid : null;
+}
+
+async function waitForDevPid(cwd: string): Promise<number> {
+  const pidFile = path.join(cwd, "dev.pid");
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    if (fs.existsSync(pidFile)) {
+      const pid = Number.parseInt(fs.readFileSync(pidFile, "utf8").trim(), 10);
+      if (Number.isFinite(pid) && pid > 0) return pid;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error("dev command never published its pid");
+}
+
 function readPgids(pid: number): { shellPgid: number; foregroundPgid: number } | null {
   const result = spawnSync("ps", ["-o", "pgid=,tpgid=", "-p", String(pid)], {
     encoding: "utf8",
@@ -183,9 +227,11 @@ function readPgids(pid: number): { shellPgid: number; foregroundPgid: number } |
   return { shellPgid, foregroundPgid };
 }
 
-afterEach(() => {
+afterEach(async () => {
   while (services.length > 0) services.pop()?.dispose();
-  while (clients.length > 0) clients.pop()?.killAll();
+  // Await termination before removing fixtures: a surviving npm or dev server
+  // still writing into the directory races the rmSync below.
+  while (clients.length > 0) await clients.pop()?.killAll();
   while (tempDirs.length > 0) {
     const dir = tempDirs.pop();
     if (dir) fs.rmSync(dir, { recursive: true, force: true });
@@ -211,41 +257,53 @@ describePosix("dev preview command completion (real PTY)", () => {
   }, 30_000);
 
   it("treats a dev command that exits 0 before serving as a failure to start", async () => {
-    const cwd = makeProject({ "dev.js": `process.exit(0);` });
+    const cwd = makeProject({
+      "dev.js": `require("fs").writeFileSync("ran", "1"); process.exit(0);`,
+    });
     const { service } = startService();
     const request = { panelId: "panel-2", projectId: "project-1" };
 
     await service.ensure({ ...request, cwd, devCommand: "node dev.js" });
 
     const final = await waitForStatus(service, request, (state) => state.status === "error");
+    // Without the marker this would also pass if `node` never launched at all.
+    expect(fs.existsSync(path.join(cwd, "ran"))).toBe(true);
+    expect(final.error?.message).toContain("code 0");
     expect(final.url).toBeNull();
   }, 30_000);
 
+  // Supporting invariant rather than a regression test for the exit bug: it
+  // asserts the wrapper is still a real interactive shell, which is what makes
+  // Ctrl-C reach the dev server instead of the wrapper.
   it("keeps a real interactive parent shell that hands the foreground to the dev command", async () => {
-    const cwd = makeProject({ "dev.js": `setTimeout(() => process.exit(0), 8000);` });
+    const cwd = makeProject({
+      "dev.js": `require("fs").writeFileSync("dev.pid", String(process.pid)); setTimeout(() => process.exit(0), 15000);`,
+    });
     const { client, service } = startService();
     const request = { panelId: "panel-3", projectId: "project-1" };
 
     const state = await service.ensure({ ...request, cwd, devCommand: "node dev.js" });
-    const pid = client.pidFor(state.terminalId ?? "");
-    expect(pid).toBeGreaterThan(0);
+    const shellPid = client.pidFor(state.terminalId ?? "");
+    expect(shellPid).toBeGreaterThan(0);
+
+    const devPid = await waitForDevPid(cwd);
+    const devPgid = readPgid(devPid);
+    expect(devPgid).toBeGreaterThan(0);
 
     let snapshot: ReturnType<typeof readPgids> = null;
     const deadline = Date.now() + 8_000;
     while (Date.now() < deadline) {
-      snapshot = readPgids(pid!);
-      if (snapshot && snapshot.shellPgid > 0 && snapshot.foregroundPgid > 0) {
-        if (snapshot.shellPgid !== snapshot.foregroundPgid) break;
-      }
+      snapshot = readPgids(shellPid!);
+      if (snapshot && snapshot.foregroundPgid === devPgid) break;
       await new Promise((resolve) => setTimeout(resolve, 100));
     }
 
-    // Job control is on, so the shell is genuinely interactive and the dev
-    // command owns its own foreground process group — Ctrl-C reaches the
-    // server, not the wrapper.
-    expect(snapshot).toBeTruthy();
+    // Job control is on and the foreground group is the dev command's own —
+    // not the shell's, and not some helper a login profile happened to run.
+    expect(snapshot?.shellPgid).toBeGreaterThan(0);
+    expect(snapshot?.foregroundPgid).toBe(devPgid);
     expect(snapshot?.foregroundPgid).not.toBe(snapshot?.shellPgid);
-  }, 30_000);
+  }, 40_000);
 
   it("detects a serving dev server exiting nonzero after it was already running", async () => {
     const cwd = makeProject({
@@ -318,42 +376,36 @@ if (fs.existsSync("package-lock.json")) {
       (state) => state.status === "error" && state.error?.type === "missing-dependencies",
       60_000
     );
+    // npm reports its own exit code, but the marker proves the failure came
+    // from the fixture's preinstall script rather than npm never running.
+    expect(fs.existsSync(path.join(cwd, "preinstall-ran"))).toBe(true);
     expect(final.error?.message).toContain("Dependency installation failed");
+    expect(final.terminalId).toBeNull();
     expect(service.getDiagnostics(request).events.map((event) => event.type)).toContain(
       "install-failed"
     );
   }, 90_000);
 
   it("reports a clean stop when the user interrupts the dev command", async () => {
-    const cwd = makeProject({ "dev.js": `setInterval(() => {}, 1000);` });
-    const { client, service } = startService();
+    const cwd = makeProject({
+      "dev.js": `require("fs").writeFileSync("dev.pid", String(process.pid)); setInterval(() => {}, 1000);`,
+    });
+    const { service } = startService();
     const request = { panelId: "panel-7", projectId: "project-1" };
 
-    const state = await service.ensure({ ...request, cwd, devCommand: "node dev.js" });
-    const pid = client.pidFor(state.terminalId ?? "");
+    await service.ensure({ ...request, cwd, devCommand: "node dev.js" });
 
-    // Wait for the child to own the foreground, then deliver a real SIGINT to
-    // it exactly as the TTY line discipline would on Ctrl-C.
-    let foreground = 0;
-    const deadline = Date.now() + 8_000;
-    while (Date.now() < deadline) {
-      const snapshot = readPgids(pid!);
-      if (
-        snapshot &&
-        snapshot.foregroundPgid > 0 &&
-        snapshot.foregroundPgid !== snapshot.shellPgid
-      ) {
-        foreground = snapshot.foregroundPgid;
-        break;
-      }
-      await new Promise((resolve) => setTimeout(resolve, 100));
-    }
-    expect(foreground).toBeGreaterThan(0);
-    process.kill(-foreground, "SIGINT");
+    // Signal the dev command's own process group, so this can't be satisfied by
+    // interrupting some startup helper instead of the server.
+    const devPid = await waitForDevPid(cwd);
+    const devPgid = readPgid(devPid);
+    expect(devPgid).toBeGreaterThan(0);
+    process.kill(-devPgid!, "SIGINT");
 
-    // The wrapper survives the interrupt and exits 128+SIGINT, which must read
-    // as a stop rather than a crash.
+    // The wrapper survives the interrupt and exits 128+SIGINT with no raw
+    // signal of its own, which must still read as a stop rather than a crash.
     const final = await waitForStatus(service, request, (state) => state.status === "stopped");
     expect(final.error).toBeNull();
-  }, 30_000);
+    expect(final.terminalId).toBeNull();
+  }, 40_000);
 });

--- a/electron/services/__tests__/DevPreviewSessionService.commandCompletion.test.ts
+++ b/electron/services/__tests__/DevPreviewSessionService.commandCompletion.test.ts
@@ -277,7 +277,7 @@ describePosix("dev preview command completion (real PTY)", () => {
   // Ctrl-C reach the dev server instead of the wrapper.
   it("keeps a real interactive parent shell that hands the foreground to the dev command", async () => {
     const cwd = makeProject({
-      "dev.js": `require("fs").writeFileSync("dev.pid", String(process.pid)); setTimeout(() => process.exit(0), 15000);`,
+      "dev.js": `require("fs").writeFileSync("dev.pid", String(process.pid)); setTimeout(() => process.exit(0), 12000);`,
     });
     const { client, service } = startService();
     const request = { panelId: "panel-3", projectId: "project-1" };
@@ -306,12 +306,17 @@ describePosix("dev preview command completion (real PTY)", () => {
   }, 40_000);
 
   it("detects a serving dev server exiting nonzero after it was already running", async () => {
+    // The server exits on a sentinel rather than a timer: a busy CI worker
+    // could otherwise blow past `running` before the test ever observed it.
     const cwd = makeProject({
       "dev.js": `
+const fs = require("fs");
 const http = require("http");
 const server = http.createServer((_, res) => res.end("ok"));
 server.listen(Number(process.env.PORT), () => console.log("ready on " + process.env.PORT));
-setTimeout(() => { server.close(); process.exit(7); }, 3000);
+setInterval(() => {
+  if (fs.existsSync("stop")) { server.close(); process.exit(7); }
+}, 50);
 `,
     });
     const { service } = startService();
@@ -320,6 +325,7 @@ setTimeout(() => { server.close(); process.exit(7); }, 3000);
     await service.ensure({ ...request, cwd, devCommand: "node dev.js" });
     await waitForStatus(service, request, (state) => state.status === "running");
 
+    fs.writeFileSync(path.join(cwd, "stop"), "1");
     const final = await waitForStatus(service, request, (state) => state.status === "error");
     expect(final.error?.message).toContain("7");
     expect(final.url).toBeNull();
@@ -334,6 +340,9 @@ if (fs.existsSync("package-lock.json")) {
   const http = require("http");
   const server = http.createServer((_, res) => res.end("ok"));
   server.listen(Number(process.env.PORT), () => console.log("ready"));
+  setInterval(() => {
+    if (fs.existsSync("stop")) { server.close(); process.exit(0); }
+  }, 50);
 } else {
   console.error("Error: Cannot find module 'react'");
   process.exit(1);

--- a/electron/services/__tests__/DevPreviewSessionService.crashLoopGuard.test.ts
+++ b/electron/services/__tests__/DevPreviewSessionService.crashLoopGuard.test.ts
@@ -119,8 +119,10 @@ async function flushAsyncWork(): Promise<void> {
  * pending" as "the guard stopped the respawn".
  */
 async function waitForReal(predicate: () => boolean, timeoutMs = 5000): Promise<boolean> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
+  // vi.setSystemTime freezes Date.now, so the deadline has to come from the
+  // real clock or it would never expire.
+  const deadline = vi.getRealSystemTime() + timeoutMs;
+  while (vi.getRealSystemTime() < deadline) {
     if (predicate()) return true;
     await new Promise((resolve) => realSetTimeout(resolve, 10));
   }

--- a/electron/services/__tests__/DevPreviewSessionService.crashLoopGuard.test.ts
+++ b/electron/services/__tests__/DevPreviewSessionService.crashLoopGuard.test.ts
@@ -113,6 +113,20 @@ async function flushAsyncWork(): Promise<void> {
   }
 }
 
+/**
+ * Wait on real time for `predicate`, leaving the fake backoff timers alone.
+ * A fixed tick count would let a slow worker read "normalization still
+ * pending" as "the guard stopped the respawn".
+ */
+async function waitForReal(predicate: () => boolean, timeoutMs = 5000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return true;
+    await new Promise((resolve) => realSetTimeout(resolve, 10));
+  }
+  return predicate();
+}
+
 describe("DevPreviewSessionService crash-loop guard", () => {
   const baseRequest = {
     panelId: "panel-1",
@@ -175,8 +189,9 @@ describe("DevPreviewSessionService crash-loop guard", () => {
     }
     // Install succeeds -> handleExit respawns the dev server (awaits port
     // allocation, which reuses the registered port -> microtask resolution).
+    const spawnsBeforeRespawn = ptyClient.spawn.mock.calls.length;
     ptyClient.emitExit(installTerminalId, 0);
-    await flushAsyncWork();
+    await waitForReal(() => ptyClient.spawn.mock.calls.length > spawnsBeforeRespawn);
     return currentTerminalId();
   }
 

--- a/electron/services/__tests__/DevPreviewSessionService.crashLoopGuard.test.ts
+++ b/electron/services/__tests__/DevPreviewSessionService.crashLoopGuard.test.ts
@@ -102,8 +102,15 @@ function createPtyClientMock() {
   };
 }
 
-async function flushMicrotasks(): Promise<void> {
-  for (let i = 0; i < 16; i++) await Promise.resolve();
+// Captured before vi.useFakeTimers() swaps the global. spawnSessionTerminal
+// awaits command normalization, which reads package.json — real threadpool I/O
+// that neither a microtask flush nor a faked timer can advance.
+const realSetTimeout = globalThis.setTimeout;
+
+async function flushAsyncWork(): Promise<void> {
+  for (let i = 0; i < 12; i++) {
+    await new Promise((resolve) => realSetTimeout(resolve, 0));
+  }
 }
 
 describe("DevPreviewSessionService crash-loop guard", () => {
@@ -169,7 +176,7 @@ describe("DevPreviewSessionService crash-loop guard", () => {
     // Install succeeds -> handleExit respawns the dev server (awaits port
     // allocation, which reuses the registered port -> microtask resolution).
     ptyClient.emitExit(installTerminalId, 0);
-    await flushMicrotasks();
+    await flushAsyncWork();
     return currentTerminalId();
   }
 
@@ -350,7 +357,7 @@ describe("DevPreviewSessionService crash-loop guard", () => {
     // no fresh PTY, still stopped — until the user restarts explicitly.
     const spawnsBeforeEnsure = ptyClient.spawn.mock.calls.length;
     const reEnsured = await service.ensure(baseRequest);
-    await flushMicrotasks();
+    await flushAsyncWork();
 
     expect(reEnsured.status).toBe("stopped");
     expect(reEnsured.crashLoopStopped).toBe(true);

--- a/electron/services/__tests__/DevPreviewSessionService.destructivePreview.test.ts
+++ b/electron/services/__tests__/DevPreviewSessionService.destructivePreview.test.ts
@@ -45,7 +45,7 @@ function createPtyClientMock() {
       if (event === "data") dataListeners.delete(callback as DataListener);
       if (event === "exit") exitListeners.delete(callback as ExitListener);
     }),
-    spawn: vi.fn((id: string, spawnOptions: { projectId?: string }) => {
+    spawn: vi.fn((id: string, spawnOptions: { projectId?: string; args?: string[] }) => {
       terminals.set(id, { projectId: spawnOptions.projectId, hasPty: true });
     }),
     kill: vi.fn((id: string) => {

--- a/electron/services/__tests__/DevPreviewSessionService.restartTiers.test.ts
+++ b/electron/services/__tests__/DevPreviewSessionService.restartTiers.test.ts
@@ -46,7 +46,7 @@ function createPtyClientMock() {
       if (event === "data") dataListeners.delete(callback as DataListener);
       if (event === "exit") exitListeners.delete(callback as ExitListener);
     }),
-    spawn: vi.fn((id: string, spawnOptions: { projectId?: string }) => {
+    spawn: vi.fn((id: string, spawnOptions: { projectId?: string; args?: string[] }) => {
       terminals.set(id, { projectId: spawnOptions.projectId, hasPty: true });
     }),
     kill: vi.fn((id: string) => {
@@ -77,6 +77,18 @@ function createPtyClientMock() {
       for (const callback of dataListeners) callback(id, data);
     },
   };
+}
+
+/**
+ * The install command now rides in the spawned shell's own arguments so the PTY
+ * ends when the install does (#12295) — it is no longer typed into the shell.
+ */
+function spawnedCommandFor(
+  spawn: { mock: { calls: Array<[string, { args?: string[] }]> } },
+  terminalId: string
+): string {
+  const call = spawn.mock.calls.find(([id]) => id === terminalId);
+  return call?.[1].args?.join("\n") ?? "";
 }
 
 describe("DevPreviewSessionService — tiered restart", () => {
@@ -206,11 +218,9 @@ describe("DevPreviewSessionService — tiered restart", () => {
       // spawn = 2). The dev server is NOT respawned until the install exits 0.
       expect(ptyClient.spawn).toHaveBeenCalledTimes(2);
 
-      await vi.waitFor(() => {
-        expect(ptyClient.submit).toHaveBeenCalledWith(expect.any(String), "bun install");
-      });
-
       const installTerminalId = result.terminalId!;
+      expect(spawnedCommandFor(ptyClient.spawn, installTerminalId)).toContain("bun install");
+
       ptyClient.emitExit(installTerminalId, 0);
       // spawnSessionTerminal awaits port allocation before calling spawn.
       await vi.waitFor(() => {
@@ -237,9 +247,7 @@ describe("DevPreviewSessionService — tiered restart", () => {
       await service.ensure(ensureRequest());
       const result = await service.reinstallAndRestart(request());
 
-      await vi.waitFor(() => {
-        expect(ptyClient.submit).toHaveBeenCalledWith(result.terminalId, "bun install");
-      });
+      expect(spawnedCommandFor(ptyClient.spawn, result.terminalId!)).toContain("bun install");
     });
 
     it("does not respawn the dev server when the install exits nonzero", async () => {

--- a/electron/services/__tests__/DevPreviewSessionService.restartTiers.test.ts
+++ b/electron/services/__tests__/DevPreviewSessionService.restartTiers.test.ts
@@ -88,7 +88,14 @@ function spawnedCommandFor(
   terminalId: string
 ): string {
   const call = spawn.mock.calls.find(([id]) => id === terminalId);
-  return call?.[1].args?.join("\n") ?? "";
+  const args = call?.[1].args ?? [];
+  // PowerShell launches carry the script as a UTF-16LE base64 -EncodedCommand,
+  // so a plain join would never reveal the command text.
+  const encodedIndex = args.indexOf("-EncodedCommand");
+  if (encodedIndex >= 0 && args[encodedIndex + 1]) {
+    return Buffer.from(args[encodedIndex + 1], "base64").toString("utf16le");
+  }
+  return args.join("\n");
 }
 
 describe("DevPreviewSessionService — tiered restart", () => {

--- a/electron/services/__tests__/DevPreviewSessionService.test.ts
+++ b/electron/services/__tests__/DevPreviewSessionService.test.ts
@@ -90,7 +90,7 @@ function createPtyClientMock(options?: { spawnError?: Error }) {
         exitListeners.delete(callback as ExitListener);
       }
     }),
-    spawn: vi.fn((id: string, spawnOptions: { projectId?: string }) => {
+    spawn: vi.fn((id: string, spawnOptions: { projectId?: string; args?: string[] }) => {
       if (options?.spawnError) {
         throw options.spawnError;
       }
@@ -393,17 +393,18 @@ describe("DevPreviewSessionService", () => {
     expect(started.status).toBe("starting");
     expect(started.terminalId).toBeTruthy();
 
-    // Mid-stream detection sets needsInstall + status: "installing"
+    // Mid-stream detection arms needsInstall and surfaces the error, but the
+    // session stays "starting" — no install has begun yet (#12295).
     ptyClient.emitData(started.terminalId!, "Error: Cannot find module 'vite'\n");
 
     const afterData = service.getState({
       panelId: baseRequest.panelId,
       projectId: baseRequest.projectId,
     });
-    expect(afterData.status).toBe("installing");
+    expect(afterData.status).toBe("starting");
     expect(afterData.error?.type).toBe("missing-dependencies");
 
-    // Exit during "installing" triggers a guarded reinstall (not an error stop)
+    // Exit after that detection triggers a guarded reinstall (not an error stop)
     ptyClient.emitExit(started.terminalId!, 1);
   });
 

--- a/electron/services/__tests__/DevPreviewSessionService.test.ts
+++ b/electron/services/__tests__/DevPreviewSessionService.test.ts
@@ -408,6 +408,45 @@ describe("DevPreviewSessionService", () => {
     ptyClient.emitExit(started.terminalId!, 1);
   });
 
+  // The wrapper shell exits normally when its child is signalled, so the raw
+  // signal is gone and node-pty reports signal 0 — the encoded 128+n status is
+  // the only evidence left (#12295).
+  it("treats an encoded SIGINT exit with node-pty's signal 0 as a clean stop", async () => {
+    const started = await service.ensure(baseRequest);
+    ptyClient.emitExit(started.terminalId!, 130, 0);
+
+    const state = service.getState({
+      panelId: baseRequest.panelId,
+      projectId: baseRequest.projectId,
+    });
+    expect(state.status).toBe("stopped");
+    expect(state.error).toBeNull();
+  });
+
+  it("keeps crash classification for an encoded SIGSEGV exit", async () => {
+    const started = await service.ensure(baseRequest);
+    ptyClient.emitExit(started.terminalId!, 139, 0);
+
+    const state = service.getState({
+      panelId: baseRequest.panelId,
+      projectId: baseRequest.projectId,
+    });
+    expect(state.status).toBe("error");
+    expect(state.error?.type).toBe("process-crash");
+  });
+
+  it("does not treat a plain nonzero exit as a signal", async () => {
+    const started = await service.ensure(baseRequest);
+    ptyClient.emitExit(started.terminalId!, 7, 0);
+
+    const state = service.getState({
+      panelId: baseRequest.panelId,
+      projectId: baseRequest.projectId,
+    });
+    expect(state.status).toBe("error");
+    expect(state.error?.message).toContain("7");
+  });
+
   it("classifies compile-error exit from buffered output", async () => {
     const started = await service.ensure(baseRequest);
     expect(started.status).toBe("starting");

--- a/electron/services/__tests__/DevPreviewSessionService.test.ts
+++ b/electron/services/__tests__/DevPreviewSessionService.test.ts
@@ -411,29 +411,35 @@ describe("DevPreviewSessionService", () => {
   // The wrapper shell exits normally when its child is signalled, so the raw
   // signal is gone and node-pty reports signal 0 — the encoded 128+n status is
   // the only evidence left (#12295).
-  it("treats an encoded SIGINT exit with node-pty's signal 0 as a clean stop", async () => {
-    const started = await service.ensure(baseRequest);
-    ptyClient.emitExit(started.terminalId!, 130, 0);
+  it.skipIf(process.platform === "win32")(
+    "treats an encoded SIGINT exit with node-pty's signal 0 as a clean stop",
+    async () => {
+      const started = await service.ensure(baseRequest);
+      ptyClient.emitExit(started.terminalId!, 130, 0);
 
-    const state = service.getState({
-      panelId: baseRequest.panelId,
-      projectId: baseRequest.projectId,
-    });
-    expect(state.status).toBe("stopped");
-    expect(state.error).toBeNull();
-  });
+      const state = service.getState({
+        panelId: baseRequest.panelId,
+        projectId: baseRequest.projectId,
+      });
+      expect(state.status).toBe("stopped");
+      expect(state.error).toBeNull();
+    }
+  );
 
-  it("keeps crash classification for an encoded SIGSEGV exit", async () => {
-    const started = await service.ensure(baseRequest);
-    ptyClient.emitExit(started.terminalId!, 139, 0);
+  it.skipIf(process.platform === "win32")(
+    "keeps crash classification for an encoded SIGSEGV exit",
+    async () => {
+      const started = await service.ensure(baseRequest);
+      ptyClient.emitExit(started.terminalId!, 139, 0);
 
-    const state = service.getState({
-      panelId: baseRequest.panelId,
-      projectId: baseRequest.projectId,
-    });
-    expect(state.status).toBe("error");
-    expect(state.error?.type).toBe("process-crash");
-  });
+      const state = service.getState({
+        panelId: baseRequest.panelId,
+        projectId: baseRequest.projectId,
+      });
+      expect(state.status).toBe("error");
+      expect(state.error?.type).toBe("process-crash");
+    }
+  );
 
   it("does not treat a plain nonzero exit as a signal", async () => {
     const started = await service.ensure(baseRequest);

--- a/electron/services/__tests__/DevPreviewTerminalController.launchCancellation.test.ts
+++ b/electron/services/__tests__/DevPreviewTerminalController.launchCancellation.test.ts
@@ -14,6 +14,7 @@ vi.mock("node:fs/promises", () => ({
 }));
 
 import {
+  invalidatePendingLaunch,
   spawnSessionTerminal,
   stopSessionTerminal,
   type TerminalControllerDeps,
@@ -135,6 +136,24 @@ describe("dev preview launch cancellation", () => {
 
     expect(spawn).not.toHaveBeenCalled();
     expect(session.terminalId).toBeNull();
+  });
+
+  // stop() and the config-change path cancel this way: they never reach
+  // stopSessionTerminal when the session has no terminal yet.
+  it("abandons a launch invalidated without going through stopSessionTerminal", async () => {
+    const releaseNormalization = gateReadFile();
+
+    const session = makeSession();
+    const { deps, spawn } = makeDeps();
+
+    const launch = spawnSessionTerminal(session, deps);
+    await vi.waitFor(() => expect(mockReadFile).toHaveBeenCalled());
+
+    invalidatePendingLaunch(session);
+    releaseNormalization();
+    await launch;
+
+    expect(spawn).not.toHaveBeenCalled();
   });
 
   it("still spawns when nothing cancelled the launch", async () => {

--- a/electron/services/__tests__/DevPreviewTerminalController.launchCancellation.test.ts
+++ b/electron/services/__tests__/DevPreviewTerminalController.launchCancellation.test.ts
@@ -13,6 +13,23 @@ vi.mock("node:fs/promises", () => ({
   readFile: (...args: unknown[]) => mockReadFile(...(args as [string, string])),
 }));
 
+const portGate = vi.hoisted(() => ({ pending: null as Promise<void> | null, reached: false }));
+
+// Holds the reservation open across the allocate await, the way a real net
+// probe does, so a cancellation can land while the port is already registered.
+vi.mock("../DevPreviewPortAllocator.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../DevPreviewPortAllocator.js")>();
+  return {
+    ...actual,
+    allocatePort: async (registry: Map<string, number>, key: string) => {
+      const port = await actual.allocatePort(registry, key);
+      portGate.reached = true;
+      if (portGate.pending) await portGate.pending;
+      return port;
+    },
+  };
+});
+
 import {
   invalidatePendingLaunch,
   spawnSessionTerminal,
@@ -114,9 +131,22 @@ function gateReadFile(): () => void {
   return open;
 }
 
+function gatePortAllocation(): () => void {
+  let open!: () => void;
+  portGate.pending = new Promise<void>((resolve) => {
+    open = resolve;
+  });
+  return () => {
+    portGate.pending = null;
+    open();
+  };
+}
+
 describe("dev preview launch cancellation", () => {
   beforeEach(() => {
     mockReadFile.mockReset();
+    portGate.pending = null;
+    portGate.reached = false;
   });
 
   it("abandons a launch whose session was stopped while its command was resolving", async () => {
@@ -153,6 +183,47 @@ describe("dev preview launch cancellation", () => {
     releaseNormalization();
     await launch;
 
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  // stopSessionTerminal deliberately keeps the registry entry so a restart
+  // reuses the port, so by the time this launch resumes the reservation may
+  // belong to the launch that replaced it.
+  it("leaves the port reservation alone when the launch was superseded mid-allocation", async () => {
+    const releaseAllocation = gatePortAllocation();
+
+    const session = makeSession();
+    const { deps, spawn } = makeDeps();
+    const key = createSessionKey("project-1", "panel-1");
+
+    const launch = spawnSessionTerminal(session, deps);
+    await vi.waitFor(() => expect(portGate.reached).toBe(true));
+
+    invalidatePendingLaunch(session);
+    releaseAllocation();
+    await launch;
+
+    expect(deps.portRegistry.get(key)).toBe(4321);
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it("rolls the reservation back when the service was disposed mid-allocation", async () => {
+    const releaseAllocation = gatePortAllocation();
+
+    const session = makeSession();
+    const { deps: baseDeps, spawn } = makeDeps();
+    let disposed = false;
+    const deps = { ...baseDeps, isDisposed: () => disposed };
+    const key = createSessionKey("project-1", "panel-1");
+
+    const launch = spawnSessionTerminal(session, deps);
+    await vi.waitFor(() => expect(portGate.reached).toBe(true));
+
+    disposed = true;
+    releaseAllocation();
+    await launch;
+
+    expect(deps.portRegistry.has(key)).toBe(false);
     expect(spawn).not.toHaveBeenCalled();
   });
 

--- a/electron/services/__tests__/DevPreviewTerminalController.launchCancellation.test.ts
+++ b/electron/services/__tests__/DevPreviewTerminalController.launchCancellation.test.ts
@@ -1,0 +1,153 @@
+/**
+ * The post-install respawn runs outside the session lock and now awaits command
+ * normalization (filesystem reads). A stop that lands inside that window leaves
+ * `generation` untouched and sees no terminal, so only the launch epoch can
+ * tell the pending launch that its session is gone (#12295).
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockReadFile = vi.hoisted(() => vi.fn<(path: string, encoding: string) => Promise<string>>());
+
+vi.mock("node:fs/promises", () => ({
+  default: { readFile: (...args: unknown[]) => mockReadFile(...(args as [string, string])) },
+  readFile: (...args: unknown[]) => mockReadFile(...(args as [string, string])),
+}));
+
+import {
+  spawnSessionTerminal,
+  stopSessionTerminal,
+  type TerminalControllerDeps,
+  type TerminalControllerSession,
+} from "../DevPreviewTerminalController.js";
+import { createSessionKey } from "../DevPreviewRequestValidators.js";
+import type { PtyClient } from "../PtyClient.js";
+
+function makeSession(): TerminalControllerSession {
+  return {
+    panelId: "panel-1",
+    projectId: "project-1",
+    cwd: "/repo",
+    devCommand: "npm run dev",
+    turbopackEnabled: true,
+    buffer: "",
+    lastErrorKey: null,
+    terminalId: null,
+    status: "installing",
+    url: null,
+    predictedUrl: null,
+    pendingUrl: null,
+    readinessAbort: null,
+    markerSeen: false,
+    needsInstall: false,
+    isRunningInstall: false,
+    installAttemptedGeneration: null,
+    launchEpoch: 0,
+    startupReplayTimer: null,
+    updatedAtPerformanceMs: 0,
+    compiling: false,
+    compilingTimer: null,
+    compilingClearTimer: null,
+    backoffAbort: null,
+    crashCount: 0,
+    devSpawnedAt: null,
+    crashLoopStopped: false,
+    generation: 3,
+  };
+}
+
+function makeDeps(): {
+  deps: TerminalControllerDeps<TerminalControllerSession>;
+  spawn: ReturnType<typeof vi.fn>;
+} {
+  const spawn = vi.fn();
+  const ptyClient = {
+    spawn,
+    kill: vi.fn(),
+    submit: vi.fn(),
+    hasTerminal: vi.fn(() => true),
+    setIpcDataMirror: vi.fn(),
+    replayHistoryAsync: vi.fn(async () => 0),
+    getTerminalAsync: vi.fn(async () => null),
+  } as unknown as PtyClient;
+
+  const portRegistry = new Map<string, number>();
+  // Pre-reserved so allocatePort returns synchronously and normalization is the
+  // only await this test has to gate.
+  portRegistry.set(createSessionKey("project-1", "panel-1"), 4321);
+
+  return {
+    spawn,
+    deps: {
+      ptyClient,
+      portRegistry,
+      terminalToSession: new Map<string, string>(),
+      portWaitAborts: new Set<AbortController>(),
+      isDisposed: () => false,
+      recordDiagnostic: vi.fn(),
+      recordSessionDiagnostic: vi.fn(),
+      updateSession: vi.fn((session, updates) => {
+        if (updates.status !== undefined) session.status = updates.status;
+        if (updates.terminalId !== undefined) session.terminalId = updates.terminalId;
+        if (updates.generation !== undefined) session.generation = updates.generation;
+      }),
+      clearCompiling: vi.fn(),
+      pollServerReadiness: vi.fn(),
+    },
+  };
+}
+
+/**
+ * One shared gate: normalization makes several reads in sequence, so releasing
+ * a single pending promise would only unblock the first of them.
+ */
+function gateReadFile(): () => void {
+  let open!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    open = resolve;
+  });
+  mockReadFile.mockImplementation(() =>
+    gate.then(() => {
+      throw new Error("ENOENT");
+    })
+  );
+  return open;
+}
+
+describe("dev preview launch cancellation", () => {
+  beforeEach(() => {
+    mockReadFile.mockReset();
+  });
+
+  it("abandons a launch whose session was stopped while its command was resolving", async () => {
+    const releaseNormalization = gateReadFile();
+
+    const session = makeSession();
+    const { deps, spawn } = makeDeps();
+
+    const launch = spawnSessionTerminal(session, deps);
+    await vi.waitFor(() => expect(mockReadFile).toHaveBeenCalled());
+
+    // The stop finds no terminal (the install PTY already exited) and does not
+    // touch `generation` — the epoch is the only thing that changes.
+    await stopSessionTerminal(session, "stop", deps);
+    releaseNormalization();
+    await launch;
+
+    expect(spawn).not.toHaveBeenCalled();
+    expect(session.terminalId).toBeNull();
+  });
+
+  it("still spawns when nothing cancelled the launch", async () => {
+    const releaseNormalization = gateReadFile();
+
+    const session = makeSession();
+    const { deps, spawn } = makeDeps();
+
+    const launch = spawnSessionTerminal(session, deps);
+    await vi.waitFor(() => expect(mockReadFile).toHaveBeenCalled());
+    releaseNormalization();
+    await launch;
+
+    expect(spawn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/electron/services/__tests__/normalizeNextjsDevCommand.test.ts
+++ b/electron/services/__tests__/normalizeNextjsDevCommand.test.ts
@@ -225,6 +225,123 @@ describe("normalizeNextjsDevCommand", () => {
       );
     });
   });
+
+  // Next 16 flipped the default: `next dev` is Turbopack unless --webpack says
+  // otherwise, and --webpack alongside --turbo/--turbopack is a fatal CLI error.
+  describe("Next.js 16 (Turbopack is the default)", () => {
+    beforeEach(() => {
+      mockResolveNextMajorVersion.mockResolvedValue(16);
+    });
+
+    it("does not inject --turbopack — it is already the default", async () => {
+      expect(await normalizeNextjsDevCommand("next dev", CWD)).toBe("next dev");
+    });
+
+    it("does not inject into a package script either", async () => {
+      mockPkg({ dev: "next dev" });
+      expect(await normalizeNextjsDevCommand("npm run dev", CWD)).toBe("npm run dev");
+    });
+
+    it("appends --webpack when the preference is off, since stripping no longer opts out", async () => {
+      expect(await normalizeNextjsDevCommand("next dev", CWD, false)).toBe("next dev --webpack");
+    });
+
+    it("appends -- --webpack for an npm script when the preference is off", async () => {
+      mockPkg({ dev: "next dev" });
+      expect(await normalizeNextjsDevCommand("npm run dev", CWD, false)).toBe(
+        "npm run dev -- --webpack"
+      );
+    });
+
+    it("appends --webpack with no separator for pnpm/yarn/bun", async () => {
+      mockPkg({ dev: "next dev" });
+      expect(await normalizeNextjsDevCommand("pnpm dev", CWD, false)).toBe("pnpm dev --webpack");
+      expect(await normalizeNextjsDevCommand("yarn dev", CWD, false)).toBe("yarn dev --webpack");
+      expect(await normalizeNextjsDevCommand("bun run dev", CWD, false)).toBe(
+        "bun run dev --webpack"
+      );
+    });
+
+    it("replaces a pre-injected --turbopack with --webpack when the preference is off", async () => {
+      expect(await normalizeNextjsDevCommand("next dev --turbopack", CWD, false)).toBe(
+        "next dev --webpack"
+      );
+    });
+
+    it("leaves an explicit --turbo spelling alone when the preference is on", async () => {
+      expect(await normalizeNextjsDevCommand("next dev --turbo", CWD)).toBe("next dev --turbo");
+    });
+
+    it("does not double-append --webpack", async () => {
+      expect(await normalizeNextjsDevCommand("next dev --webpack", CWD, false)).toBe(
+        "next dev --webpack"
+      );
+    });
+  });
+
+  describe("explicit --webpack never gains a conflicting turbo flag", () => {
+    it.each([15, 16])("leaves 'next dev --webpack' alone on Next %i", async (major) => {
+      mockResolveNextMajorVersion.mockResolvedValue(major);
+      expect(await normalizeNextjsDevCommand("next dev --webpack", CWD)).toBe("next dev --webpack");
+    });
+
+    it("does not append --turbopack to a script body that sets --webpack", async () => {
+      mockResolveNextMajorVersion.mockResolvedValue(15);
+      mockPkg({ dev: "next dev --webpack" });
+      expect(await normalizeNextjsDevCommand("npm run dev", CWD)).toBe("npm run dev");
+    });
+
+    it("strips a pre-injected turbo flag that would pair with the script's --webpack", async () => {
+      mockResolveNextMajorVersion.mockResolvedValue(16);
+      mockPkg({ dev: "next dev --webpack" });
+      expect(await normalizeNextjsDevCommand("npm run dev -- --turbopack", CWD)).toBe(
+        "npm run dev"
+      );
+    });
+
+    it("strips the turbo flag from a direct command that also names --webpack", async () => {
+      mockResolveNextMajorVersion.mockResolvedValue(16);
+      expect(await normalizeNextjsDevCommand("next dev --webpack --turbopack", CWD)).toBe(
+        "next dev --webpack"
+      );
+    });
+
+    it("reports the conflict when the preference asked for Turbopack", async () => {
+      mockResolveNextMajorVersion.mockResolvedValue(16);
+      const onConflict = vi.fn();
+      await normalizeNextjsDevCommand("next dev --webpack", CWD, true, onConflict);
+      expect(onConflict).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "bundler-conflict" })
+      );
+    });
+
+    it("stays quiet when the preference agrees with the explicit --webpack", async () => {
+      mockResolveNextMajorVersion.mockResolvedValue(16);
+      const onConflict = vi.fn();
+      await normalizeNextjsDevCommand("next dev --webpack", CWD, false, onConflict);
+      expect(onConflict).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("compound package scripts are never rewritten", () => {
+    it("leaves 'npm run dev' alone when the script body is compound", async () => {
+      mockResolveNextMajorVersion.mockResolvedValue(15);
+      mockPkg({ dev: "next dev && echo done" });
+      expect(await normalizeNextjsDevCommand("npm run dev", CWD)).toBe("npm run dev");
+    });
+
+    it("leaves a compound script body alone on Next 16 with the preference off", async () => {
+      mockResolveNextMajorVersion.mockResolvedValue(16);
+      mockPkg({ dev: "next dev; echo done" });
+      expect(await normalizeNextjsDevCommand("npm run dev", CWD, false)).toBe("npm run dev");
+    });
+
+    it("leaves a piped script body alone", async () => {
+      mockResolveNextMajorVersion.mockResolvedValue(15);
+      mockPkg({ dev: "next dev | tee log" });
+      expect(await normalizeNextjsDevCommand("npm run dev", CWD)).toBe("npm run dev");
+    });
+  });
 });
 
 describe("extractPort", () => {

--- a/electron/services/__tests__/normalizeNextjsDevCommand.test.ts
+++ b/electron/services/__tests__/normalizeNextjsDevCommand.test.ts
@@ -323,6 +323,58 @@ describe("normalizeNextjsDevCommand", () => {
     });
   });
 
+  describe("a script that owns the turbo flag is never paired with --webpack", () => {
+    it.each(["next dev --turbopack", "next dev --turbo"])(
+      "leaves 'npm run dev' alone on Next 16 with the preference off when the script is %s",
+      async (scriptBody) => {
+        mockResolveNextMajorVersion.mockResolvedValue(16);
+        mockPkg({ dev: scriptBody });
+        // Appending --webpack here would run `next dev --turbopack --webpack`,
+        // which Next 16 rejects outright.
+        expect(await normalizeNextjsDevCommand("npm run dev", CWD, false)).toBe("npm run dev");
+      }
+    );
+
+    it.each(["pnpm dev", "yarn dev", "bun run dev"])("does the same for %s", async (command) => {
+      mockResolveNextMajorVersion.mockResolvedValue(16);
+      mockPkg({ dev: "next dev --turbopack" });
+      expect(await normalizeNextjsDevCommand(command, CWD, false)).toBe(command);
+    });
+
+    it("reports the conflict so the ignored preference is visible", async () => {
+      mockResolveNextMajorVersion.mockResolvedValue(16);
+      mockPkg({ dev: "next dev --turbopack" });
+      const onConflict = vi.fn();
+      await normalizeNextjsDevCommand("npm run dev", CWD, false, onConflict);
+      expect(onConflict).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "bundler-conflict" })
+      );
+    });
+  });
+
+  describe("flag stripping respects token boundaries", () => {
+    it("does not mangle a longer flag that merely starts with --turbopack", async () => {
+      mockResolveNextMajorVersion.mockResolvedValue(14);
+      expect(await normalizeNextjsDevCommand("next dev --turbopack-root ./app", CWD)).toBe(
+        "next dev --turbopack-root ./app"
+      );
+    });
+
+    it("keeps npm's forwarding separator when other args survive the strip", async () => {
+      mockResolveNextMajorVersion.mockResolvedValue(14);
+      expect(await normalizeNextjsDevCommand("npm run dev -- --turbopack --port 3010", CWD)).toBe(
+        "npm run dev -- --port 3010"
+      );
+    });
+
+    it("drops the separator when the turbo flag was all it forwarded", async () => {
+      mockResolveNextMajorVersion.mockResolvedValue(14);
+      expect(await normalizeNextjsDevCommand("npm run dev -- --turbopack", CWD)).toBe(
+        "npm run dev"
+      );
+    });
+  });
+
   describe("compound package scripts are never rewritten", () => {
     it("leaves 'npm run dev' alone when the script body is compound", async () => {
       mockResolveNextMajorVersion.mockResolvedValue(15);

--- a/electron/services/__tests__/normalizeNextjsDevCommand.test.ts
+++ b/electron/services/__tests__/normalizeNextjsDevCommand.test.ts
@@ -367,6 +367,24 @@ describe("normalizeNextjsDevCommand", () => {
       );
     });
 
+    it("does not add a second forwarding separator to a bare 'npm run dev --'", async () => {
+      mockResolveNextMajorVersion.mockResolvedValue(15);
+      mockPkg({ dev: "next dev" });
+      expect(await normalizeNextjsDevCommand("npm run dev --", CWD)).toBe(
+        "npm run dev -- --turbopack"
+      );
+    });
+
+    it("does not reach inside a quoted argument value", async () => {
+      mockResolveNextMajorVersion.mockResolvedValue(14);
+      expect(
+        await normalizeNextjsDevCommand(
+          'next dev --turbo --experimental-https-key "certs/dev --turbopack.pem"',
+          CWD
+        )
+      ).toBe('next dev --experimental-https-key "certs/dev --turbopack.pem"');
+    });
+
     it("drops the separator when the turbo flag was all it forwarded", async () => {
       mockResolveNextMajorVersion.mockResolvedValue(14);
       expect(await normalizeNextjsDevCommand("npm run dev -- --turbopack", CWD)).toBe(

--- a/electron/services/pty/terminalShell.ts
+++ b/electron/services/pty/terminalShell.ts
@@ -9,7 +9,7 @@ export interface ShellArgsOptions {
 
 const MACOS_INTERACTIVE_SHELL_STARTUP_DELAY_SECONDS = "0.05";
 
-const WINDOWS_PS_UTF8_BOOTSTRAP =
+export const WINDOWS_PS_UTF8_BOOTSTRAP =
   "[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false); $OutputEncoding = [System.Text.UTF8Encoding]::new($false)";
 
 function shellQuote(value: string): string {

--- a/scripts/perf/lib/devPreviewOutputFixture.ts
+++ b/scripts/perf/lib/devPreviewOutputFixture.ts
@@ -435,9 +435,10 @@ export function buildAnsiBindStreamPlan(options: {
  * three of its four plants as misses against a perfectly healthy detector.
  *
  * Each row is graded on the type AND the status it routes to:
- * `missing-dependencies` is the one recoverable type and goes to `installing`,
- * every other type stops the session with `error`. A classifier that answered
- * `unknown` for everything would still be "detecting" and still fails here.
+ * `missing-dependencies` is the one recoverable type and leaves the session in
+ * a running state, every other type stops it with `error`. A classifier that
+ * answered `unknown` for everything would still be "detecting" and still fails
+ * here.
  */
 export function buildFailureStreamPlans(seed: number): DevPreviewStreamPlan[] {
   const failures: Array<{ text: string; type: DevServerErrorType }> = [
@@ -711,6 +712,9 @@ export interface DevPreviewMissCounts {
  * `detectDevServerError` sweep over the rolling buffer all run on every chunk,
  * and a single aggregate would let one of them be deleted for free.
  */
+/** A session that has not been stopped by the failure it just reported. */
+const RECOVERABLE_STATUSES: ReadonlySet<string> = new Set(["starting", "installing", "running"]);
+
 export function devPreviewPassMisses(
   plan: DevPreviewStreamPlan,
   result: DevPreviewPassResult,
@@ -743,10 +747,16 @@ export function devPreviewPassMisses(
       errorClassMisses += 1;
       continue;
     }
-    // `missing-dependencies` is the one recoverable type and must route to
-    // `installing`; every other type must stop the session.
-    const expectedStatus = expectedType === "missing-dependencies" ? "installing" : "error";
-    if (actual.status !== expectedStatus) errorClassMisses += 1;
+    // `missing-dependencies` is the one recoverable type: it arms the install
+    // and leaves the session running, because `installing` now means an install
+    // actually started rather than one that output merely predicted (#12295).
+    // Every other type must stop the session. Still two-sided: routing the
+    // recoverable type to `error`, or a terminal type anywhere else, both miss.
+    const statusOk =
+      expectedType === "missing-dependencies"
+        ? RECOVERABLE_STATUSES.has(actual.status)
+        : actual.status === "error";
+    if (!statusOk) errorClassMisses += 1;
   }
 
   return {

--- a/shared/types/ipc/devPreview.ts
+++ b/shared/types/ipc/devPreview.ts
@@ -167,6 +167,7 @@ export type DevPreviewDiagnosticEvent = DevPreviewDiagnosticEventBase &
     | { type: "ensure-requested"; configChanged: boolean }
     | { type: "config-changed"; changed: string[] }
     | { type: "command-invalid"; message: string }
+    | { type: "bundler-conflict"; message: string }
     | { type: "port-allocated"; port: number }
     | { type: "port-conflict"; port: number }
     | { type: "spawned"; terminalId: string; port: number }

--- a/src/components/DevPreview/DiagnosticsPanel.tsx
+++ b/src/components/DevPreview/DiagnosticsPanel.tsx
@@ -48,6 +48,8 @@ export function describeDiagnosticEvent(event: DevPreviewDiagnosticEvent): {
       return { label: "Config changed", detail: event.changed.join(", ") };
     case "command-invalid":
       return { label: "Command invalid", detail: event.message };
+    case "bundler-conflict":
+      return { label: "Bundler preference not applied", detail: event.message };
     case "port-allocated":
       return { label: "Port allocated", detail: `port ${event.port}` };
     case "port-conflict":


### PR DESCRIPTION
## Summary

- A dev preview session could never observe its own dev command finishing, because the command ran as typed input inside a shell PTY that survived the command's exit. Exit classification, install completion, the crash-loop guard, and the post-install restart were all dead code in practice.
- The fix runs the dev command as shell startup work through a new `exit` mode on `buildCommandLaunchShell`, so the PTY exit event now carries the command's real exit status.
- Also fixes two related bugs named in the issue: Next 16 bundler flag conflicts in `DevPreviewCommandNormalizer.ts`, and IPv4-only port checks in `DevPreviewPortAllocator.ts` that miss loopback-bound dev servers.

Resolves #12295

## The bug

`DevPreviewTerminalController` was spawning a generic `kind: "dev-preview"` PTY and then typing the configured dev command into that shell as terminal input. When the command exited, the shell it was running inside of survived, so the PTY exit event that `handleDevPreviewTerminalExit` and `DevPreviewSessionService` depend on never fired.

That left exit classification, install completion detection, the crash-loop guard, and the post-install restart all effectively dead code. A dev command exiting with a nonzero code before the server started serving left the session stuck showing `starting`. A running server that died kept showing as healthy forever. A dev command exiting because of a missing dependency left the session stuck showing `installing`, while no install ever actually ran.

## The fix

The repo already had the right mechanism one call site away. `buildCommandLaunchShell` runs an agent's command as shell startup work (`zsh|bash -lic "<command>"`) instead of typing it in, and it gained a new `exit` mode for this: still a real interactive login shell, with job control on so the dev server owns its own foreground process group, shell syntax and the user's environment preserved, but this mode ends with the launched command's own exit status, so the PTY exit event now carries the real exit code.

Command normalization now resolves before the spawn, so the normalized command can ride in the shell's arguments instead of being typed afterward. Shells that can't host a wrapper keep the old typed-input path as a fallback.

## Also in scope

Both named directly in the issue:

- **Next 16 bundler flags.** Turbopack is the default in Next 16, so disabling the turbo preference now appends `--webpack` instead of just stripping a flag. An explicit `--webpack` in the user's command now always wins over injecting a turbo flag, because Next 16 exits 1 when both are passed ("Pass either `webpack` or `turbopack`, not both"). Shell control characters are now re-checked against the resolved package-script body too, matching how `normalizeViteDevCommand` already worked.
- **IPv4-only port checks.** Node sets `SO_REUSEADDR`, so both wildcard addresses can still bind while a loopback listener is holding the port. That's measured directly, not assumed. Probing only `0.0.0.0`, or even `0.0.0.0` plus `::`, misses exactly the loopback-bound dev servers that matter, including the audit's own `ipv6Only` `::1` repro. The allocator now probes all four addresses a dev server can take, sequentially rather than concurrently (concurrent probes conflict with each other on Linux), and keeps "no usable IPv6" distinct from "IPv6 occupied".

## Smaller fixes that fell out

- Shell detection using `endsWith("sh")` matched `fish`, which has neither `trap` nor `$?` and was being handed a bourne script it silently mis-executed. Detection is now an explicit allowlist.
- POSIX `128+N` exit statuses are now decoded, so a Ctrl-C on the dev server reads as a stop rather than a crash, and an encoded SIGSEGV keeps its crash tier. node-pty reports `signal: 0` for a normal exit, and that zero was surviving through the whole exit path unchanged.
- A nonzero exit from a session in the `running` state now surfaces as an error instead of silently becoming `stopped`.
- `installing` is no longer claimed the moment output merely mentions missing dependencies. That status now only applies once an install has actually started.

## Testing

- Added `DevPreviewSessionService.commandCompletion.test.ts`, which spawns real node-pty login shells running real commands, a real HTTP server, a real `npm install` against an offline, dependency-free fixture, and a real failing install, and asserts the audit's scenarios end to end. POSIX-gated, since CI runs on Ubuntu.
- Added real-socket allocator tests (`DevPreviewPortAllocator.sockets.test.ts`) covering the `ipv6Only` `::1` repro directly.
- Added `DevPreviewTerminalController.launchCancellation.test.ts` covering launch cancellation deterministically.
- 1,008 tests pass locally across the dev-preview surface and the renderer components. Typecheck is clean. Prettier and eslint are clean on the changed files.

## Not covered

- The Windows PowerShell and cmd exit-mode branches are only unit-tested on argument shape. There's no Windows CI to actually execute them.
- `cmd.exe` argument escaping goes through node-pty's `argsToCommandLine`, which quotes differently than cmd actually expects. Pre-existing on the shared agent-launch path; this change just routes dev preview through it.
- `PKG_SCRIPT_RE` is anchored, so a wrapper carrying its own arguments (`npm run dev -- --port 3010`) still resolves no script body. Only the renderer's exact `-- --turbopack` suffix is retried.
- A dev command that backgrounds itself (`vite &`) ends the wrapper immediately. A bare `wait` would cover it but risks blocking on unrelated jobs started by the shell's own rc files.
- Shells that can't host a wrapper (fish, nushell) keep the pre-existing blindness to command exit.
