### PR TITLE
fix(dev-preview): make device emulation and console capture report real state

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -418,6 +418,7 @@ export const CHANNELS = {
   WEBVIEW_RELOAD_IGNORING_CACHE: "webview:reload-ignoring-cache",
   WEBVIEW_GET_SCROLL_POSITION: "webview:get-scroll-position",
   WEBVIEW_CAPTURE_SCREENSHOT: "webview:capture-screenshot",
+  WEBVIEW_SET_DEVICE_EMULATION: "webview:set-device-emulation",
   WEBVIEW_CONSOLE_MESSAGE: "webview:console-message",
   WEBVIEW_CONSOLE_CONTEXT_CLEARED: "webview:console-context-cleared",
   WEBVIEW_GET_NAVIGATION_HISTORY: "webview:get-navigation-history",

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -71,6 +71,7 @@ import { registerHelpAssistantHandlers } from "./handlers/helpAssistant.js";
 import { registerWebviewHandlers } from "./handlers/webview.js";
 import { registerWebviewNavigationHandlers } from "./handlers/webviewNavigation.js";
 import { registerWebviewCaptureHandlers } from "./handlers/webviewCapture.js";
+import { registerWebviewEmulationHandlers } from "./handlers/webviewEmulation.js";
 import { registerDiagnosticsHandlers } from "./handlers/diagnostics.js";
 import { registerResourceProfileHandlers } from "./handlers/resourceProfile.js";
 import { registerWhySlowHandlers } from "./handlers/whySlow.js";
@@ -206,6 +207,7 @@ export function registerIpcHandlers(deps: HandlerDependencies): () => void {
     register(() => registerWebviewHandlers(deps));
     register(() => registerWebviewNavigationHandlers(deps));
     register(() => registerWebviewCaptureHandlers(deps));
+    register(() => registerWebviewEmulationHandlers(deps));
     register(() => registerDiagnosticsHandlers(deps));
     register(() => registerResourceProfileHandlers(deps));
     register(() => registerWhySlowHandlers(deps));

--- a/electron/ipc/handlers/__tests__/webview.test.ts
+++ b/electron/ipc/handlers/__tests__/webview.test.ts
@@ -147,6 +147,7 @@ describe("registerWebviewHandlers", () => {
     // stubs an unregistered guest would otherwise leak that into every test
     // declared after it.
     mockDialogService.getPanelId.mockReturnValue("test-panel");
+    mockWebContents.once.mockImplementation(() => {});
     debuggerMock.isAttached.mockReturnValue(false);
     debuggerMock.sendCommand.mockResolvedValue(undefined);
     webContentsMock.fromId.mockReturnValue(mockWebContents);
@@ -356,6 +357,12 @@ describe("registerWebviewHandlers", () => {
       const result = await handler(null, 42, "pane-1", rowId, "stale-obj");
 
       expect(result.properties).toEqual([]);
+      // The CDP call must have been reached — otherwise an ownership rejection
+      // would be indistinguishable from the "Could not find object" path.
+      expect(debuggerMock.sendCommand).toHaveBeenCalledWith(
+        "Runtime.getProperties",
+        expect.objectContaining({ objectId: "stale-obj" })
+      );
     });
 
     it("tracks group depth correctly", async () => {
@@ -848,6 +855,8 @@ describe("registerWebviewHandlers", () => {
       cleanup = registerWebviewHandlers(deps);
       await getHandler("webview:start-console-capture")(null, 42, "pane-1");
 
+      expect(order).toContain("on:message");
+      expect(order).toContain("send:Runtime.enable");
       expect(order.indexOf("on:message")).toBeLessThan(order.indexOf("send:Runtime.enable"));
       debuggerMock.on.mockReset();
     });
@@ -873,6 +882,10 @@ describe("registerWebviewHandlers", () => {
 
       cleanup = registerWebviewHandlers(deps);
       await getHandler("webview:start-console-capture")(null, 42, "pane-1");
+      // Pin the first delivery: without it, an ordering-only regression that
+      // lost the startup row here and re-delivered it on the second start
+      // would still satisfy the combined assertion below.
+      expect(consoleRows().map((row) => row.summaryText)).toEqual(["STARTUP"]);
       await getHandler("webview:stop-console-capture")(null, 42, "pane-1");
 
       // The guest logged again while capture was off; the next enable replays
@@ -884,6 +897,153 @@ describe("registerWebviewHandlers", () => {
       await getHandler("webview:start-console-capture")(null, 42, "pane-1");
 
       expect(consoleRows().map((row) => row.summaryText)).toEqual(["STARTUP", "WHILE_STOPPED"]);
+    });
+
+    it("keeps distinct messages that share a millisecond in the first replay", async () => {
+      // CDP timestamps are epoch milliseconds and are neither unique nor
+      // strictly increasing. A watermark that only compared timestamps would
+      // keep the first of these and silently drop the rest — rows the renderer
+      // has never seen.
+      replayOnRuntimeEnable([
+        { type: "log", args: [{ type: "string", value: "first" }], timestamp: 1000 },
+        { type: "log", args: [{ type: "string", value: "second" }], timestamp: 1000 },
+        { type: "log", args: [{ type: "string", value: "third" }], timestamp: 1000 },
+      ]);
+
+      cleanup = registerWebviewHandlers(deps);
+      await getHandler("webview:start-console-capture")(null, 42, "pane-1");
+
+      expect(consoleRows().map((row) => row.summaryText)).toEqual(["first", "second", "third"]);
+    });
+
+    it("reconciles a same-millisecond replay against how many were delivered", async () => {
+      const tied = (value: string) => ({
+        type: "log",
+        args: [{ type: "string", value }],
+        timestamp: 1000,
+      });
+      replayOnRuntimeEnable([tied("first"), tied("second")]);
+
+      cleanup = registerWebviewHandlers(deps);
+      await getHandler("webview:start-console-capture")(null, 42, "pane-1");
+      await getHandler("webview:stop-console-capture")(null, 42, "pane-1");
+
+      // The guest logged a third message in that same millisecond while
+      // capture was off. Two were already delivered, so exactly two are
+      // skipped and the third comes through.
+      replayOnRuntimeEnable([tied("first"), tied("second"), tied("third")]);
+      await getHandler("webview:start-console-capture")(null, 42, "pane-1");
+
+      expect(consoleRows().map((row) => row.summaryText)).toEqual(["first", "second", "third"]);
+    });
+
+    it("does not re-deliver replayed exceptions after a stop/start cycle", async () => {
+      const thrown = {
+        timestamp: 1000,
+        exceptionDetails: { exception: { description: "TypeError: boom" } },
+      };
+      const replayExceptions = (events: Array<Record<string, unknown>>) => {
+        debuggerMock.sendCommand.mockImplementation((cmd: string) => {
+          if (cmd === "Runtime.enable") {
+            const call = debuggerMock.on.mock.calls.find(
+              ([event]: string[]) => event === "message"
+            );
+            const listener = call?.[1] as
+              ((event: unknown, method: string, params: unknown) => void) | undefined;
+            for (const event of events) listener?.({}, "Runtime.exceptionThrown", event);
+          }
+          return Promise.resolve();
+        });
+      };
+
+      replayExceptions([thrown]);
+      cleanup = registerWebviewHandlers(deps);
+      await getHandler("webview:start-console-capture")(null, 42, "pane-1");
+      await getHandler("webview:stop-console-capture")(null, 42, "pane-1");
+
+      replayExceptions([
+        thrown,
+        {
+          timestamp: 2000,
+          exceptionDetails: { exception: { description: "ReferenceError: later" } },
+        },
+      ]);
+      await getHandler("webview:start-console-capture")(null, 42, "pane-1");
+
+      expect(consoleRows().map((row) => row.summaryText)).toEqual([
+        "TypeError: boom",
+        "ReferenceError: later",
+      ]);
+    });
+
+    it("re-enables the domains for a start that raced the last stop", async () => {
+      let resolveDisable: () => void = () => {};
+      debuggerMock.sendCommand.mockImplementation((cmd: string) => {
+        if (cmd === "Runtime.disable") {
+          return new Promise<void>((resolve) => {
+            resolveDisable = resolve;
+          });
+        }
+        return Promise.resolve();
+      });
+
+      cleanup = registerWebviewHandlers(deps);
+      await getHandler("webview:start-console-capture")(null, 42, "pane-1");
+
+      const stopping = getHandler("webview:stop-console-capture")(null, 42, "pane-1");
+      // Let the stop drop its pane and reach the pending Runtime.disable, so
+      // the new pane genuinely arrives mid-teardown rather than before it.
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+
+      // The new pane sees the domain still enabled and skips enabling; without
+      // the re-enable, the stop then turns it off and this pane never receives
+      // another message.
+      await getHandler("webview:start-console-capture")(null, 42, "pane-2");
+      resolveDisable();
+      await stopping;
+
+      const enableCalls = debuggerMock.sendCommand.mock.calls.filter(
+        ([cmd]: string[]) => cmd === "Runtime.enable"
+      );
+      expect(enableCalls).toHaveLength(2);
+    });
+
+    it("does not re-deliver replayed Log entries after a stop/start cycle", async () => {
+      // Log.enable replays the guest's stored entries the same way Runtime does.
+      const buffered = {
+        entry: { source: "network", level: "error", text: "CSP violation", timestamp: 1000 },
+      };
+      const replayLogOnEnable = (entries: Array<Record<string, unknown>>) => {
+        debuggerMock.sendCommand.mockImplementation((cmd: string) => {
+          if (cmd === "Log.enable") {
+            const call = debuggerMock.on.mock.calls.find(
+              ([event]: string[]) => event === "message"
+            );
+            const listener = call?.[1] as
+              ((event: unknown, method: string, params: unknown) => void) | undefined;
+            for (const entry of entries) listener?.({}, "Log.entryAdded", entry);
+          }
+          return Promise.resolve();
+        });
+      };
+
+      replayLogOnEnable([buffered]);
+      cleanup = registerWebviewHandlers(deps);
+      await getHandler("webview:start-console-capture")(null, 42, "pane-1");
+      await getHandler("webview:stop-console-capture")(null, 42, "pane-1");
+
+      replayLogOnEnable([
+        buffered,
+        {
+          entry: { source: "network", level: "error", text: "later failure", timestamp: 2000 },
+        },
+      ]);
+      await getHandler("webview:start-console-capture")(null, 42, "pane-1");
+
+      expect(consoleRows().map((row) => row.summaryText)).toEqual([
+        "CSP violation",
+        "later failure",
+      ]);
     });
 
     it("does not rebind listeners across a stop/start cycle", async () => {
@@ -1000,6 +1160,89 @@ describe("registerWebviewHandlers", () => {
       expect(releasedIds()).toContain("late-nested");
     });
 
+    it("evicts one row's handles without touching a row still on screen", async () => {
+      // The claim is per-row ownership, not per-pane: pane-wide tracking would
+      // satisfy the eviction test above just as well.
+      cleanup = registerWebviewHandlers(deps);
+      await getHandler("webview:start-console-capture")(null, 42, "pane-1");
+      const listener = getMessageListener();
+
+      const emit = (objectId: string, timestamp: number) => {
+        listener({}, "Runtime.consoleAPICalled", {
+          type: "log",
+          args: [{ type: "object", objectId, className: "Object" }],
+          timestamp,
+        });
+      };
+
+      emit("old-obj", 1000);
+      // Rows carrying no handles still occupy renderer rows, so they have to
+      // count toward the cap or eviction drifts out of step with the store.
+      for (let i = 0; i < MAX_CONSOLE_ROWS - 1; i++) {
+        listener({}, "Runtime.consoleAPICalled", {
+          type: "log",
+          args: [{ type: "string", value: `filler-${i}` }],
+          timestamp: 1001 + i,
+        });
+      }
+      emit("kept-obj", 9000);
+
+      // Exactly one row past the cap, so only the oldest is released.
+      expect(releasedIds()).toEqual(["old-obj"]);
+    });
+
+    it("releases internal and private property handles the UI never renders", async () => {
+      cleanup = registerWebviewHandlers(deps);
+      const rowId = await emitObjectRow("pane-1", "root-obj");
+
+      debuggerMock.sendCommand.mockImplementation((cmd: string) => {
+        if (cmd === "Runtime.getProperties") {
+          return Promise.resolve({
+            result: [
+              {
+                name: "visible",
+                get: { type: "function", objectId: "getter-obj" },
+                enumerable: true,
+              },
+            ],
+            internalProperties: [
+              { name: "[[Prototype]]", value: { type: "object", objectId: "proto-obj" } },
+            ],
+            privateProperties: [
+              { name: "#secret", value: { type: "object", objectId: "private-obj" } },
+            ],
+          });
+        }
+        return Promise.resolve();
+      });
+      await getHandler("webview:get-console-properties")(null, 42, "pane-1", rowId, "root-obj");
+      await getHandler("webview:clear-console-capture")(null, 42, "pane-1");
+
+      for (const id of ["getter-obj", "proto-obj", "private-obj"]) {
+        expect(releasedIds()).toContain(id);
+      }
+    });
+
+    it("refuses an objectId the named row does not own", async () => {
+      cleanup = registerWebviewHandlers(deps);
+      const rowId = await emitObjectRow("pane-1", "root-obj");
+
+      debuggerMock.sendCommand.mockClear();
+      const result = await getHandler("webview:get-console-properties")(
+        null,
+        42,
+        "pane-1",
+        rowId,
+        "some-other-objects-handle"
+      );
+
+      expect(result).toEqual({ properties: [] });
+      expect(debuggerMock.sendCommand).not.toHaveBeenCalledWith(
+        "Runtime.getProperties",
+        expect.anything()
+      );
+    });
+
     it("refuses to expand a row that no longer owns its handles", async () => {
       cleanup = registerWebviewHandlers(deps);
       const rowId = await emitObjectRow("pane-1", "root-obj");
@@ -1019,6 +1262,28 @@ describe("registerWebviewHandlers", () => {
         "Runtime.getProperties",
         expect.anything()
       );
+    });
+  });
+
+  describe("session disposal (#12298)", () => {
+    it("disposes the session when the guest is destroyed", async () => {
+      const destroyCallbacks: Array<() => void> = [];
+      mockWebContents.once.mockImplementation((event: string, cb: () => void) => {
+        if (event === "destroyed") destroyCallbacks.push(cb);
+      });
+
+      cleanup = registerWebviewHandlers(deps);
+      await getHandler("webview:start-console-capture")(null, 42, "pane-1");
+      expect(destroyCallbacks).toHaveLength(1);
+
+      destroyCallbacks[0]!();
+
+      // Disposal detached the listeners, so the next start has to bind fresh
+      // ones rather than reuse a session for a guest that is gone.
+      expect(debuggerMock.off).toHaveBeenCalledWith("message", expect.any(Function));
+      debuggerMock.on.mockClear();
+      await getHandler("webview:start-console-capture")(null, 42, "pane-1");
+      expect(debuggerMock.on).toHaveBeenCalledWith("message", expect.any(Function));
     });
   });
 

--- a/electron/ipc/handlers/__tests__/webview.test.ts
+++ b/electron/ipc/handlers/__tests__/webview.test.ts
@@ -976,7 +976,7 @@ describe("registerWebviewHandlers", () => {
       ]);
     });
 
-    it("re-enables the domains for a start that raced the last stop", async () => {
+    it("serializes a start issued while the last stop is still tearing down", async () => {
       let resolveDisable: () => void = () => {};
       debuggerMock.sendCommand.mockImplementation((cmd: string) => {
         if (cmd === "Runtime.disable") {
@@ -991,17 +991,18 @@ describe("registerWebviewHandlers", () => {
       await getHandler("webview:start-console-capture")(null, 42, "pane-1");
 
       const stopping = getHandler("webview:stop-console-capture")(null, 42, "pane-1");
-      // Let the stop drop its pane and reach the pending Runtime.disable, so
-      // the new pane genuinely arrives mid-teardown rather than before it.
+      // Let the stop drop its pane and reach the pending Runtime.disable.
       for (let i = 0; i < 10; i++) await Promise.resolve();
 
-      // The new pane sees the domain still enabled and skips enabling; without
-      // the re-enable, the stop then turns it off and this pane never receives
-      // another message.
-      await getHandler("webview:start-console-capture")(null, 42, "pane-2");
+      // A new pane arrives mid-teardown. Interleaved, it would see the domain
+      // still enabled, skip enabling, and then be silently switched off by the
+      // stop finishing underneath it. Queued, it runs after the stop and
+      // enables the domain for itself.
+      const restarting = getHandler("webview:start-console-capture")(null, 42, "pane-2");
       resolveDisable();
-      await stopping;
+      await Promise.all([stopping, restarting]);
 
+      expect(debuggerMock.sendCommand).toHaveBeenCalledWith("Runtime.disable");
       const enableCalls = debuggerMock.sendCommand.mock.calls.filter(
         ([cmd]: string[]) => cmd === "Runtime.enable"
       );

--- a/electron/ipc/handlers/__tests__/webview.test.ts
+++ b/electron/ipc/handlers/__tests__/webview.test.ts
@@ -18,6 +18,7 @@ const mockWebContents = vi.hoisted(() => ({
   isDestroyed: vi.fn(() => false),
   debugger: debuggerMock,
   executeJavaScript: vi.fn().mockResolvedValue([]),
+  once: vi.fn(),
   hostWebContents: null as unknown,
 }));
 
@@ -95,9 +96,35 @@ vi.mock("../../utils.js", () => ({
 import { registerWebviewHandlers } from "../webview.js";
 import { sendToRenderer, broadcastToRenderer } from "../../utils.js";
 import type { HandlerDependencies } from "../../types.js";
+import { MAX_CONSOLE_ROWS } from "../../../../shared/config/devPreviewConsole.js";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const deps: HandlerDependencies = { mainWindow: mainWindowMock as any };
+
+function getMessageListener() {
+  const call = debuggerMock.on.mock.calls.find(([event]: string[]) => event === "message");
+  if (!call) throw new Error("CDP message listener was never bound");
+  return call[1] as (event: unknown, method: string, params: unknown) => void;
+}
+
+/**
+ * Emit one object-bearing console row through the real capture path and return
+ * the row id main assigned it — the ownership token `getConsoleProperties`
+ * now requires.
+ */
+async function emitObjectRow(paneId: string, objectId: string, timestamp = 1000) {
+  const start = getHandler("webview:start-console-capture");
+  await start(null, 42, paneId);
+  getMessageListener()({}, "Runtime.consoleAPICalled", {
+    type: "log",
+    args: [{ type: "object", objectId, className: "Object" }],
+    timestamp,
+  });
+  const sent = mainWindowMock.webContents.send.mock.calls.filter(
+    ([channel]: string[]) => channel === "webview:console-message"
+  );
+  return (sent[sent.length - 1][1] as { id: number }).id;
+}
 
 function getHandler(channel: string) {
   const call = ipcMainMock.handle.mock.calls.find(([ch]: string[]) => ch.includes(channel));
@@ -116,6 +143,10 @@ describe("registerWebviewHandlers", () => {
       cleanup = null;
     }
     vi.clearAllMocks();
+    // clearAllMocks resets calls but not implementations, so a suite that
+    // stubs an unregistered guest would otherwise leak that into every test
+    // declared after it.
+    mockDialogService.getPanelId.mockReturnValue("test-panel");
     debuggerMock.isAttached.mockReturnValue(false);
     debuggerMock.sendCommand.mockResolvedValue(undefined);
     webContentsMock.fromId.mockReturnValue(mockWebContents);
@@ -298,8 +329,9 @@ describe("registerWebviewHandlers", () => {
       });
 
       cleanup = registerWebviewHandlers(deps);
+      const rowId = await emitObjectRow("pane-1", "obj-123");
       const handler = getHandler("webview:get-console-properties");
-      const result = await handler(null, 42, "obj-123");
+      const result = await handler(null, 42, "pane-1", rowId, "obj-123");
 
       expect(result.properties).toHaveLength(1);
       expect(result.properties[0].name).toBe("key");
@@ -319,8 +351,9 @@ describe("registerWebviewHandlers", () => {
       });
 
       cleanup = registerWebviewHandlers(deps);
+      const rowId = await emitObjectRow("pane-1", "stale-obj");
       const handler = getHandler("webview:get-console-properties");
-      const result = await handler(null, 42, "stale-obj");
+      const result = await handler(null, 42, "pane-1", rowId, "stale-obj");
 
       expect(result.properties).toEqual([]);
     });
@@ -771,9 +804,301 @@ describe("registerWebviewHandlers", () => {
       mockDialogService.getPanelId.mockReturnValue(undefined);
       cleanup = registerWebviewHandlers(deps);
       const handler = getHandler("webview:get-console-properties");
-      const result = await handler(null, 42, "obj-123");
+      const result = await handler(null, 42, "pane-1", 0, "obj-123");
       expect(result).toEqual({ properties: [] });
       expect(debuggerMock.sendCommand).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("console capture ordering and replay (#12298)", () => {
+    /**
+     * Chrome replays the guest's buffered console messages as a side effect of
+     * `Runtime.enable`, before the command resolves. Modelling that here is the
+     * whole point: with the old enable-then-bind ordering the replayed row has
+     * nobody listening and is lost.
+     */
+    function replayOnRuntimeEnable(rows: Array<Record<string, unknown>>) {
+      debuggerMock.sendCommand.mockImplementation((cmd: string) => {
+        if (cmd === "Runtime.enable") {
+          const call = debuggerMock.on.mock.calls.find(([event]: string[]) => event === "message");
+          const listener = call?.[1] as
+            ((event: unknown, method: string, params: unknown) => void) | undefined;
+          for (const row of rows) listener?.({}, "Runtime.consoleAPICalled", row);
+        }
+        return Promise.resolve();
+      });
+    }
+
+    function consoleRows() {
+      return mainWindowMock.webContents.send.mock.calls
+        .filter(([channel]: string[]) => channel === "webview:console-message")
+        .map((call) => call[1] as { summaryText: string });
+    }
+
+    it("binds the CDP message listener before enabling the Runtime domain", async () => {
+      const order: string[] = [];
+      debuggerMock.on.mockImplementation((event: string) => {
+        order.push(`on:${event}`);
+      });
+      debuggerMock.sendCommand.mockImplementation((cmd: string) => {
+        order.push(`send:${cmd}`);
+        return Promise.resolve();
+      });
+
+      cleanup = registerWebviewHandlers(deps);
+      await getHandler("webview:start-console-capture")(null, 42, "pane-1");
+
+      expect(order.indexOf("on:message")).toBeLessThan(order.indexOf("send:Runtime.enable"));
+      debuggerMock.on.mockReset();
+    });
+
+    it("captures console messages replayed during Runtime.enable", async () => {
+      replayOnRuntimeEnable([
+        { type: "log", args: [{ type: "string", value: "AUDIT_BEFORE_ENABLE" }], timestamp: 1000 },
+      ]);
+
+      cleanup = registerWebviewHandlers(deps);
+      await getHandler("webview:start-console-capture")(null, 42, "pane-1");
+
+      expect(consoleRows().map((row) => row.summaryText)).toEqual(["AUDIT_BEFORE_ENABLE"]);
+    });
+
+    it("does not re-deliver replayed messages after a stop/start cycle", async () => {
+      const buffered = {
+        type: "log",
+        args: [{ type: "string", value: "STARTUP" }],
+        timestamp: 1000,
+      };
+      replayOnRuntimeEnable([buffered]);
+
+      cleanup = registerWebviewHandlers(deps);
+      await getHandler("webview:start-console-capture")(null, 42, "pane-1");
+      await getHandler("webview:stop-console-capture")(null, 42, "pane-1");
+
+      // The guest logged again while capture was off; the next enable replays
+      // both, and only the newer one is still news to the renderer.
+      replayOnRuntimeEnable([
+        buffered,
+        { type: "log", args: [{ type: "string", value: "WHILE_STOPPED" }], timestamp: 2000 },
+      ]);
+      await getHandler("webview:start-console-capture")(null, 42, "pane-1");
+
+      expect(consoleRows().map((row) => row.summaryText)).toEqual(["STARTUP", "WHILE_STOPPED"]);
+    });
+
+    it("does not rebind listeners across a stop/start cycle", async () => {
+      cleanup = registerWebviewHandlers(deps);
+      await getHandler("webview:start-console-capture")(null, 42, "pane-1");
+      await getHandler("webview:stop-console-capture")(null, 42, "pane-1");
+      await getHandler("webview:start-console-capture")(null, 42, "pane-1");
+
+      const messageBinds = debuggerMock.on.mock.calls.filter(
+        ([event]: string[]) => event === "message"
+      );
+      expect(messageBinds).toHaveLength(1);
+    });
+
+    it("unbinds listeners when Runtime.enable fails for the only pane", async () => {
+      debuggerMock.sendCommand.mockImplementation((cmd: string) =>
+        cmd === "Runtime.enable" ? Promise.reject(new Error("Target closed")) : Promise.resolve()
+      );
+
+      cleanup = registerWebviewHandlers(deps);
+      await getHandler("webview:start-console-capture")(null, 42, "pane-1");
+
+      expect(debuggerMock.off).toHaveBeenCalledWith("message", expect.any(Function));
+      expect(debuggerMock.off).toHaveBeenCalledWith("detach", expect.any(Function));
+    });
+  });
+
+  describe("console object ownership (#12298)", () => {
+    function releasedIds() {
+      return debuggerMock.sendCommand.mock.calls
+        .filter(([cmd]: string[]) => cmd === "Runtime.releaseObject")
+        .map((call) => (call[1] as { objectId: string }).objectId);
+    }
+
+    it("releases handles for rows evicted past the renderer's row cap", async () => {
+      cleanup = registerWebviewHandlers(deps);
+      await getHandler("webview:start-console-capture")(null, 42, "pane-1");
+      const listener = getMessageListener();
+
+      for (let i = 0; i < MAX_CONSOLE_ROWS + 2; i++) {
+        listener({}, "Runtime.consoleAPICalled", {
+          type: "log",
+          args: [{ type: "object", objectId: `obj-${i}`, className: "Object" }],
+          timestamp: 1000 + i,
+        });
+      }
+
+      // The two oldest rows fell off the cap; everything still on screen keeps
+      // its handle.
+      expect(releasedIds()).toEqual(["obj-0", "obj-1"]);
+    });
+
+    it("attributes nested handles from an expansion to the row that owns them", async () => {
+      cleanup = registerWebviewHandlers(deps);
+      const rowId = await emitObjectRow("pane-1", "root-obj");
+
+      debuggerMock.sendCommand.mockImplementation((cmd: string) => {
+        if (cmd === "Runtime.getProperties") {
+          return Promise.resolve({
+            result: [
+              {
+                name: "nested",
+                value: { type: "object", objectId: "nested-obj", className: "Object" },
+                enumerable: true,
+              },
+            ],
+          });
+        }
+        return Promise.resolve();
+      });
+      await getHandler("webview:get-console-properties")(null, 42, "pane-1", rowId, "root-obj");
+
+      await getHandler("webview:clear-console-capture")(null, 42, "pane-1");
+
+      expect(releasedIds()).toContain("root-obj");
+      expect(releasedIds()).toContain("nested-obj");
+    });
+
+    it("releases nested handles whose owning row was cleared mid-request", async () => {
+      cleanup = registerWebviewHandlers(deps);
+      const rowId = await emitObjectRow("pane-1", "root-obj");
+
+      let resolveProperties: (value: unknown) => void = () => {};
+      debuggerMock.sendCommand.mockImplementation((cmd: string) => {
+        if (cmd === "Runtime.getProperties") {
+          return new Promise((resolve) => {
+            resolveProperties = resolve;
+          });
+        }
+        return Promise.resolve();
+      });
+
+      const pending = getHandler("webview:get-console-properties")(
+        null,
+        42,
+        "pane-1",
+        rowId,
+        "root-obj"
+      );
+      await getHandler("webview:clear-console-capture")(null, 42, "pane-1");
+      resolveProperties({
+        result: [
+          {
+            name: "nested",
+            value: { type: "object", objectId: "late-nested", className: "Object" },
+            enumerable: true,
+          },
+        ],
+      });
+      await pending;
+
+      // The row lost ownership while the request was in flight, so the late
+      // descendant must be released rather than resurrect the released row.
+      expect(releasedIds()).toContain("late-nested");
+    });
+
+    it("refuses to expand a row that no longer owns its handles", async () => {
+      cleanup = registerWebviewHandlers(deps);
+      const rowId = await emitObjectRow("pane-1", "root-obj");
+      await getHandler("webview:clear-console-capture")(null, 42, "pane-1");
+
+      debuggerMock.sendCommand.mockClear();
+      const result = await getHandler("webview:get-console-properties")(
+        null,
+        42,
+        "pane-1",
+        rowId,
+        "root-obj"
+      );
+
+      expect(result).toEqual({ properties: [] });
+      expect(debuggerMock.sendCommand).not.toHaveBeenCalledWith(
+        "Runtime.getProperties",
+        expect.anything()
+      );
+    });
+  });
+
+  describe("scroll position sentinel (#12298)", () => {
+    it("returns a genuine zero when the page is at the top", async () => {
+      debuggerMock.sendCommand.mockImplementation((cmd: string) =>
+        cmd === "Page.getLayoutMetrics"
+          ? Promise.resolve({ cssLayoutViewport: { pageY: 0 } })
+          : Promise.resolve()
+      );
+
+      cleanup = registerWebviewHandlers(deps);
+      await expect(getHandler("webview:get-scroll-position")(null, 42)).resolves.toBe(0);
+    });
+
+    it("returns null when the CDP read fails", async () => {
+      debuggerMock.sendCommand.mockImplementation((cmd: string) =>
+        cmd === "Page.getLayoutMetrics"
+          ? Promise.reject(new Error("Target closed"))
+          : Promise.resolve()
+      );
+
+      cleanup = registerWebviewHandlers(deps);
+      await expect(getHandler("webview:get-scroll-position")(null, 42)).resolves.toBeNull();
+    });
+
+    it("returns null when the layout metrics are missing", async () => {
+      debuggerMock.sendCommand.mockImplementation((cmd: string) =>
+        cmd === "Page.getLayoutMetrics" ? Promise.resolve({}) : Promise.resolve()
+      );
+
+      cleanup = registerWebviewHandlers(deps);
+      await expect(getHandler("webview:get-scroll-position")(null, 42)).resolves.toBeNull();
+    });
+
+    it("returns null for an unregistered webContentsId", async () => {
+      mockDialogService.getPanelId.mockReturnValue(undefined);
+      cleanup = registerWebviewHandlers(deps);
+      await expect(getHandler("webview:get-scroll-position")(null, 42)).resolves.toBeNull();
+    });
+  });
+
+  describe("stack frame coordinates (#12298)", () => {
+    it("converts zero-based CDP line/column to one-based file locations", async () => {
+      cleanup = registerWebviewHandlers(deps);
+      await getHandler("webview:start-console-capture")(null, 42, "pane-1");
+
+      getMessageListener()({}, "Runtime.consoleAPICalled", {
+        type: "error",
+        args: [{ type: "string", value: "boom" }],
+        timestamp: 1000,
+        stackTrace: {
+          callFrames: [
+            {
+              functionName: "boot",
+              url: "http://localhost:5173/main.ts",
+              lineNumber: 0,
+              columnNumber: 0,
+            },
+            {
+              functionName: "run",
+              url: "http://localhost:5173/main.ts",
+              lineNumber: 41,
+              columnNumber: 7,
+            },
+          ],
+        },
+      });
+
+      expect(mainWindowMock.webContents.send).toHaveBeenCalledWith(
+        "webview:console-message",
+        expect.objectContaining({
+          stackTrace: {
+            callFrames: [
+              expect.objectContaining({ lineNumber: 1, columnNumber: 1 }),
+              expect.objectContaining({ lineNumber: 42, columnNumber: 8 }),
+            ],
+          },
+        })
+      );
     });
   });
 });

--- a/electron/ipc/handlers/__tests__/webview.test.ts
+++ b/electron/ipc/handlers/__tests__/webview.test.ts
@@ -18,6 +18,7 @@ const mockWebContents = vi.hoisted(() => ({
   isDestroyed: vi.fn(() => false),
   debugger: debuggerMock,
   executeJavaScript: vi.fn().mockResolvedValue([]),
+  getURL: vi.fn(() => "http://localhost:5173/"),
   once: vi.fn(),
   hostWebContents: null as unknown,
 }));
@@ -148,6 +149,7 @@ describe("registerWebviewHandlers", () => {
     // declared after it.
     mockDialogService.getPanelId.mockReturnValue("test-panel");
     mockWebContents.once.mockImplementation(() => {});
+    mockWebContents.getURL.mockReturnValue("http://localhost:5173/");
     debuggerMock.isAttached.mockReturnValue(false);
     debuggerMock.sendCommand.mockResolvedValue(undefined);
     webContentsMock.fromId.mockReturnValue(mockWebContents);
@@ -1007,6 +1009,90 @@ describe("registerWebviewHandlers", () => {
         ([cmd]: string[]) => cmd === "Runtime.enable"
       );
       expect(enableCalls).toHaveLength(2);
+    });
+
+    it("re-delivers a new document's startup messages after navigating while stopped", async () => {
+      // Navigation with capture off empties the guest's buffer without an
+      // executionContextsCleared anyone is listening for. Carrying the old
+      // document's bookkeeping across would skip the new page's startup logs.
+      mockWebContents.getURL.mockReturnValue("http://localhost:5173/");
+      replayOnRuntimeEnable([
+        { type: "log", args: [{ type: "string", value: "page-one" }], timestamp: 1000 },
+      ]);
+
+      cleanup = registerWebviewHandlers(deps);
+      await getHandler("webview:start-console-capture")(null, 42, "pane-1");
+      await getHandler("webview:stop-console-capture")(null, 42, "pane-1");
+
+      mockWebContents.getURL.mockReturnValue("http://localhost:5173/other");
+      replayOnRuntimeEnable([
+        { type: "log", args: [{ type: "string", value: "page-two boot" }], timestamp: 500 },
+      ]);
+      await getHandler("webview:start-console-capture")(null, 42, "pane-1");
+
+      expect(consoleRows().map((row) => row.summaryText)).toEqual(["page-one", "page-two boot"]);
+    });
+
+    it("realigns after console.clear() empties the guest buffer", async () => {
+      cleanup = registerWebviewHandlers(deps);
+      await getHandler("webview:start-console-capture")(null, 42, "pane-1");
+      const listener = getMessageListener();
+
+      listener({}, "Runtime.consoleAPICalled", {
+        type: "log",
+        args: [{ type: "string", value: "before" }],
+        timestamp: 1000,
+      });
+      listener({}, "Runtime.consoleAPICalled", { type: "clear", args: [], timestamp: 1001 });
+      listener({}, "Runtime.consoleAPICalled", {
+        type: "log",
+        args: [{ type: "string", value: "after" }],
+        timestamp: 1002,
+      });
+      await getHandler("webview:stop-console-capture")(null, 42, "pane-1");
+
+      // The guest buffer now holds only the clear and what followed it, so a
+      // restart must skip exactly those two and admit nothing twice.
+      replayOnRuntimeEnable([
+        { type: "clear", args: [], timestamp: 1001 },
+        { type: "log", args: [{ type: "string", value: "after" }], timestamp: 1002 },
+        { type: "log", args: [{ type: "string", value: "fresh" }], timestamp: 2000 },
+      ]);
+      await getHandler("webview:start-console-capture")(null, 42, "pane-1");
+
+      // The empty string is the `clear` event's own row. Emitting a blank row
+      // for console.clear() predates this change — `clear` is not even in
+      // CdpConsoleType — and is left alone here.
+      expect(consoleRows().map((row) => row.summaryText)).toEqual(["before", "", "after", "fresh"]);
+    });
+
+    it("keeps the session usable for a start queued behind a failed one", async () => {
+      // The first start's Runtime.enable fails while the guest survives. Its
+      // cleanup must not delete the session a queued start already holds, and
+      // must null the listener refs so that start rebinds rather than assuming
+      // listeners are live.
+      let failEnable = true;
+      debuggerMock.sendCommand.mockImplementation((cmd: string) => {
+        if (cmd === "Runtime.enable" && failEnable) {
+          failEnable = false;
+          return Promise.reject(new Error("Target closed"));
+        }
+        return Promise.resolve();
+      });
+
+      cleanup = registerWebviewHandlers(deps);
+      await getHandler("webview:start-console-capture")(null, 42, "pane-1");
+      debuggerMock.on.mockClear();
+      await getHandler("webview:start-console-capture")(null, 42, "pane-2");
+
+      expect(debuggerMock.on).toHaveBeenCalledWith("message", expect.any(Function));
+      const listener = getMessageListener();
+      listener({}, "Runtime.consoleAPICalled", {
+        type: "log",
+        args: [{ type: "string", value: "recovered" }],
+        timestamp: 1000,
+      });
+      expect(consoleRows().map((row) => row.summaryText)).toContain("recovered");
     });
 
     it("does not re-deliver replayed Log entries after a stop/start cycle", async () => {

--- a/electron/ipc/handlers/__tests__/webviewEmulation.test.ts
+++ b/electron/ipc/handlers/__tests__/webviewEmulation.test.ts
@@ -307,28 +307,7 @@ describe("webviewEmulation handler", () => {
     await expect(queued).resolves.toEqual({ applied: false });
   });
 
-  it("ignores a guest registered to a different panel", async () => {
-    const guest = makeGuest();
-    guestRegistry.set(7, guest);
-    dialogService.getPanelId.mockReturnValue("panel-b");
-
-    const handler = await getHandler();
-    const result = await handler(applyRequest());
-
-    expect(result).toEqual({ applied: false });
-    expect(guest.enableDeviceEmulation).not.toHaveBeenCalled();
-    expect(guest.setUserAgent).not.toHaveBeenCalled();
-  });
-
-  it("reports applied:false rather than letting the caller cache a lie", async () => {
-    const handler = await getHandler();
-    await expect(handler(applyRequest())).resolves.toEqual({ applied: false });
-
-    guestRegistry.set(7, makeGuest());
-    await expect(handler(applyRequest())).resolves.toEqual({ applied: true });
-  });
-
-  it("does not let a clear finish underneath a newer preset", async () => {
+  it("lets the last of three in-flight requests decide the final touch state", async () => {
     const guest = makeGuest();
     const pending: Array<() => void> = [];
     guest.debugger.sendCommand.mockImplementation(

--- a/electron/ipc/handlers/__tests__/webviewEmulation.test.ts
+++ b/electron/ipc/handlers/__tests__/webviewEmulation.test.ts
@@ -220,6 +220,116 @@ describe("webviewEmulation handler", () => {
 
   it("does not let a clear finish underneath a newer preset", async () => {
     const guest = makeGuest();
+    guestRegistry.set(7, guest);
+    const handler = await getHandler();
+
+    // Settle the first preset, so touch is *known* to be on. Without that, a
+    // clear racing a still-unsettled apply would find the cache already false
+    // and skip its touch teardown, hiding the ordering problem.
+    await handler(applyRequest());
+    expect(
+      cdpCalls(guest).filter(([cmd]) => cmd === "Emulation.setTouchEmulationEnabled")
+    ).toHaveLength(1);
+
+    // Now hold the clear's CDP commands open and select another preset behind
+    // it. Serialized, the clear finishes first and the preset's touch setup
+    // lands last; interleaved, the clear's teardown lands on top of it.
+    const pending: Array<() => void> = [];
+    guest.debugger.sendCommand.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          pending.push(resolve);
+        })
+    );
+    const cleared = handler(applyRequest({ emulation: null }));
+    const reapplied = handler(applyRequest());
+
+    for (let i = 0; i < 200; i++) {
+      while (pending.length > 0) pending.shift()!();
+      await Promise.resolve();
+    }
+    await Promise.all([cleared, reapplied]);
+
+    const touchCalls = cdpCalls(guest)
+      .filter(([cmd]) => cmd === "Emulation.setTouchEmulationEnabled")
+      .map(([, params]) => (params as { enabled: boolean }).enabled);
+    expect(touchCalls).toEqual([true, false, true]);
+  });
+
+  it("cleans up touch after a partial failure instead of trusting the cache", async () => {
+    const guest = makeGuest();
+    // The first command lands, the second does not — the guest now has touch
+    // emulation partly on, in a state a boolean cache cannot describe.
+    let call = 0;
+    guest.debugger.sendCommand.mockImplementation(() => {
+      call += 1;
+      return call === 2 ? Promise.reject(new Error("boom")) : Promise.resolve();
+    });
+    guestRegistry.set(7, guest);
+    const handler = await getHandler();
+    await handler(applyRequest());
+
+    guest.debugger.sendCommand.mockClear();
+    guest.debugger.sendCommand.mockImplementation(() => Promise.resolve());
+    await handler(applyRequest({ emulation: null }));
+
+    // A cache that recorded the failed apply as "touch off" would skip this
+    // teardown and leave the guest reporting a coarse pointer on desktop.
+    expect(cdpCalls(guest)).toContainEqual([
+      "Emulation.setTouchEmulationEnabled",
+      { enabled: false, maxTouchPoints: 1 },
+    ]);
+  });
+
+  it("reports applied:false for a queued request whose guest went away", async () => {
+    const guest = makeGuest();
+    const pending: Array<() => void> = [];
+    guest.debugger.sendCommand.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          pending.push(resolve);
+        })
+    );
+    guestRegistry.set(7, guest);
+    const handler = await getHandler();
+
+    const first = handler(applyRequest());
+    const queued = handler(applyRequest({ emulation: null }));
+
+    // The guest dies while the second request is still waiting its turn.
+    guest.isDestroyed = () => true;
+    for (let i = 0; i < 200; i++) {
+      while (pending.length > 0) pending.shift()!();
+      await Promise.resolve();
+    }
+
+    await first;
+    await expect(queued).resolves.toEqual({ applied: false });
+  });
+
+  it("ignores a guest registered to a different panel", async () => {
+    const guest = makeGuest();
+    guestRegistry.set(7, guest);
+    dialogService.getPanelId.mockReturnValue("panel-b");
+
+    const handler = await getHandler();
+    const result = await handler(applyRequest());
+
+    expect(result).toEqual({ applied: false });
+    expect(guest.enableDeviceEmulation).not.toHaveBeenCalled();
+    expect(guest.setUserAgent).not.toHaveBeenCalled();
+  });
+
+  it("reports applied:false rather than letting the caller cache a lie", async () => {
+    const handler = await getHandler();
+    await expect(handler(applyRequest())).resolves.toEqual({ applied: false });
+
+    guestRegistry.set(7, makeGuest());
+    await expect(handler(applyRequest())).resolves.toEqual({ applied: true });
+  });
+
+  it("does not let a clear finish underneath a newer preset", async () => {
+    const guest = makeGuest();
     const pending: Array<() => void> = [];
     guest.debugger.sendCommand.mockImplementation(
       () =>

--- a/electron/ipc/handlers/__tests__/webviewEmulation.test.ts
+++ b/electron/ipc/handlers/__tests__/webviewEmulation.test.ts
@@ -1,0 +1,227 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { DeviceEmulationRequest } from "../../../../shared/types/ipc/webviewEmulation.js";
+
+interface MockGuest {
+  isDestroyed: () => boolean;
+  getUserAgent: ReturnType<typeof vi.fn>;
+  setUserAgent: ReturnType<typeof vi.fn>;
+  enableDeviceEmulation: ReturnType<typeof vi.fn>;
+  disableDeviceEmulation: ReturnType<typeof vi.fn>;
+  once: ReturnType<typeof vi.fn>;
+  debugger: {
+    isAttached: () => boolean;
+    attach: ReturnType<typeof vi.fn>;
+    sendCommand: ReturnType<typeof vi.fn>;
+  };
+}
+
+const guestRegistry = vi.hoisted(() => new Map<number, MockGuest>());
+const dialogService = vi.hoisted(() => ({
+  getPanelId: vi.fn<(webContentsId: number) => string | undefined>(),
+}));
+
+vi.mock("electron", () => ({
+  webContents: {
+    fromId: vi.fn((webContentsId: number) => guestRegistry.get(webContentsId)),
+  },
+}));
+
+vi.mock("../../../services/WebviewDialogService.js", () => ({
+  getWebviewDialogService: () => dialogService,
+}));
+
+function makeGuest(overrides: Partial<MockGuest> = {}): MockGuest {
+  return {
+    isDestroyed: () => false,
+    getUserAgent: vi.fn(() => "Daintree/1.0 Electron desktop UA"),
+    setUserAgent: vi.fn(),
+    enableDeviceEmulation: vi.fn(),
+    disableDeviceEmulation: vi.fn(),
+    once: vi.fn(),
+    debugger: {
+      isAttached: () => true,
+      attach: vi.fn(),
+      sendCommand: vi.fn(() => Promise.resolve()),
+    },
+    ...overrides,
+  };
+}
+
+const IPHONE_PARAMS = {
+  screenPosition: "mobile" as const,
+  screenSize: { width: 393, height: 852 },
+  viewPosition: { x: 0, y: 0 },
+  deviceScaleFactor: 3,
+  viewSize: { width: 393, height: 852 },
+  scale: 1,
+};
+
+const MOBILE_UA = "Mozilla/5.0 (iPhone; CPU iPhone OS 19_4 like Mac OS X) Mobile/15E148";
+
+function applyRequest(overrides: Partial<DeviceEmulationRequest> = {}): DeviceEmulationRequest {
+  return {
+    webContentsId: 7,
+    panelId: "panel-a",
+    emulation: { params: IPHONE_PARAMS, userAgent: MOBILE_UA, touch: true },
+    ...overrides,
+  };
+}
+
+async function getHandler() {
+  const { webviewEmulationNamespace } = await import("../webviewEmulation.js");
+  return webviewEmulationNamespace.ops.setDeviceEmulation.handler as (
+    payload: DeviceEmulationRequest
+  ) => Promise<void>;
+}
+
+function cdpCalls(guest: MockGuest) {
+  return guest.debugger.sendCommand.mock.calls as Array<[string, Record<string, unknown>]>;
+}
+
+describe("webviewEmulation handler", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    guestRegistry.clear();
+    dialogService.getPanelId.mockReset();
+    dialogService.getPanelId.mockReturnValue("panel-a");
+  });
+
+  it("applies viewport metrics and the spoofed user agent to the registered guest", async () => {
+    const guest = makeGuest();
+    guestRegistry.set(7, guest);
+
+    const handler = await getHandler();
+    await handler(applyRequest());
+
+    expect(guest.setUserAgent).toHaveBeenCalledWith(MOBILE_UA);
+    expect(guest.enableDeviceEmulation).toHaveBeenCalledWith(IPHONE_PARAMS);
+  });
+
+  it("emulates touch and the coarse pointer/no-hover media features", async () => {
+    const guest = makeGuest();
+    guestRegistry.set(7, guest);
+
+    const handler = await getHandler();
+    await handler(applyRequest());
+
+    const calls = cdpCalls(guest);
+    expect(calls).toContainEqual([
+      "Emulation.setTouchEmulationEnabled",
+      { enabled: true, maxTouchPoints: 5 },
+    ]);
+    expect(calls).toContainEqual([
+      "Emulation.setEmitTouchEventsForMouse",
+      { enabled: true, configuration: "mobile" },
+    ]);
+    const media = calls.find(([cmd]) => cmd === "Emulation.setEmulatedMedia");
+    expect(media?.[1]).toEqual({
+      features: [
+        { name: "pointer", value: "coarse" },
+        { name: "any-pointer", value: "coarse" },
+        { name: "hover", value: "none" },
+        { name: "any-hover", value: "none" },
+      ],
+    });
+  });
+
+  it("restores the guest's own user agent and native metrics on a null payload", async () => {
+    const guest = makeGuest();
+    guestRegistry.set(7, guest);
+    const handler = await getHandler();
+
+    await handler(applyRequest());
+    await handler(applyRequest({ emulation: null }));
+
+    expect(guest.disableDeviceEmulation).toHaveBeenCalledTimes(1);
+    expect(guest.setUserAgent).toHaveBeenLastCalledWith("Daintree/1.0 Electron desktop UA");
+    expect(cdpCalls(guest)).toContainEqual([
+      "Emulation.setTouchEmulationEnabled",
+      { enabled: false, maxTouchPoints: 1 },
+    ]);
+    expect(
+      cdpCalls(guest).filter(([cmd, params]) => {
+        return cmd === "Emulation.setEmulatedMedia" && (params as { features: [] }).features;
+      })
+    ).toContainEqual(["Emulation.setEmulatedMedia", { features: [] }]);
+  });
+
+  it("captures the original user agent only once across repeated applies", async () => {
+    const guest = makeGuest();
+    guestRegistry.set(7, guest);
+    const handler = await getHandler();
+
+    await handler(applyRequest());
+    await handler(
+      applyRequest({ emulation: { params: IPHONE_PARAMS, userAgent: "other", touch: true } })
+    );
+    await handler(applyRequest({ emulation: null }));
+
+    expect(guest.getUserAgent).toHaveBeenCalledTimes(1);
+    expect(guest.setUserAgent).toHaveBeenLastCalledWith("Daintree/1.0 Electron desktop UA");
+  });
+
+  it("does not re-issue touch commands when the touch state is unchanged", async () => {
+    const guest = makeGuest();
+    guestRegistry.set(7, guest);
+    const handler = await getHandler();
+
+    await handler(applyRequest());
+    await handler(applyRequest());
+
+    const touchCalls = cdpCalls(guest).filter(
+      ([cmd]) => cmd === "Emulation.setTouchEmulationEnabled"
+    );
+    expect(touchCalls).toHaveLength(1);
+  });
+
+  it("still applies viewport metrics when the touch CDP commands fail", async () => {
+    const guest = makeGuest();
+    guest.debugger.sendCommand.mockRejectedValue(new Error("Target closed"));
+    guestRegistry.set(7, guest);
+
+    const handler = await getHandler();
+    await handler(applyRequest());
+
+    expect(guest.enableDeviceEmulation).toHaveBeenCalledWith(IPHONE_PARAMS);
+  });
+
+  it("survives a guest that never had emulation enabled", async () => {
+    const guest = makeGuest({
+      disableDeviceEmulation: vi.fn(() => {
+        throw new Error("Device emulation is not enabled");
+      }),
+    });
+    guestRegistry.set(7, guest);
+
+    const handler = await getHandler();
+    await expect(handler(applyRequest({ emulation: null }))).resolves.toBeUndefined();
+  });
+
+  it("ignores a guest registered to a different panel", async () => {
+    const guest = makeGuest();
+    guestRegistry.set(7, guest);
+    dialogService.getPanelId.mockReturnValue("panel-b");
+
+    const handler = await getHandler();
+    await handler(applyRequest());
+
+    expect(guest.enableDeviceEmulation).not.toHaveBeenCalled();
+    expect(guest.setUserAgent).not.toHaveBeenCalled();
+  });
+
+  it("ignores an unregistered guest", async () => {
+    const guest = makeGuest();
+    guestRegistry.set(7, guest);
+    dialogService.getPanelId.mockReturnValue(undefined);
+
+    const handler = await getHandler();
+    await handler(applyRequest());
+
+    expect(guest.enableDeviceEmulation).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when the guest is gone", async () => {
+    const handler = await getHandler();
+    await expect(handler(applyRequest())).resolves.toBeUndefined();
+  });
+});

--- a/electron/ipc/handlers/__tests__/webviewEmulation.test.ts
+++ b/electron/ipc/handlers/__tests__/webviewEmulation.test.ts
@@ -71,7 +71,7 @@ async function getHandler() {
   const { webviewEmulationNamespace } = await import("../webviewEmulation.js");
   return webviewEmulationNamespace.ops.setDeviceEmulation.handler as (
     payload: DeviceEmulationRequest
-  ) => Promise<void>;
+  ) => Promise<{ applied: boolean }>;
 }
 
 function cdpCalls(guest: MockGuest) {
@@ -160,7 +160,7 @@ describe("webviewEmulation handler", () => {
     expect(guest.setUserAgent).toHaveBeenLastCalledWith("Daintree/1.0 Electron desktop UA");
   });
 
-  it("does not re-issue touch commands when the touch state is unchanged", async () => {
+  it("does not re-issue touch commands when the state is known and unchanged", async () => {
     const guest = makeGuest();
     guestRegistry.set(7, guest);
     const handler = await getHandler();
@@ -194,7 +194,7 @@ describe("webviewEmulation handler", () => {
     guestRegistry.set(7, guest);
 
     const handler = await getHandler();
-    await expect(handler(applyRequest({ emulation: null }))).resolves.toBeUndefined();
+    await expect(handler(applyRequest({ emulation: null }))).resolves.toEqual({ applied: true });
   });
 
   it("ignores a guest registered to a different panel", async () => {
@@ -203,10 +203,77 @@ describe("webviewEmulation handler", () => {
     dialogService.getPanelId.mockReturnValue("panel-b");
 
     const handler = await getHandler();
-    await handler(applyRequest());
+    const result = await handler(applyRequest());
 
+    expect(result).toEqual({ applied: false });
     expect(guest.enableDeviceEmulation).not.toHaveBeenCalled();
     expect(guest.setUserAgent).not.toHaveBeenCalled();
+  });
+
+  it("reports applied:false rather than letting the caller cache a lie", async () => {
+    const handler = await getHandler();
+    await expect(handler(applyRequest())).resolves.toEqual({ applied: false });
+
+    guestRegistry.set(7, makeGuest());
+    await expect(handler(applyRequest())).resolves.toEqual({ applied: true });
+  });
+
+  it("does not let a clear finish underneath a newer preset", async () => {
+    const guest = makeGuest();
+    const pending: Array<() => void> = [];
+    guest.debugger.sendCommand.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          pending.push(resolve);
+        })
+    );
+    guestRegistry.set(7, guest);
+    const handler = await getHandler();
+
+    // Apply a preset, then clear, then apply again — all while every CDP
+    // command is still outstanding.
+    const first = handler(applyRequest());
+    const cleared = handler(applyRequest({ emulation: null }));
+    const second = handler(applyRequest());
+
+    // Requests are serialized, so the next batch of CDP commands is only
+    // issued once the previous request finishes — keep draining past the
+    // moments when nothing is outstanding.
+    for (let i = 0; i < 200; i++) {
+      while (pending.length > 0) pending.shift()!();
+      await Promise.resolve();
+    }
+    await Promise.all([first, cleared, second]);
+
+    // Serialized, so the last request wins: the guest ends up emulated, not
+    // left with the clear's touch teardown applied on top of it.
+    const touchCalls = cdpCalls(guest)
+      .filter(([cmd]) => cmd === "Emulation.setTouchEmulationEnabled")
+      .map(([, params]) => (params as { enabled: boolean }).enabled);
+    expect(touchCalls[touchCalls.length - 1]).toBe(true);
+  });
+
+  it("re-issues touch commands after a partial failure instead of trusting the cache", async () => {
+    const guest = makeGuest();
+    // The first command lands, the second does not — the guest is now in a
+    // state the cache cannot describe.
+    let call = 0;
+    guest.debugger.sendCommand.mockImplementation(() => {
+      call += 1;
+      return call === 2 ? Promise.reject(new Error("boom")) : Promise.resolve();
+    });
+    guestRegistry.set(7, guest);
+    const handler = await getHandler();
+
+    await handler(applyRequest());
+    guest.debugger.sendCommand.mockClear();
+    guest.debugger.sendCommand.mockImplementation(() => Promise.resolve());
+    await handler(applyRequest());
+
+    expect(cdpCalls(guest)).toContainEqual([
+      "Emulation.setTouchEmulationEnabled",
+      { enabled: true, maxTouchPoints: 5 },
+    ]);
   });
 
   it("ignores an unregistered guest", async () => {
@@ -222,6 +289,6 @@ describe("webviewEmulation handler", () => {
 
   it("does nothing when the guest is gone", async () => {
     const handler = await getHandler();
-    await expect(handler(applyRequest())).resolves.toBeUndefined();
+    await expect(handler(applyRequest())).resolves.toEqual({ applied: false });
   });
 });

--- a/electron/ipc/handlers/webview.ts
+++ b/electron/ipc/handlers/webview.ts
@@ -41,6 +41,13 @@ interface CdpSession {
   consoleWatermark: ReplayWatermark;
   exceptionWatermark: ReplayWatermark;
   logEntryWatermark: ReplayWatermark;
+  /**
+   * Guest URL as of the last enable. A navigation while capture is stopped
+   * empties the guest's console buffer without an `executionContextsCleared`
+   * anyone is listening for, so the replay bookkeeping has to be checked
+   * against the document it was collected on.
+   */
+  lastKnownUrl: string | null;
   /** `destroyed` cleanup hook, held so teardown can detach it with the rest. */
   destroyListener: (() => void) | null;
   /**
@@ -136,6 +143,7 @@ function getOrCreateSession(wcId: number): CdpSession {
       consoleWatermark: createReplayWatermark(),
       exceptionWatermark: createReplayWatermark(),
       logEntryWatermark: createReplayWatermark(),
+      lastKnownUrl: null,
       destroyListener: null,
       transitionQueue: Promise.resolve(),
       logRateLimit: new Map(),
@@ -298,6 +306,14 @@ function releaseObjectIds(wcId: number, objectIds: Iterable<string>): void {
  * timestamps are epoch milliseconds that are neither unique (a burst shares a
  * millisecond) nor guaranteed to increase (a clock step can move them
  * backwards), and either property alone loses real rows.
+ *
+ * Known limit: V8's message storage is bounded and evicts from the front, so a
+ * page that logs more than its capacity while capture is stopped breaks the
+ * prefix assumption and the oldest of the new messages are skipped. Aligning
+ * through that needs per-event identity, which CDP does not give us; the
+ * alternative — admitting on doubt — duplicates visible rows instead. Both
+ * remain far better than the previous behaviour, which dropped every replayed
+ * message unconditionally.
  */
 interface ReplayWatermark {
   /** Events admitted from this stream since the buffer was last cleared. */
@@ -413,7 +429,13 @@ async function releaseObjectsForPane(
   );
 }
 
-function cleanupSession(wcId: number): void {
+/**
+ * Unbind a session's debugger listeners without discarding the session.
+ * Nulling the references matters: the start handler treats a non-null
+ * `messageListener` as "already bound", so leaving a stale reference behind
+ * would make the next start skip rebinding and capture silently nothing.
+ */
+function detachSessionListeners(wcId: number): void {
   const session = sessions.get(wcId);
   if (!session) return;
 
@@ -432,6 +454,15 @@ function cleanupSession(wcId: number): void {
     }
   }
 
+  session.messageListener = null;
+  session.detachListener = null;
+  session.destroyListener = null;
+  session.runtimeEnabled = false;
+  session.logEnabled = false;
+}
+
+function cleanupSession(wcId: number): void {
+  detachSessionListeners(wcId);
   sessions.delete(wcId);
 }
 
@@ -473,6 +504,27 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
     wc: Electron.WebContents,
     session: CdpSession
   ): Promise<void> {
+    // The guest may have navigated while capture was stopped, which empties its
+    // console buffer. Without this the replay bookkeeping from the old document
+    // would skip the new one's startup messages — the exact loss this issue is
+    // about, just moved.
+    let currentUrl: string | null = null;
+    try {
+      currentUrl = wc.getURL();
+    } catch {
+      // Guest torn down mid-transition; leave the bookkeeping alone.
+    }
+    if (
+      currentUrl !== null &&
+      session.lastKnownUrl !== null &&
+      currentUrl !== session.lastKnownUrl
+    ) {
+      resetReplayWatermark(session.consoleWatermark);
+      resetReplayWatermark(session.exceptionWatermark);
+      resetReplayWatermark(session.logEntryWatermark);
+    }
+    if (currentUrl !== null) session.lastKnownUrl = currentUrl;
+
     if (!session.runtimeEnabled) {
       openReplayWindow(session.consoleWatermark, session.exceptionWatermark);
       try {
@@ -576,6 +628,11 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
               resetReplayWatermark(session.consoleWatermark);
               resetReplayWatermark(session.exceptionWatermark);
               resetReplayWatermark(session.logEntryWatermark);
+              try {
+                session.lastKnownUrl = wc.getURL();
+              } catch {
+                session.lastKnownUrl = null;
+              }
               // Reset group depth and drop stale handle ownership for all
               // panes. No release call: the guest already invalidated every
               // handle when the execution context went away.
@@ -659,9 +716,11 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
     } catch (err) {
       // Setup failed after the listeners were bound. Unwind them when this call
       // is the only thing holding the session, so a guest that can never be
-      // instrumented is not left with dangling debugger listeners.
+      // instrumented is not left with dangling debugger listeners. The session
+      // object itself stays: another start may already be queued behind this
+      // one and holds a reference to it.
       if (boundListenersHere && !session.runtimeEnabled && session.paneIds.size <= 1) {
-        cleanupSession(webContentsId);
+        detachSessionListeners(webContentsId);
       }
       const message = formatErrorMessage(err, "CDP console capture start failed");
       const isExpected =
@@ -688,6 +747,15 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
     // the enable window is reconciled, so messages logged while capture was
     // stopped still arrive.
     if (!admitEvent(session.consoleWatermark)) return;
+
+    // Read the raw protocol type for this check: `clear` is not part of
+    // CdpConsoleType, so the cast below would hide it. console.clear() empties
+    // the guest's message storage and leaves only this event in it, so the
+    // replay prefix is now exactly one event long.
+    if (p.type === "clear") {
+      session.consoleWatermark.delivered = 1;
+      resetReplayWatermark(session.exceptionWatermark);
+    }
 
     const cdpType = (p.type ?? "log") as CdpConsoleType;
 

--- a/electron/ipc/handlers/webview.ts
+++ b/electron/ipc/handlers/webview.ts
@@ -43,6 +43,13 @@ interface CdpSession {
   logEntryWatermark: ReplayWatermark;
   /** `destroyed` cleanup hook, held so teardown can detach it with the rest. */
   destroyListener: (() => void) | null;
+  /**
+   * Capture starts and stops for one guest run one at a time. Both mutate pane
+   * membership either side of an await and then decide the domain state from
+   * it, so interleaving them lets a stop disable domains a start just adopted,
+   * or delete a registration a restart just made.
+   */
+  transitionQueue: Promise<void>;
   // Per-session throttle for `Log.entryAdded` — browser-emitted entries
   // (CSP, network, deprecation) can flood. Keyed by source:level:url:line.
   logRateLimit: Map<string, { count: number; resetAt: number }>;
@@ -130,6 +137,7 @@ function getOrCreateSession(wcId: number): CdpSession {
       exceptionWatermark: createReplayWatermark(),
       logEntryWatermark: createReplayWatermark(),
       destroyListener: null,
+      transitionQueue: Promise.resolve(),
       logRateLimit: new Map(),
       ownerWindow: null,
       messageListener: null,
@@ -284,84 +292,57 @@ function releaseObjectIds(wcId: number, objectIds: Iterable<string>): void {
 /**
  * How much of one CDP event stream the renderer has already been given.
  *
- * CDP timestamps are epoch milliseconds and are neither unique nor guaranteed
- * to increase, so a timestamp alone cannot identify an event. Pairing the
- * newest timestamp with how many events carried it lets a replay skip exactly
- * the events already delivered and admit distinct ones that merely landed in
- * the same millisecond.
+ * Reconciliation is positional, not timestamp-based. The guest's console buffer
+ * is append-only and replays in emission order, so "how many we already took"
+ * identifies the already-delivered prefix exactly. Timestamps cannot: CDP
+ * timestamps are epoch milliseconds that are neither unique (a burst shares a
+ * millisecond) nor guaranteed to increase (a clock step can move them
+ * backwards), and either property alone loses real rows.
  */
 interface ReplayWatermark {
-  timestamp: number;
-  count: number;
-  /** Set while the stream's enable command is in flight — its replay window. */
+  /** Events admitted from this stream since the buffer was last cleared. */
+  delivered: number;
+  /** Events still to skip in the current replay window. */
+  skipRemaining: number;
   replaying: boolean;
-  /** Watermark as of the moment the window opened; the live one keeps moving. */
-  replayFromTimestamp: number;
-  replayFromCount: number;
-  /** Events seen at `replayFromTimestamp` since the window opened. */
-  replaySeenAtTimestamp: number;
 }
 
 function createReplayWatermark(): ReplayWatermark {
-  return {
-    timestamp: 0,
-    count: 0,
-    replaying: false,
-    replayFromTimestamp: 0,
-    replayFromCount: 0,
-    replaySeenAtTimestamp: 0,
-  };
+  return { delivered: 0, skipRemaining: 0, replaying: false };
 }
 
 function openReplayWindow(...watermarks: ReplayWatermark[]): void {
   for (const w of watermarks) {
     w.replaying = true;
-    w.replayFromTimestamp = w.timestamp;
-    w.replayFromCount = w.count;
-    w.replaySeenAtTimestamp = 0;
+    w.skipRemaining = w.delivered;
   }
 }
 
 function closeReplayWindow(...watermarks: ReplayWatermark[]): void {
-  for (const w of watermarks) w.replaying = false;
-}
-
-function resetReplayWatermark(w: ReplayWatermark): void {
-  w.timestamp = 0;
-  w.count = 0;
-  w.replayFromTimestamp = 0;
-  w.replayFromCount = 0;
-  w.replaySeenAtTimestamp = 0;
+  for (const w of watermarks) {
+    w.replaying = false;
+    w.skipRemaining = 0;
+  }
 }
 
 /**
- * Whether to deliver this event, advancing the watermark when we do.
- *
- * Inside a replay window everything up to the pre-enable watermark has already
- * reached the renderer and is dropped; everything past it is new. An event with
- * no usable timestamp can't be matched at all, so it is delivered rather than
- * risk losing something the renderer never saw.
+ * Reset after the guest's buffer is genuinely gone. Only an execution-context
+ * clear does that — a debugger detach leaves the buffer intact, so resetting
+ * there would re-admit everything on the next attach.
  */
-function admitEvent(w: ReplayWatermark, timestamp: number | null): boolean {
-  if (timestamp === null) return true;
-
-  if (w.replaying && timestamp <= w.replayFromTimestamp) {
-    if (timestamp < w.replayFromTimestamp) return false;
-    w.replaySeenAtTimestamp += 1;
-    if (w.replaySeenAtTimestamp <= w.replayFromCount) return false;
-  }
-
-  if (timestamp > w.timestamp) {
-    w.timestamp = timestamp;
-    w.count = 1;
-  } else if (timestamp === w.timestamp) {
-    w.count += 1;
-  }
-  return true;
+function resetReplayWatermark(w: ReplayWatermark): void {
+  w.delivered = 0;
+  w.skipRemaining = 0;
 }
 
-function eventTimestampOf(value: unknown): number | null {
-  return typeof value === "number" && Number.isFinite(value) ? value : null;
+/** Whether to deliver this event, counting it against the stream when we do. */
+function admitEvent(w: ReplayWatermark): boolean {
+  if (w.replaying && w.skipRemaining > 0) {
+    w.skipRemaining -= 1;
+    return false;
+  }
+  w.delivered += 1;
+  return true;
 }
 
 function objectIdsFromArgs(args: CdpRemoteArg[]): string[] {
@@ -472,6 +453,16 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
   };
 
   /**
+   * Run a capture transition after every earlier one for the same guest.
+   * A rejection is contained so one failed transition cannot wedge the queue.
+   */
+  function enqueueTransition(session: CdpSession, work: () => Promise<void>): Promise<void> {
+    const running = session.transitionQueue.then(work);
+    session.transitionQueue = running.catch(() => {});
+    return running;
+  }
+
+  /**
    * Enable the console domains for a session whose listeners are already bound.
    * Ordering matters: both enables replay their guest-side buffer, so the
    * listener has to be live first, and each enable opens its stream's replay
@@ -526,6 +517,17 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
     if (!wc || wc.isDestroyed()) return;
 
     const session = getOrCreateSession(webContentsId);
+    return enqueueTransition(session, () => startCapture(webContentsId, wc, session, paneId));
+  };
+
+  async function startCapture(
+    webContentsId: number,
+    wc: Electron.WebContents,
+    session: CdpSession,
+    paneId: string
+  ): Promise<void> {
+    if (wc.isDestroyed()) return;
+
     session.paneIds.add(paneId);
     session.groupDepthByPane.set(paneId, 0);
 
@@ -616,9 +618,10 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
             session.messageListener = null;
             session.detachListener = null;
             session.navigationGeneration++;
-            resetReplayWatermark(session.consoleWatermark);
-            resetReplayWatermark(session.exceptionWatermark);
-            resetReplayWatermark(session.logEntryWatermark);
+            // Deliberately NOT resetting the replay watermarks: a debugger
+            // detach leaves the guest's console buffer intact, so the next
+            // attach replays it and everything already delivered would arrive
+            // a second time.
             for (const pid of session.paneIds) {
               session.groupDepthByPane.set(pid, 0);
               session.rowObjectIdsByPane.get(pid)?.clear();
@@ -672,7 +675,7 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
         );
       }
     }
-  };
+  }
 
   function handleConsoleApiCalled(wcId: number, session: CdpSession, params: unknown): void {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -684,7 +687,7 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
     // store keeps its rows) would duplicate everything still on screen. Only
     // the enable window is reconciled, so messages logged while capture was
     // stopped still arrive.
-    if (!admitEvent(session.consoleWatermark, eventTimestampOf(p.timestamp))) return;
+    if (!admitEvent(session.consoleWatermark)) return;
 
     const cdpType = (p.type ?? "log") as CdpConsoleType;
 
@@ -759,7 +762,7 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
     // Runtime.enable replays buffered exceptions alongside console calls, so
     // these need their own reconciliation — the console watermark's progress
     // says nothing about which exceptions the renderer already has.
-    if (!admitEvent(session.exceptionWatermark, eventTimestampOf(p.timestamp))) return;
+    if (!admitEvent(session.exceptionWatermark)) return;
 
     const summaryText: string =
       details.exception?.description ?? details.text ?? "Uncaught (unknown exception)";
@@ -794,7 +797,7 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
     // so a stop/start cycle would duplicate CSP, network and deprecation rows
     // the renderer still displays. Reconciled before the rate limiter, so a
     // replay can't consume the allowance a live failure needs.
-    if (!admitEvent(session.logEntryWatermark, eventTimestampOf(entry.timestamp))) return;
+    if (!admitEvent(session.logEntryWatermark)) return;
 
     const source = normalizeLogEntrySource(entry.source);
     const level = logEntryLevelToLevel(entry.level);
@@ -837,6 +840,14 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
     const session = sessions.get(webContentsId);
     if (!session) return;
 
+    return enqueueTransition(session, () => stopCapture(webContentsId, session, paneId));
+  };
+
+  async function stopCapture(
+    webContentsId: number,
+    session: CdpSession,
+    paneId: string
+  ): Promise<void> {
     const wc = webContents.fromId(webContentsId);
     if (wc && !wc.isDestroyed()) {
       await releaseObjectsForPane(wc, session, paneId);
@@ -848,9 +859,10 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
 
     // If no more panes are capturing, disable the domains but keep the session.
     // Its listeners are inert while the domains are off, and holding it keeps
-    // the replay watermarks so the replay a later Runtime.enable triggers can
+    // the replay bookkeeping so the replay a later Runtime.enable triggers can
     // be reconciled against what the renderer already displays. The session is
-    // disposed by the guest's `destroyed` hook or by handler teardown.
+    // disposed by the guest's `destroyed` hook or by handler teardown. No start
+    // can interleave here — transitions are serialized per guest.
     if (session.paneIds.size === 0 && wc && !wc.isDestroyed()) {
       if (session.runtimeEnabled) {
         try {
@@ -868,22 +880,8 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
         }
         session.logEnabled = false;
       }
-
-      // A start that raced this teardown saw the domains still enabled and
-      // skipped enabling them, so it would come back to a pane that never
-      // receives another message. Re-enable for whoever arrived.
-      if (session.paneIds.size > 0) {
-        try {
-          await enableConsoleDomains(webContentsId, wc, session);
-        } catch (err) {
-          console.warn(
-            `[webview] CDP re-enable after a raced stop failed for id=${webContentsId}:`,
-            formatErrorMessage(err, "console domain re-enable failed")
-          );
-        }
-      }
     }
-  };
+  }
 
   const handleClearConsoleCapture = async (
     webContentsId: unknown,

--- a/electron/ipc/handlers/webview.ts
+++ b/electron/ipc/handlers/webview.ts
@@ -17,6 +17,7 @@ import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
 import { AppError } from "../../utils/errorTypes.js";
 import { logError, logWarn } from "../../utils/logger.js";
 import { freezeWebContents, unfreezeWebContents } from "../../utils/webContentsLifecycle.js";
+import { MAX_CONSOLE_ROWS } from "../../../shared/config/devPreviewConsole.js";
 
 interface CdpSession {
   runtimeEnabled: boolean;
@@ -24,7 +25,23 @@ interface CdpSession {
   paneIds: Set<string>;
   navigationGeneration: number;
   groupDepthByPane: Map<string, number>;
-  objectIdsByPane: Map<string, Set<string>>;
+  /**
+   * CDP remote-object handles, owned per console row rather than per pane, so
+   * evicting a row can release exactly its handles. Insertion order is the
+   * emission order, which makes the inner map the eviction FIFO.
+   */
+  rowObjectIdsByPane: Map<string, Map<number, Set<string>>>;
+  /**
+   * Newest `Runtime.consoleAPICalled` timestamp already delivered to the
+   * renderer. `Runtime.enable` replays the guest's buffered console messages,
+   * so a stop/start cycle would re-deliver everything the renderer still has on
+   * screen; replayed events at or below this watermark are dropped.
+   */
+  lastConsoleTimestamp: number;
+  /** True only while a `Runtime.enable` command is in flight (its replay window). */
+  replayingRuntimeEnable: boolean;
+  /** Whether a `destroyed` cleanup hook has been installed on the guest. */
+  destroyHookInstalled: boolean;
   // Per-session throttle for `Log.entryAdded` — browser-emitted entries
   // (CSP, network, deprecation) can flood. Keyed by source:level:url:line.
   logRateLimit: Map<string, { count: number; resetAt: number }>;
@@ -107,7 +124,10 @@ function getOrCreateSession(wcId: number): CdpSession {
       paneIds: new Set(),
       navigationGeneration: 0,
       groupDepthByPane: new Map(),
-      objectIdsByPane: new Map(),
+      rowObjectIdsByPane: new Map(),
+      lastConsoleTimestamp: 0,
+      replayingRuntimeEnable: false,
+      destroyHookInstalled: false,
       logRateLimit: new Map(),
       ownerWindow: null,
       messageListener: null,
@@ -232,22 +252,71 @@ function normalizeStackTrace(st: any): CdpStackTrace | undefined {
     callFrames: st.callFrames.map((f: any) => ({
       functionName: f.functionName ?? "",
       url: f.url ?? "",
-      lineNumber: f.lineNumber ?? 0,
-      columnNumber: f.columnNumber ?? 0,
+      // CDP `Runtime.CallFrame` line/column are zero-based; every consumer of
+      // a serialized frame (display, clipboard) wants the one-based file
+      // location developers expect, so convert once here rather than at each
+      // render site where the two could drift apart (#12298).
+      lineNumber: (f.lineNumber ?? 0) + 1,
+      columnNumber: (f.columnNumber ?? 0) + 1,
     })),
   };
 }
 
-function trackObjectIds(session: CdpSession, paneId: string, args: CdpRemoteArg[]): void {
-  let ids = session.objectIdsByPane.get(paneId);
-  if (!ids) {
-    ids = new Set();
-    session.objectIdsByPane.set(paneId, ids);
+/**
+ * Best-effort release of CDP remote-object handles. Releasing an id that the
+ * guest already invalidated (navigation, GC) is a benign CDP rejection, so
+ * every failure is swallowed.
+ */
+function releaseObjectIds(wcId: number, objectIds: Iterable<string>): void {
+  const wc = webContents.fromId(wcId);
+  if (!wc || wc.isDestroyed()) return;
+  for (const objectId of objectIds) {
+    try {
+      wc.debugger.sendCommand("Runtime.releaseObject", { objectId }).catch(() => {});
+    } catch {
+      // Debugger detached between the destroyed check and the send.
+    }
   }
+}
+
+function objectIdsFromArgs(args: CdpRemoteArg[]): string[] {
+  const ids: string[] = [];
   for (const arg of args) {
     if ((arg.type === "object" || arg.type === "function") && arg.objectId) {
-      ids.add(arg.objectId);
+      ids.push(arg.objectId);
     }
+  }
+  return ids;
+}
+
+/**
+ * Record a row's handle ownership and evict past the renderer's row cap.
+ *
+ * Every emitted row gets a record, including rows carrying no handles, because
+ * the renderer's cap counts rows, not handles — mirroring it here is what keeps
+ * main's eviction boundary identical to the store's without an extra IPC round
+ * trip per eviction. See MAX_CONSOLE_ROWS.
+ */
+function recordRowObjects(
+  wcId: number,
+  session: CdpSession,
+  paneId: string,
+  rowId: number,
+  objectIds: string[]
+): void {
+  let rows = session.rowObjectIdsByPane.get(paneId);
+  if (!rows) {
+    rows = new Map();
+    session.rowObjectIdsByPane.set(paneId, rows);
+  }
+  rows.set(rowId, new Set(objectIds));
+
+  while (rows.size > MAX_CONSOLE_ROWS) {
+    const oldest = rows.keys().next();
+    if (oldest.done) break;
+    const evictedIds = rows.get(oldest.value);
+    rows.delete(oldest.value);
+    if (evictedIds && evictedIds.size > 0) releaseObjectIds(wcId, evictedIds);
   }
 }
 
@@ -256,19 +325,26 @@ async function releaseObjectsForPane(
   session: CdpSession,
   paneId: string
 ): Promise<void> {
-  const ids = session.objectIdsByPane.get(paneId);
-  if (!ids || ids.size === 0) return;
+  const rows = session.rowObjectIdsByPane.get(paneId);
+  if (!rows || rows.size === 0) return;
 
-  const releasePromises: Promise<void>[] = [];
-  for (const objectId of ids) {
-    releasePromises.push(
+  const ids: string[] = [];
+  for (const rowIds of rows.values()) {
+    for (const objectId of rowIds) ids.push(objectId);
+  }
+  // Drop ownership before awaiting: an expansion result landing mid-release
+  // must not attach new handles to a record that is about to disappear, and
+  // must not read a released row as still owning anything.
+  rows.clear();
+  if (ids.length === 0) return;
+
+  await Promise.allSettled(
+    ids.map((objectId) =>
       wc.debugger.sendCommand("Runtime.releaseObject", { objectId }).catch(() => {
         // Ignore release failures (object may already be GC'd)
       })
-    );
-  }
-  await Promise.allSettled(releasePromises);
-  ids.clear();
+    )
+  );
 }
 
 function cleanupSession(wcId: number): void {
@@ -327,20 +403,24 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
       session.ownerWindow = hostWc ? getWindowForWebContents(hostWc) : null;
     }
 
-    if (!session.objectIdsByPane.has(paneId)) {
-      session.objectIdsByPane.set(paneId, new Set());
+    if (!session.rowObjectIdsByPane.has(paneId)) {
+      session.rowObjectIdsByPane.set(paneId, new Map());
     }
 
+    // Sessions outlive capture (see handleStopConsoleCapture), so tie their
+    // lifetime to the guest rather than to the last pane that stopped.
+    if (!session.destroyHookInstalled && typeof wc.once === "function") {
+      session.destroyHookInstalled = true;
+      wc.once("destroyed", () => cleanupSession(webContentsId));
+    }
+
+    let boundListenersHere = false;
     try {
       ensureAttached(wc);
 
-      if (!session.runtimeEnabled) {
-        await wc.debugger.sendCommand("Runtime.enable");
-        session.runtimeEnabled = true;
-      }
-
       // Bind CDP message listener once per webContents
       if (!session.messageListener) {
+        boundListenersHere = true;
         const listener = (_event: Electron.Event, method: string, params: unknown) => {
           // CDP events can arrive synchronously mid-teardown (the renderer's
           // detach hasn't flushed the buffered emit). Guard the whole body so a
@@ -349,18 +429,23 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
             if (method === "Runtime.consoleAPICalled") {
               handleConsoleApiCalled(webContentsId, session, params);
             } else if (method === "Runtime.exceptionThrown") {
-              handleExceptionThrown(session, params);
+              handleExceptionThrown(webContentsId, session, params);
             } else if (method === "Log.entryAdded") {
-              handleLogEntryAdded(session, params);
+              handleLogEntryAdded(webContentsId, session, params);
             } else if (method === "Runtime.executionContextsCleared") {
               session.navigationGeneration++;
               // Rate state from the previous page is meaningless after
               // navigation, and its keys embed that page's URLs.
               session.logRateLimit.clear();
-              // Reset group depth and clear stale objectIds for all panes
+              // The new document has not delivered anything yet, so nothing is
+              // a duplicate of what the renderer already holds.
+              session.lastConsoleTimestamp = 0;
+              // Reset group depth and drop stale handle ownership for all
+              // panes. No release call: the guest already invalidated every
+              // handle when the execution context went away.
               for (const pid of session.paneIds) {
                 session.groupDepthByPane.set(pid, 0);
-                session.objectIdsByPane.get(pid)?.clear();
+                session.rowObjectIdsByPane.get(pid)?.clear();
                 const payload = {
                   paneId: pid,
                   navigationGeneration: session.navigationGeneration,
@@ -397,9 +482,10 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
             session.messageListener = null;
             session.detachListener = null;
             session.navigationGeneration++;
+            session.lastConsoleTimestamp = 0;
             for (const pid of session.paneIds) {
               session.groupDepthByPane.set(pid, 0);
-              session.objectIdsByPane.get(pid)?.clear();
+              session.rowObjectIdsByPane.get(pid)?.clear();
               const payload = {
                 paneId: pid,
                 navigationGeneration: session.navigationGeneration,
@@ -425,6 +511,21 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
         wc.debugger.on("detach", detachListener);
       }
 
+      // Enabled AFTER the message listener is wired: Runtime.enable replays the
+      // guest's buffered console messages as a side effect, and that replay
+      // lands before this await resolves. Enabling first — as this handler used
+      // to — dropped everything the page logged before capture attached, which
+      // is every startup log for a page that had already booted (#12298).
+      if (!session.runtimeEnabled) {
+        session.replayingRuntimeEnable = true;
+        try {
+          await wc.debugger.sendCommand("Runtime.enable");
+          session.runtimeEnabled = true;
+        } finally {
+          session.replayingRuntimeEnable = false;
+        }
+      }
+
       // Log domain surfaces browser-emitted entries (CSP violations, network
       // failures, deprecations) that never reach Runtime.consoleAPICalled.
       // Enabled AFTER the message listener is wired so any entries CDP replays
@@ -443,6 +544,12 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
         }
       }
     } catch (err) {
+      // Setup failed after the listeners were bound. Unwind them when this call
+      // is the only thing holding the session, so a guest that can never be
+      // instrumented is not left with dangling debugger listeners.
+      if (boundListenersHere && !session.runtimeEnabled && session.paneIds.size <= 1) {
+        cleanupSession(webContentsId);
+      }
       const message = formatErrorMessage(err, "CDP console capture start failed");
       const isExpected =
         message.includes("Target closed") ||
@@ -457,10 +564,29 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
     }
   };
 
-  function handleConsoleApiCalled(_wcId: number, session: CdpSession, params: unknown): void {
+  function handleConsoleApiCalled(wcId: number, session: CdpSession, params: unknown): void {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const p = params as any;
     if (!p) return;
+
+    // Replay suppression. Runtime.enable re-delivers the guest's whole console
+    // buffer, so a stop/start cycle (a dev-preview tab switch, which unmounts
+    // the pane while the store keeps its rows) would duplicate everything still
+    // on screen. Only the enable window is filtered, and only up to the newest
+    // timestamp already delivered, so messages logged while capture was
+    // stopped still arrive. Ties within the same millisecond are dropped in
+    // favour of not duplicating.
+    const eventTimestamp = typeof p.timestamp === "number" ? p.timestamp : null;
+    if (
+      session.replayingRuntimeEnable &&
+      eventTimestamp !== null &&
+      eventTimestamp <= session.lastConsoleTimestamp
+    ) {
+      return;
+    }
+    if (eventTimestamp !== null && eventTimestamp > session.lastConsoleTimestamp) {
+      session.lastConsoleTimestamp = eventTimestamp;
+    }
 
     const cdpType = (p.type ?? "log") as CdpConsoleType;
 
@@ -484,13 +610,16 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
     const summaryText = buildSummaryText(args);
     const stackTrace = normalizeStackTrace(p.stackTrace);
 
+    const rootObjectIds = objectIdsFromArgs(args);
+
     for (const paneId of session.paneIds) {
       const groupDepth = session.groupDepthByPane.get(paneId) ?? 0;
 
-      trackObjectIds(session, paneId, args);
+      const rowId = _nextMessageId++;
+      recordRowObjects(wcId, session, paneId, rowId, rootObjectIds);
 
       const row: SerializedConsoleRow = {
-        id: _nextMessageId++,
+        id: rowId,
         paneId,
         level,
         cdpType,
@@ -523,7 +652,7 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
     }
   }
 
-  function handleExceptionThrown(session: CdpSession, params: unknown): void {
+  function handleExceptionThrown(wcId: number, session: CdpSession, params: unknown): void {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const p = params as any;
     const details = p?.exceptionDetails;
@@ -535,8 +664,10 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
     const timestamp = typeof p.timestamp === "number" ? Math.floor(p.timestamp) : Date.now();
 
     for (const paneId of session.paneIds) {
+      const rowId = _nextMessageId++;
+      recordRowObjects(wcId, session, paneId, rowId, []);
       const row: SerializedConsoleRow = {
-        id: _nextMessageId++,
+        id: rowId,
         paneId,
         level: "error",
         cdpType: "error",
@@ -551,7 +682,7 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
     }
   }
 
-  function handleLogEntryAdded(session: CdpSession, params: unknown): void {
+  function handleLogEntryAdded(wcId: number, session: CdpSession, params: unknown): void {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const entry = (params as any)?.entry;
     if (!entry) return;
@@ -567,8 +698,10 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
       typeof entry.timestamp === "number" ? Math.floor(entry.timestamp) : Date.now();
 
     for (const paneId of session.paneIds) {
+      const rowId = _nextMessageId++;
+      recordRowObjects(wcId, session, paneId, rowId, []);
       const row: SerializedConsoleRow = {
-        id: _nextMessageId++,
+        id: rowId,
         paneId,
         level,
         cdpType: "log-entry",
@@ -602,9 +735,13 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
 
     session.paneIds.delete(paneId);
     session.groupDepthByPane.delete(paneId);
-    session.objectIdsByPane.delete(paneId);
+    session.rowObjectIdsByPane.delete(paneId);
 
-    // If no more panes are capturing, clean up the session
+    // If no more panes are capturing, disable the domains but keep the session.
+    // Its listeners are inert while the domains are off, and holding it keeps
+    // `lastConsoleTimestamp` so the replay that a later Runtime.enable triggers
+    // can be filtered against what the renderer already displays. The session
+    // is disposed by the guest's `destroyed` hook or by handler teardown.
     if (session.paneIds.size === 0) {
       if (wc && !wc.isDestroyed() && session.runtimeEnabled) {
         try {
@@ -612,6 +749,7 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
         } catch {
           // Ignore
         }
+        session.runtimeEnabled = false;
       }
       if (wc && !wc.isDestroyed() && session.logEnabled) {
         try {
@@ -619,8 +757,8 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
         } catch {
           // Ignore
         }
+        session.logEnabled = false;
       }
-      cleanupSession(webContentsId);
     }
   };
 
@@ -645,9 +783,16 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
 
   const handleGetConsoleProperties = async (
     webContentsId: unknown,
+    paneId: unknown,
+    rowId: unknown,
     objectId: unknown
   ): Promise<{ properties: CdpPropertyDescriptor[] }> => {
-    if (typeof webContentsId !== "number" || typeof objectId !== "string") {
+    if (
+      typeof webContentsId !== "number" ||
+      typeof paneId !== "string" ||
+      typeof rowId !== "number" ||
+      typeof objectId !== "string"
+    ) {
       throw new Error("Invalid arguments");
     }
 
@@ -657,6 +802,14 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
 
     const wc = webContents.fromId(webContentsId);
     if (!wc || wc.isDestroyed()) {
+      return { properties: [] };
+    }
+
+    // Expansion is only meaningful for a row that still owns its handles. A row
+    // that was evicted, cleared or invalidated by navigation is gone from the
+    // renderer too, and inspecting it would mint descendants nothing can own.
+    const session = sessions.get(webContentsId);
+    if (!session?.rowObjectIdsByPane.get(paneId)?.has(rowId)) {
       return { properties: [] };
     }
 
@@ -670,10 +823,16 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const raw = result as any;
       const properties: CdpPropertyDescriptor[] = [];
+      const descendantIds: string[] = [];
 
       if (Array.isArray(raw.result)) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         for (const prop of raw.result as any[]) {
+          // Read handles off the raw descriptor: normalizeRemoteObject drops
+          // accessors and symbols, whose mirrors are retained just the same.
+          for (const mirror of [prop.value, prop.get, prop.set, prop.symbol]) {
+            if (mirror && typeof mirror.objectId === "string") descendantIds.push(mirror.objectId);
+          }
           properties.push({
             name: prop.name ?? "",
             value: prop.value ? normalizeRemoteObject(prop.value) : undefined,
@@ -683,6 +842,16 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
             isOwn: prop.isOwn,
           });
         }
+      }
+
+      // Re-check ownership after the await. If the row lost it while the
+      // request was in flight, these descendants belong to nobody — release
+      // them rather than letting a late result resurrect released ownership.
+      const rowIds = sessions.get(webContentsId)?.rowObjectIdsByPane.get(paneId)?.get(rowId);
+      if (rowIds) {
+        for (const id of descendantIds) rowIds.add(id);
+      } else if (descendantIds.length > 0) {
+        releaseObjectIds(webContentsId, descendantIds);
       }
 
       return { properties };
@@ -1072,15 +1241,22 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
     wc.reloadIgnoringCache();
   };
 
-  const handleGetScrollPosition = async (webContentsId: unknown): Promise<number> => {
+  /**
+   * Current scroll offset, or `null` when it could not be read.
+   *
+   * The sentinel matters: a failed read and a page genuinely scrolled to the
+   * top both used to answer `0`, so callers could not persist a real return-to-
+   * top without also persisting every CDP failure (#12298).
+   */
+  const handleGetScrollPosition = async (webContentsId: unknown): Promise<number | null> => {
     if (typeof webContentsId !== "number") {
       throw new Error("Invalid arguments: webContentsId must be number");
     }
 
-    if (!getWebviewDialogService().getPanelId(webContentsId)) return 0;
+    if (!getWebviewDialogService().getPanelId(webContentsId)) return null;
 
     const wc = webContents.fromId(webContentsId);
-    if (!wc || wc.isDestroyed()) return 0;
+    if (!wc || wc.isDestroyed()) return null;
 
     try {
       ensureAttached(wc);
@@ -1091,7 +1267,7 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
         cssLayoutViewport?: { pageY?: number };
       };
       const pageY = result?.cssLayoutViewport?.pageY;
-      return typeof pageY === "number" ? Math.round(pageY) : 0;
+      return typeof pageY === "number" && Number.isFinite(pageY) ? Math.round(pageY) : null;
     } catch (err) {
       const message = formatErrorMessage(err, "CDP getLayoutMetrics failed");
       const isExpected =
@@ -1102,7 +1278,7 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
       if (!isExpected) {
         console.warn(`[webview] getScrollPosition failed for id=${webContentsId}:`, message);
       }
-      return 0;
+      return null;
     }
   };
 

--- a/electron/ipc/handlers/webview.ts
+++ b/electron/ipc/handlers/webview.ts
@@ -32,16 +32,17 @@ interface CdpSession {
    */
   rowObjectIdsByPane: Map<string, Map<number, Set<string>>>;
   /**
-   * Newest `Runtime.consoleAPICalled` timestamp already delivered to the
-   * renderer. `Runtime.enable` replays the guest's buffered console messages,
-   * so a stop/start cycle would re-deliver everything the renderer still has on
-   * screen; replayed events at or below this watermark are dropped.
+   * Replay reconciliation, one watermark per event stream. `Runtime.enable` and
+   * `Log.enable` both re-deliver their guest-side buffer, so a stop/start cycle
+   * would duplicate everything the renderer still has on screen. Each stream
+   * gets its own watermark because one stream's progress says nothing about
+   * what another has delivered.
    */
-  lastConsoleTimestamp: number;
-  /** True only while a `Runtime.enable` command is in flight (its replay window). */
-  replayingRuntimeEnable: boolean;
-  /** Whether a `destroyed` cleanup hook has been installed on the guest. */
-  destroyHookInstalled: boolean;
+  consoleWatermark: ReplayWatermark;
+  exceptionWatermark: ReplayWatermark;
+  logEntryWatermark: ReplayWatermark;
+  /** `destroyed` cleanup hook, held so teardown can detach it with the rest. */
+  destroyListener: (() => void) | null;
   // Per-session throttle for `Log.entryAdded` — browser-emitted entries
   // (CSP, network, deprecation) can flood. Keyed by source:level:url:line.
   logRateLimit: Map<string, { count: number; resetAt: number }>;
@@ -125,9 +126,10 @@ function getOrCreateSession(wcId: number): CdpSession {
       navigationGeneration: 0,
       groupDepthByPane: new Map(),
       rowObjectIdsByPane: new Map(),
-      lastConsoleTimestamp: 0,
-      replayingRuntimeEnable: false,
-      destroyHookInstalled: false,
+      consoleWatermark: createReplayWatermark(),
+      exceptionWatermark: createReplayWatermark(),
+      logEntryWatermark: createReplayWatermark(),
+      destroyListener: null,
       logRateLimit: new Map(),
       ownerWindow: null,
       messageListener: null,
@@ -279,6 +281,89 @@ function releaseObjectIds(wcId: number, objectIds: Iterable<string>): void {
   }
 }
 
+/**
+ * How much of one CDP event stream the renderer has already been given.
+ *
+ * CDP timestamps are epoch milliseconds and are neither unique nor guaranteed
+ * to increase, so a timestamp alone cannot identify an event. Pairing the
+ * newest timestamp with how many events carried it lets a replay skip exactly
+ * the events already delivered and admit distinct ones that merely landed in
+ * the same millisecond.
+ */
+interface ReplayWatermark {
+  timestamp: number;
+  count: number;
+  /** Set while the stream's enable command is in flight — its replay window. */
+  replaying: boolean;
+  /** Watermark as of the moment the window opened; the live one keeps moving. */
+  replayFromTimestamp: number;
+  replayFromCount: number;
+  /** Events seen at `replayFromTimestamp` since the window opened. */
+  replaySeenAtTimestamp: number;
+}
+
+function createReplayWatermark(): ReplayWatermark {
+  return {
+    timestamp: 0,
+    count: 0,
+    replaying: false,
+    replayFromTimestamp: 0,
+    replayFromCount: 0,
+    replaySeenAtTimestamp: 0,
+  };
+}
+
+function openReplayWindow(...watermarks: ReplayWatermark[]): void {
+  for (const w of watermarks) {
+    w.replaying = true;
+    w.replayFromTimestamp = w.timestamp;
+    w.replayFromCount = w.count;
+    w.replaySeenAtTimestamp = 0;
+  }
+}
+
+function closeReplayWindow(...watermarks: ReplayWatermark[]): void {
+  for (const w of watermarks) w.replaying = false;
+}
+
+function resetReplayWatermark(w: ReplayWatermark): void {
+  w.timestamp = 0;
+  w.count = 0;
+  w.replayFromTimestamp = 0;
+  w.replayFromCount = 0;
+  w.replaySeenAtTimestamp = 0;
+}
+
+/**
+ * Whether to deliver this event, advancing the watermark when we do.
+ *
+ * Inside a replay window everything up to the pre-enable watermark has already
+ * reached the renderer and is dropped; everything past it is new. An event with
+ * no usable timestamp can't be matched at all, so it is delivered rather than
+ * risk losing something the renderer never saw.
+ */
+function admitEvent(w: ReplayWatermark, timestamp: number | null): boolean {
+  if (timestamp === null) return true;
+
+  if (w.replaying && timestamp <= w.replayFromTimestamp) {
+    if (timestamp < w.replayFromTimestamp) return false;
+    w.replaySeenAtTimestamp += 1;
+    if (w.replaySeenAtTimestamp <= w.replayFromCount) return false;
+  }
+
+  if (timestamp > w.timestamp) {
+    w.timestamp = timestamp;
+    w.count = 1;
+  } else if (timestamp === w.timestamp) {
+    w.count += 1;
+  }
+  return true;
+}
+
+function eventTimestampOf(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
 function objectIdsFromArgs(args: CdpRemoteArg[]): string[] {
   const ids: string[] = [];
   for (const arg of args) {
@@ -359,6 +444,11 @@ function cleanupSession(wcId: number): void {
     if (session.detachListener) {
       wc.debugger.off("detach", session.detachListener);
     }
+    // Without this, a guest that survives repeated failed starts accumulates
+    // one dead `destroyed` callback per attempt.
+    if (session.destroyListener && typeof wc.off === "function") {
+      wc.off("destroyed", session.destroyListener);
+    }
   }
 
   sessions.delete(wcId);
@@ -380,6 +470,47 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
 
     await (frozen ? freezeWebContents(wc) : unfreezeWebContents(wc));
   };
+
+  /**
+   * Enable the console domains for a session whose listeners are already bound.
+   * Ordering matters: both enables replay their guest-side buffer, so the
+   * listener has to be live first, and each enable opens its stream's replay
+   * window so already-delivered events are reconciled away.
+   */
+  async function enableConsoleDomains(
+    webContentsId: number,
+    wc: Electron.WebContents,
+    session: CdpSession
+  ): Promise<void> {
+    if (!session.runtimeEnabled) {
+      openReplayWindow(session.consoleWatermark, session.exceptionWatermark);
+      try {
+        await wc.debugger.sendCommand("Runtime.enable");
+        session.runtimeEnabled = true;
+      } finally {
+        closeReplayWindow(session.consoleWatermark, session.exceptionWatermark);
+      }
+    }
+
+    // Log surfaces browser-emitted entries (CSP violations, network failures,
+    // deprecations) that never reach Runtime.consoleAPICalled. Its own
+    // try/catch so a Log.enable failure degrades to "no log-entry rows" rather
+    // than silently breaking the already-working consoleAPICalled capture.
+    if (!session.logEnabled) {
+      try {
+        openReplayWindow(session.logEntryWatermark);
+        await wc.debugger.sendCommand("Log.enable");
+        session.logEnabled = true;
+      } catch (logErr) {
+        console.warn(
+          `[webview] CDP Log.enable failed for id=${webContentsId}:`,
+          formatErrorMessage(logErr, "Log.enable failed")
+        );
+      } finally {
+        closeReplayWindow(session.logEntryWatermark);
+      }
+    }
+  }
 
   const handleStartConsoleCapture = async (
     webContentsId: unknown,
@@ -409,9 +540,10 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
 
     // Sessions outlive capture (see handleStopConsoleCapture), so tie their
     // lifetime to the guest rather than to the last pane that stopped.
-    if (!session.destroyHookInstalled && typeof wc.once === "function") {
-      session.destroyHookInstalled = true;
-      wc.once("destroyed", () => cleanupSession(webContentsId));
+    if (!session.destroyListener && typeof wc.once === "function") {
+      const destroyListener = () => cleanupSession(webContentsId);
+      session.destroyListener = destroyListener;
+      wc.once("destroyed", destroyListener);
     }
 
     let boundListenersHere = false;
@@ -439,7 +571,9 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
               session.logRateLimit.clear();
               // The new document has not delivered anything yet, so nothing is
               // a duplicate of what the renderer already holds.
-              session.lastConsoleTimestamp = 0;
+              resetReplayWatermark(session.consoleWatermark);
+              resetReplayWatermark(session.exceptionWatermark);
+              resetReplayWatermark(session.logEntryWatermark);
               // Reset group depth and drop stale handle ownership for all
               // panes. No release call: the guest already invalidated every
               // handle when the execution context went away.
@@ -482,7 +616,9 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
             session.messageListener = null;
             session.detachListener = null;
             session.navigationGeneration++;
-            session.lastConsoleTimestamp = 0;
+            resetReplayWatermark(session.consoleWatermark);
+            resetReplayWatermark(session.exceptionWatermark);
+            resetReplayWatermark(session.logEntryWatermark);
             for (const pid of session.paneIds) {
               session.groupDepthByPane.set(pid, 0);
               session.rowObjectIdsByPane.get(pid)?.clear();
@@ -516,33 +652,7 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
       // lands before this await resolves. Enabling first — as this handler used
       // to — dropped everything the page logged before capture attached, which
       // is every startup log for a page that had already booted (#12298).
-      if (!session.runtimeEnabled) {
-        session.replayingRuntimeEnable = true;
-        try {
-          await wc.debugger.sendCommand("Runtime.enable");
-          session.runtimeEnabled = true;
-        } finally {
-          session.replayingRuntimeEnable = false;
-        }
-      }
-
-      // Log domain surfaces browser-emitted entries (CSP violations, network
-      // failures, deprecations) that never reach Runtime.consoleAPICalled.
-      // Enabled AFTER the message listener is wired so any entries CDP replays
-      // on enable are captured, and in its own try/catch so a Log.enable
-      // failure degrades to "no log-entry rows" rather than silently breaking
-      // the already-registered Runtime.consoleAPICalled capture.
-      if (!session.logEnabled) {
-        try {
-          await wc.debugger.sendCommand("Log.enable");
-          session.logEnabled = true;
-        } catch (logErr) {
-          console.warn(
-            `[webview] CDP Log.enable failed for id=${webContentsId}:`,
-            formatErrorMessage(logErr, "Log.enable failed")
-          );
-        }
-      }
+      await enableConsoleDomains(webContentsId, wc, session);
     } catch (err) {
       // Setup failed after the listeners were bound. Unwind them when this call
       // is the only thing holding the session, so a guest that can never be
@@ -569,24 +679,12 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
     const p = params as any;
     if (!p) return;
 
-    // Replay suppression. Runtime.enable re-delivers the guest's whole console
-    // buffer, so a stop/start cycle (a dev-preview tab switch, which unmounts
-    // the pane while the store keeps its rows) would duplicate everything still
-    // on screen. Only the enable window is filtered, and only up to the newest
-    // timestamp already delivered, so messages logged while capture was
-    // stopped still arrive. Ties within the same millisecond are dropped in
-    // favour of not duplicating.
-    const eventTimestamp = typeof p.timestamp === "number" ? p.timestamp : null;
-    if (
-      session.replayingRuntimeEnable &&
-      eventTimestamp !== null &&
-      eventTimestamp <= session.lastConsoleTimestamp
-    ) {
-      return;
-    }
-    if (eventTimestamp !== null && eventTimestamp > session.lastConsoleTimestamp) {
-      session.lastConsoleTimestamp = eventTimestamp;
-    }
+    // Runtime.enable re-delivers the guest's whole console buffer, so a
+    // stop/start cycle (a dev-preview tab switch unmounts the pane while the
+    // store keeps its rows) would duplicate everything still on screen. Only
+    // the enable window is reconciled, so messages logged while capture was
+    // stopped still arrive.
+    if (!admitEvent(session.consoleWatermark, eventTimestampOf(p.timestamp))) return;
 
     const cdpType = (p.type ?? "log") as CdpConsoleType;
 
@@ -658,6 +756,11 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
     const details = p?.exceptionDetails;
     if (!details) return;
 
+    // Runtime.enable replays buffered exceptions alongside console calls, so
+    // these need their own reconciliation — the console watermark's progress
+    // says nothing about which exceptions the renderer already has.
+    if (!admitEvent(session.exceptionWatermark, eventTimestampOf(p.timestamp))) return;
+
     const summaryText: string =
       details.exception?.description ?? details.text ?? "Uncaught (unknown exception)";
     const stackTrace = normalizeStackTrace(details.stackTrace);
@@ -686,6 +789,12 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const entry = (params as any)?.entry;
     if (!entry) return;
+
+    // `Log.enable` replays the guest's stored entries just like Runtime does,
+    // so a stop/start cycle would duplicate CSP, network and deprecation rows
+    // the renderer still displays. Reconciled before the rate limiter, so a
+    // replay can't consume the allowance a live failure needs.
+    if (!admitEvent(session.logEntryWatermark, eventTimestampOf(entry.timestamp))) return;
 
     const source = normalizeLogEntrySource(entry.source);
     const level = logEntryLevelToLevel(entry.level);
@@ -739,11 +848,11 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
 
     // If no more panes are capturing, disable the domains but keep the session.
     // Its listeners are inert while the domains are off, and holding it keeps
-    // `lastConsoleTimestamp` so the replay that a later Runtime.enable triggers
-    // can be filtered against what the renderer already displays. The session
-    // is disposed by the guest's `destroyed` hook or by handler teardown.
-    if (session.paneIds.size === 0) {
-      if (wc && !wc.isDestroyed() && session.runtimeEnabled) {
+    // the replay watermarks so the replay a later Runtime.enable triggers can
+    // be reconciled against what the renderer already displays. The session is
+    // disposed by the guest's `destroyed` hook or by handler teardown.
+    if (session.paneIds.size === 0 && wc && !wc.isDestroyed()) {
+      if (session.runtimeEnabled) {
         try {
           await wc.debugger.sendCommand("Runtime.disable");
         } catch {
@@ -751,13 +860,27 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
         }
         session.runtimeEnabled = false;
       }
-      if (wc && !wc.isDestroyed() && session.logEnabled) {
+      if (session.logEnabled) {
         try {
           await wc.debugger.sendCommand("Log.disable");
         } catch {
           // Ignore
         }
         session.logEnabled = false;
+      }
+
+      // A start that raced this teardown saw the domains still enabled and
+      // skipped enabling them, so it would come back to a pane that never
+      // receives another message. Re-enable for whoever arrived.
+      if (session.paneIds.size > 0) {
+        try {
+          await enableConsoleDomains(webContentsId, wc, session);
+        } catch (err) {
+          console.warn(
+            `[webview] CDP re-enable after a raced stop failed for id=${webContentsId}:`,
+            formatErrorMessage(err, "console domain re-enable failed")
+          );
+        }
       }
     }
   };
@@ -805,11 +928,13 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
       return { properties: [] };
     }
 
-    // Expansion is only meaningful for a row that still owns its handles. A row
+    // Expansion is only meaningful for a handle the named row still owns. A row
     // that was evicted, cleared or invalidated by navigation is gone from the
     // renderer too, and inspecting it would mint descendants nothing can own.
+    // Checking the handle itself — not just that the row exists — keeps a
+    // caller from inspecting an arbitrary objectId through a live row.
     const session = sessions.get(webContentsId);
-    if (!session?.rowObjectIdsByPane.get(paneId)?.has(rowId)) {
+    if (!session?.rowObjectIdsByPane.get(paneId)?.get(rowId)?.has(objectId)) {
       return { properties: [] };
     }
 
@@ -825,14 +950,22 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
       const properties: CdpPropertyDescriptor[] = [];
       const descendantIds: string[] = [];
 
+      // Handles come off the raw descriptors, not the normalized ones:
+      // normalizeRemoteObject drops accessors and symbols, and CDP hands back
+      // mirrors in three sibling arrays. A Map, a Promise or an object with
+      // private fields allocates handles in the latter two, and anything not
+      // collected here can never be released.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const collectHandles = (prop: any): void => {
+        for (const mirror of [prop?.value, prop?.get, prop?.set, prop?.symbol]) {
+          if (mirror && typeof mirror.objectId === "string") descendantIds.push(mirror.objectId);
+        }
+      };
+
       if (Array.isArray(raw.result)) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         for (const prop of raw.result as any[]) {
-          // Read handles off the raw descriptor: normalizeRemoteObject drops
-          // accessors and symbols, whose mirrors are retained just the same.
-          for (const mirror of [prop.value, prop.get, prop.set, prop.symbol]) {
-            if (mirror && typeof mirror.objectId === "string") descendantIds.push(mirror.objectId);
-          }
+          collectHandles(prop);
           properties.push({
             name: prop.name ?? "",
             value: prop.value ? normalizeRemoteObject(prop.value) : undefined,
@@ -842,6 +975,11 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
             isOwn: prop.isOwn,
           });
         }
+      }
+      // Not surfaced in the UI, but CDP retains their mirrors all the same.
+      for (const list of [raw.internalProperties, raw.privateProperties]) {
+        if (!Array.isArray(list)) continue;
+        for (const prop of list) collectHandles(prop);
       }
 
       // Re-check ownership after the await. If the row lost it while the

--- a/electron/ipc/handlers/webviewEmulation.preload.ts
+++ b/electron/ipc/handlers/webviewEmulation.preload.ts
@@ -1,0 +1,26 @@
+import type { IpcInvokeMap } from "../../types/index.js";
+
+export const WEBVIEW_EMULATION_METHOD_CHANNELS = {
+  setDeviceEmulation: "webview:set-device-emulation",
+} as const satisfies Record<string, keyof IpcInvokeMap>;
+
+type Methods = typeof WEBVIEW_EMULATION_METHOD_CHANNELS;
+
+export type WebviewEmulationPreloadBindings = {
+  [M in keyof Methods]: (
+    ...args: IpcInvokeMap[Methods[M]]["args"]
+  ) => Promise<IpcInvokeMap[Methods[M]]["result"]>;
+};
+
+type Invoker = (channel: string, ...args: unknown[]) => Promise<unknown>;
+
+export function buildWebviewEmulationPreloadBindings(
+  invoke: Invoker
+): WebviewEmulationPreloadBindings {
+  const out: Record<string, (...args: unknown[]) => Promise<unknown>> = {};
+  for (const method of Object.keys(WEBVIEW_EMULATION_METHOD_CHANNELS) as Array<keyof Methods>) {
+    const channel = WEBVIEW_EMULATION_METHOD_CHANNELS[method];
+    out[method as string] = (...args) => invoke(channel, ...args);
+  }
+  return out as unknown as WebviewEmulationPreloadBindings;
+}

--- a/electron/ipc/handlers/webviewEmulation.ts
+++ b/electron/ipc/handlers/webviewEmulation.ts
@@ -31,7 +31,18 @@ import type { DeviceEmulationRequest } from "../../../shared/types/ipc/webviewEm
  */
 interface GuestEmulationState {
   originalUserAgent: string;
-  touchEmulated: boolean;
+  /**
+   * Whether touch is currently emulated, or `null` when we no longer know —
+   * a partially-applied CDP sequence leaves the guest in a state this cache
+   * cannot describe, and the next request must re-issue rather than skip.
+   */
+  touchEmulated: boolean | null;
+  /**
+   * Requests for one guest run one at a time. Without this, a desktop clear
+   * still awaiting its CDP commands can finish after a newly-selected phone
+   * preset and turn that preset's touch emulation back off.
+   */
+  queue: Promise<void>;
 }
 
 const guestEmulation = new Map<number, GuestEmulationState>();
@@ -91,31 +102,22 @@ async function setTouchEmulation(wc: Electron.WebContents, enabled: boolean): Pr
   }
 }
 
-async function handleSetDeviceEmulation(payload: DeviceEmulationRequest): Promise<void> {
-  const { webContentsId, panelId, emulation } = payload;
-
-  // Ownership gate: only the panel that registered this guest may drive it.
-  if (getWebviewDialogService().getPanelId(webContentsId) !== panelId) return;
-
-  const wc = webContents.fromId(webContentsId);
-  if (!wc || wc.isDestroyed()) {
-    guestEmulation.delete(webContentsId);
-    return;
-  }
-
-  let state = guestEmulation.get(webContentsId);
-  if (!state) {
-    state = { originalUserAgent: wc.getUserAgent(), touchEmulated: false };
-    guestEmulation.set(webContentsId, state);
-    wc.once("destroyed", () => guestEmulation.delete(webContentsId));
-  }
+async function applyEmulation(
+  wc: Electron.WebContents,
+  state: GuestEmulationState,
+  emulation: DeviceEmulationRequest["emulation"]
+): Promise<void> {
+  if (wc.isDestroyed()) return;
 
   if (emulation) {
     wc.setUserAgent(emulation.userAgent);
     wc.enableDeviceEmulation(emulation.params as Electron.Parameters);
     if (emulation.touch !== state.touchEmulated) {
-      const applied = await setTouchEmulation(wc, emulation.touch);
-      if (applied) state.touchEmulated = emulation.touch;
+      // Mark unknown across the await: a failure part-way through leaves some
+      // overrides set and others not, and claiming either value would let a
+      // later request skip the cleanup the guest actually needs.
+      state.touchEmulated = null;
+      if (await setTouchEmulation(wc, emulation.touch)) state.touchEmulated = emulation.touch;
     }
     return;
   }
@@ -128,10 +130,54 @@ async function handleSetDeviceEmulation(payload: DeviceEmulationRequest): Promis
   if (state.originalUserAgent) {
     wc.setUserAgent(state.originalUserAgent);
   }
-  if (state.touchEmulated) {
-    const applied = await setTouchEmulation(wc, false);
-    if (applied) state.touchEmulated = false;
+  if (state.touchEmulated !== false) {
+    state.touchEmulated = null;
+    if (await setTouchEmulation(wc, false)) state.touchEmulated = false;
   }
+}
+
+/**
+ * Apply or clear device emulation for one guest.
+ *
+ * Resolves `{ applied: false }` when nothing was done — an unregistered or
+ * destroyed guest — so the renderer never caches a preset as active on a guest
+ * that never received it.
+ */
+async function handleSetDeviceEmulation(
+  payload: DeviceEmulationRequest
+): Promise<{ applied: boolean }> {
+  const { webContentsId, panelId, emulation } = payload;
+
+  // Ownership gate: only the panel that registered this guest may drive it.
+  if (getWebviewDialogService().getPanelId(webContentsId) !== panelId) {
+    return { applied: false };
+  }
+
+  const wc = webContents.fromId(webContentsId);
+  if (!wc || wc.isDestroyed()) {
+    guestEmulation.delete(webContentsId);
+    return { applied: false };
+  }
+
+  let state = guestEmulation.get(webContentsId);
+  if (!state) {
+    state = {
+      originalUserAgent: wc.getUserAgent(),
+      touchEmulated: false,
+      queue: Promise.resolve(),
+    };
+    guestEmulation.set(webContentsId, state);
+    if (typeof wc.once === "function") {
+      wc.once("destroyed", () => guestEmulation.delete(webContentsId));
+    }
+  }
+
+  const settled = state.queue.then(() => applyEmulation(wc, state, emulation));
+  // Keep the chain alive after a rejection so one failed request cannot wedge
+  // every later one for this guest.
+  state.queue = settled.catch(() => {});
+  await settled;
+  return { applied: true };
 }
 
 export const webviewEmulationNamespace = defineIpcNamespace({

--- a/electron/ipc/handlers/webviewEmulation.ts
+++ b/electron/ipc/handlers/webviewEmulation.ts
@@ -1,0 +1,154 @@
+import { webContents } from "electron";
+import { defineIpcNamespace, opValidated } from "../define.js";
+import { getWebviewDialogService } from "../../services/WebviewDialogService.js";
+import { WEBVIEW_EMULATION_METHOD_CHANNELS } from "./webviewEmulation.preload.js";
+import { WebviewSetDeviceEmulationPayloadSchema } from "../../schemas/ipc.js";
+import { ensureAttached } from "../../utils/webContentsLifecycle.js";
+import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
+import type { HandlerDependencies } from "../types.js";
+import type { DeviceEmulationRequest } from "../../../shared/types/ipc/webviewEmulation.js";
+
+/**
+ * Device emulation for dev-preview webview guests.
+ *
+ * This lives in the main process because `<webview>` has no renderer-side
+ * `getWebContents()` — that was only ever an `@electron/remote` shim, and the
+ * renderer-side call it replaced silently threw for every preset (#12298). The
+ * renderer sends its guest id from `getWebContentsId()` and main resolves the
+ * real WebContents, matching the `getScrollPosition` / `reloadIgnoringCache`
+ * pattern in `webview.ts`.
+ *
+ * `enableDeviceEmulation` only drives viewport size, device scale factor and
+ * meta-viewport handling. Pointer/hover media features and touch dispatch are
+ * separate CDP `Emulation.*` commands, so a preset that stops at
+ * `enableDeviceEmulation` still reports `(pointer: fine)` to the page.
+ */
+
+/**
+ * Per-guest emulation bookkeeping. The guest's own user agent has to be read
+ * before the first override, because Electron has no "reset to default" for
+ * `setUserAgent` — restoring desktop means writing the captured string back.
+ */
+interface GuestEmulationState {
+  originalUserAgent: string;
+  touchEmulated: boolean;
+}
+
+const guestEmulation = new Map<number, GuestEmulationState>();
+
+// Emulation racing guest teardown or a navigation is routine; only unexpected
+// failures deserve a log line.
+const EXPECTED_CDP_ERRORS = [
+  "Target closed",
+  "Inspected target navigated",
+  "Cannot attach",
+  "debugger is already attached",
+  "No debugger attached",
+];
+
+function isExpectedCdpError(message: string): boolean {
+  return EXPECTED_CDP_ERRORS.some((expected) => message.includes(expected));
+}
+
+/**
+ * Touch/pointer emulation over CDP, best-effort: a failure here degrades the
+ * preset to "right size, desktop pointer" rather than aborting the whole apply,
+ * which would leave the guest sized for a phone with no emulation at all.
+ */
+async function setTouchEmulation(wc: Electron.WebContents, enabled: boolean): Promise<boolean> {
+  try {
+    ensureAttached(wc);
+    // Drives navigator.maxTouchPoints and Blink's available pointer/hover
+    // types, which is what flips `(pointer: coarse)` for the page.
+    await wc.debugger.sendCommand("Emulation.setTouchEmulationEnabled", {
+      enabled,
+      maxTouchPoints: enabled ? 5 : 1,
+    });
+    await wc.debugger.sendCommand("Emulation.setEmitTouchEventsForMouse", {
+      enabled,
+      configuration: enabled ? "mobile" : "desktop",
+    });
+    // Belt and braces over setTouchEmulationEnabled: an explicit media-feature
+    // override so the four pointer/hover queries answer consistently. An empty
+    // feature list clears the override and returns the page to native values.
+    await wc.debugger.sendCommand("Emulation.setEmulatedMedia", {
+      features: enabled
+        ? [
+            { name: "pointer", value: "coarse" },
+            { name: "any-pointer", value: "coarse" },
+            { name: "hover", value: "none" },
+            { name: "any-hover", value: "none" },
+          ]
+        : [],
+    });
+    return true;
+  } catch (err) {
+    const message = formatErrorMessage(err, "CDP touch emulation failed");
+    if (!isExpectedCdpError(message)) {
+      console.warn(`[webviewEmulation] touch emulation (enabled=${enabled}) failed:`, message);
+    }
+    return false;
+  }
+}
+
+async function handleSetDeviceEmulation(payload: DeviceEmulationRequest): Promise<void> {
+  const { webContentsId, panelId, emulation } = payload;
+
+  // Ownership gate: only the panel that registered this guest may drive it.
+  if (getWebviewDialogService().getPanelId(webContentsId) !== panelId) return;
+
+  const wc = webContents.fromId(webContentsId);
+  if (!wc || wc.isDestroyed()) {
+    guestEmulation.delete(webContentsId);
+    return;
+  }
+
+  let state = guestEmulation.get(webContentsId);
+  if (!state) {
+    state = { originalUserAgent: wc.getUserAgent(), touchEmulated: false };
+    guestEmulation.set(webContentsId, state);
+    wc.once("destroyed", () => guestEmulation.delete(webContentsId));
+  }
+
+  if (emulation) {
+    wc.setUserAgent(emulation.userAgent);
+    wc.enableDeviceEmulation(emulation.params as Electron.Parameters);
+    if (emulation.touch !== state.touchEmulated) {
+      const applied = await setTouchEmulation(wc, emulation.touch);
+      if (applied) state.touchEmulated = emulation.touch;
+    }
+    return;
+  }
+
+  try {
+    wc.disableDeviceEmulation();
+  } catch {
+    // Throws when emulation was never enabled for this guest.
+  }
+  if (state.originalUserAgent) {
+    wc.setUserAgent(state.originalUserAgent);
+  }
+  if (state.touchEmulated) {
+    const applied = await setTouchEmulation(wc, false);
+    if (applied) state.touchEmulated = false;
+  }
+}
+
+export const webviewEmulationNamespace = defineIpcNamespace({
+  name: "webviewEmulation",
+  ops: {
+    setDeviceEmulation: opValidated(
+      WEBVIEW_EMULATION_METHOD_CHANNELS.setDeviceEmulation,
+      WebviewSetDeviceEmulationPayloadSchema,
+      handleSetDeviceEmulation
+    ),
+  },
+});
+
+export function registerWebviewEmulationHandlers(_deps: HandlerDependencies): () => void {
+  const dispose = webviewEmulationNamespace.register();
+  return () => {
+    dispose();
+    guestEmulation.clear();
+  };
+}

--- a/electron/ipc/handlers/webviewEmulation.ts
+++ b/electron/ipc/handlers/webviewEmulation.ts
@@ -102,12 +102,13 @@ async function setTouchEmulation(wc: Electron.WebContents, enabled: boolean): Pr
   }
 }
 
+/** Resolves false when the guest went away before this queued request ran. */
 async function applyEmulation(
   wc: Electron.WebContents,
   state: GuestEmulationState,
   emulation: DeviceEmulationRequest["emulation"]
-): Promise<void> {
-  if (wc.isDestroyed()) return;
+): Promise<boolean> {
+  if (wc.isDestroyed()) return false;
 
   if (emulation) {
     wc.setUserAgent(emulation.userAgent);
@@ -119,7 +120,7 @@ async function applyEmulation(
       state.touchEmulated = null;
       if (await setTouchEmulation(wc, emulation.touch)) state.touchEmulated = emulation.touch;
     }
-    return;
+    return true;
   }
 
   try {
@@ -134,6 +135,7 @@ async function applyEmulation(
     state.touchEmulated = null;
     if (await setTouchEmulation(wc, false)) state.touchEmulated = false;
   }
+  return true;
 }
 
 /**
@@ -175,9 +177,14 @@ async function handleSetDeviceEmulation(
   const settled = state.queue.then(() => applyEmulation(wc, state, emulation));
   // Keep the chain alive after a rejection so one failed request cannot wedge
   // every later one for this guest.
-  state.queue = settled.catch(() => {});
-  await settled;
-  return { applied: true };
+  state.queue = settled.then(
+    () => {},
+    () => {}
+  );
+  // A request that waited behind another can find the guest gone by the time it
+  // runs, and must say so rather than let the caller cache a preset that was
+  // never applied.
+  return { applied: await settled };
 }
 
 export const webviewEmulationNamespace = defineIpcNamespace({

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -89,6 +89,7 @@ import { buildProjectRelocationPreloadBindings } from "./ipc/handlers/projectRel
 import { buildPaintFabricSurfacePreloadBindings } from "./ipc/handlers/paintFabricSurface.preload.js";
 import { buildWebviewNavigationPreloadBindings } from "./ipc/handlers/webviewNavigation.preload.js";
 import { buildWebviewCapturePreloadBindings } from "./ipc/handlers/webviewCapture.preload.js";
+import { buildWebviewEmulationPreloadBindings } from "./ipc/handlers/webviewEmulation.preload.js";
 import { buildWorktreeConfigPreloadBindings } from "./ipc/handlers/worktreeConfig.preload.js";
 import { buildTerminalLayoutPreloadBindings } from "./ipc/handlers/terminalLayout.preload.js";
 import { buildTerminalConfigPreloadBindings } from "./ipc/handlers/terminalConfig.preload.js";
@@ -2348,8 +2349,19 @@ function buildElectronApi(): ElectronAPI {
         _unwrappingInvoke(CHANNELS.WEBVIEW_STOP_CONSOLE_CAPTURE, webContentsId, paneId),
       clearConsoleCapture: (webContentsId: number, paneId: string): Promise<void> =>
         _unwrappingInvoke(CHANNELS.WEBVIEW_CLEAR_CONSOLE_CAPTURE, webContentsId, paneId),
-      getConsoleProperties: (webContentsId: number, objectId: string) =>
-        _unwrappingInvoke(CHANNELS.WEBVIEW_GET_CONSOLE_PROPERTIES, webContentsId, objectId),
+      getConsoleProperties: (
+        webContentsId: number,
+        paneId: string,
+        rowId: number,
+        objectId: string
+      ) =>
+        _unwrappingInvoke(
+          CHANNELS.WEBVIEW_GET_CONSOLE_PROPERTIES,
+          webContentsId,
+          paneId,
+          rowId,
+          objectId
+        ),
       onConsoleMessage: (
         callback: (
           row: import("../shared/types/ipc/webviewConsole.js").SerializedConsoleRow
@@ -2360,10 +2372,11 @@ function buildElectronApi(): ElectronAPI {
       ): (() => void) => _typedOn(CHANNELS.WEBVIEW_CONSOLE_CONTEXT_CLEARED, callback),
       reloadIgnoringCache: (webContentsId: number, panelId: string): Promise<void> =>
         _unwrappingInvoke(CHANNELS.WEBVIEW_RELOAD_IGNORING_CACHE, webContentsId, panelId),
-      getScrollPosition: (webContentsId: number): Promise<number> =>
+      getScrollPosition: (webContentsId: number): Promise<number | null> =>
         _unwrappingInvoke(CHANNELS.WEBVIEW_GET_SCROLL_POSITION, webContentsId),
       ...buildWebviewNavigationPreloadBindings(_unwrappingInvoke),
       ...buildWebviewCapturePreloadBindings(_unwrappingInvoke),
+      ...buildWebviewEmulationPreloadBindings(_unwrappingInvoke),
     },
 
     // Hibernation API

--- a/electron/schemas/ipc.ts
+++ b/electron/schemas/ipc.ts
@@ -1222,3 +1222,38 @@ export function parseAssistantHostSessionDescriptor(
 
 /** Re-exported so callers validating a handshake don't import two modules. */
 export { ASSISTANT_HOST_PROTOCOL_VERSION };
+
+const DimensionSchema = z.object({
+  width: z.number().int().min(1).max(20000),
+  height: z.number().int().min(1).max(20000),
+});
+
+const DeviceEmulationParametersSchema = z.object({
+  screenPosition: z.enum(["desktop", "mobile"]),
+  screenSize: DimensionSchema,
+  viewPosition: z.object({
+    x: z.number().int().min(0).max(20000),
+    y: z.number().int().min(0).max(20000),
+  }),
+  deviceScaleFactor: z.number().min(0).max(10),
+  viewSize: DimensionSchema,
+  scale: z.number().min(0.01).max(10),
+});
+
+export const WebviewSetDeviceEmulationPayloadSchema = z.object({
+  webContentsId: z.number().int().nonnegative(),
+  panelId: z.string().min(1).max(256),
+  emulation: z
+    .object({
+      params: DeviceEmulationParametersSchema,
+      // Guest-visible header value; keep it printable ASCII so a malformed
+      // override cannot inject header separators.
+      userAgent: z
+        .string()
+        .min(1)
+        .max(1024)
+        .regex(/^[\x20-\x7e]+$/, "User agent must be printable ASCII"),
+      touch: z.boolean(),
+    })
+    .nullable(),
+});

--- a/shared/config/devPreviewConsole.ts
+++ b/shared/config/devPreviewConsole.ts
@@ -1,0 +1,11 @@
+/**
+ * Maximum console rows retained per dev-preview pane.
+ *
+ * Shared because both ends of the console pipeline evict against it and they
+ * must not drift: `consoleCaptureStore` caps the rows it keeps, and the main
+ * process caps the per-row CDP remote-object owner records it keeps, releasing
+ * the handles of rows that have aged past the same boundary. If the two caps
+ * diverge, main either releases handles for rows still on screen or leaks
+ * handles for rows the renderer has already dropped.
+ */
+export const MAX_CONSOLE_ROWS = 500;

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1174,7 +1174,7 @@ export interface ElectronAPI extends GeneratedElectronAPI {
      */
     setDeviceEmulation(
       payload: import("./webviewEmulation.js").DeviceEmulationRequest
-    ): Promise<void>;
+    ): Promise<{ applied: boolean }>;
     /** Capture the panel's webview viewport as a PNG, returned base64-encoded */
     captureScreenshot(
       panelId: string

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1141,9 +1141,15 @@ export interface ElectronAPI extends GeneratedElectronAPI {
     stopConsoleCapture(webContentsId: number, paneId: string): Promise<void>;
     /** Clear tracked object references for a webview panel */
     clearConsoleCapture(webContentsId: number, paneId: string): Promise<void>;
-    /** Fetch properties for a CDP remote object */
+    /**
+     * Fetch properties for a CDP remote object. `paneId`/`rowId` name the
+     * console row that owns the handle, so main can attribute the nested
+     * handles this returns and release them when that row is evicted.
+     */
     getConsoleProperties(
       webContentsId: number,
+      paneId: string,
+      rowId: number,
       objectId: string
     ): Promise<import("./webviewConsole.js").CdpGetPropertiesResult>;
     /** Subscribe to structured console messages */
@@ -1156,8 +1162,19 @@ export interface ElectronAPI extends GeneratedElectronAPI {
     ): () => void;
     /** Reload a webview bypassing HTTP cache */
     reloadIgnoringCache(webContentsId: number, panelId: string): Promise<void>;
-    /** Read the current scroll position from Blink layout — works on frozen pages */
-    getScrollPosition(webContentsId: number): Promise<number>;
+    /**
+     * Read the current scroll position from Blink layout — works on frozen
+     * pages. Resolves `null` when the position could not be read at all, which
+     * callers must distinguish from a genuine `0` (page is at the top).
+     */
+    getScrollPosition(webContentsId: number): Promise<number | null>;
+    /**
+     * Apply (or, with `emulation: null`, clear) device emulation on a webview
+     * guest: viewport metrics, DPR, user agent and touch/pointer traits.
+     */
+    setDeviceEmulation(
+      payload: import("./webviewEmulation.js").DeviceEmulationRequest
+    ): Promise<void>;
     /** Capture the panel's webview viewport as a PNG, returned base64-encoded */
     captureScreenshot(
       panelId: string

--- a/shared/types/ipc/generated-api.ts
+++ b/shared/types/ipc/generated-api.ts
@@ -827,6 +827,9 @@ export interface GeneratedElectronAPI {
     goToHistoryIndex(
       ...args: IpcInvokeMap["webview:go-to-history-index"]["args"]
     ): Promise<IpcInvokeMap["webview:go-to-history-index"]["result"]>;
+    setDeviceEmulation(
+      ...args: IpcInvokeMap["webview:set-device-emulation"]["args"]
+    ): Promise<IpcInvokeMap["webview:set-device-emulation"]["result"]>;
   };
   windowChrome: {
     setBannerSeverity(

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -1890,7 +1890,7 @@ export interface GeneratedIpcInvokeMap {
   };
   "webview:set-device-emulation": {
     args: [payload: import("./webviewEmulation.js").DeviceEmulationRequest];
-    result: void;
+    result: { applied: boolean };
   };
   "window-chrome:set-banner-severity": {
     args: [payload: { severity: "success" | "error" | "info" | "warning" | "neutral" | null }];

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -1888,6 +1888,10 @@ export interface GeneratedIpcInvokeMap {
     args: [webContentsId: number, index: number];
     result: void;
   };
+  "webview:set-device-emulation": {
+    args: [payload: import("./webviewEmulation.js").DeviceEmulationRequest];
+    result: void;
+  };
   "window-chrome:set-banner-severity": {
     args: [payload: { severity: "success" | "error" | "info" | "warning" | "neutral" | null }];
     result: void;

--- a/shared/types/ipc/index.ts
+++ b/shared/types/ipc/index.ts
@@ -29,6 +29,7 @@ export * from "./agentSubagents.js";
 export * from "./api.js";
 export * from "./crashRecovery.js";
 export * from "./webviewConsole.js";
+export * from "./webviewEmulation.js";
 export * from "./demo.js";
 export * from "./telemetryPreview.js";
 export * from "./help.js";

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1206,7 +1206,7 @@ export interface IpcInvokeMap extends GeneratedIpcInvokeMap {
     result: void;
   };
   "webview:get-console-properties": {
-    args: [webContentsId: number, objectId: string];
+    args: [webContentsId: number, paneId: string, rowId: number, objectId: string];
     result: import("./webviewConsole.js").CdpGetPropertiesResult;
   };
   "webview:reload-ignoring-cache": {
@@ -1214,8 +1214,9 @@ export interface IpcInvokeMap extends GeneratedIpcInvokeMap {
     result: void;
   };
   "webview:get-scroll-position": {
+    // `null` means the read failed; `0` means the page is genuinely at the top.
     args: [webContentsId: number];
-    result: number;
+    result: number | null;
   };
 
   // Demo mode channels (dev-only, gated by --demo-mode flag)

--- a/shared/types/ipc/webviewConsole.ts
+++ b/shared/types/ipc/webviewConsole.ts
@@ -24,7 +24,13 @@ export type CdpRemoteArg = CdpRemoteArgPrimitive | CdpRemoteArgObject | CdpRemot
 export interface CdpStackFrame {
   functionName: string;
   url: string;
+  /**
+   * One-based, unlike the zero-based `Runtime.CallFrame` it is derived from.
+   * The main-process mapper converts once so display and clipboard cannot
+   * drift apart; consumers must not add another offset.
+   */
   lineNumber: number;
+  /** One-based — see {@link CdpStackFrame.lineNumber}. */
   columnNumber: number;
 }
 

--- a/shared/types/ipc/webviewEmulation.ts
+++ b/shared/types/ipc/webviewEmulation.ts
@@ -1,0 +1,36 @@
+/**
+ * Device-emulation payloads for dev-preview webview guests.
+ *
+ * `DeviceEmulationParameters` mirrors `Electron.Parameters` field for field,
+ * declared locally because `shared/` has no ambient Electron namespace and the
+ * payload has to survive structured cloning across the IPC boundary. The main
+ * process casts it back to `Electron.Parameters` at the `enableDeviceEmulation`
+ * call site.
+ */
+export interface DeviceEmulationParameters {
+  screenPosition: "desktop" | "mobile";
+  screenSize: { width: number; height: number };
+  viewPosition: { x: number; y: number };
+  deviceScaleFactor: number;
+  viewSize: { width: number; height: number };
+  scale: number;
+}
+
+export interface DeviceEmulationSettings {
+  params: DeviceEmulationParameters;
+  /** Preset user agent to override the guest's own with. */
+  userAgent: string;
+  /**
+   * Whether to emulate a touch screen. `enableDeviceEmulation` only drives
+   * viewport/DSF/meta-viewport — pointer and hover media features and touch
+   * dispatch need separate CDP `Emulation.*` commands.
+   */
+  touch: boolean;
+}
+
+/** `emulation: null` restores the guest to desktop (native metrics + its own UA). */
+export interface DeviceEmulationRequest {
+  webContentsId: number;
+  panelId: string;
+  emulation: DeviceEmulationSettings | null;
+}

--- a/src/components/DevPreview/ConsolePanel.tsx
+++ b/src/components/DevPreview/ConsolePanel.tsx
@@ -139,7 +139,13 @@ const ConsoleRow = memo(function ConsoleRow({
             msg.args.map((arg, i) => (
               <span key={i}>
                 {i > 0 && <span className="mx-1" />}
-                <ObjectInspector arg={arg} webContentsId={webContentsId} isStale={msg.isStale} />
+                <ObjectInspector
+                  arg={arg}
+                  webContentsId={webContentsId}
+                  paneId={msg.paneId}
+                  rowId={msg.id}
+                  isStale={msg.isStale}
+                />
               </span>
             ))
           ) : (

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -259,8 +259,6 @@ export function DevPreviewPane({
   const isConsoleOpen = terminal?.devPreviewConsoleOpen ?? false;
   const activeConsoleTab = terminal?.devPreviewConsoleTab ?? "output";
   const [guestWebContentsId, setGuestWebContentsId] = useState<number | undefined>(undefined);
-  // Store the original guest UA so we can restore it when clearing a preset
-  const originalUaRef = useRef<string | null>(null);
   const isSettingsLoading = useProjectSettingsStore((state) => state.isLoading);
 
   const isMountedRef = useRef(true);
@@ -429,7 +427,6 @@ export function DevPreviewPane({
     zoomFactor,
     evictingRef,
     lastSetUrlRef,
-    originalUaRef,
     setHistory,
     setBlockedNav: dispatchBlockedNav,
     onRenderProcessGone: handleRenderProcessGone,
@@ -700,7 +697,6 @@ export function DevPreviewPane({
     viewportFit,
     isWebviewReady,
     webviewElement,
-    originalUaRef,
     setViewportPreset,
     setViewportRotated,
     setViewportDpr,
@@ -1028,7 +1024,11 @@ export function DevPreviewPane({
                 className={cn(
                   "relative",
                   viewportPreset
-                    ? "rounded-lg border border-overlay/50 shadow-[var(--theme-shadow-floating)] overflow-hidden"
+                    ? // Outline, not border: this element carries the preset's
+                      // exact width/height and box-sizing is border-box, so a
+                      // 1px border would shave 2px off the content box the
+                      // guest is emulated at (#12298).
+                      "rounded-lg outline outline-1 -outline-offset-1 outline-overlay/50 shadow-[var(--theme-shadow-floating)] overflow-hidden"
                     : "h-full"
                 )}
                 style={

--- a/src/components/DevPreview/ObjectInspector.tsx
+++ b/src/components/DevPreview/ObjectInspector.tsx
@@ -5,6 +5,13 @@ import { cn } from "@/lib/utils";
 interface ObjectInspectorProps {
   arg: CdpRemoteArg;
   webContentsId?: number;
+  /**
+   * Pane and row that own this handle. Main attributes the descendant handles
+   * an expansion returns to that row, so they are released with it rather than
+   * outliving the row on screen (#12298).
+   */
+  paneId: string;
+  rowId: number;
   isStale?: boolean;
   depth?: number;
 }
@@ -35,11 +42,15 @@ function PrimitiveValue({ arg }: { arg: CdpRemoteArg & { type: "primitive" } }) 
 function PropertyTree({
   properties,
   webContentsId,
+  paneId,
+  rowId,
   isStale,
   depth,
 }: {
   properties: CdpPropertyDescriptor[];
   webContentsId?: number;
+  paneId: string;
+  rowId: number;
   isStale?: boolean;
   depth: number;
 }) {
@@ -56,6 +67,8 @@ function PropertyTree({
             <ObjectInspector
               arg={prop.value}
               webContentsId={webContentsId}
+              paneId={paneId}
+              rowId={rowId}
               isStale={isStale}
               depth={depth + 1}
             />
@@ -71,6 +84,8 @@ function PropertyTree({
 export function ObjectInspector({
   arg,
   webContentsId,
+  paneId,
+  rowId,
   isStale = false,
   depth = 0,
 }: ObjectInspectorProps) {
@@ -104,6 +119,8 @@ export function ObjectInspector({
     try {
       const result = await window.electron.webview.getConsoleProperties(
         webContentsId,
+        paneId,
+        rowId,
         arg.objectId
       );
       setProperties(result.properties);
@@ -114,7 +131,7 @@ export function ObjectInspector({
     } finally {
       setIsLoading(false);
     }
-  }, [isExpanded, properties, arg, webContentsId, isStale, depth]);
+  }, [isExpanded, properties, arg, webContentsId, paneId, rowId, isStale, depth]);
 
   if (arg.type === "primitive") {
     return <PrimitiveValue arg={arg} />;
@@ -160,6 +177,8 @@ export function ObjectInspector({
         <PropertyTree
           properties={properties}
           webContentsId={webContentsId}
+          paneId={paneId}
+          rowId={rowId}
           isStale={isStale}
           depth={depth}
         />

--- a/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
@@ -17,13 +17,6 @@ vi.mock("@/lib/notify", () => ({
   notify: (args: unknown) => notifyMock(args),
 }));
 
-type MockWebContents = {
-  setUserAgent: ReturnType<typeof vi.fn>;
-  getUserAgent: ReturnType<typeof vi.fn>;
-  enableDeviceEmulation: ReturnType<typeof vi.fn>;
-  disableDeviceEmulation: ReturnType<typeof vi.fn>;
-};
-
 /**
  * One entry per `<webview>` element React actually created. `srcWrites` are seed writes
  * (React setting the attribute); `loadURLs` are imperative navigations. The mock's
@@ -43,7 +36,6 @@ type MockWebviewElement = HTMLElement & {
   isLoading: ReturnType<typeof vi.fn>;
   executeJavaScript: ReturnType<typeof vi.fn>;
   getWebContentsId: ReturnType<typeof vi.fn>;
-  getWebContents: () => MockWebContents;
   capturePage: ReturnType<typeof vi.fn>;
   setMockLoading: (value: boolean) => void;
 };
@@ -93,13 +85,6 @@ function decorateWebviewElement(element: HTMLElement): MockWebviewElement {
   webview.isLoading = vi.fn(() => loading);
   webview.executeJavaScript = vi.fn().mockResolvedValue(0);
   webview.getWebContentsId = vi.fn(() => 42);
-  const mockWc = {
-    setUserAgent: vi.fn(),
-    getUserAgent: vi.fn(() => "original-ua"),
-    enableDeviceEmulation: vi.fn(),
-    disableDeviceEmulation: vi.fn(),
-  };
-  webview.getWebContents = vi.fn(() => mockWc);
   webview.capturePage = vi.fn(() =>
     Promise.resolve({ toPNG: () => new Uint8Array([0x89, 0x50, 0x4e, 0x47]) })
   );
@@ -482,6 +467,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
         onConsoleMessage: vi.fn(() => vi.fn()),
         onConsoleContextCleared: vi.fn(() => vi.fn()),
         reloadIgnoringCache: vi.fn(() => Promise.resolve()),
+        setDeviceEmulation: vi.fn(() => Promise.resolve()),
         onUnresponsive: vi.fn(() => vi.fn()),
         onResponsive: vi.fn(() => vi.fn()),
       },
@@ -726,10 +712,18 @@ describe("DevPreviewPane webview lifecycle regression", () => {
       }));
     };
 
-    const getEmulationMock = (container: HTMLElement) =>
-      getWebviewElement(container).getWebContents().enableDeviceEmulation;
-    const getDisableEmulationMock = (container: HTMLElement) =>
-      getWebviewElement(container).getWebContents().disableDeviceEmulation;
+    // Emulation is a main-process IPC call keyed by the guest's webContents id.
+    // The webview tag has no getWebContents(); mocking one is what made the
+    // broken renderer-side path look tested (#12298).
+    type EmulationPayload = { webContentsId: number; panelId: string; emulation: unknown };
+    const setDeviceEmulationMock = () =>
+      (window as unknown as { electron: { webview: { setDeviceEmulation: unknown } } }).electron
+        .webview.setDeviceEmulation as unknown as {
+        mock: { calls: Array<[EmulationPayload]> };
+        mockClear: () => void;
+      };
+    const emulationCalls = (): EmulationPayload[] =>
+      setDeviceEmulationMock().mock.calls.map(([payload]) => payload);
 
     it("applies device emulation for the active preset without reloading the page", async () => {
       withPreset("iphone");
@@ -740,13 +734,21 @@ describe("DevPreviewPane webview lifecycle regression", () => {
         await Promise.resolve();
       });
 
-      expect(getEmulationMock(container)).toHaveBeenCalledWith({
-        screenPosition: "mobile",
-        screenSize: { width: 393, height: 852 },
-        viewPosition: { x: 0, y: 0 },
-        deviceScaleFactor: 1,
-        viewSize: { width: 393, height: 852 },
-        scale: 1,
+      expect(emulationCalls()).toContainEqual({
+        webContentsId: 42,
+        panelId: "dev-preview-panel-1",
+        emulation: {
+          params: {
+            screenPosition: "mobile",
+            screenSize: { width: 393, height: 852 },
+            viewPosition: { x: 0, y: 0 },
+            deviceScaleFactor: 1,
+            viewSize: { width: 393, height: 852 },
+            scale: 1,
+          },
+          userAgent: expect.stringContaining("iPhone"),
+          touch: true,
+        },
       });
       expect(webview.reload).not.toHaveBeenCalled();
     });
@@ -760,13 +762,18 @@ describe("DevPreviewPane webview lifecycle regression", () => {
         await Promise.resolve();
       });
 
-      getEmulationMock(container).mockClear();
+      setDeviceEmulationMock().mockClear();
 
       act(() => {
         emitWebviewEvent(webview, "did-finish-load");
       });
+      await act(async () => {
+        await Promise.resolve();
+      });
 
-      expect(getEmulationMock(container)).toHaveBeenCalledWith({
+      const firstCall = emulationCalls()[0];
+      if (!firstCall) throw new Error("expected a device-emulation call");
+      expect((firstCall.emulation as { params: unknown }).params).toEqual({
         screenPosition: "mobile",
         screenSize: { width: 360, height: 780 },
         viewPosition: { x: 0, y: 0 },
@@ -785,7 +792,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
         await Promise.resolve();
       });
 
-      getEmulationMock(container).mockClear();
+      setDeviceEmulationMock().mockClear();
       withPreset(undefined);
       rerender(<DevPreviewPane {...baseProps} />);
 
@@ -793,7 +800,11 @@ describe("DevPreviewPane webview lifecycle regression", () => {
         await Promise.resolve();
       });
 
-      expect(getDisableEmulationMock(container)).toHaveBeenCalled();
+      expect(emulationCalls()).toContainEqual({
+        webContentsId: 42,
+        panelId: "dev-preview-panel-1",
+        emulation: null,
+      });
       expect(webview.reload).not.toHaveBeenCalled();
     });
   });
@@ -1089,11 +1100,11 @@ describe("DevPreviewPane webview lifecycle regression", () => {
     expect(webview.executeJavaScript).not.toHaveBeenCalledWith("window.scrollY");
   });
 
-  it("does not persist scrollY=0 from CDP (avoids clobbering prior position)", async () => {
-    // Defense: handleGetScrollPosition returns 0 on CDP error. If we persisted
-    // {scrollY: 0}, an earlier captured position could be silently overwritten.
-    // The renderer guard `> 0` keeps the prior value intact.
-    const getScrollPosition = vi.fn().mockResolvedValue(0);
+  it("does not persist a failed CDP scroll read (null sentinel)", async () => {
+    // handleGetScrollPosition answers `null` when it could not read at all, and
+    // only then must the prior stored position survive. A genuine 0 is a real
+    // position and is covered by the sibling test below (#12298).
+    const getScrollPosition = vi.fn().mockResolvedValue(null);
     (window as unknown as { electron: Record<string, unknown> }).electron = {
       system: { openExternal: vi.fn() },
       window: { onDestroyHiddenWebviews: vi.fn(() => vi.fn()) },
@@ -1130,6 +1141,48 @@ describe("DevPreviewPane webview lifecycle regression", () => {
 
     expect(getScrollPosition).toHaveBeenCalled();
     expect(terminalStoreState.setDevPreviewScrollPosition).not.toHaveBeenCalled();
+  });
+
+  it("persists a successful scrollY=0 so a return to the top overwrites a stale offset", async () => {
+    const getScrollPosition = vi.fn().mockResolvedValue(0);
+    (window as unknown as { electron: Record<string, unknown> }).electron = {
+      system: { openExternal: vi.fn() },
+      window: { onDestroyHiddenWebviews: vi.fn(() => vi.fn()) },
+      webview: {
+        registerPanel: vi.fn(() => Promise.resolve()),
+        onDialogRequest: vi.fn(() => vi.fn()),
+        onFindShortcut: vi.fn(() => vi.fn()),
+        onReloadShortcut: vi.fn(() => vi.fn()),
+        onCloseShortcut: vi.fn(() => vi.fn()),
+        onNavigationBlocked: vi.fn(() => vi.fn()),
+        onOAuthLoopbackStatus: vi.fn(() => vi.fn()),
+        onUnresponsive: vi.fn(() => vi.fn()),
+        onResponsive: vi.fn(() => vi.fn()),
+        setLifecycleState: vi.fn().mockResolvedValue(undefined),
+        getScrollPosition,
+        startConsoleCapture: vi.fn(() => Promise.resolve()),
+        stopConsoleCapture: vi.fn(() => Promise.resolve()),
+        onConsoleMessage: vi.fn(() => vi.fn()),
+        onConsoleContextCleared: vi.fn(() => vi.fn()),
+      },
+    };
+
+    const { unmount } = render(<DevPreviewPane {...baseProps} />);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      unmount();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(terminalStoreState.setDevPreviewScrollPosition).toHaveBeenCalledWith(
+      "dev-preview-panel-1",
+      { url: "http://localhost:5173/", scrollY: 0 }
+    );
   });
 
   it("captures scroll position when status transitions from running", async () => {

--- a/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
@@ -467,7 +467,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
         onConsoleMessage: vi.fn(() => vi.fn()),
         onConsoleContextCleared: vi.fn(() => vi.fn()),
         reloadIgnoringCache: vi.fn(() => Promise.resolve()),
-        setDeviceEmulation: vi.fn(() => Promise.resolve()),
+        setDeviceEmulation: vi.fn(() => Promise.resolve({ applied: true })),
         onUnresponsive: vi.fn(() => vi.fn()),
         onResponsive: vi.fn(() => vi.fn()),
       },

--- a/src/components/DevPreview/__tests__/useDevPreviewScrollCapture.test.tsx
+++ b/src/components/DevPreview/__tests__/useDevPreviewScrollCapture.test.tsx
@@ -135,8 +135,33 @@ describe("useDevPreviewScrollCapture — captureScrollViaCdp (frozen-safe) path"
     });
   });
 
-  it("does not persist a CDP-returned 0 (error-path guard), unlike the executeJavaScript path", async () => {
+  it("persists a successful 0 so a return to the top overwrites a stale offset", async () => {
     getScrollPositionMock.mockResolvedValue(0);
+    const webview = makeWebview();
+    const setDevPreviewScrollPosition = vi.fn();
+    const { result } = renderHook(() =>
+      useDevPreviewScrollCapture({
+        id: PANE_ID,
+        status: "running",
+        webviewElement: null,
+        setDevPreviewScrollPosition,
+      })
+    );
+
+    await act(async () => {
+      result.current.captureScrollViaCdp(webview);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(setDevPreviewScrollPosition).toHaveBeenCalledWith(PANE_ID, {
+      url: "http://localhost:3000/page",
+      scrollY: 0,
+    });
+  });
+
+  it("leaves any stored position untouched when the read fails (null sentinel)", async () => {
+    getScrollPositionMock.mockResolvedValue(null);
     const webview = makeWebview();
     const setDevPreviewScrollPosition = vi.fn();
     const { result } = renderHook(() =>

--- a/src/components/DevPreview/__tests__/useDevPreviewScrollCapture.test.tsx
+++ b/src/components/DevPreview/__tests__/useDevPreviewScrollCapture.test.tsx
@@ -211,6 +211,78 @@ describe("useDevPreviewScrollCapture — captureScrollViaCdp (frozen-safe) path"
     expect(setDevPreviewScrollPosition).not.toHaveBeenCalled();
   });
 
+  it("keeps an unconfirmable non-zero offset from the eviction capture", async () => {
+    // The tag is detached by the time the reading lands. A real offset cannot
+    // have come from a freshly blanked page, and discarding it would lose the
+    // capture this path exists for.
+    const webview = makeWebview({
+      getURL: vi.fn(() => {
+        throw new Error("The WebView must be attached to the DOM");
+      }),
+    });
+    // The first call, before the request, has to succeed.
+    let firstCall = true;
+    (webview.getURL as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      if (firstCall) {
+        firstCall = false;
+        return "http://localhost:3000/page";
+      }
+      throw new Error("The WebView must be attached to the DOM");
+    });
+    getScrollPositionMock.mockResolvedValue(240);
+    const setDevPreviewScrollPosition = vi.fn();
+    const { result } = renderHook(() =>
+      useDevPreviewScrollCapture({
+        id: PANE_ID,
+        status: "running",
+        webviewElement: null,
+        setDevPreviewScrollPosition,
+      })
+    );
+
+    await act(async () => {
+      result.current.captureScrollViaCdp(webview);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(setDevPreviewScrollPosition).toHaveBeenCalledWith(PANE_ID, {
+      url: "http://localhost:3000/page",
+      scrollY: 240,
+    });
+  });
+
+  it("discards an unconfirmable zero, which may be the blanked page", async () => {
+    let firstCall = true;
+    const webview = makeWebview({
+      getURL: vi.fn(() => {
+        if (firstCall) {
+          firstCall = false;
+          return "http://localhost:3000/page";
+        }
+        throw new Error("The WebView must be attached to the DOM");
+      }),
+    });
+    getScrollPositionMock.mockResolvedValue(0);
+    const setDevPreviewScrollPosition = vi.fn();
+    const { result } = renderHook(() =>
+      useDevPreviewScrollCapture({
+        id: PANE_ID,
+        status: "running",
+        webviewElement: null,
+        setDevPreviewScrollPosition,
+      })
+    );
+
+    await act(async () => {
+      result.current.captureScrollViaCdp(webview);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(setDevPreviewScrollPosition).not.toHaveBeenCalled();
+  });
+
   it("skips capture entirely when the webview URL is about:blank", async () => {
     const webview = makeWebview({ getURL: vi.fn(() => "about:blank") });
     const setDevPreviewScrollPosition = vi.fn();

--- a/src/components/DevPreview/__tests__/useDevPreviewScrollCapture.test.tsx
+++ b/src/components/DevPreview/__tests__/useDevPreviewScrollCapture.test.tsx
@@ -182,6 +182,35 @@ describe("useDevPreviewScrollCapture — captureScrollViaCdp (frozen-safe) path"
     expect(setDevPreviewScrollPosition).not.toHaveBeenCalled();
   });
 
+  it("discards a reading whose document changed while the request was in flight", async () => {
+    // The eviction path blanks the guest right after asking for the offset.
+    // Now that a zero is persisted, an answer arriving after that would file
+    // the blank page's 0 against the previous URL.
+    let urlNow = "http://localhost:3000/page";
+    const webview = makeWebview({ getURL: vi.fn(() => urlNow) });
+    getScrollPositionMock.mockImplementation(() => {
+      urlNow = "about:blank";
+      return Promise.resolve(0);
+    });
+    const setDevPreviewScrollPosition = vi.fn();
+    const { result } = renderHook(() =>
+      useDevPreviewScrollCapture({
+        id: PANE_ID,
+        status: "running",
+        webviewElement: null,
+        setDevPreviewScrollPosition,
+      })
+    );
+
+    await act(async () => {
+      result.current.captureScrollViaCdp(webview);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(setDevPreviewScrollPosition).not.toHaveBeenCalled();
+  });
+
   it("skips capture entirely when the webview URL is about:blank", async () => {
     const webview = makeWebview({ getURL: vi.fn(() => "about:blank") });
     const setDevPreviewScrollPosition = vi.fn();

--- a/src/components/DevPreview/__tests__/useDevPreviewViewport.test.tsx
+++ b/src/components/DevPreview/__tests__/useDevPreviewViewport.test.tsx
@@ -383,6 +383,45 @@ describe("useDevPreviewViewport — device emulation effect", () => {
     expect(calls[1]!.emulation).toBeNull();
   });
 
+  it("re-issues the last confirmed state when a newer request is still pending", async () => {
+    // Desktop is confirmed, a preset is requested, then desktop again before
+    // that preset lands. Deduplicating against the confirmed desktop key would
+    // skip the clear and leave the guest emulated once the preset arrives.
+    let resolvePreset: (value: { applied: boolean }) => void = () => {};
+    const webview = makeWebview();
+    const { rerender } = renderHook((props) => useDevPreviewViewport(props), {
+      initialProps: baseParams({
+        viewportPreset: undefined,
+        isWebviewReady: true,
+        webviewElement: webview,
+      }),
+    });
+    await settleEmulation();
+    expect(setDeviceEmulation).not.toHaveBeenCalled();
+
+    setDeviceEmulation.mockImplementationOnce(
+      () =>
+        new Promise<{ applied: boolean }>((resolve) => {
+          resolvePreset = resolve;
+        })
+    );
+    rerender(
+      baseParams({ viewportPreset: "iphone", isWebviewReady: true, webviewElement: webview })
+    );
+    await settleEmulation();
+
+    rerender(
+      baseParams({ viewportPreset: undefined, isWebviewReady: true, webviewElement: webview })
+    );
+    await settleEmulation();
+    resolvePreset({ applied: true });
+    await settleEmulation();
+
+    const calls = emulationCalls();
+    expect(calls).toHaveLength(2);
+    expect(calls[1]!.emulation).toBeNull();
+  });
+
   it("does not record a preset main reported it did not apply", async () => {
     setDeviceEmulation.mockResolvedValueOnce({ applied: false });
     const webview = makeWebview();

--- a/src/components/DevPreview/__tests__/useDevPreviewViewport.test.tsx
+++ b/src/components/DevPreview/__tests__/useDevPreviewViewport.test.tsx
@@ -10,7 +10,10 @@ const PANE_ID = "pane-1";
 // Emulation runs in the main process now: the renderer only hands over the
 // guest id. A webview tag never had `getWebContents()` — mocking it is what let
 // the broken code path pass its tests (#12298).
-const setDeviceEmulation = vi.fn<(payload: unknown) => Promise<void>>(() => Promise.resolve());
+const setDeviceEmulation = vi.fn<(payload: unknown) => Promise<{ applied: boolean }>>(() =>
+  Promise.resolve({ applied: true })
+);
+const registerPanel = vi.fn<() => Promise<void>>(() => Promise.resolve());
 
 function makeWebview(webContentsId = 42): Electron.WebviewTag {
   return {
@@ -24,6 +27,17 @@ function makeDetachedWebview(): Electron.WebviewTag {
       throw new Error("The WebView must be attached to the DOM");
     }),
   } as unknown as Electron.WebviewTag;
+}
+
+/**
+ * Drain the register→apply→record promise chain. Each apply crosses several
+ * microtask boundaries now that registration is chained ahead of it, so a
+ * fixed couple of `Promise.resolve()` turns would be passing by luck.
+ */
+async function settleEmulation() {
+  await act(async () => {
+    for (let i = 0; i < 12; i++) await Promise.resolve();
+  });
 }
 
 function emulationCalls() {
@@ -52,9 +66,11 @@ function baseParams(overrides: Partial<Parameters<typeof useDevPreviewViewport>[
 beforeEach(() => {
   vi.restoreAllMocks();
   setDeviceEmulation.mockClear();
-  setDeviceEmulation.mockResolvedValue(undefined);
+  setDeviceEmulation.mockResolvedValue({ applied: true });
+  registerPanel.mockClear();
+  registerPanel.mockResolvedValue(undefined);
   (globalThis as unknown as { window: { electron: unknown } }).window.electron = {
-    webview: { setDeviceEmulation },
+    webview: { setDeviceEmulation, registerPanel },
   };
   class ResizeObserverStub {
     observe = vi.fn();
@@ -195,9 +211,7 @@ describe("useDevPreviewViewport — device emulation effect", () => {
       )
     );
 
-    await act(async () => {
-      await Promise.resolve();
-    });
+    await settleEmulation();
 
     expect(emulationCalls()).toEqual([
       {
@@ -231,9 +245,7 @@ describe("useDevPreviewViewport — device emulation effect", () => {
       )
     );
 
-    await act(async () => {
-      await Promise.resolve();
-    });
+    await settleEmulation();
 
     const firstCall = emulationCalls()[0];
     if (!firstCall) throw new Error("expected a device-emulation call");
@@ -252,16 +264,12 @@ describe("useDevPreviewViewport — device emulation effect", () => {
         webviewElement: webview,
       }),
     });
-    await act(async () => {
-      await Promise.resolve();
-    });
+    await settleEmulation();
 
     rerender(
       baseParams({ viewportPreset: undefined, isWebviewReady: true, webviewElement: webview })
     );
-    await act(async () => {
-      await Promise.resolve();
-    });
+    await settleEmulation();
 
     const calls = emulationCalls();
     expect(calls).toHaveLength(2);
@@ -279,9 +287,7 @@ describe("useDevPreviewViewport — device emulation effect", () => {
       )
     );
 
-    await act(async () => {
-      await Promise.resolve();
-    });
+    await settleEmulation();
 
     expect(setDeviceEmulation).not.toHaveBeenCalled();
   });
@@ -295,27 +301,23 @@ describe("useDevPreviewViewport — device emulation effect", () => {
         webviewElement: webview,
       }),
     });
-    await act(async () => {
-      await Promise.resolve();
-    });
+    await settleEmulation();
     expect(setDeviceEmulation).toHaveBeenCalledTimes(1);
 
     rerender(
       baseParams({ viewportPreset: "iphone", isWebviewReady: true, webviewElement: webview })
     );
-    await act(async () => {
-      await Promise.resolve();
-    });
+    await settleEmulation();
     expect(setDeviceEmulation).toHaveBeenCalledTimes(1);
   });
 
   it("records the newest request when two applies resolve out of order", async () => {
     // Applying is an IPC round trip now, so a slow first apply can land after a
     // fast second one. The stale reply must not overwrite what is applied.
-    let resolveFirst: () => void = () => {};
+    let resolveFirst: (value: { applied: boolean }) => void = () => {};
     setDeviceEmulation.mockImplementationOnce(
       () =>
-        new Promise<void>((resolve) => {
+        new Promise<{ applied: boolean }>((resolve) => {
           resolveFirst = resolve;
         })
     );
@@ -332,21 +334,100 @@ describe("useDevPreviewViewport — device emulation effect", () => {
     rerender(
       baseParams({ viewportPreset: "galaxy", isWebviewReady: true, webviewElement: webview })
     );
-    await act(async () => {
-      resolveFirst();
-      await Promise.resolve();
-      await Promise.resolve();
-    });
+    await settleEmulation();
+    // Now the superseded iPhone request finally answers.
+    resolveFirst({ applied: true });
+    await settleEmulation();
     expect(setDeviceEmulation).toHaveBeenCalledTimes(2);
 
-    // Galaxy is what actually landed, so re-rendering with it must not re-apply.
+    // Galaxy is what actually landed. Switching back to iPhone must re-apply —
+    // if the stale reply had been allowed to record iPhone, this would dedupe
+    // and never reach main.
+    rerender(
+      baseParams({ viewportPreset: "iphone", isWebviewReady: true, webviewElement: webview })
+    );
+    await settleEmulation();
+    expect(setDeviceEmulation).toHaveBeenCalledTimes(3);
+  });
+
+  it("clears emulation requested while the first apply is still in flight", async () => {
+    // Selecting a preset and going straight back to desktop must still reach
+    // main: skipping the clear because nothing had been *confirmed* applied
+    // would leave the guest emulated while the toolbar reads desktop.
+    let resolveFirst: (value: { applied: boolean }) => void = () => {};
+    setDeviceEmulation.mockImplementationOnce(
+      () =>
+        new Promise<{ applied: boolean }>((resolve) => {
+          resolveFirst = resolve;
+        })
+    );
+
+    const webview = makeWebview();
+    const { rerender } = renderHook((props) => useDevPreviewViewport(props), {
+      initialProps: baseParams({
+        viewportPreset: "iphone",
+        isWebviewReady: true,
+        webviewElement: webview,
+      }),
+    });
+    await settleEmulation();
+
+    rerender(
+      baseParams({ viewportPreset: undefined, isWebviewReady: true, webviewElement: webview })
+    );
+    resolveFirst({ applied: true });
+    await settleEmulation();
+
+    const calls = emulationCalls();
+    expect(calls).toHaveLength(2);
+    expect(calls[1]!.emulation).toBeNull();
+  });
+
+  it("does not record a preset main reported it did not apply", async () => {
+    setDeviceEmulation.mockResolvedValueOnce({ applied: false });
+    const webview = makeWebview();
+    const { rerender } = renderHook((props) => useDevPreviewViewport(props), {
+      initialProps: baseParams({
+        viewportPreset: "iphone",
+        isWebviewReady: false,
+        webviewElement: webview,
+      }),
+    });
+    rerender(
+      baseParams({ viewportPreset: "iphone", isWebviewReady: true, webviewElement: webview })
+    );
+    await settleEmulation();
+    expect(setDeviceEmulation).toHaveBeenCalledTimes(1);
+
+    // A guest that was not yet registered gets another go on the next
+    // transition rather than being cached as emulated.
     rerender(
       baseParams({ viewportPreset: "galaxy", isWebviewReady: true, webviewElement: webview })
     );
-    await act(async () => {
-      await Promise.resolve();
-    });
-    expect(setDeviceEmulation).toHaveBeenCalledTimes(2);
+    await settleEmulation();
+    rerender(
+      baseParams({ viewportPreset: "iphone", isWebviewReady: true, webviewElement: webview })
+    );
+    await settleEmulation();
+    expect(setDeviceEmulation).toHaveBeenCalledTimes(3);
+  });
+
+  it("registers the panel before applying so main can resolve ownership", async () => {
+    renderHook(() =>
+      useDevPreviewViewport(
+        baseParams({
+          viewportPreset: "iphone",
+          isWebviewReady: true,
+          webviewElement: makeWebview(7),
+        })
+      )
+    );
+    await settleEmulation();
+
+    expect(registerPanel).toHaveBeenCalledWith(7, PANE_ID);
+    expect(registerPanel.mock.invocationCallOrder[0]!).toBeLessThan(
+      setDeviceEmulation.mock.invocationCallOrder[0]!
+    );
   });
 
   it("reports a rejected apply instead of throwing", async () => {
@@ -364,10 +445,7 @@ describe("useDevPreviewViewport — device emulation effect", () => {
       )
     ).not.toThrow();
 
-    await act(async () => {
-      await Promise.resolve();
-      await Promise.resolve();
-    });
+    await settleEmulation();
     expect(setDeviceEmulation).toHaveBeenCalledTimes(1);
   });
 

--- a/src/components/DevPreview/__tests__/useDevPreviewViewport.test.tsx
+++ b/src/components/DevPreview/__tests__/useDevPreviewViewport.test.tsx
@@ -7,20 +7,29 @@ import { useDevPreviewViewport } from "../useDevPreviewViewport";
 
 const PANE_ID = "pane-1";
 
-function makeWebContents(overrides: Partial<Record<string, unknown>> = {}) {
+// Emulation runs in the main process now: the renderer only hands over the
+// guest id. A webview tag never had `getWebContents()` — mocking it is what let
+// the broken code path pass its tests (#12298).
+const setDeviceEmulation = vi.fn<(payload: unknown) => Promise<void>>(() => Promise.resolve());
+
+function makeWebview(webContentsId = 42): Electron.WebviewTag {
   return {
-    getUserAgent: vi.fn(() => "original-ua"),
-    setUserAgent: vi.fn(),
-    enableDeviceEmulation: vi.fn(),
-    disableDeviceEmulation: vi.fn(),
-    ...overrides,
-  };
+    getWebContentsId: vi.fn(() => webContentsId),
+  } as unknown as Electron.WebviewTag;
 }
 
-function makeWebview(webContents: ReturnType<typeof makeWebContents>): Electron.WebviewTag {
+function makeDetachedWebview(): Electron.WebviewTag {
   return {
-    getWebContents: vi.fn(() => webContents),
+    getWebContentsId: vi.fn(() => {
+      throw new Error("The WebView must be attached to the DOM");
+    }),
   } as unknown as Electron.WebviewTag;
+}
+
+function emulationCalls() {
+  return setDeviceEmulation.mock.calls.map(
+    ([payload]) => payload as { webContentsId: number; panelId: string; emulation: unknown }
+  );
 }
 
 function baseParams(overrides: Partial<Parameters<typeof useDevPreviewViewport>[0]> = {}) {
@@ -32,7 +41,6 @@ function baseParams(overrides: Partial<Parameters<typeof useDevPreviewViewport>[
     viewportFit: false,
     isWebviewReady: false,
     webviewElement: null,
-    originalUaRef: { current: null },
     setViewportPreset: vi.fn(),
     setViewportRotated: vi.fn(),
     setViewportDpr: vi.fn(),
@@ -43,6 +51,11 @@ function baseParams(overrides: Partial<Parameters<typeof useDevPreviewViewport>[
 
 beforeEach(() => {
   vi.restoreAllMocks();
+  setDeviceEmulation.mockClear();
+  setDeviceEmulation.mockResolvedValue(undefined);
+  (globalThis as unknown as { window: { electron: unknown } }).window.electron = {
+    webview: { setDeviceEmulation },
+  };
   class ResizeObserverStub {
     observe = vi.fn();
     disconnect = vi.fn();
@@ -158,83 +171,123 @@ describe("useDevPreviewViewport — effectiveViewport / fitScale", () => {
 
 describe("useDevPreviewViewport — device emulation effect", () => {
   it("does nothing while the webview isn't ready", () => {
-    const webContents = makeWebContents();
-    const webview = makeWebview(webContents);
-    renderHook(() =>
-      useDevPreviewViewport(
-        baseParams({ viewportPreset: "iphone", isWebviewReady: false, webviewElement: webview })
-      )
-    );
-    expect(webContents.enableDeviceEmulation).not.toHaveBeenCalled();
-  });
-
-  it("enables emulation and seeds originalUaRef once, when ready with a preset", () => {
-    const webContents = makeWebContents();
-    const webview = makeWebview(webContents);
-    const originalUaRef = { current: null as string | null };
     renderHook(() =>
       useDevPreviewViewport(
         baseParams({
           viewportPreset: "iphone",
-          isWebviewReady: true,
-          webviewElement: webview,
-          originalUaRef,
+          isWebviewReady: false,
+          webviewElement: makeWebview(),
         })
       )
     );
-
-    expect(webContents.setUserAgent).toHaveBeenCalledWith(expect.stringContaining("iPhone"));
-    expect(webContents.enableDeviceEmulation).toHaveBeenCalledTimes(1);
-    expect(originalUaRef.current).toBe("original-ua");
+    expect(setDeviceEmulation).not.toHaveBeenCalled();
   });
 
-  it("does not re-seed originalUaRef if it was already captured", () => {
-    const webContents = makeWebContents();
-    const webview = makeWebview(webContents);
-    const originalUaRef = { current: "already-seeded" };
+  it("sends the preset's metrics, user agent and touch flag keyed by guest id", async () => {
     renderHook(() =>
       useDevPreviewViewport(
         baseParams({
           viewportPreset: "iphone",
+          viewportDpr: 3,
           isWebviewReady: true,
-          webviewElement: webview,
-          originalUaRef,
+          webviewElement: makeWebview(7),
         })
       )
     );
-    expect(originalUaRef.current).toBe("already-seeded");
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(emulationCalls()).toEqual([
+      {
+        webContentsId: 7,
+        panelId: PANE_ID,
+        emulation: {
+          params: {
+            screenPosition: "mobile",
+            screenSize: { width: 393, height: 852 },
+            viewPosition: { x: 0, y: 0 },
+            deviceScaleFactor: 3,
+            viewSize: { width: 393, height: 852 },
+            scale: 1,
+          },
+          userAgent: expect.stringContaining("iPhone"),
+          touch: true,
+        },
+      },
+    ]);
   });
 
-  it("disables emulation and restores the original UA when the preset clears", () => {
-    const webContents = makeWebContents();
-    const webview = makeWebview(webContents);
-    const originalUaRef = { current: null as string | null };
+  it("swaps width and height when the preset is rotated", async () => {
+    renderHook(() =>
+      useDevPreviewViewport(
+        baseParams({
+          viewportPreset: "iphone",
+          viewportRotated: true,
+          isWebviewReady: true,
+          webviewElement: makeWebview(),
+        })
+      )
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const firstCall = emulationCalls()[0];
+    if (!firstCall) throw new Error("expected a device-emulation call");
+    const emulation = firstCall.emulation as {
+      params: { viewSize: { width: number; height: number } };
+    };
+    expect(emulation.params.viewSize).toEqual({ width: 852, height: 393 });
+  });
+
+  it("clears emulation with a null payload when the preset clears", async () => {
+    const webview = makeWebview();
     const { rerender } = renderHook((props) => useDevPreviewViewport(props), {
       initialProps: baseParams({
         viewportPreset: "iphone",
         isWebviewReady: true,
         webviewElement: webview,
-        originalUaRef,
       }),
     });
-    expect(webContents.enableDeviceEmulation).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      await Promise.resolve();
+    });
 
     rerender(
-      baseParams({
-        viewportPreset: undefined,
-        isWebviewReady: true,
-        webviewElement: webview,
-        originalUaRef,
-      })
+      baseParams({ viewportPreset: undefined, isWebviewReady: true, webviewElement: webview })
     );
+    await act(async () => {
+      await Promise.resolve();
+    });
 
-    expect(webContents.disableDeviceEmulation).toHaveBeenCalledTimes(1);
-    expect(webContents.setUserAgent).toHaveBeenLastCalledWith("original-ua");
+    const calls = emulationCalls();
+    expect(calls).toHaveLength(2);
+    expect(calls[1]!.emulation).toBeNull();
   });
 
-  it("does not re-apply emulation when the preset/rotation/dpr key is unchanged", () => {
-    const webContents = makeWebContents();
-    const webview = makeWebview(webContents);
+  it("does not clear emulation that was never applied", async () => {
+    renderHook(() =>
+      useDevPreviewViewport(
+        baseParams({
+          viewportPreset: undefined,
+          isWebviewReady: true,
+          webviewElement: makeWebview(),
+        })
+      )
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(setDeviceEmulation).not.toHaveBeenCalled();
+  });
+
+  it("does not re-apply emulation when the preset/rotation/dpr key is unchanged", async () => {
+    const webview = makeWebview();
     const { rerender } = renderHook((props) => useDevPreviewViewport(props), {
       initialProps: baseParams({
         viewportPreset: "iphone",
@@ -242,11 +295,94 @@ describe("useDevPreviewViewport — device emulation effect", () => {
         webviewElement: webview,
       }),
     });
-    expect(webContents.enableDeviceEmulation).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(setDeviceEmulation).toHaveBeenCalledTimes(1);
 
     rerender(
       baseParams({ viewportPreset: "iphone", isWebviewReady: true, webviewElement: webview })
     );
-    expect(webContents.enableDeviceEmulation).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(setDeviceEmulation).toHaveBeenCalledTimes(1);
+  });
+
+  it("records the newest request when two applies resolve out of order", async () => {
+    // Applying is an IPC round trip now, so a slow first apply can land after a
+    // fast second one. The stale reply must not overwrite what is applied.
+    let resolveFirst: () => void = () => {};
+    setDeviceEmulation.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveFirst = resolve;
+        })
+    );
+
+    const webview = makeWebview();
+    const { rerender } = renderHook((props) => useDevPreviewViewport(props), {
+      initialProps: baseParams({
+        viewportPreset: "iphone",
+        isWebviewReady: true,
+        webviewElement: webview,
+      }),
+    });
+
+    rerender(
+      baseParams({ viewportPreset: "galaxy", isWebviewReady: true, webviewElement: webview })
+    );
+    await act(async () => {
+      resolveFirst();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(setDeviceEmulation).toHaveBeenCalledTimes(2);
+
+    // Galaxy is what actually landed, so re-rendering with it must not re-apply.
+    rerender(
+      baseParams({ viewportPreset: "galaxy", isWebviewReady: true, webviewElement: webview })
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(setDeviceEmulation).toHaveBeenCalledTimes(2);
+  });
+
+  it("reports a rejected apply instead of throwing", async () => {
+    setDeviceEmulation.mockRejectedValueOnce(new Error("guest went away"));
+
+    expect(() =>
+      renderHook(() =>
+        useDevPreviewViewport(
+          baseParams({
+            viewportPreset: "iphone",
+            isWebviewReady: true,
+            webviewElement: makeWebview(),
+          })
+        )
+      )
+    ).not.toThrow();
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(setDeviceEmulation).toHaveBeenCalledTimes(1);
+  });
+
+  it("survives a webview detached before its guest id can be read", async () => {
+    expect(() =>
+      renderHook(() =>
+        useDevPreviewViewport(
+          baseParams({
+            viewportPreset: "iphone",
+            isWebviewReady: true,
+            webviewElement: makeDetachedWebview(),
+          })
+        )
+      )
+    ).not.toThrow();
+    expect(setDeviceEmulation).not.toHaveBeenCalled();
   });
 });

--- a/src/components/DevPreview/__tests__/viewportEmulation.test.ts
+++ b/src/components/DevPreview/__tests__/viewportEmulation.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { buildEmulationParams } from "../viewportEmulation";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { applyDevPreviewEmulation, buildEmulationParams } from "../viewportEmulation";
 
 describe("buildEmulationParams", () => {
   it("returns null when no preset is active", () => {
@@ -33,5 +33,64 @@ describe("buildEmulationParams", () => {
   it('builds iPad Air 11" params', () => {
     const params = buildEmulationParams("ipad", false, 1);
     expect(params!.screenSize).toEqual({ width: 820, height: 1180 });
+  });
+});
+
+describe("applyDevPreviewEmulation", () => {
+  const setDeviceEmulation = vi.fn<(payload: unknown) => Promise<void>>(() => Promise.resolve());
+
+  function makeWebview(webContentsId = 42): Electron.WebviewTag {
+    return {
+      getWebContentsId: vi.fn(() => webContentsId),
+    } as unknown as Electron.WebviewTag;
+  }
+
+  beforeEach(() => {
+    setDeviceEmulation.mockClear();
+    (globalThis as unknown as { window: { electron: unknown } }).window = {
+      electron: { webview: { setDeviceEmulation } },
+    } as never;
+  });
+
+  it("sends the preset metrics, spoofed UA and touch flag keyed by guest id", async () => {
+    await applyDevPreviewEmulation(makeWebview(7), "panel-1", "pixel", false, 2);
+
+    expect(setDeviceEmulation).toHaveBeenCalledWith({
+      webContentsId: 7,
+      panelId: "panel-1",
+      emulation: {
+        params: {
+          screenPosition: "mobile",
+          screenSize: { width: 412, height: 923 },
+          viewPosition: { x: 0, y: 0 },
+          deviceScaleFactor: 2,
+          viewSize: { width: 412, height: 923 },
+          scale: 1,
+        },
+        userAgent: expect.stringContaining("Pixel 10"),
+        touch: true,
+      },
+    });
+  });
+
+  it("sends a null payload to restore desktop", async () => {
+    await applyDevPreviewEmulation(makeWebview(7), "panel-1", undefined, false, 1);
+
+    expect(setDeviceEmulation).toHaveBeenCalledWith({
+      webContentsId: 7,
+      panelId: "panel-1",
+      emulation: null,
+    });
+  });
+
+  it("propagates a detached webview synchronously instead of invoking IPC", () => {
+    const detached = {
+      getWebContentsId: vi.fn(() => {
+        throw new Error("The WebView must be attached to the DOM");
+      }),
+    } as unknown as Electron.WebviewTag;
+
+    expect(() => applyDevPreviewEmulation(detached, "panel-1", "iphone", false, 1)).toThrow();
+    expect(setDeviceEmulation).not.toHaveBeenCalled();
   });
 });

--- a/src/components/DevPreview/__tests__/viewportEmulation.test.ts
+++ b/src/components/DevPreview/__tests__/viewportEmulation.test.ts
@@ -37,7 +37,10 @@ describe("buildEmulationParams", () => {
 });
 
 describe("applyDevPreviewEmulation", () => {
-  const setDeviceEmulation = vi.fn<(payload: unknown) => Promise<void>>(() => Promise.resolve());
+  const setDeviceEmulation = vi.fn<(payload: unknown) => Promise<{ applied: boolean }>>(() =>
+    Promise.resolve({ applied: true })
+  );
+  const registerPanel = vi.fn<() => Promise<void>>(() => Promise.resolve());
 
   function makeWebview(webContentsId = 42): Electron.WebviewTag {
     return {
@@ -47,8 +50,11 @@ describe("applyDevPreviewEmulation", () => {
 
   beforeEach(() => {
     setDeviceEmulation.mockClear();
+    setDeviceEmulation.mockResolvedValue({ applied: true });
+    registerPanel.mockClear();
+    registerPanel.mockResolvedValue(undefined);
     (globalThis as unknown as { window: { electron: unknown } }).window = {
-      electron: { webview: { setDeviceEmulation } },
+      electron: { webview: { setDeviceEmulation, registerPanel } },
     } as never;
   });
 
@@ -92,5 +98,25 @@ describe("applyDevPreviewEmulation", () => {
 
     expect(() => applyDevPreviewEmulation(detached, "panel-1", "iphone", false, 1)).toThrow();
     expect(setDeviceEmulation).not.toHaveBeenCalled();
+  });
+
+  it("registers the guest before applying, so main can resolve ownership", async () => {
+    await applyDevPreviewEmulation(makeWebview(7), "panel-1", "iphone", false, 1);
+
+    expect(registerPanel).toHaveBeenCalledWith(7, "panel-1");
+    expect(registerPanel.mock.invocationCallOrder[0]!).toBeLessThan(
+      setDeviceEmulation.mock.invocationCallOrder[0]!
+    );
+  });
+
+  it("passes main's applied verdict back to the caller", async () => {
+    setDeviceEmulation.mockResolvedValueOnce({ applied: false });
+    await expect(
+      applyDevPreviewEmulation(makeWebview(), "panel-1", "iphone", false, 1)
+    ).resolves.toBe(false);
+
+    await expect(
+      applyDevPreviewEmulation(makeWebview(), "panel-1", "iphone", false, 1)
+    ).resolves.toBe(true);
   });
 });

--- a/src/components/DevPreview/useDevPreviewLoadLifecycle.ts
+++ b/src/components/DevPreview/useDevPreviewLoadLifecycle.ts
@@ -4,8 +4,8 @@ import { useUrlHistoryStore } from "@/store/urlHistoryStore";
 import type { BrowserHistory } from "@shared/types/browser";
 import { isDevPreviewPanel } from "@shared/types/panel";
 import { DEV_PREVIEW_PROXY_STATUS_TEXT } from "@shared/utils/devPreviewProxy";
-import { getViewportPreset } from "@/panels/dev-preview/viewportPresets";
-import { getDevPreviewWebContents, buildEmulationParams } from "./viewportEmulation";
+import { applyDevPreviewEmulation } from "./viewportEmulation";
+import { safeFireAndForget } from "@/utils/safeFireAndForget";
 import { pushBrowserHistory } from "../Browser/historyUtils";
 import { loadWebviewUrl } from "./loadWebviewUrl";
 import type { BlockedNavAction } from "./BlockedNavBanner";
@@ -72,7 +72,6 @@ interface UseDevPreviewLoadLifecycleParams {
   zoomFactor: number;
   evictingRef: React.RefObject<boolean>;
   lastSetUrlRef: React.MutableRefObject<string>;
-  originalUaRef: React.MutableRefObject<string | null>;
   setHistory: React.Dispatch<React.SetStateAction<BrowserHistory>>;
   setBlockedNav: React.Dispatch<BlockedNavAction>;
   onRenderProcessGone?: (details: { reason: string; exitCode: number }) => void;
@@ -98,7 +97,6 @@ export function useDevPreviewLoadLifecycle({
   zoomFactor,
   evictingRef,
   lastSetUrlRef,
-  originalUaRef,
   setHistory,
   setBlockedNav,
   onRenderProcessGone,
@@ -344,36 +342,28 @@ export function useDevPreviewLoadLifecycle({
         proxyRetryRef.current = null;
       }
 
-      // Device emulation and the UA override do NOT persist across
-      // cross-origin navigation (renderer process swap), so re-apply both
-      // here. Without this, navigating within the preview silently drops
-      // the emulated viewport and the spoofed user agent.
+      // Device emulation does not persist across cross-origin navigation
+      // (renderer process swap), so re-apply it here. Without this, navigating
+      // within the preview silently drops the emulated viewport. Only re-apply
+      // while a preset is active: clearing is driven by the toolbar, and main
+      // already restored the guest's own user agent when the preset was
+      // cleared, so a redundant clear on every load would be noise.
       const activePreset = viewportPresetRef.current;
-      const activeRotated = viewportRotatedRef.current;
-      const activeDpr = viewportDprRef.current;
-      try {
-        const wc = getDevPreviewWebContents(webview);
-        if (wc) {
-          if (originalUaRef.current === null) {
-            originalUaRef.current = wc.getUserAgent();
-          }
-          if (activePreset) {
-            wc.setUserAgent(getViewportPreset(activePreset).userAgent);
-            const params = buildEmulationParams(activePreset, activeRotated, activeDpr);
-            if (params) {
-              wc.enableDeviceEmulation(params);
-            }
-          } else if (originalUaRef.current !== null) {
-            wc.setUserAgent(originalUaRef.current);
-            try {
-              wc.disableDeviceEmulation();
-            } catch {
-              // disableDeviceEmulation may throw if emulation was never enabled
-            }
-          }
+      if (activePreset) {
+        try {
+          safeFireAndForget(
+            applyDevPreviewEmulation(
+              webview,
+              id,
+              activePreset,
+              viewportRotatedRef.current,
+              viewportDprRef.current
+            ),
+            { context: "Re-applying dev-preview device emulation after navigation" }
+          );
+        } catch {
+          // getWebContentsId() throws on a detached webview.
         }
-      } catch {
-        // WebContents not available (webview detached)
       }
     };
 
@@ -687,7 +677,6 @@ export function useDevPreviewLoadLifecycle({
     setHistory,
     setBlockedNav,
     id,
-    originalUaRef,
     onRenderProcessGone,
   ]);
 
@@ -701,14 +690,6 @@ export function useDevPreviewLoadLifecycle({
     const handleDomReady = () => {
       setIsWebviewReady(true);
       webview.setZoomFactor(zoomFactor);
-      try {
-        const wc = getDevPreviewWebContents(webview);
-        if (wc && originalUaRef.current === null) {
-          originalUaRef.current = wc.getUserAgent();
-        }
-      } catch {
-        // WebContents not available yet
-      }
       // The watchdog and the blocking "Loading preview" overlay share this one
       // finish boundary. dom-ready is DOMContentLoaded: the document is committed
       // and usable, while did-finish-load/did-stop-loading additionally wait on the
@@ -747,14 +728,6 @@ export function useDevPreviewLoadLifecycle({
       if (existingUrl && existingUrl !== "about:blank" && !webview.isLoading()) {
         setIsWebviewReady(true);
         webview.setZoomFactor(zoomFactor);
-        try {
-          const wc = getDevPreviewWebContents(webview);
-          if (wc && originalUaRef.current === null) {
-            originalUaRef.current = wc.getUserAgent();
-          }
-        } catch {
-          // WebContents not available
-        }
         // dom-ready already fired before this listener attached. Run scroll
         // restore here so the position survives tab switches and other
         // re-renders that don't trigger another dom-ready.
@@ -781,7 +754,7 @@ export function useDevPreviewLoadLifecycle({
     return () => {
       webview.removeEventListener("dom-ready", handleDomReady);
     };
-  }, [id, zoomFactor, webviewElement, originalUaRef]);
+  }, [id, zoomFactor, webviewElement]);
 
   useEffect(() => {
     return () => {

--- a/src/components/DevPreview/useDevPreviewScrollCapture.ts
+++ b/src/components/DevPreview/useDevPreviewScrollCapture.ts
@@ -72,14 +72,14 @@ export function useDevPreviewScrollCapture({
       const wcId = (webview as unknown as { getWebContentsId(): number }).getWebContentsId();
       window.electron.webview
         .getScrollPosition(wcId)
-        .then((scrollY: number) => {
+        .then((scrollY: number | null) => {
           if (scrollCaptureGenerationRef.current !== captureGeneration) return;
-          // Guard `> 0`: a CDP error returns 0, and the user being at top of
-          // page has nothing worth restoring — both cases should leave any
-          // prior stored position untouched rather than clobber it.
-          if (typeof scrollY === "number" && Number.isFinite(scrollY) && scrollY > 0) {
-            setDevPreviewScrollPosition(id, { url: currentWebviewUrl, scrollY });
-          }
+          // `null` is the read-failed sentinel — leave any prior stored
+          // position alone. A successful `0` is a real position and must
+          // overwrite, or scrolling back to the top before eviction leaves a
+          // stale offset that a remount restores (#12298).
+          if (scrollY === null || !Number.isFinite(scrollY)) return;
+          setDevPreviewScrollPosition(id, { url: currentWebviewUrl, scrollY });
         })
         .catch(() => {});
     },

--- a/src/components/DevPreview/useDevPreviewScrollCapture.ts
+++ b/src/components/DevPreview/useDevPreviewScrollCapture.ts
@@ -81,15 +81,19 @@ export function useDevPreviewScrollCapture({
           if (scrollY === null || !Number.isFinite(scrollY)) return;
           // Now that a zero is persisted, the document it was measured on
           // matters: the eviction path blanks the guest immediately after
-          // asking, and a reading that lands after that would file the blank
-          // page's 0 against the previous URL.
-          let settledUrl: string;
+          // asking, and a reading landing after that would file the blank
+          // page's 0 against the previous URL. Only a URL we can still read
+          // *and* that differs is evidence of that — a detached tag can no
+          // longer tell us, and the read was taken before teardown began, so
+          // discarding it there would lose the eviction capture this path
+          // exists for.
+          let settledUrl: string | null;
           try {
             settledUrl = webview.getURL();
           } catch {
-            return;
+            settledUrl = null;
           }
-          if (settledUrl !== currentWebviewUrl) return;
+          if (settledUrl !== null && settledUrl !== currentWebviewUrl) return;
           setDevPreviewScrollPosition(id, { url: currentWebviewUrl, scrollY });
         })
         .catch(() => {});

--- a/src/components/DevPreview/useDevPreviewScrollCapture.ts
+++ b/src/components/DevPreview/useDevPreviewScrollCapture.ts
@@ -93,7 +93,16 @@ export function useDevPreviewScrollCapture({
           } catch {
             settledUrl = null;
           }
-          if (settledUrl !== null && settledUrl !== currentWebviewUrl) return;
+          if (settledUrl === null) {
+            // The tag is gone, so the document cannot be confirmed. A non-zero
+            // offset could not have come from a freshly blanked page, so it is
+            // safe to keep — this is the eviction capture doing its job. An
+            // unconfirmable zero is exactly the blank-page reading that must
+            // not be filed against the previous URL.
+            if (scrollY === 0) return;
+          } else if (settledUrl !== currentWebviewUrl) {
+            return;
+          }
           setDevPreviewScrollPosition(id, { url: currentWebviewUrl, scrollY });
         })
         .catch(() => {});

--- a/src/components/DevPreview/useDevPreviewScrollCapture.ts
+++ b/src/components/DevPreview/useDevPreviewScrollCapture.ts
@@ -79,6 +79,17 @@ export function useDevPreviewScrollCapture({
           // overwrite, or scrolling back to the top before eviction leaves a
           // stale offset that a remount restores (#12298).
           if (scrollY === null || !Number.isFinite(scrollY)) return;
+          // Now that a zero is persisted, the document it was measured on
+          // matters: the eviction path blanks the guest immediately after
+          // asking, and a reading that lands after that would file the blank
+          // page's 0 against the previous URL.
+          let settledUrl: string;
+          try {
+            settledUrl = webview.getURL();
+          } catch {
+            return;
+          }
+          if (settledUrl !== currentWebviewUrl) return;
           setDevPreviewScrollPosition(id, { url: currentWebviewUrl, scrollY });
         })
         .catch(() => {});

--- a/src/components/DevPreview/useDevPreviewViewport.ts
+++ b/src/components/DevPreview/useDevPreviewViewport.ts
@@ -1,10 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import {
-  getViewportPreset,
-  getEffectiveViewportSize,
-  computeFitScale,
-} from "@/panels/dev-preview/viewportPresets";
-import { getDevPreviewWebContents, buildEmulationParams } from "./viewportEmulation";
+import { getEffectiveViewportSize, computeFitScale } from "@/panels/dev-preview/viewportPresets";
+import { applyDevPreviewEmulation } from "./viewportEmulation";
+import { safeFireAndForget } from "@/utils/safeFireAndForget";
 import type { ViewportPresetId } from "@shared/types/panel";
 
 interface UseDevPreviewViewportParams {
@@ -15,10 +12,6 @@ interface UseDevPreviewViewportParams {
   viewportFit: boolean;
   isWebviewReady: boolean;
   webviewElement: Electron.WebviewTag | null;
-  // Shared with useDevPreviewLoadLifecycle, which re-applies emulation after
-  // cross-origin navigation — the parent owns this ref so both hooks see the
-  // same seeded user agent.
-  originalUaRef: React.MutableRefObject<string | null>;
   setViewportPreset: (id: string, preset: ViewportPresetId | undefined) => void;
   setViewportRotated: (id: string, rotated: boolean) => void;
   setViewportDpr: (id: string, dpr: 1 | 2 | 3) => void;
@@ -41,7 +34,6 @@ export function useDevPreviewViewport({
   viewportFit,
   isWebviewReady,
   webviewElement,
-  originalUaRef,
   setViewportPreset,
   setViewportRotated,
   setViewportDpr,
@@ -108,47 +100,52 @@ export function useDevPreviewViewport({
       : 1;
 
   // Apply device emulation when viewport preset, rotation, or DPR changes.
-  // Uses enableDeviceEmulation which drives CSS media queries and window.innerWidth
-  // without a page reload, preserving in-page state across preset switches.
+  // The main process calls enableDeviceEmulation, which drives CSS media
+  // queries and window.innerWidth without a page reload, preserving in-page
+  // state across preset switches.
   const prevEmulationKeyRef = useRef<string | null>(null);
   const hasAppliedEmulationRef = useRef(false);
+  // Applying is an async IPC round trip now, so two fast preset switches can
+  // resolve out of order. Only the newest request may record what is applied.
+  const emulationSeqRef = useRef(0);
   useEffect(() => {
     if (!isWebviewReady || !webviewElement) return;
     const emulationKey = `${viewportPreset ?? "none"}-${viewportRotated}-${viewportDpr}`;
     if (prevEmulationKeyRef.current === emulationKey) return;
-    const hadPrevious = hasAppliedEmulationRef.current;
-
-    const wc = getDevPreviewWebContents(webviewElement);
-    if (!wc) return;
-
-    try {
-      if (viewportPreset) {
-        if (originalUaRef.current === null) {
-          // eslint-disable-next-line react-compiler/react-compiler -- originalUaRef is a parent-owned ref threaded in as a hook param; the compiler can't see through the boundary that it's a stable ref, not a prop
-          originalUaRef.current = wc.getUserAgent();
-        }
-        wc.setUserAgent(getViewportPreset(viewportPreset).userAgent);
-        wc.enableDeviceEmulation(
-          buildEmulationParams(viewportPreset, viewportRotated, viewportDpr)!
-        );
-        prevEmulationKeyRef.current = emulationKey;
-        hasAppliedEmulationRef.current = true;
-      } else if (hadPrevious) {
-        try {
-          wc.disableDeviceEmulation();
-        } catch {
-          // disableDeviceEmulation may throw if emulation was never enabled
-        }
-        if (originalUaRef.current) {
-          wc.setUserAgent(originalUaRef.current);
-        }
-        prevEmulationKeyRef.current = emulationKey;
-        hasAppliedEmulationRef.current = false;
-      }
-    } catch {
-      // WebContents not available (webview detached)
+    // Clearing emulation that was never applied is a no-op, but the key still
+    // has to advance so a later switch back to the same desktop state is not
+    // mistaken for a repeat.
+    if (!viewportPreset && !hasAppliedEmulationRef.current) {
+      prevEmulationKeyRef.current = emulationKey;
+      return;
     }
-  }, [viewportPreset, viewportRotated, viewportDpr, isWebviewReady, webviewElement, originalUaRef]);
+
+    // eslint-disable-next-line react-compiler/react-compiler -- refs mutated inside an effect the compiler cannot prove is not render-phase
+    const seq = ++emulationSeqRef.current;
+    let applied: Promise<void>;
+    try {
+      applied = applyDevPreviewEmulation(
+        webviewElement,
+        id,
+        viewportPreset,
+        viewportRotated,
+        viewportDpr
+      );
+    } catch {
+      // getWebContentsId() throws on a detached webview; the next ready
+      // transition re-runs this effect against the replacement guest.
+      return;
+    }
+
+    safeFireAndForget(
+      applied.then(() => {
+        if (emulationSeqRef.current !== seq) return;
+        prevEmulationKeyRef.current = emulationKey;
+        hasAppliedEmulationRef.current = viewportPreset !== undefined;
+      }),
+      { context: "Applying dev-preview device emulation" }
+    );
+  }, [id, viewportPreset, viewportRotated, viewportDpr, isWebviewReady, webviewElement]);
 
   return {
     effectiveViewport,

--- a/src/components/DevPreview/useDevPreviewViewport.ts
+++ b/src/components/DevPreview/useDevPreviewViewport.ts
@@ -108,23 +108,26 @@ export function useDevPreviewViewport({
   // Applying is an async IPC round trip now, so two fast preset switches can
   // resolve out of order. Only the newest request may record what is applied.
   const emulationSeqRef = useRef(0);
+  const inFlightEmulationRef = useRef(0);
   useEffect(() => {
     if (!isWebviewReady || !webviewElement) return;
     const emulationKey = `${viewportPreset ?? "none"}-${viewportRotated}-${viewportDpr}`;
     if (prevEmulationKeyRef.current === emulationKey) return;
     // Clearing emulation that was never applied is a no-op, but the key still
     // has to advance so a later switch back to the same desktop state is not
-    // mistaken for a repeat.
-    if (!viewportPreset && !hasAppliedEmulationRef.current) {
+    // mistaken for a repeat. An in-flight request counts as applied for this
+    // purpose: skipping the clear while a preset apply is still on the wire
+    // would leave the guest emulated with the toolbar showing desktop.
+    if (!viewportPreset && !hasAppliedEmulationRef.current && inFlightEmulationRef.current === 0) {
       prevEmulationKeyRef.current = emulationKey;
       return;
     }
 
     // eslint-disable-next-line react-compiler/react-compiler -- refs mutated inside an effect the compiler cannot prove is not render-phase
     const seq = ++emulationSeqRef.current;
-    let applied: Promise<void>;
+    let request: Promise<boolean>;
     try {
-      applied = applyDevPreviewEmulation(
+      request = applyDevPreviewEmulation(
         webviewElement,
         id,
         viewportPreset,
@@ -137,12 +140,21 @@ export function useDevPreviewViewport({
       return;
     }
 
+    inFlightEmulationRef.current += 1;
     safeFireAndForget(
-      applied.then(() => {
-        if (emulationSeqRef.current !== seq) return;
-        prevEmulationKeyRef.current = emulationKey;
-        hasAppliedEmulationRef.current = viewportPreset !== undefined;
-      }),
+      request
+        .then((applied) => {
+          // A superseded request must not record what it asked for, and main
+          // reporting `applied: false` (guest gone, or not registered to this
+          // panel) must not be cached as success — either way the next
+          // preset/ready transition re-issues.
+          if (!applied || emulationSeqRef.current !== seq) return;
+          prevEmulationKeyRef.current = emulationKey;
+          hasAppliedEmulationRef.current = viewportPreset !== undefined;
+        })
+        .finally(() => {
+          inFlightEmulationRef.current -= 1;
+        }),
       { context: "Applying dev-preview device emulation" }
     );
   }, [id, viewportPreset, viewportRotated, viewportDpr, isWebviewReady, webviewElement]);

--- a/src/components/DevPreview/useDevPreviewViewport.ts
+++ b/src/components/DevPreview/useDevPreviewViewport.ts
@@ -112,13 +112,17 @@ export function useDevPreviewViewport({
   useEffect(() => {
     if (!isWebviewReady || !webviewElement) return;
     const emulationKey = `${viewportPreset ?? "none"}-${viewportRotated}-${viewportDpr}`;
-    if (prevEmulationKeyRef.current === emulationKey) return;
+    // Both shortcuts below are only safe while nothing is on the wire. A
+    // request in flight is about to move the guest somewhere else, so
+    // returning to the last confirmed state — plain desktop included — has to
+    // re-issue rather than dedupe, or that pending request lands and leaves
+    // the guest somewhere the toolbar is not showing.
+    const isSettled = inFlightEmulationRef.current === 0;
+    if (isSettled && prevEmulationKeyRef.current === emulationKey) return;
     // Clearing emulation that was never applied is a no-op, but the key still
     // has to advance so a later switch back to the same desktop state is not
-    // mistaken for a repeat. An in-flight request counts as applied for this
-    // purpose: skipping the clear while a preset apply is still on the wire
-    // would leave the guest emulated with the toolbar showing desktop.
-    if (!viewportPreset && !hasAppliedEmulationRef.current && inFlightEmulationRef.current === 0) {
+    // mistaken for a repeat.
+    if (isSettled && !viewportPreset && !hasAppliedEmulationRef.current) {
       prevEmulationKeyRef.current = emulationKey;
       return;
     }

--- a/src/components/DevPreview/useDevPreviewViewport.ts
+++ b/src/components/DevPreview/useDevPreviewViewport.ts
@@ -127,7 +127,6 @@ export function useDevPreviewViewport({
       return;
     }
 
-    // eslint-disable-next-line react-compiler/react-compiler -- refs mutated inside an effect the compiler cannot prove is not render-phase
     const seq = ++emulationSeqRef.current;
     let request: Promise<boolean>;
     try {

--- a/src/components/DevPreview/viewportEmulation.ts
+++ b/src/components/DevPreview/viewportEmulation.ts
@@ -1,31 +1,12 @@
 import type { ViewportPresetId } from "@shared/types/panel";
-import { getEffectiveViewportSize } from "@/panels/dev-preview/viewportPresets";
-
-export type DevPreviewWebContents = {
-  setUserAgent(ua: string): void;
-  getUserAgent(): string;
-  enableDeviceEmulation(parameters: Electron.Parameters): void;
-  disableDeviceEmulation(): void;
-};
-
-export function getDevPreviewWebContents(
-  webviewElement: Electron.WebviewTag | null
-): DevPreviewWebContents | null {
-  if (!webviewElement) return null;
-  try {
-    return (
-      webviewElement as unknown as { getWebContents(): DevPreviewWebContents }
-    ).getWebContents();
-  } catch {
-    return null;
-  }
-}
+import type { DeviceEmulationParameters } from "@shared/types/ipc/webviewEmulation";
+import { getEffectiveViewportSize, getViewportPreset } from "@/panels/dev-preview/viewportPresets";
 
 export function buildEmulationParams(
   presetId: ViewportPresetId | undefined,
   rotated: boolean,
   dpr: number
-): Electron.Parameters | null {
+): DeviceEmulationParameters | null {
   if (!presetId) return null;
   const { width, height } = getEffectiveViewportSize(presetId, rotated);
   return {
@@ -36,4 +17,41 @@ export function buildEmulationParams(
     viewSize: { width, height },
     scale: 1,
   };
+}
+
+/**
+ * Apply (or clear, with `presetId` undefined) device emulation on the guest.
+ *
+ * The work happens in the main process: `<webview>` has no renderer-side
+ * `getWebContents()`, so the UA override and `enableDeviceEmulation` that used
+ * to be called here threw into a swallowing catch and never ran (#12298). Main
+ * resolves the guest from `getWebContentsId()` and owns the original-UA
+ * bookkeeping needed to restore desktop.
+ *
+ * Throws if the webview is already detached (`getWebContentsId()` raises
+ * synchronously); callers decide whether that is worth reporting.
+ */
+export function applyDevPreviewEmulation(
+  webviewElement: Electron.WebviewTag,
+  panelId: string,
+  presetId: ViewportPresetId | undefined,
+  rotated: boolean,
+  dpr: number
+): Promise<void> {
+  const webContentsId = webviewElement.getWebContentsId();
+  const params = buildEmulationParams(presetId, rotated, dpr);
+  return window.electron.webview.setDeviceEmulation({
+    webContentsId,
+    panelId,
+    emulation:
+      presetId && params
+        ? {
+            params,
+            userAgent: getViewportPreset(presetId).userAgent,
+            // Every preset in the table is a phone or tablet, so a preset being
+            // active is the same signal as "emulate a touch screen".
+            touch: true,
+          }
+        : null,
+  });
 }

--- a/src/components/DevPreview/viewportEmulation.ts
+++ b/src/components/DevPreview/viewportEmulation.ts
@@ -28,8 +28,14 @@ export function buildEmulationParams(
  * resolves the guest from `getWebContentsId()` and owns the original-UA
  * bookkeeping needed to restore desktop.
  *
- * Throws if the webview is already detached (`getWebContentsId()` raises
- * synchronously); callers decide whether that is worth reporting.
+ * Registration is chained ahead of the apply because main gates every
+ * guest-keyed handler on the panel registry: emulation can otherwise reach main
+ * before the capture hook has registered the guest and be silently dropped.
+ * `registerPanel` is idempotent, so the duplicate call is free.
+ *
+ * Resolves `false` when main reports it did not apply, so callers do not cache
+ * a preset as active on a guest that never received it. Throws if the webview
+ * is already detached (`getWebContentsId()` raises synchronously).
  */
 export function applyDevPreviewEmulation(
   webviewElement: Electron.WebviewTag,
@@ -37,21 +43,26 @@ export function applyDevPreviewEmulation(
   presetId: ViewportPresetId | undefined,
   rotated: boolean,
   dpr: number
-): Promise<void> {
+): Promise<boolean> {
   const webContentsId = webviewElement.getWebContentsId();
   const params = buildEmulationParams(presetId, rotated, dpr);
-  return window.electron.webview.setDeviceEmulation({
-    webContentsId,
-    panelId,
-    emulation:
-      presetId && params
-        ? {
-            params,
-            userAgent: getViewportPreset(presetId).userAgent,
-            // Every preset in the table is a phone or tablet, so a preset being
-            // active is the same signal as "emulate a touch screen".
-            touch: true,
-          }
-        : null,
-  });
+  return window.electron.webview
+    .registerPanel(webContentsId, panelId)
+    .then(() =>
+      window.electron.webview.setDeviceEmulation({
+        webContentsId,
+        panelId,
+        emulation:
+          presetId && params
+            ? {
+                params,
+                userAgent: getViewportPreset(presetId).userAgent,
+                // Every preset in the table is a phone or tablet, so a preset
+                // being active is the same signal as "emulate a touch screen".
+                touch: true,
+              }
+            : null,
+      })
+    )
+    .then((result) => result.applied);
 }

--- a/src/store/consoleCaptureStore.ts
+++ b/src/store/consoleCaptureStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import type { SerializedConsoleRow, CdpConsoleType } from "@shared/types/ipc/webviewConsole";
+import { MAX_CONSOLE_ROWS } from "@shared/config/devPreviewConsole";
 
 export type ConsoleLevel = "log" | "info" | "warning" | "error";
 
@@ -23,7 +24,9 @@ export const ZERO_COUNTS: ConsoleCounts = Object.freeze({
   warnCount: 0,
 }) as ConsoleCounts;
 
-const MAX_MESSAGES = 500;
+// Shared with the main-process console handler, which mirrors this cap to
+// decide when a row's CDP object handles can be released.
+const MAX_MESSAGES = MAX_CONSOLE_ROWS;
 
 interface ConsoleCaptureState {
   messages: Map<string, ConsoleMessage[]>;


### PR DESCRIPTION
## Summary

This fixes six defects in the dev preview panel's device emulation and console capture, all silent-failure shaped, found through an external audit tied to #12298.

1. **Device emulation was frame resizing and nothing else.** `getDevPreviewWebContents()` called `webviewElement.getWebContents()`, a method that has never existed on a webview tag (only ever an `@electron/remote` shim). It threw into a swallowing catch, so every UA override and `enableDeviceEmulation` call silently no-opped. Emulation now runs in the main process behind a new `webview:set-device-emulation` channel, resolving the guest via `webContents.fromId(getWebContentsId())` under the same panel-ownership gate the other webview handlers use. The renderer registers the panel before applying and honors an `{ applied }` verdict, so it can never cache a preset as active on a guest main never touched.
2. **Pointer/hover/touch never applied.** `enableDeviceEmulation` only drove viewport, DPR, and meta-viewport, so a phone preset still reported `(pointer: fine)`. Added CDP `Emulation.setTouchEmulationEnabled`, `setEmitTouchEventsForMouse`, and `setEmulatedMedia`.
3. **Console capture dropped everything logged before it attached.** `Runtime.enable` was awaited before the CDP message listener was bound, and the enable replays the guest's buffered messages, so every startup log of an already-booted page went to nobody. The listener now binds first.
4. **CDP remote-object handles outlived their rows.** Ownership was per pane, so evicted rows leaked handles, and nested handles from `Runtime.getProperties` were tracked nowhere. Ownership is now per row, mirroring the renderer's 500-row cap via a shared constant, and covers `internalProperties`/`privateProperties`/accessors/symbols.
5. **`getScrollPosition` returned `0` for both a failed read and a genuine top-of-page**, so returning to the top could never overwrite a stale offset. It now returns `number | null`.
6. **CDP stack line/column are zero-based but were displayed raw.** Converted once in the main-process mapper, fixing display and clipboard together.

Plus: the device frame's 1px border sat on the element carrying the preset's exact width/height, and box-sizing is border-box, so it shaved 2px off the content box. It's a non-layout outline now.

Resolves #12298

## Found in review

Three adversarial Codex passes on the first cut of this fix turned up 16 further issues, all fixed. The notable ones:

- Reconciling replayed console messages had to move from timestamp matching to positional matching. CDP timestamps are neither unique nor monotonic, so timestamp comparison was dropping real rows.
- Exceptions and browser log entries needed the same reconciliation, since their enable commands replay buffered data too.
- Starting and stopping capture needed to be serialized per guest. Both operations mutate pane membership on either side of an `await`, and interleaving them left a pane silently deaf.
- A navigation while capture is stopped empties the guest's buffer with no `executionContextsCleared` to observe, so the bookkeeping is now checked against the document it was collected on.

## Known limit

V8's console message storage is bounded and evicts from the front. A page that logs past its capacity while capture is stopped breaks the positional prefix, and the oldest of the new messages get skipped. Aligning through that would need a per-event identity CDP doesn't provide; the alternative duplicates rows already visible. Both are still a big step up from the previous behavior, which dropped every replayed message unconditionally. Documented at the mechanism in `webview.ts`.

## Testing

- Typecheck clean.
- 631 tests across 30 files green, including `electron/ipc/handlers/__tests__/webview.test.ts`, `webviewEmulation.test.ts`, `webviewCapture.test.ts`, `devPreview.session.test.ts`, `src/components/DevPreview/__tests__`, `src/panels/dev-preview/__tests__`, `src/store/__tests__/consoleCaptureStore.test.ts`, and `src/hooks/__tests__/useWebviewThrottle.test.tsx`.
- Prettier and eslint clean on changed files (0 errors).
- `check:channels`, `check:ipc`, `check:ipc-renderer`, `check:ipc-handwritten`, and `check:api-surface` all pass.
- `lint:ratchet` passes (one warning below baseline).

The old tests mocked the nonexistent `getWebContents()` and asserted it was called, which is exactly how this shipped green in the first place. Those are rewritten to exercise the real IPC path.

## Not covered

- The 2px frame fix has no automated test. jsdom doesn't do layout, and E2E is out of scope for this pipeline.
- The new `Emulation.*` CDP commands haven't been exercised against a frozen/throttled guest via `npm run test:freeze-harness`.
- `npm run compiler-budget:check` is currently red on `plugins/builtin/github/renderer/components/GitHubResourceList.tsx`. This branch doesn't touch that file and the failure predates it, so I left the baseline alone.

The new IPC channel goes through `defineIpcNamespace`/`opValidated` rather than a hand-written `maps.ts` entry, so `check:ipc-handwritten` stays green.
