### PR TITLE
fix(dev-preview): make readiness report what it saw, on a real deadline

### DIFF
--- a/electron/services/DevPreviewDiagnosticsRing.ts
+++ b/electron/services/DevPreviewDiagnosticsRing.ts
@@ -29,6 +29,27 @@ export function capDiagnosticText(text: string): string {
 }
 
 /**
+ * Strip credentials and query/fragment from a URL before it enters the
+ * timeline. A dev server's own URL is normally innocuous, but a configured one
+ * can carry a token in userinfo or a query parameter, and the timeline is
+ * user-visible and copyable. Origin plus path is all a reader needs to tell one
+ * candidate from another.
+ */
+export function sanitizeDiagnosticUrl(url: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return capDiagnosticText(url);
+  }
+  parsed.username = "";
+  parsed.password = "";
+  parsed.search = "";
+  parsed.hash = "";
+  return capDiagnosticText(parsed.toString());
+}
+
+/**
  * Append a diagnostic event to a session key's bounded ring. Consecutive
  * identical proxy failures coalesce into one event with a count so a webview
  * retry storm can't evict the lifecycle history. Writing touches the key's

--- a/electron/services/DevPreviewOutputProcessor.ts
+++ b/electron/services/DevPreviewOutputProcessor.ts
@@ -22,6 +22,8 @@ export interface OutputProcessorSession {
   markerSeen: boolean;
   /** False until this launch's terminal has produced any output. */
   sawOutput: boolean;
+  /** See DevPreviewSession.readinessDeadline — one budget per launch. */
+  readinessDeadline: number | null;
   generation: number;
   isRunningInstall: boolean;
   needsInstall: boolean;
@@ -220,6 +222,10 @@ export function processDevPreviewOutput<TSession extends OutputProcessorSession>
   session.readinessAbort = null;
   session.pendingUrl = null;
   session.markerSeen = false;
+  // This abort ends the probe without ending the launch, so nothing downstream
+  // will clear the budget. Leaving it set would charge the next probe for time
+  // spent sitting in an error state.
+  session.readinessDeadline = null;
   deps.clearCompiling(session);
 
   if (result.error.type === "missing-dependencies") {

--- a/electron/services/DevPreviewOutputProcessor.ts
+++ b/electron/services/DevPreviewOutputProcessor.ts
@@ -16,9 +16,12 @@ export interface OutputProcessorSession {
   status: DevPreviewSessionStatus;
   url: string | null;
   pendingUrl: string | null;
+  predictedUrl: string | null;
   buffer: string;
   readinessAbort: AbortController | null;
   markerSeen: boolean;
+  /** False until this launch's terminal has produced any output. */
+  sawOutput: boolean;
   generation: number;
   isRunningInstall: boolean;
   needsInstall: boolean;
@@ -67,6 +70,12 @@ export function processDevPreviewOutput<TSession extends OutputProcessorSession>
   if (session.isRunningInstall) return;
 
   const dataString = typeof data === "string" ? data : deps.textDecoder.decode(data);
+
+  if (!session.sawOutput && dataString.length > 0) {
+    session.sawOutput = true;
+    deps.recordSessionDiagnostic(session, { type: "first-output" });
+  }
+
   const result: ScanResult = deps.detector.scanOutput(dataString, session.buffer);
   session.buffer = result.buffer;
 
@@ -82,6 +91,11 @@ export function processDevPreviewOutput<TSession extends OutputProcessorSession>
       type: "url-detected",
       url: capDiagnosticText(result.url),
     });
+    deps.recordSessionDiagnostic(session, {
+      type: "candidate-url-chosen",
+      url: capDiagnosticText(result.url),
+      source: "output",
+    });
 
     session.readinessAbort?.abort();
     const abort = new AbortController();
@@ -95,17 +109,37 @@ export function processDevPreviewOutput<TSession extends OutputProcessorSession>
     urlJustStarted = true;
   }
 
+  if (result.readyMarker || result.compileMarker) {
+    deps.recordSessionDiagnostic(session, {
+      type: "marker-recognized",
+      marker: result.readyMarker ? "ready" : "compile",
+    });
+  }
+
   // A framework readiness line ("ready in N ms", "✓ Ready in", "compiled
   // successfully") confirms the HTTP server is bound. When a poll is already
   // mid-cycle (sleeping between HEAD attempts), abort it and re-probe now to
   // skip the remaining poll interval. The poll itself stays the fallback for
   // unrecognized frameworks, so no marker means no behavior change.
-  if (result.readyMarker && !session.markerSeen && !urlJustStarted && session.pendingUrl) {
+  //
+  // The target falls back to predictedUrl because a predicted-port startup has
+  // no pendingUrl to accelerate — pendingUrl means "a URL was observed in the
+  // server's own output", and two recovery paths (startup replay, stale-start
+  // respawn) read it that way, so the allocator's guess must not be written
+  // there. `readinessAbort` is what actually proves a poll is in flight.
+  const acceleratableUrl = session.pendingUrl ?? session.predictedUrl;
+  if (
+    result.readyMarker &&
+    !session.markerSeen &&
+    !urlJustStarted &&
+    acceleratableUrl &&
+    session.readinessAbort
+  ) {
     session.markerSeen = true;
-    session.readinessAbort?.abort();
+    session.readinessAbort.abort();
     const abort = new AbortController();
     session.readinessAbort = abort;
-    deps.pollServerReadiness(session, session.pendingUrl, abort.signal, session.generation);
+    deps.pollServerReadiness(session, acceleratableUrl, abort.signal, session.generation);
   }
 
   // Compile marker detection fires whenever the framework emits a
@@ -125,7 +159,7 @@ export function processDevPreviewOutput<TSession extends OutputProcessorSession>
         clearTimeout(session.compilingClearTimer);
         session.compilingClearTimer = setTimeout(() => {
           session.compilingClearTimer = null;
-          deps.recordSessionDiagnostic(session, { type: "compile-cleared" });
+          deps.recordSessionDiagnostic(session, { type: "compile-cleared", reason: "silence" });
           deps.clearCompiling(session);
           deps.emitStateChanged(session);
         }, COMPILE_CLEAR_MS);
@@ -147,7 +181,7 @@ export function processDevPreviewOutput<TSession extends OutputProcessorSession>
         deps.updateSession(session, { phaseLabel: "Compiling" });
         session.compilingClearTimer = setTimeout(() => {
           session.compilingClearTimer = null;
-          deps.recordSessionDiagnostic(session, { type: "compile-cleared" });
+          deps.recordSessionDiagnostic(session, { type: "compile-cleared", reason: "silence" });
           deps.clearCompiling(session);
           deps.emitStateChanged(session);
         }, COMPILE_CLEAR_MS);
@@ -163,7 +197,7 @@ export function processDevPreviewOutput<TSession extends OutputProcessorSession>
       session.compilingTimer = null;
     }
     if (session.compiling) {
-      deps.recordSessionDiagnostic(session, { type: "compile-cleared" });
+      deps.recordSessionDiagnostic(session, { type: "compile-cleared", reason: "ready-marker" });
     }
     deps.clearCompiling(session);
     deps.emitStateChanged(session);

