### PR TITLE
fix(forge): let providers supply the PR-head refspec for PR checkout

### DIFF
--- a/electron/ipc/handlers/__tests__/forgeResolution.test.ts
+++ b/electron/ipc/handlers/__tests__/forgeResolution.test.ts
@@ -60,7 +60,11 @@ const pluginServiceMock = vi.hoisted(() => ({
 
 vi.mock("../../../services/PluginService.js", () => ({ pluginService: pluginServiceMock }));
 
-import { resolveForCwd, resolveForgeRemoteNameForCwd } from "../forgeResolution.js";
+import {
+  resolveForCwd,
+  resolveForgeRemoteNameForCwd,
+  resolvePRHeadRefspecForCwd,
+} from "../forgeResolution.js";
 
 const giteaEntry: ForgeProviderEntry = {
   pluginId: "acme",
@@ -615,5 +619,161 @@ describe("resolveForgeRemoteNameForCwd", () => {
     gitServiceMock.listRemotes.mockResolvedValue([]);
 
     await expect(resolveForgeRemoteNameForCwd("/repo")).resolves.toBeNull();
+  });
+});
+
+describe("resolvePRHeadRefspecForCwd", () => {
+  const GITLAB_REFSPEC = "refs/merge-requests/42/head:feature/my-branch";
+
+  /** A resolvable provider whose impl is whatever the test hands in. */
+  function withProvider(impl: Record<string, unknown>): void {
+    registryMock.getForgeProviderImpl.mockReturnValue({
+      parseRemote: vi.fn(() => ({ owner: "owner", repo: "repo" })),
+      ...impl,
+    });
+    resolverMock.resolveForgeProvider.mockReturnValue({
+      entry: giteaEntry,
+      resolvedVia: "hostname",
+    });
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    gitServiceCacheMock.getGitService.mockReturnValue(gitServiceMock);
+    gitServiceMock.getRemoteUrl.mockResolvedValue("https://gitea.example.com/owner/repo.git");
+    gitServiceMock.listWorktrees.mockResolvedValue([
+      { path: "/repo", branch: "main", bare: false, isMainWorktree: true },
+    ]);
+    gitServiceMock.getRepositoryRoot.mockResolvedValue("/repo");
+    projectStoreMock.getProjectByPath.mockResolvedValue({ id: "project-1", path: "/repo" });
+    projectStoreMock.getProjectSettings.mockResolvedValue({ runCommands: [] });
+    gitServiceMock.listRemotes.mockResolvedValue([
+      { name: "origin", fetchUrl: "https://gitea.example.com/owner/repo.git" },
+    ]);
+    registryMock.listMatchingProviders.mockReturnValue([{}]);
+  });
+
+  it("returns the provider's refspec verbatim", async () => {
+    const buildPRHeadRefspec = vi.fn(() => GITLAB_REFSPEC);
+    withProvider({ buildPRHeadRefspec });
+
+    await expect(resolvePRHeadRefspecForCwd("/repo", 42, "feature/my-branch")).resolves.toBe(
+      GITLAB_REFSPEC
+    );
+    expect(buildPRHeadRefspec).toHaveBeenCalledWith(42, "feature/my-branch");
+  });
+
+  it("activates a lazily bound provider to read the capability", async () => {
+    const buildPRHeadRefspec = vi.fn(() => GITLAB_REFSPEC);
+    registryMock.getForgeProviderImpl.mockReturnValueOnce(undefined);
+    pluginServiceMock.activatePluginForForgeProvider.mockImplementationOnce(async () => {
+      registryMock.getForgeProviderImpl.mockReturnValue({
+        parseRemote: vi.fn(() => ({ owner: "owner", repo: "repo" })),
+        buildPRHeadRefspec,
+      });
+    });
+    resolverMock.resolveForgeProvider.mockReturnValue({
+      entry: giteaEntry,
+      resolvedVia: "hostname",
+    });
+
+    await expect(resolvePRHeadRefspecForCwd("/repo", 42, "feature/my-branch")).resolves.toBe(
+      GITLAB_REFSPEC
+    );
+    expect(pluginServiceMock.activatePluginForForgeProvider).toHaveBeenCalledWith("acme.gitea");
+  });
+
+  it("preserves an explicit null — the forge has no fetchable PR ref", async () => {
+    // Bitbucket Cloud. Distinct from `undefined`: the caller reports it rather
+    // than attempting a fetch that cannot succeed.
+    withProvider({ buildPRHeadRefspec: vi.fn(() => null) });
+
+    await expect(resolvePRHeadRefspecForCwd("/repo", 42, "feature/x")).resolves.toBeNull();
+  });
+
+  it("returns undefined when the provider has no such capability", async () => {
+    withProvider({});
+
+    await expect(resolvePRHeadRefspecForCwd("/repo", 42, "feature/x")).resolves.toBeUndefined();
+  });
+
+  it("returns undefined for a capability explicitly set to undefined", async () => {
+    // The `in` operator would report this as present and then call a non-function.
+    withProvider({ buildPRHeadRefspec: undefined });
+
+    await expect(resolvePRHeadRefspecForCwd("/repo", 42, "feature/x")).resolves.toBeUndefined();
+  });
+
+  it("returns undefined when no provider is registered, never another's shape", async () => {
+    resolverMock.resolveForgeProvider.mockReturnValue({ entry: null, resolvedVia: null });
+
+    await expect(resolvePRHeadRefspecForCwd("/repo", 42, "feature/x")).resolves.toBeUndefined();
+  });
+
+  it("returns undefined when the plugin fails to activate", async () => {
+    registryMock.getForgeProviderImpl.mockReturnValue(undefined);
+    pluginServiceMock.activatePluginForForgeProvider.mockRejectedValueOnce(
+      new Error("activation failed")
+    );
+    resolverMock.resolveForgeProvider.mockReturnValue({
+      entry: giteaEntry,
+      resolvedVia: "hostname",
+    });
+
+    await expect(resolvePRHeadRefspecForCwd("/repo", 42, "feature/x")).resolves.toBeUndefined();
+  });
+
+  it("returns undefined when the builder throws", async () => {
+    // A throw is "capability unknown", not "unsupported" — only `null` says that.
+    withProvider({
+      buildPRHeadRefspec: vi.fn(() => {
+        throw new Error("provider blew up");
+      }),
+    });
+
+    await expect(resolvePRHeadRefspecForCwd("/repo", 42, "feature/x")).resolves.toBeUndefined();
+  });
+
+  it("returns undefined for a path that is not a git repository", async () => {
+    gitServiceCacheMock.getGitService.mockReturnValue(null);
+
+    await expect(
+      resolvePRHeadRefspecForCwd("/not-a-repo", 42, "feature/x")
+    ).resolves.toBeUndefined();
+  });
+
+  it("swallows a stale-remote failure rather than rethrowing it", async () => {
+    // Callers resolve the remote name first precisely because this one cannot
+    // be trusted to surface that failure — asserted here so the ordering
+    // requirement in `branches.ts` stays visibly load-bearing.
+    gitServiceMock.listRemotes.mockResolvedValue([
+      { name: "origin", fetchUrl: "https://gitea.example.com/owner/repo.git" },
+    ]);
+    projectStoreMock.getProjectSettings.mockResolvedValue({
+      runCommands: [],
+      forgeRemote: "gone",
+    });
+
+    await expect(resolvePRHeadRefspecForCwd("/repo", 42, "feature/x")).resolves.toBeUndefined();
+  });
+
+  it.each([
+    ["an empty string", ""],
+    ["whitespace only", "   "],
+    ["a refspec with no destination", "refs/merge-requests/42/head"],
+    ["a non-string", 42 as unknown as string],
+  ])("rejects %s and falls back", async (_label, value) => {
+    withProvider({ buildPRHeadRefspec: vi.fn(() => value) });
+
+    await expect(resolvePRHeadRefspecForCwd("/repo", 42, "feature/x")).resolves.toBeUndefined();
+  });
+
+  it("rejects a force refspec so a provider cannot clobber the local branch", async () => {
+    // This fetch has never force-updated; a `+` prefix would change that silently.
+    withProvider({
+      buildPRHeadRefspec: vi.fn(() => "+refs/merge-requests/42/head:feature/x"),
+    });
+
+    await expect(resolvePRHeadRefspecForCwd("/repo", 42, "feature/x")).resolves.toBeUndefined();
   });
 });

--- a/electron/ipc/handlers/__tests__/forgeResolution.test.ts
+++ b/electron/ipc/handlers/__tests__/forgeResolution.test.ts
@@ -757,10 +757,26 @@ describe("resolvePRHeadRefspecForCwd", () => {
     await expect(resolvePRHeadRefspecForCwd("/repo", 42, "feature/x")).resolves.toBeUndefined();
   });
 
+  it("accepts a fully-qualified destination for the same branch", async () => {
+    withProvider({
+      buildPRHeadRefspec: vi.fn(() => "refs/merge-requests/42/head:refs/heads/feature/x"),
+    });
+
+    await expect(resolvePRHeadRefspecForCwd("/repo", 42, "feature/x")).resolves.toBe(
+      "refs/merge-requests/42/head:refs/heads/feature/x"
+    );
+  });
+
   it.each([
     ["an empty string", ""],
     ["whitespace only", "   "],
-    ["a refspec with no destination", "refs/merge-requests/42/head"],
+    ["no destination at all", "refs/merge-requests/42/head"],
+    ["an empty destination", "refs/merge-requests/42/head:"],
+    ["an empty source", ":feature/x"],
+    ["more than one mapping separator", "refs/merge-requests/42/head:feature/x:extra"],
+    ["a wildcard mapping", "refs/merge-requests/*:refs/heads/*"],
+    ["surrounding whitespace", " refs/merge-requests/42/head:feature/x "],
+    ["a smuggled second argument", "refs/merge-requests/42/head:feature/x --depth=1"],
     ["a non-string", 42 as unknown as string],
   ])("rejects %s and falls back", async (_label, value) => {
     withProvider({ buildPRHeadRefspec: vi.fn(() => value) });
@@ -768,11 +784,25 @@ describe("resolvePRHeadRefspecForCwd", () => {
     await expect(resolvePRHeadRefspecForCwd("/repo", 42, "feature/x")).resolves.toBeUndefined();
   });
 
-  it("rejects a force refspec so a provider cannot clobber the local branch", async () => {
-    // This fetch has never force-updated; a `+` prefix would change that silently.
-    withProvider({
-      buildPRHeadRefspec: vi.fn(() => "+refs/merge-requests/42/head:feature/x"),
-    });
+  it.each([
+    ["a force refspec", "+refs/merge-requests/42/head:feature/x"],
+    ["a negative refspec", "^refs/merge-requests/42/head:feature/x"],
+    ["something git would read as an option", "--filter=blob:none"],
+  ])("rejects %s so git cannot reinterpret the argument", async (_label, value) => {
+    withProvider({ buildPRHeadRefspec: vi.fn(() => value) });
+
+    await expect(resolvePRHeadRefspecForCwd("/repo", 42, "feature/x")).resolves.toBeUndefined();
+  });
+
+  it.each([
+    ["an unrelated local branch", "refs/merge-requests/42/head:refs/heads/main"],
+    ["the bare name of another branch", "refs/merge-requests/42/head:main"],
+    ["a ref outside refs/heads", "refs/merge-requests/42/head:refs/daintree/pwned"],
+    ["a near-miss on the requested name", "refs/merge-requests/42/head:feature/x2"],
+  ])("refuses to write to %s", async (_label, value) => {
+    // git needs no `+` to fast-forward another branch, and outside
+    // refs/heads/* it will take a non-fast-forward update too.
+    withProvider({ buildPRHeadRefspec: vi.fn(() => value) });
 
     await expect(resolvePRHeadRefspecForCwd("/repo", 42, "feature/x")).resolves.toBeUndefined();
   });

--- a/electron/ipc/handlers/forgeResolution.ts
+++ b/electron/ipc/handlers/forgeResolution.ts
@@ -224,6 +224,60 @@ export async function resolveForgeRemoteNameForCwd(cwd: string): Promise<string 
   return null;
 }
 
+/**
+ * The provider-shaped refspec that fetches a PR's head into `headRefName`, for
+ * the checkout fallback that runs when the head branch isn't already local
+ * (#12324). Resolved here, next to the remote name, so the workspace host never
+ * gains a forge-provider dependency.
+ *
+ * Three outcomes, and the difference between the last two is the whole point:
+ *
+ *  - a string — the provider's refspec, used verbatim.
+ *  - `null` — the provider says this forge has no fetchable PR-head ref at all
+ *    (Bitbucket Cloud). The caller reports that instead of fetching.
+ *  - `undefined` — we could not find out. No provider is registered for this
+ *    repo, none is installed, the plugin failed to activate, the capability is
+ *    absent, or the builder threw or returned something unusable. The caller
+ *    falls back to the GitHub-shaped default, which is exactly the pre-#12324
+ *    behavior — a repo whose PR fetch worked before must never start failing
+ *    because a *capability lookup* did (#10192).
+ *
+ * Unlike {@link resolveForgeRemoteNameForCwd} this does activate the provider:
+ * the builder lives on the implementation, and there is no manifest-level
+ * declaration to read instead. Deciding the refspec from whichever plugins
+ * happen to be warm would make the same repo fetch differently run to run. The
+ * cost is bounded — activation is coalesced by PluginService, and the caller
+ * is about to do a network fetch regardless.
+ *
+ * Callers must resolve the remote name BEFORE calling this. That call fails
+ * closed on a stale or unverifiable remote, and this function's catch-all would
+ * otherwise swallow the same failure into a silent GitHub-shaped fallback.
+ */
+export async function resolvePRHeadRefspecForCwd(
+  cwd: string,
+  prNumber: number,
+  headRefName: string
+): Promise<string | null | undefined> {
+  let refspec: string | null;
+  try {
+    const { impl } = await resolveForCwd(cwd);
+    // Truthiness, never `in`: a capability explicitly set to `undefined` still
+    // satisfies `in` and would be called as a non-function.
+    if (!impl.buildPRHeadRefspec) return undefined;
+    refspec = impl.buildPRHeadRefspec(prNumber, headRefName);
+  } catch {
+    return undefined;
+  }
+  if (refspec === null) return null;
+  // The value goes straight into `git fetch` argv, so a provider bug must not
+  // become a surprising local-ref write. A `+` prefix would silently turn a
+  // fetch that has never force-updated into one that clobbers the destination.
+  if (typeof refspec !== "string") return undefined;
+  const trimmed = refspec.trim();
+  if (!trimmed || trimmed.startsWith("+") || !trimmed.includes(":")) return undefined;
+  return trimmed;
+}
+
 export async function resolveForCwd(cwd: string): Promise<ResolvedForgeContext> {
   if (typeof cwd !== "string" || !cwd) {
     throw new Error("Invalid working directory");

--- a/electron/ipc/handlers/forgeResolution.ts
+++ b/electron/ipc/handlers/forgeResolution.ts
@@ -225,6 +225,41 @@ export async function resolveForgeRemoteNameForCwd(cwd: string): Promise<string 
 }
 
 /**
+ * Accept a provider's refspec only if it maps one source ref onto exactly the
+ * branch the caller asked for. The provider owns the source hierarchy; the
+ * destination is the host's, and this is where that stops being a convention.
+ *
+ * The value goes into `git fetch` argv, and git updates whatever destination it
+ * is handed. Everything rejected here is something git would otherwise accept
+ * and do:
+ *
+ *  - `...:refs/heads/main` fast-forwards an unrelated local branch. A leading
+ *    `+` is not required for that, and outside `refs/heads/*` and `refs/tags/*`
+ *    git takes even non-fast-forward updates without one.
+ *  - `:feature/x` is not a delete on fetch the way it is on push — it fetches
+ *    the remote's HEAD, so the worktree would be built on the default branch
+ *    instead of the PR, silently and successfully.
+ *  - `refs/merge-requests/42/head:` fetches the objects and creates no branch,
+ *    which the host would still report as a successful fetch.
+ *  - A leading `-` is parsed as an option rather than a refspec, which drops the
+ *    mapping and lets the repo's configured fetch refspecs apply instead.
+ *  - A `*` maps a whole hierarchy, writing refs nobody asked for.
+ *
+ * Whitespace is rejected rather than trimmed: a ref name cannot contain any, so
+ * its presence means the provider built the string wrong, and trimming would
+ * hide that. It also keeps JS whitespace semantics from quietly reshaping a ref
+ * name git would have read differently.
+ */
+function isRefspecForBranch(refspec: string, headRefName: string): boolean {
+  if (/^[+^-]/.test(refspec) || /\s/.test(refspec) || refspec.includes("*")) return false;
+  const parts = refspec.split(":");
+  if (parts.length !== 2) return false;
+  const [src, dst] = parts;
+  if (!src || !dst) return false;
+  return dst === headRefName || dst === `refs/heads/${headRefName}`;
+}
+
+/**
  * The provider-shaped refspec that fetches a PR's head into `headRefName`, for
  * the checkout fallback that runs when the head branch isn't already local
  * (#12324). Resolved here, next to the remote name, so the workspace host never
@@ -269,13 +304,10 @@ export async function resolvePRHeadRefspecForCwd(
     return undefined;
   }
   if (refspec === null) return null;
-  // The value goes straight into `git fetch` argv, so a provider bug must not
-  // become a surprising local-ref write. A `+` prefix would silently turn a
-  // fetch that has never force-updated into one that clobbers the destination.
-  if (typeof refspec !== "string") return undefined;
-  const trimmed = refspec.trim();
-  if (!trimmed || trimmed.startsWith("+") || !trimmed.includes(":")) return undefined;
-  return trimmed;
+  // A provider bug must not become a surprising local-ref write, so anything
+  // that doesn't land on exactly the requested branch degrades to the default.
+  if (typeof refspec !== "string" || !isRefspecForBranch(refspec, headRefName)) return undefined;
+  return refspec;
 }
 
 export async function resolveForCwd(cwd: string): Promise<ResolvedForgeContext> {

--- a/electron/ipc/handlers/worktree/__tests__/branches.test.ts
+++ b/electron/ipc/handlers/worktree/__tests__/branches.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const ipcHandlers = vi.hoisted(() => new Map<string, unknown>());
+const ipcMainMock = vi.hoisted(() => ({
+  handle: vi.fn((channel: string, fn: unknown) => ipcHandlers.set(channel, fn)),
+  removeHandler: vi.fn((channel: string) => ipcHandlers.delete(channel)),
+}));
+
+vi.mock("electron", () => ({ ipcMain: ipcMainMock }));
+
+vi.mock("../../../utils.js", () => {
+  const typedHandle = (channel: string, handler: unknown) => {
+    ipcMainMock.handle(channel, (_e: unknown, ...args: unknown[]) =>
+      (handler as (...a: unknown[]) => unknown)(...args)
+    );
+    return () => ipcMainMock.removeHandler(channel);
+  };
+  return {
+    checkRateLimit: vi.fn(),
+    waitForRateLimitSlot: vi.fn().mockResolvedValue(undefined),
+    waitForBurstRateLimitSlot: vi.fn().mockResolvedValue(undefined),
+    typedHandle,
+    typedHandleWithContext: typedHandle,
+    typedHandleValidated: typedHandle,
+    typedHandleWithContextValidated: typedHandle,
+  };
+});
+
+const resolveForgeRemoteNameForCwdMock = vi.hoisted(() =>
+  vi.fn<(cwd: string) => Promise<string | null>>(async () => "origin")
+);
+const resolvePRHeadRefspecForCwdMock = vi.hoisted(() =>
+  vi.fn<(cwd: string, prNumber: number, headRefName: string) => Promise<string | null | undefined>>(
+    async () => undefined
+  )
+);
+
+vi.mock("../../forgeResolution.js", () => ({
+  resolveForgeRemoteNameForCwd: resolveForgeRemoteNameForCwdMock,
+  resolvePRHeadRefspecForCwd: resolvePRHeadRefspecForCwdMock,
+}));
+
+vi.mock("../../../../services/GitServiceCache.js", () => ({
+  gitServiceCache: { getGitService: vi.fn() },
+}));
+
+vi.mock("../../../../utils/worktreePattern.js", () => ({
+  resolveWorktreePattern: vi.fn().mockResolvedValue("../wt/{branch}"),
+}));
+
+vi.mock("../../../../../shared/utils/pathPattern.js", () => ({
+  generateWorktreePath: vi.fn(),
+  validatePathPattern: vi.fn(() => ({ valid: true })),
+}));
+
+import { registerWorktreeBranchHandlers } from "../branches.js";
+import { CHANNELS } from "../../../channels.js";
+import type { HandlerDependencies } from "../../../types.js";
+
+type Handler = (event: unknown, ...args: unknown[]) => Promise<unknown>;
+
+const PAYLOAD = { rootPath: "/repo", prNumber: 42, headRefName: "feature/my-branch" };
+const GITLAB_REFSPEC = "refs/merge-requests/42/head:feature/my-branch";
+
+describe("handleWorktreeFetchPRBranch", () => {
+  let cleanup: () => void;
+  let fetchPRBranch: ReturnType<typeof vi.fn>;
+
+  function invoke(payload: unknown = PAYLOAD): Promise<unknown> {
+    const handler = ipcHandlers.get(CHANNELS.WORKTREE_FETCH_PR_BRANCH) as Handler | undefined;
+    if (!handler) throw new Error("fetchPRBranch handler not registered");
+    return handler(null, payload);
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ipcHandlers.clear();
+    resolveForgeRemoteNameForCwdMock.mockResolvedValue("origin");
+    resolvePRHeadRefspecForCwdMock.mockResolvedValue(undefined);
+    fetchPRBranch = vi.fn().mockResolvedValue(undefined);
+    cleanup = registerWorktreeBranchHandlers({
+      worktreeService: { fetchPRBranch },
+    } as unknown as HandlerDependencies);
+  });
+
+  afterEach(() => {
+    cleanup?.();
+  });
+
+  it("threads the resolved remote and refspec to the workspace host", async () => {
+    resolveForgeRemoteNameForCwdMock.mockResolvedValue("upstream");
+    resolvePRHeadRefspecForCwdMock.mockResolvedValue(GITLAB_REFSPEC);
+
+    await invoke();
+
+    expect(resolvePRHeadRefspecForCwdMock).toHaveBeenCalledWith("/repo", 42, "feature/my-branch");
+    expect(fetchPRBranch).toHaveBeenCalledWith(
+      "/repo",
+      42,
+      "feature/my-branch",
+      "upstream",
+      GITLAB_REFSPEC
+    );
+  });
+
+  it("passes undefined through so the host applies its GitHub-shaped default", async () => {
+    resolveForgeRemoteNameForCwdMock.mockResolvedValue("upstream");
+
+    await invoke();
+
+    expect(fetchPRBranch).toHaveBeenCalledWith(
+      "/repo",
+      42,
+      "feature/my-branch",
+      "upstream",
+      undefined
+    );
+  });
+
+  it("maps a null remote to undefined, leaving the host's origin default", async () => {
+    resolveForgeRemoteNameForCwdMock.mockResolvedValue(null);
+
+    await invoke();
+
+    expect(fetchPRBranch).toHaveBeenCalledWith(
+      "/repo",
+      42,
+      "feature/my-branch",
+      undefined,
+      undefined
+    );
+  });
+
+  it("refuses to fetch when the forge publishes no PR-head ref", async () => {
+    // `null` is the provider saying so positively; the GitHub default would
+    // fail with an unrelated "couldn't find remote ref".
+    resolvePRHeadRefspecForCwdMock.mockResolvedValue(null);
+
+    await expect(invoke()).rejects.toThrow(/doesn't publish a fetchable ref/);
+    expect(fetchPRBranch).not.toHaveBeenCalled();
+  });
+
+  it("propagates a stale-remote failure without resolving a refspec", async () => {
+    // Ordering is load-bearing: the refspec resolver swallows every failure
+    // into the GitHub default, so it must never run before this one.
+    resolveForgeRemoteNameForCwdMock.mockRejectedValue(
+      new Error('This project is set to use the "gone" remote, which isn\'t available.')
+    );
+
+    await expect(invoke()).rejects.toThrow(/"gone" remote/);
+    expect(resolvePRHeadRefspecForCwdMock).not.toHaveBeenCalled();
+    expect(fetchPRBranch).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["a missing rootPath", { ...PAYLOAD, rootPath: "" }, /rootPath is required/],
+    ["a zero prNumber", { ...PAYLOAD, prNumber: 0 }, /prNumber must be a positive number/],
+    ["a missing headRefName", { ...PAYLOAD, headRefName: "" }, /headRefName is required/],
+  ])("rejects %s before any forge resolution", async (_label, payload, matcher) => {
+    await expect(invoke(payload)).rejects.toThrow(matcher);
+    expect(resolveForgeRemoteNameForCwdMock).not.toHaveBeenCalled();
+    expect(resolvePRHeadRefspecForCwdMock).not.toHaveBeenCalled();
+    expect(fetchPRBranch).not.toHaveBeenCalled();
+  });
+});

--- a/electron/ipc/handlers/worktree/__tests__/branches.test.ts
+++ b/electron/ipc/handlers/worktree/__tests__/branches.test.ts
@@ -136,7 +136,11 @@ describe("handleWorktreeFetchPRBranch", () => {
     // fail with an unrelated "couldn't find remote ref".
     resolvePRHeadRefspecForCwdMock.mockResolvedValue(null);
 
+    // The PR number and branch are the actionable parts — this message is all
+    // the caller gets, since no fetch will run to produce a git error.
     await expect(invoke()).rejects.toThrow(/doesn't publish a fetchable ref/);
+    await expect(invoke()).rejects.toThrow(/pull request #42/);
+    await expect(invoke()).rejects.toThrow(/"feature\/my-branch"/);
     expect(fetchPRBranch).not.toHaveBeenCalled();
   });
 

--- a/electron/ipc/handlers/worktree/branches.ts
+++ b/electron/ipc/handlers/worktree/branches.ts
@@ -4,7 +4,7 @@ import type { BranchInfo } from "../../../../shared/types/git.js";
 import { generateWorktreePath, validatePathPattern } from "../../../../shared/utils/pathPattern.js";
 import { resolveWorktreePattern } from "../../../utils/worktreePattern.js";
 import { gitServiceCache } from "../../../services/GitServiceCache.js";
-import { resolveForgeRemoteNameForCwd } from "../forgeResolution.js";
+import { resolveForgeRemoteNameForCwd, resolvePRHeadRefspecForCwd } from "../forgeResolution.js";
 import { defineIpcNamespace, op } from "../../define.js";
 
 export function registerWorktreeBranchHandlers(deps: HandlerDependencies): () => void {
@@ -42,11 +42,32 @@ export function registerWorktreeBranchHandlers(deps: HandlerDependencies): () =>
     // than falling back: PR numbers are per-repository, so guessing a remote
     // could fetch an unrelated PR that happens to share the number.
     const remoteName = await resolveForgeRemoteNameForCwd(payload.rootPath);
+    // Strictly after the remote name: that call fails closed on a stale or
+    // unverifiable remote, and the refspec resolver swallows everything into a
+    // GitHub-shaped fallback, so resolving it first would bury that failure.
+    //
+    // The ref shape is the forge's, not the host's (#12324) — GitHub serves
+    // `pull/<n>/head`, GitLab `refs/merge-requests/<n>/head`. `undefined` means
+    // we could not determine it and the host's GitHub-shaped default applies.
+    const refspec = await resolvePRHeadRefspecForCwd(
+      payload.rootPath,
+      payload.prNumber,
+      payload.headRefName
+    );
+    if (refspec === null) {
+      // The provider positively told us this forge has no fetchable PR-head
+      // ref, so the default would fail with a confusing "couldn't find remote
+      // ref" instead of saying what is actually wrong.
+      throw new Error(
+        `This forge doesn't publish a fetchable ref for pull request #${payload.prNumber}. Fetch the "${payload.headRefName}" branch yourself, then create the worktree from that existing branch.`
+      );
+    }
     await deps.worktreeService.fetchPRBranch(
       payload.rootPath,
       payload.prNumber,
       payload.headRefName,
-      remoteName ?? undefined
+      remoteName ?? undefined,
+      refspec
     );
   };
 

--- a/electron/services/WorkspaceClient.ts
+++ b/electron/services/WorkspaceClient.ts
@@ -1121,7 +1121,8 @@ export class WorkspaceClient extends EventEmitter {
     rootPath: string,
     prNumber: number,
     headRefName: string,
-    remoteName?: string
+    remoteName?: string,
+    refspec?: string
   ): Promise<void> {
     const host = this.pool.resolveHostForPath(rootPath);
     if (!host) throw new Error("No workspace host for project");
@@ -1133,6 +1134,7 @@ export class WorkspaceClient extends EventEmitter {
       prNumber,
       headRefName,
       remoteName,
+      refspec,
     });
   }
 

--- a/electron/services/__tests__/WorkspaceClient.resilience.test.ts
+++ b/electron/services/__tests__/WorkspaceClient.resilience.test.ts
@@ -2085,29 +2085,44 @@ describe("WorkspaceClient multi-process manager", () => {
       expect(hostBReqs).toHaveLength(0);
     });
 
-    it("carries the resolved remote and refspec on the fetch-pr-branch request", async () => {
+    it("carries the whole fetch to the owning host, remote and refspec included", async () => {
       // Both are resolved in main so the workspace host stays forge-neutral
       // (#11747, #12324); dropping either here silently reverts the fetch to
-      // `origin pull/<n>/head`.
-      const load = client.loadProject("/project-a", 1);
+      // `origin pull/<n>/head`. Two hosts are loaded because the pool falls
+      // back to its only host when one is loaded, which would let a wrong
+      // lookup still look correct.
+      const load1 = client.loadProject("/project-a", 1);
       await readyAndResolveLoad(0);
-      await load;
+      await load1;
+
+      const load2 = client.loadProject("/project-b", 2);
+      await readyAndResolveLoad(1);
+      await load2;
 
       const fetchPromise = client.fetchPRBranch(
-        "/project-a",
+        "/project-b",
         42,
         "feature/x",
         "upstream",
         "refs/merge-requests/42/head:feature/x"
       );
       await tick();
-      const req = h(0).getLastRequest()! as any;
-      expect(req.type).toBe("fetch-pr-branch");
-      expect(req.remoteName).toBe("upstream");
-      expect(req.refspec).toBe("refs/merge-requests/42/head:feature/x");
-      h(0).resolveRequest(req.requestId, {});
-
+      const req = h(1).getLastRequest()! as any;
+      expect(req).toMatchObject({
+        type: "fetch-pr-branch",
+        rootPath: "/project-b",
+        prNumber: 42,
+        headRefName: "feature/x",
+        remoteName: "upstream",
+        refspec: "refs/merge-requests/42/head:feature/x",
+      });
+      h(1).resolveRequest(req.requestId, {});
       await fetchPromise;
+
+      const hostAFetches = h(0)
+        .getAllRequests()
+        .filter((r: any) => r.type === "fetch-pr-branch");
+      expect(hostAFetches).toHaveLength(0);
     });
 
     it("omits both when the caller resolved neither", async () => {

--- a/electron/services/__tests__/WorkspaceClient.resilience.test.ts
+++ b/electron/services/__tests__/WorkspaceClient.resilience.test.ts
@@ -2085,6 +2085,47 @@ describe("WorkspaceClient multi-process manager", () => {
       expect(hostBReqs).toHaveLength(0);
     });
 
+    it("carries the resolved remote and refspec on the fetch-pr-branch request", async () => {
+      // Both are resolved in main so the workspace host stays forge-neutral
+      // (#11747, #12324); dropping either here silently reverts the fetch to
+      // `origin pull/<n>/head`.
+      const load = client.loadProject("/project-a", 1);
+      await readyAndResolveLoad(0);
+      await load;
+
+      const fetchPromise = client.fetchPRBranch(
+        "/project-a",
+        42,
+        "feature/x",
+        "upstream",
+        "refs/merge-requests/42/head:feature/x"
+      );
+      await tick();
+      const req = h(0).getLastRequest()! as any;
+      expect(req.type).toBe("fetch-pr-branch");
+      expect(req.remoteName).toBe("upstream");
+      expect(req.refspec).toBe("refs/merge-requests/42/head:feature/x");
+      h(0).resolveRequest(req.requestId, {});
+
+      await fetchPromise;
+    });
+
+    it("omits both when the caller resolved neither", async () => {
+      const load = client.loadProject("/project-a", 1);
+      await readyAndResolveLoad(0);
+      await load;
+
+      const fetchPromise = client.fetchPRBranch("/project-a", 42, "feature/x");
+      await tick();
+      const req = h(0).getLastRequest()! as any;
+      expect(req.type).toBe("fetch-pr-branch");
+      expect(req.remoteName).toBeUndefined();
+      expect(req.refspec).toBeUndefined();
+      h(0).resolveRequest(req.requestId, {});
+
+      await fetchPromise;
+    });
+
     it("resolves child paths to parent project host", async () => {
       const load = client.loadProject("/project-a", 1);
       await readyAndResolveLoad(0);

--- a/electron/workspace-host.ts
+++ b/electron/workspace-host.ts
@@ -595,7 +595,8 @@ port.on("message", async (rawMsg: any) => {
           request.rootPath,
           request.prNumber,
           request.headRefName,
-          request.remoteName
+          request.remoteName,
+          request.refspec
         );
         break;
 

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -4610,22 +4610,26 @@ export class WorkspaceService {
    * "couldn't find remote ref". Defaults to `origin` when the caller can't
    * resolve one, which is the pre-fix behavior.
    *
-   * The refspec itself stays GitHub-shaped (`pull/<n>/head`, also served by
-   * Gitea and Forgejo). GitLab's `merge-requests/<n>/head` and Bitbucket's
-   * variants would need per-provider refspec mapping — a separate gap this
-   * doesn't claim to close.
+   * `refspec` is the complete `src:dst` pair the forge provider built, also
+   * resolved in main (#12324) — the host must not know forge ref shapes.
+   * Omitted falls back to the GitHub-shaped `pull/<n>/head`, which Gitea and
+   * Forgejo also serve and which was the only shape before #12324. GitLab's
+   * `refs/merge-requests/<n>/head` arrives through this parameter.
    */
   async fetchPRBranch(
     requestId: string,
     rootPath: string,
     prNumber: number,
     headRefName: string,
-    remoteName?: string
+    remoteName?: string,
+    refspec?: string
   ): Promise<void> {
     try {
       const git = await createAuthenticatedGit(rootPath);
       const remote = remoteName && remoteName.length > 0 ? remoteName : "origin";
-      await git.raw(["fetch", remote, `pull/${prNumber}/head:${headRefName}`]);
+      const effectiveRefspec =
+        refspec && refspec.length > 0 ? refspec : `pull/${prNumber}/head:${headRefName}`;
+      await git.raw(["fetch", remote, effectiveRefspec]);
       this.sendEvent({ type: "fetch-pr-branch-result", requestId, success: true });
     } catch (error) {
       const gitReason = classifyGitError(error);

--- a/electron/workspace-host/__tests__/WorkspaceService.fetchPRBranch.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.fetchPRBranch.test.ts
@@ -157,6 +157,87 @@ describe("WorkspaceService.fetchPRBranch", () => {
     expect(mockSimpleGit.raw).toHaveBeenCalledWith(["fetch", "origin", "pull/7/head:feature/x"]);
   });
 
+  it("uses the provider's refspec verbatim when main resolved one", async () => {
+    mockSimpleGit.raw.mockResolvedValueOnce("");
+
+    // GitLab publishes MR heads under a different hierarchy than GitHub's
+    // `pull/<n>/head`, so the shape has to come from the provider (#12324).
+    await service.fetchPRBranch(
+      "req-gitlab",
+      "/test/root",
+      42,
+      "feature/my-branch",
+      "upstream",
+      "refs/merge-requests/42/head:feature/my-branch"
+    );
+
+    expect(mockSimpleGit.raw).toHaveBeenCalledWith([
+      "fetch",
+      "upstream",
+      "refs/merge-requests/42/head:feature/my-branch",
+    ]);
+  });
+
+  it("combines a resolved refspec with the origin remote default", async () => {
+    mockSimpleGit.raw.mockResolvedValueOnce("");
+
+    await service.fetchPRBranch(
+      "req-gitlab-origin",
+      "/test/root",
+      7,
+      "feature/x",
+      undefined,
+      "refs/merge-requests/7/head:feature/x"
+    );
+
+    expect(mockSimpleGit.raw).toHaveBeenCalledWith([
+      "fetch",
+      "origin",
+      "refs/merge-requests/7/head:feature/x",
+    ]);
+  });
+
+  it("falls back to the GitHub-shaped refspec when none was resolved", async () => {
+    // The whole compatibility guarantee: a repo that fetched before #12324
+    // must issue byte-identical argv when no provider capability resolves.
+    mockSimpleGit.raw.mockResolvedValueOnce("");
+
+    await service.fetchPRBranch(
+      "req-no-refspec",
+      "/test/root",
+      42,
+      "feature/x",
+      "upstream",
+      undefined
+    );
+
+    expect(mockSimpleGit.raw).toHaveBeenCalledWith(["fetch", "upstream", "pull/42/head:feature/x"]);
+  });
+
+  it("reports a failed provider-shaped fetch with the same classification", async () => {
+    mockSimpleGit.raw.mockRejectedValueOnce(
+      new Error("fatal: couldn't find remote ref refs/merge-requests/999/head")
+    );
+
+    await service.fetchPRBranch(
+      "req-gitlab-miss",
+      "/test/root",
+      999,
+      "gone",
+      "origin",
+      "refs/merge-requests/999/head:gone"
+    );
+
+    expect(mockSendEvent).toHaveBeenCalledWith({
+      type: "fetch-pr-branch-result",
+      requestId: "req-gitlab-miss",
+      success: false,
+      error: "fatal: couldn't find remote ref refs/merge-requests/999/head",
+      gitReason: "pathspec-invalid",
+      recoveryAction: undefined,
+    });
+  });
+
   it("should fetch PR branch using createAuthenticatedGit and emit success", async () => {
     const { createAuthenticatedGit } = await import("../../utils/hardenedGit.js");
     const { createHardenedGit } = await import("../../utils/hardenedGit.js");

--- a/packages/plugin-sdk/api-report/index.d.ts
+++ b/packages/plugin-sdk/api-report/index.d.ts
@@ -1061,10 +1061,16 @@ interface ForgeProviderImpl {
      * fetch that cannot succeed. Throwing is not a way to signal this: the host
      * treats a throw as "capability unknown" and falls back to the default.
      *
-     * The returned refspec must not force-update (no leading `+`); the host
-     * rejects one that does and falls back. Note the PR-head ref is not
-     * guaranteed to be permanent — GitLab prunes merged/closed MR refs after
-     * roughly two weeks, so an old PR can stop being fetchable.
+     * You choose the source ref; the destination is the host's. It must be
+     * exactly `headRefName` or `refs/heads/${headRefName}` — the host rejects a
+     * refspec that would write anywhere else and falls back to the default,
+     * because git would otherwise happily update an unrelated local branch. For
+     * the same reason it rejects a leading `+`, `-` or `^`, a `*` wildcard,
+     * whitespace, more than one `:`, and an empty half on either side.
+     *
+     * Note the PR-head ref is not guaranteed to be permanent — GitLab prunes
+     * merged/closed MR refs after roughly two weeks, so an old PR can stop being
+     * fetchable.
      */
     buildPRHeadRefspec?(prNumber: number, headRefName: string): string | null;
     /**

--- a/packages/plugin-sdk/api-report/index.d.ts
+++ b/packages/plugin-sdk/api-report/index.d.ts
@@ -1043,6 +1043,31 @@ interface ForgeProviderImpl {
      */
     buildPRFileUrl?(repo: RepoRef, number: number, path: string): string;
     /**
+     * Optional. Build the refspec that fetches a pull request's head into the
+     * local branch `headRefName`, for the fallback checkout path that runs when
+     * the head branch isn't already known locally (a fork PR, or one never
+     * fetched). Returns the complete `src:dst` pair — the provider knows its own
+     * ref hierarchy, so the host never reconstructs a forge-shaped ref.
+     *
+     * Omit the field to accept the host's GitHub-shaped default,
+     * `pull/<n>/head:<headRefName>`, which Gitea and Forgejo also serve. GitLab
+     * would return `refs/merge-requests/${prNumber}/head:${headRefName}` — fully
+     * qualified, since `merge-requests/` is not a hierarchy git expands on its
+     * own. `prNumber` is the project-scoped number the PR's URL shows (GitLab's
+     * `iid`), not a forge-global id.
+     *
+     * Return `null` when the forge exposes no fetchable PR-head ref at all
+     * (Bitbucket Cloud) — the host then reports that rather than attempting a
+     * fetch that cannot succeed. Throwing is not a way to signal this: the host
+     * treats a throw as "capability unknown" and falls back to the default.
+     *
+     * The returned refspec must not force-update (no leading `+`); the host
+     * rejects one that does and falls back. Note the PR-head ref is not
+     * guaranteed to be permanent — GitLab prunes merged/closed MR refs after
+     * roughly two weeks, so an old PR can stop being fetchable.
+     */
+    buildPRHeadRefspec?(prNumber: number, headRefName: string): string | null;
+    /**
      * Create a new issue and return the normalized {@link Issue}. Providers that
      * can't create issues throw `"Not supported"`, matching the assignment
      * convention. The host clears its issue caches after a successful create so

--- a/shared/types/forge.ts
+++ b/shared/types/forge.ts
@@ -1146,6 +1146,31 @@ export interface ForgeProviderImpl {
    * doesn't support PR-file deep-links.
    */
   buildPRFileUrl?(repo: RepoRef, number: number, path: string): string;
+  /**
+   * Optional. Build the refspec that fetches a pull request's head into the
+   * local branch `headRefName`, for the fallback checkout path that runs when
+   * the head branch isn't already known locally (a fork PR, or one never
+   * fetched). Returns the complete `src:dst` pair — the provider knows its own
+   * ref hierarchy, so the host never reconstructs a forge-shaped ref.
+   *
+   * Omit the field to accept the host's GitHub-shaped default,
+   * `pull/<n>/head:<headRefName>`, which Gitea and Forgejo also serve. GitLab
+   * would return `refs/merge-requests/${prNumber}/head:${headRefName}` — fully
+   * qualified, since `merge-requests/` is not a hierarchy git expands on its
+   * own. `prNumber` is the project-scoped number the PR's URL shows (GitLab's
+   * `iid`), not a forge-global id.
+   *
+   * Return `null` when the forge exposes no fetchable PR-head ref at all
+   * (Bitbucket Cloud) — the host then reports that rather than attempting a
+   * fetch that cannot succeed. Throwing is not a way to signal this: the host
+   * treats a throw as "capability unknown" and falls back to the default.
+   *
+   * The returned refspec must not force-update (no leading `+`); the host
+   * rejects one that does and falls back. Note the PR-head ref is not
+   * guaranteed to be permanent — GitLab prunes merged/closed MR refs after
+   * roughly two weeks, so an old PR can stop being fetchable.
+   */
+  buildPRHeadRefspec?(prNumber: number, headRefName: string): string | null;
 
   // Mutations — providers that don't support a mutation throw "Not supported".
   /**

--- a/shared/types/forge.ts
+++ b/shared/types/forge.ts
@@ -1165,10 +1165,16 @@ export interface ForgeProviderImpl {
    * fetch that cannot succeed. Throwing is not a way to signal this: the host
    * treats a throw as "capability unknown" and falls back to the default.
    *
-   * The returned refspec must not force-update (no leading `+`); the host
-   * rejects one that does and falls back. Note the PR-head ref is not
-   * guaranteed to be permanent — GitLab prunes merged/closed MR refs after
-   * roughly two weeks, so an old PR can stop being fetchable.
+   * You choose the source ref; the destination is the host's. It must be
+   * exactly `headRefName` or `refs/heads/${headRefName}` — the host rejects a
+   * refspec that would write anywhere else and falls back to the default,
+   * because git would otherwise happily update an unrelated local branch. For
+   * the same reason it rejects a leading `+`, `-` or `^`, a `*` wildcard,
+   * whitespace, more than one `:`, and an empty half on either side.
+   *
+   * Note the PR-head ref is not guaranteed to be permanent — GitLab prunes
+   * merged/closed MR refs after roughly two weeks, so an old PR can stop being
+   * fetchable.
    */
   buildPRHeadRefspec?(prNumber: number, headRefName: string): string | null;
 

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -505,6 +505,12 @@ export type WorkspaceHostRequest =
        * to `origin` (#11747).
        */
       remoteName?: string;
+      /**
+       * Complete `src:dst` refspec from the forge provider, resolved in main
+       * (#12324) so the host stays forge-neutral. Omitted falls back to the
+       * GitHub-shaped `pull/<n>/head:<headRefName>`.
+       */
+      refspec?: string;
     }
   // Git operations
   | {

--- a/src/services/actions/definitions/__tests__/workflowActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/workflowActions.adversarial.test.ts
@@ -377,6 +377,67 @@ describe("worktree.createWithRecipe", () => {
     expect(worktreeClientMock.create).not.toHaveBeenCalled();
   });
 
+  it("PR path names the branch and a way forward, keeping the git reason", async () => {
+    // The agent gets no banner and no retry affordance, so the raw
+    // "couldn't find remote ref" has to be wrapped into something it can act
+    // on — without losing the only part that says why (#12324).
+    forgeClientMock.getPR.mockResolvedValue({
+      number: 42,
+      headRef: "contrib/x",
+      title: "x",
+      url: "u",
+    });
+    worktreeClientMock.fetchPRBranch.mockRejectedValue(
+      new Error("fatal: couldn't find remote ref pull/42/head")
+    );
+    const def = setupActions(makeCallbacks())("worktree.createWithRecipe");
+
+    await expect(def.run({ source: pullRequest(42) }, {} as never)).rejects.toThrow(
+      /Couldn't fetch branch "contrib\/x" for pull request #42/
+    );
+    await expect(def.run({ source: pullRequest(42) }, {} as never)).rejects.toThrow(
+      /source\.kind="existingBranch"/
+    );
+    await expect(def.run({ source: pullRequest(42) }, {} as never)).rejects.toThrow(
+      /couldn't find remote ref pull\/42\/head/
+    );
+    expect(worktreeClientMock.create).not.toHaveBeenCalled();
+  });
+
+  it("PR path keeps the original error as the cause", async () => {
+    forgeClientMock.getPR.mockResolvedValue({
+      number: 42,
+      headRef: "contrib/x",
+      title: "x",
+      url: "u",
+    });
+    const original = new Error("git fetch failed");
+    worktreeClientMock.fetchPRBranch.mockRejectedValue(original);
+    const def = setupActions(makeCallbacks())("worktree.createWithRecipe");
+
+    await expect(def.run({ source: pullRequest(42) }, {} as never)).rejects.toMatchObject({
+      cause: original,
+    });
+  });
+
+  it("PR path survives a rejection that is not an Error", async () => {
+    // Electron's structured clone strips the Error prototype across IPC, so
+    // the wrap must read `{ message }` duck-typed values too.
+    forgeClientMock.getPR.mockResolvedValue({
+      number: 42,
+      headRef: "contrib/x",
+      title: "x",
+      url: "u",
+    });
+    worktreeClientMock.fetchPRBranch.mockRejectedValue({ message: "cloned failure" });
+    const def = setupActions(makeCallbacks())("worktree.createWithRecipe");
+
+    await expect(def.run({ source: pullRequest(42) }, {} as never)).rejects.toThrow(
+      /cloned failure/
+    );
+    expect(worktreeClientMock.create).not.toHaveBeenCalled();
+  });
+
   // This used to be a runtime throw inside run(), which meant the advertised
   // schema said the call was valid and only a dispatch could teach otherwise.
   // It is a schema rejection now, so assert it where it actually lives.

--- a/src/services/actions/definitions/__tests__/workflowActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/workflowActions.adversarial.test.ts
@@ -415,9 +415,16 @@ describe("worktree.createWithRecipe", () => {
     worktreeClientMock.fetchPRBranch.mockRejectedValue(original);
     const def = setupActions(makeCallbacks())("worktree.createWithRecipe");
 
-    await expect(def.run({ source: pullRequest(42) }, {} as never)).rejects.toMatchObject({
-      cause: original,
-    });
+    // Identity, not shape: `toMatchObject` compares nested Errors structurally,
+    // so a freshly built Error carrying the same message would satisfy it while
+    // having lost the original stack.
+    const thrown = await def.run({ source: pullRequest(42) }, {} as never).then(
+      () => {
+        throw new Error("expected the PR path to reject");
+      },
+      (error: unknown) => error as Error
+    );
+    expect(thrown.cause).toBe(original);
   });
 
   it("PR path survives a rejection that is not an Error", async () => {

--- a/src/services/actions/definitions/workflowCreationActions.ts
+++ b/src/services/actions/definitions/workflowCreationActions.ts
@@ -281,7 +281,22 @@ export function registerWorkflowCreationActions(
               `Pull request #${source.pullRequestNumber} has no head branch — cannot create worktree`
             );
           }
-          await worktreeClient.fetchPRBranch(rootPath, source.pullRequestNumber, pr.headRef);
+          // Unlike the dialogs, which try a remote-tracking branch and a local
+          // branch first and render a banner when the fetch fails, this path
+          // fetches unconditionally and its caller is an agent. A raw
+          // "couldn't find remote ref" tells it nothing about what to do next,
+          // so name the branch and the way out. The original git message stays
+          // in the text — it is the only part that says why.
+          try {
+            await worktreeClient.fetchPRBranch(rootPath, source.pullRequestNumber, pr.headRef);
+          } catch (error) {
+            throw new Error(
+              `Couldn't fetch branch "${pr.headRef}" for pull request #${source.pullRequestNumber}. ` +
+                `Fetch it yourself, then retry with source.kind="existingBranch" and source.branchName="${pr.headRef}". ` +
+                `Details: ${formatErrorMessage(error, "the git fetch failed")}`,
+              { cause: error }
+            );
+          }
           requestedBranch = pr.headRef;
           candidateBranch = pr.headRef;
           effectiveBase = pr.headRef;


### PR DESCRIPTION
## Summary

`fetchPRBranch` in `WorkspaceService` hardcoded GitHub's `pull/<n>/head` refspec. GitLab publishes merge request heads at `refs/merge-requests/<iid>/head`, so checking out a fork MR, or any branch that hadn't been fetched yet, failed with a "couldn't find remote ref" error. The forge remote *name* was already resolved per provider (#11747). Only the ref shape was hardcoded. `fetchPRBranch` is a fallback, not the primary path (the dialogs try a remote-tracking branch and a local branch first), so this specifically hit fork PRs and never-fetched branches.

Resolves #12324

## Changes

- Added an optional `buildPRHeadRefspec?(prNumber, headRefName): string | null` to `ForgeProviderImpl`, returning the complete `src:dst` refspec for a provider that publishes one.
- Resolved on the main side by a new `resolvePRHeadRefspecForCwd` in `electron/ipc/handlers/forgeResolution.ts`, then threaded through to the workspace host, which stays forge-neutral.
- The return value is a deliberate tri-state contract: a string is used verbatim, `null` means the forge has no fetchable PR-head ref at all (Bitbucket Cloud is the example) and the handler reports that instead of attempting a fetch, and `undefined` means the capability couldn't be determined and the host falls back to the exact GitHub-shaped refspec it used before. A fetch that worked yesterday can't start failing just because a capability lookup failed.
- Fixed an ordering invariant: the remote name resolves before the refspec, because remote name resolution fails closed on a stale remote, and the refspec resolver's catch-all would otherwise bury that earlier failure. Pinned by tests in two suites.
- Locked down destination ownership: the provider chooses the source ref, the host owns and validates the destination. A returned refspec has to land on exactly `headRefName` or `refs/heads/<headRefName>`. Review flagged that a `+`-only guard was far too weak, since git needs no force marker to fast-forward another local branch, and outside `refs/heads/*` it accepts non-fast-forward updates anyway. Also now rejected: an empty source (on fetch, `:branch` pulls the remote's HEAD rather than doing nothing), an empty destination (fetches objects, creates no branch, still reports success), a leading `-` on the source (git reads it as an option and silently drops the mapping), and any `^`, `*`, multiple mappings, or whitespace (rejected outright, not trimmed).
- Wrapped the previously unguarded `worktreeClient.fetchPRBranch` call in the `worktree.create` MCP action, so an agent driving worktree creation gets the branch name and a recovery instruction instead of a raw git error, with the original message and cause preserved.

Scope is intentionally narrow: GitHub doesn't implement the new capability at all, since its existing fallback already matches the shape it needs, so that fallback path stays exercised by the only forge provider built in today. There's no GitLab provider on `develop` yet (#5167, and #11062 is still open), so for now this is an interface-only extension point. Nothing exercises the GitLab branch of logic until a real GitLab plugin registers.

One known gap worth stating plainly: the dispatch in `electron/workspace-host.ts` that forwards `request.refspec` through to the fetch call isn't covered by a test. The param is optional, so deleting it would still typecheck and pass every suite. It's an unexported function in a process-entry module, and the `remoteName` param from #11747 carries the identical exposure, so this isn't a new category of risk.

## Testing

435 tests pass across the 7 affected suites: `forgeResolution` (71), a new `branches` test file (8), `WorkspaceService.fetchPRBranch` (11), `WorkspaceClient.resilience` (105), `workflowActions.adversarial` (101), `NewWorktreeDialog` (51), `BulkCreateWorktreeDialog` (88). Typecheck, eslint, and prettier are all clean, the lint ratchet improved by 1, and the SDK's API surface snapshot was regenerated. No E2E run since there's no GitLab provider yet to exercise this end to end.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Z27Da1RQjmkwWG3F9W1Yj
