### PR TITLE
fix(editor): honour the editor preference and stop faking launch success

### DIFF
--- a/electron/services/EditorService.ts
+++ b/electron/services/EditorService.ts
@@ -358,7 +358,20 @@ export async function openFile(
       child.unref();
       // Suppress unhandled async rejection from the detached process
       child.catch(() => {});
-      return true;
+      // execa never throws synchronously for a broken command — ENOENT and
+      // EACCES surface only as an async rejection, and its early-error path
+      // hands back a dummy child that emits no events at all. Racing "spawned"
+      // against the promise settling reads both channels, so a missing binary
+      // reports failure and the fallback chain gets its turn. It cannot hang:
+      // the promise always settles on the failure paths, and a GUI editor that
+      // outlives us wins on 'spawn' long before its promise would settle.
+      return await Promise.race([
+        new Promise<boolean>((resolve) => child.once("spawn", () => resolve(true))),
+        child.then(
+          () => true,
+          () => false
+        ),
+      ]);
     } catch {
       return false;
     }

--- a/electron/services/__tests__/EditorService.adversarial.test.ts
+++ b/electron/services/__tests__/EditorService.adversarial.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mockExecaChildren } from "./helpers/editorChild.js";
 
 const fsMock = vi.hoisted(() => ({
   statSync: vi.fn<(path: string) => { isFile: () => boolean }>(),
@@ -57,7 +58,7 @@ describe("EditorService adversarial", () => {
     delete process.env.EDITOR;
     setPlatform("linux");
     shellMock.openPath.mockResolvedValue("");
-    execaMock.execa.mockReturnValue({ unref: vi.fn(), catch: vi.fn() });
+    mockExecaChildren(execaMock.execa, ["spawned"]);
   });
 
   afterEach(() => {

--- a/electron/services/__tests__/EditorService.test.ts
+++ b/electron/services/__tests__/EditorService.test.ts
@@ -366,7 +366,53 @@ describe("EditorService.openFile", () => {
 
     // Promise settlement is the only channel this path uses, so an
     // event-only implementation would hang here rather than fail.
+    expect(execaMock.execa).toHaveBeenCalledTimes(1);
+    expect(execaMock.execa.mock.calls[0]?.[0]).toBe("/bin/broken-editor");
     expect(shell.openPath).toHaveBeenCalledWith("/absolute/path/file.ts");
+  });
+
+  it("holds the fallback until the launch verdict arrives, rather than assuming success", async () => {
+    Object.defineProperty(process, "platform", { value: "linux" });
+    const children = mockLaunches("manual");
+
+    const { shell } = await import("electron");
+    vi.mocked(shell.openPath).mockResolvedValue("");
+
+    const openFile = await loadOpenFile();
+    const pending = openFile("/absolute/path/file.ts", undefined, undefined, CUSTOM_EDITOR);
+
+    await vi.waitFor(() => expect(children).toHaveLength(1));
+    // Nothing has reported either way yet, so nothing downstream may run.
+    expect(shell.openPath).not.toHaveBeenCalled();
+
+    children[0]!.rejectLaunch();
+    await pending;
+
+    expect(shell.openPath).toHaveBeenCalledWith("/absolute/path/file.ts");
+  });
+
+  it("exhausts every candidate when they all fail asynchronously, then surfaces the shell error", async () => {
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    process.env.VISUAL = "code";
+    process.env.EDITOR = "subl --wait";
+    mockLaunches("enoent");
+
+    const { shell } = await import("electron");
+    vi.mocked(shell.openPath).mockResolvedValue("Access denied");
+
+    const openFile = await loadOpenFile();
+    await expect(
+      openFile("/absolute/path/file.ts", undefined, undefined, CUSTOM_EDITOR)
+    ).rejects.toThrow("Failed to open file: Access denied");
+
+    // Configured editor, then $VISUAL, then $EDITOR, then the macOS handler —
+    // an async failure must not stop the chain at any link.
+    expect(execaMock.execa.mock.calls.map((call) => call[0])).toEqual([
+      "/bin/broken-editor",
+      "code",
+      "subl",
+      "open",
+    ]);
   });
 
   it("counts a spawn that later exits nonzero as launched — exit status is not observed", async () => {

--- a/electron/services/__tests__/EditorService.test.ts
+++ b/electron/services/__tests__/EditorService.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mockExecaChildren, type ChildBehaviour } from "./helpers/editorChild.js";
 
 const fsMock = vi.hoisted(() => ({
   statSync: vi.fn<(path: string) => { isFile: () => boolean }>(),
@@ -222,20 +223,21 @@ describe("EditorService.openFile", () => {
   let originalVISUAL: string | undefined;
   let originalEDITOR: string | undefined;
 
-  function makeChild(overrides: { throwOnCatch?: boolean } = {}) {
-    const child = {
-      unref: vi.fn(),
-      catch: vi.fn(),
-    };
-    if (overrides.throwOnCatch) {
-      execaMock.execa.mockImplementation(() => {
-        throw new Error("spawn ENOENT");
-      });
-    } else {
-      execaMock.execa.mockReturnValue(child);
-    }
-    return child;
+  function mockLaunches(...behaviours: ChildBehaviour[]) {
+    return mockExecaChildren(execaMock.execa, behaviours);
   }
+
+  function mockSyncThrow() {
+    execaMock.execa.mockImplementation(() => {
+      throw new Error("spawn ENOENT");
+    });
+  }
+
+  const CUSTOM_EDITOR = {
+    id: "custom",
+    customCommand: "/bin/broken-editor",
+    customTemplate: "{file}",
+  } as const;
 
   beforeEach(() => {
     vi.resetModules();
@@ -270,7 +272,7 @@ describe("EditorService.openFile", () => {
 
   it("macOS fallback calls launchEditor with 'open' and suppresses async rejection", async () => {
     Object.defineProperty(process, "platform", { value: "darwin" });
-    const child = makeChild();
+    const children = mockLaunches("spawned");
 
     const openFile = await loadOpenFile();
     await openFile("/absolute/path/file.ts");
@@ -280,8 +282,15 @@ describe("EditorService.openFile", () => {
       stdio: "ignore",
       cleanup: false,
     });
+    const child = children[0]!;
     expect(child.unref).toHaveBeenCalled();
     expect(child.catch).toHaveBeenCalledWith(expect.any(Function));
+    // The suppression catch is separate from the verification consumer; both
+    // read the same promise.
+    expect(child.then).toHaveBeenCalled();
+    // 'spawn' won the race and `once` removed itself, so nothing stays attached
+    // to a detached child that may outlive the app.
+    expect(child.listenerCount("spawn")).toBe(0);
 
     const { shell } = await import("electron");
     expect(shell.openPath).not.toHaveBeenCalled();
@@ -289,7 +298,7 @@ describe("EditorService.openFile", () => {
 
   it("macOS fallback falls through to shell.openPath when open throws", async () => {
     Object.defineProperty(process, "platform", { value: "darwin" });
-    makeChild({ throwOnCatch: true });
+    mockSyncThrow();
 
     const { shell } = await import("electron");
     vi.mocked(shell.openPath).mockResolvedValue("");
@@ -311,6 +320,67 @@ describe("EditorService.openFile", () => {
 
     expect(execaMock.execa).not.toHaveBeenCalledWith("open", expect.anything(), expect.anything());
     expect(shell.openPath).toHaveBeenCalledWith("/absolute/path/file.ts");
+  });
+
+  it("treats an emitted 'spawn' as launched without waiting for the process to exit", async () => {
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    mockLaunches("spawned");
+
+    const openFile = await loadOpenFile();
+    await openFile("/absolute/path/file.ts", undefined, undefined, CUSTOM_EDITOR);
+
+    // A detached GUI editor's promise settles only when it exits, which may be
+    // hours away — this times out if launchEditor ever awaits the child itself.
+    expect(execaMock.execa).toHaveBeenCalledTimes(1);
+    expect(execaMock.execa.mock.calls[0]?.[0]).toBe("/bin/broken-editor");
+
+    const { shell } = await import("electron");
+    expect(shell.openPath).not.toHaveBeenCalled();
+  });
+
+  it("advances to the next candidate when the launch rejects without emitting 'spawn'", async () => {
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    const children = mockLaunches("enoent", "spawned");
+
+    const openFile = await loadOpenFile();
+    await openFile("/absolute/path/file.ts", undefined, undefined, CUSTOM_EDITOR);
+
+    expect(execaMock.execa).toHaveBeenCalledTimes(2);
+    expect(execaMock.execa.mock.calls[0]?.[0]).toBe("/bin/broken-editor");
+    expect(execaMock.execa.mock.calls[1]?.[0]).toBe("open");
+    expect(children[0]!.unref).toHaveBeenCalled();
+
+    const { shell } = await import("electron");
+    expect(shell.openPath).not.toHaveBeenCalled();
+  });
+
+  it("advances when the child emits neither 'spawn' nor 'error' (execa's early-error path)", async () => {
+    Object.defineProperty(process, "platform", { value: "linux" });
+    mockLaunches("early-error");
+
+    const { shell } = await import("electron");
+    vi.mocked(shell.openPath).mockResolvedValue("");
+
+    const openFile = await loadOpenFile();
+    await openFile("/absolute/path/file.ts", undefined, undefined, CUSTOM_EDITOR);
+
+    // Promise settlement is the only channel this path uses, so an
+    // event-only implementation would hang here rather than fail.
+    expect(shell.openPath).toHaveBeenCalledWith("/absolute/path/file.ts");
+  });
+
+  it("counts a spawn that later exits nonzero as launched — exit status is not observed", async () => {
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    mockLaunches("spawned-then-exit");
+
+    const openFile = await loadOpenFile();
+    await openFile("/absolute/path/file.ts", undefined, undefined, CUSTOM_EDITOR);
+
+    // Indistinguishable at spawn time from a CLI shim that hands off to a GUI
+    // and exits 0, so it deliberately stops the chain.
+    expect(execaMock.execa).toHaveBeenCalledTimes(1);
+    const { shell } = await import("electron");
+    expect(shell.openPath).not.toHaveBeenCalled();
   });
 
   it("rejects non-absolute paths before reaching execa or shell", async () => {

--- a/electron/services/__tests__/helpers/editorChild.ts
+++ b/electron/services/__tests__/helpers/editorChild.ts
@@ -33,24 +33,22 @@ export interface ChildDouble {
 }
 
 export function makeChildDouble(behaviour: ChildBehaviour): ChildDouble {
-  const listeners = new Map<string, Set<() => void>>();
   // A plain registry rather than an EventEmitter: emitting 'error' with no
   // listener would throw synchronously, which is the very failure shape these
-  // doubles exist to rule out.
-  const once = new WeakSet<() => void>();
-  const register = (event: string, listener: () => void, removeAfterCall: boolean) => {
-    const registered = listeners.get(event) ?? new Set<() => void>();
-    registered.add(listener);
-    listeners.set(event, registered);
-    if (removeAfterCall) once.add(listener);
+  // doubles exist to rule out. Lifetime is tracked per registration, not per
+  // function, so one callback can be both a `once` and an `on` listener.
+  const listeners = new Map<string, { listener: () => void; once: boolean }[]>();
+  const register = (event: string, listener: () => void, once: boolean) => {
+    listeners.set(event, [...(listeners.get(event) ?? []), { listener, once }]);
   };
   const emit = (event: string) => {
     const registered = listeners.get(event);
     if (!registered) return;
-    for (const listener of [...registered]) {
-      if (once.has(listener)) registered.delete(listener);
-      listener();
-    }
+    listeners.set(
+      event,
+      registered.filter((entry) => !entry.once)
+    );
+    for (const entry of registered) entry.listener();
   };
 
   let resolvePromise!: () => void;
@@ -76,7 +74,7 @@ export function makeChildDouble(behaviour: ChildBehaviour): ChildDouble {
       register(event, listener, false);
       return child;
     }),
-    listenerCount: (event: string) => listeners.get(event)?.size ?? 0,
+    listenerCount: (event: string) => listeners.get(event)?.length ?? 0,
     emitSpawn: () => emit("spawn"),
     rejectLaunch: (error = new Error("spawn ENOENT")) => rejectPromise(error),
   };

--- a/electron/services/__tests__/helpers/editorChild.ts
+++ b/electron/services/__tests__/helpers/editorChild.ts
@@ -1,0 +1,106 @@
+import { vi, type Mock } from "vitest";
+
+/**
+ * The launch outcomes execa 9.6.1 actually produces, verified against the
+ * installed package. None of them is a synchronous throw: `execa()` converts
+ * every broken command into an async rejection, and its early-error path hands
+ * back a real `ChildProcess` that never emits anything at all.
+ */
+export type ChildBehaviour =
+  /** A detached GUI editor: 'spawn' fires and the promise outlives us. */
+  | "spawned"
+  /** Exec succeeded, the process then failed. Still a launch — see #12327. */
+  | "spawned-then-exit"
+  /** Missing or non-executable binary: 'error' fires, no 'spawn', rejects. */
+  | "enoent"
+  /** execa's early-error dummy child: no events whatsoever, still rejects. */
+  | "early-error"
+  /** Exited 0 before anything observed 'spawn'. */
+  | "resolved";
+
+export interface ChildDouble {
+  unref: Mock;
+  catch: Mock;
+  then: Mock;
+  once: Mock;
+  listenerCount: (event: string) => number;
+}
+
+export function makeChildDouble(behaviour: ChildBehaviour): ChildDouble {
+  const listeners = new Map<string, Set<() => void>>();
+  // A plain registry rather than an EventEmitter: emitting 'error' with no
+  // listener would throw synchronously, which is the very failure shape these
+  // doubles exist to rule out.
+  const emit = (event: string) => {
+    const registered = listeners.get(event);
+    if (!registered) return;
+    for (const listener of [...registered]) {
+      registered.delete(listener);
+      listener();
+    }
+  };
+
+  let resolvePromise!: () => void;
+  let rejectPromise!: (error: Error) => void;
+  const promise = new Promise<void>((resolve, reject) => {
+    resolvePromise = resolve;
+    rejectPromise = reject;
+  });
+
+  const child: ChildDouble = {
+    unref: vi.fn(),
+    catch: vi.fn((onRejected: (reason: unknown) => unknown) => promise.catch(onRejected)),
+    then: vi.fn((onFulfilled?: () => unknown, onRejected?: () => unknown) =>
+      promise.then(onFulfilled, onRejected)
+    ),
+    once: vi.fn((event: string, listener: () => void) => {
+      const registered = listeners.get(event) ?? new Set<() => void>();
+      registered.add(listener);
+      listeners.set(event, registered);
+      return child;
+    }),
+    listenerCount: (event: string) => listeners.get(event)?.size ?? 0,
+  };
+
+  // Deferred by one microtask so the caller has attached its listeners first —
+  // the same ordering the real package produces, since execa() returns before
+  // the OS has answered.
+  queueMicrotask(() => {
+    switch (behaviour) {
+      case "spawned":
+        emit("spawn");
+        break;
+      case "spawned-then-exit":
+        emit("spawn");
+        rejectPromise(new Error("Command failed with exit code 1"));
+        break;
+      case "enoent":
+        emit("error");
+        rejectPromise(new Error("spawn ENOENT"));
+        break;
+      case "early-error":
+        rejectPromise(new Error("The `uid` option is invalid"));
+        break;
+      case "resolved":
+        resolvePromise();
+        break;
+    }
+  });
+
+  return child;
+}
+
+/**
+ * Hand one child per `execa()` call. The last behaviour repeats, so a single
+ * entry covers however many candidates the fallback chain tries.
+ */
+export function mockExecaChildren(execa: Mock, behaviours: ChildBehaviour[]): ChildDouble[] {
+  const created: ChildDouble[] = [];
+  execa.mockImplementation(() => {
+    const behaviour = behaviours[Math.min(created.length, behaviours.length - 1)]!;
+    const child = makeChildDouble(behaviour);
+    created.push(child);
+    return child;
+  });
+  return created;
+}

--- a/electron/services/__tests__/helpers/editorChild.ts
+++ b/electron/services/__tests__/helpers/editorChild.ts
@@ -16,14 +16,20 @@ export type ChildBehaviour =
   /** execa's early-error dummy child: no events whatsoever, still rejects. */
   | "early-error"
   /** Exited 0 before anything observed 'spawn'. */
-  | "resolved";
+  | "resolved"
+  /** Nothing happens until the test drives it — see `ChildDouble` controls. */
+  | "manual";
 
 export interface ChildDouble {
   unref: Mock;
   catch: Mock;
   then: Mock;
   once: Mock;
+  on: Mock;
   listenerCount: (event: string) => number;
+  /** Drive a "manual" child from the test, one channel at a time. */
+  emitSpawn: () => void;
+  rejectLaunch: (error?: Error) => void;
 }
 
 export function makeChildDouble(behaviour: ChildBehaviour): ChildDouble {
@@ -31,11 +37,18 @@ export function makeChildDouble(behaviour: ChildBehaviour): ChildDouble {
   // A plain registry rather than an EventEmitter: emitting 'error' with no
   // listener would throw synchronously, which is the very failure shape these
   // doubles exist to rule out.
+  const once = new WeakSet<() => void>();
+  const register = (event: string, listener: () => void, removeAfterCall: boolean) => {
+    const registered = listeners.get(event) ?? new Set<() => void>();
+    registered.add(listener);
+    listeners.set(event, registered);
+    if (removeAfterCall) once.add(listener);
+  };
   const emit = (event: string) => {
     const registered = listeners.get(event);
     if (!registered) return;
     for (const listener of [...registered]) {
-      registered.delete(listener);
+      if (once.has(listener)) registered.delete(listener);
       listener();
     }
   };
@@ -54,12 +67,18 @@ export function makeChildDouble(behaviour: ChildBehaviour): ChildDouble {
       promise.then(onFulfilled, onRejected)
     ),
     once: vi.fn((event: string, listener: () => void) => {
-      const registered = listeners.get(event) ?? new Set<() => void>();
-      registered.add(listener);
-      listeners.set(event, registered);
+      register(event, listener, true);
+      return child;
+    }),
+    // Present so an event-only implementation written against `on` registers
+    // here and hangs, rather than dying on a missing method and looking fixed.
+    on: vi.fn((event: string, listener: () => void) => {
+      register(event, listener, false);
       return child;
     }),
     listenerCount: (event: string) => listeners.get(event)?.size ?? 0,
+    emitSpawn: () => emit("spawn"),
+    rejectLaunch: (error = new Error("spawn ENOENT")) => rejectPromise(error),
   };
 
   // Deferred by one microtask so the caller has attached its listeners first —
@@ -83,6 +102,8 @@ export function makeChildDouble(behaviour: ChildBehaviour): ChildDouble {
         break;
       case "resolved":
         resolvePromise();
+        break;
+      case "manual":
         break;
     }
   });

--- a/src/components/Settings/EditorIntegrationTab.tsx
+++ b/src/components/Settings/EditorIntegrationTab.tsx
@@ -282,7 +282,7 @@ export function EditorIntegrationTab() {
 
             {testResult === "ok" && (
               <span className="flex items-center gap-1 text-xs text-status-success">
-                <CheckCircle className="w-3.5 h-3.5" /> Editor launched
+                <CheckCircle className="w-3.5 h-3.5" /> Open requested
               </span>
             )}
             {testResult === "error" && (

--- a/src/components/Settings/EditorIntegrationTab.tsx
+++ b/src/components/Settings/EditorIntegrationTab.tsx
@@ -131,7 +131,10 @@ export function EditorIntegrationTab() {
       // Open the active project's root to test the editor integration. It is a
       // known-to-exist path inside an allowed root, so it passes the main-process
       // path-containment guard (homeDir would now be rejected as outside-root).
-      await window.electron.system.openInEditor({ path: activeProjectPath });
+      await window.electron.system.openInEditor({
+        path: activeProjectPath,
+        projectId: activeProjectId,
+      });
       if (!isMountedRef.current) return;
       setTestResult("ok");
     } catch {
@@ -279,7 +282,7 @@ export function EditorIntegrationTab() {
 
             {testResult === "ok" && (
               <span className="flex items-center gap-1 text-xs text-status-success">
-                <CheckCircle className="w-3.5 h-3.5" /> Editor opened
+                <CheckCircle className="w-3.5 h-3.5" /> Editor launched
               </span>
             )}
             {testResult === "error" && (

--- a/src/components/Settings/__tests__/EditorIntegrationTab.test.tsx
+++ b/src/components/Settings/__tests__/EditorIntegrationTab.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+/**
+ * EditorIntegrationTab — the Test button has to exercise the preference it
+ * sits next to (#12327). Without a project id the main process never loads
+ * `preferredEditor` and silently launches whatever discovery finds first, so
+ * the button reported success for an editor the user had not chosen.
+ */
+import type { ReactNode } from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+
+const { getConfigMock, setConfigMock, discoverMock, openInEditorMock } = vi.hoisted(() => ({
+  getConfigMock: vi.fn(),
+  setConfigMock: vi.fn().mockResolvedValue(undefined),
+  discoverMock: vi.fn().mockResolvedValue([]),
+  openInEditorMock: vi.fn(),
+}));
+
+vi.mock("@/clients/editorClient", () => ({
+  editorClient: { getConfig: getConfigMock, setConfig: setConfigMock, discover: discoverMock },
+}));
+
+vi.mock("@/utils/logger", () => ({ logError: vi.fn(), logDebug: vi.fn() }));
+
+// Radix tooltip machinery is irrelevant here and lazy-loads its primitives.
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipContent: () => null,
+}));
+
+const PROJECT = { id: "proj-42", path: "/repos/daintree" };
+
+vi.mock("@/store", () => ({
+  useProjectStore: (selector: (state: { currentProject: typeof PROJECT }) => unknown) =>
+    selector({ currentProject: PROJECT }),
+}));
+
+import { EditorIntegrationTab } from "../EditorIntegrationTab";
+
+describe("EditorIntegrationTab", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getConfigMock.mockResolvedValue({
+      preferredEditor: { id: "custom", customCommand: "mine", customTemplate: "{file}" },
+      discoveredEditors: [],
+    });
+    discoverMock.mockResolvedValue([]);
+    openInEditorMock.mockResolvedValue(undefined);
+    Object.defineProperty(window, "electron", {
+      value: { system: { openInEditor: openInEditorMock } },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  async function renderTab() {
+    render(<EditorIntegrationTab />);
+    await waitFor(() => expect(getConfigMock).toHaveBeenCalledWith(PROJECT.id));
+    return screen.getByRole("button", { name: "Test" });
+  }
+
+  it("sends the active project id so the saved preference is the thing under test", async () => {
+    const testButton = await renderTab();
+
+    fireEvent.click(testButton);
+
+    await waitFor(() => expect(openInEditorMock).toHaveBeenCalledTimes(1));
+    expect(openInEditorMock).toHaveBeenCalledWith({
+      path: PROJECT.path,
+      projectId: PROJECT.id,
+    });
+  });
+
+  it("reports the launch only once the main process answers, and claims no more than it saw", async () => {
+    let settle!: () => void;
+    openInEditorMock.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          settle = resolve;
+        })
+    );
+
+    const testButton = await renderTab();
+    fireEvent.click(testButton);
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Testing…" })).toBeDefined());
+    expect(screen.queryByText("Editor launched")).toBeNull();
+
+    await act(async () => {
+      settle();
+    });
+
+    // "launched" is what we observed — a spawned process. Whether a window
+    // appeared is not something this path can verify.
+    await waitFor(() => expect(screen.getByText("Editor launched")).toBeDefined());
+  });
+
+  it("surfaces a failed launch instead of a success message", async () => {
+    openInEditorMock.mockRejectedValue(new Error("no such binary"));
+
+    const testButton = await renderTab();
+    fireEvent.click(testButton);
+
+    await waitFor(() => expect(screen.getByText("Failed to open")).toBeDefined());
+    expect(screen.queryByText("Editor launched")).toBeNull();
+  });
+});

--- a/src/components/Settings/__tests__/EditorIntegrationTab.test.tsx
+++ b/src/components/Settings/__tests__/EditorIntegrationTab.test.tsx
@@ -85,15 +85,16 @@ describe("EditorIntegrationTab", () => {
     fireEvent.click(testButton);
 
     await waitFor(() => expect(screen.getByRole("button", { name: "Testing…" })).toBeDefined());
-    expect(screen.queryByText("Editor launched")).toBeNull();
+    expect(screen.queryByText("Open requested")).toBeNull();
 
     await act(async () => {
       settle();
     });
 
-    // "launched" is what we observed — a spawned process. Whether a window
-    // appeared is not something this path can verify.
-    await waitFor(() => expect(screen.getByText("Editor launched")).toBeDefined());
+    // All this path verifies is that the request was handled. The chain can
+    // end in a fallback editor, or in shell.openPath, so naming an editor
+    // would claim more than was observed.
+    await waitFor(() => expect(screen.getByText("Open requested")).toBeDefined());
   });
 
   it("surfaces a failed launch instead of a success message", async () => {
@@ -103,6 +104,6 @@ describe("EditorIntegrationTab", () => {
     fireEvent.click(testButton);
 
     await waitFor(() => expect(screen.getByText("Failed to open")).toBeDefined());
-    expect(screen.queryByText("Editor launched")).toBeNull();
+    expect(screen.queryByText("Open requested")).toBeNull();
   });
 });

--- a/src/components/Worktree/ReviewHub/ReviewHubContent.tsx
+++ b/src/components/Worktree/ReviewHub/ReviewHubContent.tsx
@@ -39,6 +39,7 @@ import { isProtectedBranch } from "@shared/utils/gitConstants";
 import { useUIStore } from "@/store/uiStore";
 import { useGitPushConfirmStore } from "@/store/gitPushConfirmStore";
 import { usePreferencesStore } from "@/store/preferencesStore";
+import { useProjectStore } from "@/store/projectStore";
 import { useDiffViewedStore, selectViewedSet } from "@/store/diffViewedStore";
 import type { DiffChangeSetEntry } from "@/components/FileViewer/diffChangeSet";
 import { Skeleton, SkeletonBone, SkeletonHint } from "@/components/ui/Skeleton";
@@ -1201,7 +1202,12 @@ export function ReviewHubContent({
       try {
         const base = worktreePath.replace(/\\/g, "/").replace(/\/+$/, "");
         const tail = filePath.replace(/\\/g, "/").replace(/^\/+/, "");
-        const payload: { path: string; line?: number } = { path: `${base}/${tail}` };
+        const payload: { path: string; line?: number; projectId?: string } = {
+          path: `${base}/${tail}`,
+          // Read at click time rather than subscribing — without it the main
+          // process never loads the project's preferred-editor setting.
+          projectId: useProjectStore.getState().currentProject?.id,
+        };
         if (typeof line === "number" && Number.isFinite(line) && line > 0) {
           payload.line = line;
         }

--- a/src/components/Worktree/ReviewHub/__tests__/ReviewHub.conflictMode.test.tsx
+++ b/src/components/Worktree/ReviewHub/__tests__/ReviewHub.conflictMode.test.tsx
@@ -352,9 +352,14 @@ describe("ReviewHub", () => {
     openInEditorMock.mockReset().mockResolvedValue(undefined);
     // Deliberately unlike the fixture worktree id — a worktree id is not a
     // project id, and only the project id loads the preferred-editor setting.
-    useProjectStore.setState({
-      currentProject: { id: REVIEW_PROJECT_ID, name: "review", path: "/repo" } as Project,
-    });
+    const project: Project = {
+      id: REVIEW_PROJECT_ID,
+      name: "review",
+      path: "/repo",
+      emoji: "🌳",
+      lastOpened: 0,
+    };
+    useProjectStore.setState({ currentProject: project });
     stageFileMock.mockReset().mockResolvedValue(undefined);
     unstageFileMock.mockReset().mockResolvedValue(undefined);
     stageFilesMock.mockReset().mockResolvedValue(undefined);

--- a/src/components/Worktree/ReviewHub/__tests__/ReviewHub.conflictMode.test.tsx
+++ b/src/components/Worktree/ReviewHub/__tests__/ReviewHub.conflictMode.test.tsx
@@ -5,7 +5,10 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, waitFor, fireEvent, within } from "@testing-library/react";
 import type { ReactNode } from "react";
 import type { StagingStatus } from "@shared/types";
-import type { WorktreeState } from "@shared/types";
+import type { WorktreeState, Project } from "@shared/types";
+import { useProjectStore } from "@/store/projectStore";
+
+const REVIEW_PROJECT_ID = "proj-review-1";
 
 const {
   getStagingStatusMock,
@@ -347,6 +350,11 @@ describe("ReviewHub", () => {
     scanConflictMarkersMock.mockReset().mockResolvedValue([]);
     checkoutOursTheirsMock.mockReset().mockResolvedValue(undefined);
     openInEditorMock.mockReset().mockResolvedValue(undefined);
+    // Deliberately unlike the fixture worktree id — a worktree id is not a
+    // project id, and only the project id loads the preferred-editor setting.
+    useProjectStore.setState({
+      currentProject: { id: REVIEW_PROJECT_ID, name: "review", path: "/repo" } as Project,
+    });
     stageFileMock.mockReset().mockResolvedValue(undefined);
     unstageFileMock.mockReset().mockResolvedValue(undefined);
     stageFilesMock.mockReset().mockResolvedValue(undefined);
@@ -569,6 +577,7 @@ describe("ReviewHub", () => {
       await waitFor(() => {
         expect(openInEditorMock).toHaveBeenCalledWith({
           path: `${WORKTREE_PATH}/src/app.ts`,
+          projectId: REVIEW_PROJECT_ID,
         });
       });
     });
@@ -595,6 +604,7 @@ describe("ReviewHub", () => {
         expect(openInEditorMock).toHaveBeenCalledWith({
           path: `${WORKTREE_PATH}/src/app.ts`,
           line: 17,
+          projectId: REVIEW_PROJECT_ID,
         });
       });
     });

--- a/src/services/terminal/FileLinksAddon.ts
+++ b/src/services/terminal/FileLinksAddon.ts
@@ -773,12 +773,16 @@ class FileLink implements ILink {
           { path: this._absolutePath, line: this._line, col: this._col },
           { source: "user" }
         )
-        .then((result) => {
+        .then(async (result) => {
           if (result.ok) return;
+          // Lazy import: projectStore pulls in TerminalInstanceService, which
+          // imports this module — a static import would close that cycle.
+          const { useProjectStore } = await import("@/store/projectStore");
           return systemClient.openInEditor({
             path: this._absolutePath,
             line: this._line,
             col: this._col,
+            projectId: useProjectStore.getState().currentProject?.id,
           });
         })
         .catch((error) => {

--- a/src/services/terminal/__tests__/FileLinksAddon.test.ts
+++ b/src/services/terminal/__tests__/FileLinksAddon.test.ts
@@ -17,6 +17,14 @@ vi.mock("@/clients", () => ({
   systemClient: { openPath: vi.fn(), openInEditor: vi.fn(), showItemInFolderUnconfined: vi.fn() },
 }));
 
+const { PROJECT_ID } = vi.hoisted(() => ({ PROJECT_ID: "proj-terminal-1" }));
+
+// The addon lazily imports the project store (a static import would close the
+// projectStore -> TerminalInstanceService -> FileLinksAddon cycle).
+vi.mock("@/store/projectStore", () => ({
+  useProjectStore: { getState: () => ({ currentProject: { id: PROJECT_ID } }) },
+}));
+
 describe("FileLinksAddon", () => {
   const createMockTerminal = () => {
     return {
@@ -1053,6 +1061,14 @@ describe("FileLinksAddon", () => {
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       expect(systemClient.openInEditor).toHaveBeenCalledTimes(1);
+      // The fallback has to carry the project id too, or it launches whatever
+      // editor discovery finds first instead of the configured one (#12327).
+      expect(systemClient.openInEditor).toHaveBeenCalledWith({
+        path: "/home/user/project/src/App.tsx",
+        line: 10,
+        col: undefined,
+        projectId: PROJECT_ID,
+      });
       expect(notify).toHaveBeenCalledTimes(1);
       const payload = vi.mocked(notify).mock.calls[0]?.[0] as { message: string };
       expect(payload.message).toContain("no editor configured");

--- a/src/services/terminal/__tests__/FileLinksAddon.test.ts
+++ b/src/services/terminal/__tests__/FileLinksAddon.test.ts
@@ -1058,9 +1058,11 @@ describe("FileLinksAddon", () => {
       vi.mocked(systemClient.openInEditor).mockRejectedValue(new Error("no editor configured"));
 
       link!.activate(makeClick({ metaKey: true }), link!.text);
-      await new Promise((resolve) => setTimeout(resolve, 0));
+      // The fallback awaits a dynamic import, so a single macrotask is not a
+      // completion barrier — wait for the observable call instead.
+      await vi.waitFor(() => expect(systemClient.openInEditor).toHaveBeenCalledTimes(1));
+      await vi.waitFor(() => expect(notify).toHaveBeenCalledTimes(1));
 
-      expect(systemClient.openInEditor).toHaveBeenCalledTimes(1);
       // The fallback has to carry the project id too, or it launches whatever
       // editor discovery finds first instead of the configured one (#12327).
       expect(systemClient.openInEditor).toHaveBeenCalledWith({
@@ -1069,7 +1071,6 @@ describe("FileLinksAddon", () => {
         col: undefined,
         projectId: PROJECT_ID,
       });
-      expect(notify).toHaveBeenCalledTimes(1);
       const payload = vi.mocked(notify).mock.calls[0]?.[0] as { message: string };
       expect(payload.message).toContain("no editor configured");
     });
@@ -1136,10 +1137,9 @@ describe("FileLinksAddon", () => {
       );
 
       link!.activate(makeClick({ metaKey: true }), link!.text);
-      await new Promise((resolve) => setTimeout(resolve, 0));
+      await vi.waitFor(() => expect(systemClient.openInEditor).toHaveBeenCalledTimes(1));
+      await vi.waitFor(() => expect(notify).toHaveBeenCalledTimes(1));
 
-      expect(systemClient.openInEditor).toHaveBeenCalledTimes(1);
-      expect(notify).toHaveBeenCalledTimes(1);
       const payload = vi.mocked(notify).mock.calls[0]?.[0] as { message: string };
       expect(payload.message).toContain("Path is not a valid file");
     });


### PR DESCRIPTION
## Summary

- A user configured a custom editor in Settings, hit Test, and got Sublime Text opening with an "Editor opened" success message. Two separate bugs, one report.
- Three call sites skip the project id, so the saved editor preference never gets loaded and everything falls through to `$VISUAL`, `$EDITOR`, then a scan of `KNOWN_EDITORS`.
- `launchEditor` was reporting success as soon as `execa()` didn't throw synchronously, but execa 9.6.1 never throws synchronously for a broken command, so a missing binary was always a false "success."

Resolves #12327

## Missing project id

Three call sites never passed a project id into `handleSystemOpenInEditor`, so `settings.preferredEditor` was never read:

- The Test button in `EditorIntegrationTab.tsx`
- Review Hub's open-in-editor action in `ReviewHubContent.tsx`
- The modifier-click fallback in `FileLinksAddon.ts`

All three now pass it. `ReviewHubContent` only had a `worktreeId` in scope, which isn't a project id, so it now reads the project store instead. `FileLinksAddon` imports the project store lazily inside the handler rather than statically, since a static import would close an import cycle: `projectStore` -> `TerminalInstanceService` -> `FileLinksAddon`.

## Launch success reported before the process could fail

`launchEditor` returned `true` the moment `execa()` didn't throw synchronously. execa 9.6.1 never throws synchronously for a broken command: `ENOENT` and `EACCES` only surface as an async rejection, and execa's early-error path hands back a real `ChildProcess` that never actually spawned and emits nothing at all. The old test simulated spawn failure as a synchronous throw, which is exactly why this slipped through.

The fix races the child's `'spawn'` event against the promise settling, since promise settlement is the one signal guaranteed on every failure path. A missing binary now correctly reports failure and the fallback chain gets its turn, and a long-running GUI editor resolves on `'spawn'` instead of waiting on an exit that may never come. `child.unref()` and the `child.catch(() => {})` rejection suppression are untouched, the race just adds a second, independent consumer of the same promise.

Explicitly out of scope: exec succeeding and the process exiting nonzero milliseconds later. At spawn time that's indistinguishable from a CLI shim that hands off to a background GUI app and exits 0 itself, and the issue rules out timeout heuristics anyway.

## Honest reporting

The Test result now reads "Open requested" instead of "Editor opened." The fallback chain can end at `shell.openPath`, which on a project directory opens the file manager, not an editor, so "editor" was claiming more than we'd actually observed.

## Changes

- `electron/services/EditorService.ts`: race `'spawn'` against promise settlement instead of trusting a synchronous `execa()` return
- `electron/ipc/handlers/systemShell.ts` callers, `src/components/Settings/EditorIntegrationTab.tsx`, `src/components/Worktree/ReviewHub/ReviewHubContent.tsx`, `src/services/terminal/FileLinksAddon.ts`: pass the project id through at all three call sites
- Test result copy changed from "Editor opened" to "Open requested"
- `electron/services/__tests__/helpers/editorChild.ts`: new shared test double, both a thenable and a real event emitter, replacing the old bare `{ unref, catch }` object that couldn't exercise any of this

## Testing

The old child-process fixture was a bare object with just `unref` and `catch`, no event surface, not even a thenable, so none of this was testable. The new shared double covers: spawn-only success where the promise never settles, async rejection with no `'spawn'` event, execa's silent early-error path, a spawn that later exits nonzero, and full async exhaustion down to `shell.openPath`'s own error propagation.

Added coverage for all three project-id call sites, each asserting a non-empty id, and for Review Hub specifically, a project id deliberately distinct from the fixture's worktree id, to catch accidental reuse of the wrong one.

Known follow-up, not in this PR: Test still can't certify that the *configured* editor is what actually ran. If the saved command is broken, a fallback editor opens and it's still reported as success. Fixing that needs a structured launch result threaded through the service, IPC, and client layers.

Locally: 2,096 tests green across `EditorService`, the `systemShell` handlers, the full terminal and ReviewHub test directories, Settings, and `fileActions`. Prettier and eslint clean (exit 0) on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DsjX2Dt6zAcBvD6KExAqnR