--- a/electron/services/DevPreviewOutputProcessor.ts
+++ b/electron/services/DevPreviewOutputProcessor.ts
@@ -24,6 +24,8 @@ export interface OutputProcessorSession {
   sawOutput: boolean;
   /** See DevPreviewSession.readinessDeadline — one budget per launch. */
   readinessDeadline: number | null;
+  /** See DevPreviewSession.readinessSaw5xx — latched for one launch only. */
+  readinessSaw5xx: boolean;
   generation: number;
   isRunningInstall: boolean;
   needsInstall: boolean;
@@ -223,9 +225,11 @@ export function processDevPreviewOutput<TSession extends OutputProcessorSession>
   session.pendingUrl = null;
   session.markerSeen = false;
   // This abort ends the probe without ending the launch, so nothing downstream
-  // will clear the budget. Leaving it set would charge the next probe for time
-  // spent sitting in an error state.
+  // will clear its state. Leaving the budget set would charge the next probe for
+  // time spent sitting in an error state, and leaving the latch set would make
+  // it wait an extra round for a 5xx only the abandoned probe ever saw.
   session.readinessDeadline = null;
+  session.readinessSaw5xx = false;
   deps.clearCompiling(session);
 
   if (result.error.type === "missing-dependencies") {

--- a/electron/services/DevPreviewReadinessProbe.ts
+++ b/electron/services/DevPreviewReadinessProbe.ts
@@ -136,12 +136,25 @@ async function probeUrl(
  * to "running" (#8294, #9317). The confirming round ends the candidate loop so
  * two loopback aliases in one pass cannot satisfy both halves back to back.
  */
+export interface WaitForServerReadyOptions {
+  onAttempt?: (attempt: ReadinessAttempt) => void;
+  /**
+   * Seeds the 5xx latch from an earlier probe of the same launch. A ready
+   * marker or a new URL aborts the in-flight wait and starts another one;
+   * without this the replacement forgets that the server has been serving a
+   * compiling shell, and its next transient 200 publishes "running" — the exact
+   * bug #8294 and #9317 fixed.
+   */
+  seenServerError?: boolean;
+}
+
 export async function waitForServerReady(
   url: string,
   signal: AbortSignal,
   timeoutMs = READINESS_TIMEOUT_MS,
-  onAttempt?: (attempt: ReadinessAttempt) => void
+  options: WaitForServerReadyOptions = {}
 ): Promise<boolean> {
+  const { onAttempt, seenServerError = false } = options;
   const deadline = performance.now() + timeoutMs;
   let useHttps: boolean;
   const urls = buildReadinessUrls(url);
@@ -161,7 +174,7 @@ export async function waitForServerReady(
   const timeoutSignal = AbortSignal.timeout(timeoutMs);
   const probeSignal = AbortSignal.any([signal, timeoutSignal]);
 
-  let hasSeen5xx = false;
+  let hasSeen5xx = seenServerError;
   let awaitingConfirmation = false;
   let attempt = 0;
   // Last reported outcome per candidate. A poll against a refused port settles
@@ -209,12 +222,12 @@ export async function waitForServerReady(
           if (signal.aborted) return false;
           return true;
         }
-        // First success after a 5xx only arms the confirmation. End the round
-        // here so the confirming observation lands after a poll interval —
-        // a sibling candidate answering in the same pass proves nothing about
-        // whether the compile finished.
+        // First success after a 5xx only arms the confirmation; a later
+        // observation has to confirm it. Deliberately NOT breaking out of the
+        // round: skipping the remaining candidates starves an alias that is the
+        // only one answering when a sibling 5xxes every round, and the address
+        // families must all stay reachable (#9752).
         awaitingConfirmation = true;
-        break;
       }
     }
 

--- a/electron/services/DevPreviewReadinessProbe.ts
+++ b/electron/services/DevPreviewReadinessProbe.ts
@@ -174,8 +174,15 @@ export async function waitForServerReady(
   const timeoutSignal = AbortSignal.timeout(timeoutMs);
   const probeSignal = AbortSignal.any([signal, timeoutSignal]);
 
+  // The 5xx latch is global — a compiling shell answers 500 on every alias of
+  // the same port, so one 5xx is evidence about the server, not one address.
+  // The confirmation is per candidate and remembers WHICH ROUND armed it, which
+  // is what makes the confirming success land a poll interval later. Tracking it
+  // globally instead either lets a sibling alias confirm in the same pass (no
+  // temporal separation at all) or lets one permanently-500 alias reset the
+  // confirmation every round and starve the healthy ones (#9752).
   let hasSeen5xx = seenServerError;
-  let awaitingConfirmation = false;
+  const armedAtRound = new Map<string, number>();
   let attempt = 0;
   // Last reported outcome per candidate. A poll against a refused port settles
   // identically every 500ms; reporting only changes keeps the timeline to one
@@ -216,18 +223,23 @@ export async function waitForServerReady(
 
       if (result.outcome === "server-error") {
         hasSeen5xx = true;
-        awaitingConfirmation = false;
+        // Only this candidate regressed. Clearing every candidate's progress
+        // would let one permanently-sick alias veto the others forever.
+        armedAtRound.delete(candidateUrl);
       } else if (result.outcome === "reachable") {
-        if (!hasSeen5xx || awaitingConfirmation) {
+        if (!hasSeen5xx) {
           if (signal.aborted) return false;
           return true;
         }
-        // First success after a 5xx only arms the confirmation; a later
-        // observation has to confirm it. Deliberately NOT breaking out of the
-        // round: skipping the remaining candidates starves an alias that is the
-        // only one answering when a sibling 5xxes every round, and the address
-        // families must all stay reachable (#9752).
-        awaitingConfirmation = true;
+        const armed = armedAtRound.get(candidateUrl);
+        if (armed !== undefined && attempt > armed) {
+          if (signal.aborted) return false;
+          return true;
+        }
+        // First success after a 5xx only arms the confirmation, and it cannot
+        // confirm itself in the round that armed it. The round keeps going so
+        // every address family stays reachable.
+        if (armed === undefined) armedAtRound.set(candidateUrl, attempt);
       }
     }
 

--- a/electron/services/DevPreviewReadinessProbe.ts
+++ b/electron/services/DevPreviewReadinessProbe.ts
@@ -1,19 +1,32 @@
 import http from "node:http";
 import https from "node:https";
-import WebSocket from "ws";
+import type {
+  DevPreviewReadinessOutcome,
+  DevPreviewReadinessRetryCause,
+} from "../../shared/types/ipc/devPreview.js";
 
 export const READINESS_TIMEOUT_MS = 30000;
 export const READINESS_POLL_INTERVAL_MS = 500;
 export const READINESS_REQUEST_TIMEOUT_MS = 5000;
-export const READINESS_HMR_TIMEOUT_MS = 1500;
 
-type ProbeResult = "ready" | "5xx" | "fail";
+interface ProbeResult {
+  outcome: DevPreviewReadinessOutcome;
+  status?: number;
+  cause?: DevPreviewReadinessRetryCause;
+}
 
-const HMR_PROBE_CANDIDATES: ReadonlyArray<{ path: string; subprotocols?: string[] }> = [
-  { path: "/", subprotocols: ["vite-hmr"] },
-  { path: "/_next/webpack-hmr" },
-  { path: "/ws" },
-];
+/** One settled request, reported to the caller for the diagnostics timeline. */
+export interface ReadinessAttempt {
+  url: string;
+  outcome: DevPreviewReadinessOutcome;
+  status?: number;
+  cause?: DevPreviewReadinessRetryCause;
+  /** 1-based poll round this request belonged to. */
+  attempt: number;
+  elapsedMs: number;
+  /** Budget left when the request settled; 0 once the deadline has passed. */
+  remainingMs: number;
+}
 
 function buildReadinessUrls(url: string): string[] | null {
   let parsed: URL;
@@ -35,7 +48,24 @@ function buildReadinessUrls(url: string): string[] | null {
   return [...new Set(urls)];
 }
 
-async function probeUrl(url: string, useHttps: boolean, signal: AbortSignal): Promise<ProbeResult> {
+/**
+ * Issue one readiness GET and classify what came back.
+ *
+ * A final HTTP response proves the server is bound and serving, so 401/403/404
+ * resolve as `reachable` rather than looping until the deadline — an auth-gated
+ * dev server or one with no route at `/` is a working server, and interpreting
+ * its status is the webview's job, not the probe's. 5xx stays separate because
+ * frameworks answer 500 from a shell that is still compiling.
+ *
+ * `timeoutMs` is clamped by the caller to the budget left, so a single request
+ * can never outlive the overall deadline.
+ */
+async function probeUrl(
+  url: string,
+  useHttps: boolean,
+  signal: AbortSignal,
+  timeoutMs: number
+): Promise<ProbeResult> {
   const requestModule = useHttps ? https : http;
 
   return new Promise<ProbeResult>((resolve) => {
@@ -47,148 +77,70 @@ async function probeUrl(url: string, useHttps: boolean, signal: AbortSignal): Pr
       signal.removeEventListener("abort", onAbort);
       resolve(value);
     };
+    const retry = (cause: DevPreviewReadinessRetryCause) => settle({ outcome: "retry", cause });
 
     try {
       const req = requestModule.request(
         url,
         {
           method: "GET",
-          timeout: READINESS_REQUEST_TIMEOUT_MS,
+          timeout: timeoutMs,
           ...(useHttps ? { rejectUnauthorized: false } : {}),
         },
         (res) => {
           res.resume();
           const status = res.statusCode ?? 0;
-          if (status >= 200 && status < 400) {
-            settle("ready");
-          } else if (status >= 500 && status < 600) {
-            settle("5xx");
+          if (status >= 500 && status < 600) {
+            settle({ outcome: "server-error", status });
+          } else if (status >= 200 && status < 500) {
+            settle({ outcome: "reachable", status });
           } else {
-            settle("fail");
+            // 1xx and anything out of range is not a completed final response;
+            // never claim readiness from it.
+            settle({ outcome: "retry", status, cause: "bad-status" });
           }
         }
       );
       onAbort = () => {
         req.destroy();
-        settle("fail");
+        retry("connection-error");
       };
-      req.on("error", () => settle("fail"));
+      req.on("error", () => retry("connection-error"));
       req.on("timeout", () => {
         req.destroy();
-        settle("fail");
+        retry("request-timeout");
       });
       if (signal.aborted) {
         req.destroy();
-        settle("fail");
+        retry("connection-error");
       } else {
         signal.addEventListener("abort", onAbort, { once: true });
         req.end();
       }
     } catch {
-      settle("fail");
+      retry("connection-error");
     }
   });
 }
 
-export async function probeHmrWebSocket(
-  httpUrl: string,
-  signal: AbortSignal,
-  timeoutMs = READINESS_HMR_TIMEOUT_MS
-): Promise<boolean> {
-  let parsed: URL;
-  try {
-    parsed = new URL(httpUrl);
-  } catch {
-    return false;
-  }
-
-  const wsScheme = parsed.protocol === "https:" ? "wss:" : "ws:";
-  const origin = `${parsed.protocol}//${parsed.host}`;
-  const sockets: WebSocket[] = [];
-
-  return new Promise<boolean>((resolve) => {
-    let settled = false;
-    let timer: ReturnType<typeof setTimeout> | undefined;
-    let onAbort: () => void = () => {};
-
-    const cleanup = () => {
-      if (timer !== undefined) {
-        clearTimeout(timer);
-        timer = undefined;
-      }
-      signal.removeEventListener("abort", onAbort);
-      for (const socket of sockets) {
-        try {
-          socket.terminate();
-        } catch {
-          // best-effort cleanup
-        }
-      }
-    };
-
-    const settle = (value: boolean) => {
-      if (settled) return;
-      settled = true;
-      cleanup();
-      resolve(value);
-    };
-
-    if (signal.aborted) {
-      settle(false);
-      return;
-    }
-
-    let pending = HMR_PROBE_CANDIDATES.length;
-
-    const isSecure = wsScheme === "wss:";
-    const baseOptions = {
-      headers: { Origin: origin },
-      ...(isSecure ? { rejectUnauthorized: false } : {}),
-    };
-
-    for (const candidate of HMR_PROBE_CANDIDATES) {
-      const wsUrl = `${wsScheme}//${parsed.host}${candidate.path}`;
-      let socket: WebSocket;
-      try {
-        socket = candidate.subprotocols
-          ? new WebSocket(wsUrl, candidate.subprotocols, baseOptions)
-          : new WebSocket(wsUrl, baseOptions);
-      } catch {
-        pending -= 1;
-        if (pending === 0) settle(false);
-        continue;
-      }
-      sockets.push(socket);
-
-      // ws emits both "error" and "close" on a failed connection. Guard so a single
-      // socket can only decrement `pending` once regardless of event ordering.
-      let counted = false;
-      const onFail = () => {
-        if (counted) return;
-        counted = true;
-        pending -= 1;
-        if (pending === 0 && !settled) settle(false);
-      };
-      socket.once("open", () => settle(true));
-      socket.once("error", onFail);
-      socket.once("close", onFail);
-    }
-
-    if (pending === 0) {
-      settle(false);
-      return;
-    }
-
-    onAbort = () => settle(false);
-    signal.addEventListener("abort", onAbort, { once: true });
-    timer = setTimeout(() => settle(false), timeoutMs);
-  });
-}
-
+/**
+ * Poll a dev server until it answers, or until `timeoutMs` is genuinely spent.
+ *
+ * The budget is a real deadline, not a between-rounds check: it is composed
+ * once into an AbortSignal that every request shares, and each request's own
+ * timeout is clamped to the time left, so a round of slow candidates cannot
+ * overshoot the way a fixed 5s-per-candidate round could.
+ *
+ * A 5xx latches `hasSeen5xx` and requires a confirming success in a *later*
+ * round — a Next.js 500 served from a compiling shell must not flip the panel
+ * to "running" (#8294, #9317). The confirming round ends the candidate loop so
+ * two loopback aliases in one pass cannot satisfy both halves back to back.
+ */
 export async function waitForServerReady(
   url: string,
   signal: AbortSignal,
-  timeoutMs = READINESS_TIMEOUT_MS
+  timeoutMs = READINESS_TIMEOUT_MS,
+  onAttempt?: (attempt: ReadinessAttempt) => void
 ): Promise<boolean> {
   const deadline = performance.now() + timeoutMs;
   let useHttps: boolean;
@@ -201,25 +153,68 @@ export async function waitForServerReady(
     return false;
   }
 
+  if (signal.aborted) return false;
+
+  // Composed once, not per request: every candidate and every round shares this
+  // signal, so the deadline fires exactly once and cancellation from the caller
+  // (an output error aborting the in-flight poll) still propagates.
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
+  const probeSignal = AbortSignal.any([signal, timeoutSignal]);
+
   let hasSeen5xx = false;
   let awaitingConfirmation = false;
+  let attempt = 0;
+  // Last reported outcome per candidate. A poll against a refused port settles
+  // identically every 500ms; reporting only changes keeps the timeline to one
+  // row per candidate instead of flooding a 100-event ring.
+  const lastReported = new Map<string, string>();
+
+  const report = (candidateUrl: string, result: ProbeResult, elapsedMs: number) => {
+    if (!onAttempt) return;
+    const key = `${result.outcome}:${result.status ?? ""}:${result.cause ?? ""}`;
+    if (lastReported.get(candidateUrl) === key) return;
+    lastReported.set(candidateUrl, key);
+    onAttempt({
+      url: candidateUrl,
+      outcome: result.outcome,
+      ...(result.status !== undefined ? { status: result.status } : {}),
+      ...(result.cause !== undefined ? { cause: result.cause } : {}),
+      attempt,
+      elapsedMs: Math.round(elapsedMs),
+      remainingMs: Math.max(0, Math.round(deadline - performance.now())),
+    });
+  };
 
   while (performance.now() < deadline) {
     if (signal.aborted) return false;
+    attempt += 1;
 
     for (const candidateUrl of urls) {
       if (signal.aborted) return false;
-      const result = await probeUrl(candidateUrl, useHttps, signal);
-      if (result === "5xx") {
+      // Clamp each request to what is actually left. Without this a round of
+      // three candidates could spend 15s against a 30s budget that had 2s left.
+      const budget = deadline - performance.now();
+      if (budget <= 0) break;
+      const requestTimeout = Math.min(READINESS_REQUEST_TIMEOUT_MS, Math.ceil(budget));
+
+      const startedAt = performance.now();
+      const result = await probeUrl(candidateUrl, useHttps, probeSignal, requestTimeout);
+      report(candidateUrl, result, performance.now() - startedAt);
+
+      if (result.outcome === "server-error") {
         hasSeen5xx = true;
         awaitingConfirmation = false;
-      } else if (result === "ready") {
+      } else if (result.outcome === "reachable") {
         if (!hasSeen5xx || awaitingConfirmation) {
-          await probeHmrWebSocket(candidateUrl, signal);
           if (signal.aborted) return false;
           return true;
         }
+        // First success after a 5xx only arms the confirmation. End the round
+        // here so the confirming observation lands after a poll interval —
+        // a sibling candidate answering in the same pass proves nothing about
+        // whether the compile finished.
         awaitingConfirmation = true;
+        break;
       }
     }
 

--- a/electron/services/DevPreviewSessionService.ts
+++ b/electron/services/DevPreviewSessionService.ts
@@ -13,6 +13,7 @@ import {
 } from "./DevPreviewDiskUsage.js";
 import {
   capDiagnosticText,
+  sanitizeDiagnosticUrl,
   recordDevPreviewDiagnostic,
   type DevPreviewDiagnosticInput,
   type DevPreviewDiagnosticsRingMap,
@@ -74,6 +75,14 @@ interface DevPreviewSession extends DevPreviewSessionState {
   pendingUrl: string | null;
   readinessAbort: AbortController | null;
   markerSeen: boolean;
+  sawOutput: boolean;
+  /**
+   * Monotonic deadline (performance.now basis) for this launch's readiness, set
+   * when the first poll starts and kept across marker- and URL-triggered
+   * re-polls. Without it each restart handed `waitForServerReady` a fresh 30s,
+   * so the 30s the UI promises could stretch to a multiple of itself.
+   */
+  readinessDeadline: number | null;
   needsInstall: boolean;
   isRunningInstall: boolean;
   installAttemptedGeneration: number | null;
@@ -1107,6 +1116,8 @@ export class DevPreviewSessionService {
       pendingUrl: null,
       readinessAbort: null,
       markerSeen: false,
+      sawOutput: false,
+      readinessDeadline: null,
       needsInstall: false,
       isRunningInstall: false,
       installAttemptedGeneration: null,
@@ -1409,13 +1420,34 @@ export class DevPreviewSessionService {
     signal: AbortSignal,
     generation: number
   ): void {
-    void waitForServerReady(url, signal)
+    // One budget per launch. A ready marker or a newly detected URL restarts
+    // the probe, and each restart used to get a full READINESS_TIMEOUT_MS —
+    // so the deadline the error message quotes was not the one being enforced.
+    if (session.readinessDeadline === null) {
+      session.readinessDeadline = performance.now() + READINESS_TIMEOUT_MS;
+    }
+    const remainingMs = Math.max(1, Math.round(session.readinessDeadline - performance.now()));
+
+    void waitForServerReady(url, signal, remainingMs, (attempt) => {
+      if (signal.aborted || session.generation !== generation) return;
+      this.recordSessionDiagnostic(session, {
+        type: "readiness-http-attempt",
+        url: sanitizeDiagnosticUrl(attempt.url),
+        outcome: attempt.outcome,
+        ...(attempt.status !== undefined ? { status: attempt.status } : {}),
+        ...(attempt.cause !== undefined ? { cause: attempt.cause } : {}),
+        attempt: attempt.attempt,
+        elapsedMs: attempt.elapsedMs,
+        remainingMs: attempt.remainingMs,
+      });
+    })
       .then((ready) => {
         if (signal.aborted || session.generation !== generation) return;
         if (session.readinessAbort?.signal !== signal) return;
 
         session.pendingUrl = null;
         session.readinessAbort = null;
+        session.readinessDeadline = null;
 
         if (ready) {
           session.needsInstall = false;
@@ -1462,6 +1494,7 @@ export class DevPreviewSessionService {
 
         session.pendingUrl = null;
         session.readinessAbort = null;
+        session.readinessDeadline = null;
 
         const message = formatErrorMessage(err, "Dev server readiness check failed");
         console.warn("[DevPreviewSessionService] Readiness poll error:", {

--- a/electron/services/DevPreviewSessionService.ts
+++ b/electron/services/DevPreviewSessionService.ts
@@ -1426,15 +1426,11 @@ export class DevPreviewSessionService {
     // One budget per launch. A ready marker or a newly detected URL restarts
     // the probe, and each restart used to get a full READINESS_TIMEOUT_MS —
     // so the deadline the error message quotes was not the one being enforced.
-    // An already-spent deadline belongs to a probe that has since been
-    // abandoned — an output error aborts the poll without ending the launch,
-    // and re-attaching a live terminal replays its output minutes later. Reusing
-    // it would hand the new probe ~0ms and report "did not respond within 30
-    // seconds" without having waited at all.
-    const now = performance.now();
-    if (session.readinessDeadline === null || session.readinessDeadline <= now) {
-      session.readinessDeadline = now + READINESS_TIMEOUT_MS;
-    }
+    // Renewal is tied to lifecycle transitions that abandon a probe, never to
+    // the clock: "the deadline has passed, so start another one" cannot tell an
+    // abandoned budget from a live wait whose timeout has yet to fire, and a URL
+    // arriving at each expiry would then buy 30s forever.
+    session.readinessDeadline ??= performance.now() + READINESS_TIMEOUT_MS;
     const remainingMs = Math.max(1, Math.round(session.readinessDeadline - performance.now()));
 
     void waitForServerReady(url, signal, remainingMs, {

--- a/electron/services/DevPreviewSessionService.ts
+++ b/electron/services/DevPreviewSessionService.ts
@@ -83,6 +83,8 @@ interface DevPreviewSession extends DevPreviewSessionState {
    * so the 30s the UI promises could stretch to a multiple of itself.
    */
   readinessDeadline: number | null;
+  /** True once any probe in this launch saw a 5xx; see waitForServerReady. */
+  readinessSaw5xx: boolean;
   needsInstall: boolean;
   isRunningInstall: boolean;
   installAttemptedGeneration: number | null;
@@ -1118,6 +1120,7 @@ export class DevPreviewSessionService {
       markerSeen: false,
       sawOutput: false,
       readinessDeadline: null,
+      readinessSaw5xx: false,
       needsInstall: false,
       isRunningInstall: false,
       installAttemptedGeneration: null,
@@ -1423,23 +1426,35 @@ export class DevPreviewSessionService {
     // One budget per launch. A ready marker or a newly detected URL restarts
     // the probe, and each restart used to get a full READINESS_TIMEOUT_MS —
     // so the deadline the error message quotes was not the one being enforced.
-    if (session.readinessDeadline === null) {
-      session.readinessDeadline = performance.now() + READINESS_TIMEOUT_MS;
+    // An already-spent deadline belongs to a probe that has since been
+    // abandoned — an output error aborts the poll without ending the launch,
+    // and re-attaching a live terminal replays its output minutes later. Reusing
+    // it would hand the new probe ~0ms and report "did not respond within 30
+    // seconds" without having waited at all.
+    const now = performance.now();
+    if (session.readinessDeadline === null || session.readinessDeadline <= now) {
+      session.readinessDeadline = now + READINESS_TIMEOUT_MS;
     }
     const remainingMs = Math.max(1, Math.round(session.readinessDeadline - performance.now()));
 
-    void waitForServerReady(url, signal, remainingMs, (attempt) => {
-      if (signal.aborted || session.generation !== generation) return;
-      this.recordSessionDiagnostic(session, {
-        type: "readiness-http-attempt",
-        url: sanitizeDiagnosticUrl(attempt.url),
-        outcome: attempt.outcome,
-        ...(attempt.status !== undefined ? { status: attempt.status } : {}),
-        ...(attempt.cause !== undefined ? { cause: attempt.cause } : {}),
-        attempt: attempt.attempt,
-        elapsedMs: attempt.elapsedMs,
-        remainingMs: attempt.remainingMs,
-      });
+    void waitForServerReady(url, signal, remainingMs, {
+      seenServerError: session.readinessSaw5xx,
+      onAttempt: (attempt) => {
+        if (signal.aborted || session.generation !== generation) return;
+        // Latched for the whole launch: a marker or a new URL replaces this
+        // wait, and the replacement must not forget the compiling shell.
+        if (attempt.outcome === "server-error") session.readinessSaw5xx = true;
+        this.recordSessionDiagnostic(session, {
+          type: "readiness-http-attempt",
+          url: sanitizeDiagnosticUrl(attempt.url),
+          outcome: attempt.outcome,
+          ...(attempt.status !== undefined ? { status: attempt.status } : {}),
+          ...(attempt.cause !== undefined ? { cause: attempt.cause } : {}),
+          attempt: attempt.attempt,
+          elapsedMs: attempt.elapsedMs,
+          remainingMs: attempt.remainingMs,
+        });
+      },
     })
       .then((ready) => {
         if (signal.aborted || session.generation !== generation) return;
@@ -1448,6 +1463,7 @@ export class DevPreviewSessionService {
         session.pendingUrl = null;
         session.readinessAbort = null;
         session.readinessDeadline = null;
+        session.readinessSaw5xx = false;
 
         if (ready) {
           session.needsInstall = false;
@@ -1495,6 +1511,7 @@ export class DevPreviewSessionService {
         session.pendingUrl = null;
         session.readinessAbort = null;
         session.readinessDeadline = null;
+        session.readinessSaw5xx = false;
 
         const message = formatErrorMessage(err, "Dev server readiness check failed");
         console.warn("[DevPreviewSessionService] Readiness poll error:", {

--- a/electron/services/DevPreviewTerminalController.ts
+++ b/electron/services/DevPreviewTerminalController.ts
@@ -53,6 +53,10 @@ export interface TerminalControllerSession extends CrashLoopGuardSession {
   pendingUrl: string | null;
   readinessAbort: AbortController | null;
   markerSeen: boolean;
+  /** False until this launch's terminal has produced any output. */
+  sawOutput: boolean;
+  /** See DevPreviewSession.readinessDeadline — one budget per launch. */
+  readinessDeadline: number | null;
   needsInstall: boolean;
   isRunningInstall: boolean;
   installAttemptedGeneration: number | null;
@@ -474,6 +478,8 @@ async function prepareAndSpawnSessionTerminal<TSession extends TerminalControlle
   session.buffer = "";
   session.lastErrorKey = null;
   session.markerSeen = false;
+  session.sawOutput = false;
+  session.readinessDeadline = null;
   session.predictedUrl = predictedUrl;
   deps.clearCompiling(session);
   attachTerminal(session, terminalId, deps);
@@ -505,6 +511,12 @@ async function prepareAndSpawnSessionTerminal<TSession extends TerminalControlle
       terminalId,
     });
     deps.recordSessionDiagnostic(session, { type: "spawned", terminalId, port });
+    // The command rides in the shell's own arguments when a launch shell was
+    // built, so the spawn *is* the submission. Without one it is typed into the
+    // PTY later, and only submitFallbackCommand knows when that happened.
+    if (launch) {
+      deps.recordSessionDiagnostic(session, { type: "command-submitted", via: "shell-args" });
+    }
 
     // predictedUrl is the allocator-derived starting point for the readiness
     // poller — it's accurate for frameworks that honor env.PORT or the
@@ -518,6 +530,11 @@ async function prepareAndSpawnSessionTerminal<TSession extends TerminalControlle
 
       const abort = new AbortController();
       session.readinessAbort = abort;
+      deps.recordSessionDiagnostic(session, {
+        type: "candidate-url-chosen",
+        url: capDiagnosticText(predictedUrl),
+        source: "predicted",
+      });
       deps.pollServerReadiness(session, predictedUrl, abort.signal, nextGeneration);
     }, 0);
   } catch (error) {
@@ -538,7 +555,12 @@ async function prepareAndSpawnSessionTerminal<TSession extends TerminalControlle
     return;
   }
 
-  if (!launch) submitFallbackCommand(terminalId, normalizedCommand, deps);
+  if (!launch) {
+    submitFallbackCommand(terminalId, normalizedCommand, deps, () => {
+      if (session.terminalId !== terminalId) return;
+      deps.recordSessionDiagnostic(session, { type: "command-submitted", via: "pty-write" });
+    });
+  }
 
   scheduleStartupReplay(session, deps);
 }
@@ -551,12 +573,16 @@ async function prepareAndSpawnSessionTerminal<TSession extends TerminalControlle
 function submitFallbackCommand<TSession extends TerminalControllerSession>(
   terminalId: string,
   command: string,
-  deps: Pick<TerminalControllerDeps<TSession>, "ptyClient">
+  deps: Pick<TerminalControllerDeps<TSession>, "ptyClient">,
+  onSubmitted?: () => void
 ): void {
   setTimeout(() => {
     try {
       if (deps.ptyClient.hasTerminal(terminalId)) {
         deps.ptyClient.submit(terminalId, command);
+        // Called after the write, not before it: the timeline must say the
+        // command was submitted only when it actually was.
+        onSubmitted?.();
       }
     } catch (err) {
       console.warn("[DevPreviewSessionService] Failed to submit dev command:", err);

--- a/electron/services/DevPreviewTerminalController.ts
+++ b/electron/services/DevPreviewTerminalController.ts
@@ -57,6 +57,8 @@ export interface TerminalControllerSession extends CrashLoopGuardSession {
   sawOutput: boolean;
   /** See DevPreviewSession.readinessDeadline — one budget per launch. */
   readinessDeadline: number | null;
+  /** See DevPreviewSession.readinessSaw5xx — latched for one launch only. */
+  readinessSaw5xx: boolean;
   needsInstall: boolean;
   isRunningInstall: boolean;
   installAttemptedGeneration: number | null;
@@ -245,6 +247,8 @@ export async function stopSessionTerminal<TSession extends TerminalControllerSes
   clearStartupReplay(session);
   session.readinessAbort?.abort();
   session.readinessAbort = null;
+  session.readinessDeadline = null;
+  session.readinessSaw5xx = false;
   // Cancel a pending crash-loop backoff: otherwise the deferred re-install
   // fires after the terminal is gone (and, on the delete paths, after the
   // session is removed), spawning an orphan PTY on a stopped session.
@@ -345,6 +349,13 @@ export async function ensureSessionTerminal<TSession extends TerminalControllerS
       }
 
       if ((session.status === "starting" || session.status === "installing") && !session.url) {
+        // Replayed output can start a readiness probe. Any budget left over
+        // from this terminal's earlier, abandoned probe would otherwise be
+        // charged to it — potentially a spent one, failing it instantly.
+        if (!session.readinessAbort) {
+          session.readinessDeadline = null;
+          session.readinessSaw5xx = false;
+        }
         await replayRecentOutput(terminalId, deps);
       }
 
@@ -362,6 +373,8 @@ export async function ensureSessionTerminal<TSession extends TerminalControllerS
     detachTerminal(session, deps);
     session.readinessAbort?.abort();
     session.readinessAbort = null;
+    session.readinessDeadline = null;
+    session.readinessSaw5xx = false;
     session.pendingUrl = null;
     session.markerSeen = false;
     session.needsInstall = false;
@@ -480,6 +493,7 @@ async function prepareAndSpawnSessionTerminal<TSession extends TerminalControlle
   session.markerSeen = false;
   session.sawOutput = false;
   session.readinessDeadline = null;
+  session.readinessSaw5xx = false;
   session.predictedUrl = predictedUrl;
   deps.clearCompiling(session);
   attachTerminal(session, terminalId, deps);
@@ -707,6 +721,8 @@ export function handleDevPreviewTerminalExit<TSession extends TerminalController
   clearStartupReplay(session);
   session.readinessAbort?.abort();
   session.readinessAbort = null;
+  session.readinessDeadline = null;
+  session.readinessSaw5xx = false;
   session.pendingUrl = null;
   session.markerSeen = false;
   deps.clearCompiling(session);

--- a/electron/services/UrlDetector.ts
+++ b/electron/services/UrlDetector.ts
@@ -38,6 +38,57 @@ const COMPILE_MARKERS: RegExp[] = [
   /\bcompiling\s+\//i,
 ];
 
+// How much of the previous buffer is prepended before matching markers. PTY
+// transport splits output at arbitrary byte offsets, so a marker line can
+// straddle two chunks; every pattern above is far shorter than this window, so
+// prepending it is enough to reunite any split marker with its own tail.
+const MARKER_CARRY_MAX = 512;
+
+function toGlobal(pattern: RegExp): RegExp {
+  return pattern.flags.includes("g") ? pattern : new RegExp(pattern.source, `${pattern.flags}g`);
+}
+
+// Global clones so every occurrence in the window can be walked, not just the
+// first — see matchesAcrossBoundary.
+const READY_MARKERS_GLOBAL = READY_MARKERS.map(toGlobal);
+const COMPILE_MARKERS_GLOBAL = COMPILE_MARKERS.map(toGlobal);
+
+/**
+ * Match `patterns` against the boundary between the carried tail of previous
+ * output and the newly arrived chunk, accepting only matches that *end* inside
+ * the new text.
+ *
+ * That end-position rule is what makes this fire exactly once: a marker wholly
+ * contained in the carry has already been reported by the scan that received
+ * it, and a marker completed by this chunk necessarily ends past the boundary.
+ * Scanning the full 8192-char buffer instead would re-report every marker on
+ * every subsequent chunk, which for the ready marker means restarting the
+ * readiness poll on each keystroke of server output.
+ *
+ * Every occurrence has to be walked, not just the first: when the same marker
+ * appears twice — an HMR update already in the carry and a fresh one in the new
+ * chunk — the leading match ends inside the carry and would mask the one that
+ * actually just landed.
+ */
+function matchesAcrossBoundary(patterns: RegExp[], carry: string, chunk: string): boolean {
+  if (chunk.length === 0) return false;
+  const window = carry + chunk;
+  for (const pattern of patterns) {
+    pattern.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = pattern.exec(window)) !== null) {
+      if (match.index + match[0].length > carry.length) {
+        pattern.lastIndex = 0;
+        return true;
+      }
+      // These patterns cannot match empty, but a zero-width match would spin
+      // the loop forever on `lastIndex` — advance defensively.
+      if (match[0].length === 0) pattern.lastIndex += 1;
+    }
+  }
+  return false;
+}
+
 export class UrlDetector {
   scanOutput(data: string, buffer: string): ScanResult {
     const newBuffer =
@@ -56,9 +107,16 @@ export class UrlDetector {
     const preferredUrl = urls.length > 0 ? this.selectPreferredUrl(urls) : null;
     const error = detectDevServerError(newBuffer);
 
+    // Stripped separately so the boundary offset stays exact — stripping the
+    // concatenation would shift it by however many escape bytes the carry held.
+    const strippedCarry = stripAnsiAndOscCodes(buffer.slice(-MARKER_CARRY_MAX));
     const strippedChunk = stripAnsiAndOscCodes(data);
-    const readyMarker = READY_MARKERS.some((pattern) => pattern.test(strippedChunk));
-    const compileMarker = COMPILE_MARKERS.some((pattern) => pattern.test(strippedChunk));
+    const readyMarker = matchesAcrossBoundary(READY_MARKERS_GLOBAL, strippedCarry, strippedChunk);
+    const compileMarker = matchesAcrossBoundary(
+      COMPILE_MARKERS_GLOBAL,
+      strippedCarry,
+      strippedChunk
+    );
 
     return {
       url: preferredUrl,

--- a/electron/services/UrlDetector.ts
+++ b/electron/services/UrlDetector.ts
@@ -69,15 +69,19 @@ const COMPILE_MARKERS_GLOBAL = COMPILE_MARKERS.map(toGlobal);
  * appears twice — an HMR update already in the carry and a fresh one in the new
  * chunk — the leading match ends inside the carry and would mask the one that
  * actually just landed.
+ *
+ * Not strictly exactly-once: a pattern ending in `\d+` can match again when the
+ * next chunk extends the digits ("ready in 8" then "7 ms"). That costs one extra
+ * diagnostic row and nothing else — `markerSeen` already makes a repeated ready
+ * marker inert, and compile markers are debounced by their own timers.
  */
-function matchesAcrossBoundary(patterns: RegExp[], carry: string, chunk: string): boolean {
-  if (chunk.length === 0) return false;
-  const window = carry + chunk;
+function matchesAcrossBoundary(patterns: RegExp[], window: string, boundary: number): boolean {
+  if (window.length <= boundary) return false;
   for (const pattern of patterns) {
     pattern.lastIndex = 0;
     let match: RegExpExecArray | null;
     while ((match = pattern.exec(window)) !== null) {
-      if (match.index + match[0].length > carry.length) {
+      if (match.index + match[0].length > boundary) {
         pattern.lastIndex = 0;
         return true;
       }
@@ -107,16 +111,18 @@ export class UrlDetector {
     const preferredUrl = urls.length > 0 ? this.selectPreferredUrl(urls) : null;
     const error = detectDevServerError(newBuffer);
 
-    // Stripped separately so the boundary offset stays exact — stripping the
-    // concatenation would shift it by however many escape bytes the carry held.
-    const strippedCarry = stripAnsiAndOscCodes(buffer.slice(-MARKER_CARRY_MAX));
+    // Strip the joined window, not each half: an escape sequence can itself be
+    // split by the transport ("\x1b[3" + "2m"), and stripping the halves apart
+    // leaves that residue sitting inside the very marker we are trying to match.
+    // The boundary is then derived from the chunk side, which is intact. If a
+    // straddling escape did get removed, the boundary lands slightly early and
+    // the match is accepted — erring toward one duplicate rather than a miss.
+    const carry = buffer.slice(-MARKER_CARRY_MAX);
+    const strippedWindow = stripAnsiAndOscCodes(carry + data);
     const strippedChunk = stripAnsiAndOscCodes(data);
-    const readyMarker = matchesAcrossBoundary(READY_MARKERS_GLOBAL, strippedCarry, strippedChunk);
-    const compileMarker = matchesAcrossBoundary(
-      COMPILE_MARKERS_GLOBAL,
-      strippedCarry,
-      strippedChunk
-    );
+    const boundary = Math.max(0, strippedWindow.length - strippedChunk.length);
+    const readyMarker = matchesAcrossBoundary(READY_MARKERS_GLOBAL, strippedWindow, boundary);
+    const compileMarker = matchesAcrossBoundary(COMPILE_MARKERS_GLOBAL, strippedWindow, boundary);
 
     return {
       url: preferredUrl,

--- a/electron/services/UrlDetector.ts
+++ b/electron/services/UrlDetector.ts
@@ -70,10 +70,14 @@ const COMPILE_MARKERS_GLOBAL = COMPILE_MARKERS.map(toGlobal);
  * chunk — the leading match ends inside the carry and would mask the one that
  * actually just landed.
  *
- * Not strictly exactly-once: a pattern ending in `\d+` can match again when the
- * next chunk extends the digits ("ready in 8" then "7 ms"). That costs one extra
- * diagnostic row and nothing else — `markerSeen` already makes a repeated ready
- * marker inert, and compile markers are debounced by their own timers.
+ * Not strictly exactly-once. A pattern ending in `\d+` re-matches when the next
+ * chunk extends the digits ("ready in 8" then "7 ms"), and a straddling escape
+ * shifts the boundary early enough to re-report a marker that sits wholly in the
+ * carry. Both cost an extra `marker-recognized` row; a repeated ready marker is
+ * otherwise inert (`markerSeen` gates acceleration, and clearing an already
+ * clear compile phase is a no-op), while a repeated compile marker can re-arm
+ * the Compiling label for its debounce window. Cheap enough to accept, and far
+ * cheaper than missing the marker outright.
  */
 function matchesAcrossBoundary(patterns: RegExp[], window: string, boundary: number): boolean {
   if (window.length <= boundary) return false;
@@ -114,13 +118,20 @@ export class UrlDetector {
     // Strip the joined window, not each half: an escape sequence can itself be
     // split by the transport ("\x1b[3" + "2m"), and stripping the halves apart
     // leaves that residue sitting inside the very marker we are trying to match.
-    // The boundary is then derived from the chunk side, which is intact. If a
-    // straddling escape did get removed, the boundary lands slightly early and
-    // the match is accepted — erring toward one duplicate rather than a miss.
+    //
+    // When nothing straddles, the two halves strip independently and their
+    // lengths give the boundary exactly. When something does, the joined strip
+    // is shorter, and deriving the boundary from the intact chunk side puts it
+    // slightly early — which re-reports a marker rather than losing one. That is
+    // the right direction to err, and it is now confined to actual straddles.
     const carry = buffer.slice(-MARKER_CARRY_MAX);
     const strippedWindow = stripAnsiAndOscCodes(carry + data);
     const strippedChunk = stripAnsiAndOscCodes(data);
-    const boundary = Math.max(0, strippedWindow.length - strippedChunk.length);
+    const strippedCarry = stripAnsiAndOscCodes(carry);
+    const boundary =
+      strippedCarry.length + strippedChunk.length === strippedWindow.length
+        ? strippedCarry.length
+        : Math.max(0, strippedWindow.length - strippedChunk.length);
     const readyMarker = matchesAcrossBoundary(READY_MARKERS_GLOBAL, strippedWindow, boundary);
     const compileMarker = matchesAcrossBoundary(COMPILE_MARKERS_GLOBAL, strippedWindow, boundary);
 

--- a/electron/services/__tests__/DevPreviewPortRegistry4.test.ts
+++ b/electron/services/__tests__/DevPreviewPortRegistry4.test.ts
@@ -70,6 +70,23 @@ function mockHttpOk() {
   vi.mocked(https.request).mockImplementation(impl);
 }
 
+/**
+ * A server that accepts the connection and never answers, so the readiness poll
+ * stays in flight for the whole test. dispose() aborts it in afterEach.
+ */
+function mockHttpNeverResponds() {
+  const impl = ((_: unknown, __: unknown, _cb: (res: MockIncomingMessage) => void) => {
+    const req: MockRequest = {
+      on: () => req,
+      end: () => {},
+      destroy: () => {},
+    };
+    return req;
+  }) as unknown as typeof http.request;
+  vi.mocked(http.request).mockImplementation(impl);
+  vi.mocked(https.request).mockImplementation(impl);
+}
+
 function createPtyClientMock() {
   const dataListeners = new Set<DataListener>();
   const exitListeners = new Set<ExitListener>();
@@ -172,6 +189,12 @@ describe("DevPreviewSessionService — worktreeToSession map invariants (adversa
   });
 
   it("BUG-V3: after panel-2 steals wt-1 then stops, panel-1 getState still works normally", async () => {
+    // This case asserts a transient status, so the readiness probe must not be
+    // able to resolve underneath it. `mockHttpOk` would flip panel-1 to
+    // "running" on the predicted-port poll, and only the latency of the old HMR
+    // handshake was keeping that from happening inside the test's window.
+    mockHttpNeverResponds();
+
     const s1 = await service.ensure({ ...project, panelId: "panel-1", worktreeId: "wt-1" });
     expect(s1.predictedUrl).toBeTruthy();
 

--- a/electron/services/__tests__/DevPreviewReadinessProbe.test.ts
+++ b/electron/services/__tests__/DevPreviewReadinessProbe.test.ts
@@ -8,11 +8,24 @@ type MockRequest = {
   destroy: ReturnType<typeof vi.fn>;
 };
 
-const { mockRequest } = vi.hoisted(() => ({
+const { mockRequest, wsConstructed } = vi.hoisted(() => ({
   mockRequest:
     vi.fn<
       (url: string, options: Record<string, unknown>, callback: RequestCallback) => MockRequest
     >(),
+  wsConstructed: [] as string[],
+}));
+
+// The readiness path must not reach for a socket at all. Recording construction
+// is what makes that assertable — a timing check cannot distinguish a fast
+// handshake from no handshake.
+vi.mock("ws", () => ({
+  default: class {
+    constructor(url: string) {
+      wsConstructed.push(url);
+      throw new Error("readiness must not open a WebSocket");
+    }
+  },
 }));
 
 vi.mock("node:http", () => ({
@@ -24,7 +37,7 @@ vi.mock("node:https", () => ({
   request: mockRequest,
 }));
 
-import { waitForServerReady } from "../DevPreviewReadinessProbe.js";
+import { waitForServerReady, READINESS_REQUEST_TIMEOUT_MS } from "../DevPreviewReadinessProbe.js";
 
 function mockResponseWithStatus(statusCode: number) {
   const req: MockRequest = { on: vi.fn(), end: vi.fn(), destroy: vi.fn() };
@@ -70,6 +83,7 @@ function mockConnectionRefused() {
 describe("waitForServerReady", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    wsConstructed.length = 0;
   });
 
   it("returns true on HTTP 200", async () => {
@@ -173,14 +187,14 @@ describe("waitForServerReady", () => {
   });
 
   describe("no WebSocket handshake on the ready path (#12299)", () => {
-    it("resolves without importing or opening a WebSocket", async () => {
+    it("never constructs a WebSocket", async () => {
       mockResponseWithStatus(200);
       const signal = new AbortController().signal;
-      const started = performance.now();
       const result = await waitForServerReady("http://localhost:3000", signal, 5000);
       expect(result).toBe(true);
-      // The discarded HMR probe used to hold this path for up to 1500ms.
-      expect(performance.now() - started).toBeLessThan(500);
+      // Recorded at construction rather than timed: a wall-clock assertion
+      // could not tell a fast handshake from no handshake at all.
+      expect(wsConstructed).toHaveLength(0);
     });
   });
 
@@ -197,7 +211,7 @@ describe("waitForServerReady", () => {
       mockResponseWithStatus(200);
       const signal = new AbortController().signal;
       await waitForServerReady("http://localhost:3000", signal, 30000);
-      expect(mockRequest.mock.calls[0]?.[1]?.timeout).toBe(5000);
+      expect(mockRequest.mock.calls[0]?.[1]?.timeout).toBe(READINESS_REQUEST_TIMEOUT_MS);
     });
 
     it("shrinks the clamp as candidates consume the budget", async () => {
@@ -227,9 +241,9 @@ describe("waitForServerReady", () => {
       mockResponseWithStatus(200);
       const attempts: Array<Record<string, unknown>> = [];
       const signal = new AbortController().signal;
-      await waitForServerReady("http://localhost:3000", signal, 5000, (attempt) =>
-        attempts.push({ ...attempt })
-      );
+      await waitForServerReady("http://localhost:3000", signal, 5000, {
+        onAttempt: (attempt) => attempts.push({ ...attempt }),
+      });
       expect(attempts).toHaveLength(1);
       expect(attempts[0]).toMatchObject({
         url: "http://localhost:3000/",
@@ -244,9 +258,9 @@ describe("waitForServerReady", () => {
       mockConnectionRefused();
       const attempts: Array<Record<string, unknown>> = [];
       const signal = new AbortController().signal;
-      await waitForServerReady("http://127.0.0.1:3000", signal, 120, (attempt) =>
-        attempts.push({ ...attempt })
-      );
+      await waitForServerReady("http://127.0.0.1:3000", signal, 120, {
+        onAttempt: (attempt) => attempts.push({ ...attempt }),
+      });
       expect(attempts.length).toBeGreaterThanOrEqual(1);
       expect(attempts[0]).toMatchObject({ outcome: "retry", cause: "connection-error" });
       expect(attempts[0].status).toBeUndefined();
@@ -258,9 +272,9 @@ describe("waitForServerReady", () => {
       const signal = new AbortController().signal;
       // ~4 rounds x 3 candidates worth of requests, but every one settles the
       // same way — the timeline must not carry a row for each.
-      await waitForServerReady("http://localhost:3000", signal, 2000, (attempt) =>
-        attempts.push({ ...attempt })
-      );
+      await waitForServerReady("http://localhost:3000", signal, 2000, {
+        onAttempt: (attempt) => attempts.push({ ...attempt }),
+      });
       expect(mockRequest.mock.calls.length).toBeGreaterThan(4);
       expect(attempts).toHaveLength(3);
       expect(new Set(attempts.map((a) => a.url)).size).toBe(3);
@@ -270,9 +284,9 @@ describe("waitForServerReady", () => {
       mockResponseSequence([503, 503, 200, 200]);
       const attempts: Array<Record<string, unknown>> = [];
       const signal = new AbortController().signal;
-      await waitForServerReady("http://127.0.0.1:3000", signal, 5000, (attempt) =>
-        attempts.push({ ...attempt })
-      );
+      await waitForServerReady("http://127.0.0.1:3000", signal, 5000, {
+        onAttempt: (attempt) => attempts.push({ ...attempt }),
+      });
       expect(attempts.map((a) => a.outcome)).toEqual(["server-error", "reachable"]);
     });
   });
@@ -340,28 +354,48 @@ describe("waitForServerReady", () => {
       expect(mockRequest.mock.calls.length).toBeGreaterThanOrEqual(5);
     });
 
-    // #12299: the confirming success has to land in a *later* round. A sibling
-    // loopback alias answering in the same pass says nothing about whether the
-    // compile that produced the 5xx has finished.
-    it("does not confirm recovery through a sibling candidate in the same round", async () => {
-      mockResponseSequence([502, 200]);
+    // #12299: an alias that 5xxes every round must not starve the aliases that
+    // answer. Arming the confirmation deliberately does NOT end the round, so
+    // every address family stays reachable (#9752).
+    it("keeps probing siblings after a 5xx arms the confirmation", async () => {
+      mockRequest.mockImplementation(
+        (url: string, _options: Record<string, unknown>, callback: RequestCallback) => {
+          const req: MockRequest = { on: vi.fn(), end: vi.fn(), destroy: vi.fn() };
+          callback({ statusCode: url.includes("localhost") ? 502 : 200, resume: vi.fn() });
+          return req;
+        }
+      );
       const signal = new AbortController().signal;
-      // localhost fans out to 127.0.0.1 and [::1]; a round is three candidates,
-      // and 300ms is under one 500ms poll interval, so only round 1 can run.
       const result = await waitForServerReady("http://localhost:3000", signal, 300);
-      expect(result).toBe(false);
-    });
-
-    it("ends the round once confirmation is armed rather than probing siblings", async () => {
-      mockResponseSequence([502, 200]);
-      const signal = new AbortController().signal;
-      await waitForServerReady("http://localhost:3000", signal, 300);
-      // 502 on localhost, 200 on 127.0.0.1 arms confirmation and breaks —
-      // [::1] is never dialled in that round.
+      expect(result).toBe(true);
+      // localhost 502 latches; 127.0.0.1 200 arms the confirmation; [::1] 200
+      // confirms it — a permanently sick alias cannot veto the healthy ones.
       expect(mockRequest.mock.calls.map((call) => call[0])).toEqual([
         "http://localhost:3000/",
         "http://127.0.0.1:3000/",
+        "http://[::1]:3000/",
       ]);
+    });
+
+    // The confirming success may need to be separated from a 5xx seen by an
+    // EARLIER wait: a ready marker replaces the in-flight probe, and the
+    // replacement must not forget the compiling shell (#8294, #9317).
+    it("carries a prior 5xx into a replacement wait", async () => {
+      mockResponseWithStatus(200);
+      const signal = new AbortController().signal;
+      const result = await waitForServerReady("http://127.0.0.1:3000", signal, 300, {
+        seenServerError: true,
+      });
+      expect(result).toBe(false);
+    });
+
+    it("resolves normally when no earlier probe saw a 5xx", async () => {
+      mockResponseWithStatus(200);
+      const signal = new AbortController().signal;
+      const result = await waitForServerReady("http://127.0.0.1:3000", signal, 300, {
+        seenServerError: false,
+      });
+      expect(result).toBe(true);
     });
   });
 });

--- a/electron/services/__tests__/DevPreviewReadinessProbe.test.ts
+++ b/electron/services/__tests__/DevPreviewReadinessProbe.test.ts
@@ -357,7 +357,7 @@ describe("waitForServerReady", () => {
     // #12299: an alias that 5xxes every round must not starve the aliases that
     // answer. Arming the confirmation deliberately does NOT end the round, so
     // every address family stays reachable (#9752).
-    it("keeps probing siblings after a 5xx arms the confirmation", async () => {
+    it("does not let one permanently-5xx alias starve the healthy ones", async () => {
       mockRequest.mockImplementation(
         (url: string, _options: Record<string, unknown>, callback: RequestCallback) => {
           const req: MockRequest = { on: vi.fn(), end: vi.fn(), destroy: vi.fn() };
@@ -366,15 +366,52 @@ describe("waitForServerReady", () => {
         }
       );
       const signal = new AbortController().signal;
-      const result = await waitForServerReady("http://localhost:3000", signal, 300);
+      // Round 1 arms 127.0.0.1 and [::1]; round 2 confirms one of them. The
+      // 502 on localhost must not clear their progress every round.
+      const result = await waitForServerReady("http://localhost:3000", signal, 900);
       expect(result).toBe(true);
-      // localhost 502 latches; 127.0.0.1 200 arms the confirmation; [::1] 200
-      // confirms it — a permanently sick alias cannot veto the healthy ones.
-      expect(mockRequest.mock.calls.map((call) => call[0])).toEqual([
+      // Every address family was dialled before any confirmation (#9752).
+      const round1 = mockRequest.mock.calls.slice(0, 3).map((call) => call[0]);
+      expect(round1).toEqual([
         "http://localhost:3000/",
         "http://127.0.0.1:3000/",
         "http://[::1]:3000/",
       ]);
+    });
+
+    // The whole point of the latch: a compiling shell 5xxes on every alias, and
+    // a brief window where they all answer 200 must not read as recovery.
+    it("does not confirm through a sibling alias inside the arming round", async () => {
+      let round = 0;
+      mockRequest.mockImplementation(
+        (_url: string, _options: Record<string, unknown>, callback: RequestCallback) => {
+          const req: MockRequest = { on: vi.fn(), end: vi.fn(), destroy: vi.fn() };
+          // Round 1: every alias 500. Round 2: every alias 200.
+          round += 1;
+          callback({ statusCode: round <= 3 ? 500 : 200, resume: vi.fn() });
+          return req;
+        }
+      );
+      const signal = new AbortController().signal;
+      // 900ms covers rounds 1 and 2 but not a third, so the only way to resolve
+      // true would be confirming inside round 2 itself.
+      const result = await waitForServerReady("http://localhost:3000", signal, 900);
+      expect(result).toBe(false);
+    });
+
+    it("confirms in the round after the one that armed it", async () => {
+      let round = 0;
+      mockRequest.mockImplementation(
+        (_url: string, _options: Record<string, unknown>, callback: RequestCallback) => {
+          const req: MockRequest = { on: vi.fn(), end: vi.fn(), destroy: vi.fn() };
+          round += 1;
+          callback({ statusCode: round <= 3 ? 500 : 200, resume: vi.fn() });
+          return req;
+        }
+      );
+      const signal = new AbortController().signal;
+      const result = await waitForServerReady("http://localhost:3000", signal, 1400);
+      expect(result).toBe(true);
     });
 
     // The confirming success may need to be separated from a 5xx seen by an

--- a/electron/services/__tests__/DevPreviewReadinessProbe.test.ts
+++ b/electron/services/__tests__/DevPreviewReadinessProbe.test.ts
@@ -8,28 +8,11 @@ type MockRequest = {
   destroy: ReturnType<typeof vi.fn>;
 };
 
-type WsListener = (...args: unknown[]) => void;
-type WsHeaders = Record<string, string>;
-type MockWebSocket = {
-  url: string;
-  subprotocols: string[];
-  headers: WsHeaders;
-  listeners: { open: WsListener[]; error: WsListener[]; close: WsListener[] };
-  once: ReturnType<typeof vi.fn>;
-  terminate: ReturnType<typeof vi.fn>;
-  emit: (event: "open" | "error" | "close", ...args: unknown[]) => void;
-};
-
-const { mockRequest, wsInstances, wsBehavior } = vi.hoisted(() => ({
+const { mockRequest } = vi.hoisted(() => ({
   mockRequest:
     vi.fn<
       (url: string, options: Record<string, unknown>, callback: RequestCallback) => MockRequest
     >(),
-  wsInstances: [] as MockWebSocket[],
-  wsBehavior: {
-    mode: "error" as "error" | "open" | "throw" | "openOn" | "manual",
-    openOnUrl: "",
-  },
 }));
 
 vi.mock("node:http", () => ({
@@ -41,65 +24,7 @@ vi.mock("node:https", () => ({
   request: mockRequest,
 }));
 
-vi.mock("ws", () => {
-  class WebSocketMock {
-    url: string;
-    subprotocols: string[];
-    headers: WsHeaders;
-    listeners: MockWebSocket["listeners"] = { open: [], error: [], close: [] };
-    once = vi.fn((event: "open" | "error" | "close", listener: WsListener) => {
-      this.listeners[event].push(listener);
-      return this;
-    });
-    terminate = vi.fn();
-    emit(event: "open" | "error" | "close", ...args: unknown[]) {
-      const listeners = this.listeners[event];
-      this.listeners[event] = [];
-      for (const listener of listeners) listener(...args);
-    }
-    constructor(url: string, protocolsOrOptions?: unknown, maybeOptions?: unknown) {
-      this.url = url;
-      const hasProtocols = Array.isArray(protocolsOrOptions);
-      this.subprotocols = hasProtocols ? (protocolsOrOptions as string[]) : [];
-      const options = (hasProtocols ? maybeOptions : protocolsOrOptions) as
-        { headers?: WsHeaders } | undefined;
-      this.headers = options?.headers ?? {};
-
-      if (wsBehavior.mode === "throw") {
-        throw new Error("invalid ws url");
-      }
-
-      wsInstances.push(this as unknown as MockWebSocket);
-
-      if (wsBehavior.mode === "manual") {
-        return;
-      }
-
-      const shouldOpen =
-        wsBehavior.mode === "open" ||
-        (wsBehavior.mode === "openOn" && url === wsBehavior.openOnUrl);
-
-      queueMicrotask(() => {
-        if (shouldOpen) {
-          this.emit("open");
-        } else {
-          this.emit("error", new Error("ws connect failed"));
-        }
-      });
-    }
-  }
-  return {
-    default: WebSocketMock,
-  };
-});
-
-import { waitForServerReady, probeHmrWebSocket } from "../DevPreviewReadinessProbe.js";
-
-function resetWsState() {
-  wsInstances.length = 0;
-  wsBehavior.mode = "error";
-  wsBehavior.openOnUrl = "";
-}
+import { waitForServerReady } from "../DevPreviewReadinessProbe.js";
 
 function mockResponseWithStatus(statusCode: number) {
   const req: MockRequest = { on: vi.fn(), end: vi.fn(), destroy: vi.fn() };
@@ -145,7 +70,6 @@ function mockConnectionRefused() {
 describe("waitForServerReady", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    resetWsState();
   });
 
   it("returns true on HTTP 200", async () => {
@@ -218,15 +142,139 @@ describe("waitForServerReady", () => {
       expect(result).toBe(true);
     });
 
-    it.each([100, 199, 400, 401, 404, 405, 499, 500, 502, 503, 599])(
-      "returns false on HTTP %i",
+    // #12299: a final 4xx proves the server is bound and serving. An auth-gated
+    // dev server or one with no route at `/` used to be retried until the 30s
+    // deadline and then reported as "did not respond".
+    it.each([400, 401, 403, 404, 405, 499])(
+      "accepts HTTP %i as a responding server",
       async (status) => {
         mockResponseWithStatus(status);
         const signal = new AbortController().signal;
         const result = await waitForServerReady("http://localhost:3000", signal, 100);
-        expect(result).toBe(false);
+        expect(result).toBe(true);
       }
     );
+
+    it("resolves a 404 on the first request rather than polling to the deadline", async () => {
+      mockResponseWithStatus(404);
+      const signal = new AbortController().signal;
+      const result = await waitForServerReady("http://localhost:3000", signal, 5000);
+      expect(result).toBe(true);
+      expect(mockRequest.mock.calls.length).toBe(1);
+    });
+
+    // 1xx is not a completed final response, and 5xx is a compiling shell.
+    it.each([100, 199, 500, 502, 503, 599])("returns false on HTTP %i", async (status) => {
+      mockResponseWithStatus(status);
+      const signal = new AbortController().signal;
+      const result = await waitForServerReady("http://localhost:3000", signal, 100);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("no WebSocket handshake on the ready path (#12299)", () => {
+    it("resolves without importing or opening a WebSocket", async () => {
+      mockResponseWithStatus(200);
+      const signal = new AbortController().signal;
+      const started = performance.now();
+      const result = await waitForServerReady("http://localhost:3000", signal, 5000);
+      expect(result).toBe(true);
+      // The discarded HMR probe used to hold this path for up to 1500ms.
+      expect(performance.now() - started).toBeLessThan(500);
+    });
+  });
+
+  describe("deadline enforcement (#12299)", () => {
+    it("clamps a request timeout to the remaining budget", async () => {
+      mockResponseWithStatus(200);
+      const signal = new AbortController().signal;
+      await waitForServerReady("http://localhost:3000", signal, 120);
+      const timeout = mockRequest.mock.calls[0]?.[1]?.timeout;
+      expect(timeout).toBeLessThanOrEqual(120);
+    });
+
+    it("uses the full per-request ceiling when the budget is large", async () => {
+      mockResponseWithStatus(200);
+      const signal = new AbortController().signal;
+      await waitForServerReady("http://localhost:3000", signal, 30000);
+      expect(mockRequest.mock.calls[0]?.[1]?.timeout).toBe(5000);
+    });
+
+    it("shrinks the clamp as candidates consume the budget", async () => {
+      // Every candidate refuses, so all three run inside one round.
+      mockRequest.mockImplementation(
+        (_url: string, _options: Record<string, unknown>, _callback: RequestCallback) => {
+          const req: MockRequest = { on: vi.fn(), end: vi.fn(), destroy: vi.fn() };
+          setTimeout(() => {
+            const errorHandler = req.on.mock.calls.find((c: unknown[]) => c[0] === "error")?.[1] as
+              ((err: Error) => void) | undefined;
+            errorHandler?.(new Error("ECONNREFUSED"));
+          }, 20);
+          return req;
+        }
+      );
+      const signal = new AbortController().signal;
+      await waitForServerReady("http://localhost:3000", signal, 100);
+      const timeouts = mockRequest.mock.calls.map((call) => call[1]?.timeout as number);
+      expect(timeouts.length).toBeGreaterThanOrEqual(2);
+      expect(timeouts[1]).toBeLessThan(timeouts[0]);
+      for (const timeout of timeouts) expect(timeout).toBeLessThanOrEqual(100);
+    });
+  });
+
+  describe("attempt reporting (#12299)", () => {
+    it("reports the settled response with status, attempt and budget", async () => {
+      mockResponseWithStatus(200);
+      const attempts: Array<Record<string, unknown>> = [];
+      const signal = new AbortController().signal;
+      await waitForServerReady("http://localhost:3000", signal, 5000, (attempt) =>
+        attempts.push({ ...attempt })
+      );
+      expect(attempts).toHaveLength(1);
+      expect(attempts[0]).toMatchObject({
+        url: "http://localhost:3000/",
+        outcome: "reachable",
+        status: 200,
+        attempt: 1,
+      });
+      expect(attempts[0].remainingMs).toBeLessThanOrEqual(5000);
+    });
+
+    it("reports a retry cause rather than a status when the connection fails", async () => {
+      mockConnectionRefused();
+      const attempts: Array<Record<string, unknown>> = [];
+      const signal = new AbortController().signal;
+      await waitForServerReady("http://127.0.0.1:3000", signal, 120, (attempt) =>
+        attempts.push({ ...attempt })
+      );
+      expect(attempts.length).toBeGreaterThanOrEqual(1);
+      expect(attempts[0]).toMatchObject({ outcome: "retry", cause: "connection-error" });
+      expect(attempts[0].status).toBeUndefined();
+    });
+
+    it("reports one row per candidate while the outcome is unchanged", async () => {
+      mockConnectionRefused();
+      const attempts: Array<Record<string, unknown>> = [];
+      const signal = new AbortController().signal;
+      // ~4 rounds x 3 candidates worth of requests, but every one settles the
+      // same way — the timeline must not carry a row for each.
+      await waitForServerReady("http://localhost:3000", signal, 2000, (attempt) =>
+        attempts.push({ ...attempt })
+      );
+      expect(mockRequest.mock.calls.length).toBeGreaterThan(4);
+      expect(attempts).toHaveLength(3);
+      expect(new Set(attempts.map((a) => a.url)).size).toBe(3);
+    });
+
+    it("reports again when a candidate's outcome changes", async () => {
+      mockResponseSequence([503, 503, 200, 200]);
+      const attempts: Array<Record<string, unknown>> = [];
+      const signal = new AbortController().signal;
+      await waitForServerReady("http://127.0.0.1:3000", signal, 5000, (attempt) =>
+        attempts.push({ ...attempt })
+      );
+      expect(attempts.map((a) => a.outcome)).toEqual(["server-error", "reachable"]);
+    });
   });
 
   describe("5xx memory", () => {
@@ -291,154 +339,29 @@ describe("waitForServerReady", () => {
       expect(result).toBe(true);
       expect(mockRequest.mock.calls.length).toBeGreaterThanOrEqual(5);
     });
-  });
 
-  describe("HMR WebSocket handshake", () => {
-    it("opens WS probe after HTTP succeeds", async () => {
-      mockResponseWithStatus(200);
-      wsBehavior.mode = "error";
+    // #12299: the confirming success has to land in a *later* round. A sibling
+    // loopback alias answering in the same pass says nothing about whether the
+    // compile that produced the 5xx has finished.
+    it("does not confirm recovery through a sibling candidate in the same round", async () => {
+      mockResponseSequence([502, 200]);
       const signal = new AbortController().signal;
-      const result = await waitForServerReady("http://localhost:3000", signal, 5000);
-      expect(result).toBe(true);
-      expect(wsInstances.length).toBe(3);
+      // localhost fans out to 127.0.0.1 and [::1]; a round is three candidates,
+      // and 300ms is under one 500ms poll interval, so only round 1 can run.
+      const result = await waitForServerReady("http://localhost:3000", signal, 300);
+      expect(result).toBe(false);
     });
 
-    it("returns true even when all WS candidates fail (opportunistic)", async () => {
-      mockResponseWithStatus(200);
-      wsBehavior.mode = "error";
+    it("ends the round once confirmation is armed rather than probing siblings", async () => {
+      mockResponseSequence([502, 200]);
       const signal = new AbortController().signal;
-      const result = await waitForServerReady("http://localhost:3000", signal, 5000);
-      expect(result).toBe(true);
-    });
-
-    it("spoofs Origin header on every WS candidate", async () => {
-      mockResponseWithStatus(200);
-      wsBehavior.mode = "error";
-      const signal = new AbortController().signal;
-      await waitForServerReady("http://localhost:3000", signal, 5000);
-      for (const instance of wsInstances) {
-        expect(instance.headers.Origin).toBe("http://localhost:3000");
-      }
-    });
-
-    it("uses vite-hmr subprotocol on the root WS path", async () => {
-      mockResponseWithStatus(200);
-      wsBehavior.mode = "error";
-      const signal = new AbortController().signal;
-      await waitForServerReady("http://localhost:3000", signal, 5000);
-      const root = wsInstances.find((ws) => ws.url === "ws://localhost:3000/");
-      expect(root).toBeDefined();
-      expect(root?.subprotocols).toEqual(["vite-hmr"]);
-    });
-
-    it("probes all three HMR endpoints", async () => {
-      mockResponseWithStatus(200);
-      wsBehavior.mode = "error";
-      const signal = new AbortController().signal;
-      await waitForServerReady("http://localhost:3000", signal, 5000);
-      const urls = wsInstances.map((ws) => ws.url).sort();
-      expect(urls).toEqual([
-        "ws://localhost:3000/",
-        "ws://localhost:3000/_next/webpack-hmr",
-        "ws://localhost:3000/ws",
+      await waitForServerReady("http://localhost:3000", signal, 300);
+      // 502 on localhost, 200 on 127.0.0.1 arms confirmation and breaks —
+      // [::1] is never dialled in that round.
+      expect(mockRequest.mock.calls.map((call) => call[0])).toEqual([
+        "http://localhost:3000/",
+        "http://127.0.0.1:3000/",
       ]);
     });
-
-    it("derives wss:// scheme from https:// HTTP URL", async () => {
-      mockResponseWithStatus(200);
-      wsBehavior.mode = "error";
-      const signal = new AbortController().signal;
-      await waitForServerReady("https://localhost:3000", signal, 5000);
-      expect(wsInstances.every((ws) => ws.url.startsWith("wss://"))).toBe(true);
-    });
-
-    it("terminates all sockets after settlement", async () => {
-      mockResponseWithStatus(200);
-      wsBehavior.mode = "error";
-      const signal = new AbortController().signal;
-      await waitForServerReady("http://localhost:3000", signal, 5000);
-      for (const instance of wsInstances) {
-        expect(instance.terminate).toHaveBeenCalled();
-      }
-    });
-
-    it("survives a synchronous WS constructor throw", async () => {
-      mockResponseWithStatus(200);
-      wsBehavior.mode = "throw";
-      const signal = new AbortController().signal;
-      const result = await waitForServerReady("http://localhost:3000", signal, 5000);
-      expect(result).toBe(true);
-    });
-  });
-});
-
-describe("probeHmrWebSocket", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    resetWsState();
-  });
-
-  it("resolves true when any candidate opens", async () => {
-    wsBehavior.mode = "openOn";
-    wsBehavior.openOnUrl = "ws://localhost:3000/_next/webpack-hmr";
-    const signal = new AbortController().signal;
-    const result = await probeHmrWebSocket("http://localhost:3000", signal);
-    expect(result).toBe(true);
-  });
-
-  it("resolves false when all candidates error", async () => {
-    wsBehavior.mode = "error";
-    const signal = new AbortController().signal;
-    const result = await probeHmrWebSocket("http://localhost:3000", signal);
-    expect(result).toBe(false);
-  });
-
-  it("resolves false when signal is already aborted", async () => {
-    wsBehavior.mode = "open";
-    const controller = new AbortController();
-    controller.abort();
-    const result = await probeHmrWebSocket("http://localhost:3000", controller.signal);
-    expect(result).toBe(false);
-    expect(wsInstances.length).toBe(0);
-  });
-
-  it("resolves false on invalid URL", async () => {
-    wsBehavior.mode = "open";
-    const signal = new AbortController().signal;
-    const result = await probeHmrWebSocket("not-a-url", signal);
-    expect(result).toBe(false);
-  });
-
-  it("resolves false when all WS constructors throw", async () => {
-    wsBehavior.mode = "throw";
-    const signal = new AbortController().signal;
-    const result = await probeHmrWebSocket("http://localhost:3000", signal);
-    expect(result).toBe(false);
-  });
-
-  it("does not double-count error+close on the same failed socket", async () => {
-    // Regression: ws emits both "error" and "close" on a failed connection.
-    // Without per-socket guarding, two failed sockets (4 events) would settle
-    // the probe to false before the third (successful) socket fires "open".
-    wsBehavior.mode = "manual";
-    const signal = new AbortController().signal;
-    const probePromise = probeHmrWebSocket("http://localhost:3000", signal);
-
-    // Let the constructor loop complete (synchronous), then drive events.
-    await Promise.resolve();
-    expect(wsInstances.length).toBe(3);
-
-    // Two sockets fail with both error then close (the ws-native sequence).
-    wsInstances[0].emit("error", new Error("refused"));
-    wsInstances[0].emit("close");
-    wsInstances[1].emit("error", new Error("refused"));
-    wsInstances[1].emit("close");
-
-    // Third socket opens successfully — guard must have kept pending > 0 so
-    // settle(false) wasn't called prematurely.
-    wsInstances[2].emit("open");
-
-    const result = await probePromise;
-    expect(result).toBe(true);
   });
 });

--- a/electron/services/__tests__/DevPreviewSessionService.adversarial.test.ts
+++ b/electron/services/__tests__/DevPreviewSessionService.adversarial.test.ts
@@ -591,6 +591,51 @@ describe("DevPreviewSessionService adversarial", () => {
     expect(state.error?.type).toBe("missing-dependencies");
   });
 
+  // #12299: the 5xx latch is carried across re-probes within a launch, so it
+  // must die with the launch. Inheriting it would make a healthy restart wait an
+  // extra poll round for a compiling shell the previous launch saw.
+  it("does not inherit a previous launch's 5xx history across a restart", async () => {
+    let status = 500;
+    const impl = ((_: unknown, __: unknown, cb: (res: MockIncomingMessage) => void) => {
+      const req: MockRequest = {
+        on: () => req,
+        end: () => setTimeout(() => cb({ statusCode: status, resume: () => {} }), 0),
+        destroy: () => {},
+      };
+      return req;
+    }) as unknown as typeof http.request;
+    vi.mocked(http.request).mockImplementation(impl);
+
+    scanOutputMock.mockImplementation((data, buffer) => {
+      if (data.includes("localhost:3000")) return { buffer, url: "http://localhost:3000/" };
+      return { buffer };
+    });
+
+    const started = await service.ensure(baseRequest);
+    ptyClient.emitData(started.terminalId!, "Local: http://localhost:3000/");
+    // Let the launch observe a 5xx and latch it.
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(
+      service.getState({ panelId: baseRequest.panelId, projectId: baseRequest.projectId }).status
+    ).toBe("starting");
+
+    // A restart is a new launch; its server is healthy from the first response.
+    status = 200;
+    await service.restart({ panelId: baseRequest.panelId, projectId: baseRequest.projectId });
+    const restarted = service.getState({
+      panelId: baseRequest.panelId,
+      projectId: baseRequest.projectId,
+    });
+    ptyClient.emitData(restarted.terminalId!, "Local: http://localhost:3000/");
+
+    // Under an inherited latch the first 200 would only arm a confirmation and
+    // this would still be "starting" until another poll round.
+    await vi.advanceTimersByTimeAsync(100);
+    expect(
+      service.getState({ panelId: baseRequest.panelId, projectId: baseRequest.projectId }).status
+    ).toBe("running");
+  });
+
   // #12299: every marker- or URL-triggered re-probe used to hand
   // waitForServerReady a fresh READINESS_TIMEOUT_MS, so the 30s the error
   // message quotes could stretch to a multiple of itself. One budget per launch.
@@ -686,10 +731,18 @@ describe("DevPreviewSessionService adversarial", () => {
     // The session then sits in that state for longer than the whole budget.
     await vi.advanceTimersByTimeAsync(60_000);
 
-    // A URL now shows up (a replay after remount, or the server recovering).
-    failHttp = false;
+    // A URL now shows up (a replay after remount, or the server recovering),
+    // but the server needs several seconds before it answers. A probe charged
+    // the spent budget would have given up long before that — so the wait here
+    // is what proves the budget was genuinely restored, not merely non-zero.
     ptyClient.emitData(started.terminalId!, "Local: http://localhost:3000/");
-    await vi.advanceTimersByTimeAsync(100);
+    await vi.advanceTimersByTimeAsync(8_000);
+    expect(
+      service.getState({ panelId: baseRequest.panelId, projectId: baseRequest.projectId }).status
+    ).toBe("starting");
+
+    failHttp = false;
+    await vi.advanceTimersByTimeAsync(1_000);
 
     const state = service.getState({
       panelId: baseRequest.panelId,

--- a/electron/services/__tests__/DevPreviewSessionService.adversarial.test.ts
+++ b/electron/services/__tests__/DevPreviewSessionService.adversarial.test.ts
@@ -505,6 +505,61 @@ describe("DevPreviewSessionService adversarial", () => {
     expect(vi.mocked(http.request).mock.calls.length).toBeGreaterThan(callsBeforeSecondMarker);
   });
 
+  // #12299: the predicted-port path polls the allocator's URL but never sets
+  // pendingUrl (two recovery paths read that field as "a URL was seen in
+  // output"), so marker acceleration was gated off for the whole common case
+  // where the framework prints its ready line before its URL line.
+  it("lets a readiness marker accelerate a predicted-port poll with no URL in output", async () => {
+    const impl = ((_: unknown, __: unknown, _cb: (res: MockIncomingMessage) => void) => {
+      const req: MockRequest = {
+        on: (event, handler) => {
+          if (event === "error") setTimeout(() => handler(new Error("ECONNREFUSED")), 0);
+          return req;
+        },
+        end: () => {},
+        destroy: () => {},
+      };
+      return req;
+    }) as unknown as typeof http.request;
+    vi.mocked(http.request).mockImplementation(impl);
+
+    // No URL is ever detected — only the ready marker.
+    scanOutputMock.mockImplementation((data, buffer) => {
+      if (data.includes("ready in")) return { buffer, readyMarker: true };
+      return { buffer };
+    });
+
+    const started = await service.ensure(baseRequest);
+    // Let the predicted-port poll start and settle into its poll interval.
+    await vi.advanceTimersByTimeAsync(50);
+    const callsBeforeMarker = vi.mocked(http.request).mock.calls.length;
+    expect(callsBeforeMarker).toBeGreaterThan(0);
+
+    ptyClient.emitData(started.terminalId!, "VITE v6.0.0  ready in 200 ms");
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(vi.mocked(http.request).mock.calls.length).toBeGreaterThan(callsBeforeMarker);
+  });
+
+  it("ignores a readiness marker when no readiness poll is in flight", async () => {
+    scanOutputMock.mockImplementation((data, buffer) => {
+      if (data.includes("ready in")) return { buffer, readyMarker: true };
+      return { buffer };
+    });
+
+    const started = await service.ensure(baseRequest);
+    await vi.advanceTimersByTimeAsync(50);
+    // Stop clears readinessAbort; predictedUrl survives on the session, so the
+    // liveness check is the only thing keeping a stray marker from re-probing.
+    await service.stop({ panelId: baseRequest.panelId, projectId: baseRequest.projectId });
+    const callsAfterStop = vi.mocked(http.request).mock.calls.length;
+
+    ptyClient.emitData(started.terminalId!, "VITE v6.0.0  ready in 200 ms");
+    await vi.advanceTimersByTimeAsync(50);
+
+    expect(vi.mocked(http.request).mock.calls.length).toBe(callsAfterStop);
+  });
+
   it("suppresses late state changes after dispose while stop is still waiting for the terminal to die", async () => {
     const started = await service.ensure(baseRequest);
     const terminalId = started.terminalId!;

--- a/electron/services/__tests__/DevPreviewSessionService.adversarial.test.ts
+++ b/electron/services/__tests__/DevPreviewSessionService.adversarial.test.ts
@@ -541,23 +541,162 @@ describe("DevPreviewSessionService adversarial", () => {
     expect(vi.mocked(http.request).mock.calls.length).toBeGreaterThan(callsBeforeMarker);
   });
 
+  // The terminal must stay attached for this to reach the guard at all — a
+  // stopped session is filtered out much earlier, and stop() clears
+  // predictedUrl too. An output error is the case that leaves predictedUrl set
+  // and readinessAbort null on a live terminal.
   it("ignores a readiness marker when no readiness poll is in flight", async () => {
+    const impl = ((_: unknown, __: unknown, _cb: (res: MockIncomingMessage) => void) => {
+      const req: MockRequest = {
+        on: (event, handler) => {
+          if (event === "error") setTimeout(() => handler(new Error("ECONNREFUSED")), 0);
+          return req;
+        },
+        end: () => {},
+        destroy: () => {},
+      };
+      return req;
+    }) as unknown as typeof http.request;
+    vi.mocked(http.request).mockImplementation(impl);
+
     scanOutputMock.mockImplementation((data, buffer) => {
+      if (data.includes("ready in")) return { buffer, readyMarker: true };
+      if (data.includes("Cannot find module")) {
+        return {
+          buffer,
+          error: { type: "missing-dependencies", message: "Cannot find module 'x'" },
+        };
+      }
+      return { buffer };
+    });
+
+    const started = await service.ensure(baseRequest);
+    await vi.advanceTimersByTimeAsync(50);
+
+    // Aborts the poll and nulls readinessAbort, without exiting the terminal.
+    ptyClient.emitData(started.terminalId!, "Error: Cannot find module 'x'");
+    await vi.advanceTimersByTimeAsync(10);
+    const callsAfterError = vi.mocked(http.request).mock.calls.length;
+
+    ptyClient.emitData(started.terminalId!, "VITE v6.0.0  ready in 200 ms");
+    await vi.advanceTimersByTimeAsync(50);
+
+    // predictedUrl is still set, so only the liveness check stops the marker
+    // from resurrecting a probe the error deliberately cancelled.
+    expect(vi.mocked(http.request).mock.calls.length).toBe(callsAfterError);
+    const state = service.getState({
+      panelId: baseRequest.panelId,
+      projectId: baseRequest.projectId,
+    });
+    expect(state.error?.type).toBe("missing-dependencies");
+  });
+
+  // #12299: every marker- or URL-triggered re-probe used to hand
+  // waitForServerReady a fresh READINESS_TIMEOUT_MS, so the 30s the error
+  // message quotes could stretch to a multiple of itself. One budget per launch.
+  it("does not extend the readiness budget across re-probes", async () => {
+    const impl = ((_: unknown, __: unknown, _cb: (res: MockIncomingMessage) => void) => {
+      const req: MockRequest = {
+        on: (event, handler) => {
+          if (event === "error") setTimeout(() => handler(new Error("ECONNREFUSED")), 0);
+          return req;
+        },
+        end: () => {},
+        destroy: () => {},
+      };
+      return req;
+    }) as unknown as typeof http.request;
+    vi.mocked(http.request).mockImplementation(impl);
+
+    scanOutputMock.mockImplementation((data, buffer) => {
+      if (data.includes("localhost:3001")) return { buffer, url: "http://localhost:3001/" };
+      if (data.includes("localhost:3000")) return { buffer, url: "http://localhost:3000/" };
       if (data.includes("ready in")) return { buffer, readyMarker: true };
       return { buffer };
     });
 
     const started = await service.ensure(baseRequest);
     await vi.advanceTimersByTimeAsync(50);
-    // Stop clears readinessAbort; predictedUrl survives on the session, so the
-    // liveness check is the only thing keeping a stray marker from re-probing.
-    await service.stop({ panelId: baseRequest.panelId, projectId: baseRequest.projectId });
-    const callsAfterStop = vi.mocked(http.request).mock.calls.length;
 
+    // Each of these replaces the in-flight wait. Under the old code every one
+    // of them restarted the 30s clock.
+    ptyClient.emitData(started.terminalId!, "Local: http://localhost:3000/");
+    await vi.advanceTimersByTimeAsync(10_000);
     ptyClient.emitData(started.terminalId!, "VITE v6.0.0  ready in 200 ms");
+    await vi.advanceTimersByTimeAsync(10_000);
+    ptyClient.emitData(started.terminalId!, "Port taken, using http://localhost:3001/");
+    await vi.advanceTimersByTimeAsync(9_000);
+
+    // Still inside the original 30s — the launch has not given up yet.
+    expect(
+      service.getState({ panelId: baseRequest.panelId, projectId: baseRequest.projectId }).status
+    ).toBe("starting");
+
+    // Crossing the ORIGINAL deadline ends it, rather than a fourth fresh 30s.
+    await vi.advanceTimersByTimeAsync(3_000);
+    const after = service.getState({
+      panelId: baseRequest.panelId,
+      projectId: baseRequest.projectId,
+    });
+    expect(after.status).toBe("error");
+    expect(after.error?.message).toContain("did not respond");
+  });
+
+  // #12299: the readiness budget is per launch, but an output error aborts the
+  // poll without ending the launch. If the spent deadline survived, the next
+  // probe would inherit ~0ms and report "did not respond within 30 seconds"
+  // without having waited at all.
+  it("does not charge a new readiness probe for time spent in an error state", async () => {
+    let failHttp = true;
+    const impl = ((_: unknown, __: unknown, cb: (res: MockIncomingMessage) => void) => {
+      const req: MockRequest = {
+        on: (event, handler) => {
+          if (event === "error" && failHttp) {
+            setTimeout(() => handler(new Error("ECONNREFUSED")), 0);
+          }
+          return req;
+        },
+        end: () => {
+          if (!failHttp) setTimeout(() => cb({ statusCode: 200, resume: () => {} }), 0);
+        },
+        destroy: () => {},
+      };
+      return req;
+    }) as unknown as typeof http.request;
+    vi.mocked(http.request).mockImplementation(impl);
+
+    scanOutputMock.mockImplementation((data, buffer) => {
+      if (data.includes("localhost:3000")) return { buffer, url: "http://localhost:3000/" };
+      if (data.includes("Cannot find module")) {
+        return {
+          buffer,
+          error: { type: "missing-dependencies", message: "Cannot find module 'x'" },
+        };
+      }
+      return { buffer };
+    });
+
+    const started = await service.ensure(baseRequest);
     await vi.advanceTimersByTimeAsync(50);
 
-    expect(vi.mocked(http.request).mock.calls.length).toBe(callsAfterStop);
+    // An output error aborts the in-flight poll but leaves the launch alive.
+    ptyClient.emitData(started.terminalId!, "Error: Cannot find module 'x'");
+    await vi.advanceTimersByTimeAsync(10);
+
+    // The session then sits in that state for longer than the whole budget.
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    // A URL now shows up (a replay after remount, or the server recovering).
+    failHttp = false;
+    ptyClient.emitData(started.terminalId!, "Local: http://localhost:3000/");
+    await vi.advanceTimersByTimeAsync(100);
+
+    const state = service.getState({
+      panelId: baseRequest.panelId,
+      projectId: baseRequest.projectId,
+    });
+    expect(state.status).toBe("running");
+    expect(state.url).toBe("http://localhost:3000/");
   });
 
   it("suppresses late state changes after dispose while stop is still waiting for the terminal to die", async () => {

--- a/electron/services/__tests__/DevPreviewSessionService.diagnostics.test.ts
+++ b/electron/services/__tests__/DevPreviewSessionService.diagnostics.test.ts
@@ -192,6 +192,88 @@ describe("DevPreviewSessionService diagnostics", () => {
     expect(snapshot.restoredFromManifest).toBe(false);
   });
 
+  // #12299: "command launched" and "server responding" have to be separate
+  // observations rather than things inferred from the poll's outcome.
+  describe("startup observations (#12299)", () => {
+    it("records command-submitted and first-output once per launch", async () => {
+      const started = await service.ensure(baseRequest);
+      const terminalId = started.terminalId!;
+
+      expect(eventTypes().filter((t) => t === "command-submitted")).toHaveLength(1);
+      expect(eventTypes()).not.toContain("first-output");
+
+      ptyClient.emitData(terminalId, "starting up\n");
+      ptyClient.emitData(terminalId, "still starting\n");
+
+      expect(eventTypes().filter((t) => t === "first-output")).toHaveLength(1);
+    });
+
+    it("does not count an empty chunk as first output", async () => {
+      const started = await service.ensure(baseRequest);
+      ptyClient.emitData(started.terminalId!, "");
+      expect(eventTypes()).not.toContain("first-output");
+    });
+
+    it("names the predicted URL as the probe's first candidate", async () => {
+      await service.ensure(baseRequest);
+      await vi.waitFor(() => {
+        expect(eventTypes()).toContain("candidate-url-chosen");
+      });
+      const chosen = service
+        .getDiagnostics(stateRequest)
+        .events.filter((event) => event.type === "candidate-url-chosen");
+      expect(chosen[0]).toMatchObject({ source: "predicted" });
+    });
+
+    it("records the URL from output as an output-sourced candidate", async () => {
+      const started = await service.ensure(baseRequest);
+      scanOutputMock.mockImplementation((_data, buffer) => ({
+        buffer,
+        url: "http://localhost:4173",
+      }));
+      ptyClient.emitData(started.terminalId!, "ready at http://localhost:4173\n");
+
+      await vi.waitFor(() => {
+        expect(service.getState(stateRequest).status).toBe("running");
+      });
+
+      const chosen = service
+        .getDiagnostics(stateRequest)
+        .events.filter((event) => event.type === "candidate-url-chosen");
+      expect(chosen.some((event) => "source" in event && event.source === "output")).toBe(true);
+    });
+
+    it("records a settled HTTP attempt with its status and budget", async () => {
+      const started = await service.ensure(baseRequest);
+      scanOutputMock.mockImplementation((_data, buffer) => ({
+        buffer,
+        url: "http://localhost:4173",
+      }));
+      ptyClient.emitData(started.terminalId!, "ready at http://localhost:4173\n");
+
+      await vi.waitFor(() => {
+        expect(service.getState(stateRequest).status).toBe("running");
+      });
+
+      const attempt = service
+        .getDiagnostics(stateRequest)
+        .events.find((event) => event.type === "readiness-http-attempt");
+      expect(attempt).toMatchObject({ outcome: "reachable", status: 200, attempt: 1 });
+    });
+
+    it("records a recognized ready marker", async () => {
+      const started = await service.ensure(baseRequest);
+      scanOutputMock.mockImplementation((_data, buffer) => ({ buffer, readyMarker: true }));
+      ptyClient.emitData(started.terminalId!, "VITE v8.0.1 ready in 87 ms\n");
+
+      const recognized = service
+        .getDiagnostics(stateRequest)
+        .events.filter((event) => event.type === "marker-recognized");
+      expect(recognized).toHaveLength(1);
+      expect(recognized[0]).toMatchObject({ marker: "ready" });
+    });
+  });
+
   it("records a repeat ensure as configChanged:false without a second spawn", async () => {
     await service.ensure(baseRequest);
     const spawnsAfterFirst = ptyClient.spawn.mock.calls.length;

--- a/electron/services/__tests__/DevPreviewSessionService.test.ts
+++ b/electron/services/__tests__/DevPreviewSessionService.test.ts
@@ -672,9 +672,30 @@ describe("DevPreviewSessionService", () => {
     expect(after.status).toBe("error");
   });
 
-  it("does not treat HTTP 4xx as ready (waits for 2xx/3xx)", async () => {
+  // #12299: a 404 means the server answered. It has no route at `/`, which is
+  // the webview's problem to render, not grounds for "did not respond".
+  it("treats HTTP 4xx as a responding server", async () => {
     vi.useFakeTimers();
     mockHttpResponse(404);
+
+    const started = await service.ensure(baseRequest);
+    expect(started.terminalId).toBeTruthy();
+
+    ptyClient.emitData(started.terminalId!, "ready at http://localhost:4173\n");
+
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    const after = service.getState({
+      panelId: baseRequest.panelId,
+      projectId: baseRequest.projectId,
+    });
+    expect(after.status).toBe("running");
+    expect(after.url).toBe("http://localhost:4173/");
+  });
+
+  it("still rejects HTTP 5xx as a compiling shell", async () => {
+    vi.useFakeTimers();
+    mockHttpResponse(500);
 
     const started = await service.ensure(baseRequest);
     expect(started.terminalId).toBeTruthy();

--- a/electron/services/__tests__/DevPreviewTerminalController.launchCancellation.test.ts
+++ b/electron/services/__tests__/DevPreviewTerminalController.launchCancellation.test.ts
@@ -56,6 +56,8 @@ function makeSession(): TerminalControllerSession {
     pendingUrl: null,
     readinessAbort: null,
     markerSeen: false,
+    sawOutput: false,
+    readinessDeadline: null,
     needsInstall: false,
     isRunningInstall: false,
     installAttemptedGeneration: null,

--- a/electron/services/__tests__/DevPreviewTerminalController.launchCancellation.test.ts
+++ b/electron/services/__tests__/DevPreviewTerminalController.launchCancellation.test.ts
@@ -58,6 +58,7 @@ function makeSession(): TerminalControllerSession {
     markerSeen: false,
     sawOutput: false,
     readinessDeadline: null,
+    readinessSaw5xx: false,
     needsInstall: false,
     isRunningInstall: false,
     installAttemptedGeneration: null,

--- a/electron/services/__tests__/UrlDetector.test.ts
+++ b/electron/services/__tests__/UrlDetector.test.ts
@@ -419,5 +419,84 @@ describe("UrlDetector", () => {
         expect(result.compileMarker).toBe(false);
       });
     });
+
+    // #12299: PTY transport splits output at arbitrary offsets, so a marker
+    // line regularly arrives in two pieces. Matching only the current chunk
+    // dropped those markers permanently.
+    describe("markers split across chunk boundaries", () => {
+      const READY_LINE = "  VITE v8.0.1  ready in 87 ms";
+      const COMPILE_LINE = "[vite] hmr update /src/App.tsx";
+
+      function feed(chunks: string[]): Array<{ readyMarker: boolean; compileMarker: boolean }> {
+        let buffer = "";
+        return chunks.map((chunk) => {
+          const result = detector.scanOutput(chunk, buffer);
+          buffer = result.buffer;
+          return { readyMarker: result.readyMarker, compileMarker: result.compileMarker };
+        });
+      }
+
+      it("detects a ready marker at every split position", () => {
+        for (let split = 1; split < READY_LINE.length; split++) {
+          detector = new UrlDetector();
+          const results = feed([READY_LINE.slice(0, split), READY_LINE.slice(split)]);
+          expect(
+            results.some((r) => r.readyMarker),
+            `split at ${split}`
+          ).toBe(true);
+        }
+      });
+
+      it("detects a compile marker at every split position", () => {
+        for (let split = 1; split < COMPILE_LINE.length; split++) {
+          detector = new UrlDetector();
+          const results = feed([COMPILE_LINE.slice(0, split), COMPILE_LINE.slice(split)]);
+          expect(
+            results.some((r) => r.compileMarker),
+            `split at ${split}`
+          ).toBe(true);
+        }
+      });
+
+      it("detects a ready marker split across three chunks", () => {
+        const results = feed(["  VITE v8.0", ".1  ready", " in 87 ms"]);
+        expect(results.some((r) => r.readyMarker)).toBe(true);
+      });
+
+      it("reports a split marker exactly once", () => {
+        const results = feed(["  VITE v8.0.1  rea", "dy in 87 ms", "\nwatching for changes"]);
+        expect(results.filter((r) => r.readyMarker)).toHaveLength(1);
+      });
+
+      it("does not re-report a completed marker on later unrelated chunks", () => {
+        const results = feed([READY_LINE, "\n", "  ➜  press h + enter to show help", ""]);
+        expect(results.filter((r) => r.readyMarker)).toHaveLength(1);
+      });
+
+      it("reports a second genuine marker later in the stream", () => {
+        const results = feed([COMPILE_LINE, "\nsome unrelated output\n", COMPILE_LINE]);
+        expect(results.filter((r) => r.compileMarker)).toHaveLength(2);
+      });
+
+      it("detects a marker whose ANSI colour codes are split across chunks", () => {
+        const results = feed(["\x1b[36m  VITE v6.3.1\x1b[39m  \x1b[32mready", " in 456 ms\x1b[0m"]);
+        expect(results.some((r) => r.readyMarker)).toBe(true);
+      });
+
+      it("does not report a marker that lies wholly in the carried tail", () => {
+        const first = detector.scanOutput(READY_LINE, "");
+        expect(first.readyMarker).toBe(true);
+        const second = detector.scanOutput("still nothing to see", first.buffer);
+        expect(second.readyMarker).toBe(false);
+      });
+
+      it("keeps markers out of an unrelated session's buffer", () => {
+        // scanOutput is stateless — the caller's buffer is the only carry.
+        const other = detector.scanOutput("plain output", "");
+        expect(other.readyMarker).toBe(false);
+        const fresh = detector.scanOutput("dy in 87 ms", "");
+        expect(fresh.readyMarker).toBe(false);
+      });
+    });
   });
 });

--- a/electron/services/__tests__/UrlDetector.test.ts
+++ b/electron/services/__tests__/UrlDetector.test.ts
@@ -483,6 +483,20 @@ describe("UrlDetector", () => {
         expect(results.some((r) => r.readyMarker)).toBe(true);
       });
 
+      // The escape SEQUENCE itself straddles the boundary, so neither half
+      // contains a complete one. Stripping the halves independently leaves
+      // "\x1b[0m" embedded between the glyph and "Ready", and the marker is
+      // lost for good.
+      it("detects a marker when an escape sequence straddles the boundary", () => {
+        const results = feed(["\x1b[32m✓\x1b[0", "m Ready in 87ms"]);
+        expect(results.some((r) => r.readyMarker)).toBe(true);
+      });
+
+      it("detects a compile marker when an escape straddles the boundary", () => {
+        const results = feed(["\x1b[36mcompil\x1b[3", "6ming..."]);
+        expect(results.some((r) => r.compileMarker)).toBe(true);
+      });
+
       it("does not report a marker that lies wholly in the carried tail", () => {
         const first = detector.scanOutput(READY_LINE, "");
         expect(first.readyMarker).toBe(true);

--- a/scripts/perf/lib/devPreviewOutputFixture.ts
+++ b/scripts/perf/lib/devPreviewOutputFixture.ts
@@ -486,6 +486,7 @@ export function createDevPreviewSession(
     readinessAbort: null,
     markerSeen: false,
     sawOutput: false,
+    readinessDeadline: null,
     generation: 1,
     isRunningInstall: false,
     needsInstall: false,

--- a/scripts/perf/lib/devPreviewOutputFixture.ts
+++ b/scripts/perf/lib/devPreviewOutputFixture.ts
@@ -487,6 +487,7 @@ export function createDevPreviewSession(
     markerSeen: false,
     sawOutput: false,
     readinessDeadline: null,
+    readinessSaw5xx: false,
     generation: 1,
     isRunningInstall: false,
     needsInstall: false,

--- a/scripts/perf/lib/devPreviewOutputFixture.ts
+++ b/scripts/perf/lib/devPreviewOutputFixture.ts
@@ -485,6 +485,7 @@ export function createDevPreviewSession(
     buffer: "",
     readinessAbort: null,
     markerSeen: false,
+    sawOutput: false,
     generation: 1,
     isRunningInstall: false,
     needsInstall: false,

--- a/scripts/perf/lib/devPreviewOutputFixture.ts
+++ b/scripts/perf/lib/devPreviewOutputFixture.ts
@@ -85,8 +85,14 @@ export interface DevPreviewFrame {
  * recorded the right number of the wrong events still scores.
  */
 export interface DevPreviewDiagnosticExpectation {
-  type: "url-detected" | "output-error";
-  detail: string;
+  type:
+    "first-output" | "url-detected" | "candidate-url-chosen" | "marker-recognized" | "output-error";
+  /**
+   * The field of the event that says WHICH plant it came from — the URL for a
+   * bind, the error type for a fault, the marker kind for a recognition. Absent
+   * for `first-output`, which carries no detail of its own.
+   */
+  detail?: string;
 }
 
 export interface DevPreviewStreamPlan {
@@ -111,11 +117,13 @@ export interface DevPreviewStreamPlan {
   /**
    * The diagnostics-ring writes the pass must leave behind, in order.
    *
-   * Only the two the per-chunk handler makes synchronously: `url-detected` on
-   * a new bind and `output-error` on a newly-classified fault. The compile
-   * events are written from `setTimeout` callbacks (COMPILE_ARM_MS /
-   * COMPILE_CLEAR_MS) that cannot fire inside a synchronous feed loop, so
-   * expecting them would grade a healthy pass as broken.
+   * Only what the per-chunk handler writes synchronously, in its own order:
+   * `first-output` once, then per frame `url-detected` + `candidate-url-chosen`
+   * on a new bind, `marker-recognized` on a ready/compile line, and
+   * `output-error` on a newly-classified fault. The compile events are written
+   * from `setTimeout` callbacks (COMPILE_ARM_MS / COMPILE_CLEAR_MS) that cannot
+   * fire inside a synchronous feed loop, so expecting them would grade a
+   * healthy pass as broken.
    */
   expectedDiagnostics: DevPreviewDiagnosticExpectation[];
   decoyFrames: number;
@@ -132,6 +140,7 @@ class PlanBuilder {
   private readonly expectedUrls: string[] = [];
   private readonly expectedPolls: string[] = [];
   private pendingUrl: string | null = null;
+  private sawOutput = false;
   private readonly expectedErrorTypes: DevServerErrorType[] = [];
   private readonly expectedDiagnostics: DevPreviewDiagnosticExpectation[] = [];
   private readyAccelerations = 0;
@@ -143,11 +152,19 @@ class PlanBuilder {
   push(frame: DevPreviewFrame): this {
     this.frames.push(frame);
     this.chars += frame.text.length;
+    // Mirrors the emission order inside processDevPreviewOutput: the
+    // first-output probe runs before the scan, the URL branch before the marker
+    // check, and the error branch last.
+    if (!this.sawOutput && frame.text.length > 0) {
+      this.sawOutput = true;
+      this.expectedDiagnostics.push({ type: "first-output" });
+    }
     if (frame.expectsUrl !== undefined) {
       this.expectedUrls.push(frame.expectsUrl);
       this.expectedPolls.push(frame.expectsUrl);
       this.pendingUrl = frame.expectsUrl;
       this.expectedDiagnostics.push({ type: "url-detected", detail: frame.expectsUrl });
+      this.expectedDiagnostics.push({ type: "candidate-url-chosen", detail: frame.expectsUrl });
     }
     if (frame.isDecoy) this.decoys += 1;
     if (frame.expectsReadyAcceleration) {
@@ -156,6 +173,16 @@ class PlanBuilder {
     }
     if (frame.expectsCompileArm) this.compileArms += 1;
     if (frame.expectsCompileClear) this.compileClears += 1;
+    // A ready line and a compile line both surface as one recognition; the
+    // product labels it "ready" whenever the ready marker matched.
+    const readyLine = frame.expectsReadyAcceleration === true || frame.expectsCompileClear === true;
+    const compileLine = frame.expectsCompileArm === true;
+    if (readyLine || compileLine) {
+      this.expectedDiagnostics.push({
+        type: "marker-recognized",
+        detail: readyLine ? "ready" : "compile",
+      });
+    }
     if (frame.expectsErrorType !== undefined) {
       this.expectedErrorTypes.push(frame.expectsErrorType);
       this.expectedDiagnostics.push({ type: "output-error", detail: frame.expectsErrorType });
@@ -812,6 +839,8 @@ function diagnosticRingMisses(
       continue;
     }
     if (event.type === "url-detected" && event.url !== expected.detail) misses += 1;
+    if (event.type === "candidate-url-chosen" && event.url !== expected.detail) misses += 1;
+    if (event.type === "marker-recognized" && event.marker !== expected.detail) misses += 1;
     if (event.type === "output-error" && event.errorType !== expected.detail) misses += 1;
   }
 

--- a/shared/types/ipc/devPreview.ts
+++ b/shared/types/ipc/devPreview.ts
@@ -155,6 +155,16 @@ export type DevPreviewUpstreamResolution =
 // evict the lifecycle history.
 export type DevPreviewDiagnosticEventType = DevPreviewDiagnosticEvent["type"];
 
+/**
+ * What one settled readiness request observed. `reachable` means the server
+ * produced a final HTTP response — including 401/403/404, which prove the
+ * server is bound and serving. `server-error` is 5xx, which a framework emits
+ * from a still-compiling shell, so it is deliberately not `reachable`.
+ */
+export type DevPreviewReadinessOutcome = "reachable" | "server-error" | "retry";
+
+export type DevPreviewReadinessRetryCause = "connection-error" | "request-timeout" | "bad-status";
+
 interface DevPreviewDiagnosticEventBase {
   at: number;
   seq: number;
@@ -172,15 +182,36 @@ export type DevPreviewDiagnosticEvent = DevPreviewDiagnosticEventBase &
     | { type: "port-conflict"; port: number }
     | { type: "spawned"; terminalId: string; port: number }
     | { type: "spawn-failed"; message: string }
+    | { type: "command-submitted"; via: "shell-args" | "pty-write" }
+    | { type: "first-output" }
     | { type: "install-started"; command: string }
     | { type: "install-completed" }
     | { type: "install-failed"; message: string }
     | { type: "url-detected"; url: string }
+    | { type: "candidate-url-chosen"; url: string; source: "predicted" | "output" }
+    | { type: "marker-recognized"; marker: "ready" | "compile" }
+    // One settled HTTP readiness request. Recorded only when its outcome for
+    // that candidate changes, so a 30s poll against a refused port leaves one
+    // row per candidate rather than sixty — the transitions are the story, and
+    // lifecycle events must not be evicted to record repetition.
+    | {
+        type: "readiness-http-attempt";
+        url: string;
+        outcome: DevPreviewReadinessOutcome;
+        status?: number;
+        cause?: DevPreviewReadinessRetryCause;
+        attempt: number;
+        elapsedMs: number;
+        remainingMs: number;
+      }
     | { type: "readiness-probe-succeeded"; url: string }
     | { type: "readiness-probe-timed-out"; url: string; timeoutMs: number }
     | { type: "readiness-probe-failed"; message: string }
     | { type: "compile-started" }
-    | { type: "compile-cleared" }
+    // `reason` keeps the observation honest: "ready-marker" is a framework
+    // completion line we actually saw, "silence" is only the absence of further
+    // compile markers. The UI must not present the latter as "finished".
+    | { type: "compile-cleared"; reason: "silence" | "ready-marker" }
     | { type: "output-error"; errorType: string; message: string }
     | { type: "restart-requested"; mode: "restart" | "clear-cache" | "reinstall" }
     | { type: "stop-requested"; context: string }

--- a/src/components/DevPreview/DiagnosticsPanel.tsx
+++ b/src/components/DevPreview/DiagnosticsPanel.tsx
@@ -29,6 +29,33 @@ function describeProxyCause(cause: string, code?: string): string {
   return code ? `${label} (${code})` : label;
 }
 
+const RETRY_CAUSE_LABELS: Record<string, string> = {
+  "connection-error": "no connection",
+  "request-timeout": "request timed out",
+  "bad-status": "unusable response",
+};
+
+type ReadinessAttemptEvent = Extract<DevPreviewDiagnosticEvent, { type: "readiness-http-attempt" }>;
+
+/**
+ * Attempt rows say what the response was, never what it implied. A 404 is
+ * reported as a server that answered, because it is one — the probe stops there
+ * and the webview decides what the page means.
+ */
+function describeAttemptLabel(event: ReadinessAttemptEvent): string {
+  if (event.outcome === "reachable") return "Server responded";
+  if (event.outcome === "server-error") return "Server error response";
+  return "No response";
+}
+
+function describeAttemptDetail(event: ReadinessAttemptEvent): string {
+  const what =
+    event.status !== undefined
+      ? `HTTP ${event.status}`
+      : (RETRY_CAUSE_LABELS[event.cause ?? ""] ?? "failed");
+  return `${event.url} — ${what}, attempt ${event.attempt}, ${event.elapsedMs}ms (${Math.round(event.remainingMs / 1000)}s budget left)`;
+}
+
 /**
  * Human-readable line for one timeline event. Exported for tests — the switch
  * is exhaustive over the event union, so a new event type fails typecheck here
@@ -64,8 +91,26 @@ export function describeDiagnosticEvent(event: DevPreviewDiagnosticEvent): {
       return { label: "Install completed" };
     case "install-failed":
       return { label: "Install failed", detail: event.message };
+    case "command-submitted":
+      return {
+        label: "Command submitted",
+        detail: event.via === "shell-args" ? "with the shell launch" : "typed into the terminal",
+      };
+    case "first-output":
+      return { label: "First output received" };
     case "url-detected":
       return { label: "URL detected", detail: event.url };
+    case "candidate-url-chosen":
+      return {
+        label: "Probing",
+        detail: `${event.url} (${event.source === "predicted" ? "allocated port" : "server output"})`,
+      };
+    case "marker-recognized":
+      return {
+        label: event.marker === "ready" ? "Ready line seen" : "Compile line seen",
+      };
+    case "readiness-http-attempt":
+      return { label: describeAttemptLabel(event), detail: describeAttemptDetail(event) };
     case "readiness-probe-succeeded":
       return { label: "Server ready", detail: event.url };
     case "readiness-probe-timed-out":
@@ -78,7 +123,11 @@ export function describeDiagnosticEvent(event: DevPreviewDiagnosticEvent): {
     case "compile-started":
       return { label: "Compile started" };
     case "compile-cleared":
-      return { label: "Compile finished" };
+      // "Compile finished" was a claim the timer path could not support: it
+      // only knew that compile lines had stopped arriving.
+      return event.reason === "ready-marker"
+        ? { label: "Compile finished", detail: "ready line observed" }
+        : { label: "Compile output quiet" };
     case "output-error":
       return { label: `Error (${event.errorType})`, detail: event.message };
     case "restart-requested":

--- a/src/components/DevPreview/__tests__/DiagnosticsPanel.test.tsx
+++ b/src/components/DevPreview/__tests__/DiagnosticsPanel.test.tsx
@@ -170,12 +170,50 @@ describe("describeDiagnosticEvent", () => {
       { ...base, type: "install-started", command: "npm install" },
       { ...base, type: "install-completed" },
       { ...base, type: "install-failed", message: "exit 1" },
+      { ...base, type: "command-submitted", via: "shell-args" },
+      { ...base, type: "command-submitted", via: "pty-write" },
+      { ...base, type: "first-output" },
       { ...base, type: "url-detected", url: "http://localhost:1" },
+      { ...base, type: "candidate-url-chosen", url: "http://localhost:1", source: "predicted" },
+      { ...base, type: "candidate-url-chosen", url: "http://localhost:1", source: "output" },
+      { ...base, type: "marker-recognized", marker: "ready" },
+      { ...base, type: "marker-recognized", marker: "compile" },
+      {
+        ...base,
+        type: "readiness-http-attempt",
+        url: "http://localhost:1",
+        outcome: "reachable",
+        status: 404,
+        attempt: 1,
+        elapsedMs: 12,
+        remainingMs: 29000,
+      },
+      {
+        ...base,
+        type: "readiness-http-attempt",
+        url: "http://localhost:1",
+        outcome: "retry",
+        cause: "connection-error",
+        attempt: 3,
+        elapsedMs: 5,
+        remainingMs: 21000,
+      },
+      {
+        ...base,
+        type: "readiness-http-attempt",
+        url: "http://localhost:1",
+        outcome: "server-error",
+        status: 500,
+        attempt: 2,
+        elapsedMs: 40,
+        remainingMs: 25000,
+      },
       { ...base, type: "readiness-probe-succeeded", url: "http://localhost:1" },
       { ...base, type: "readiness-probe-timed-out", url: "http://localhost:1", timeoutMs: 30000 },
       { ...base, type: "readiness-probe-failed", message: "boom" },
       { ...base, type: "compile-started" },
-      { ...base, type: "compile-cleared" },
+      { ...base, type: "compile-cleared", reason: "silence" },
+      { ...base, type: "compile-cleared", reason: "ready-marker" },
       { ...base, type: "output-error", errorType: "oom", message: "heap" },
       { ...base, type: "restart-requested", mode: "clear-cache" },
       { ...base, type: "stop-requested", context: "project-hibernated" },
@@ -191,6 +229,47 @@ describe("describeDiagnosticEvent", () => {
       const { label } = describeDiagnosticEvent(event);
       expect(label.length, `label for ${event.type}`).toBeGreaterThan(0);
     }
+  });
+
+  // #12299: the silence timer only knows compile lines stopped arriving, so it
+  // must not claim the compile finished.
+  it("only claims a compile finished when a ready marker was observed", () => {
+    expect(
+      describeDiagnosticEvent({ ...base, type: "compile-cleared", reason: "ready-marker" }).label
+    ).toBe("Compile finished");
+    expect(
+      describeDiagnosticEvent({ ...base, type: "compile-cleared", reason: "silence" }).label
+    ).not.toMatch(/finished/i);
+  });
+
+  it("reports a 4xx attempt as a server that responded", () => {
+    const { label, detail } = describeDiagnosticEvent({
+      ...base,
+      type: "readiness-http-attempt",
+      url: "http://localhost:1",
+      outcome: "reachable",
+      status: 404,
+      attempt: 1,
+      elapsedMs: 12,
+      remainingMs: 29000,
+    });
+    expect(label).toBe("Server responded");
+    expect(detail).toContain("HTTP 404");
+  });
+
+  it("names the retry cause when no status came back", () => {
+    const { label, detail } = describeDiagnosticEvent({
+      ...base,
+      type: "readiness-http-attempt",
+      url: "http://localhost:1",
+      outcome: "retry",
+      cause: "request-timeout",
+      attempt: 4,
+      elapsedMs: 5000,
+      remainingMs: 10000,
+    });
+    expect(label).toBe("No response");
+    expect(detail).toContain("request timed out");
   });
 
   it("names the restart tier in the label", () => {

--- a/src/hooks/__tests__/useDevServer.adversarial.test.tsx
+++ b/src/hooks/__tests__/useDevServer.adversarial.test.tsx
@@ -909,6 +909,82 @@ describe("useDevServer adversarial races", () => {
     }
   });
 
+  // #12299: the downgrade effect used `prev >= 2`, so a compile signal arriving
+  // *after* Tier 3 had fired collapsed the 45s warning to Tier 1 — the opposite
+  // of the "Tier 3 still fires at 45s even mid-compile" rule it sits next to.
+  it("keeps Tier 3 when a compile signal arrives after the 45s mark (#12299)", async () => {
+    vi.useFakeTimers();
+    try {
+      ensureMock.mockImplementation((request: { projectId: string }) =>
+        Promise.resolve(
+          buildState({
+            panelId: "panel-1",
+            projectId: request.projectId,
+            status: "starting",
+            terminalId: `term-${request.projectId}`,
+          })
+        )
+      );
+      getStateMock.mockImplementation((request: { projectId: string }) =>
+        Promise.resolve(
+          buildState({
+            panelId: "panel-1",
+            projectId: request.projectId,
+            status: "starting",
+            terminalId: `term-${request.projectId}`,
+          })
+        )
+      );
+      let stateChangedHandler: ((payload: { state: DevPreviewSessionState }) => void) | null = null;
+      onStateChangedMock.mockImplementation(
+        (cb: (payload: { state: DevPreviewSessionState }) => void) => {
+          stateChangedHandler = cb;
+          return vi.fn();
+        }
+      );
+
+      const { result } = renderHook(() =>
+        useDevServer({
+          panelId: "panel-1",
+          devCommand: "npm run dev",
+          cwd: "/repo",
+        })
+      );
+
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      // Run all three timers out with no compile signal at all.
+      await act(async () => {
+        vi.advanceTimersByTime(45000);
+        await Promise.resolve();
+      });
+      expect(result.current.stuckTier).toBe(3);
+
+      // Only now does the backend report a compile. A 45s start that is still
+      // compiling is exactly the case Tier 3 exists to surface.
+      await act(async () => {
+        stateChangedHandler?.({
+          state: buildState({
+            panelId: "panel-1",
+            projectId: "project-1",
+            status: "starting",
+            terminalId: "term-project-1",
+            phaseLabel: "Compiling",
+          }),
+        });
+        await Promise.resolve();
+      });
+
+      expect(result.current.phaseLabel).toBe("Compiling");
+      expect(result.current.stuckTier).toBe(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("allows Tier 2 to fire normally when phaseLabel never reaches 'Compiling' (#9099)", async () => {
     vi.useFakeTimers();
     try {

--- a/src/hooks/useDevServer.ts
+++ b/src/hooks/useDevServer.ts
@@ -547,7 +547,10 @@ export function useDevServer({
   // reset when phaseLabel toggles (Tier 3 at 45s must still fire).
   useEffect(() => {
     if (phaseLabel === "Compiling") {
-      setStuckTier((prev) => (prev >= 2 ? 1 : prev));
+      // Only Tier 2 downgrades. Tier 3 means the server has been starting for
+      // 45s, which a compile signal explains but does not excuse — collapsing
+      // it to Tier 1 here erased the warning the main effect had just raised.
+      setStuckTier((prev) => (prev === 2 ? 1 : prev));
     }
   }, [phaseLabel]);
 


### PR DESCRIPTION
## Summary

- An external audit of #12299 examined the dev preview readiness path and found seven distinct problems, all still live at HEAD. This PR fixes all seven and adds a startup timeline to the diagnostics ring.
- Reviewed with three passes of Codex (adversarial correctness, test coverage, then fix verification), which drove two rounds of fixes before merge.
- One piece of the original ask is deliberately out of scope here and called out below as a follow-up.

Resolves #12299

## Changes

**A working server is no longer rejected.** `probeUrl` treated any HTTP response outside the 200 to 399 range as a failure, so a dev server that required authentication, or one with no route defined at the root path, was retried until the 30 second deadline passed and then reported as not responding. Any final HTTP response now proves the server is bound and serving; interpreting a 401 or 404 is the webview's job, not the probe's. 5xx stays a separate case, since a framework can answer with a 500 from a shell that is still compiling.

**The 1.5 second HMR check is gone.** A hot module reload websocket handshake was being awaited on the success path of the readiness check, and its boolean result then discarded, costing 1.5 seconds every time. Vite's fix for [GHSA-vg6x-rcgg-rjx6](https://github.com/vitejs/vite/security/advisories/GHSA-vg6x-rcgg-rjx6) requires a query token a plain websocket client can't supply, so this check is now expected to fail against modern Vite. Deleted rather than downgraded to a warning: ongoing HMR liveness is already monitored from the browser side, in a hook named `useDevPreviewConsoleCapture`.

**The timeout is now an actual deadline.** It was only checked between polling rounds, not during one. A round of serial candidate checks could run 5 seconds each plus 1.5 seconds of HMR checking, running over budget, and every marker-triggered re-probe reset a fresh 30 second clock instead of respecting the original deadline. Now there's one composed `AbortSignal.any` per wait, each HTTP request is clamped to whatever budget remains, and there's one budget per launch attempt, cleared only on the code paths that actually end a launch.

**Markers survive PTY chunk boundaries.** `UrlDetector` matched ready and compile markers only against the current PTY output chunk, while URL and error detection already matched against the accumulated buffer. PTY chunks are transport boundaries, not line boundaries, so a marker split across two chunks by the transport was permanently missed. It now matches against a carry window of recent output, accepts only matches that end in the newly arrived data, and strips the joined window afterward so a terminal escape sequence split across the boundary can't leave residue inside a marker.

**Marker acceleration works on the predicted-port path.** It was gated on `session.pendingUrl`, which is never set during a predicted-port startup, the common case where a server starts before the framework has printed its own URL. Setting `pendingUrl` to the port allocator's guess would have been the wrong fix: two other code paths, startup replay and stale-start recovery, both read that same field to mean a URL was actually observed in process output. Instead, the gate now falls back to a separate field, `predictedUrl`, and additionally requires a live probe to be in progress.

**Status labels say what was seen.** `compile-cleared` was previously published by a 1.5 second silence timer that only knew compile-related output lines had stopped arriving, and the UI rendered that as "Compile finished", claiming more than was actually observed. It now carries a `reason` field, and only an observed ready marker is allowed to claim the compile finished; when it's just silence, the reason reported is `compile output quiet`.

**Tier 3 stuck warnings survive a compile signal.** `prev >= 2 ? 1 : prev` downgraded a Tier 3 stuck warning to Tier 1 on every compile signal, even though the comment three lines above it says the intent was only to downgrade Tier 2. A 45 second startup that is still compiling is exactly the situation Tier 3 exists to warn about; it should survive a compile signal, not get erased by one.

**Timeline.** Startup now records five kinds of event on the existing diagnostics ring: command submitted, first output, candidate URL chosen, marker recognized, and the outcome of each HTTP attempt made against a candidate. Recorded URLs are stripped of credentials and query strings. Attempt rows are only recorded when a candidate's outcome actually changes, so a 30 second poll against a refused port leaves one row per candidate in the ring instead of sixty, and can't push out older lifecycle history.

**Deliberately not included:** half of what the audit asked for, separate timestamped observations for a `page-loaded` event and a `proxy-origin-resolved` event. Those need a new renderer to main process IPC method, which is a public contract in this codebase, and would roughly double the size of this diff. Worth a follow-up.

## Review

Three passes of automated review with Codex: an adversarial correctness pass, a test coverage pass, then a pass verifying the fixes actually held up. Together they drove two rounds of fixes before merge. Notable catches: a stale readiness deadline value could make a probe fail in about 1 millisecond while still reporting "did not respond within 30 seconds," which was flatly misleading; an early version of the fix ended a round of candidate checks as soon as one candidate was confirmed working, which starved a sibling alias URL that only answers successfully when its sibling is returning a 500; and the 5xx-tracking latch had to be carried over across probe replacement events but still reset when a launch fully ends, otherwise it leaks state into the next launch. Three existing tests were rewritten after review showed they were passing even without the fix applied, meaning they weren't testing what they claimed to test.

## Testing

`npm test` against the 15 dev preview and related hook test files: all 430 tests passing. `npm run typecheck`: clean. `prettier --check` and `eslint` against all 18 changed files: both clean. Full suite and production build also run automatically in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019UB9uPKKVZFffavCxJ9RLy
