### PR TITLE
Capture the current worktree when submitting assistant messages

### DIFF
--- a/docs/architecture/assistant-native-host.md
+++ b/docs/architecture/assistant-native-host.md
@@ -60,3 +60,7 @@ Load-bearing rules. Each encodes a lesson; breaking one reintroduces a known inc
 ## Deliberately out of scope for Daintree
 
 Payment, subscription storage, quota calculation, Supabase integration, OAuth URL construction, loopback callback handling, and any settings-based login. Each would duplicate an authority that lives in one of the other three projects and reopen the boundary this design closed. Daintree never decides which address is the RIGHT one — it constructs no account URL, infers none from a hostname, substitutes none, and hard-codes none. It does decide whether an address the engine chose to say is safe to hand to the system browser, which is invariant 8 and is a navigation question rather than an account one.
+
+### Message worktree
+
+Each native prompt carries a worktree snapshot captured in the submitting project view before IPC (`id`, `path`, and `branch`; `null` for an absent or unresolved selection). The engine uses this snapshot as the default for new work until another message updates it at a completed tool-batch boundary, so opening the panel in another worktree or switching during generation cannot move its launches. Message metadata survives queued feedback and recovery. Feedback to an existing job continues to use that job's recorded terminals and worktree unless the user redirects it. An agent name selects an agent type for fresh work; it does not authorize borrowing an unrelated open terminal.

--- a/electron/schemas/__tests__/assistantHostProtocol.test.ts
+++ b/electron/schemas/__tests__/assistantHostProtocol.test.ts
@@ -336,3 +336,17 @@ describe("AssistantHostCommandSchema / EventSchema separation", () => {
     ).toBeNull();
   });
 });
+
+describe("prompt worktree context", () => {
+  it("preserves a send-time selection and distinguishes no selection from an older caller", () => {
+    const prompt = { type: "prompt", sessionId: "s1", text: "start the contest" };
+    const worktree = { id: "wt-b", path: "/repo/b", branch: "topic-b" };
+    expect(parseAssistantHostCommand({ ...prompt, worktree })).toEqual({ ...prompt, worktree });
+    expect(parseAssistantHostCommand({ ...prompt, worktree: null })).toEqual({
+      ...prompt,
+      worktree: null,
+    });
+    expect(parseAssistantHostCommand(prompt)).toEqual(prompt);
+    expect(parseAssistantHostCommand({ ...prompt, worktree: { id: "wt-b" } })).toBeNull();
+  });
+});

