### PR TITLE
feat(mcp): let a bound session see its binding, and let the user keep it resident

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -1147,6 +1147,13 @@ export const CHANNELS = {
   // both stores, so an MCP client can look a workspace id up instead of
   // deriving one (#12307).
   WORKSPACE_LIST: "workspace:list",
+
+  // The user's "keep this workspace resident" grant (#12313). Renderer-only by
+  // design: the action manifest is the MCP tool surface, so routing this
+  // through an action would let a bound client grant itself the residency
+  // #11790 refused to grant it automatically.
+  WORKSPACE_RESIDENCY_GET: "workspace-residency:get",
+  WORKSPACE_RESIDENCY_SET: "workspace-residency:set",
 } as const;
 
 export type ChannelName = (typeof CHANNELS)[keyof typeof CHANNELS];

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -26,6 +26,7 @@ import { registerIdleTerminalHandlers } from "./handlers/idleTerminals.js";
 import { registerIdleBackgroundAutoCloseHandlers } from "./handlers/idleBackgroundAutoClose.js";
 import { registerSystemSleepHandlers } from "./handlers/systemSleep.js";
 import { registerAppVersionInfoHandlers } from "./handlers/appVersionInfo.js";
+import { registerWorkspaceResidencyHandlers } from "./handlers/workspaceResidency.js";
 import { registerOsDndHandlers } from "./handlers/osDnd.js";
 import { registerKeybindingHandlers } from "./handlers/keybinding.js";
 import { registerWorktreeConfigHandlers } from "./handlers/worktreeConfig.js";
@@ -166,6 +167,7 @@ export function registerIpcHandlers(deps: HandlerDependencies): () => void {
     register(() => registerIdleBackgroundAutoCloseHandlers(deps));
     register(() => registerSystemSleepHandlers(deps));
     register(() => registerAppVersionInfoHandlers());
+    register(() => registerWorkspaceResidencyHandlers());
     register(() => registerOsDndHandlers(deps));
     register(() => registerKeybindingHandlers(deps));
     register(() => registerWorktreeConfigHandlers(deps));

--- a/electron/ipc/handlers/__tests__/workspaceResidency.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/workspaceResidency.handlers.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("electron", () => ({
+  ipcMain: {
+    handle: vi.fn(),
+    removeHandler: vi.fn(),
+  },
+}));
+
+const residencyMock = vi.hoisted(() => ({
+  isWorkspaceKeepResident: vi.fn(() => false),
+  setWorkspaceKeepResident: vi.fn(),
+}));
+
+vi.mock("../../../services/workspaceResidency.js", () => residencyMock);
+
+import { ipcMain } from "electron";
+import { registerWorkspaceResidencyHandlers } from "../workspaceResidency.js";
+
+type Handler = (event: Electron.IpcMainInvokeEvent, ...args: unknown[]) => Promise<unknown>;
+
+function getHandler(channel: string): Handler {
+  const match = vi.mocked(ipcMain.handle).mock.calls.find(([ch]) => ch === channel);
+  if (!match) throw new Error(`No handler registered for ${channel}`);
+  return match[1] as Handler;
+}
+
+const EVENT = {} as Electron.IpcMainInvokeEvent;
+const WORKSPACE = "a".repeat(64);
+
+let dispose: () => void;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  residencyMock.isWorkspaceKeepResident.mockReturnValue(false);
+  dispose = registerWorkspaceResidencyHandlers();
+});
+
+afterEach(() => {
+  dispose();
+});
+
+describe("workspace residency IPC (#12313)", () => {
+  it("reads the grant for a workspace", async () => {
+    residencyMock.isWorkspaceKeepResident.mockReturnValue(true);
+
+    const result = await getHandler("workspace-residency:get")(EVENT, { workspaceId: WORKSPACE });
+
+    expect(residencyMock.isWorkspaceKeepResident).toHaveBeenCalledWith(WORKSPACE);
+    expect(result).toBe(true);
+  });
+
+  it("writes both directions of the grant", async () => {
+    const set = getHandler("workspace-residency:set");
+
+    await set(EVENT, { workspaceId: WORKSPACE, keepResident: true });
+    expect(residencyMock.setWorkspaceKeepResident).toHaveBeenCalledWith(WORKSPACE, true);
+
+    await set(EVENT, { workspaceId: WORKSPACE, keepResident: false });
+    expect(residencyMock.setWorkspaceKeepResident).toHaveBeenCalledWith(WORKSPACE, false);
+  });
+
+  it("rejects a malformed payload at the boundary", async () => {
+    const set = getHandler("workspace-residency:set");
+
+    // Validated before the handler body, so a bad payload can never reach the
+    // preference write — the grant is a user authority, and the one thing this
+    // boundary must not do is take a write it cannot vouch for.
+    await expect(set(EVENT, { workspaceId: "", keepResident: true })).rejects.toThrow(
+      /IPC validation failed/
+    );
+    await expect(set(EVENT, { workspaceId: WORKSPACE, keepResident: "yes" })).rejects.toThrow(
+      /IPC validation failed/
+    );
+
+    expect(residencyMock.setWorkspaceKeepResident).not.toHaveBeenCalled();
+  });
+
+  it("removes its handlers on dispose", () => {
+    dispose();
+    const removed = vi.mocked(ipcMain.removeHandler).mock.calls.map(([ch]) => ch);
+    expect(removed).toContain("workspace-residency:get");
+    expect(removed).toContain("workspace-residency:set");
+    // Re-registering in afterEach's dispose must stay safe.
+    dispose = () => {};
+  });
+});

--- a/electron/ipc/handlers/workspaceResidency.preload.ts
+++ b/electron/ipc/handlers/workspaceResidency.preload.ts
@@ -1,0 +1,27 @@
+import type { IpcInvokeMap } from "../../types/index.js";
+
+export const WORKSPACE_RESIDENCY_METHOD_CHANNELS = {
+  get: "workspace-residency:get",
+  set: "workspace-residency:set",
+} as const satisfies Record<string, keyof IpcInvokeMap>;
+
+type Methods = typeof WORKSPACE_RESIDENCY_METHOD_CHANNELS;
+
+export type WorkspaceResidencyPreloadBindings = {
+  [M in keyof Methods]: (
+    ...args: IpcInvokeMap[Methods[M]]["args"]
+  ) => Promise<IpcInvokeMap[Methods[M]]["result"]>;
+};
+
+type Invoker = (channel: string, ...args: unknown[]) => Promise<unknown>;
+
+export function buildWorkspaceResidencyPreloadBindings(
+  invoke: Invoker
+): WorkspaceResidencyPreloadBindings {
+  const out: Record<string, (...args: unknown[]) => Promise<unknown>> = {};
+  for (const method of Object.keys(WORKSPACE_RESIDENCY_METHOD_CHANNELS) as Array<keyof Methods>) {
+    const channel = WORKSPACE_RESIDENCY_METHOD_CHANNELS[method];
+    out[method as string] = (...args) => invoke(channel, ...args);
+  }
+  return out as unknown as WorkspaceResidencyPreloadBindings;
+}

--- a/electron/ipc/handlers/workspaceResidency.ts
+++ b/electron/ipc/handlers/workspaceResidency.ts
@@ -1,0 +1,46 @@
+import { z } from "zod";
+import { defineIpcNamespace, opValidated } from "../define.js";
+import { WORKSPACE_RESIDENCY_METHOD_CHANNELS } from "./workspaceResidency.preload.js";
+import {
+  isWorkspaceKeepResident,
+  setWorkspaceKeepResident,
+} from "../../services/workspaceResidency.js";
+
+const WorkspaceIdSchema = z.object({ workspaceId: z.string().min(1) });
+const SetResidencySchema = WorkspaceIdSchema.extend({ keepResident: z.boolean() });
+
+/**
+ * The user's "keep this workspace resident" grant (#12313).
+ *
+ * Its own namespace, and deliberately not an `ActionService` action: the action
+ * manifest is the MCP tool surface, so an action here would let a bound client
+ * grant itself the residency #11790 refused to give it automatically. Reaching
+ * this needs the renderer, which needs the user.
+ */
+export const workspaceResidencyNamespace = defineIpcNamespace({
+  name: "workspaceResidency",
+  ops: {
+    get: opValidated(
+      WORKSPACE_RESIDENCY_METHOD_CHANNELS.get,
+      WorkspaceIdSchema,
+      (payload): boolean => isWorkspaceKeepResident(payload.workspaceId)
+    ),
+    set: opValidated(
+      WORKSPACE_RESIDENCY_METHOD_CHANNELS.set,
+      SetResidencySchema,
+      (payload): void => {
+        const { workspaceId, keepResident } = payload;
+        // Not validated against the project catalog on purpose. A grant for a
+        // workspace that does not exist protects nothing — eviction only ever
+        // applies it to a live view — so refusing here would buy no safety and
+        // would make the toggle fail during a project move, when the id is
+        // stable but the record is briefly in flight.
+        setWorkspaceKeepResident(workspaceId, keepResident);
+      }
+    ),
+  },
+});
+
+export function registerWorkspaceResidencyHandlers(): () => void {
+  return workspaceResidencyNamespace.register();
+}

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -80,6 +80,7 @@ import { buildAgentCapabilitiesPreloadBindings } from "./ipc/handlers/agentCapab
 import { buildHelpAssistantPreloadBindings } from "./ipc/handlers/helpAssistant.preload.js";
 import { buildMenuPreloadBindings } from "./ipc/handlers/menu.preload.js";
 import { buildCliPreloadBindings } from "./ipc/handlers/cli.preload.js";
+import { buildWorkspaceResidencyPreloadBindings } from "./ipc/handlers/workspaceResidency.preload.js";
 import { buildGlobalRecipesPreloadBindings } from "./ipc/handlers/globalRecipes.preload.js";
 import { buildEditorConfigPreloadBindings } from "./ipc/handlers/editorConfig.preload.js";
 import { buildWindowChromePreloadBindings } from "./ipc/handlers/windowChrome.preload.js";
