### PR TITLE
fix(diff): stop treating submodule gitlinks as readable files

### DIFF
--- a/electron/ipc/handlers/__tests__/files.read.test.ts
+++ b/electron/ipc/handlers/__tests__/files.read.test.ts
@@ -321,6 +321,26 @@ describe("files:read handler", () => {
     });
   });
 
+  it("throws AppError(NOT_A_FILE) when readFile raises EISDIR on a directory", async () => {
+    // A submodule gitlink's path is a directory, and the generic fallback
+    // reported that as "Invalid file path" with a Retry that could never
+    // succeed (#12309).
+    fsMock.stat.mockResolvedValue({ size: 128 });
+    const handle = {
+      readFile: vi
+        .fn()
+        .mockRejectedValue(Object.assign(new Error("illegal operation"), { code: "EISDIR" })),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    fsMock.open.mockResolvedValue(handle);
+    registerFilesHandlers();
+
+    await expect(getReadHandler()({}, { path: file, rootPath: root })).rejects.toMatchObject({
+      name: "AppError",
+      code: "NOT_A_FILE",
+    });
+  });
+
   it("throws AppError(PERMISSION) when readFile raises EACCES", async () => {
     fsMock.stat.mockResolvedValue({ size: 100 });
     const handle = {

--- a/electron/ipc/handlers/files.ts
+++ b/electron/ipc/handlers/files.ts
@@ -81,6 +81,19 @@ export function registerFilesHandlers(): () => void {
           cause: error instanceof Error ? error : undefined,
         });
       }
+      // A submodule gitlink's path is the submodule's own checkout, so the diff
+      // and file panels can arrive here aimed at a directory. `open` succeeds on
+      // one; `readFile` is what fails, with EISDIR on all three platforms. Left
+      // to the fallback it was reported as an invalid path (#12309).
+      if (errCode === "EISDIR") {
+        return new AppError({
+          code: "NOT_A_FILE",
+          message: "Path is a directory, not a file",
+          userMessage: "This is a folder, not a file.",
+          context: { filePath },
+          cause: error instanceof Error ? error : undefined,
+        });
+      }
       if (errCode === "EACCES" || errCode === "EPERM") {
         return new AppError({
           code: "PERMISSION",

--- a/electron/services/GitService.ts
+++ b/electron/services/GitService.ts
@@ -509,6 +509,10 @@ ${lines.map((l) => "+" + l).join("\n")}`;
           "--no-ext-diff",
           "--no-textconv",
           "--no-color",
+          // Pins the gitlink format against the user's `diff.submodule`, which
+          // would otherwise replace the patch with a commit summary or with the
+          // submodule's own files (#12309).
+          "--submodule=short",
           ...(ignoreWhitespace ? ["--ignore-all-space"] : []),
           "--end-of-options",
           range,

--- a/electron/services/__tests__/GitService.test.ts
+++ b/electron/services/__tests__/GitService.test.ts
@@ -337,6 +337,18 @@ index 1a2b3c4..5d6e7f8 100644
       expect(rangeIdx).toBeGreaterThan(eooIdx);
     });
 
+    it("pins --submodule=short on a per-file diff so diff.submodule can't reshape it", async () => {
+      // A user's `diff.submodule=log` replaces the gitlink patch with a commit
+      // summary that is not a unified diff at all (#12309).
+      gitClientMock.raw.mockResolvedValue("diff --git a/vendor/sub b/vendor/sub\n");
+
+      const service = new GitService(tempDir);
+      await service.compareWorktrees("main", "feature/test", "vendor/sub");
+
+      const args = gitClientMock.raw.mock.calls[0][0] as string[];
+      expect(args).toContain("--submodule=short");
+    });
+
     it("returns file list for two-dot range", async () => {
       gitClientMock.raw.mockResolvedValue("M\tsrc/app.ts\nA\tsrc/new.ts\n");
 

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -4755,11 +4755,16 @@ export class WorkspaceService {
         // submodule's own checkout, so there is no file to inline. Git already
         // knows how to describe it (`new file mode 160000`), so fall through to
         // the tracked path rather than failing the request (#12309).
+        //
+        // Only for `added`: an untracked directory has no index entry, so the
+        // tracked diff would come back empty and report NO_CHANGES — which
+        // claims something the request cannot know.
         let buffer: Buffer | null = null;
         try {
           buffer = await readFile(absolutePath);
         } catch (error) {
-          if ((error as NodeJS.ErrnoException).code !== "EISDIR") throw error;
+          const isDirectory = (error as NodeJS.ErrnoException).code === "EISDIR";
+          if (!isDirectory || status !== "added") throw error;
         }
 
         if (buffer !== null) {

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -4751,43 +4751,60 @@ export class WorkspaceService {
 
       if (status === "untracked" || status === "added") {
         const { readFile } = await import("fs/promises");
-        const buffer = await readFile(absolutePath);
+        // A newly added submodule is `added` with a path that is the
+        // submodule's own checkout, so there is no file to inline. Git already
+        // knows how to describe it (`new file mode 160000`), so fall through to
+        // the tracked path rather than failing the request (#12309).
+        let buffer: Buffer | null = null;
+        try {
+          buffer = await readFile(absolutePath);
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== "EISDIR") throw error;
+        }
 
-        let isBinary = false;
-        const checkLength = Math.min(buffer.length, 8192);
-        for (let i = 0; i < checkLength; i++) {
-          if (buffer[i] === 0) {
-            isBinary = true;
-            break;
+        if (buffer !== null) {
+          let isBinary = false;
+          const checkLength = Math.min(buffer.length, 8192);
+          for (let i = 0; i < checkLength; i++) {
+            if (buffer[i] === 0) {
+              isBinary = true;
+              break;
+            }
           }
-        }
 
-        if (isBinary) {
-          sendSentinel("BINARY_FILE");
-          return;
-        }
+          if (isBinary) {
+            sendSentinel("BINARY_FILE");
+            return;
+          }
 
-        const content = buffer.toString("utf-8");
-        const lines = content.split("\n");
+          const content = buffer.toString("utf-8");
+          const lines = content.split("\n");
 
-        const diff = `diff --git a/${gitPath} b/${gitPath}
+          const diff = `diff --git a/${gitPath} b/${gitPath}
 new file mode 100644
 --- /dev/null
 +++ b/${gitPath}
 @@ -0,0 +1,${lines.length} @@
 ${lines.map((l) => "+" + l).join("\n")}`;
 
-        sendWindow(diff);
-        return;
+          sendWindow(diff);
+          return;
+        }
       }
 
       // `--no-textconv` blocks user-defined diff drivers that would otherwise
       // execute arbitrary binaries via `.gitattributes` textconv mappings.
+      // `--submodule=short` pins the gitlink format: a user's `diff.submodule`
+      // of `log` emits a `Submodule <path> a..b:` summary that is not a unified
+      // diff at all, and `diff` emits patches for files INSIDE the submodule
+      // under their own paths — neither of which this pane can render or
+      // recognise as a gitlink (#12309).
       const diff = await git.diff([
         "HEAD",
         "--no-ext-diff",
         "--no-textconv",
         "--no-color",
+        "--submodule=short",
         ...(ignoreWhitespace ? ["--ignore-all-space"] : []),
         "--",
         normalizedPath,

--- a/electron/workspace-host/__tests__/WorkspaceService.getFileDiff.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.getFileDiff.test.ts
@@ -245,6 +245,25 @@ describe("WorkspaceService.getFileDiff", () => {
     expect(event.error).toBeUndefined();
   });
 
+  it("refuses to call an untracked directory NO_CHANGES", async () => {
+    // An embedded repository shows as `?? vendor/sub/` and has no index entry,
+    // so the tracked diff would come back empty — reporting that as "no
+    // changes" would claim something this request cannot know (#12309).
+    const { readFile } = await import("fs/promises");
+    vi.mocked(readFile).mockRejectedValueOnce(
+      Object.assign(new Error("illegal operation on a directory"), { code: "EISDIR" })
+    );
+
+    await service.getFileDiff("req-sub-4", "/test/repo", "vendor/sub", "untracked");
+
+    const event = mockSendEvent.mock.calls
+      .map((call) => call[0])
+      .find((e) => e.requestId === "req-sub-4");
+    expect(event.error).toBeTruthy();
+    expect(event.diff).not.toBe("NO_CHANGES");
+    expect(mockSimpleGit.diff).not.toHaveBeenCalled();
+  });
+
   it("still rethrows a non-directory read failure on an added file", async () => {
     const { readFile } = await import("fs/promises");
     vi.mocked(readFile).mockRejectedValueOnce(

--- a/electron/workspace-host/__tests__/WorkspaceService.getFileDiff.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.getFileDiff.test.ts
@@ -210,6 +210,55 @@ describe("WorkspaceService.getFileDiff", () => {
     expect(mockSimpleGit.diff).toHaveBeenCalledWith(expect.arrayContaining(["--no-textconv"]));
   });
 
+  it("pins --submodule=short so a user's diff.submodule can't reshape the patch", async () => {
+    // `diff.submodule=log` emits a `Submodule <path> a..b:` summary that is not
+    // a unified diff at all, and `diff` emits patches for files INSIDE the
+    // submodule under their own paths (#12309).
+    mockSimpleGit.diff.mockResolvedValueOnce(
+      "diff --git a/vendor/sub b/vendor/sub\nindex ada605e..029ae62 160000"
+    );
+    await service.getFileDiff("req-sub-1", "/test/repo", "vendor/sub", "modified");
+
+    expect(mockSimpleGit.diff).toHaveBeenCalledWith(expect.arrayContaining(["--submodule=short"]));
+  });
+
+  it("asks git for an added gitlink instead of reading its checkout directory", async () => {
+    // An added submodule's path is a directory, so the synthetic added-file
+    // branch cannot inline it — it used to fail the whole request (#12309).
+    const { readFile } = await import("fs/promises");
+    vi.mocked(readFile).mockRejectedValueOnce(
+      Object.assign(new Error("illegal operation on a directory"), { code: "EISDIR" })
+    );
+    const gitlinkPatch =
+      "diff --git a/vendor/sub b/vendor/sub\nnew file mode 160000\nindex 0000000..ada605e";
+    mockSimpleGit.diff.mockResolvedValueOnce(gitlinkPatch);
+
+    await service.getFileDiff("req-sub-2", "/test/repo", "vendor/sub", "added");
+
+    expect(mockSendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ requestId: "req-sub-2", diff: gitlinkPatch })
+    );
+    // Not an error result, and not the synthetic `new file mode 100644` shape.
+    const event = mockSendEvent.mock.calls
+      .map((call) => call[0])
+      .find((e) => e.requestId === "req-sub-2");
+    expect(event.error).toBeUndefined();
+  });
+
+  it("still rethrows a non-directory read failure on an added file", async () => {
+    const { readFile } = await import("fs/promises");
+    vi.mocked(readFile).mockRejectedValueOnce(
+      Object.assign(new Error("permission denied"), { code: "EACCES" })
+    );
+
+    await service.getFileDiff("req-sub-3", "/test/repo", "secret.txt", "added");
+
+    expect(mockSendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ requestId: "req-sub-3", error: "permission denied" })
+    );
+    expect(mockSimpleGit.diff).not.toHaveBeenCalled();
+  });
+
   it("refuses a file past the source ceiling without reading it or diffing", async () => {
     const { stat, readFile } = await import("fs/promises");
     vi.mocked(stat).mockResolvedValueOnce({ size: GIT_FILE_DIFF_MAX_SOURCE_BYTES + 1 } as never);

--- a/shared/types/appError.ts
+++ b/shared/types/appError.ts
@@ -16,6 +16,10 @@ export type AppErrorCode =
   // pattern-matching library error text after the fact (#11409). `NOT_FOUND`
   // and `PERMISSION` cover the rest of that set.
   | "NOT_A_DIRECTORY"
+  // The path resolved to a directory where a file was required. A submodule
+  // gitlink is the case that surfaces it: its path is the submodule's own
+  // checkout, so reading it as a file gets EISDIR (#12309).
+  | "NOT_A_FILE"
   | "GIT_NOT_INSTALLED"
   | "DUBIOUS_OWNERSHIP"
   | "PROJECT_OPEN_FAILED"

--- a/shared/types/ipc/files.ts
+++ b/shared/types/ipc/files.ts
@@ -39,6 +39,7 @@ export type FileReadErrorCode = _AssertSubset<
   | "NOT_FOUND"
   | "OUTSIDE_ROOT"
   | "INVALID_PATH"
+  | "NOT_A_FILE"
   | "PERMISSION"
 >;
 

--- a/src/components/FileViewer/fileReadErrors.ts
+++ b/src/components/FileViewer/fileReadErrors.ts
@@ -8,6 +8,7 @@ export const FILE_READ_ERROR_MESSAGES: Record<FileReadErrorCode, string> = {
   NOT_FOUND: "File no longer exists",
   OUTSIDE_ROOT: "File is outside the project root",
   INVALID_PATH: "Invalid file path",
+  NOT_A_FILE: "This is a folder, not a file",
   PERMISSION: "Permission denied — you don't have access to this file",
 };
 

--- a/src/panels/diff/DiffPane.tsx
+++ b/src/panels/diff/DiffPane.tsx
@@ -487,10 +487,10 @@ export function DiffPane({
 
   const isImageMode = Boolean(
     filePath &&
-      fileStatus &&
-      !isGitlink &&
-      isImageDiffCandidate(filePath) &&
-      panel?.diffSource !== "base-branch"
+    fileStatus &&
+    !isGitlink &&
+    isImageDiffCandidate(filePath) &&
+    panel?.diffSource !== "base-branch"
   );
   // Media shows only the current working-tree version (no side-by-side diff —
   // the media pipeline has no cheap "old vs new" comparison), so unlike

--- a/src/panels/diff/DiffPane.tsx
+++ b/src/panels/diff/DiffPane.tsx
@@ -482,7 +482,10 @@ export function DiffPane({
   // A submodule's path is its checkout directory, so every mode below that
   // would read or preview the file on disk has to stand down (#12309). Read
   // from the patch rather than the change set because the patch is the one
-  // thing guaranteed present: every read this gates is downstream of `hasDiff`.
+  // thing guaranteed present by the time the whole-file and rendered-layout
+  // reads ask — both are downstream of `hasDiff`. The media modes below are
+  // not, so they correct themselves when the patch lands rather than never
+  // being wrong.
   const isGitlink = hasDiff && isGitlinkPatch(content);
 
   const isImageMode = Boolean(

--- a/src/panels/diff/DiffPane.tsx
+++ b/src/panels/diff/DiffPane.tsx
@@ -62,6 +62,7 @@ import { useDiffViewedStore, selectViewedSet } from "@/store/diffViewedStore";
 import { useDiffContent } from "./useDiffContent";
 import { useDiffFileSource } from "./useDiffFileSource";
 import { getFullFileAvailability } from "./fullFileAvailability";
+import { isGitlinkPatch } from "./gitlinkPatch";
 import {
   getRenderedMarkdownAvailability,
   isRenderedMarkdownSupported,
@@ -468,19 +469,6 @@ export function DiffPane({
     return () => root?.removeEventListener("keydown", onKeyDown);
   }, [isFocused, navigateFile, currentEntry, worktreePath, toggleViewed]);
 
-  const isImageMode = Boolean(
-    filePath && fileStatus && isImageDiffCandidate(filePath) && panel?.diffSource !== "base-branch"
-  );
-  // Media shows only the current working-tree version (no side-by-side diff —
-  // the media pipeline has no cheap "old vs new" comparison), so unlike
-  // isImageMode this applies to every diff source, base-branch included.
-  const isVideoMode = Boolean(filePath && isVideoFilePath(filePath));
-  const isAudioMode = Boolean(filePath && isAudioFilePath(filePath));
-  const isMediaMode = isVideoMode || isAudioMode;
-  // PDFs likewise show only the current working-tree version: the built-in
-  // viewer renders a whole document, not a comparison, so like media this
-  // applies to every diff source.
-  const isPdfMode = Boolean(filePath && isPdfFilePath(filePath));
   // Sentinels the viewer turns into empty states rather than a rendered diff.
   // `NO_CHANGES`/`ERROR` gate the pane's own branches below; the binary and
   // oversized ones matter to the full-file scope, which has nothing to expand
@@ -491,13 +479,36 @@ export function DiffPane({
     content === "BINARY_FILE" ||
     content === "FILE_TOO_LARGE";
   const hasDiff = Boolean(content && content.trim() && !isDiffSentinel);
+  // A submodule's path is its checkout directory, so every mode below that
+  // would read or preview the file on disk has to stand down (#12309). Read
+  // from the patch rather than the change set because the patch is the one
+  // thing guaranteed present: every read this gates is downstream of `hasDiff`.
+  const isGitlink = hasDiff && isGitlinkPatch(content);
+
+  const isImageMode = Boolean(
+    filePath &&
+      fileStatus &&
+      !isGitlink &&
+      isImageDiffCandidate(filePath) &&
+      panel?.diffSource !== "base-branch"
+  );
+  // Media shows only the current working-tree version (no side-by-side diff —
+  // the media pipeline has no cheap "old vs new" comparison), so unlike
+  // isImageMode this applies to every diff source, base-branch included.
+  const isVideoMode = Boolean(filePath && !isGitlink && isVideoFilePath(filePath));
+  const isAudioMode = Boolean(filePath && !isGitlink && isAudioFilePath(filePath));
+  const isMediaMode = isVideoMode || isAudioMode;
+  // PDFs likewise show only the current working-tree version: the built-in
+  // viewer renders a whole document, not a comparison, so like media this
+  // applies to every diff source.
+  const isPdfMode = Boolean(filePath && !isGitlink && isPdfFilePath(filePath));
 
   // Whether this file *can* show its whole contents, independent of whether the
   // user currently wants to — the toggle stays visible either way so the option
   // is discoverable, and explains itself when it can't be used.
   const sourceAvailability = useMemo(
-    () => getFullFileAvailability(diffSource, fileStatus),
-    [diffSource, fileStatus]
+    () => getFullFileAvailability(diffSource, fileStatus, isGitlink),
+    [diffSource, fileStatus, isGitlink]
   );
   // An image diff already shows the whole asset, and a diff that hasn't loaded
   // has nothing to expand — folding both into the availability verdict keeps
@@ -538,7 +549,8 @@ export function DiffPane({
   // against. Without it, a Refresh after a partial revert would verify the one
   // surviving hunk and then copy the reverted text out of the stale snapshot as
   // trusted context.
-  const renderedNeedsSource = renderedRequested && hasDiff && !stale && fileStatus !== "deleted";
+  const renderedNeedsSource =
+    renderedRequested && hasDiff && !stale && !isGitlink && fileStatus !== "deleted";
   const { source, errorCode: sourceErrorCode } = useDiffFileSource(
     sourceSubject,
     wantsFullFile || renderedNeedsSource
@@ -607,6 +619,7 @@ export function DiffPane({
     // a failed full-file read says nothing about a layout that never asked.
     sourceErrorCode: renderedNeedsSource ? sourceErrorCode : null,
     engineFailure: renderedEngineFailure,
+    isGitlink,
   });
 
   // What the body actually shows. A requested rendered layout that turns out to
@@ -649,7 +662,12 @@ export function DiffPane({
   const fullFileNotice: { message: string; recoverable: boolean } | null =
     wantsFullFile && !showRendered
       ? sourceErrorCode
-        ? { message: FILE_READ_ERROR_MESSAGES[sourceErrorCode], recoverable: true }
+        ? {
+            message: FILE_READ_ERROR_MESSAGES[sourceErrorCode],
+            // A directory never becomes readable as a file, so this one gets no
+            // action rather than a Retry that can only fail again (#12309).
+            recoverable: sourceErrorCode !== "NOT_A_FILE",
+          }
         : activeViewerFallback
           ? {
               message: FULL_FILE_FALLBACK_MESSAGES[activeViewerFallback],

--- a/src/panels/diff/__tests__/DiffPane.test.tsx
+++ b/src/panels/diff/__tests__/DiffPane.test.tsx
@@ -210,6 +210,8 @@ beforeEach(() => {
   preferences.diffWrapLines = null;
   preferences.setDiffWrapLines.mockClear();
   preferences.diffMarkdownRendered = false;
+  preferences.diffFullFile = false;
+  (preferences.setDiffFullFile as ReturnType<typeof vi.fn>).mockReset();
   (preferences.setDiffMarkdownRendered as ReturnType<typeof vi.fn>).mockReset();
   (preferences.setDiffViewType as ReturnType<typeof vi.fn>).mockReset();
   worktrees.clear();
@@ -1250,5 +1252,108 @@ describe("DiffPane — rendered Markdown layout (#12171)", () => {
 
     const second = await screen.findByTestId("rendered-markdown-mock");
     expect(second.getAttribute("data-attempt-key")).not.toBe(firstAttempt);
+  });
+});
+
+describe("DiffPane — submodule gitlinks (#12309)", () => {
+  // Real `git diff` output for a submodule whose recorded commit moved. The
+  // trailing 160000 on the index line is what marks the entry a gitlink.
+  const GITLINK_DIFF = `diff --git a/vendor/sub b/vendor/sub
+index ada605e..029ae62 160000
+--- a/vendor/sub
++++ b/vendor/sub
+@@ -1 +1 @@
+-Subproject commit ada605e3957df590939d8d977a26e1735b98390f
++Subproject commit 029ae62ae5f30fb47a84aa76407e4e42dd165e6d`;
+
+  function seedGitlink(overrides: Record<string, unknown> = {}): void {
+    useDiffContentMock.mockReturnValue({ content: GITLINK_DIFF, stale: false, retry: vi.fn() });
+    seedPanel({
+      filePath: "vendor/sub",
+      fileStatus: "modified",
+      changeSet: [entry("vendor/sub")],
+      ...overrides,
+    });
+  }
+
+  it("never asks to read a submodule path, even with Full file on", () => {
+    // The path is the submodule's checkout directory, so the read fails with a
+    // message no Retry can clear. It must never be requested.
+    preferences.diffFullFile = true;
+    seedGitlink();
+    renderPane();
+
+    expect(sourceEnabledCalls().some(Boolean)).toBe(false);
+  });
+
+  it("disables Full file with a reason instead of raising a failed-read banner", () => {
+    preferences.diffFullFile = true;
+    seedGitlink();
+    renderPane();
+
+    const group = screen.getByRole("group", { name: "Diff content" });
+    const describedBy = group.getAttribute("aria-describedby");
+    if (!describedBy) throw new Error("scope group carries no aria-describedby");
+    expect(document.getElementById(describedBy)?.textContent).toMatch(/submodule/i);
+
+    const fullFile = [...group.querySelectorAll("button")].find(
+      (button) => button.textContent === "Full file"
+    );
+    expect(fullFile?.hasAttribute("disabled")).toBe(true);
+    // The bug: a warning banner claiming the read failed, with a dead Retry.
+    expect(screen.queryByText("Showing changed lines only")).toBeNull();
+    expect(
+      [...document.querySelectorAll("button")].some((button) => button.textContent === "Retry")
+    ).toBe(false);
+  });
+
+  it("still renders the commit-pair patch", () => {
+    preferences.diffFullFile = true;
+    seedGitlink();
+    renderPane();
+
+    expect(screen.getByTestId("diff-viewer-mock")).toBeTruthy();
+  });
+
+  it("leaves an ordinary file's Full file scope alone", () => {
+    // The guard keys off the patch, so it must not leak onto everything else.
+    preferences.diffFullFile = true;
+    useDiffContentMock.mockReturnValue({
+      content: `diff --git a/a.ts b/a.ts\nindex 83db48f..bf269f4 100644`,
+      stale: false,
+      retry: vi.fn(),
+    });
+    seedPanel({ filePath: "a.ts", fileStatus: "modified", changeSet: [entry("a.ts")] });
+    renderPane();
+
+    const group = screen.getByRole("group", { name: "Diff content" });
+    const fullFile = [...group.querySelectorAll("button")].find(
+      (button) => button.textContent === "Full file"
+    );
+    expect(fullFile?.hasAttribute("disabled")).toBe(false);
+    expect(sourceEnabledCalls().some(Boolean)).toBe(true);
+  });
+
+  it("refuses the rendered layout for a .md-suffixed submodule rather than reading it", async () => {
+    // The rendered layout is a second, independent reason to read the new side.
+    preferences.diffMarkdownRendered = true;
+    seedGitlink({ filePath: "vendor/docs.md", changeSet: [entry("vendor/docs.md")] });
+    renderPane();
+
+    await act(async () => {});
+    expect(sourceEnabledCalls().some(Boolean)).toBe(false);
+    const layoutGroup = screen.getByRole("group", { name: "Diff layout" });
+    const describedBy = layoutGroup.getAttribute("aria-describedby");
+    if (!describedBy) throw new Error("layout group carries no aria-describedby");
+    expect(document.getElementById(describedBy)?.textContent).toMatch(/submodule/i);
+  });
+
+  it("does not treat an image-suffixed submodule as an image", () => {
+    isImageDiffCandidateMock.mockReturnValue(true);
+    seedGitlink({ filePath: "vendor/icons.png", changeSet: [entry("vendor/icons.png")] });
+    renderPane();
+
+    expect(screen.queryByTestId("image-diff-mock")).toBeNull();
+    expect(screen.getByTestId("diff-viewer-mock")).toBeTruthy();
   });
 });

--- a/src/panels/diff/__tests__/DiffPane.test.tsx
+++ b/src/panels/diff/__tests__/DiffPane.test.tsx
@@ -31,8 +31,14 @@ vi.mock("@/components/ui/tooltip", () => ({
 vi.mock("@/components/Worktree/DiffViewer", () => ({
   // Surfaces `wrapLines` so the auto/override resolution is observable from the
   // prop the viewer actually receives, not just from the toolbar's pressed state.
-  DiffViewer: (props: { wrapLines?: boolean }) => (
-    <div data-testid="diff-viewer-mock" data-wrap-lines={String(props.wrapLines)} />
+  // `diff` rides along so a test can prove the viewer received the patch it
+  // names, not merely that something mounted.
+  DiffViewer: (props: { wrapLines?: boolean; diff?: string }) => (
+    <div
+      data-testid="diff-viewer-mock"
+      data-wrap-lines={String(props.wrapLines)}
+      data-diff={props.diff}
+    />
   ),
   FULL_FILE_MAX_LINES: 5000,
 }));
@@ -1307,12 +1313,14 @@ index ada605e..029ae62 160000
     ).toBe(false);
   });
 
-  it("still renders the commit-pair patch", () => {
+  it("still hands the viewer the commit-pair patch", () => {
     preferences.diffFullFile = true;
     seedGitlink();
     renderPane();
 
-    expect(screen.getByTestId("diff-viewer-mock")).toBeTruthy();
+    // Refusing the full-file scope must not cost the patch that IS renderable.
+    const viewer = screen.getByTestId("diff-viewer-mock");
+    expect(viewer.getAttribute("data-diff")).toContain("Subproject commit");
   });
 
   it("leaves an ordinary file's Full file scope alone", () => {
@@ -1346,6 +1354,41 @@ index ada605e..029ae62 160000
     const describedBy = layoutGroup.getAttribute("aria-describedby");
     if (!describedBy) throw new Error("layout group carries no aria-describedby");
     expect(document.getElementById(describedBy)?.textContent).toMatch(/submodule/i);
+  });
+
+  it("shows a folder read failure without a Retry that cannot work", () => {
+    // Belt and braces: the guard above stops the read being issued, but any
+    // residual path that still reaches a directory must not offer a retry.
+    preferences.diffFullFile = true;
+    useDiffFileSourceMock.mockReturnValue({ source: undefined, errorCode: "NOT_A_FILE" });
+    useDiffContentMock.mockReturnValue({
+      content: `diff --git a/a.ts b/a.ts\nindex 83db48f..bf269f4 100644`,
+      stale: false,
+      retry: vi.fn(),
+    });
+    seedPanel({ filePath: "a.ts", fileStatus: "modified", changeSet: [entry("a.ts")] });
+    renderPane();
+
+    expect(screen.getByText("This is a folder, not a file")).toBeTruthy();
+    expect(
+      [...document.querySelectorAll("button")].some((button) => button.textContent === "Retry")
+    ).toBe(false);
+  });
+
+  it("keeps Retry for a read failure that a refresh could clear", () => {
+    preferences.diffFullFile = true;
+    useDiffFileSourceMock.mockReturnValue({ source: undefined, errorCode: "PERMISSION" });
+    useDiffContentMock.mockReturnValue({
+      content: `diff --git a/a.ts b/a.ts\nindex 83db48f..bf269f4 100644`,
+      stale: false,
+      retry: vi.fn(),
+    });
+    seedPanel({ filePath: "a.ts", fileStatus: "modified", changeSet: [entry("a.ts")] });
+    renderPane();
+
+    expect(
+      [...document.querySelectorAll("button")].some((button) => button.textContent === "Retry")
+    ).toBe(true);
   });
 
   it("does not treat an image-suffixed submodule as an image", () => {

--- a/src/panels/diff/__tests__/fullFileAvailability.test.ts
+++ b/src/panels/diff/__tests__/fullFileAvailability.test.ts
@@ -50,6 +50,30 @@ describe("getFullFileAvailability", () => {
     }
   });
 
+  it("refuses a submodule gitlink, whose path is a directory rather than a file", () => {
+    // The reported bug: status `modified` on a working-tree diff looked like an
+    // ordinary edit, so the scope was offered and the read failed (#12309).
+    const result = getFullFileAvailability("working-tree", "modified", true);
+    expect(result.available).toBe(false);
+    expect(result.available === false && result.reason).toMatch(/submodule/i);
+  });
+
+  it("outranks every other reason, so a submodule always says submodule", () => {
+    // An added gitlink would otherwise be told its diff already carries the
+    // whole file — true of a file, meaningless for a commit reference.
+    for (const status of ["added", "deleted", "renamed", "conflicted"] as GitStatus[]) {
+      const result = getFullFileAvailability("working-tree", status, true);
+      expect(result.available === false && result.reason).toMatch(/submodule/i);
+    }
+    const staged = getFullFileAvailability("staged", "modified", true);
+    expect(staged.available === false && staged.reason).toMatch(/submodule/i);
+  });
+
+  it("leaves ordinary files untouched when the flag is absent or false", () => {
+    expect(getFullFileAvailability("working-tree", "modified", false).available).toBe(true);
+    expect(getFullFileAvailability("working-tree", "modified").available).toBe(true);
+  });
+
   it("always explains itself when it says no", () => {
     const sources = ["working-tree", "unstaged", "staged", "base-branch", undefined] as const;
     const statuses: (GitStatus | undefined)[] = [

--- a/src/panels/diff/__tests__/gitlinkPatch.test.ts
+++ b/src/panels/diff/__tests__/gitlinkPatch.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { isGitlinkPatch } from "../gitlinkPatch";
 
-// Every fixture below is real `git diff` output, captured from a scratch
+// The gitlink fixtures are real `git diff` output, captured from a scratch
 // repository with a submodule rather than written from memory — the type-change
 // shape in particular is not the one it looks like it should be.
 
@@ -97,10 +97,7 @@ index 0000000..ada605e
     expect(
       isGitlinkPatch(`diff --git a/run.sh b/run.sh
 old mode 100644
-new mode 100755
-index 83db48f..83db48f
---- a/run.sh
-+++ b/run.sh`)
+new mode 100755`)
     ).toBe(false);
   });
 
@@ -112,7 +109,7 @@ index 83db48f..83db48f
 index 83db48f..bf269f4 100644
 --- a/docs/submodules.md
 +++ b/docs/submodules.md
-@@ -1,4 +1,5 @@
+@@ -1,3 +1,4 @@
  A submodule patch looks like this:
 -index abc..def 160000
 +new file mode 160000

--- a/src/panels/diff/__tests__/gitlinkPatch.test.ts
+++ b/src/panels/diff/__tests__/gitlinkPatch.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import { isGitlinkPatch } from "../gitlinkPatch";
+
+// Every fixture below is real `git diff` output, captured from a scratch
+// repository with a submodule rather than written from memory — the type-change
+// shape in particular is not the one it looks like it should be.
+
+const MOVED_COMMIT = `diff --git a/vendor/sub b/vendor/sub
+index ada605e..029ae62 160000
+--- a/vendor/sub
++++ b/vendor/sub
+@@ -1 +1 @@
+-Subproject commit ada605e3957df590939d8d977a26e1735b98390f
++Subproject commit 029ae62ae5f30fb47a84aa76407e4e42dd165e6d`;
+
+const ADDED = `diff --git a/vendor/sub b/vendor/sub
+new file mode 160000
+index 0000000..ada605e
+--- /dev/null
++++ b/vendor/sub
+@@ -0,0 +1 @@
++Subproject commit ada605e3957df590939d8d977a26e1735b98390f`;
+
+const DELETED = `diff --git a/vendor/sub b/vendor/sub
+deleted file mode 160000
+index ada605e..0000000
+--- a/vendor/sub
++++ /dev/null
+@@ -1 +0,0 @@
+-Subproject commit ada605e3957df590939d8d977a26e1735b98390f`;
+
+// Git spells a submodule → file replacement as two records, not `old mode` /
+// `new mode`. The gitlink mode is present, but the new side is readable.
+const REPLACED_BY_FILE = `diff --git a/vendor/sub b/vendor/sub
+deleted file mode 160000
+index ada605e..0000000
+--- a/vendor/sub
++++ /dev/null
+@@ -1 +0,0 @@
+-Subproject commit ada605e3957df590939d8d977a26e1735b98390f
+diff --git a/vendor/sub b/vendor/sub
+new file mode 100644
+index 0000000..2a79fdf
+--- /dev/null
++++ b/vendor/sub
+@@ -0,0 +1 @@
++now a real file`;
+
+const ORDINARY_EDIT = `diff --git a/src/app.ts b/src/app.ts
+index 83db48f..bf269f4 100644
+--- a/src/app.ts
++++ b/src/app.ts
+@@ -1,2 +1,2 @@
+-const a = 1;
++const a = 2;
+ export { a };`;
+
+describe("isGitlinkPatch", () => {
+  it("recognises a submodule whose recorded commit moved", () => {
+    expect(isGitlinkPatch(MOVED_COMMIT)).toBe(true);
+  });
+
+  it("recognises an added and a deleted submodule", () => {
+    expect(isGitlinkPatch(ADDED)).toBe(true);
+    expect(isGitlinkPatch(DELETED)).toBe(true);
+  });
+
+  it("leaves an ordinary file edit alone", () => {
+    expect(isGitlinkPatch(ORDINARY_EDIT)).toBe(false);
+  });
+
+  it("follows the new side when a submodule is replaced by a real file", () => {
+    // The replacement is readable from disk, so the full-file scope stays on
+    // offer even though the patch opens with a gitlink mode.
+    expect(isGitlinkPatch(REPLACED_BY_FILE)).toBe(false);
+  });
+
+  it("follows the new side when a real file is replaced by a submodule", () => {
+    const fileToSubmodule = `diff --git a/vendor/sub b/vendor/sub
+deleted file mode 100644
+index 2a79fdf..0000000
+--- a/vendor/sub
++++ /dev/null
+@@ -1 +0,0 @@
+-was a real file
+diff --git a/vendor/sub b/vendor/sub
+new file mode 160000
+index 0000000..ada605e
+--- /dev/null
++++ b/vendor/sub
+@@ -0,0 +1 @@
++Subproject commit ada605e3957df590939d8d977a26e1735b98390f`;
+    expect(isGitlinkPatch(fileToSubmodule)).toBe(true);
+  });
+
+  it("ignores a permission-only change, which names both modes", () => {
+    expect(
+      isGitlinkPatch(`diff --git a/run.sh b/run.sh
+old mode 100644
+new mode 100755
+index 83db48f..83db48f
+--- a/run.sh
++++ b/run.sh`)
+    ).toBe(false);
+  });
+
+  it("reads modes from the header only, never the patch body", () => {
+    // A file documenting gitlink patches is not itself one. Every giveaway line
+    // appears in the body, prefixed the way git prefixes body lines.
+    expect(
+      isGitlinkPatch(`diff --git a/docs/submodules.md b/docs/submodules.md
+index 83db48f..bf269f4 100644
+--- a/docs/submodules.md
++++ b/docs/submodules.md
+@@ -1,4 +1,5 @@
+ A submodule patch looks like this:
+-index abc..def 160000
++new file mode 160000
++Subproject commit 029ae62ae5f30fb47a84aa76407e4e42dd165e6d
+ and that is all it is.`)
+    ).toBe(false);
+  });
+
+  it("survives CRLF headers and says no to sentinels and empty input", () => {
+    expect(isGitlinkPatch(MOVED_COMMIT.replaceAll("\n", "\r\n"))).toBe(true);
+    expect(isGitlinkPatch(undefined)).toBe(false);
+    expect(isGitlinkPatch("")).toBe(false);
+    expect(isGitlinkPatch("NO_CHANGES")).toBe(false);
+    expect(isGitlinkPatch("BINARY_FILE")).toBe(false);
+  });
+});

--- a/src/panels/diff/__tests__/renderedMarkdownAvailability.test.ts
+++ b/src/panels/diff/__tests__/renderedMarkdownAvailability.test.ts
@@ -46,6 +46,15 @@ describe("getRenderedMarkdownAvailability", () => {
     });
   });
 
+  it("refuses a .md-suffixed submodule, whose path is a directory (#12309)", () => {
+    const result = getRenderedMarkdownAvailability(input({ isGitlink: true }));
+    expect(result).toEqual({
+      visible: true,
+      enabled: false,
+      reason: expect.stringMatching(/submodule/i),
+    });
+  });
+
   it("enables it for a working-tree markdown diff", () => {
     expect(getRenderedMarkdownAvailability(input())).toEqual({ visible: true, enabled: true });
   });

--- a/src/panels/diff/__tests__/useDiffContent.test.tsx
+++ b/src/panels/diff/__tests__/useDiffContent.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { DiffSubject } from "../diffContentCache";
+import { useDiffContent } from "../useDiffContent";
+
+const { requestDiffMock } = vi.hoisted(() => ({
+  requestDiffMock: vi.fn<(subject: DiffSubject) => Promise<{ content: string } | null>>(),
+}));
+
+vi.mock("../diffContentCache", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../diffContentCache")>()),
+  requestDiff: requestDiffMock,
+  purgeWhitespaceEntriesExcept: vi.fn(),
+}));
+
+// No worktree-store provider is mounted, so freshness never fires — this file
+// is about which subject the returned content belongs to.
+vi.mock("@/store/preferencesStore", () => ({
+  usePreferencesStore: (selector: (state: unknown) => unknown) =>
+    selector({ diffIgnoreWhitespace: false }),
+}));
+
+function subject(filePath: string): DiffSubject {
+  return { source: "working-tree", worktreePath: "/repo", filePath, status: "modified" };
+}
+
+const PATCH_A = "diff --git a/a.ts b/a.ts\nindex 83db48f..bf269f4 100644";
+const PATCH_B = "diff --git a/vendor/sub b/vendor/sub\nindex ada605e..029ae62 160000";
+
+beforeEach(() => {
+  requestDiffMock.mockReset();
+});
+
+describe("useDiffContent", () => {
+  it("never reports one file's patch under another file's subject", async () => {
+    // Callers read the patch to decide what the new side IS — a gitlink has no
+    // readable file (#12309) — so handing back the previous file's patch for
+    // even one render lets a whole-file read fire at the wrong path.
+    requestDiffMock.mockImplementation(async (s) => ({
+      content: s.filePath === "a.ts" ? PATCH_A : PATCH_B,
+    }));
+
+    const { result, rerender } = renderHook(({ file }) => useDiffContent(subject(file)), {
+      initialProps: { file: "a.ts" },
+    });
+    await waitFor(() => expect(result.current.content).toBe(PATCH_A));
+
+    rerender({ file: "vendor/sub" });
+    // The synchronous read after retargeting: A's patch must already be gone,
+    // not merely replaced once an effect runs.
+    expect(result.current.content).toBeUndefined();
+
+    await waitFor(() => expect(result.current.content).toBe(PATCH_B));
+  });
+
+  it("reports a failed fetch as ERROR for the subject it failed on", async () => {
+    requestDiffMock.mockRejectedValue(new Error("git exploded"));
+
+    const { result } = renderHook(() => useDiffContent(subject("a.ts")));
+
+    await waitFor(() => expect(result.current.content).toBe("ERROR"));
+  });
+
+  it("holds no content for a null subject", () => {
+    const { result } = renderHook(() => useDiffContent(null));
+
+    expect(result.current.content).toBeUndefined();
+    expect(requestDiffMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/panels/diff/__tests__/useDiffContent.test.tsx
+++ b/src/panels/diff/__tests__/useDiffContent.test.tsx
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+import { useMemo } from "react";
 import { renderHook, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import type { DiffSubject } from "../diffContentCache";
@@ -21,12 +22,20 @@ vi.mock("@/store/preferencesStore", () => ({
     selector({ diffIgnoreWhitespace: false }),
 }));
 
-function subject(filePath: string): DiffSubject {
-  return { source: "working-tree", worktreePath: "/repo", filePath, status: "modified" };
-}
-
 const PATCH_A = "diff --git a/a.ts b/a.ts\nindex 83db48f..bf269f4 100644";
 const PATCH_B = "diff --git a/vendor/sub b/vendor/sub\nindex ada605e..029ae62 160000";
+
+/**
+ * The hook depends on its subject by identity ("callers must memoize them"), so
+ * a fresh object each render would rebuild `fetchDiff` and refetch forever.
+ */
+function useSubject(filePath: string): DiffSubject {
+  return useMemo(
+    () =>
+      ({ source: "working-tree", worktreePath: "/repo", filePath, status: "modified" }) as const,
+    [filePath]
+  );
+}
 
 beforeEach(() => {
   requestDiffMock.mockReset();
@@ -41,23 +50,39 @@ describe("useDiffContent", () => {
       content: s.filePath === "a.ts" ? PATCH_A : PATCH_B,
     }));
 
-    const { result, rerender } = renderHook(({ file }) => useDiffContent(subject(file)), {
-      initialProps: { file: "a.ts" },
-    });
+    // Recorded during render: the offending pairing existed for exactly one
+    // commit, which an assertion made after `act` has flushed would miss.
+    const seen: Array<{ file: string; content: string | undefined }> = [];
+    const { result, rerender } = renderHook(
+      ({ file }) => {
+        const value = useDiffContent(useSubject(file));
+        seen.push({ file, content: value.content });
+        return value;
+      },
+      { initialProps: { file: "a.ts" } }
+    );
     await waitFor(() => expect(result.current.content).toBe(PATCH_A));
 
     rerender({ file: "vendor/sub" });
-    // The synchronous read after retargeting: A's patch must already be gone,
-    // not merely replaced once an effect runs.
-    expect(result.current.content).toBeUndefined();
-
     await waitFor(() => expect(result.current.content).toBe(PATCH_B));
+
+    expect(seen.some((r) => r.file === "vendor/sub" && r.content === PATCH_A)).toBe(false);
+    expect(seen.some((r) => r.file === "a.ts" && r.content === PATCH_B)).toBe(false);
   });
 
-  it("reports a failed fetch as ERROR for the subject it failed on", async () => {
+  it("fetches once per subject rather than looping on its own output", async () => {
+    requestDiffMock.mockResolvedValue({ content: PATCH_A });
+
+    const { result } = renderHook(() => useDiffContent(useSubject("a.ts")));
+    await waitFor(() => expect(result.current.content).toBe(PATCH_A));
+
+    expect(requestDiffMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports a failed fetch as ERROR", async () => {
     requestDiffMock.mockRejectedValue(new Error("git exploded"));
 
-    const { result } = renderHook(() => useDiffContent(subject("a.ts")));
+    const { result } = renderHook(() => useDiffContent(useSubject("a.ts")));
 
     await waitFor(() => expect(result.current.content).toBe("ERROR"));
   });

--- a/src/panels/diff/fullFileAvailability.ts
+++ b/src/panels/diff/fullFileAvailability.ts
@@ -3,10 +3,10 @@ import type { DiffPanelData } from "@shared/types/panel";
 
 /**
  * Whether the full-file scope can be offered for one file, and why not when it
- * can't. Two independent things disqualify a file, so both are checked here
- * rather than in the toolbar: the diff may already carry the whole file (an
- * addition has no hidden context to reveal), or the new side may not be
- * readable from disk at all.
+ * can't. Three independent things disqualify a file, so all are checked here
+ * rather than in the toolbar: the entry may not be a file at all (a submodule
+ * gitlink), the diff may already carry the whole file (an addition has no
+ * hidden context to reveal), or the new side may not be readable from disk.
  */
 export type FullFileAvailability = { available: true } | { available: false; reason: string };
 
@@ -36,8 +36,20 @@ const DISK_BACKED_SOURCES: ReadonlySet<string> = new Set(["working-tree", "unsta
 
 export function getFullFileAvailability(
   diffSource: DiffPanelData["diffSource"],
-  fileStatus: GitStatus | undefined
+  fileStatus: GitStatus | undefined,
+  isGitlink = false
 ): FullFileAvailability {
+  // Outranks every status and source reason below: a gitlink's new side is a
+  // commit reference, so the path on disk is the submodule's own working
+  // directory. Offering the scope sends `files:read` at a directory, which
+  // fails with a message no retry can clear (#12309).
+  if (isGitlink) {
+    return {
+      available: false,
+      reason: "This is a submodule — its diff is a commit reference, not file contents",
+    };
+  }
+
   // Mirrors `buildSubject`, which defaults a missing status the same way.
   const status = fileStatus ?? "modified";
 

--- a/src/panels/diff/gitlinkPatch.ts
+++ b/src/panels/diff/gitlinkPatch.ts
@@ -24,9 +24,12 @@ function modeAfter(line: string, prefix: string): string | null {
  * (a plain deletion) does the old side answer.
  *
  * Deliberately derived from the patch the pane already holds rather than
- * carried alongside the file's status: every read this gates is downstream of
- * `hasDiff`, so the patch is always on hand by the time the answer is needed —
- * for a restored panel and a direct open just as much as a live one.
+ * carried alongside the file's status: the whole-file and rendered-layout reads
+ * are both downstream of `hasDiff`, so the patch is always on hand by the time
+ * either asks — for a restored panel and a direct open just as much as a live
+ * one. The media previews are the exception: they key off the extension alone
+ * and mount before any patch lands, so a submodule directory named `*.png` gets
+ * the right viewer only once its patch arrives.
  */
 export function isGitlinkPatch(diffText: string | undefined): boolean {
   if (!diffText) return false;

--- a/src/panels/diff/gitlinkPatch.ts
+++ b/src/panels/diff/gitlinkPatch.ts
@@ -1,0 +1,80 @@
+/** Tree mode git records a submodule reference under. */
+const GITLINK_MODE = "160000";
+
+/** The mode a header line declares, or null when it names none. */
+function modeAfter(line: string, prefix: string): string | null {
+  if (!line.startsWith(prefix)) return null;
+  return line.slice(prefix.length).trim() || null;
+}
+
+/**
+ * Whether a unified diff describes a gitlink — a submodule reference recorded
+ * in the tree as mode 160000 — rather than a file (issue #12309).
+ *
+ * Read from the patch's own mode headers, never from its body. The
+ * `Subproject commit …` line pair is the visible symptom, but a file that
+ * documents submodules contains the same text; the mode is git's own statement
+ * of what the entry is.
+ *
+ * The NEW side decides, because that is the side a whole-file read would go
+ * looking for on disk. Git spells a type change as two records — a
+ * `deleted file mode 160000` followed by a `new file mode 100644` — so a
+ * submodule replaced by a regular file must come out false even though a
+ * gitlink mode appears in the patch. Only when no record declares a new side
+ * (a plain deletion) does the old side answer.
+ *
+ * Deliberately derived from the patch the pane already holds rather than
+ * carried alongside the file's status: every read this gates is downstream of
+ * `hasDiff`, so the patch is always on hand by the time the answer is needed —
+ * for a restored panel and a direct open just as much as a live one.
+ */
+export function isGitlinkPatch(diffText: string | undefined): boolean {
+  if (!diffText) return false;
+
+  let newSide: boolean | null = null;
+  let oldSideGitlink = false;
+  // Body lines carry a +/-/space prefix, so an unprefixed `index …` or
+  // `new file mode …` can only be a header. Tracking the section anyway keeps a
+  // diff-of-a-diff from mattering at all.
+  let inHeader = false;
+
+  for (const rawLine of diffText.split("\n")) {
+    const line = rawLine.endsWith("\r") ? rawLine.slice(0, -1) : rawLine;
+
+    if (line.startsWith("diff --git ")) {
+      inHeader = true;
+      continue;
+    }
+    if (line.startsWith("@@")) {
+      inHeader = false;
+      continue;
+    }
+    if (!inHeader) continue;
+
+    const created = modeAfter(line, "new file mode ");
+    if (created !== null) {
+      newSide = created === GITLINK_MODE;
+      continue;
+    }
+    const removed = modeAfter(line, "deleted file mode ");
+    if (removed !== null) {
+      oldSideGitlink ||= removed === GITLINK_MODE;
+      continue;
+    }
+    // A permission change spells both modes out instead of one on `index`.
+    const replacement = modeAfter(line, "new mode ");
+    if (replacement !== null) {
+      newSide = replacement === GITLINK_MODE;
+      continue;
+    }
+    // `index <old>..<new> <mode>` — git prints the trailing mode only when both
+    // sides share it, and omits it entirely on a create or delete record, so an
+    // absent one must not overwrite the verdict those already gave.
+    if (line.startsWith("index ")) {
+      const mode = line.slice("index ".length).split(" ")[1];
+      if (mode) newSide = mode === GITLINK_MODE;
+    }
+  }
+
+  return newSide ?? oldSideGitlink;
+}

--- a/src/panels/diff/renderedMarkdownAvailability.ts
+++ b/src/panels/diff/renderedMarkdownAvailability.ts
@@ -60,6 +60,11 @@ export interface RenderedMarkdownAvailabilityInput {
   sourceErrorCode: FileReadErrorCode | null;
   /** The engine's verdict on the diff currently shown, once it has one. */
   engineFailure: MarkdownDiffFailure | null;
+  /**
+   * The patch describes a submodule gitlink, so the path names a directory
+   * rather than the Markdown document the reconstruction would read (#12309).
+   */
+  isGitlink?: boolean;
 }
 
 /**
@@ -86,8 +91,19 @@ export function getRenderedMarkdownAvailability({
   stale,
   sourceErrorCode,
   engineFailure,
+  isGitlink = false,
 }: RenderedMarkdownAvailabilityInput): RenderedMarkdownAvailability {
   if (!filePath || !isMarkdownFilePath(filePath)) return { visible: false };
+
+  // A `.md`-suffixed submodule directory still reaches here, and the layout is
+  // rebuilt from a whole-file read the path can never satisfy.
+  if (isGitlink) {
+    return {
+      visible: true,
+      enabled: false,
+      reason: "This is a submodule — its diff is a commit reference, not a Markdown document",
+    };
+  }
 
   if (!isRenderedMarkdownSupported(filePath, diffSource)) {
     return {

--- a/src/panels/diff/useDiffContent.ts
+++ b/src/panels/diff/useDiffContent.ts
@@ -44,7 +44,16 @@ export function useDiffContent(
   nextSubject?: DiffSubject | null,
   options?: UseDiffContentOptions
 ): UseDiffContentResult {
-  const [content, setContent] = useState<string | undefined>(undefined);
+  // Tagged with the cache key it was fetched under, for the same reason
+  // `freshnessBaseline` is: a retarget updates `subject` a commit before the
+  // effect clears the old patch, so an untagged value is handed out under the
+  // NEW file's path for one render. Callers read the patch to decide what the
+  // new side is — a gitlink has no readable file (#12309) — so answering with
+  // the previous file's patch is answering about the wrong file.
+  const [contentEntry, setContentEntry] = useState<{
+    subject: string;
+    value: string;
+  } | null>(null);
   // Freshness key the shown diff was fetched under, tagged with its cache key
   // so a navigation in progress never compares one file's baseline against
   // another file's live key.
@@ -102,17 +111,17 @@ export function useDiffContent(
       const freshnessKey = worktreeStore
         ? selectDiffFreshnessKey(worktreeStore.getState(), subject.worktreePath, subject.filePath)
         : undefined;
-      setContent(undefined);
+      setContentEntry(null);
       try {
         const entry = await requestDiff(subject, ignoreWhitespace, bypassCache, freshnessKey);
         if (requestRef.current !== requestId) return;
         // Baseline from the entry, not the local key: a joined in-flight
         // request's content corresponds to its initiator's capture time.
         if (entry) setFreshnessBaseline({ subject: cacheKey, key: entry.freshnessKey });
-        setContent(entry?.content ?? "ERROR");
+        setContentEntry({ subject: cacheKey, value: entry?.content ?? "ERROR" });
       } catch {
         if (requestRef.current !== requestId) return;
-        setContent("ERROR");
+        setContentEntry({ subject: cacheKey, value: "ERROR" });
       }
     },
     [subject, ignoreWhitespace, worktreeStore]
@@ -124,7 +133,7 @@ export function useDiffContent(
 
   useEffect(() => {
     if (subjectKey === null) {
-      setContent(undefined);
+      setContentEntry(null);
       setFreshnessBaseline(null);
       // Invalidate any in-flight response so it can't land on the next subject.
       requestRef.current++;
@@ -138,6 +147,11 @@ export function useDiffContent(
   // skeleton. The dwell timer keeps rapid scrubbing from bursting requests
   // against the shared gitOps rate limit; failures are silently dropped — the
   // foreground fetch will retry and surface its own error.
+  // Read through the tag, so a retarget reports "loading" rather than the patch
+  // the previous file left behind.
+  const content =
+    contentEntry !== null && contentEntry.subject === subjectKey ? contentEntry.value : undefined;
+
   useEffect(() => {
     if (!nextSubject || content === undefined || content === "ERROR") return;
     const timer = window.setTimeout(() => {

--- a/src/panels/file/FilePane.tsx
+++ b/src/panels/file/FilePane.tsx
@@ -1291,17 +1291,21 @@ export function FilePane({
               {errorMessage ?? FILE_READ_ERROR_MESSAGES[errorCode]}
             </p>
             {/* An unsupported format is deterministic — retrying the same
-                extension can never succeed, so the action would be dead. */}
-            {!isUnsupportedVideoFilePath(filePath) && !isUnsupportedAudioFilePath(filePath) && (
-              <button
-                type="button"
-                onClick={() => loadFile("explicit")}
-                className="flex items-center gap-1.5 px-3 py-1.5 text-xs text-text-primary bg-border-default hover:bg-daintree-border/80 rounded transition-colors"
-              >
-                <RefreshCw className="w-3.5 h-3.5" />
-                Retry
-              </button>
-            )}
+                extension can never succeed, so the action would be dead. A
+                directory is the same: it never becomes a readable file
+                (#12309). */}
+            {errorCode !== "NOT_A_FILE" &&
+              !isUnsupportedVideoFilePath(filePath) &&
+              !isUnsupportedAudioFilePath(filePath) && (
+                <button
+                  type="button"
+                  onClick={() => loadFile("explicit")}
+                  className="flex items-center gap-1.5 px-3 py-1.5 text-xs text-text-primary bg-border-default hover:bg-daintree-border/80 rounded transition-colors"
+                >
+                  <RefreshCw className="w-3.5 h-3.5" />
+                  Retry
+                </button>
+              )}
           </div>
         )}
 

--- a/src/panels/file/__tests__/FilePane.test.tsx
+++ b/src/panels/file/__tests__/FilePane.test.tsx
@@ -3274,6 +3274,22 @@ describe("FilePane copy file contents (#12136)", () => {
     }
   );
 
+  it.each([
+    ["NOT_A_FILE", false],
+    ["PERMISSION", true],
+  ] as const)("offers Retry for %s: %s", async (code, expected) => {
+    // A directory never becomes a readable file, so its Retry would be dead
+    // (#12309) — while a permission failure can genuinely clear.
+    readMock.mockRejectedValue(new ClientAppError(code, code));
+    await renderPane("/repo/vendor/sub");
+
+    expect(await screen.findByText(FILE_READ_ERROR_MESSAGES[code])).toBeTruthy();
+    const hasRetry = [...document.querySelectorAll("button")].some(
+      (button) => button.textContent === "Retry"
+    );
+    expect(hasRetry).toBe(expected);
+  });
+
   // Video and audio fetch their bytes into a blob URL; without the stub the
   // element never mounts and the absence assertions below would pass for the
   // wrong reason. Restored one global at a time rather than through


### PR DESCRIPTION
## Summary

The problem: a submodule whose recorded commit moved is reported as `modified`, so `getFullFileAvailability` offered the Full file scope, `DiffPane` sent `files:read` at the submodule's checkout directory, the read failed with `EISDIR`, and `fsErrorToAppError` had no branch for it. It surfaced as "Showing changed lines only / Invalid file path" with a Retry that could never succeed.

Resolves #12309

Approach: rather than plumbing an `isGitlink` flag from the main-process git status through the status producers, IPC types, panel persistence and store setters (~28 files), the verdict is read from the diff patch the pane already holds. Every read it gates is downstream of `hasDiff`, and `diffContentCache` requests the patch at offset 0 (returning the `FILE_TOO_LARGE` sentinel when truncated), so the `index <hash>..<hash> 160000` header is always present by the time the answer is needed, on a restored panel and a direct open as much as a live one.

## Changes

- New `src/panels/diff/gitlinkPatch.ts`: `isGitlinkPatch` reads mode `160000` from the patch's own headers, never its body, and follows the NEW side. Git spells a submodule replaced by a regular file as two records (`deleted file mode 160000` then `new file mode 100644`), so new-side-wins is what keeps that case readable. Verified against real `git diff` output, not written from memory.
- `getFullFileAvailability` gains a gitlink branch that outranks every status and source reason; the toggle is disabled with a reason instead of raising a failed-read banner.
- The rendered-Markdown layout gets the same refusal. It is a second, independent reason to read the new side.
- Gitlinks stay out of image/video/audio/PDF mode.
- Both diff producers now pass `--submodule=short`. A user's `diff.submodule=log` replaces the patch with a `Submodule <path> a..b:` summary that is not a unified diff at all, and `diff` emits patches for files inside the submodule at mode `100644`. Either would defeat detection and render nonsense. `--name-status` and `--numstat` are unaffected, so the change list and churn counts stay unpinned.
- An added submodule no longer fails the whole request: the producer inlined its checkout directory and got `EISDIR`. It now falls through to git, which already knows how to describe it (`new file mode 160000`). Scoped to `added` only: an untracked directory has no index entry, so the tracked diff would come back empty and get reported as `NO_CHANGES`.
- `useDiffContent` now tags content with the cache key it was fetched under, mirroring the `freshnessBaseline` discipline already in that file. A retarget updated `subject` a commit before the effect cleared the old patch, so the previous file's patch answered for the new one for one render, long enough to enable a read at the wrong path.
- `EISDIR` maps to a new `NOT_A_FILE` code ("This is a folder, not a file") and gets no Retry, in `DiffPane` and `FilePane` both.

## Testing

New `gitlinkPatch.test.ts` and `useDiffContent.test.ts`; extended `DiffPane`, `fullFileAvailability`, `renderedMarkdownAvailability`, `FilePane`, `files.read`, `WorkspaceService.getFileDiff`, and `GitService` tests. 2359 tests across the touched areas pass, typecheck clean. The navigation test was mutation-checked: it fails with the subject tag removed.

## Known and deliberately not fixed

A submodule directory named with a media extension (`vendor/logo.png`) briefly enters image mode before its patch lands, because the media modes key off the extension alone. Gating them on loaded content would delay every ordinary media preview to defend against a case that does not occur in practice.

Also unfixed: a submodule added to a repo with no commits at all still fails, since the fallthrough diffs against HEAD. Pre-existing and vanishingly rare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XsdxnSZeDXm71saZyvfMtY