--- a/electron/schemas/ipc.ts
+++ b/electron/schemas/ipc.ts
@@ -1546,6 +1546,10 @@ export const AssistantHostCommandSchema = z.discriminatedUnion("type", [
     type: z.literal("prompt"),
     sessionId: IdString,
     text: z.string(),
+    worktree: z
+      .object({ id: IdString, path: z.string().min(1), branch: z.string() })
+      .nullable()
+      .optional(),
   }),
   z.object({
     type: z.literal("approval:decide"),

--- a/shared/types/ipc/assistantHost.ts
+++ b/shared/types/ipc/assistantHost.ts
@@ -934,6 +934,13 @@ export type AssistantHostEventType = AssistantHostEvent["type"];
 // Daintree → engine commands
 // ============================================================================
 
+/** Worktree captured at message submission. */
+export interface AssistantPromptWorktree {
+  id: string;
+  path: string;
+  branch: string;
+}
+
 /**
  * Submit a user prompt.
  *
@@ -946,6 +953,8 @@ export interface AssistantPromptCommand {
   type: "prompt";
   sessionId: string;
   text: string;
+  /** null means no selected worktree; omission is reserved for older callers. */
+  worktree?: AssistantPromptWorktree | null;
 }
 
 /** Answer an outstanding `approval:requested`. */

--- a/src/components/AssistantPanel/__tests__/useAssistantSession.lifecycle.test.tsx
+++ b/src/components/AssistantPanel/__tests__/useAssistantSession.lifecycle.test.tsx
@@ -1,7 +1,11 @@
 // @vitest-environment jsdom
 import { renderHook, act, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { setWorktreeSelectionAccessor, setWorktreePathIndexAccessor } from "@/store/storeAccessors";
+import {
+  setWorktreeSelectionAccessor,
+  setWorktreePathIndexAccessor,
+  setWorktreeBranchAccessor,
+} from "@/store/storeAccessors";
 import { useAssistantSession } from "../useAssistantSession";
 import { useAssistantStore } from "@/store/assistantStore";
 
@@ -160,8 +164,17 @@ describe("useAssistantSession — a dead session refuses work", () => {
         new Map([
           ["wt-open", "/open"],
           ["wt-send", "/send"],
+          ["wt-detached", "/detached"],
         ])
     );
+    // "" is what the view store's accessor answers for a detached HEAD, and the engine
+    // names the branch back to the user — so a message must carry the real one.
+    const branches = new Map([
+      ["wt-open", "feature/open"],
+      ["wt-send", "feature/send"],
+      ["wt-detached", ""],
+    ]);
+    setWorktreeBranchAccessor((worktreeId) => branches.get(worktreeId));
     const { result } = await live();
     selected = "wt-send";
     act(() => {
@@ -169,17 +182,26 @@ describe("useAssistantSession — a dead session refuses work", () => {
     });
     const submitted = send.mock.calls.find(([command]) => command.type === "prompt")![0];
     selected = "wt-open";
-    expect(submitted.worktree).toEqual({ id: "wt-send", path: "/send", branch: "" });
+    expect(submitted.worktree).toEqual({ id: "wt-send", path: "/send", branch: "feature/send" });
     act(() => {
       result.current.submit("ask those agents to vote");
     });
     expect(send).toHaveBeenLastCalledWith(
       expect.objectContaining({
         text: "ask those agents to vote",
-        worktree: { id: "wt-open", path: "/open", branch: "" },
+        worktree: { id: "wt-open", path: "/open", branch: "feature/open" },
       })
     );
     expect(start).toHaveBeenCalledTimes(1);
+    selected = "wt-detached";
+    act(() => {
+      result.current.submit("ask about this tree");
+    });
+    expect(send).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        worktree: { id: "wt-detached", path: "/detached", branch: "" },
+      })
+    );
     selected = "missing";
     act(() => {
       result.current.submit("new task");

--- a/src/components/AssistantPanel/__tests__/useAssistantSession.lifecycle.test.tsx
+++ b/src/components/AssistantPanel/__tests__/useAssistantSession.lifecycle.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { renderHook, act, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setWorktreeSelectionAccessor, setWorktreePathIndexAccessor } from "@/store/storeAccessors";
 import { useAssistantSession } from "../useAssistantSession";
 import { useAssistantStore } from "@/store/assistantStore";
 
@@ -74,6 +75,8 @@ beforeEach(() => {
     clearTimeout(id as unknown as NodeJS.Timeout)
   );
   useAssistantStore.getState().reset(null);
+  setWorktreeSelectionAccessor(() => ({ activeWorktreeId: null, restoreWorktreeId: null }));
+  setWorktreePathIndexAccessor(() => new Map());
 });
 
 afterEach(() => {
@@ -144,6 +147,44 @@ describe("useAssistantSession — a dead session refuses work", () => {
       expect.objectContaining({ type: "prompt", sessionId: "ses_live" })
     );
     expect(useAssistantStore.getState().turns.some((t) => t.role === "user")).toBe(true);
+  });
+
+  it("captures each message's current worktree without restarting the assistant", async () => {
+    let selected = "wt-open";
+    setWorktreeSelectionAccessor(() => ({
+      activeWorktreeId: selected,
+      restoreWorktreeId: selected,
+    }));
+    setWorktreePathIndexAccessor(
+      () =>
+        new Map([
+          ["wt-open", "/open"],
+          ["wt-send", "/send"],
+        ])
+    );
+    const { result } = await live();
+    selected = "wt-send";
+    act(() => {
+      result.current.submit("ask Claude and Codex for a fact");
+    });
+    const submitted = send.mock.calls.find(([command]) => command.type === "prompt")![0];
+    selected = "wt-open";
+    expect(submitted.worktree).toEqual({ id: "wt-send", path: "/send", branch: "" });
+    act(() => {
+      result.current.submit("ask those agents to vote");
+    });
+    expect(send).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        text: "ask those agents to vote",
+        worktree: { id: "wt-open", path: "/open", branch: "" },
+      })
+    );
+    expect(start).toHaveBeenCalledTimes(1);
+    selected = "missing";
+    act(() => {
+      result.current.submit("new task");
+    });
+    expect(send).toHaveBeenLastCalledWith(expect.objectContaining({ worktree: null }));
   });
 
   it("refuses a prompt after the engine exits, and records no user turn", async () => {

--- a/src/components/AssistantPanel/useAssistantSession.ts
+++ b/src/components/AssistantPanel/useAssistantSession.ts
@@ -1,5 +1,9 @@
 import { useCallback, useEffect, useRef } from "react";
-import { getWorktreeSelectionSnapshot, getWorktreePathIndex } from "@/store/storeAccessors";
+import {
+  getWorktreeSelectionSnapshot,
+  getWorktreePathIndex,
+  getWorktreeBranchById,
+} from "@/store/storeAccessors";
 import { assistantStoreForSlot, type AssistantStoreApi } from "@/store/assistantStore";
 import { DEFAULT_ASSISTANT_SLOT } from "@shared/config/assistantSlots";
 import type { AssistantHostEvent } from "@shared/types/ipc/assistantHost";
@@ -538,7 +542,10 @@ export function useAssistantSession(opts: AssistantSessionOptions): AssistantSes
       // Capture before IPC or any await: a later focus change must not retarget this message.
       const worktreeId = getWorktreeSelectionSnapshot()?.activeWorktreeId;
       const path = worktreeId ? getWorktreePathIndex()?.get(worktreeId) : undefined;
-      const worktree = worktreeId && path ? { id: worktreeId, path, branch: "" } : null;
+      const worktree =
+        worktreeId && path
+          ? { id: worktreeId, path, branch: getWorktreeBranchById(worktreeId) ?? "" }
+          : null;
       const localTurnId = store.getState().appendUserTurn(text);
       // The local checks above can only see what the renderer knows. The engine can
       // exit between them and main receiving this command, in which case main answers

--- a/src/components/AssistantPanel/useAssistantSession.ts
+++ b/src/components/AssistantPanel/useAssistantSession.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef } from "react";
+import { getWorktreeSelectionSnapshot, getWorktreePathIndex } from "@/store/storeAccessors";
 import { assistantStoreForSlot, type AssistantStoreApi } from "@/store/assistantStore";
 import { DEFAULT_ASSISTANT_SLOT } from "@shared/config/assistantSlots";
 import type { AssistantHostEvent } from "@shared/types/ipc/assistantHost";
@@ -534,6 +535,10 @@ export function useAssistantSession(opts: AssistantSessionOptions): AssistantSes
       // Appended locally because the engine does not echo the prompt back — and a
       // prompt sent mid-turn is folded into the RUNNING turn as an interjection, so
       // the store's own turn list is the only place a user turn exists.
+      // Capture before IPC or any await: a later focus change must not retarget this message.
+      const worktreeId = getWorktreeSelectionSnapshot()?.activeWorktreeId;
+      const path = worktreeId ? getWorktreePathIndex()?.get(worktreeId) : undefined;
+      const worktree = worktreeId && path ? { id: worktreeId, path, branch: "" } : null;
       const localTurnId = store.getState().appendUserTurn(text);
       // The local checks above can only see what the renderer knows. The engine can
       // exit between them and main receiving this command, in which case main answers
@@ -541,7 +546,7 @@ export function useAssistantSession(opts: AssistantSessionOptions): AssistantSes
       // transcript that nothing will ever answer. Take it back out and say so.
       safeFireAndForget(
         window.electron.assistantHost
-          .send({ type: "prompt", sessionId, text })
+          .send({ type: "prompt", sessionId, text, worktree })
           .then(({ delivered }) => {
             if (delivered) return;
             const state = store.getState();

--- a/src/store/rendererStoreOrchestrator.ts
+++ b/src/store/rendererStoreOrchestrator.ts
@@ -27,6 +27,7 @@ import {
   setWorktreeSelectionAccessor,
   setWorktreeIdSetAccessor,
   setWorktreeGitDirAccessor,
+  setWorktreeBranchAccessor,
   setWorktreePathIndexAccessor,
   setFleetArmingClearAccessor,
   setFleetArmedIdsAccessor,
@@ -87,6 +88,11 @@ export function initStoreOrchestrator(): () => void {
     const viewStore = getCurrentViewStoreOrNull();
     if (!viewStore) return undefined;
     return viewStore.getState().worktrees.get(worktreeId)?.gitDir || undefined;
+  });
+  setWorktreeBranchAccessor((worktreeId) => {
+    const viewStore = getCurrentViewStoreOrNull();
+    if (!viewStore) return undefined;
+    return viewStore.getState().worktrees.get(worktreeId)?.branch ?? "";
   });
   setWorktreePathIndexAccessor(() => {
     const viewStore = getCurrentViewStoreOrNull();

--- a/src/store/storeAccessors.ts
+++ b/src/store/storeAccessors.ts
@@ -33,6 +33,7 @@ let _getPanelStoreState: (() => PanelStoreSnapshot) | null = null;
 let _getWorktreeSelectionState: (() => WorktreeSelectionSnapshot) | null = null;
 let _getWorktreeIdSet: (() => Set<string> | null) | null = null;
 let _getWorktreeGitDirById: ((worktreeId: string) => string | undefined) | null = null;
+let _getWorktreeBranchById: ((worktreeId: string) => string | undefined) | null = null;
 let _getWorktreePathIndex: (() => ReadonlyMap<string, string> | null) | null = null;
 let _getProjectPathIndex: (() => ReadonlyMap<string, string> | null) | null = null;
 let _setPanelExtensionState: ((panelId: string, patch: Record<string, unknown>) => boolean) | null =
@@ -84,6 +85,21 @@ export function setWorktreeGitDirAccessor(
  */
 export function getWorktreeGitDirById(worktreeId: string): string | undefined {
   return _getWorktreeGitDirById?.(worktreeId);
+}
+
+export function setWorktreeBranchAccessor(
+  getter: (worktreeId: string) => string | undefined
+): void {
+  _getWorktreeBranchById = getter;
+}
+
+/**
+ * The branch checked out in a worktree of the current view, `""` on a detached
+ * HEAD, or `undefined` when no view store is mounted. Travels with each native
+ * assistant message so a result can name where a spawn landed.
+ */
+export function getWorktreeBranchById(worktreeId: string): string | undefined {
+  return _getWorktreeBranchById?.(worktreeId);
 }
 
 export function setWorktreePathIndexAccessor(
@@ -183,6 +199,7 @@ export function resetStoreAccessorsForTesting(): void {
   _getWorktreeSelectionState = null;
   _getWorktreeIdSet = null;
   _getWorktreeGitDirById = null;
+  _getWorktreeBranchById = null;
   _getWorktreePathIndex = null;
   _getProjectPathIndex = null;
   _setPanelExtensionState = null;


### PR DESCRIPTION
Opening the assistant in worktree A and sending a request after selecting B previously sent only text to the engine. Capture the current worktree synchronously on every prompt, including feedback, and carry it through the IPC schema into the host command. An absent or unresolved selection is explicit null, so it cannot silently reuse the opening worktree.

The engine pin is advanced to daintreehq/assistant#378, which uses the submitted location for new work, preserves it through queues, and keeps a tool batch stable across later UI switches. Existing-job feedback uses the job’s recorded targets. The matching policy correction in daintreehq/assistant-backend#70 distinguishes a request for Claude from permission to borrow an unrelated Claude terminal.

This is a stacked follow-up to #12189, based on `feature/native-daintree-assistant`, so its diff contains only this fix. Merge the engine change and the parent native-panel PR before retargeting this follow-up to `develop`. The pin also includes the upstream OAuth fixes already on the engine’s develop branch.

Validation:
- 75 focused tests passed across the submission hook, host command schema, and multi-surface host service. Coverage includes open in A/send in B/switch back, repeat submissions without restarting, absent selection, and schema preservation.
- `npm run typecheck` passed. Scoped ESLint had no errors (three existing warnings); changed-file Prettier and diff checks passed.
- Final full `npm test -- --maxWorkers=8`: 58,095 passed, 23 skipped, one todo, no failures (2,605 files passed). This run used the initialized engine submodule at the final pin.
- `npm run check` stops at a stale generated sample plugin artifact, reproduced on untouched base 8b6dec3bd. The generated artifact was restored rather than mixed into this fix.
- No live five-agent contest or Electron E2E was run. The engine PR includes a scripted-MCP five-agent launch regression with an unrelated Claude terminal present.

Draft pending parent/dependency integration and a clean application gate.