@@ -2632,6 +2633,8 @@ function buildElectronApi(): ElectronAPI {
 
     // Daintree CLI install API
     cli: buildCliPreloadBindings(_unwrappingInvoke),
+
+    workspaceResidency: buildWorkspaceResidencyPreloadBindings(_unwrappingInvoke),
 
     // Commands API
     commands: buildCommandsPreloadBindings(_unwrappingInvoke),

--- a/electron/services/__tests__/McpServerService.promptsAndResources.test.ts
+++ b/electron/services/__tests__/McpServerService.promptsAndResources.test.ts
@@ -896,7 +896,7 @@ describe("McpServerService", () => {
       expect(uris).not.toContain("daintree://agent/term-2/state");
     });
 
-    it("listResources still returns the static issues URI when enumeration fails", async () => {
+    it("listResources still returns the dispatch-free URIs when enumeration fails", async () => {
       const dispatchMock = vi.fn((_payload: DispatchRequest): ActionDispatchResult => ({
         ok: false,
         error: { code: "EXECUTION_ERROR", message: "no view" },
@@ -911,7 +911,14 @@ describe("McpServerService", () => {
 
       const result = await client.listResources();
       const uris = result.resources.map((r) => r.uri);
-      expect(uris).toEqual(["daintree://project/current/issues"]);
+      // Both entries answer without a renderer, so a failed enumeration cannot
+      // take them. The binding resource leads (#12313): it is the one a
+      // workspace-bound session with no live view has to be handed, since it is
+      // what tells that session why the rest of the listing is missing.
+      expect(uris).toEqual([
+        "daintree://workspace/current/binding",
+        "daintree://project/current/issues",
+      ]);
     });
 
     it("listResourceTemplates returns the four template patterns", async () => {

--- a/electron/services/__tests__/workspaceResidency.test.ts
+++ b/electron/services/__tests__/workspaceResidency.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const storeData: Record<string, unknown> = {};
+const liveViewsByWorkspace = new Map<string, number>();
+
+vi.mock("../../store.js", () => ({
+  store: {
+    get: (key: string) => storeData[key],
+    set: (key: string, value: unknown) => {
+      storeData[key] = value;
+    },
+  },
+}));
+
+vi.mock("../../window/webContentsRegistry.js", () => ({
+  getWebContentsForProject: (projectId: string) =>
+    Array.from({ length: liveViewsByWorkspace.get(projectId) ?? 0 }, (_, i) => ({ id: i })),
+}));
+
+const {
+  __resetWorkspaceResidencyForTests,
+  clearWorkspaceEviction,
+  isWorkspaceKeepResident,
+  notifyWorkspaceViewsChanged,
+  onWorkspaceResidencyChanged,
+  readWorkspaceBindingState,
+  recordWorkspaceEviction,
+  setWorkspaceKeepResident,
+} = await import("../workspaceResidency.js");
+
+const WORKSPACE = "a".repeat(64);
+const OTHER = "b".repeat(64);
+
+beforeEach(() => {
+  for (const key of Object.keys(storeData)) delete storeData[key];
+  liveViewsByWorkspace.clear();
+  __resetWorkspaceResidencyForTests();
+});
+
+describe("keep-resident preference (#12313)", () => {
+  it("is off for a workspace the user never granted", () => {
+    expect(isWorkspaceKeepResident(WORKSPACE)).toBe(false);
+  });
+
+  it("round-trips a grant and removes the key when revoked", () => {
+    setWorkspaceKeepResident(WORKSPACE, true);
+    expect(isWorkspaceKeepResident(WORKSPACE)).toBe(true);
+    expect(storeData.workspaceKeepResident).toEqual({ [WORKSPACE]: true });
+
+    setWorkspaceKeepResident(WORKSPACE, false);
+    expect(isWorkspaceKeepResident(WORKSPACE)).toBe(false);
+    // Absence is the only "off" this key has — a `false` entry left behind
+    // would grow the record for every workspace ever toggled.
+    expect(storeData.workspaceKeepResident).toEqual({});
+  });
+
+  it("treats anything but an exact true as no grant", () => {
+    // The record is keyed by workspace id and nothing prunes it, so a value
+    // that arrived from a hand-edited config must not protect a view.
+    storeData.workspaceKeepResident = { [WORKSPACE]: "yes", [OTHER]: 1 };
+    expect(isWorkspaceKeepResident(WORKSPACE)).toBe(false);
+    expect(isWorkspaceKeepResident(OTHER)).toBe(false);
+  });
+
+  it("leaves other workspaces' grants alone when one changes", () => {
+    setWorkspaceKeepResident(WORKSPACE, true);
+    setWorkspaceKeepResident(OTHER, true);
+    setWorkspaceKeepResident(WORKSPACE, false);
+    expect(isWorkspaceKeepResident(OTHER)).toBe(true);
+  });
+});
+
+describe("binding state read (#12313)", () => {
+  it("answers unbound without inventing a workspace", () => {
+    // An unbound session routes to the focused view. Substituting that view's
+    // workspace here would be the cross-workspace answer the binding exists to
+    // refuse (#7003).
+    expect(readWorkspaceBindingState(null)).toMatchObject({
+      workspaceId: null,
+      routeState: "unbound",
+      liveViewCount: 0,
+      keepResident: false,
+      evictedAt: null,
+    });
+  });
+
+  it("mirrors the bridge's zero/one/many rule", () => {
+    expect(readWorkspaceBindingState(WORKSPACE).routeState).toBe("not-found");
+
+    liveViewsByWorkspace.set(WORKSPACE, 1);
+    expect(readWorkspaceBindingState(WORKSPACE)).toMatchObject({
+      routeState: "available",
+      liveViewCount: 1,
+    });
+
+    liveViewsByWorkspace.set(WORKSPACE, 2);
+    // Two views is not "reachable" — `getWorkspaceWebContents` refuses it as
+    // ambiguous, and this read must not disagree with what routing would do.
+    expect(readWorkspaceBindingState(WORKSPACE)).toMatchObject({
+      routeState: "ambiguous",
+      liveViewCount: 2,
+    });
+  });
+
+  it("reports the grant alongside the route", () => {
+    setWorkspaceKeepResident(WORKSPACE, true);
+    expect(readWorkspaceBindingState(WORKSPACE).keepResident).toBe(true);
+  });
+
+  it("distinguishes an evicted workspace from one never opened", () => {
+    // The whole point of the ledger: before this, a bound client could not tell
+    // "temporarily gone" from "this id was always wrong".
+    expect(readWorkspaceBindingState(WORKSPACE).evictedAt).toBeNull();
+
+    recordWorkspaceEviction(WORKSPACE, "pressure");
+    const state = readWorkspaceBindingState(WORKSPACE);
+    expect(state.routeState).toBe("not-found");
+    expect(state.evictionReason).toBe("pressure");
+    expect(typeof state.evictedAt).toBe("number");
+  });
+
+  it("forgets the eviction once the workspace is open again", () => {
+    recordWorkspaceEviction(WORKSPACE, "lru");
+    clearWorkspaceEviction(WORKSPACE);
+    expect(readWorkspaceBindingState(WORKSPACE).evictedAt).toBeNull();
+  });
+
+  it("does not record an eviction while another window still holds a view", () => {
+    liveViewsByWorkspace.set(WORKSPACE, 1);
+    recordWorkspaceEviction(WORKSPACE, "pressure");
+    liveViewsByWorkspace.set(WORKSPACE, 0);
+    // The pass took one window's view; the route still resolved through the
+    // other, so that pass was not this workspace's eviction and must not be
+    // reported as one after the second view closes for its own reasons.
+    expect(readWorkspaceBindingState(WORKSPACE).evictedAt).toBeNull();
+  });
+
+  it("suppresses a stale record while a view is live", () => {
+    recordWorkspaceEviction(WORKSPACE, "pressure");
+    liveViewsByWorkspace.set(WORKSPACE, 1);
+    // Read-side belt to the write-side check above: a recovered workspace must
+    // never report a loss beside a route that currently resolves.
+    expect(readWorkspaceBindingState(WORKSPACE).evictedAt).toBeNull();
+  });
+});
+
+describe("residency subscriptions (#12313)", () => {
+  it("fires for eviction, reopen, view changes and grant changes", () => {
+    const seen = vi.fn();
+    onWorkspaceResidencyChanged(WORKSPACE, seen);
+
+    recordWorkspaceEviction(WORKSPACE, "lru");
+    clearWorkspaceEviction(WORKSPACE);
+    notifyWorkspaceViewsChanged(WORKSPACE);
+    setWorkspaceKeepResident(WORKSPACE, true);
+
+    expect(seen).toHaveBeenCalledTimes(4);
+  });
+
+  it("does not wake a subscriber for another workspace", () => {
+    const seen = vi.fn();
+    onWorkspaceResidencyChanged(WORKSPACE, seen);
+    recordWorkspaceEviction(OTHER, "lru");
+    expect(seen).not.toHaveBeenCalled();
+  });
+
+  it("stops firing after unsubscribe, and unsubscribing twice is harmless", () => {
+    const seen = vi.fn();
+    const off = onWorkspaceResidencyChanged(WORKSPACE, seen);
+    off();
+    off();
+    recordWorkspaceEviction(WORKSPACE, "lru");
+    expect(seen).not.toHaveBeenCalled();
+  });
+
+  it("keeps notifying the rest when one listener throws", () => {
+    // A subscription belongs to an MCP session whose transport may already be
+    // gone; one failing send must not strand every other subscriber.
+    const good = vi.fn();
+    onWorkspaceResidencyChanged(WORKSPACE, () => {
+      throw new Error("transport gone");
+    });
+    onWorkspaceResidencyChanged(WORKSPACE, good);
+    recordWorkspaceEviction(WORKSPACE, "lru");
+    expect(good).toHaveBeenCalledTimes(1);
+  });
+
+  it("survives a listener that unsubscribes itself while being notified", () => {
+    const other = vi.fn();
+    const off: Array<() => void> = [];
+    off.push(
+      onWorkspaceResidencyChanged(WORKSPACE, () => {
+        off[0]?.();
+      })
+    );
+    onWorkspaceResidencyChanged(WORKSPACE, other);
+    expect(() => recordWorkspaceEviction(WORKSPACE, "lru")).not.toThrow();
+    expect(other).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not notify a grant write that changed nothing", () => {
+    setWorkspaceKeepResident(WORKSPACE, true);
+    const seen = vi.fn();
+    onWorkspaceResidencyChanged(WORKSPACE, seen);
+    setWorkspaceKeepResident(WORKSPACE, true);
+    expect(seen).not.toHaveBeenCalled();
+  });
+});

--- a/electron/services/__tests__/workspaceResidency.test.ts
+++ b/electron/services/__tests__/workspaceResidency.test.ts
@@ -125,21 +125,21 @@ describe("binding state read (#12313)", () => {
     expect(readWorkspaceBindingState(WORKSPACE).evictedAt).toBeNull();
   });
 
-  it("does not record an eviction while another window still holds a view", () => {
+  it("never reports a loss while the route still resolves", () => {
+    // The single gate on the record, since writes are unconditional — so this
+    // carries the whole guarantee. Covers both orderings: a second window's
+    // view already live when the pass runs, and a workspace reopened after one.
     liveViewsByWorkspace.set(WORKSPACE, 1);
     recordWorkspaceEviction(WORKSPACE, "pressure");
-    liveViewsByWorkspace.set(WORKSPACE, 0);
-    // The pass took one window's view; the route still resolved through the
-    // other, so that pass was not this workspace's eviction and must not be
-    // reported as one after the second view closes for its own reasons.
-    expect(readWorkspaceBindingState(WORKSPACE).evictedAt).toBeNull();
-  });
+    expect(readWorkspaceBindingState(WORKSPACE)).toMatchObject({
+      routeState: "available",
+      evictedAt: null,
+      evictionReason: null,
+    });
 
-  it("suppresses a stale record while a view is live", () => {
-    recordWorkspaceEviction(WORKSPACE, "pressure");
+    liveViewsByWorkspace.set(WORKSPACE, 0);
+    recordWorkspaceEviction(WORKSPACE, "lru");
     liveViewsByWorkspace.set(WORKSPACE, 1);
-    // Read-side belt to the write-side check above: a recovered workspace must
-    // never report a loss beside a route that currently resolves.
     expect(readWorkspaceBindingState(WORKSPACE).evictedAt).toBeNull();
   });
 });

--- a/electron/services/mcp-server/__tests__/sessionServer.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionServer.test.ts
@@ -39,6 +39,7 @@ import {
   MCP_SERVER_INSTRUCTIONS,
   MCP_SERVER_INSTRUCTIONS_MAX_BYTES,
   TIER_ALLOWLISTS,
+  WORKSPACE_BINDING_RESOURCE_URI,
 } from "../shared.js";
 import type { DispatchedWorkspaceRef } from "../shared.js";
 import { TOOL_RESULT_TEXT_MAX_BYTES } from "../toolCallResult.js";
@@ -5704,37 +5705,138 @@ describe("workspace-bound external sessions (#11789)", () => {
       );
     });
 
-    it.each([
-      ["resources/list", {}],
+    it("reports an unreachable workspace on a resource read rather than answering as if it were empty", async () => {
+      // `tools/list` gets a host surface because the tool *set* is knowable
+      // without a view; a resource read is not — it reads what is actually open
+      // in that workspace. Answering emptily would be an authoritative "you
+      // have nothing", the same lie the terminal handshake told.
+      //
       // `scrollback` is backed by `terminal.getOutput`, which the external tier
       // permits — a `pulse` URI would be refused as TIER_NOT_PERMITTED before
       // dispatch and never reach the binding at all.
-      ["resources/read", { uri: "daintree://terminal/t-1/scrollback" }],
-    ])(
-      "reports an unreachable workspace on %s rather than answering as if it were empty",
-      async (method, params) => {
-        // `tools/list` gets a host surface because the tool *set* is knowable
-        // without a view; a resource listing is not — it enumerates what is
-        // actually open in that workspace. Answering `{ resources: [] }` there
-        // would be an authoritative "you have nothing", which is the same lie
-        // the terminal handshake told, in a quieter place.
-        const deps = boundDeps({
-          dispatchAction: vi
-            .fn()
-            .mockRejectedValue(new WorkspaceBindingError(WORKSPACE, "not-found")),
-          requestManifest: vi
-            .fn()
-            .mockRejectedValue(new WorkspaceBindingError(WORKSPACE, "not-found")),
-          getCachedManifest: vi.fn(() => null),
-        });
-        const server = createSessionServer(SESSION, deps);
-        await server.connect(makeMockTransport());
+      const deps = boundDeps({
+        dispatchAction: vi
+          .fn()
+          .mockRejectedValue(new WorkspaceBindingError(WORKSPACE, "not-found")),
+        requestManifest: vi
+          .fn()
+          .mockRejectedValue(new WorkspaceBindingError(WORKSPACE, "not-found")),
+        getCachedManifest: vi.fn(() => null),
+      });
+      const server = createSessionServer(SESSION, deps);
+      await server.connect(makeMockTransport());
 
-        await expect(callHandler(server, method, params)).rejects.toMatchObject({
-          data: { code: SESSION_BINDING_GONE, retriable: true, errorCategory: "business" },
-        });
-      }
-    );
+      await expect(
+        callHandler(server, "resources/read", { uri: "daintree://terminal/t-1/scrollback" })
+      ).rejects.toMatchObject({
+        data: { code: SESSION_BINDING_GONE, retriable: true, errorCategory: "business" },
+      });
+    });
+
+    it("answers resources/list with the binding resource instead of refusing outright (#12313)", async () => {
+      // The refusal above used to cover `resources/list` too, on the reasoning
+      // that an empty listing is an authoritative "you have nothing". That
+      // reasoning still holds — what changed is that the listing is no longer
+      // empty. It leads with the binding resource, so dropping the categories
+      // that needed a renderer is not a claim about the workspace's contents:
+      // the client is handed the thing that says the route is gone.
+      //
+      // It has to be `resources/list` specifically that recovers, because a
+      // bound session with no view cannot call anything else — refusing here
+      // left it knowing it was evicted with nothing to ask.
+      const deps = boundDeps({
+        dispatchAction: vi
+          .fn()
+          .mockRejectedValue(new WorkspaceBindingError(WORKSPACE, "not-found")),
+        requestManifest: vi
+          .fn()
+          .mockRejectedValue(new WorkspaceBindingError(WORKSPACE, "not-found")),
+        getCachedManifest: vi.fn(() => null),
+      });
+      const server = createSessionServer(SESSION, deps);
+      await server.connect(makeMockTransport());
+
+      const listed = (await callHandler(server, "resources/list", {})) as {
+        resources: Array<{ uri: string }>;
+      };
+      const uris = listed.resources.map((r) => r.uri);
+
+      expect(uris[0]).toBe(WORKSPACE_BINDING_RESOURCE_URI);
+      // The dispatch-backed categories are omitted, not invented.
+      expect(uris.some((u) => u.includes("/scrollback"))).toBe(false);
+      expect(uris.some((u) => u.includes("/pulse"))).toBe(false);
+    });
+
+    it("serves the binding resource without dispatching or probing the route (#12313)", async () => {
+      // The exemption the issue asked for, obtained by construction rather than
+      // by a special case: this read touches no renderer, so there is no route
+      // for `assertBoundRouteReachable` to be protecting. If it ever grew a
+      // dispatch it would start failing exactly when it is needed most.
+      const dispatchAction = vi
+        .fn()
+        .mockRejectedValue(new WorkspaceBindingError(WORKSPACE, "not-found"));
+      const deps = boundDeps({
+        dispatchAction,
+        requestManifest: vi
+          .fn()
+          .mockRejectedValue(new WorkspaceBindingError(WORKSPACE, "not-found")),
+        getCachedManifest: vi.fn(() => null),
+      });
+      const server = createSessionServer(SESSION, deps);
+      await server.connect(makeMockTransport());
+
+      const read = (await callHandler(server, "resources/read", {
+        uri: WORKSPACE_BINDING_RESOURCE_URI,
+      })) as { contents: Array<{ text: string; mimeType: string }> };
+
+      expect(dispatchAction).not.toHaveBeenCalled();
+      const state = JSON.parse(read.contents[0].text);
+      expect(state.workspaceId).toBe(WORKSPACE);
+      expect(state.routeState).toBe("not-found");
+    });
+
+    it("accepts a subscription to the binding resource", async () => {
+      // `pulse` and `agentState` were the only subscribable kinds; a client that
+      // must poll to notice its workspace returning is the case the issue calls
+      // out, so the push half has to exist even though it is best effort.
+      const server = createSessionServer(SESSION, boundDeps());
+      await server.connect(makeMockTransport());
+
+      await expect(
+        callHandler(server, "resources/subscribe", { uri: WORKSPACE_BINDING_RESOURCE_URI })
+      ).resolves.toEqual({});
+    });
+
+    it("refuses a binding URI naming another workspace", async () => {
+      // `current` is the only id this resource takes. Rejecting at the parse
+      // step means no URI shape can reach the reader asking about a workspace
+      // the session is not bound to.
+      const server = createSessionServer(SESSION, boundDeps());
+      await server.connect(makeMockTransport());
+
+      await expect(
+        callHandler(server, "resources/read", { uri: `daintree://workspace/${WORKSPACE}/binding` })
+      ).rejects.toThrow(/Unknown resource URI/);
+    });
+
+    it("still refuses resources/list for a dead pin, which has no later state to recover into", async () => {
+      // A `SessionBindingError` is a destroyed WebContents the session can never
+      // re-resolve — unlike a workspace, which comes back when the user reopens
+      // it. Degrading the listing there would promise a recovery that cannot
+      // happen, so narrowing the fallback to `WorkspaceBindingError` is
+      // load-bearing rather than incidental.
+      const deps = boundDeps({
+        dispatchAction: vi.fn().mockRejectedValue(new SessionBindingError(1234)),
+        requestManifest: vi.fn().mockRejectedValue(new SessionBindingError(1234)),
+        getCachedManifest: vi.fn(() => null),
+      });
+      const server = createSessionServer(SESSION, deps);
+      await server.connect(makeMockTransport());
+
+      await expect(callHandler(server, "resources/list", {})).rejects.toMatchObject({
+        data: { code: SESSION_BINDING_GONE },
+      });
+    });
 
     it.each([["resources/read"], ["resources/subscribe"]])(
       "refuses %s for host-global agent state while the workspace is unreachable",

--- a/electron/services/mcp-server/__tests__/sessionServer.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionServer.test.ts
@@ -5761,10 +5761,10 @@ describe("workspace-bound external sessions (#11789)", () => {
       };
       const uris = listed.resources.map((r) => r.uri);
 
-      expect(uris[0]).toBe(WORKSPACE_BINDING_RESOURCE_URI);
-      // The dispatch-backed categories are omitted, not invented.
-      expect(uris.some((u) => u.includes("/scrollback"))).toBe(false);
-      expect(uris.some((u) => u.includes("/pulse"))).toBe(false);
+      // Asserted whole rather than by absence: a listing that degraded the
+      // dispatch-backed categories but fabricated an entry in their place would
+      // satisfy any "does not contain" check while telling the same lie.
+      expect(uris).toEqual([WORKSPACE_BINDING_RESOURCE_URI]);
     });
 
     it("serves the binding resource without dispatching or probing the route (#12313)", async () => {
@@ -5790,21 +5790,61 @@ describe("workspace-bound external sessions (#11789)", () => {
       })) as { contents: Array<{ text: string; mimeType: string }> };
 
       expect(dispatchAction).not.toHaveBeenCalled();
+      // `assertBoundRouteReachable` probes through `requestManifest`, so an
+      // untouched manifest is what proves the exemption is structural rather
+      // than a branch that could be reordered back into the path.
+      expect(deps.requestManifest).not.toHaveBeenCalled();
       const state = JSON.parse(read.contents[0].text);
       expect(state.workspaceId).toBe(WORKSPACE);
       expect(state.routeState).toBe("not-found");
+      expect(state.liveViewCount).toBe(0);
+      expect(state.keepResident).toBe(false);
     });
 
-    it("accepts a subscription to the binding resource", async () => {
+    it("answers `unbound` for a session with no binding rather than borrowing a workspace", async () => {
+      // The failure this guards is argument mis-wiring: a reader handed the
+      // focused workspace, or a stale one from another session, would look
+      // right in every bound test and be exactly the cross-workspace answer the
+      // binding exists to refuse (#7003).
+      const server = createSessionServer("unbound-session", unboundDeps());
+      await server.connect(makeMockTransport());
+
+      const read = (await callHandler(server, "resources/read", {
+        uri: WORKSPACE_BINDING_RESOURCE_URI,
+      })) as { contents: Array<{ text: string }> };
+
+      const state = JSON.parse(read.contents[0].text);
+      expect(state.workspaceId).toBeNull();
+      expect(state.routeState).toBe("unbound");
+    });
+
+    it("installs and tears down a real subscription to the binding resource", async () => {
       // `pulse` and `agentState` were the only subscribable kinds; a client that
       // must poll to notice its workspace returning is the case the issue calls
       // out, so the push half has to exist even though it is best effort.
-      const server = createSessionServer(SESSION, boundDeps());
+      //
+      // Asserted through the session's subscription bucket rather than the `{}`
+      // acknowledgement: returning `{}` without installing anything would
+      // satisfy the acknowledgement while the client waited forever. The
+      // unsubscribe is also load-bearing here — the listener lives on a
+      // process-global registry, so a test that only subscribes leaks one into
+      // every case that runs after it.
+      const deps = boundDeps();
+      const server = createSessionServer(SESSION, deps);
       await server.connect(makeMockTransport());
 
-      await expect(
-        callHandler(server, "resources/subscribe", { uri: WORKSPACE_BINDING_RESOURCE_URI })
-      ).resolves.toEqual({});
+      await callHandler(server, "resources/subscribe", { uri: WORKSPACE_BINDING_RESOURCE_URI });
+      expect(
+        deps.sessionStore.resourceSubscriptions.get(SESSION)?.has(WORKSPACE_BINDING_RESOURCE_URI)
+      ).toBe(true);
+
+      await callHandler(server, "resources/unsubscribe", { uri: WORKSPACE_BINDING_RESOURCE_URI });
+      // `?? false` because an emptied bucket is dropped from the map entirely,
+      // so "no bucket" and "bucket without this uri" are the same answer here.
+      expect(
+        deps.sessionStore.resourceSubscriptions.get(SESSION)?.has(WORKSPACE_BINDING_RESOURCE_URI) ??
+          false
+      ).toBe(false);
     });
 
     it("refuses a binding URI naming another workspace", async () => {

--- a/electron/services/mcp-server/sessionServer.ts
+++ b/electron/services/mcp-server/sessionServer.ts
@@ -24,6 +24,7 @@ import { isGenericNativeGrantEligible } from "../../../shared/config/nativeGrant
 import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
 import { getAgentAvailabilityStore } from "../AgentAvailabilityStore.js";
 import { events } from "../events.js";
+import { onWorkspaceResidencyChanged, readWorkspaceBindingState } from "../workspaceResidency.js";
 import type { AuditOutcome } from "./auditLog.js";
 import type {
   McpTier,
@@ -61,6 +62,7 @@ import {
   WORKSPACE_BINDING_CAPABILITY_KEY,
   type DispatchedWorkspaceRef,
   type McpWorkspaceBinding,
+  WORKSPACE_BINDING_RESOURCE_URI,
 } from "./shared.js";
 import {
   INTERACTIVE_WAIT_UNTIL_IDLE_TIMEOUT_CAP_MS,
@@ -2141,8 +2143,16 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
       );
     }
     if (parsed.kind === "agentState") await assertBoundRouteReachable();
+    // `binding` deliberately skips the probe above, and needs no exemption
+    // branch to do it: it dispatches nothing, so there is no route for a probe
+    // to be protecting. That is the whole point — it is the one read a session
+    // whose workspace is gone can still make (#12313).
     try {
-      return { contents: [await readResourceContents(uri, parsed, dispatchAction)] };
+      return {
+        contents: [
+          await readResourceContents(uri, parsed, dispatchAction, workspaceBinding?.workspaceId),
+        ],
+      };
     } catch (err) {
       const routed = routeBindingMcpError(err);
       if (routed) throw routed;
@@ -2173,7 +2183,7 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
     // listener on a process-global event and would push another workspace's
     // updates at a session that cannot reach its own.
     if (parsed.kind === "agentState") await assertBoundRouteReachable();
-    subscribeResource(sessionId, server, uri, parsed, sessionStore);
+    subscribeResource(sessionId, server, uri, parsed, sessionStore, workspaceBinding?.workspaceId);
     return {};
   });
 
@@ -2258,6 +2268,25 @@ async function listConcreteResources(
 ): Promise<Array<{ uri: string; name: string; mimeType: string; description?: string }>> {
   const resources: Array<{ uri: string; name: string; mimeType: string; description?: string }> =
     [];
+  // First, and before anything that dispatches. A workspace-bound session whose
+  // view is gone cannot reach a renderer, so this is the only entry it is
+  // guaranteed to get — and it is what makes the degraded listing below honest
+  // rather than an authoritative "you have nothing" (#12313).
+  if (isResourcePermitted(tier, "binding")) {
+    resources.push({
+      uri: WORKSPACE_BINDING_RESOURCE_URI,
+      name: "This session — workspace binding",
+      mimeType: "application/json",
+      description:
+        "Whether this session's bound workspace has a live view, when eviction last took one, and whether the user asked to keep it resident.",
+    });
+  }
+  // Captured before the first await, so the decision below is a value this
+  // function already holds rather than a state read from inside a catch
+  // (lesson #10222). Its meaning is narrow: an unreachable workspace may only
+  // drop the categories that needed a renderer if the client is simultaneously
+  // being handed the resource that explains why they are missing.
+  const bindingListed = resources.length > 0;
   if (isResourcePermitted(tier, "issues")) {
     resources.push({
       uri: "daintree://project/current/issues",
@@ -2267,7 +2296,7 @@ async function listConcreteResources(
     });
   }
   if (isResourcePermitted(tier, "pulse")) {
-    const worktrees = await tryDispatchList("worktree.list", deps.dispatchAction);
+    const worktrees = await tryDispatchList("worktree.list", deps.dispatchAction, bindingListed);
     for (const wt of worktrees) {
       const id = readStringField(wt, ["id", "worktreeId"]);
       const label = readStringField(wt, ["branch", "name", "path"]) ?? id;
@@ -2281,7 +2310,7 @@ async function listConcreteResources(
     }
   }
   if (isResourcePermitted(tier, "scrollback") || isResourcePermitted(tier, "agentState")) {
-    const terminals = await tryDispatchList("terminal.list", deps.dispatchAction);
+    const terminals = await tryDispatchList("terminal.list", deps.dispatchAction, bindingListed);
     for (const term of terminals) {
       const id = readStringField(term, ["id", "terminalId"]);
       const label = readStringField(term, ["title", "name"]) ?? id;
@@ -2346,8 +2375,16 @@ function listResourceTemplates(
 async function readResourceContents(
   uri: string,
   parsed: ParsedResourceUri,
-  dispatchAction: SessionServerDeps["dispatchAction"]
+  dispatchAction: SessionServerDeps["dispatchAction"],
+  boundWorkspaceId: string | undefined
 ): Promise<{ uri: string; mimeType: string; text: string }> {
+  if (parsed.kind === "binding") {
+    // Resolved fresh on every read, from the same registry routing consults, so
+    // "this says available" and "a call would route" cannot drift (#7003 — never
+    // a cache, and never another session's or window's state).
+    const state = readWorkspaceBindingState(boundWorkspaceId ?? null);
+    return { uri, mimeType: "application/json", text: JSON.stringify(state) };
+  }
   if (parsed.kind === "pulse") {
     const envelope = await dispatchAction("git.getProjectPulse", {
       worktreeId: parsed.id,
@@ -2401,7 +2438,8 @@ async function readResourceContents(
 
 async function tryDispatchList(
   actionId: string,
-  dispatchAction: SessionServerDeps["dispatchAction"]
+  dispatchAction: SessionServerDeps["dispatchAction"],
+  bindingResourceListed: boolean
 ): Promise<unknown[]> {
   try {
     const envelope = await dispatchAction(actionId, {});
@@ -2420,6 +2458,20 @@ async function tryDispatchList(
     // have nothing" for a bound session whose workspace is simply not open —
     // the same lie the terminal handshake used to tell, in a quieter place.
     // Ordinary enumeration failures keep degrading to a partial listing.
+    //
+    // What changed in #12313 is that the listing can now say so. When the
+    // binding resource is in the response, dropping this category is not a
+    // claim about the workspace's contents — the client is holding a resource
+    // that reports the route is gone, when eviction took it, and that it will
+    // come back. Without that resource the old refusal is still the only honest
+    // answer, so the flag is checked rather than assumed.
+    //
+    // Narrowed to `WorkspaceBindingError` deliberately. A `SessionBindingError`
+    // is a dead WebContents pin: the session's identity is a destroyed view it
+    // can never re-resolve, so there is no later state in which the listing
+    // fills back in, and degrading it would promise a recovery that cannot
+    // happen. That one still refuses.
+    if (bindingResourceListed && err instanceof WorkspaceBindingError) return [];
     const routed = routeBindingMcpError(err);
     if (routed) throw routed;
     console.error(`[MCP] Failed to enumerate resources via ${actionId}:`, err);
@@ -2443,9 +2495,10 @@ function subscribeResource(
   server: Server,
   uri: string,
   parsed: ParsedResourceUri,
-  sessionStore: SessionStore
+  sessionStore: SessionStore,
+  boundWorkspaceId: string | undefined
 ): void {
-  if (parsed.kind !== "pulse" && parsed.kind !== "agentState") {
+  if (parsed.kind !== "pulse" && parsed.kind !== "agentState" && parsed.kind !== "binding") {
     throw new McpError(
       ErrorCode.InvalidRequest,
       `Subscriptions are not supported for resource '${uri}'.`
@@ -2466,7 +2519,22 @@ function subscribeResource(
   };
 
   let unsub: () => void;
-  if (parsed.kind === "agentState") {
+  if (parsed.kind === "binding") {
+    // Push is latency reduction, never the contract. The transport is built
+    // without an `eventStore` (`httpLifecycle.ts`), and the SDK's `send()`
+    // returns silently when no client is holding the standalone GET stream, so
+    // a notification can be dropped with no error anywhere — which is exactly
+    // why the read above is the authoritative half and this only says "read
+    // again" (#12313).
+    //
+    // An unbound session subscribing gets a live, permanently quiet
+    // subscription: it has no binding, so nothing can change about one. Cheaper
+    // and more predictable than refusing, and its read still answers `unbound`.
+    unsub =
+      boundWorkspaceId === undefined
+        ? () => {}
+        : onWorkspaceResidencyChanged(boundWorkspaceId, fire);
+  } else if (parsed.kind === "agentState") {
     unsub = events.on("agent:state-changed", (payload) => {
       if (payload.agentId === parsed.id) fire();
     });

--- a/electron/services/mcp-server/shared.ts
+++ b/electron/services/mcp-server/shared.ts
@@ -735,7 +735,7 @@ export function minimumPermittingTier(toolId: string): "workbench" | "action" | 
   return null;
 }
 
-export type ResourceKind = "pulse" | "scrollback" | "agentState" | "issues";
+export type ResourceKind = "pulse" | "scrollback" | "agentState" | "issues" | "binding";
 
 export interface ParsedResourceUri {
   kind: ResourceKind;
@@ -747,7 +747,23 @@ export const RESOURCE_BACKING_ACTIONS: Readonly<Record<ResourceKind, string>> = 
   scrollback: "terminal.getOutput",
   agentState: "terminal.list",
   issues: "forge.listIssues",
+  // `binding` reads no renderer state at all, so its gate is about who should
+  // be able to ask "is my workspace reachable" — the same audience that can
+  // enumerate workspaces. Riding an already-permitted tool id is also what
+  // keeps this off the external tool budget, which is spent (#12313).
+  binding: "workspace.list",
 };
+
+/**
+ * The one URI for {@link ResourceKind} `binding` — a session's own binding, not
+ * an addressable workspace.
+ *
+ * `current` follows `daintree://project/current/issues`: a caller-relative
+ * pseudo-id, because a bound session has exactly one binding and naming another
+ * workspace here would invite exactly the cross-workspace read the binding
+ * exists to prevent.
+ */
+export const WORKSPACE_BINDING_RESOURCE_URI = "daintree://workspace/current/binding";
 
 export const RESOURCE_TEXT_MAX_BYTES = 50 * 1024;
 
@@ -1035,7 +1051,7 @@ export interface McpHttpSession {
 }
 
 const RESOURCE_URI_PATTERN =
-  /^daintree:\/\/(worktree|terminal|agent|project)\/([^/]+)\/(pulse|scrollback|state|issues)$/;
+  /^daintree:\/\/(worktree|terminal|agent|project|workspace)\/([^/]+)\/(pulse|scrollback|state|issues|binding)$/;
 
 export function parseResourceUri(uri: string): ParsedResourceUri | null {
   const match = RESOURCE_URI_PATTERN.exec(uri);
@@ -1052,6 +1068,13 @@ export function parseResourceUri(uri: string): ParsedResourceUri | null {
   if (host === "terminal" && verb === "scrollback") return { kind: "scrollback", id };
   if (host === "agent" && verb === "state") return { kind: "agentState", id };
   if (host === "project" && id === "current" && verb === "issues") return { kind: "issues", id };
+  // `current` only — this resource is about the caller's own binding, so an
+  // arbitrary workspace id must not parse. Rejecting it here rather than in the
+  // read handler means there is no shape of URI that could reach the reader
+  // asking about somebody else's workspace.
+  if (host === "workspace" && id === "current" && verb === "binding") {
+    return { kind: "binding", id };
+  }
   return null;
 }
 

--- a/electron/services/workspaceResidency.ts
+++ b/electron/services/workspaceResidency.ts
@@ -1,0 +1,252 @@
+/**
+ * Workspace residency: the user's "keep this one loaded" grant, the record of
+ * views eviction has taken, and the authoritative read a bound MCP session uses
+ * to find out which of those happened to it (#12313).
+ *
+ * A workspace-bound session routes every call through the one view its binding
+ * resolves to (`getWorkspaceWebContents`), so an eviction pass taking that view
+ * leaves the session `SESSION_BINDING_GONE` on everything — including the
+ * surfaces it would use to ask what went wrong. The two halves here are the two
+ * answers to that: a grant the *user* spends to make eviction less likely, and a
+ * read that is honest about it either way.
+ *
+ * Deliberately NOT a floor. #11790 refused an automatic one because a client
+ * could hold it just by staying connected; this is the same refusal from the
+ * other side — the client cannot grant itself residency, and the grant it does
+ * get still yields to memory pressure. What changes is that losing the view
+ * stops being silent.
+ *
+ * Reachable from both `electron/window/` (eviction, view registration) and
+ * `electron/services/mcp-server/` (the resource), which is why it imports only
+ * the store and the view registry — both already reached directly from each
+ * side, so this adds no edge either graph did not have.
+ */
+
+import { store } from "../store.js";
+import { getWebContentsForProject } from "../window/webContentsRegistry.js";
+
+/** Why a workspace's last live view went away, as eviction itself classified it. */
+export type WorkspaceEvictionReason =
+  "lru" | "limit-change" | "pressure" | "memory-eviction" | "crash";
+
+/**
+ * What a workspace-bound MCP session can learn about its own binding without
+ * reaching a renderer.
+ *
+ * `routeState` mirrors `getWorkspaceWebContents`'s zero/one/many rule exactly,
+ * so this resource cannot disagree with what routing would actually do — the
+ * point is an authoritative read, and a second opinion would be worse than
+ * none. `keepResident` reports the grant, not a promise: it says what the user
+ * chose, not that a slot is reserved this instant.
+ */
+export interface McpWorkspaceBindingState {
+  /** The bound workspace, or null for a session that binds to nothing. */
+  workspaceId: string | null;
+  /**
+   * `unbound` — this session routes to the focused view, so there is no binding
+   * to lose. `available` — exactly one live view, the route resolves.
+   * `not-found` — no live view; every routed call refuses. `ambiguous` — more
+   * than one live view, so the bound target is undecidable and calls refuse for
+   * that reason instead.
+   */
+  routeState: "unbound" | "available" | "not-found" | "ambiguous";
+  liveViewCount: number;
+  keepResident: boolean;
+  /**
+   * When eviction took this workspace's last live view, or null.
+   *
+   * Present only while there is no live view, which is what makes it safe: it
+   * is the difference between "this workspace was here and got taken" and "no
+   * view of it has been open this run", the distinction a bound client could
+   * not draw before and the reason a bare notification was not enough.
+   */
+  evictedAt: number | null;
+  evictionReason: WorkspaceEvictionReason | null;
+  observedAt: number;
+}
+
+interface EvictionRecord {
+  at: number;
+  reason: WorkspaceEvictionReason;
+}
+
+/**
+ * App-lifetime, cross-window ledger of workspaces eviction has taken.
+ *
+ * `ProjectViewManager.evictionTimestamps` cannot serve this: it is per-window
+ * and read by the switch controller for its own telemetry, so a workspace
+ * evicted in one window is invisible from another, and nothing about it is
+ * reachable once the view is gone. This is keyed by workspace id, which
+ * outlives every view.
+ *
+ * At most one record per workspace, cleared the moment a view registers again.
+ */
+const evictions = new Map<string, EvictionRecord>();
+
+type ResidencyListener = () => void;
+const listeners = new Map<string, Set<ResidencyListener>>();
+
+function emitResidencyChanged(workspaceId: string): void {
+  const bucket = listeners.get(workspaceId);
+  if (!bucket) return;
+  // Copied before iterating: a listener that unsubscribes itself while being
+  // notified would otherwise mutate the set mid-iteration.
+  for (const listener of [...bucket]) {
+    try {
+      listener();
+    } catch (err) {
+      console.error("[residency] listener threw:", err);
+    }
+  }
+}
+
+/**
+ * Whether the user granted `workspaceId` residency.
+ *
+ * Only an exact `true` counts. The record is keyed by workspace id and nothing
+ * prunes it when a project is deleted, so a stale entry has to be inert — and
+ * it is, twice over: eviction only ever applies this to a view that actually
+ * exists, and this read refuses anything that is not the literal value written.
+ */
+export function isWorkspaceKeepResident(workspaceId: string): boolean {
+  return (store.get("workspaceKeepResident") ?? {})[workspaceId] === true;
+}
+
+/** Set or clear the user's residency grant for `workspaceId`. */
+export function setWorkspaceKeepResident(workspaceId: string, keepResident: boolean): void {
+  const current = store.get("workspaceKeepResident") ?? {};
+  if ((current[workspaceId] === true) === keepResident) return;
+  const next = { ...current };
+  if (keepResident) {
+    next[workspaceId] = true;
+  } else {
+    // Deleted rather than stored as `false`: absence is the only "off" this key
+    // has, so keeping a falsy entry would grow the record for every workspace
+    // the toggle was ever flipped on and back off.
+    delete next[workspaceId];
+  }
+  store.set("workspaceKeepResident", next);
+  emitResidencyChanged(workspaceId);
+}
+
+/**
+ * Record that eviction took the last live view of `workspaceId`.
+ *
+ * Call it *after* the view is torn down, so the liveness check below sees the
+ * settled state. A second window's view of the same workspace is not affected
+ * by this pass — the route still resolves there — so an eviction that leaves
+ * one standing is not this workspace's eviction and is not recorded as one.
+ *
+ * {@link readWorkspaceBindingState} suppresses the record whenever a live view
+ * exists regardless, so the read stays correct without depending on this check
+ * winning any particular race; this one keeps the ledger itself from carrying a
+ * reason that never applied.
+ */
+export function recordWorkspaceEviction(
+  workspaceId: string,
+  reason: WorkspaceEvictionReason
+): void {
+  if (getWebContentsForProject(workspaceId).length > 0) {
+    // Still reachable, but the view set changed — tell subscribers to re-read.
+    emitResidencyChanged(workspaceId);
+    return;
+  }
+  evictions.set(workspaceId, { at: Date.now(), reason });
+  emitResidencyChanged(workspaceId);
+}
+
+/**
+ * Forget any eviction recorded for `workspaceId` — the view is back.
+ *
+ * Called from view registration, not from the eviction side. A subscriber that
+ * reads on notification has to see the reopen, not the eviction that preceded
+ * it (lesson #10821): a ledger written on the way out and never cleared would
+ * let a subscribe-then-read client settle on a state the workspace has already
+ * left.
+ */
+export function clearWorkspaceEviction(workspaceId: string): void {
+  evictions.delete(workspaceId);
+  emitResidencyChanged(workspaceId);
+}
+
+/**
+ * Notify that `workspaceId`'s live views changed without the ledger changing —
+ * an ordinary close, a window teardown, a second view opening or closing.
+ *
+ * Separate from the two ledger writes because those cases are not evictions and
+ * must not be reported as any: the read recomputes liveness itself, so the
+ * subscriber gets the truth either way.
+ */
+export function notifyWorkspaceViewsChanged(workspaceId: string): void {
+  emitResidencyChanged(workspaceId);
+}
+
+/** Subscribe to residency changes for one workspace. Returns its unsubscribe. */
+export function onWorkspaceResidencyChanged(
+  workspaceId: string,
+  listener: ResidencyListener
+): () => void {
+  let bucket = listeners.get(workspaceId);
+  if (!bucket) {
+    bucket = new Set();
+    listeners.set(workspaceId, bucket);
+  }
+  bucket.add(listener);
+  let disposed = false;
+  return () => {
+    if (disposed) return;
+    disposed = true;
+    const current = listeners.get(workspaceId);
+    if (!current) return;
+    current.delete(listener);
+    if (current.size === 0) listeners.delete(workspaceId);
+  };
+}
+
+/**
+ * The authoritative answer for a session's own binding.
+ *
+ * Resolved fresh on every call — never cached, never another session's or
+ * window's state (#7003). The live-view count comes from the same registry
+ * routing consults, so "this read says available" and "a call would route" are
+ * the same fact rather than two that can drift.
+ */
+export function readWorkspaceBindingState(
+  boundWorkspaceId: string | null
+): McpWorkspaceBindingState {
+  const observedAt = Date.now();
+  if (boundWorkspaceId === null) {
+    return {
+      workspaceId: null,
+      routeState: "unbound",
+      liveViewCount: 0,
+      keepResident: false,
+      evictedAt: null,
+      evictionReason: null,
+      observedAt,
+    };
+  }
+
+  const liveViewCount = getWebContentsForProject(boundWorkspaceId).length;
+  // A live view means the workspace is here now, whatever took an earlier one:
+  // reporting a stale eviction beside it would describe a loss that has already
+  // been recovered, and in a second window's case one that never applied to
+  // this route at all.
+  const record = liveViewCount === 0 ? (evictions.get(boundWorkspaceId) ?? null) : null;
+
+  return {
+    workspaceId: boundWorkspaceId,
+    routeState: liveViewCount === 0 ? "not-found" : liveViewCount === 1 ? "available" : "ambiguous",
+    liveViewCount,
+    keepResident: isWorkspaceKeepResident(boundWorkspaceId),
+    evictedAt: record?.at ?? null,
+    evictionReason: record?.reason ?? null,
+    observedAt,
+  };
+}
+
+/** Test seam — drops the ledger and every subscription. */
+export function __resetWorkspaceResidencyForTests(): void {
+  evictions.clear();
+  listeners.clear();
+}

--- a/electron/services/workspaceResidency.ts
+++ b/electron/services/workspaceResidency.ts
@@ -130,27 +130,25 @@ export function setWorkspaceKeepResident(workspaceId: string, keepResident: bool
 }
 
 /**
- * Record that eviction took the last live view of `workspaceId`.
+ * Record that an eviction pass took a view of `workspaceId`.
  *
- * Call it *after* the view is torn down, so the liveness check below sees the
- * settled state. A second window's view of the same workspace is not affected
- * by this pass — the route still resolves there — so an eviction that leaves
- * one standing is not this workspace's eviction and is not recorded as one.
+ * Deliberately unconditional — it does not ask whether another window still
+ * holds a view. Checking here would be marginally more precise about *why* a
+ * workspace is unreachable later, and it would put a `getWebContentsForProject`
+ * call on a path eleven window test fixtures stub without it: a coupling that
+ * broad, bought that cheaply, is the wrong trade.
  *
- * {@link readWorkspaceBindingState} suppresses the record whenever a live view
- * exists regardless, so the read stays correct without depending on this check
- * winning any particular race; this one keeps the ledger itself from carrying a
- * reason that never applied.
+ * It costs nothing real, because the claim stays true either way. This says a
+ * view was evicted at T, which it was; {@link readWorkspaceBindingState} is what
+ * decides whether that is worth reporting, and it only surfaces the record while
+ * no view is live. A workspace still reachable through another window therefore
+ * never shows a loss, which is the property that actually matters — and what is
+ * reported is an observation the host made, not a conclusion about the cause.
  */
 export function recordWorkspaceEviction(
   workspaceId: string,
   reason: WorkspaceEvictionReason
 ): void {
-  if (getWebContentsForProject(workspaceId).length > 0) {
-    // Still reachable, but the view set changed — tell subscribers to re-read.
-    emitResidencyChanged(workspaceId);
-    return;
-  }
   evictions.set(workspaceId, { at: Date.now(), reason });
   emitResidencyChanged(workspaceId);
 }
@@ -229,9 +227,10 @@ export function readWorkspaceBindingState(
 
   const liveViewCount = getWebContentsForProject(boundWorkspaceId).length;
   // A live view means the workspace is here now, whatever took an earlier one:
-  // reporting a stale eviction beside it would describe a loss that has already
-  // been recovered, and in a second window's case one that never applied to
-  // this route at all.
+  // reporting an eviction beside it would describe a loss that has already been
+  // recovered, and in a second window's case one that never applied to this
+  // route at all. This is the only gate on the record, so it carries the whole
+  // guarantee — see `recordWorkspaceEviction`, which writes unconditionally.
   const record = liveViewCount === 0 ? (evictions.get(boundWorkspaceId) ?? null) : null;
 
   return {

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -577,6 +577,23 @@ export interface StoreSchema {
     defaultHiddenPluginIds: string[];
     projectOverrides: Record<string, Record<string, boolean>>;
   };
+
+  /**
+   * Workspaces the user asked to keep resident in the project-view cache
+   * (#12313), keyed by workspace id — a project's 64-hex id or a scratch
+   * workspace's UUID, the same vocabulary `ProjectViewManager.views` and an MCP
+   * session binding use.
+   *
+   * A grant, not a floor: eviction honours at most `effectiveMax - 1` of these
+   * at a time, so residency never carries the cache over the user's configured
+   * cap, and critical pressure collapses `effectiveMax` to 1 and admits them
+   * all. The client cannot set this — only the user, through project settings.
+   *
+   * Additive key with no numbered migration, matching `projectPluginTrust`
+   * above: every read goes through `?? {}`, and only an exact `true` counts, so
+   * a stale entry for a deleted workspace grants nothing.
+   */
+  workspaceKeepResident?: Record<string, true>;
 }
 
 const storeOptions = {
@@ -775,6 +792,7 @@ const storeOptions = {
     },
     pluginCapabilityConsent: {},
     projectPluginTrust: {},
+    workspaceKeepResident: {},
   },
   cwd: process.env.DAINTREE_USER_DATA,
 };

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -584,10 +584,13 @@ export interface StoreSchema {
    * workspace's UUID, the same vocabulary `ProjectViewManager.views` and an MCP
    * session binding use.
    *
-   * A grant, not a floor: eviction honours at most `effectiveMax - 1` of these
-   * at a time, so residency never carries the cache over the user's configured
-   * cap, and critical pressure collapses `effectiveMax` to 1 and admits them
-   * all. The client cannot set this — only the user, through project settings.
+   * A grant, not a floor: it orders the workspace last in the eviction
+   * candidate queue, so a grant is surrendered only once every ungranted
+   * candidate is gone. That ordering is the whole mechanism — residency never
+   * carries the cache over the user's configured cap, because a candidate is
+   * always available to take, and a forced critical reclaim (`effectiveMax`
+   * collapsed to 1) takes the grants along with everything else. The client
+   * cannot set this — only the user, through project settings.
    *
    * Additive key with no numbered migration, matching `projectPluginTrust`
    * above: every read goes through `?? {}`, and only an exact `true` counts, so

--- a/electron/window/ProjectViewEvictionController.ts
+++ b/electron/window/ProjectViewEvictionController.ts
@@ -13,6 +13,10 @@ import type { ProjectViewManager } from "./ProjectViewManager.js";
 import type { EvictionReason, ViewEntry } from "./ProjectViewManagerTypes.js";
 import { readAvailableSystemMemoryMb } from "../utils/systemMemory.js";
 import { memoryPressureTarget } from "../utils/cachedProjectViews.js";
+import {
+  isWorkspaceKeepResident,
+  recordWorkspaceEviction,
+} from "../services/workspaceResidency.js";
 
 /** A view eligible for eviction; the flags beyond the entry are carried into the eviction log line. */
 type EvictionCandidate = {
@@ -21,6 +25,7 @@ type EvictionCandidate = {
   activeAgent: boolean;
   liveAssistantBackend: boolean;
   boundMcpSession: boolean;
+  keepResident: boolean;
 };
 
 /**
@@ -105,6 +110,11 @@ export function evictDeadView(
     });
     host.evictionTimestamps.set(projectId, Date.now());
     cleanupEntry(host, projectId);
+    // After the teardown, so the ledger's own liveness check sees the settled
+    // view set (#12313). A bound MCP session learns from this that its route
+    // went away and roughly when, which is the difference between a workspace
+    // it can wait for and an id that was never right.
+    recordWorkspaceEviction(projectId, trigger);
   });
 }
 
@@ -324,9 +334,15 @@ export function evictStaleViews(
   // nothing dies with the renderer the way an assistant's process tree does,
   // and enough concurrent bound sessions would otherwise defeat the pressure
   // policy. So it yields under real pressure, just last.
+  //
+  // A workspace the *user* granted residency (#12313) is the one tier a client
+  // cannot give itself, so it outranks the bound-session ordering above and
+  // sits directly under the assistant floor. It is still not a floor: the
+  // number protected is bounded by the cap the user configured, below.
   const safeToEvict: EvictionCandidate[] = [];
   const activeAgentFallback: EvictionCandidate[] = [];
   const boundMcpSessionFallback: EvictionCandidate[] = [];
+  const residentGranted: EvictionCandidate[] = [];
   const assistantProtected: EvictionCandidate[] = [];
   for (const [projectId, entry] of evictable) {
     const activeAgent = hasActiveAgent(host, projectId);
@@ -335,9 +351,16 @@ export function evictStaleViews(
     // it must not reach the exclusion set above, or one broken callback would
     // pin every cached view straight through critical pressure.
     const boundMcpSession = mcp.liveBinding || mcp.unknown;
-    const base = { projectId, entry, activeAgent, boundMcpSession };
+    // Read per pass rather than cached: the grant is a live user setting, and
+    // this is also the liveness half (#11162) — the preference record is keyed
+    // by workspace id and nothing prunes it when a project is deleted, so a
+    // stale entry only ever meets this loop for a view that actually exists.
+    const keepResident = isWorkspaceKeepResident(projectId);
+    const base = { projectId, entry, activeAgent, boundMcpSession, keepResident };
     if (hasLiveAssistantBackend(host, projectId, entry)) {
       assistantProtected.push({ ...base, liveAssistantBackend: true });
+    } else if (keepResident) {
+      residentGranted.push({ ...base, liveAssistantBackend: false });
     } else if (boundMcpSession) {
       boundMcpSessionFallback.push({ ...base, liveAssistantBackend: false });
     } else if (activeAgent) {
@@ -347,11 +370,45 @@ export function evictStaleViews(
     }
   }
 
-  const candidates = [...safeToEvict, ...activeAgentFallback, ...boundMcpSessionFallback];
+  // How many granted workspaces this pass will actually hold.
+  //
+  // The whole bound is `effectiveMax - 1`: the active view is excluded from
+  // `evictable` and occupies one slot, so protected residents plus the active
+  // view can never exceed the cap. That is the "inside the configured cap"
+  // half of the issue's ask, as an invariant rather than a policy — residency
+  // alone can never carry the cache over `effectiveMax`, and the loop below
+  // always has enough candidates left to converge.
+  //
+  // It is also the whole of the "yields at critical pressure" half, with no
+  // branch anywhere: `effectiveMax` is already 1 on a forced reclaim and
+  // already `targetMax` under gradual pressure, so the slots go to zero exactly
+  // when the pressure ladder says they should and every granted view drops back
+  // into the ordinary queue. A soft band that still allows 3 views still honours
+  // 2 grants, which is the behaviour the issue thread converged on.
+  //
+  // `evictable` is LRU-ascending, so the most recently used grants are its tail
+  // — when the user has granted more workspaces than fit, the ones they have
+  // actually been working in are the ones held.
+  const residentSlots = Math.max(0, effectiveMax - 1);
+  const residentProtected = residentSlots === 0 ? [] : residentGranted.slice(-residentSlots);
+  const residentOverflow = residentGranted.slice(
+    0,
+    residentGranted.length - residentProtected.length
+  );
+
+  // Overflow grants go last: one the cap could not hold is still a view the
+  // user asked for, so it outranks every ungranted candidate — including a
+  // bound-but-quiet session's, which is ordering the client got for free.
+  const candidates = [
+    ...safeToEvict,
+    ...activeAgentFallback,
+    ...boundMcpSessionFallback,
+    ...residentOverflow,
+  ];
 
   let evictedCount = 0;
   while (host.views.size > effectiveMax && candidates.length > 0 && evictedCount < evictionBudget) {
-    const { projectId, entry, activeAgent, liveAssistantBackend, boundMcpSession } =
+    const { projectId, entry, activeAgent, liveAssistantBackend, boundMcpSession, keepResident } =
       candidates.shift()!;
     const ageMs = Date.now() - entry.lastUsed;
     const memoryKb = memoryFor(entry);
@@ -367,12 +424,20 @@ export function evictStaleViews(
     // the pass that took its view, rather than looking like the binding broke
     // on its own.
     if (boundMcpSession) ctx.boundMcpSession = true;
+    // The user granted this workspace residency and it is being evicted anyway
+    // — the cap could not hold every grant, or pressure took the slots. Logged
+    // so the override is attributable rather than looking like the grant was
+    // ignored (#11162).
+    if (keepResident) ctx.keepResident = true;
     if (memoryKb > 0) ctx.memoryKb = memoryKb;
     if (guestMemoryKb > 0) ctx.guestMemoryKb = guestMemoryKb;
     if (availableMb != null) ctx.memoryAvailableMb = availableMb;
     logInfo("projectview.eviction", ctx);
     host.evictionTimestamps.set(projectId, Date.now());
     cleanupEntry(host, projectId);
+    // After the teardown, so the ledger's liveness check reads the settled view
+    // set — see `recordWorkspaceEviction` (#12313).
+    recordWorkspaceEviction(projectId, effectiveReason);
     evictedCount++;
   }
 
@@ -394,7 +459,7 @@ export function evictStaleViews(
   if (
     host.views.size > effectiveMax &&
     candidates.length === 0 &&
-    (assistantProtected.length > 0 || mcpLeasedProjectIds.size > 0)
+    (assistantProtected.length > 0 || mcpLeasedProjectIds.size > 0 || residentProtected.length > 0)
   ) {
     // `overflow` counts views over target; the two counts beside it say what is
     // holding them, so a reader can tell a pinned assistant (persistent, this
@@ -423,6 +488,12 @@ export function evictStaleViews(
       // mid-dispatch as transient when its floor outlives the call. Kept apart,
       // each count means exactly one thing.
       mcpLeasedCount: mcpLeasedProjectIds.size,
+      // Residency alone cannot cause the overflow — it is bounded by
+      // `effectiveMax - 1`, so held grants plus the active view always fit the
+      // cap. It can still be part of an over-cap cache alongside an assistant
+      // floor or a dispatch lease, and a reader tracing the extra renderers
+      // needs to see which held views were the user's own choice (#12313).
+      residentProtectedCount: residentProtected.length,
       protectedProjectIds: assistantProtected.map(({ projectId }) => projectId),
     });
   }

--- a/electron/window/ProjectViewEvictionController.ts
+++ b/electron/window/ProjectViewEvictionController.ts
@@ -110,10 +110,13 @@ export function evictDeadView(
     });
     host.evictionTimestamps.set(projectId, Date.now());
     cleanupEntry(host, projectId);
-    // After the teardown, so the ledger's own liveness check sees the settled
-    // view set (#12313). A bound MCP session learns from this that its route
-    // went away and roughly when, which is the difference between a workspace
-    // it can wait for and an id that was never right.
+    // After the teardown, because the write is unconditional and the liveness
+    // gate lives on the read side: `readWorkspaceBindingState` surfaces the
+    // record only while no view is live, so recording first would notify
+    // subscribers into a read that still sees this view and swallows the loss
+    // (#12313). A bound MCP session learns from this that its route went away
+    // and roughly when, which is the difference between a workspace it can wait
+    // for and an id that was never right.
     recordWorkspaceEviction(projectId, trigger);
   });
 }
@@ -434,8 +437,8 @@ export function evictStaleViews(
     logInfo("projectview.eviction", ctx);
     host.evictionTimestamps.set(projectId, Date.now());
     cleanupEntry(host, projectId);
-    // After the teardown, so the ledger's liveness check reads the settled view
-    // set — see `recordWorkspaceEviction` (#12313).
+    // After the teardown, because the read side is what gates the record on
+    // liveness — see `readWorkspaceBindingState` (#12313).
     recordWorkspaceEviction(projectId, effectiveReason);
     evictedCount++;
   }

--- a/electron/window/ProjectViewEvictionController.ts
+++ b/electron/window/ProjectViewEvictionController.ts
@@ -336,9 +336,8 @@ export function evictStaleViews(
   // policy. So it yields under real pressure, just last.
   //
   // A workspace the *user* granted residency (#12313) is the one tier a client
-  // cannot give itself, so it outranks the bound-session ordering above and
-  // sits directly under the assistant floor. It is still not a floor: the
-  // number protected is bounded by the cap the user configured, below.
+  // cannot give itself, so it outranks the bound-session ordering above. Still
+  // not a floor, and deliberately not an exclusion — see the ordering below.
   const safeToEvict: EvictionCandidate[] = [];
   const activeAgentFallback: EvictionCandidate[] = [];
   const boundMcpSessionFallback: EvictionCandidate[] = [];
@@ -370,40 +369,40 @@ export function evictStaleViews(
     }
   }
 
-  // How many granted workspaces this pass will actually hold.
+  // Granted workspaces go last, and stay in `candidates` rather than becoming a
+  // fourth exclusion.
   //
-  // The whole bound is `effectiveMax - 1`: the active view is excluded from
-  // `evictable` and occupies one slot, so protected residents plus the active
-  // view can never exceed the cap. That is the "inside the configured cap"
-  // half of the issue's ask, as an invariant rather than a policy — residency
-  // alone can never carry the cache over `effectiveMax`, and the loop below
-  // always has enough candidates left to converge.
+  // Being last is the whole mechanism, and it is enough: a pass evicts only
+  // until the cache is back at `effectiveMax`, so a grant is taken only once
+  // every ungranted candidate is gone — which is exactly "keep this one while
+  // there is anything else to give up". Rotating through other projects can no
+  // longer evict the workspace holding an orchestrator's agents, because those
+  // other projects are always the cheaper answer.
   //
-  // It is also the whole of the "yields at critical pressure" half, with no
-  // branch anywhere: `effectiveMax` is already 1 on a forced reclaim and
-  // already `targetMax` under gradual pressure, so the slots go to zero exactly
-  // when the pressure ladder says they should and every granted view drops back
-  // into the ordinary queue. A soft band that still allows 3 views still honours
-  // 2 grants, which is the behaviour the issue thread converged on.
+  // Reserving slots instead was the obvious design and is strictly worse. Any
+  // reservation big enough to be safe (`effectiveMax` minus the active view,
+  // the bridges, the leases and the assistant floor) is by construction never
+  // reached — the loop always converges before it needs a reserved view — so
+  // the arithmetic produces this same ordering with more code. Sized any larger
+  // it stops being safe: with a cap of 2, an active view, a live assistant's
+  // floor and one grant, a reservation leaves the pass nothing it may evict and
+  // pins three views indefinitely, where the plain tier settles at two.
   //
-  // `evictable` is LRU-ascending, so the most recently used grants are its tail
-  // — when the user has granted more workspaces than fit, the ones they have
-  // actually been working in are the ones held.
-  const residentSlots = Math.max(0, effectiveMax - 1);
-  const residentProtected = residentSlots === 0 ? [] : residentGranted.slice(-residentSlots);
-  const residentOverflow = residentGranted.slice(
-    0,
-    residentGranted.length - residentProtected.length
-  );
-
-  // Overflow grants go last: one the cap could not hold is still a view the
-  // user asked for, so it outranks every ungranted candidate — including a
-  // bound-but-quiet session's, which is ordering the client got for free.
+  // Both halves of the issue's ask fall out of staying in `candidates`, with no
+  // branch for either. Residency can never carry the cache over the configured
+  // cap, because a candidate is always available to take. And it yields at
+  // critical pressure for the same reason — a forced reclaim converges on the
+  // active view alone, and a grant is not exempt from that, it is merely the
+  // last thing surrendered.
+  //
+  // What the user gets over `boundMcpSessionFallback` is precedence, which is
+  // the right shape: that tier is ordering a client earns just by connecting,
+  // and this one is ordering the user granted deliberately.
   const candidates = [
     ...safeToEvict,
     ...activeAgentFallback,
     ...boundMcpSessionFallback,
-    ...residentOverflow,
+    ...residentGranted,
   ];
 
   let evictedCount = 0;
@@ -459,7 +458,7 @@ export function evictStaleViews(
   if (
     host.views.size > effectiveMax &&
     candidates.length === 0 &&
-    (assistantProtected.length > 0 || mcpLeasedProjectIds.size > 0 || residentProtected.length > 0)
+    (assistantProtected.length > 0 || mcpLeasedProjectIds.size > 0)
   ) {
     // `overflow` counts views over target; the two counts beside it say what is
     // holding them, so a reader can tell a pinned assistant (persistent, this
@@ -488,12 +487,6 @@ export function evictStaleViews(
       // mid-dispatch as transient when its floor outlives the call. Kept apart,
       // each count means exactly one thing.
       mcpLeasedCount: mcpLeasedProjectIds.size,
-      // Residency alone cannot cause the overflow — it is bounded by
-      // `effectiveMax - 1`, so held grants plus the active view always fit the
-      // cap. It can still be part of an over-cap cache alongside an assistant
-      // floor or a dispatch lease, and a reader tracing the extra renderers
-      // needs to see which held views were the user's own choice (#12313).
-      residentProtectedCount: residentProtected.length,
       protectedProjectIds: assistantProtected.map(({ projectId }) => projectId),
     });
   }

--- a/electron/window/ProjectViewLifecycleController.ts
+++ b/electron/window/ProjectViewLifecycleController.ts
@@ -12,6 +12,7 @@ import {
   unregisterProjectView,
   unregisterWebContents,
 } from "./webContentsRegistry.js";
+import { notifyWorkspaceViewsChanged } from "../services/workspaceResidency.js";
 import { forgetBlinkSample, forgetEluSample } from "../services/ProcessMemoryMonitor.js";
 import { forgetRendererTerminalDiagnostics } from "../services/RendererTerminalDiagnosticsCache.js";
 import { detachRendererConsoleCapture } from "./rendererConsoleCapture.js";
@@ -479,6 +480,11 @@ export function cleanupEntry(host: ProjectViewManager, projectId: string): void 
 
     host.webContentsToProject.delete(wcId);
     unregisterProjectView(wcId);
+    // Every teardown, not just eviction (#12313). An ordinary close or a window
+    // going away also takes a bound session's route, and it is not an eviction
+    // — so this only wakes subscribers to re-read, and never writes a reason
+    // the pass did not have.
+    notifyWorkspaceViewsChanged(projectId);
     forgetBlinkSample(wcId);
     forgetEluSample(wcId);
     forgetRendererTerminalDiagnostics(wcId);

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -16,6 +16,7 @@
 import { BrowserWindow, type WebContentsView } from "electron";
 import { performance } from "node:perf_hooks";
 import { registerProjectView } from "./webContentsRegistry.js";
+import { clearWorkspaceEviction } from "../services/workspaceResidency.js";
 import { isValidScratchStateId } from "../services/projectStorePaths.js";
 import { logInfo, logWarn } from "../utils/logger.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
@@ -491,6 +492,9 @@ export class ProjectViewManager {
     this.views.set(projectId, entry);
     this.webContentsToProject.set(view.webContents.id, projectId);
     registerProjectView(projectId, view.webContents);
+    // Same reopen clear as the cold-start path (#12313) — the startup view
+    // never goes through `performSwitch`, so it needs its own.
+    clearWorkspaceEviction(projectId);
     this.activeProjectId = projectId;
     // The startup view never goes through `performSwitch`, so it needs its own
     // open signal — otherwise a relaunch straight into a trusted project would

--- a/electron/window/ProjectViewSwitchController.ts
+++ b/electron/window/ProjectViewSwitchController.ts
@@ -15,6 +15,7 @@ import {
   registerAppView,
   registerProjectView,
 } from "./webContentsRegistry.js";
+import { clearWorkspaceEviction } from "../services/workspaceResidency.js";
 import { notifyError } from "../ipc/errorHandlers.js";
 import { AppError } from "../utils/errorTypes.js";
 import { logInfo, logWarn } from "../utils/logger.js";
@@ -292,6 +293,11 @@ export async function performSwitch(
   host.views.set(projectId, entry);
   host.webContentsToProject.set(view.webContents.id, projectId);
   registerProjectView(projectId, view.webContents);
+  // The workspace is reachable again, so any eviction recorded against it is
+  // history (#12313). Cleared on the way back in rather than only written on
+  // the way out: a bound MCP session that subscribes and then reads has to see
+  // the reopen, not the loss it already recovered from (lesson #10821).
+  clearWorkspaceEviction(projectId);
 
   // Set up security handlers and attach to window
   setupViewHandlers(host, view, entry);

--- a/electron/window/__tests__/ProjectViewManager.eviction.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.eviction.test.ts
@@ -92,11 +92,15 @@ vi.mock("../webContentsRegistry.js", () => ({
   unregisterCachedViewWebContents: vi.fn(),
 }));
 
-vi.mock("../../services/workspaceResidency.js", () => ({
-  isWorkspaceKeepResident: (workspaceId: string) => residentWorkspaces.has(workspaceId),
+const residencyLedger = vi.hoisted(() => ({
   recordWorkspaceEviction: vi.fn(),
   clearWorkspaceEviction: vi.fn(),
   notifyWorkspaceViewsChanged: vi.fn(),
+}));
+
+vi.mock("../../services/workspaceResidency.js", () => ({
+  isWorkspaceKeepResident: (workspaceId: string) => residentWorkspaces.has(workspaceId),
+  ...residencyLedger,
 }));
 
 vi.mock("../../setup/protocols.js", () => ({
@@ -3773,6 +3777,13 @@ describe("ProjectViewManager — user-granted workspace residency (#12313)", () 
     await flushImmediates();
   }
 
+  /** Bind a running assistant to the project's current view — the view the session pinned. */
+  function bindLiveAssistant(mgr: ProjectViewManager, projectId: string, terminalId: string) {
+    const wc = mgr.getAllViews().find((v) => v.projectId === projectId)!.view.webContents;
+    assistantBackends.set(projectId, { terminalId, webContentsId: wc.id });
+    liveTerminals.add(terminalId);
+  }
+
   beforeEach(() => {
     nextWebContentsId = 100;
     nextOsProcessId = 1000;
@@ -3866,6 +3877,30 @@ describe("ProjectViewManager — user-granted workspace residency (#12313)", () 
     expect(mgr.getAllViews().map((v) => v.projectId)).toEqual(["proj-c"]);
   });
 
+  it("tells the ledger which workspace it took, and why", async () => {
+    // Without this the ledger mocks are unchecked and every production call
+    // site could be deleted with the suite still green — while a bound session
+    // would silently lose the one signal that distinguishes "evicted" from
+    // "this id was never right".
+    const mgr = makeManager(3);
+    await seedThreeViews(mgr);
+
+    mgr.setCachedViewLimit(2);
+
+    expect(residencyLedger.recordWorkspaceEviction).toHaveBeenCalledWith("proj-a", "limit-change");
+  });
+
+  it("clears the ledger for a workspace that opens again", async () => {
+    // The reopen half (lesson #10821): a ledger only ever written would let a
+    // subscribe-then-read client settle on a loss the workspace has recovered
+    // from.
+    const mgr = makeManager(3);
+    await seedThreeViews(mgr);
+
+    expect(residencyLedger.clearWorkspaceEviction).toHaveBeenCalledWith("proj-b");
+    expect(residencyLedger.clearWorkspaceEviction).toHaveBeenCalledWith("proj-c");
+  });
+
   it("records the grant on the eviction it was overridden by", async () => {
     // Eviction reported rather than silent. Without this the log reads as if
     // the grant were simply ignored, instead of outranked by the cap.
@@ -3896,6 +3931,28 @@ describe("ProjectViewManager — user-granted workspace residency (#12313)", () 
         .map((v) => v.projectId)
         .sort()
     ).toEqual(["proj-a", "proj-c"]);
+  });
+
+  it("does not widen an overflow another protection already caused", async () => {
+    // The cap bound only means anything in composition. A live assistant's
+    // floor is unconditional and already holds the cache over its cap; if
+    // residency budgeted against the raw cap it would hold a third view on top,
+    // where without the grant the pass settles at two. Held slots are counted,
+    // so the assistant still overflows as it is entitled to and the grant does
+    // not add to it.
+    const mgr = makeManager(3);
+    await seedThreeViews(mgr);
+    bindLiveAssistant(mgr, "proj-b", "term-assistant");
+    residentWorkspaces.add("proj-a");
+
+    mgr.setCachedViewLimit(2);
+
+    expect(
+      mgr
+        .getAllViews()
+        .map((v) => v.projectId)
+        .sort()
+    ).toEqual(["proj-b", "proj-c"]);
   });
 
   it("protects nothing for a grant with no live view", async () => {

--- a/electron/window/__tests__/ProjectViewManager.eviction.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.eviction.test.ts
@@ -3935,11 +3935,11 @@ describe("ProjectViewManager — user-granted workspace residency (#12313)", () 
 
   it("does not widen an overflow another protection already caused", async () => {
     // The cap bound only means anything in composition. A live assistant's
-    // floor is unconditional and already holds the cache over its cap; if
-    // residency budgeted against the raw cap it would hold a third view on top,
-    // where without the grant the pass settles at two. Held slots are counted,
-    // so the assistant still overflows as it is entitled to and the grant does
-    // not add to it.
+    // floor is unconditional and already holds the cache over its cap; a grant
+    // that could refuse eviction would hold a third view on top, where without
+    // it the pass settles at two. Because `residentGranted` only sits last in
+    // `candidates`, the grant is the one thing this pass may still take, so the
+    // assistant overflows as it is entitled to and the grant adds nothing.
     const mgr = makeManager(3);
     await seedThreeViews(mgr);
     bindLiveAssistant(mgr, "proj-b", "term-assistant");

--- a/electron/window/__tests__/ProjectViewManager.eviction.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.eviction.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 
+/** Workspaces the user granted residency, read by the mocked preference below. */
+const residentWorkspaces = new Set<string>();
+
 let nextWebContentsId = 100;
 let nextOsProcessId = 1000;
 
@@ -87,6 +90,13 @@ vi.mock("../webContentsRegistry.js", () => ({
   unregisterProjectView: vi.fn(),
   registerCachedViewWebContents: vi.fn(),
   unregisterCachedViewWebContents: vi.fn(),
+}));
+
+vi.mock("../../services/workspaceResidency.js", () => ({
+  isWorkspaceKeepResident: (workspaceId: string) => residentWorkspaces.has(workspaceId),
+  recordWorkspaceEviction: vi.fn(),
+  clearWorkspaceEviction: vi.fn(),
+  notifyWorkspaceViewsChanged: vi.fn(),
 }));
 
 vi.mock("../../setup/protocols.js", () => ({
@@ -3707,5 +3717,216 @@ describe("ProjectViewManager — MCP bound sessions and dispatch leases (#11790)
     mgr.setCachedViewLimit(1);
 
     expect(mgr.getAllViews().map((v) => v.projectId)).toEqual(["proj-c"]);
+  });
+});
+
+describe("ProjectViewManager — user-granted workspace residency (#12313)", () => {
+  let win: ReturnType<typeof createMockWindow>;
+  let boundWorkspaces: Set<string>;
+  let managers: ProjectViewManager[];
+
+  type MemInfo = { free: number; purgeable?: number; total: number };
+  const originalSystemMemoryInfo = (process as unknown as { getSystemMemoryInfo?: () => MemInfo })
+    .getSystemMemoryInfo;
+
+  function setAvailableMb(availableMb: number) {
+    Object.defineProperty(process, "getSystemMemoryInfo", {
+      configurable: true,
+      value: () => ({ free: availableMb * 1024, purgeable: 0, total: 8 * 1024 * 1024 }),
+    });
+  }
+
+  const evictionLogFor = (projectId: string) =>
+    vi
+      .mocked(logInfo)
+      .mock.calls.find(
+        ([event, ctx]) =>
+          event === "projectview.eviction" && (ctx as { projectId: string }).projectId === projectId
+      )?.[1] as Record<string, unknown> | undefined;
+
+  function makeManager(cachedProjectViews: number) {
+    const mgr = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
+      warmPaintGateTimeoutMs: 0,
+      warmPaintGateHardTimeoutMs: 0,
+      cachedProjectViews,
+      assistantBackendsForProject,
+      isTerminalLive,
+      mcpViewActivity: (workspaceId: string) => ({
+        liveBinding: boundWorkspaces.has(workspaceId),
+        dispatchLease: false,
+      }),
+    });
+    managers.push(mgr);
+    return mgr;
+  }
+
+  /** Three views: proj-a and proj-b cached (oldest-first), proj-c active. */
+  async function seedThreeViews(mgr: ProjectViewManager) {
+    const wcA = createMockWebContents();
+    mgr.registerInitialView({ webContents: wcA, setBounds: vi.fn() } as never, "proj-a", "/path/a");
+    await mgr.switchTo("proj-b", "/path/b");
+    await flushImmediates();
+    await mgr.switchTo("proj-c", "/path/c");
+    await flushImmediates();
+  }
+
+  beforeEach(() => {
+    nextWebContentsId = 100;
+    nextOsProcessId = 1000;
+    vi.clearAllMocks();
+    mockGetAllTerminals.mockReset();
+    mockGetAllTerminals.mockResolvedValue([]);
+    mockGetAppMetrics.mockReset();
+    mockGetAppMetrics.mockReturnValue([]);
+    assistantBackends.clear();
+    liveTerminals.clear();
+    residentWorkspaces.clear();
+    boundWorkspaces = new Set();
+    managers = [];
+    win = createMockWindow();
+  });
+
+  afterEach(() => {
+    for (const mgr of managers) mgr.dispose();
+    managers = [];
+    residentWorkspaces.clear();
+    Object.defineProperty(process, "getSystemMemoryInfo", {
+      configurable: true,
+      value: originalSystemMemoryInfo,
+    });
+  });
+
+  it("keeps a granted workspace resident even though it is the LRU candidate", async () => {
+    // The whole ask: an operator rotating through other projects evicts the one
+    // holding their orchestrator's agents, and no cached-view limit makes it
+    // reliably resident. proj-a is the oldest, so pure LRU takes it first.
+    const mgr = makeManager(3);
+    await seedThreeViews(mgr);
+    residentWorkspaces.add("proj-a");
+
+    mgr.setCachedViewLimit(2);
+
+    expect(
+      mgr
+        .getAllViews()
+        .map((v) => v.projectId)
+        .sort()
+    ).toEqual(["proj-a", "proj-c"]);
+  });
+
+  it("holds at most one grant fewer than the cap, keeping the most recently used", async () => {
+    // Residency spends the user's own budget rather than adding to it. With a
+    // cap of 2 the active view takes one slot, so exactly one grant can be held
+    // — and it is the workspace they have actually been working in.
+    const mgr = makeManager(3);
+    await seedThreeViews(mgr);
+    residentWorkspaces.add("proj-a");
+    residentWorkspaces.add("proj-b");
+
+    mgr.setCachedViewLimit(2);
+
+    expect(
+      mgr
+        .getAllViews()
+        .map((v) => v.projectId)
+        .sort()
+    ).toEqual(["proj-b", "proj-c"]);
+  });
+
+  it("never carries the cache over the configured cap", async () => {
+    // The invariant that makes this a grant and not the floor #11790 refused:
+    // held grants plus the active view can never exceed `effectiveMax`, so
+    // granting every workspace cannot pin the cache.
+    const mgr = makeManager(3);
+    await seedThreeViews(mgr);
+    residentWorkspaces.add("proj-a");
+    residentWorkspaces.add("proj-b");
+    residentWorkspaces.add("proj-c");
+
+    mgr.setCachedViewLimit(1);
+
+    expect(mgr.getAllViews().map((v) => v.projectId)).toEqual(["proj-c"]);
+  });
+
+  it("yields every grant to a forced critical reclaim", async () => {
+    // The pressure valve stays working. `effectiveMax` is 1 on a forced pass,
+    // so the slot count reaches zero on its own — residency needs no
+    // critical-pressure branch to get out of the way.
+    const mgr = makeManager(3);
+    mgr.setMemoryPressurePolicy({ criticalMb: 1000, warningMb: 2000 });
+    setAvailableMb(2500);
+    await seedThreeViews(mgr);
+    residentWorkspaces.add("proj-a");
+    residentWorkspaces.add("proj-b");
+
+    expect(mgr.reclaimCachedViewsUnderPressure()).toBe(2);
+    expect(mgr.getAllViews().map((v) => v.projectId)).toEqual(["proj-c"]);
+  });
+
+  it("records the grant on the eviction it was overridden by", async () => {
+    // Eviction reported rather than silent. Without this the log reads as if
+    // the grant were simply ignored, instead of outranked by the cap.
+    const mgr = makeManager(3);
+    await seedThreeViews(mgr);
+    residentWorkspaces.add("proj-a");
+    residentWorkspaces.add("proj-b");
+
+    mgr.setCachedViewLimit(2);
+
+    expect(evictionLogFor("proj-a")).toMatchObject({ keepResident: true });
+  });
+
+  it("outranks a quiet bound session, which the client got for free", async () => {
+    // `boundMcpSessionFallback` is automatic ordering any connected client
+    // earns by existing; a grant is the user spending their own budget. When
+    // only one can be held, the user's choice wins.
+    const mgr = makeManager(3);
+    await seedThreeViews(mgr);
+    residentWorkspaces.add("proj-a");
+    boundWorkspaces.add("proj-b");
+
+    mgr.setCachedViewLimit(2);
+
+    expect(
+      mgr
+        .getAllViews()
+        .map((v) => v.projectId)
+        .sort()
+    ).toEqual(["proj-a", "proj-c"]);
+  });
+
+  it("protects nothing for a grant with no live view", async () => {
+    // The preference record is keyed by workspace id and nothing prunes it when
+    // a project is deleted or moved, so the grant only ever meets a view that
+    // actually exists — a stale row cannot hold the cache open (#11162).
+    const mgr = makeManager(3);
+    await seedThreeViews(mgr);
+    residentWorkspaces.add("proj-never-opened");
+
+    mgr.setCachedViewLimit(2);
+
+    expect(
+      mgr
+        .getAllViews()
+        .map((v) => v.projectId)
+        .sort()
+    ).toEqual(["proj-b", "proj-c"]);
+  });
+
+  it("changes nothing when the user has granted no workspace", async () => {
+    const mgr = makeManager(3);
+    await seedThreeViews(mgr);
+
+    mgr.setCachedViewLimit(2);
+
+    expect(
+      mgr
+        .getAllViews()
+        .map((v) => v.projectId)
+        .sort()
+    ).toEqual(["proj-b", "proj-c"]);
   });
 });

--- a/shared/types/ipc/generated-api.ts
+++ b/shared/types/ipc/generated-api.ts
@@ -841,4 +841,12 @@ export interface GeneratedElectronAPI {
       ...args: IpcInvokeMap["workspace:list"]["args"]
     ): Promise<IpcInvokeMap["workspace:list"]["result"]>;
   };
+  workspaceResidency: {
+    get(
+      ...args: IpcInvokeMap["workspace-residency:get"]["args"]
+    ): Promise<IpcInvokeMap["workspace-residency:get"]["result"]>;
+    set(
+      ...args: IpcInvokeMap["workspace-residency:set"]["args"]
+    ): Promise<IpcInvokeMap["workspace-residency:set"]["result"]>;
+  };
 }

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -1896,6 +1896,14 @@ export interface GeneratedIpcInvokeMap {
     args: [payload: { severity: "success" | "error" | "info" | "warning" | "neutral" | null }];
     result: void;
   };
+  "workspace-residency:get": {
+    args: [payload: { workspaceId: string }];
+    result: boolean;
+  };
+  "workspace-residency:set": {
+    args: [payload: { workspaceId: string; keepResident: boolean }];
+    result: void;
+  };
   "workspace:list": {
     args: [];
     result: import("./workspace.js").WorkspaceListEntry[];

--- a/src/clients/workspaceResidencyClient.ts
+++ b/src/clients/workspaceResidencyClient.ts
@@ -1,0 +1,9 @@
+export const workspaceResidencyClient = {
+  get: (workspaceId: string): Promise<boolean> => {
+    return window.electron.workspaceResidency.get({ workspaceId });
+  },
+
+  set: (workspaceId: string, keepResident: boolean): Promise<void> => {
+    return window.electron.workspaceResidency.set({ workspaceId, keepResident });
+  },
+};

--- a/src/components/Project/GeneralTab.tsx
+++ b/src/components/Project/GeneralTab.tsx
@@ -133,6 +133,10 @@ export function GeneralTab({
 }: GeneralTabProps) {
   const [isEmojiPickerOpen, setIsEmojiPickerOpen] = useState(false);
   const [keepResident, setKeepResident] = useState(false);
+  // Read by the residency save handler to tell "still this project" from "the
+  // dialog moved on"; a captured `projectId` would only ever equal itself.
+  const projectIdRef = useRef(projectId);
+  projectIdRef.current = projectId;
   const [keepResidentBusy, setKeepResidentBusy] = useState(true);
   const [keepResidentError, setKeepResidentError] = useState<string | null>(null);
   const [iconError, setIconError] = useState<string | null>(null);
@@ -339,7 +343,12 @@ export function GeneralTab({
   // place that reads it — so a fresh read when the tab opens is both simpler and
   // more current than anything cached would be.
   useEffect(() => {
-    if (!isOpen || !projectId) return;
+    if (!isOpen || !projectId) {
+      // The toggle starts disabled and only the load re-enables it, so a tab
+      // that never loads must not leave it stuck that way.
+      setKeepResidentBusy(false);
+      return;
+    }
     let cancelled = false;
     setKeepResidentBusy(true);
     setKeepResidentError(null);
@@ -365,15 +374,23 @@ export function GeneralTab({
 
   const handleKeepResidentToggle = async () => {
     const next = !keepResident;
+    // The write is for the project as it stands now. The dialog can be pointed
+    // at another project while it is in flight, and the load effect's own guard
+    // does not cover this direction — without the capture, a slow save for one
+    // project lands its result on whichever project the tab is showing when it
+    // settles, reporting the wrong grant or the wrong error.
+    const savingProjectId = projectId;
     setKeepResidentBusy(true);
     setKeepResidentError(null);
     try {
-      await workspaceResidencyClient.set(projectId, next);
-      setKeepResident(next);
+      await workspaceResidencyClient.set(savingProjectId, next);
+      if (savingProjectId === projectIdRef.current) setKeepResident(next);
     } catch (err) {
-      setKeepResidentError(formatErrorMessage(err, "Failed to save the residency setting"));
+      if (savingProjectId === projectIdRef.current) {
+        setKeepResidentError(formatErrorMessage(err, "Failed to save the residency setting"));
+      }
     } finally {
-      setKeepResidentBusy(false);
+      if (savingProjectId === projectIdRef.current) setKeepResidentBusy(false);
     }
   };
 
@@ -675,8 +692,8 @@ export function GeneralTab({
             disabled={keepResidentBusy}
           />
           <p className="text-xs text-text-secondary">
-            Spends one of your cached-view slots rather than adding to them, so it competes with
-            other projects you keep open. Low memory can still unload it.
+            Other projects are closed first to stay within your cached-view limit, rather than
+            raising it. Low memory can still unload this one.
           </p>
           {keepResidentError && (
             <div

--- a/src/components/Project/GeneralTab.tsx
+++ b/src/components/Project/GeneralTab.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect, useCallback, useMemo } from "react";
 import {
+  Anchor,
   Image,
   Upload,
   X,
@@ -25,6 +26,7 @@ import { GITIGNORE_SNIPPET } from "./projectSettingsConstants";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { isClientAppError } from "@/utils/clientAppError";
 import type { DaintreeMcpTier, Project } from "@shared/types/project";
+import { workspaceResidencyClient } from "@/clients/workspaceResidencyClient";
 import { useProjectSettingsStore } from "@/store/projectSettingsStore";
 import { useProjectRelocationStore } from "@/store/projectRelocationStore";
 import { findDevServerCandidate } from "@/utils/devServerDetection";
@@ -130,6 +132,9 @@ export function GeneralTab({
   isOpen,
 }: GeneralTabProps) {
   const [isEmojiPickerOpen, setIsEmojiPickerOpen] = useState(false);
+  const [keepResident, setKeepResident] = useState(false);
+  const [keepResidentBusy, setKeepResidentBusy] = useState(true);
+  const [keepResidentError, setKeepResidentError] = useState<string | null>(null);
   const [iconError, setIconError] = useState<string | null>(null);
   const [isDraggingIcon, setIsDraggingIcon] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -326,6 +331,49 @@ export function GeneralTab({
       setInRepoError(formatErrorMessage(err, "Failed to disable in-repo settings"));
     } finally {
       setInRepoEnabling(false);
+    }
+  };
+
+  // Loaded on open rather than held in a store: the grant lives in
+  // electron-store, another window can change it, and this dialog is the only
+  // place that reads it — so a fresh read when the tab opens is both simpler and
+  // more current than anything cached would be.
+  useEffect(() => {
+    if (!isOpen || !projectId) return;
+    let cancelled = false;
+    setKeepResidentBusy(true);
+    setKeepResidentError(null);
+    void workspaceResidencyClient
+      .get(projectId)
+      .then((value) => {
+        if (!cancelled) setKeepResident(value);
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setKeepResidentError(formatErrorMessage(err, "Failed to read the residency setting"));
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setKeepResidentBusy(false);
+      });
+    return () => {
+      // Guards the late response after the dialog closes or the project
+      // changes — otherwise a slow read lands on the next project's toggle.
+      cancelled = true;
+    };
+  }, [isOpen, projectId]);
+
+  const handleKeepResidentToggle = async () => {
+    const next = !keepResident;
+    setKeepResidentBusy(true);
+    setKeepResidentError(null);
+    try {
+      await workspaceResidencyClient.set(projectId, next);
+      setKeepResident(next);
+    } catch (err) {
+      setKeepResidentError(formatErrorMessage(err, "Failed to save the residency setting"));
+    } finally {
+      setKeepResidentBusy(false);
     }
   };
 
@@ -582,7 +630,7 @@ export function GeneralTab({
         </div>
       </div>
 
-      <div className="mb-6 pb-6 border-b border-border-default">
+      <div id="project-agent-integrations" className="mb-6 pb-6 border-b border-border-default">
         <h3 className="text-sm font-semibold text-text-primary mb-2 flex items-center gap-2">
           <McpServerIcon className="h-4 w-4" />
           Agent integrations
@@ -614,6 +662,28 @@ export function GeneralTab({
                 irreversible or visible to teammates. Only enable it for projects where you trust
                 the agent to take that kind of action.
               </div>
+            </div>
+          )}
+
+          <SettingsSwitchCard
+            icon={Anchor}
+            title="Keep workspace resident"
+            subtitle="Holds this project's view in the cache so a bound MCP session stays reachable"
+            isEnabled={keepResident}
+            onChange={() => void handleKeepResidentToggle()}
+            ariaLabel="Keep workspace resident"
+            disabled={keepResidentBusy}
+          />
+          <p className="text-xs text-text-secondary">
+            Spends one of your cached-view slots rather than adding to them, so it competes with
+            other projects you keep open. Low memory can still unload it.
+          </p>
+          {keepResidentError && (
+            <div
+              className="whitespace-pre-line text-xs text-status-error bg-status-error/10 border border-status-error/20 rounded-[var(--radius-md)] p-2"
+              role="alert"
+            >
+              {keepResidentError}
             </div>
           )}
         </div>

--- a/src/components/Project/__tests__/GeneralTab.devServerSuggestion.test.tsx
+++ b/src/components/Project/__tests__/GeneralTab.devServerSuggestion.test.tsx
@@ -36,6 +36,17 @@ vi.mock("@/components/Settings/SettingsSwitchCard", () => ({
   SettingsSwitchCard: () => null,
 }));
 
+// The residency toggle reads its grant over IPC on mount (#12313), and this
+// fixture renders the real component with no `window.electron` — the client
+// reaches through it directly, like every other client in the renderer, so the
+// stub belongs here rather than as a defensive branch in production code.
+vi.mock("@/clients/workspaceResidencyClient", () => ({
+  workspaceResidencyClient: {
+    get: vi.fn(() => Promise.resolve(false)),
+    set: vi.fn(() => Promise.resolve()),
+  },
+}));
+
 vi.mock("@/components/Settings/SettingsChoicebox", () => ({
   SettingsChoicebox: () => null,
 }));

--- a/src/components/Settings/settingsTabRegistry.tsx
+++ b/src/components/Settings/settingsTabRegistry.tsx
@@ -1789,6 +1789,13 @@ export const PROJECT_SETTINGS_SECTIONS: Readonly<
         keywords: ["dev", "server", "preview", "start", "command"],
       },
       {
+        id: "project-agent-integrations",
+        section: "Agent integrations",
+        title: "Keep Workspace Resident",
+        description: "Hold this project's view in the cache so a bound MCP session stays reachable",
+        keywords: ["resident", "mcp", "cache", "evict", "keep", "warm", "tier"],
+      },
+      {
         id: "project-in-repo-settings",
         section: "In-Repo Settings",
         title: "In-Repo Settings",


### PR DESCRIPTION
## Summary

- A workspace-bound MCP session routes every call through the one live project view its binding resolves to. When the LRU project-view cache evicts that view, every call fails `SESSION_BINDING_GONE`, including the reads the session would use to find out what happened. `resources/list` threw for exactly the session that needed it, leaving the client with no information and nothing to ask until a human reopens the project.
- Ships the first two asks from #12313 and defers the third (a reopen-request surface), following the issue's own ranking and because `tierAuth` already withholds confirm-gated tools from bound sessions.
- Adds a binding resource clients can read after eviction, stops `resources/list` from refusing outright, and adds a user-granted "keep workspace resident" toggle.

Resolves #12313

## Changes

### A binding resource

New resource at `daintree://workspace/current/binding`: route state, live view count, the residency grant, and when eviction last took the workspace. It dispatches nothing, so it's exempt from the route probe by construction rather than a special case. A `not-found` response with an `evictedAt` timestamp means the workspace was open and got evicted; `not-found` with `evictedAt` null means it was never seen open this run, a distinction clients couldn't draw before. It's a resource rather than a tool because the external tool allowlist is already full at 29/29 slots, and it rides `workspace.list`'s existing tier permission, so it costs no additional budget.

### `resources/list` no longer refuses

An unreachable workspace now degrades the dispatch-backed categories in the response instead of aborting the whole call, but only while the binding resource is still included, so the listing is never a bare empty response. That's the property the original test protected. A dead WebContents pin still causes a refusal, because unlike a workspace it has no later state to recover into.

### Keep workspace resident

A user-granted toggle in Project settings, under Agent integrations. When granted, eviction places that workspace last in the candidate queue, so rotating through other projects can no longer evict the one holding an orchestrator's agents. It respects both constraints from the issue without a special case for either: it can never push the cache over the configured cap, and it still yields under critical memory pressure. It's not an `ActionService` action, because the action manifest is also the MCP tool surface, and that would let a client grant itself the residency #11790 explicitly refused to grant automatically.

### Review notes

An earlier implementation reserved cache slots for grants, but that reservation could pin the cache indefinitely when combined with the assistant's hard floor: cap of 2, plus an active view, plus the assistant, plus a grant, leaves nothing evictable and holds three views forever. No test could tell the reservation apart from plain ordering. Both problems traced to the same cause: any reservation large enough to be safe is never reached, because the eviction pass converges first. Replaced the reservation with a plain eviction tier, same behavior in less code. Review also caught nine broken tests in `GeneralTab.devServerSuggestion.test.tsx` (the new mount-time read had no `window.electron` in that test setup) and a missing stale-guard on the residency save.

## Testing

2457 tests passing across every touched module (`electron/window/`, `electron/services/mcp-server/`, the store, the settings registry, `GeneralTab`), clean typecheck, lint ratchet satisfied, `check:channels` passing, IPC types regenerated via codegen rather than hand-edited.

Known issue, left deliberately unaddressed: returning to the General tab after another window changes the grant can show a stale toggle, because the settings dialog keeps visited tabs mounted so the load effect's dependencies don't refire. Fixing it needs a renderer broadcast channel for the two-window edge case.