### PR TITLE
fix(settings): stop closing the dialog reverting out-of-band saves

### DIFF
--- a/src/components/Settings/EditorIntegrationTab.tsx
+++ b/src/components/Settings/EditorIntegrationTab.tsx
@@ -6,7 +6,8 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { editorClient } from "@/clients/editorClient";
 import type { EditorConfig, DiscoveredEditor, KnownEditorId } from "@shared/types/editor";
 import { KNOWN_EDITOR_IDS } from "@shared/types/editor";
-import { useProjectStore } from "@/store";
+import { useProjectStore, patchCachedProjectSettings } from "@/store";
+import { invalidateProjectSettingsCache } from "@/clients/projectClient";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { logError } from "@/utils/logger";
 
@@ -103,6 +104,11 @@ export function EditorIntegrationTab() {
         customTemplate: selectedId === "custom" ? customTemplate.trim() || undefined : undefined,
       };
       await editorClient.setConfig({ editor, projectId: activeProjectId });
+      // Main writes preferredEditor straight into the project settings file, so
+      // every renderer-side copy is now stale. Both must be refreshed before
+      // anything else reads or re-saves the whole settings object (#12326).
+      invalidateProjectSettingsCache(activeProjectId);
+      patchCachedProjectSettings(activeProjectId, { preferredEditor: editor });
       if (!isMountedRef.current) return;
       setPreferredEditor(editor);
     } catch (err) {

--- a/src/components/Settings/ImageViewerTab.tsx
+++ b/src/components/Settings/ImageViewerTab.tsx
@@ -11,7 +11,7 @@ import {
 import { cn } from "@/lib/utils";
 import { Image } from "lucide-react";
 import { SettingsSection } from "@/components/Settings/SettingsSection";
-import { useProjectStore } from "@/store";
+import { useProjectStore, patchCachedProjectSettings } from "@/store";
 import { projectClient } from "@/clients";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { logError } from "@/utils/logger";
@@ -106,14 +106,16 @@ export function ImageViewerTab() {
       // Routed through projectClient so the per-projectId getSettings cache
       // is invalidated on save. Bypassing it left other readers reading
       // stale data for up to the cache TTL.
+      const preferredImageViewer = {
+        mode,
+        customCommand: mode === "custom" ? customCommand.trim() : undefined,
+      };
       const settings = await projectClient.getSettings(activeProjectId);
-      await projectClient.saveSettings(activeProjectId, {
-        ...settings,
-        preferredImageViewer: {
-          mode,
-          customCommand: mode === "custom" ? customCommand.trim() : undefined,
-        },
-      });
+      await projectClient.saveSettings(activeProjectId, { ...settings, preferredImageViewer });
+      // Merge into whatever the cache holds now, not into the object fetched
+      // before the await — a concurrent write may have landed in between. A
+      // stale cache here is what reverts this save on dialog close (#12326).
+      patchCachedProjectSettings(activeProjectId, { preferredImageViewer });
       if (!isMountedRef.current) return;
       setSaved(true);
     } catch (err) {

--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -1047,7 +1047,7 @@ function ProjectFormTabContent({
           onEnvironmentVariablesChange={projectForm.setEnvironmentVariables}
           settings={projectForm.projectSettings}
           isOpen={isOpen}
-          onFlush={projectForm.flush}
+          onFlush={projectForm.saveNow}
           projectLabel={projectLabel}
           globalEnvironmentVariables={globalEnvVars}
         />

--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -756,7 +756,7 @@ function SettingsDialogInner({
                 <SettingsLoadErrorBanner
                   title={`Couldn't save settings for ${projectLabel}`}
                   message={projectForm.projectAutoSaveError}
-                  onRetry={() => void projectForm.flush()}
+                  onRetry={() => void projectForm.saveNow()}
                 />
               )}
               {showProjectLoading && (

--- a/src/components/Settings/__tests__/EditorIntegrationTab.test.tsx
+++ b/src/components/Settings/__tests__/EditorIntegrationTab.test.tsx
@@ -1,109 +1,289 @@
 // @vitest-environment jsdom
 /**
- * EditorIntegrationTab — the Test button has to exercise the preference it
- * sits next to (#12327). Without a project id the main process never loads
- * `preferredEditor` and silently launches whatever discovery finds first, so
- * the button reported success for an editor the user had not chosen.
+ * EditorIntegrationTab covers two threads that meet in the same handler pair:
+ *
+ * - #12327: the Test button has to exercise the preference it sits next to.
+ *   Without a project id the main process never loads `preferredEditor` and
+ *   silently launches whatever discovery finds first, so the button reported
+ *   success for an editor the user had not chosen.
+ * - #12326: main writes `preferredEditor` straight into the settings file, so
+ *   every renderer-side copy goes stale and the next settings-form save reverts
+ *   it unless both the cache and the store are refreshed on save.
+ *
+ * The stores are used for real rather than mocked: the component reads
+ * `useProjectStore` and `patchCachedProjectSettings` from the same `@/store`
+ * barrel, and a wholesale module mock would have to restate both halves of it.
  */
-import type { ReactNode } from "react";
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi, beforeEach } from "vitest";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { EditorIntegrationTab } from "../EditorIntegrationTab";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { useProjectStore } from "@/store/projectStore";
+import { cleanupProjectSettingsStore, useProjectSettingsStore } from "@/store/projectSettingsStore";
+import { invalidateProjectSettingsCache, projectClient } from "@/clients/projectClient";
+import type { Project, ProjectSettings } from "@shared/types/project";
 
 const { getConfigMock, setConfigMock, discoverMock, openInEditorMock } = vi.hoisted(() => ({
   getConfigMock: vi.fn(),
-  setConfigMock: vi.fn().mockResolvedValue(undefined),
-  discoverMock: vi.fn().mockResolvedValue([]),
+  setConfigMock: vi.fn(),
+  discoverMock: vi.fn(),
   openInEditorMock: vi.fn(),
 }));
 
 vi.mock("@/clients/editorClient", () => ({
-  editorClient: { getConfig: getConfigMock, setConfig: setConfigMock, discover: discoverMock },
+  editorClient: {
+    getConfig: getConfigMock,
+    setConfig: setConfigMock,
+    discover: discoverMock,
+  },
 }));
 
-vi.mock("@/utils/logger", () => ({ logError: vi.fn(), logDebug: vi.fn() }));
-
-// Radix tooltip machinery is irrelevant here and lazy-loads its primitives.
-vi.mock("@/components/ui/tooltip", () => ({
-  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
-  TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
-  TooltipContent: () => null,
+vi.mock("@/utils/logger", () => ({
+  logError: vi.fn(),
+  logWarn: vi.fn(),
+  logInfo: vi.fn(),
+  logDebug: vi.fn(),
 }));
 
-const PROJECT = { id: "proj-42", path: "/repos/daintree" };
+/** Settings seeded into the cache, with sentinels a bad write would disturb. */
+const SEEDED_SETTINGS: ProjectSettings = {
+  runCommands: [],
+  devServerCommand: "npm run dev",
+  preferredImageViewer: { mode: "os" },
+};
 
-vi.mock("@/store", () => ({
-  useProjectStore: (selector: (state: { currentProject: typeof PROJECT }) => unknown) =>
-    selector({ currentProject: PROJECT }),
-}));
+// Explicit return type: inferring it from the literal narrows to
+// `{ runCommands: never[] }`, and the richer mockResolvedValue payloads below
+// then fail typecheck as excess properties.
+const ipcGetSettings = vi.fn(async (): Promise<ProjectSettings> => ({ runCommands: [] }));
 
-import { EditorIntegrationTab } from "../EditorIntegrationTab";
+const TEST_PROJECT: Project = {
+  id: "proj-1",
+  path: "/repo",
+  name: "Repo",
+  emoji: "🌲",
+  lastOpened: 0,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useProjectStore.setState({ currentProject: null });
+  cleanupProjectSettingsStore();
+  // Module-level cache in the real projectClient — leaks between tests otherwise.
+  invalidateProjectSettingsCache();
+  getConfigMock.mockResolvedValue({
+    preferredEditor: { id: "vscode" },
+    discoveredEditors: [
+      { id: "vscode", available: true, executablePath: "/usr/bin/code" },
+      { id: "zed", available: true, executablePath: "/usr/bin/zed" },
+    ],
+  });
+  setConfigMock.mockResolvedValue(undefined);
+  discoverMock.mockResolvedValue([]);
+  openInEditorMock.mockResolvedValue(undefined);
+  ipcGetSettings.mockClear();
+  // stubGlobal rather than assigning onto a cast window: only the handful of
+  // members the real projectClient and the Test button reach are stubbed here.
+  vi.stubGlobal("electron", {
+    project: {
+      getSettings: ipcGetSettings,
+      onSwitch: vi.fn(() => () => {}),
+    },
+    system: {
+      openInEditor: openInEditorMock,
+    },
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+/** Render for "proj-1" and wait for the editor config to load. */
+async function renderLoadedTab() {
+  useProjectStore.setState({ currentProject: TEST_PROJECT });
+  render(
+    <TooltipProvider>
+      <EditorIntegrationTab />
+    </TooltipProvider>
+  );
+  await waitFor(() => {
+    expect(getConfigMock).toHaveBeenCalledWith("proj-1");
+  });
+  await screen.findByText(/Saved:/i);
+  return screen.getByRole("button", { name: /^save$/i }) as HTMLButtonElement;
+}
+
+/** Same render, but hands back the Test button. */
+async function renderTabForTestButton() {
+  await renderLoadedTab();
+  return screen.getByRole("button", { name: "Test" });
+}
+
+function selectEditor(id: string) {
+  const select = screen.getByLabelText("Editor") as HTMLSelectElement;
+  fireEvent.change(select, { target: { value: id } });
+}
 
 describe("EditorIntegrationTab", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    getConfigMock.mockResolvedValue({
-      preferredEditor: { id: "custom", customCommand: "mine", customTemplate: "{file}" },
-      discoveredEditors: [],
-    });
-    discoverMock.mockResolvedValue([]);
-    openInEditorMock.mockResolvedValue(undefined);
-    Object.defineProperty(window, "electron", {
-      value: { system: { openInEditor: openInEditorMock } },
-      writable: true,
-      configurable: true,
-    });
-  });
-
-  async function renderTab() {
-    render(<EditorIntegrationTab />);
-    await waitFor(() => expect(getConfigMock).toHaveBeenCalledWith(PROJECT.id));
-    return screen.getByRole("button", { name: "Test" });
-  }
-
-  it("sends the active project id so the saved preference is the thing under test", async () => {
-    const testButton = await renderTab();
-
-    fireEvent.click(testButton);
-
-    await waitFor(() => expect(openInEditorMock).toHaveBeenCalledTimes(1));
-    expect(openInEditorMock).toHaveBeenCalledWith({
-      path: PROJECT.path,
-      projectId: PROJECT.id,
-    });
-  });
-
-  it("reports the launch only once the main process answers, and claims no more than it saw", async () => {
-    let settle!: () => void;
-    openInEditorMock.mockImplementation(
-      () =>
-        new Promise<void>((resolve) => {
-          settle = resolve;
-        })
+  it("shows the empty-project hint when no project is open", () => {
+    render(
+      <TooltipProvider>
+        <EditorIntegrationTab />
+      </TooltipProvider>
     );
-
-    const testButton = await renderTab();
-    fireEvent.click(testButton);
-
-    await waitFor(() => expect(screen.getByRole("button", { name: "Testing…" })).toBeDefined());
-    expect(screen.queryByText("Open requested")).toBeNull();
-
-    await act(async () => {
-      settle();
-    });
-
-    // All this path verifies is that the request was handled. The chain can
-    // end in a fallback editor, or in shell.openPath, so naming an editor
-    // would claim more than was observed.
-    await waitFor(() => expect(screen.getByText("Open requested")).toBeDefined());
+    expect(screen.getByText(/Open a project to configure its editor preference/i)).toBeTruthy();
+    expect(getConfigMock).not.toHaveBeenCalled();
   });
 
-  it("surfaces a failed launch instead of a success message", async () => {
-    openInEditorMock.mockRejectedValue(new Error("no such binary"));
+  it("saves the selected editor through the editor IPC", async () => {
+    const saveButton = await renderLoadedTab();
+    selectEditor("zed");
 
-    const testButton = await renderTab();
-    fireEvent.click(testButton);
+    fireEvent.click(saveButton);
 
-    await waitFor(() => expect(screen.getByText("Failed to open")).toBeDefined());
-    expect(screen.queryByText("Open requested")).toBeNull();
+    await waitFor(() => {
+      expect(setConfigMock).toHaveBeenCalledWith({
+        editor: { id: "zed", customCommand: undefined, customTemplate: undefined },
+        projectId: "proj-1",
+      });
+    });
+  });
+
+  // The Test button has to launch the editor the preference names, which the
+  // main process only resolves when it is told which project to look at (#12327).
+  describe("Test button", () => {
+    it("sends the active project id so the saved preference is the thing under test", async () => {
+      const testButton = await renderTabForTestButton();
+
+      fireEvent.click(testButton);
+
+      await waitFor(() => expect(openInEditorMock).toHaveBeenCalledTimes(1));
+      expect(openInEditorMock).toHaveBeenCalledWith({
+        path: TEST_PROJECT.path,
+        projectId: TEST_PROJECT.id,
+      });
+    });
+
+    it("reports the launch only once the main process answers, and claims no more than it saw", async () => {
+      let settle!: () => void;
+      openInEditorMock.mockImplementation(
+        () =>
+          new Promise<void>((resolve) => {
+            settle = resolve;
+          })
+      );
+
+      const testButton = await renderTabForTestButton();
+      fireEvent.click(testButton);
+
+      await waitFor(() => expect(screen.getByRole("button", { name: "Testing…" })).toBeDefined());
+      expect(screen.queryByText("Open requested")).toBeNull();
+
+      await act(async () => {
+        settle();
+      });
+
+      // All this path verifies is that the request was handled. The chain can
+      // end in a fallback editor, or in shell.openPath, so naming an editor
+      // would claim more than was observed.
+      await waitFor(() => expect(screen.getByText("Open requested")).toBeDefined());
+    });
+
+    it("surfaces a failed launch instead of a success message", async () => {
+      openInEditorMock.mockRejectedValue(new Error("no such binary"));
+
+      const testButton = await renderTabForTestButton();
+      fireEvent.click(testButton);
+
+      await waitFor(() => expect(screen.getByText("Failed to open")).toBeDefined());
+      expect(screen.queryByText("Open requested")).toBeNull();
+    });
+  });
+
+  // Main writes preferredEditor straight into the settings file, so every
+  // renderer-side copy goes stale and the next settings-form save reverts it
+  // unless both the cache and the store are refreshed here (#12326).
+  describe("renderer-side settings refresh", () => {
+    it("merges the saved editor into the cached settings, preserving unrelated fields", async () => {
+      useProjectSettingsStore.setState({ settings: SEEDED_SETTINGS, projectId: "proj-1" });
+      const saveButton = await renderLoadedTab();
+      selectEditor("zed");
+
+      fireEvent.click(saveButton);
+
+      await waitFor(() => {
+        expect(useProjectSettingsStore.getState().settings?.preferredEditor).toEqual({
+          id: "zed",
+          customCommand: undefined,
+          customTemplate: undefined,
+        });
+      });
+      expect(useProjectSettingsStore.getState().settings?.devServerCommand).toBe("npm run dev");
+      expect(useProjectSettingsStore.getState().settings?.preferredImageViewer).toEqual({
+        mode: "os",
+      });
+    });
+
+    it("leaves the cached settings untouched when the save rejects", async () => {
+      useProjectSettingsStore.setState({ settings: SEEDED_SETTINGS, projectId: "proj-1" });
+      setConfigMock.mockRejectedValue(new Error("setConfig blew up"));
+      const saveButton = await renderLoadedTab();
+      selectEditor("zed");
+
+      fireEvent.click(saveButton);
+
+      await screen.findByText(/setConfig blew up|Failed to save editor preference/i);
+      // Asserting the whole object, not just the absent preference — wiping the
+      // cache outright would satisfy a `?.preferredEditor` check.
+      expect(useProjectSettingsStore.getState().settings).toEqual(SEEDED_SETTINGS);
+      expect(useProjectSettingsStore.getState().projectId).toBe("proj-1");
+    });
+
+    it("leaves the cached settings untouched when the store holds a different project", async () => {
+      useProjectSettingsStore.setState({ settings: SEEDED_SETTINGS, projectId: "proj-2" });
+      const saveButton = await renderLoadedTab();
+      selectEditor("zed");
+
+      fireEvent.click(saveButton);
+
+      await waitFor(() => {
+        expect(setConfigMock).toHaveBeenCalledTimes(1);
+      });
+      expect(useProjectSettingsStore.getState().settings).toEqual(SEEDED_SETTINGS);
+      expect(useProjectSettingsStore.getState().projectId).toBe("proj-2");
+    });
+
+    it("invalidates the projectClient settings cache so the next read is not stale", async () => {
+      // The cache entry expires 500ms after it is written, so with a real clock
+      // a slow runner would refetch anyway and the test would pass regardless.
+      const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_000_000);
+      try {
+        ipcGetSettings
+          .mockResolvedValueOnce({ runCommands: [], preferredEditor: { id: "vscode" } })
+          .mockResolvedValue({ runCommands: [], preferredEditor: { id: "zed" } });
+        const saveButton = await renderLoadedTab();
+
+        // Prime the per-projectId cache the way another reader would, and
+        // confirm the second read really is served from it.
+        const first = await projectClient.getSettings("proj-1");
+        expect(first.preferredEditor).toEqual({ id: "vscode" });
+        expect(ipcGetSettings).toHaveBeenCalledTimes(1);
+        await projectClient.getSettings("proj-1");
+        expect(ipcGetSettings).toHaveBeenCalledTimes(1);
+
+        selectEditor("zed");
+        fireEvent.click(saveButton);
+        await waitFor(() => {
+          expect(setConfigMock).toHaveBeenCalledTimes(1);
+        });
+
+        const afterSave = await projectClient.getSettings("proj-1");
+        expect(ipcGetSettings).toHaveBeenCalledTimes(2);
+        expect(afterSave.preferredEditor).toEqual({ id: "zed" });
+      } finally {
+        nowSpy.mockRestore();
+      }
+    });
   });
 });

--- a/src/components/Settings/__tests__/ImageViewerTab.test.tsx
+++ b/src/components/Settings/__tests__/ImageViewerTab.test.tsx
@@ -1,9 +1,11 @@
 // @vitest-environment jsdom
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { ImageViewerTab } from "../ImageViewerTab";
 import { useProjectStore } from "@/store/projectStore";
-import type { Project } from "@shared/types/project";
+import { useProjectSettingsStore } from "@/store/projectSettingsStore";
+import { projectClient } from "@/clients";
+import type { Project, ProjectSettings } from "@shared/types/project";
 
 vi.mock("@/utils/logger", () => ({
   logError: vi.fn(),
@@ -50,7 +52,22 @@ function installElectron(getSettings: () => Promise<unknown>) {
 beforeEach(() => {
   vi.clearAllMocks();
   setProject(null);
+  useProjectSettingsStore.setState({ settings: null, projectId: null });
+  vi.mocked(projectClient.getSettings).mockResolvedValue({ runCommands: [] } as ProjectSettings);
+  vi.mocked(projectClient.saveSettings).mockResolvedValue(undefined);
 });
+
+/** Render for "proj-1" with settings loaded and the Save button enabled. */
+async function renderLoadedTab() {
+  installElectron(async () => ({}));
+  setProject({ id: "proj-1", path: "/repo", name: "Repo" } as Project);
+  render(<ImageViewerTab />);
+  const osRadio = screen.getByRole("radio", { name: /Use OS default/i }) as HTMLInputElement;
+  await waitFor(() => {
+    expect(osRadio.disabled).toBe(false);
+  });
+  return screen.getByRole("button", { name: /save/i }) as HTMLButtonElement;
+}
 
 describe("ImageViewerTab", () => {
   it("renders section chrome and disabled controls while settings are loading", async () => {
@@ -169,5 +186,78 @@ describe("ImageViewerTab", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  // A save here never reaches useProjectSettingsStore on its own, so the cache
+  // keeps the pre-save value and the next settings-form write reverts it (#12326).
+  describe("cached settings write-through", () => {
+    it("merges the saved preference into the cache, preserving unrelated fields", async () => {
+      useProjectSettingsStore.setState({
+        settings: { runCommands: [], devServerCommand: "npm run dev" },
+        projectId: "proj-1",
+      });
+      const saveButton = await renderLoadedTab();
+
+      fireEvent.click(saveButton);
+
+      await waitFor(() => {
+        expect(useProjectSettingsStore.getState().settings?.preferredImageViewer).toEqual({
+          mode: "os",
+          customCommand: undefined,
+        });
+      });
+      expect(useProjectSettingsStore.getState().settings?.devServerCommand).toBe("npm run dev");
+      expect(projectClient.saveSettings).toHaveBeenCalledTimes(1);
+    });
+
+    it("merges into the settings the cache holds after the save, not the pre-await copy", async () => {
+      useProjectSettingsStore.setState({
+        settings: { runCommands: [], devServerCommand: "npm run dev" },
+        projectId: "proj-1",
+      });
+      // A concurrent writer lands while the save IPC is in flight.
+      vi.mocked(projectClient.saveSettings).mockImplementation(async () => {
+        useProjectSettingsStore.setState({
+          settings: { runCommands: [], devServerCommand: "npm run other" },
+        });
+      });
+      const saveButton = await renderLoadedTab();
+
+      fireEvent.click(saveButton);
+
+      await waitFor(() => {
+        expect(useProjectSettingsStore.getState().settings?.preferredImageViewer).toBeTruthy();
+      });
+      expect(useProjectSettingsStore.getState().settings?.devServerCommand).toBe("npm run other");
+    });
+
+    it("leaves the cache untouched when the save rejects", async () => {
+      useProjectSettingsStore.setState({
+        settings: { runCommands: [] },
+        projectId: "proj-1",
+      });
+      vi.mocked(projectClient.saveSettings).mockRejectedValue(new Error("save blew up"));
+      const saveButton = await renderLoadedTab();
+
+      fireEvent.click(saveButton);
+
+      await screen.findByText(/save blew up|Failed to save image viewer preference/i);
+      expect(useProjectSettingsStore.getState().settings?.preferredImageViewer).toBeUndefined();
+    });
+
+    it("leaves the cache untouched when it holds a different project", async () => {
+      useProjectSettingsStore.setState({
+        settings: { runCommands: [] },
+        projectId: "proj-2",
+      });
+      const saveButton = await renderLoadedTab();
+
+      fireEvent.click(saveButton);
+
+      await waitFor(() => {
+        expect(projectClient.saveSettings).toHaveBeenCalledTimes(1);
+      });
+      expect(useProjectSettingsStore.getState().settings?.preferredImageViewer).toBeUndefined();
+    });
   });
 });

--- a/src/components/Settings/__tests__/ImageViewerTab.test.tsx
+++ b/src/components/Settings/__tests__/ImageViewerTab.test.tsx
@@ -3,10 +3,7 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { ImageViewerTab } from "../ImageViewerTab";
 import { useProjectStore } from "@/store/projectStore";
-import {
-  cleanupProjectSettingsStore,
-  useProjectSettingsStore,
-} from "@/store/projectSettingsStore";
+import { cleanupProjectSettingsStore, useProjectSettingsStore } from "@/store/projectSettingsStore";
 import { projectClient } from "@/clients";
 import type { Project, ProjectSettings } from "@shared/types/project";
 
@@ -72,10 +69,18 @@ const SEEDED_SETTINGS: ProjectSettings = {
   preferredEditor: { id: "vscode" },
 };
 
+const TEST_PROJECT: Project = {
+  id: "proj-1",
+  path: "/repo",
+  name: "Repo",
+  emoji: "🌲",
+  lastOpened: 0,
+};
+
 /** Render for "proj-1" with settings loaded and the Save button enabled. */
 async function renderLoadedTab() {
   installElectron(async () => ({}));
-  setProject({ id: "proj-1", path: "/repo", name: "Repo" } as Project);
+  setProject(TEST_PROJECT);
   render(<ImageViewerTab />);
   const osRadio = screen.getByRole("radio", { name: /Use OS default/i }) as HTMLInputElement;
   await waitFor(() => {

--- a/src/components/Settings/__tests__/ImageViewerTab.test.tsx
+++ b/src/components/Settings/__tests__/ImageViewerTab.test.tsx
@@ -3,7 +3,10 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { ImageViewerTab } from "../ImageViewerTab";
 import { useProjectStore } from "@/store/projectStore";
-import { useProjectSettingsStore } from "@/store/projectSettingsStore";
+import {
+  cleanupProjectSettingsStore,
+  useProjectSettingsStore,
+} from "@/store/projectSettingsStore";
 import { projectClient } from "@/clients";
 import type { Project, ProjectSettings } from "@shared/types/project";
 
@@ -52,10 +55,22 @@ function installElectron(getSettings: () => Promise<unknown>) {
 beforeEach(() => {
   vi.clearAllMocks();
   setProject(null);
-  useProjectSettingsStore.setState({ settings: null, projectId: null });
-  vi.mocked(projectClient.getSettings).mockResolvedValue({ runCommands: [] } as ProjectSettings);
+  cleanupProjectSettingsStore();
+  // Carries the pre-save value, so merging this fetched copy over the cache
+  // instead of patching only the preference would be caught below.
+  vi.mocked(projectClient.getSettings).mockResolvedValue({
+    runCommands: [],
+    devServerCommand: "npm run dev",
+  } as ProjectSettings);
   vi.mocked(projectClient.saveSettings).mockResolvedValue(undefined);
 });
+
+/** Settings seeded into the cache, with a sentinel a bad write would disturb. */
+const SEEDED_SETTINGS: ProjectSettings = {
+  runCommands: [],
+  devServerCommand: "npm run dev",
+  preferredEditor: { id: "vscode" },
+};
 
 /** Render for "proj-1" with settings loaded and the Save button enabled. */
 async function renderLoadedTab() {
@@ -192,10 +207,7 @@ describe("ImageViewerTab", () => {
   // keeps the pre-save value and the next settings-form write reverts it (#12326).
   describe("cached settings write-through", () => {
     it("merges the saved preference into the cache, preserving unrelated fields", async () => {
-      useProjectSettingsStore.setState({
-        settings: { runCommands: [], devServerCommand: "npm run dev" },
-        projectId: "proj-1",
-      });
+      useProjectSettingsStore.setState({ settings: SEEDED_SETTINGS, projectId: "proj-1" });
       const saveButton = await renderLoadedTab();
 
       fireEvent.click(saveButton);
@@ -207,14 +219,14 @@ describe("ImageViewerTab", () => {
         });
       });
       expect(useProjectSettingsStore.getState().settings?.devServerCommand).toBe("npm run dev");
+      expect(useProjectSettingsStore.getState().settings?.preferredEditor).toEqual({
+        id: "vscode",
+      });
       expect(projectClient.saveSettings).toHaveBeenCalledTimes(1);
     });
 
     it("merges into the settings the cache holds after the save, not the pre-await copy", async () => {
-      useProjectSettingsStore.setState({
-        settings: { runCommands: [], devServerCommand: "npm run dev" },
-        projectId: "proj-1",
-      });
+      useProjectSettingsStore.setState({ settings: SEEDED_SETTINGS, projectId: "proj-1" });
       // A concurrent writer lands while the save IPC is in flight.
       vi.mocked(projectClient.saveSettings).mockImplementation(async () => {
         useProjectSettingsStore.setState({
@@ -232,24 +244,21 @@ describe("ImageViewerTab", () => {
     });
 
     it("leaves the cache untouched when the save rejects", async () => {
-      useProjectSettingsStore.setState({
-        settings: { runCommands: [] },
-        projectId: "proj-1",
-      });
+      useProjectSettingsStore.setState({ settings: SEEDED_SETTINGS, projectId: "proj-1" });
       vi.mocked(projectClient.saveSettings).mockRejectedValue(new Error("save blew up"));
       const saveButton = await renderLoadedTab();
 
       fireEvent.click(saveButton);
 
       await screen.findByText(/save blew up|Failed to save image viewer preference/i);
-      expect(useProjectSettingsStore.getState().settings?.preferredImageViewer).toBeUndefined();
+      // Asserting the whole object, not just the absent preference — wiping the
+      // cache outright would satisfy a `?.preferredImageViewer` check.
+      expect(useProjectSettingsStore.getState().settings).toEqual(SEEDED_SETTINGS);
+      expect(useProjectSettingsStore.getState().projectId).toBe("proj-1");
     });
 
     it("leaves the cache untouched when it holds a different project", async () => {
-      useProjectSettingsStore.setState({
-        settings: { runCommands: [] },
-        projectId: "proj-2",
-      });
+      useProjectSettingsStore.setState({ settings: SEEDED_SETTINGS, projectId: "proj-2" });
       const saveButton = await renderLoadedTab();
 
       fireEvent.click(saveButton);
@@ -257,7 +266,8 @@ describe("ImageViewerTab", () => {
       await waitFor(() => {
         expect(projectClient.saveSettings).toHaveBeenCalledTimes(1);
       });
-      expect(useProjectSettingsStore.getState().settings?.preferredImageViewer).toBeUndefined();
+      expect(useProjectSettingsStore.getState().settings).toEqual(SEEDED_SETTINGS);
+      expect(useProjectSettingsStore.getState().projectId).toBe("proj-2");
     });
   });
 });

--- a/src/components/Settings/__tests__/SettingsDialog.saveWiring.contract.test.ts
+++ b/src/components/Settings/__tests__/SettingsDialog.saveWiring.contract.test.ts
@@ -17,37 +17,87 @@ import ts from "typescript";
 //               Retry both re-save deliberately *unchanged* values.
 //
 // Wire a user-facing callback to flush() and it becomes a no-op the moment the
-// form is clean — the exact case both of those callers exist for. No render
-// test can see the difference: both are `() => Promise<void>` and both resolve.
-// So the rule is enforced on the source. flush() belongs to the dialog's own
-// teardown path and nowhere else; anything reachable from a JSX prop is a user
+// form is clean — the exact case both of those callers exist for. The two are
+// interchangeable at the type level, so nothing in the signature catches it.
+//
+// Source enforcement rather than a rendering assertion is a cost call, not an
+// impossibility: SettingsDialog is ~1600 lines of lazily-loaded tabs, and
+// standing that up to click one Retry button buys a single assertion. The rule
+// itself is structural anyway — flush() belongs to the dialog's own teardown
+// path and nowhere else, so anything reachable from a JSX prop is a user
 // action and must use saveNow().
 
 const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
 const DIALOG_PATH = path.resolve(TEST_DIR, "../SettingsDialog.tsx");
 
-/** The object the form hook is destructured onto in SettingsDialog. */
+/** The object the form hook's return value is bound to in SettingsDialog. */
 const FORM_OBJECT = "projectForm";
 
 function parseDialog(): ts.SourceFile {
   const source = fs.readFileSync(DIALOG_PATH, "utf8");
-  return ts.createSourceFile(DIALOG_PATH, source, ts.ScriptTarget.Latest, /* setParentNodes */ true);
+  return ts.createSourceFile(
+    DIALOG_PATH,
+    source,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true
+  );
 }
 
-/** Every `projectForm.<member>` access in the file, with the member name. */
-function collectFormAccesses(sourceFile: ts.SourceFile): ts.PropertyAccessExpression[] {
-  const found: ts.PropertyAccessExpression[] = [];
-  const visit = (node: ts.Node): void => {
+function walk(node: ts.Node, visit: (node: ts.Node) => void): void {
+  visit(node);
+  ts.forEachChild(node, (child) => walk(child, visit));
+}
+
+/**
+ * Names destructured off `projectForm` (`const { flush } = projectForm`), so a
+ * refactor to bare identifiers stays covered instead of silently passing.
+ */
+function collectDestructuredNames(sourceFile: ts.SourceFile): Set<string> {
+  const names = new Set<string>();
+  walk(sourceFile, (node) => {
+    if (
+      !ts.isVariableDeclaration(node) ||
+      !node.initializer ||
+      !ts.isIdentifier(node.initializer) ||
+      node.initializer.text !== FORM_OBJECT ||
+      !ts.isObjectBindingPattern(node.name)
+    ) {
+      return;
+    }
+    for (const element of node.name.elements) {
+      const source = element.propertyName ?? element.name;
+      if (ts.isIdentifier(source)) names.add(source.text);
+    }
+  });
+  return names;
+}
+
+/** Every reference to `projectForm.<member>`, in property-access or destructured form. */
+function collectMemberReferences(sourceFile: ts.SourceFile, member: string): ts.Node[] {
+  const destructured = collectDestructuredNames(sourceFile);
+  const found: ts.Node[] = [];
+  walk(sourceFile, (node) => {
     if (
       ts.isPropertyAccessExpression(node) &&
       ts.isIdentifier(node.expression) &&
-      node.expression.text === FORM_OBJECT
+      node.expression.text === FORM_OBJECT &&
+      node.name.text === member
+    ) {
+      found.push(node);
+      return;
+    }
+    // A bare identifier only counts once the name is bound off projectForm,
+    // otherwise unrelated locals named `flush` would be swept in.
+    if (
+      destructured.has(member) &&
+      ts.isIdentifier(node) &&
+      node.text === member &&
+      !ts.isPropertyAccessExpression(node.parent) &&
+      !ts.isBindingElement(node.parent)
     ) {
       found.push(node);
     }
-    ts.forEachChild(node, visit);
-  };
-  ts.forEachChild(sourceFile, visit);
+  });
   return found;
 }
 
@@ -63,36 +113,24 @@ function lineOf(node: ts.Node, sourceFile: ts.SourceFile): number {
 }
 
 describe("SettingsDialog persist wiring", () => {
-  it("routes every JSX-prop persist callback through saveNow, never flush", () => {
+  it("never hands the lifecycle flush to a JSX callback prop", () => {
     const sourceFile = parseDialog();
-    const accesses = collectFormAccesses(sourceFile);
+    const flushRefs = collectMemberReferences(sourceFile, "flush");
 
-    const flushInProps = accesses
-      .filter((node) => node.name.text === "flush" && isInsideJsxAttribute(node))
+    const inProps = flushRefs
+      .filter(isInsideJsxAttribute)
       .map((node) => `line ${lineOf(node, sourceFile)}`);
 
-    expect(flushInProps).toEqual([]);
+    expect(inProps).toEqual([]);
   });
 
-  it("still hands flush to the dialog's own teardown path", () => {
+  it("still uses both entry points, so the rule above cannot pass vacuously", () => {
     const sourceFile = parseDialog();
-    const accesses = collectFormAccesses(sourceFile);
 
-    // Guards the assertion above against passing vacuously once `flush` is
-    // renamed or the teardown call is dropped altogether.
-    const flushCalls = accesses.filter((node) => node.name.text === "flush");
-    expect(flushCalls.length).toBeGreaterThan(0);
-    expect(flushCalls.every((node) => !isInsideJsxAttribute(node))).toBe(true);
-  });
-
-  it("wires the explicit user-initiated saves to saveNow", () => {
-    const sourceFile = parseDialog();
-    const accesses = collectFormAccesses(sourceFile);
-
-    // The environment-variable editor's onFlush and the autosave-error Retry.
-    const saveNowInProps = accesses.filter(
-      (node) => node.name.text === "saveNow" && isInsideJsxAttribute(node)
-    );
-    expect(saveNowInProps.length).toBeGreaterThanOrEqual(2);
+    // flush() reaching nothing at all would mean teardown stopped persisting;
+    // saveNow() reaching nothing would mean the explicit saves regressed to a
+    // dirty-gated write. Either makes the assertion above meaningless.
+    expect(collectMemberReferences(sourceFile, "flush").length).toBeGreaterThan(0);
+    expect(collectMemberReferences(sourceFile, "saveNow").length).toBeGreaterThan(0);
   });
 });

--- a/src/components/Settings/__tests__/SettingsDialog.saveWiring.contract.test.ts
+++ b/src/components/Settings/__tests__/SettingsDialog.saveWiring.contract.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+
+// The project settings form exposes two persist entry points that differ only
+// in whether they write when nothing changed, and picking the wrong one fails
+// silently in opposite directions:
+//
+//   flush()   — lifecycle (dialog close, WebContentsView detach). Skips the
+//               write when the form is clean, because that write spreads a
+//               cached settings snapshot and would revert fields other tabs
+//               saved out-of-band (#12326).
+//   saveNow() — explicit user-initiated save. Always writes, because the
+//               environment-variable migration button and the autosave-error
+//               Retry both re-save deliberately *unchanged* values.
+//
+// Wire a user-facing callback to flush() and it becomes a no-op the moment the
+// form is clean — the exact case both of those callers exist for. No render
+// test can see the difference: both are `() => Promise<void>` and both resolve.
+// So the rule is enforced on the source. flush() belongs to the dialog's own
+// teardown path and nowhere else; anything reachable from a JSX prop is a user
+// action and must use saveNow().
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const DIALOG_PATH = path.resolve(TEST_DIR, "../SettingsDialog.tsx");
+
+/** The object the form hook is destructured onto in SettingsDialog. */
+const FORM_OBJECT = "projectForm";
+
+function parseDialog(): ts.SourceFile {
+  const source = fs.readFileSync(DIALOG_PATH, "utf8");
+  return ts.createSourceFile(DIALOG_PATH, source, ts.ScriptTarget.Latest, /* setParentNodes */ true);
+}
+
+/** Every `projectForm.<member>` access in the file, with the member name. */
+function collectFormAccesses(sourceFile: ts.SourceFile): ts.PropertyAccessExpression[] {
+  const found: ts.PropertyAccessExpression[] = [];
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isPropertyAccessExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === FORM_OBJECT
+    ) {
+      found.push(node);
+    }
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(sourceFile, visit);
+  return found;
+}
+
+function isInsideJsxAttribute(node: ts.Node): boolean {
+  for (let current: ts.Node | undefined = node; current; current = current.parent) {
+    if (ts.isJsxAttribute(current)) return true;
+  }
+  return false;
+}
+
+function lineOf(node: ts.Node, sourceFile: ts.SourceFile): number {
+  return sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1;
+}
+
+describe("SettingsDialog persist wiring", () => {
+  it("routes every JSX-prop persist callback through saveNow, never flush", () => {
+    const sourceFile = parseDialog();
+    const accesses = collectFormAccesses(sourceFile);
+
+    const flushInProps = accesses
+      .filter((node) => node.name.text === "flush" && isInsideJsxAttribute(node))
+      .map((node) => `line ${lineOf(node, sourceFile)}`);
+
+    expect(flushInProps).toEqual([]);
+  });
+
+  it("still hands flush to the dialog's own teardown path", () => {
+    const sourceFile = parseDialog();
+    const accesses = collectFormAccesses(sourceFile);
+
+    // Guards the assertion above against passing vacuously once `flush` is
+    // renamed or the teardown call is dropped altogether.
+    const flushCalls = accesses.filter((node) => node.name.text === "flush");
+    expect(flushCalls.length).toBeGreaterThan(0);
+    expect(flushCalls.every((node) => !isInsideJsxAttribute(node))).toBe(true);
+  });
+
+  it("wires the explicit user-initiated saves to saveNow", () => {
+    const sourceFile = parseDialog();
+    const accesses = collectFormAccesses(sourceFile);
+
+    // The environment-variable editor's onFlush and the autosave-error Retry.
+    const saveNowInProps = accesses.filter(
+      (node) => node.name.text === "saveNow" && isInsideJsxAttribute(node)
+    );
+    expect(saveNowInProps.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/src/hooks/__tests__/useProjectSettingsForm.test.tsx
+++ b/src/hooks/__tests__/useProjectSettingsForm.test.tsx
@@ -241,7 +241,93 @@ describe("useProjectSettingsForm", () => {
     await act(async () => {
       await result.current.flush();
     });
-    expect(mockSaveSettings).toHaveBeenCalled();
+    // The pending debounce persists; the direct fallback must not persist again.
+    expect(mockSaveSettings).toHaveBeenCalledTimes(1);
+
+    // Nothing changed since, so a second flush is a no-op.
+    await act(async () => {
+      await result.current.flush();
+    });
+    expect(mockSaveSettings).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
+
+  it("flush() does not save when the form is untouched", async () => {
+    vi.useFakeTimers();
+    const { result, rerender } = renderHook(
+      ({ isOpen }: { isOpen: boolean; tick: number }) =>
+        useProjectSettingsForm({ projectId: "proj-1", isOpen }),
+      { initialProps: { isOpen: false, tick: 0 } }
+    );
+    rerender({ isOpen: true, tick: 1 });
+    mockSettings.value = baseSettings;
+    rerender({ isOpen: true, tick: 2 });
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+    expect(result.current.projectIsInitialized).toBe(true);
+
+    vi.clearAllMocks();
+    // Closing a dialog nobody edited must not rewrite the cached settings —
+    // that write reverts fields other tabs saved out-of-band (#12326).
+    await act(async () => {
+      await result.current.flush();
+    });
+    expect(mockSaveSettings).not.toHaveBeenCalled();
+    expect(mockUpdateProject).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  it("saveNow() persists even when the form is untouched", async () => {
+    vi.useFakeTimers();
+    const { result, rerender } = renderHook(
+      ({ isOpen }: { isOpen: boolean; tick: number }) =>
+        useProjectSettingsForm({ projectId: "proj-1", isOpen }),
+      { initialProps: { isOpen: false, tick: 0 } }
+    );
+    rerender({ isOpen: true, tick: 1 });
+    mockSettings.value = baseSettings;
+    rerender({ isOpen: true, tick: 2 });
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+    expect(result.current.projectIsInitialized).toBe(true);
+
+    vi.clearAllMocks();
+    // The environment-variable migration button re-saves unchanged values on
+    // purpose, so the explicit entry point must stay unconditional.
+    await act(async () => {
+      await result.current.saveNow();
+    });
+    expect(mockSaveSettings).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
+
+  it("flush() persists the edited value exactly once when the form is dirty", async () => {
+    vi.useFakeTimers();
+    const { result, rerender } = renderHook(
+      ({ isOpen }: { isOpen: boolean; tick: number }) =>
+        useProjectSettingsForm({ projectId: "proj-1", isOpen }),
+      { initialProps: { isOpen: false, tick: 0 } }
+    );
+    rerender({ isOpen: true, tick: 1 });
+    mockSettings.value = baseSettings;
+    rerender({ isOpen: true, tick: 2 });
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+
+    vi.clearAllMocks();
+    act(() => {
+      result.current.setDevServerCommand("npm run serve");
+    });
+    await act(async () => {
+      await result.current.flush();
+    });
+    expect(mockSaveSettings).toHaveBeenCalledTimes(1);
+    expect(mockSaveSettings.mock.calls[0]![0]).toMatchObject({
+      devServerCommand: "npm run serve",
+    });
     vi.useRealTimers();
   });
 

--- a/src/hooks/__tests__/useProjectSettingsForm.test.tsx
+++ b/src/hooks/__tests__/useProjectSettingsForm.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { act, renderHook, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ProjectSettings } from "@/types";
 
 const {
@@ -124,6 +124,12 @@ describe("useProjectSettingsForm", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetMocks();
+  });
+
+  // Every timer restore below is on the success path, so a failed assertion
+  // would leave fake timers installed and hang the async tests after it.
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("stays uninitialized when isOpen is false", () => {
@@ -326,6 +332,43 @@ describe("useProjectSettingsForm", () => {
     });
     expect(mockSaveSettings).toHaveBeenCalledTimes(1);
     expect(mockSaveSettings.mock.calls[0]![0]).toMatchObject({
+      devServerCommand: "npm run serve",
+    });
+    vi.useRealTimers();
+  });
+
+  it("a later form save carries the preference the cache holds, not the one it opened with", async () => {
+    vi.useFakeTimers();
+    const { result, rerender } = renderHook(
+      ({ isOpen }: { isOpen: boolean; tick: number }) =>
+        useProjectSettingsForm({ projectId: "proj-1", isOpen }),
+      { initialProps: { isOpen: false, tick: 0 } }
+    );
+    rerender({ isOpen: true, tick: 1 });
+    mockSettings.value = { ...baseSettings, preferredEditor: { id: "vscode" } };
+    rerender({ isOpen: true, tick: 2 });
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+    expect(result.current.projectIsInitialized).toBe(true);
+
+    // Another tab saved a new editor and wrote through to the cache. The form
+    // spreads the cache on every save, so it must pick up the new value —
+    // this is what patchCachedProjectSettings exists to make true (#12326).
+    mockSettings.value = { ...baseSettings, preferredEditor: { id: "zed" } };
+    rerender({ isOpen: true, tick: 3 });
+
+    vi.clearAllMocks();
+    act(() => {
+      result.current.setDevServerCommand("npm run serve");
+    });
+    await act(async () => {
+      await result.current.flush();
+    });
+
+    expect(mockSaveSettings).toHaveBeenCalledTimes(1);
+    expect(mockSaveSettings.mock.calls[0]![0]).toMatchObject({
+      preferredEditor: { id: "zed" },
       devServerCommand: "npm run serve",
     });
     vi.useRealTimers();

--- a/src/hooks/useProjectSettingsForm.ts
+++ b/src/hooks/useProjectSettingsForm.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useRef } from "react";
+import { useState, useEffect, useLayoutEffect, useMemo, useRef } from "react";
 import { useProjectSettings } from "@/hooks/useProjectSettings";
 import { useProjectStore } from "@/store/projectStore";
 import { useWorktrees } from "@/hooks/useWorktrees";
@@ -179,7 +179,11 @@ export function useProjectSettingsForm({ projectId, isOpen }: UseProjectSettings
     daintreeMcpTier,
     forgeProviderOverride,
   ]);
-  useEffect(() => {
+  // Layout effect, not passive: callers such as EnvironmentVariablesEditor push
+  // new values and invoke flush() in the same tick, and flush() reads this ref
+  // to decide whether anything changed. A passive effect lands after that read,
+  // so the edit would look clean and be dropped.
+  useLayoutEffect(() => {
     currentProjectSnapshotRef.current = currentProjectSnapshot;
   }, [currentProjectSnapshot]);
 
@@ -441,8 +445,9 @@ export function useProjectSettingsForm({ projectId, isOpen }: UseProjectSettings
   };
 
   // projectPersist is recreated each render; sync it to the ref so the
-  // debounced wrapper always calls the latest closure.
-  useEffect(() => {
+  // debounced wrapper always calls the latest closure. Layout phase for the
+  // same reason as currentProjectSnapshotRef above.
+  useLayoutEffect(() => {
     projectPersistRef.current = projectPersist;
   });
 
@@ -455,14 +460,31 @@ export function useProjectSettingsForm({ projectId, isOpen }: UseProjectSettings
     debouncedProjectSaveRef.current?.();
   }, [currentProjectSnapshot, projectIsInitialized]);
 
-  const flush = async () => {
-    // First try flushing any pending debounced save
+  // Explicit user-initiated save. Persists unconditionally, so a re-save of
+  // unchanged values still reaches main — the environment-variable migration
+  // button relies on that to relocate insecure values.
+  const saveNow = async () => {
     await debouncedProjectSaveRef.current?.flush();
-    // If no debounced save was pending (state changed but useEffect hasn't
-    // scheduled it yet), force a direct save to avoid data loss on close
     if (projectIsInitialized && projectPersistRef.current) {
       await projectPersistRef.current();
     }
+  };
+
+  // Lifecycle save, run on dialog close and on WebContentsView detach. Unlike
+  // saveNow it must not write when the form is clean: projectPersist spreads
+  // the cached settings snapshot, so a no-op write would revert fields saved
+  // out-of-band by other tabs since that snapshot was taken (#12326).
+  const flush = async () => {
+    // First drain any pending debounced save — that also settles an in-flight
+    // one, so the snapshot comparison below sees its result.
+    await debouncedProjectSaveRef.current?.flush();
+    if (!projectIsInitialized || !projectPersistRef.current) return;
+    const lastSaved = lastSavedSnapshotRef.current;
+    const current = currentProjectSnapshotRef.current;
+    // Missing either snapshot means we cannot prove the form is clean; persist
+    // rather than risk losing an edit on close.
+    if (lastSaved && current && areSnapshotsEqual(lastSaved, current)) return;
+    await projectPersistRef.current();
   };
 
   return {
@@ -534,6 +556,7 @@ export function useProjectSettingsForm({ projectId, isOpen }: UseProjectSettings
     worktreeMap,
     worktrees,
     flush,
+    saveNow,
   };
 }
 

--- a/src/store/__tests__/projectSettingsStore.test.ts
+++ b/src/store/__tests__/projectSettingsStore.test.ts
@@ -137,14 +137,19 @@ describe("projectSettingsStore", () => {
       useProjectSettingsStore.setState({
         settings: { ...SETTINGS_WITH_COMMANDS, devServerCommand: "npm run dev" },
         projectId: "project-a",
+        allDetectedRunners: DETECTED_RUNNERS,
+        detectedRunners: [DETECTED_RUNNERS[1]!],
       });
 
       patchCachedProjectSettings("project-a", { preferredEditor: { id: "zed" } });
 
-      const settings = useProjectSettingsStore.getState().settings;
-      expect(settings?.preferredEditor).toEqual({ id: "zed" });
-      expect(settings?.devServerCommand).toBe("npm run dev");
-      expect(settings?.runCommands).toHaveLength(2);
+      const state = useProjectSettingsStore.getState();
+      expect(state.settings?.preferredEditor).toEqual({ id: "zed" });
+      expect(state.settings?.devServerCommand).toBe("npm run dev");
+      expect(state.settings?.runCommands).toHaveLength(2);
+      // setSettings recomputes these from allDetectedRunners; a preference-only
+      // patch must not drop a runner that is still undetected-and-unsaved.
+      expect(state.detectedRunners).toEqual([DETECTED_RUNNERS[1]]);
     });
 
     it("ignores a patch for a project the store no longer holds", () => {

--- a/src/store/__tests__/projectSettingsStore.test.ts
+++ b/src/store/__tests__/projectSettingsStore.test.ts
@@ -13,7 +13,11 @@ vi.mock("@/clients", () => ({
   },
 }));
 
-import { cleanupProjectSettingsStore, useProjectSettingsStore } from "../projectSettingsStore";
+import {
+  cleanupProjectSettingsStore,
+  patchCachedProjectSettings,
+  useProjectSettingsStore,
+} from "../projectSettingsStore";
 
 function createDeferred<T>() {
   let resolve: (value: T) => void;
@@ -126,5 +130,40 @@ describe("projectSettingsStore", () => {
     expect(state.detectedRunners).toEqual([
       { id: "det-2", name: "Build", command: "npm run build" },
     ]);
+  });
+
+  describe("patchCachedProjectSettings", () => {
+    it("merges the patch into the cached settings, preserving unrelated fields", () => {
+      useProjectSettingsStore.setState({
+        settings: { ...SETTINGS_WITH_COMMANDS, devServerCommand: "npm run dev" },
+        projectId: "project-a",
+      });
+
+      patchCachedProjectSettings("project-a", { preferredEditor: { id: "zed" } });
+
+      const settings = useProjectSettingsStore.getState().settings;
+      expect(settings?.preferredEditor).toEqual({ id: "zed" });
+      expect(settings?.devServerCommand).toBe("npm run dev");
+      expect(settings?.runCommands).toHaveLength(2);
+    });
+
+    it("ignores a patch for a project the store no longer holds", () => {
+      useProjectSettingsStore.setState({
+        settings: SETTINGS_WITH_COMMANDS,
+        projectId: "project-a",
+      });
+
+      patchCachedProjectSettings("project-b", { preferredEditor: { id: "zed" } });
+
+      expect(useProjectSettingsStore.getState().settings?.preferredEditor).toBeUndefined();
+    });
+
+    it("ignores a patch when no settings are cached", () => {
+      useProjectSettingsStore.setState({ settings: null, projectId: "project-a" });
+
+      patchCachedProjectSettings("project-a", { preferredEditor: { id: "zed" } });
+
+      expect(useProjectSettingsStore.getState().settings).toBeNull();
+    });
   });
 });

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -17,7 +17,11 @@ export { useEventStore } from "./eventStore";
 
 export { useProjectStore } from "./projectStore";
 
-export { useProjectSettingsStore, cleanupProjectSettingsStore } from "./projectSettingsStore";
+export {
+  useProjectSettingsStore,
+  cleanupProjectSettingsStore,
+  patchCachedProjectSettings,
+} from "./projectSettingsStore";
 
 export { useFocusStore } from "./focusStore";
 export type { PanelState } from "./focusStore";

--- a/src/store/projectSettingsStore.ts
+++ b/src/store/projectSettingsStore.ts
@@ -192,6 +192,21 @@ export const useProjectSettingsStore = create<ProjectSettingsState & ProjectSett
   createProjectSettingsStore
 );
 
+/**
+ * Merge fields persisted outside the settings form into the cached settings.
+ * Without this the cache keeps the pre-write values, and the next form save —
+ * which spreads that cache — reverts them (#12326). No-op unless the store
+ * still holds the project the write targeted.
+ */
+export function patchCachedProjectSettings(
+  projectId: string,
+  patch: Partial<ProjectSettings>
+): void {
+  const state = useProjectSettingsStore.getState();
+  if (state.projectId !== projectId || !state.settings) return;
+  state.setSettings({ ...state.settings, ...patch });
+}
+
 /** Cleanup function for project switch */
 export function cleanupProjectSettingsStore(): void {
   useProjectSettingsStore.getState().reset();


### PR DESCRIPTION
## Summary

THE BUG: closing the Settings dialog re-persisted the cached project settings whether or not anything had changed. `projectPersist` in `useProjectSettingsForm.ts` spreads `...projectSettings` — the snapshot cached in `useProjectSettingsStore` — and overrides only the fields the form owns. So any ProjectSettings field written *outside* that store got rewritten back to its pre-save value the moment the dialog closed, on project switch, or on window close.

Two tabs write out of band. `EditorIntegrationTab` calls `editorClient.setConfig`, after which the *main* process writes `preferredEditor` into the settings file — the renderer store never hears about it. `ImageViewerTab` calls `projectClient.getSettings` + `saveSettings` directly (deliberately, to invalidate the per-projectId cache) and likewise never touches the store.

That means there were really two bugs, and the dirty check the issue proposes only fixes the first:
1. Save a preference, close the dialog with the form untouched → reverted.
2. Save a preference, then change *anything* in the form → the form's own legitimate save spreads the stale preference back over the fresh one.

THE FIX, in three parts:

1. `flush()` — the lifecycle save wired to dialog close and `visibilitychange` — now skips persisting when the form is clean, reusing the `areSnapshotsEqual` / `lastSavedSnapshotRef` machinery the debounce trigger already used. It deliberately still persists when either snapshot is missing: not being able to prove the form is clean should cost a redundant write, not a lost edit.

2. The unconditional behaviour did not just disappear — it moved to a new `saveNow()`, because two callers depend on it. The environment-variable editor's "Move N values out of shared settings" button re-saves *deliberately unchanged* values so main's codec relocates them, and the autosave-error banner's Retry has to work after a save that failed while the form was clean. Both now call `saveNow()`. A source-contract test pins the rule (flush is teardown-only; anything reachable from a JSX prop is a user action) since the two share a signature.

3. New `patchCachedProjectSettings()` keeps the cache honest: both tabs merge their saved preference into the store after a successful write, guarded on the store still holding that project, and the editor path also invalidates the `projectClient` settings cache — `editorClient.setConfig` bypassed it, so a subsequent read could serve a ≤500ms-stale object and write it back.

Also promoted the `currentProjectSnapshotRef` / `projectPersistRef` syncs from `useEffect` to `useLayoutEffect`. This is load-bearing for the new gate, not tidying: `EnvironmentVariablesEditor.handleSave` pushes rows and awaits `onFlush()` in the same tick, and a passive effect lands *after* the microtask that reads the snapshot — so the gate would have read a stale snapshot and silently dropped a real env-var save.

Resolves #12326

## Changes

- `src/hooks/useProjectSettingsForm.ts` — dirty-check gate on `flush()`, new `saveNow()` for explicit user actions, `useLayoutEffect` promotion for the snapshot refs
- `src/store/projectSettingsStore.ts` / `src/store/index.ts` — new `patchCachedProjectSettings()` to keep the cache honest after out-of-band writes
- `src/components/Settings/SettingsDialog.tsx` — wires `saveNow()` for the autosave-error Retry
- `src/components/Settings/EditorIntegrationTab.tsx` — patches the cache and invalidates the `projectClient` settings cache after `editorClient.setConfig`
- `src/components/Settings/ImageViewerTab.tsx` — patches the cache after its direct `saveSettings` call
- 5 test files updated, 2 new: `EditorIntegrationTab.test.tsx`, `SettingsDialog.saveWiring.contract.test.ts`

## Testing

22 covering suites, 314 tests green. New coverage for the pristine-flush no-op, `saveNow()` persisting when clean, no double-persist when a debounce is pending, the second-order clobber, store write-through in both tabs (including whole-object assertions on the negative cases, so wiping the cache can't pass), and cache invalidation with a frozen clock so the 500ms TTL can't make it pass by accident. Own-file eslint/prettier clean with zero net lint-ratchet warnings.

## Not fixed here

- Overlapping saves are still not serialised. `debounce.flush()` awaits only the newest run, so an older in-flight save can land on disk after a newer one. On develop the unconditional close-write accidentally repaired that interleaving; the gate no longer does. Trading a rare interleaving for a 100%-reproducible revert is the right way round, but serialising persistence is the actual fix and it is a separate change — chaining persists on the teardown path risks blocking close behind a hung IPC.
- An already-executing `projectPersist` closure captured `projectSettings` before the patch, so it can still write a stale preference back. Fixing that needs partial-update IPC semantics across ~20 `saveSettings` call sites.
- `loadSettings()` resolving after a preference patch can still overwrite it; it needs a settings revision counter.
- The standard project settings save handler still has no settings-change broadcast, so other renderer stores and windows can hold stale copies.