### PR TITLE
fix(electron/services): stop Grok idle redraws holding the agent busy

### DIFF
--- a/electron/services/ActivityMonitor.ts
+++ b/electron/services/ActivityMonitor.ts
@@ -634,7 +634,12 @@ export class ActivityMonitor {
       // #8867 focus gate), treat that as activity: refresh the activity clock
       // so heavy streaming keeps the agent working, and recover idle→busy.
       if (this.simpleOutputVolumeDetector) {
-        const filteredLength = Buffer.byteLength(stripIdleTerminalSequences(data), "utf8");
+        // Cursor placement and SGR resets carry bytes without new text. Grok
+        // emits these after a turn, so counting them can hold busy forever.
+        const filteredLength = Buffer.byteLength(
+          stripAnsi(stripIdleTerminalSequences(data)),
+          "utf8"
+        );
         if (
           filteredLength > 0 &&
           this.simpleOutputVolumeDetector.update(filteredLength, now) &&

--- a/electron/services/__tests__/ActivityMonitor.simple-output.test.ts
+++ b/electron/services/__tests__/ActivityMonitor.simple-output.test.ts
@@ -862,6 +862,40 @@ describe("ActivityMonitor", () => {
       const plainOptions = buildActivityMonitorOptions(undefined, {});
       expect(plainOptions.simpleOutputVolumeRecovery).toBeUndefined();
     });
+
+    it.each(["busy", "idle"] as const)(
+      "ignores sustained Grok idle redraws when initially %s",
+      (initialState) => {
+        const onStateChange = vi.fn();
+        const visible = ["READY", "Worked for 3.7s", "minimal · /help", "❯"];
+        const monitor = new ActivityMonitor("grok-redraw", 1000, onStateChange, {
+          ...buildActivityMonitorOptions("grok", {
+            getVisibleLines: () => visible,
+            getCursorLine: () => "❯",
+          }),
+          initialState,
+        });
+        monitor.startPolling();
+
+        // Grok 1.0.13 emits this frame after answering: SGR resets, a Kitty
+        // image deletion, and cursor placement, with no visible text change.
+        const redraw =
+          "\x1b[?2026h\x1b[?2026h\x1b[m\x1b[m\x1b[m\x1b[0m" +
+          "\x1b_Ga=d,d=i,i=1,q=2\x1b\\\x1b[25;3H\x1b[?2026l";
+        for (let i = 0; i < 300; i += 1) {
+          monitor.onData(redraw);
+          vi.advanceTimersByTime(100);
+        }
+
+        expect(monitor.getState()).toBe("idle");
+        expect(
+          onStateChange.mock.calls.filter(
+            (call) => call[2] === "busy" && call[3]?.trigger === "output"
+          )
+        ).toHaveLength(0);
+        monitor.dispose();
+      }
+    );
   });
 
   describe("notifySubmission (hybrid input bar)", () => {

--- a/electron/services/pty/IdleSequenceFilter.ts
+++ b/electron/services/pty/IdleSequenceFilter.ts
@@ -41,6 +41,11 @@ const CPR_NOISE = /\x1b\[\d{1,4};\d{1,4}R/gu;
 const DSR_NOISE = /\x1b\[6n/gu;
 // eslint-disable-next-line no-control-regex
 const BPASTE_NOISE = /\x1b\[20[01]~/gu;
+// Grok redraws delete the same Kitty image even when it is already absent.
+// Keep image transmission/display commands observable; only delete commands
+// without an image payload are protocol noise.
+// eslint-disable-next-line no-control-regex
+const KITTY_DELETE_NOISE = /\x1b_Ga=d(?:,[a-zA-Z]=[a-zA-Z0-9]{1,10}){0,16}\x1b\\/gu;
 
 export function stripIdleTerminalSequences(data: string): string {
   // Every pattern below requires a literal ESC; skip all passes when absent.
@@ -52,5 +57,6 @@ export function stripIdleTerminalSequences(data: string): string {
     .replace(DECSET_NOISE, "")
     .replace(CPR_NOISE, "")
     .replace(DSR_NOISE, "")
-    .replace(BPASTE_NOISE, "");
+    .replace(BPASTE_NOISE, "")
+    .replace(KITTY_DELETE_NOISE, "");
 }

--- a/electron/services/pty/__tests__/IdleSequenceFilter.test.ts
+++ b/electron/services/pty/__tests__/IdleSequenceFilter.test.ts
@@ -2,6 +2,19 @@ import { describe, it, expect } from "vitest";
 import { stripIdleTerminalSequences } from "../IdleSequenceFilter.js";
 
 describe("stripIdleTerminalSequences", () => {
+  it("strips Grok's repeated Kitty image deletion without removing visible output", () => {
+    const deletion = "\x1b_Ga=d,d=i,i=1,q=2\x1b\\";
+    expect(stripIdleTerminalSequences(deletion)).toBe("");
+    expect(stripIdleTerminalSequences(`READY${deletion}❯`)).toBe("READY❯");
+  });
+
+  it("preserves Kitty image transmission and incomplete delete commands", () => {
+    const transmission = "\x1b_Ga=T,f=100;AAAA\x1b\\";
+    const incomplete = "\x1b_Ga=d,d=i,i=1,q=2";
+    expect(stripIdleTerminalSequences(transmission)).toBe(transmission);
+    expect(stripIdleTerminalSequences(incomplete)).toBe(incomplete);
+  });
+
   it("returns plain text unchanged", () => {
     expect(stripIdleTerminalSequences("hello world")).toBe("hello world");
   });


### PR DESCRIPTION
## Summary

Grok 1.0.13 redraws its prompt after every answer with a frame that carries no new text: a run of SGR resets, a Kitty image delete for an image that is already gone, and a cursor move. The simple-output volume detector counted those bytes as streaming output, so a Grok terminal could sit on "working" indefinitely after the turn had finished.

Those sequences are now excluded from the activity count. Real output still recovers idle to busy exactly as before.

## Changes

- `ActivityMonitor.ts`: run the chunk through `stripAnsi()` after `stripIdleTerminalSequences()` before measuring simple-output volume, so cursor placement and colour resets carry no weight.
- `IdleSequenceFilter.ts`: add `KITTY_DELETE_NOISE` so payload-less Kitty image delete commands (`ESC _ G a=d ... ESC \`) are treated as protocol noise. Image transmission and display commands, and incomplete delete commands, are left untouched so they stay observable.
- Tests: a filter test for the delete sequence and the preserved cases, plus an `ActivityMonitor` test that replays the Grok post-answer frame 300 times from both `busy` and `idle` and asserts no output-triggered busy transition.

## Testing

- The full vitest suite (57,497 tests), typecheck, lint, and format check all passed. The one failure was `check:sample-views`, which is a known worktree-path false positive unrelated to this change.
- Re-ran `ActivityMonitor.simple-output.test.ts` and `IdleSequenceFilter.test.ts` before opening this PR: 72 tests, all passing.

The counting path has been in place since June, so this is not a fresh regression. Confirming it fixes the observed Grok session needs a build with this change in it.