### PR TITLE
fix(worktree): use the configured editor, not the OS handler

### DIFF
--- a/electron/ipc/handlers/__tests__/systemShell.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/systemShell.handlers.test.ts
@@ -365,6 +365,26 @@ describe("system:open-in-editor containment", () => {
     expect(projectStoreMock.getProjectSettings).toHaveBeenCalledWith("proj-1");
     expect(openFileMock).toHaveBeenCalledWith(dirPath, undefined, undefined, preferredEditor, true);
   });
+
+  it("keeps the directory flag when the settings read fails", async () => {
+    projectStoreMock.getProjectSettings.mockRejectedValue(new Error("db closed"));
+    fsMock.promises.stat.mockResolvedValue({ isFile: () => false, isDirectory: () => true });
+    const handler = getHandler(CHANNELS.SYSTEM_OPEN_IN_EDITOR);
+    const dirPath = path.join(PROJECT_ROOT, "packages", "app");
+
+    await handler(fakeEvent, { path: dirPath, projectId: "proj-1" });
+
+    expect(openFileMock).toHaveBeenCalledWith(dirPath, undefined, undefined, null, true);
+  });
+
+  it("propagates a launch failure to the renderer", async () => {
+    openFileMock.mockRejectedValueOnce(new Error("no editor"));
+    const handler = getHandler(CHANNELS.SYSTEM_OPEN_IN_EDITOR);
+
+    await expect(
+      handler(fakeEvent, { path: path.join(PROJECT_ROOT, "src", "app.ts") })
+    ).rejects.toThrow("no editor");
+  });
 });
 
 describe("system:show-item-in-folder containment", () => {

--- a/electron/ipc/handlers/__tests__/systemShell.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/systemShell.handlers.test.ts
@@ -36,7 +36,11 @@ vi.mock("fs", () => ({ default: fsMock, ...fsMock }));
 
 const projectStoreMock = vi.hoisted(() => ({
   getAllProjects: vi.fn<() => Array<{ path: string }>>(() => []),
-  getProjectSettings: vi.fn(() => Promise.resolve({ preferredEditor: null })),
+  // Typed to the real settings shape, not to the null default, so a test can
+  // hand back an actual editor preference.
+  getProjectSettings: vi.fn<
+    (projectId: string) => Promise<{ preferredEditor: { id: string } | null }>
+  >(() => Promise.resolve({ preferredEditor: null })),
 }));
 
 vi.mock("../../../services/ProjectStore.js", () => ({
@@ -141,6 +145,10 @@ function resetGitMocks() {
   gitServiceMock.listWorktrees.mockResolvedValue([]);
   gitServiceCacheMock.getGitService.mockReturnValue(gitServiceMock);
   fsMock.promises.access.mockResolvedValue(undefined);
+  // The editor handler classifies its resolved target and reads the project's
+  // editor preference, so both are per-suite state like the rest of these.
+  fsMock.promises.stat.mockResolvedValue({ isFile: () => true, isDirectory: () => false });
+  projectStoreMock.getProjectSettings.mockResolvedValue({ preferredEditor: null });
 }
 
 // Rejects the `.git` probe for the given roots, marking them as no longer
@@ -277,7 +285,7 @@ describe("system:open-in-editor containment", () => {
     const handler = getHandler(CHANNELS.SYSTEM_OPEN_IN_EDITOR);
     const filePath = path.join(PROJECT_ROOT, "src", "app.ts");
     await handler(fakeEvent, { path: filePath, line: 5, col: 2 });
-    expect(openFileMock).toHaveBeenCalledWith(filePath, 5, 2, null);
+    expect(openFileMock).toHaveBeenCalledWith(filePath, 5, 2, null, false);
   });
 
   it("rejects an out-of-root file without invoking the editor", async () => {
@@ -300,7 +308,62 @@ describe("system:open-in-editor containment", () => {
         ? path.join(PROJECT_ROOT, "scripts", "deploy.ps1")
         : path.join(PROJECT_ROOT, "scripts", "setup.desktop");
     await handler(fakeEvent, { path: scriptPath });
-    expect(openFileMock).toHaveBeenCalledWith(scriptPath, undefined, undefined, null);
+    expect(openFileMock).toHaveBeenCalledWith(scriptPath, undefined, undefined, null, false);
+  });
+
+  // The worktree "Open in Editor" action targets a folder (#12329). The handler
+  // classifies it so EditorService can pick folder-appropriate argv.
+  it("marks a directory target as a directory for the editor service", async () => {
+    fsMock.promises.stat.mockResolvedValue({ isFile: () => false, isDirectory: () => true });
+    const handler = getHandler(CHANNELS.SYSTEM_OPEN_IN_EDITOR);
+    const dirPath = path.join(PROJECT_ROOT, "packages", "app");
+
+    await handler(fakeEvent, { path: dirPath });
+
+    expect(openFileMock).toHaveBeenCalledWith(dirPath, undefined, undefined, null, true);
+  });
+
+  it("classifies the resolved target, not the raw request path", async () => {
+    const linkPath = path.join(PROJECT_ROOT, "current");
+    const realDir = path.join(PROJECT_ROOT, "releases", "v2");
+    fsMock.promises.realpath.mockImplementation((p: string) =>
+      Promise.resolve(path.normalize(p) === linkPath ? realDir : path.normalize(p))
+    );
+    fsMock.promises.stat.mockImplementation((p: string) =>
+      Promise.resolve({ isFile: () => p !== realDir, isDirectory: () => p === realDir })
+    );
+    const handler = getHandler(CHANNELS.SYSTEM_OPEN_IN_EDITOR);
+
+    await handler(fakeEvent, { path: linkPath });
+
+    expect(fsMock.promises.stat).toHaveBeenCalledWith(realDir);
+    expect(openFileMock).toHaveBeenCalledWith(realDir, undefined, undefined, null, true);
+  });
+
+  // Containment already realpath'd the target, so a stat failure here is a lost
+  // race rather than a bad request. Falling back to "file" keeps every existing
+  // file launch behaving exactly as before instead of inventing a new error.
+  it("still opens the target as a file when classification fails", async () => {
+    fsMock.promises.stat.mockRejectedValue(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
+    const handler = getHandler(CHANNELS.SYSTEM_OPEN_IN_EDITOR);
+    const filePath = path.join(PROJECT_ROOT, "src", "app.ts");
+
+    await handler(fakeEvent, { path: filePath });
+
+    expect(openFileMock).toHaveBeenCalledWith(filePath, undefined, undefined, null, false);
+  });
+
+  it("passes the project's configured editor through with the directory flag", async () => {
+    const preferredEditor = { id: "zed" as const };
+    projectStoreMock.getProjectSettings.mockResolvedValue({ preferredEditor });
+    fsMock.promises.stat.mockResolvedValue({ isFile: () => false, isDirectory: () => true });
+    const handler = getHandler(CHANNELS.SYSTEM_OPEN_IN_EDITOR);
+    const dirPath = path.join(PROJECT_ROOT, "packages", "app");
+
+    await handler(fakeEvent, { path: dirPath, projectId: "proj-1" });
+
+    expect(projectStoreMock.getProjectSettings).toHaveBeenCalledWith("proj-1");
+    expect(openFileMock).toHaveBeenCalledWith(dirPath, undefined, undefined, preferredEditor, true);
   });
 });
 
@@ -428,7 +491,7 @@ describe("system path-allowlist: tracked worktree roots", () => {
     const handler = getHandler(CHANNELS.SYSTEM_OPEN_IN_EDITOR);
     const filePath = path.join(customWorktree, "src", "index.ts");
     await handler(fakeEvent, { path: filePath, line: 1, col: 1 });
-    expect(openFileMock).toHaveBeenCalledWith(filePath, 1, 1, null);
+    expect(openFileMock).toHaveBeenCalledWith(filePath, 1, 1, null, false);
   });
 
   // `git worktree add ~/scratch/hotfix` puts the worktree somewhere no pattern
@@ -563,7 +626,7 @@ describe("system path-allowlist: tracked worktree roots", () => {
     // The healthy linked worktree alongside it is still admitted.
     const filePath = path.join(UNPREDICTED_WORKTREE, "src", "index.ts");
     await handler(fakeEvent, { path: filePath });
-    expect(openFileMock).toHaveBeenCalledWith(filePath, undefined, undefined, null);
+    expect(openFileMock).toHaveBeenCalledWith(filePath, undefined, undefined, null, false);
   });
 
   // The escalated branch must hand the sink the canonical target, not the

--- a/electron/ipc/handlers/systemShell.ts
+++ b/electron/ipc/handlers/systemShell.ts
@@ -324,6 +324,22 @@ export function registerSystemShellHandlers(_deps: HandlerDependencies): () => v
   }: SystemOpenInEditorPayload) => {
     const realTarget = await assertPathAllowed(targetPath, "editor");
 
+    // The worktree "Open in Editor" action targets a folder (#12329), and
+    // EditorService needs to know: a folder takes different argv on the VS Code
+    // family and cannot go through the macOS plain-text fallback at all.
+    // Classified here rather than declared by the renderer, so it describes the
+    // resolved target the sink actually receives and no IPC field is needed.
+    // `assertPathAllowed` already realpath'd it, so the target existed a moment
+    // ago; a stat that fails now lost a race, and reading that as "not a
+    // directory" leaves the file path behaving exactly as it does today.
+    let isDirectory = false;
+    try {
+      const stats = await nodeFs.promises.stat(realTarget);
+      isDirectory = stats.isDirectory();
+    } catch {
+      // ignore — treat an unclassifiable target as a file
+    }
+
     let editorConfig = null;
     if (projectId) {
       try {
@@ -335,7 +351,7 @@ export function registerSystemShellHandlers(_deps: HandlerDependencies): () => v
     }
 
     const { openFile } = await import("../../services/EditorService.js");
-    await openFile(realTarget, line, col, editorConfig);
+    await openFile(realTarget, line, col, editorConfig, isDirectory);
   };
   handlers.push(
     typedHandleValidated(

--- a/electron/services/EditorService.ts
+++ b/electron/services/EditorService.ts
@@ -11,8 +11,14 @@ interface EditorDefinition {
   binaries: string[];
   /** Additional directories to search beyond PATH (e.g. JetBrains Toolbox) */
   extraDirs?: () => string[];
-  /** Build the argv for opening a file at line/col */
-  buildArgs(filePath: string, line?: number, col?: number): string[];
+  /**
+   * Build the argv for opening a target at line/col. `isDirectory` is true when
+   * the target is a folder, in which case `line`/`col` are always undefined —
+   * `openFile` drops them before it gets here, since no editor CLI can navigate
+   * to a coordinate inside a directory. Most builders therefore need no branch:
+   * their no-coordinate form (a bare path) is already the folder-open syntax.
+   */
+  buildArgs(filePath: string, line?: number, col?: number, isDirectory?: boolean): string[];
 }
 
 const KNOWN_EDITORS: EditorDefinition[] = [
@@ -22,7 +28,10 @@ const KNOWN_EDITORS: EditorDefinition[] = [
     binaries: ["code"],
     extraDirs: () =>
       macAppBundleDirs([{ name: "Visual Studio Code", subPath: "Contents/Resources/app/bin" }]),
-    buildArgs(filePath, line, col) {
+    // `--goto` names a file to navigate into; handed a folder the whole VS Code
+    // family opens the path as a text buffer instead of the workspace (#12329).
+    buildArgs(filePath, line, col, isDirectory) {
+      if (isDirectory) return [filePath];
       const target =
         line !== undefined ? `${filePath}:${line}${col !== undefined ? `:${col}` : ""}` : filePath;
       return ["--goto", target];
@@ -36,7 +45,8 @@ const KNOWN_EDITORS: EditorDefinition[] = [
       macAppBundleDirs([
         { name: "Visual Studio Code - Insiders", subPath: "Contents/Resources/app/bin" },
       ]),
-    buildArgs(filePath, line, col) {
+    buildArgs(filePath, line, col, isDirectory) {
+      if (isDirectory) return [filePath];
       const target =
         line !== undefined ? `${filePath}:${line}${col !== undefined ? `:${col}` : ""}` : filePath;
       return ["--goto", target];
@@ -47,7 +57,8 @@ const KNOWN_EDITORS: EditorDefinition[] = [
     name: "Cursor",
     binaries: ["cursor"],
     extraDirs: () => macAppBundleDirs([{ name: "Cursor", subPath: "Contents/Resources/app/bin" }]),
-    buildArgs(filePath, line, col) {
+    buildArgs(filePath, line, col, isDirectory) {
+      if (isDirectory) return [filePath];
       const target =
         line !== undefined ? `${filePath}:${line}${col !== undefined ? `:${col}` : ""}` : filePath;
       return ["--goto", target];
@@ -59,7 +70,8 @@ const KNOWN_EDITORS: EditorDefinition[] = [
     binaries: ["windsurf"],
     extraDirs: () =>
       macAppBundleDirs([{ name: "Windsurf", subPath: "Contents/Resources/app/bin" }]),
-    buildArgs(filePath, line, col) {
+    buildArgs(filePath, line, col, isDirectory) {
+      if (isDirectory) return [filePath];
       const target =
         line !== undefined ? `${filePath}:${line}${col !== undefined ? `:${col}` : ""}` : filePath;
       return ["--goto", target];
@@ -143,7 +155,8 @@ const KNOWN_EDITORS: EditorDefinition[] = [
     binaries: ["antigravity-ide"],
     extraDirs: () =>
       macAppBundleDirs([{ name: "Antigravity IDE", subPath: "Contents/Resources/app/bin" }]),
-    buildArgs(filePath, line, col) {
+    buildArgs(filePath, line, col, isDirectory) {
+      if (isDirectory) return [filePath];
       const target =
         line !== undefined ? `${filePath}:${line}${col !== undefined ? `:${col}` : ""}` : filePath;
       return ["--goto", target];
@@ -311,6 +324,31 @@ export function discover(): DiscoveredEditor[] {
   });
 }
 
+/**
+ * A placeholder together with the separator that introduces it, so an absent
+ * coordinate takes its own punctuation with it. `:` is the documented form
+ * (`{file}:{line}:{col}`); `,` and `+` cover the other conventions users write
+ * by hand.
+ */
+const CUSTOM_PLACEHOLDER = /([:,+])?\{(file|line|col)\}/g;
+
+type CustomPlaceholder = "file" | "line" | "col";
+
+/**
+ * Interpolate a custom-editor template, dropping the punctuation an absent
+ * coordinate would otherwise strand. The settings UI defaults the template to
+ * `{file}:{line}:{col}`, so without this a target with no line renders
+ * `/path/to/thing::` — which every editor treats as a different, missing file.
+ * That is unconditional for a directory (folders have no coordinates) and was
+ * already reachable for any file opened without one.
+ *
+ * A token that held placeholders and interpolated away entirely is dropped
+ * rather than passed as an empty argv entry, so a `+{line}` token disappears
+ * with its coordinate. A separate flag token that names a coordinate
+ * (`--line {line}`) is left standing — stripping arbitrary flags out of a
+ * command the user wrote is not something this can do safely, and an
+ * unaccompanied flag is no worse than today's empty argument.
+ */
 function buildCustomArgs(
   template: string,
   command: string,
@@ -318,13 +356,27 @@ function buildCustomArgs(
   line?: number,
   col?: number
 ): { binary: string; args: string[] } {
-  const lineStr = line !== undefined ? String(line) : "";
-  const colStr = col !== undefined ? String(col) : "";
+  const values: Record<CustomPlaceholder, string> = {
+    file: filePath,
+    line: line !== undefined ? String(line) : "",
+    col: col !== undefined ? String(col) : "",
+  };
 
-  const tokens = tokenizeArgString(template);
-  const args = tokens.map((token) =>
-    token.replaceAll("{file}", filePath).replaceAll("{line}", lineStr).replaceAll("{col}", colStr)
-  );
+  const args: string[] = [];
+  for (const token of tokenizeArgString(template)) {
+    let hadPlaceholder = false;
+    const interpolated = token.replace(
+      CUSTOM_PLACEHOLDER,
+      (_match, separator: string | undefined, name: CustomPlaceholder) => {
+        hadPlaceholder = true;
+        const value = values[name];
+        if (value === "") return "";
+        return `${separator ?? ""}${value}`;
+      }
+    );
+    if (hadPlaceholder && interpolated === "") continue;
+    args.push(interpolated);
+  }
   return { binary: command, args };
 }
 
@@ -350,15 +402,33 @@ async function tryEnvEditor(
   return launchEditor(binary, [...extraArgs, filePath]);
 }
 
+/**
+ * Launch `filePath` in the user's editor, trying the configured editor, then
+ * `$VISUAL`/`$EDITOR`, then whatever is discoverable, then the platform
+ * launcher.
+ *
+ * `isDirectory` marks the target as a folder — the worktree "Open in Editor"
+ * action opens one (#12329). Coordinates are meaningless there, so they are
+ * dropped up front: that alone gives most editors their correct folder syntax,
+ * since a bare path is what they already emit with no line. The two places a
+ * folder still needs its own answer are the VS Code family's `--goto` and the
+ * macOS `open -t` step, which forces the plain-text UTI handler and cannot open
+ * a directory at all.
+ */
 export async function openFile(
   filePath: string,
   line?: number,
   col?: number,
-  config?: EditorConfig | null
+  config?: EditorConfig | null,
+  isDirectory = false
 ): Promise<void> {
   if (!path.isAbsolute(filePath)) {
     throw new Error("Only absolute paths are allowed");
   }
+
+  // A folder has no coordinates to navigate to, so they never reach a builder.
+  const targetLine = isDirectory ? undefined : line;
+  const targetCol = isDirectory ? undefined : col;
 
   const { execa } = await import("execa");
 
@@ -397,7 +467,13 @@ export async function openFile(
       const command = config.customCommand?.trim();
       const template = config.customTemplate?.trim() ?? "{file}";
       if (command) {
-        const { binary, args } = buildCustomArgs(template, command, filePath, line, col);
+        const { binary, args } = buildCustomArgs(
+          template,
+          command,
+          filePath,
+          targetLine,
+          targetCol
+        );
         const launched = await launchEditor(binary, args);
         if (launched) return;
       }
@@ -406,7 +482,7 @@ export async function openFile(
       if (def) {
         const executable = findExecutable(def);
         if (executable) {
-          const args = def.buildArgs(filePath, line, col);
+          const args = def.buildArgs(filePath, targetLine, targetCol, isDirectory);
           const launched = await launchEditor(executable, args);
           if (launched) return;
         }
@@ -426,7 +502,7 @@ export async function openFile(
   for (const def of KNOWN_EDITORS) {
     const executable = findExecutable(def);
     if (executable) {
-      const args = def.buildArgs(filePath, line, col);
+      const args = def.buildArgs(filePath, targetLine, targetCol, isDirectory);
       const launched = await launchEditor(executable, args);
       if (launched) return;
     }
@@ -434,13 +510,17 @@ export async function openFile(
 
   // 4. macOS .app fallback (no line support). `-t` opens with the user's default
   // text editor (public.plain-text UTI handler) rather than the file-extension
-  // association, so .ts/.tsx files don't route through Xcode/Cursor.
-  if (process.platform === "darwin") {
+  // association, so .ts/.tsx files don't route through Xcode/Cursor. That same
+  // forcing is why a directory skips this step: a plain-text handler cannot
+  // open a folder, so `open -t` would report success while showing nothing.
+  if (process.platform === "darwin" && !isDirectory) {
     const launched = await launchEditor("open", ["-t", filePath]);
     if (launched) return;
   }
 
-  // 5. shell.openPath as last resort
+  // 5. shell.openPath as last resort — the OS default handler, which for a
+  // directory means the file manager. Reaching it is the failure the worktree
+  // action used to start from, so it stays strictly last.
   const errorString = await shell.openPath(filePath);
   if (errorString) {
     throw new Error(`Failed to open file: ${errorString}`);

--- a/electron/services/EditorService.ts
+++ b/electron/services/EditorService.ts
@@ -325,12 +325,14 @@ export function discover(): DiscoveredEditor[] {
 }
 
 /**
- * A placeholder together with the separator that introduces it, so an absent
- * coordinate takes its own punctuation with it. `:` is the documented form
- * (`{file}:{line}:{col}`); `,` and `+` cover the other conventions users write
- * by hand.
+ * A placeholder together with the `:` that introduces it, so an absent
+ * coordinate takes its own punctuation with it. Deliberately only `:` — the
+ * form this app's settings UI documents and defaults to. Punctuation in a
+ * hand-written template can carry meaning we have no basis to reinterpret: a
+ * bare `+` is vim's "start at the last line", and a `,` may be a field
+ * delimiter whose empty slot the wrapper still counts.
  */
-const CUSTOM_PLACEHOLDER = /([:,+])?\{(file|line|col)\}/g;
+const CUSTOM_PLACEHOLDER = /(:)?\{(file|line|col)\}/g;
 
 type CustomPlaceholder = "file" | "line" | "col";
 
@@ -342,12 +344,12 @@ type CustomPlaceholder = "file" | "line" | "col";
  * That is unconditional for a directory (folders have no coordinates) and was
  * already reachable for any file opened without one.
  *
- * Only punctuation *inside* a token is dropped, and the token itself always
- * survives — a template can be positional (`"{line}" "{col}" "{file}"`), where
- * removing an empty argument would slide the path into the column's slot. For
- * the same reason a flag token that names a coordinate (`--line {line}`) is
- * left standing: guessing which of a user's own arguments were only there to
- * carry a line is not something this can do safely.
+ * Nothing else about the template is second-guessed. The token itself always
+ * survives, because a template can be positional (`"{line}" "{col}" "{file}"`)
+ * and removing an empty argument would slide the path into the column's slot;
+ * and a flag token that names a coordinate (`--line {line}`) is left standing,
+ * since working out which of a user's own arguments existed only to carry a
+ * line means guessing at a command grammar we don't know.
  */
 function buildCustomArgs(
   template: string,

--- a/electron/services/EditorService.ts
+++ b/electron/services/EditorService.ts
@@ -342,12 +342,12 @@ type CustomPlaceholder = "file" | "line" | "col";
  * That is unconditional for a directory (folders have no coordinates) and was
  * already reachable for any file opened without one.
  *
- * A token that held placeholders and interpolated away entirely is dropped
- * rather than passed as an empty argv entry, so a `+{line}` token disappears
- * with its coordinate. A separate flag token that names a coordinate
- * (`--line {line}`) is left standing — stripping arbitrary flags out of a
- * command the user wrote is not something this can do safely, and an
- * unaccompanied flag is no worse than today's empty argument.
+ * Only punctuation *inside* a token is dropped, and the token itself always
+ * survives — a template can be positional (`"{line}" "{col}" "{file}"`), where
+ * removing an empty argument would slide the path into the column's slot. For
+ * the same reason a flag token that names a coordinate (`--line {line}`) is
+ * left standing: guessing which of a user's own arguments were only there to
+ * carry a line is not something this can do safely.
  */
 function buildCustomArgs(
   template: string,
@@ -362,21 +362,12 @@ function buildCustomArgs(
     col: col !== undefined ? String(col) : "",
   };
 
-  const args: string[] = [];
-  for (const token of tokenizeArgString(template)) {
-    let hadPlaceholder = false;
-    const interpolated = token.replace(
-      CUSTOM_PLACEHOLDER,
-      (_match, separator: string | undefined, name: CustomPlaceholder) => {
-        hadPlaceholder = true;
-        const value = values[name];
-        if (value === "") return "";
-        return `${separator ?? ""}${value}`;
-      }
-    );
-    if (hadPlaceholder && interpolated === "") continue;
-    args.push(interpolated);
-  }
+  const args = tokenizeArgString(template).map((token) =>
+    token.replace(CUSTOM_PLACEHOLDER, (_match, separator: string | undefined, name) => {
+      const value = values[name as CustomPlaceholder];
+      return value === "" ? "" : `${separator ?? ""}${value}`;
+    })
+  );
   return { binary: command, args };
 }
 

--- a/electron/services/__tests__/EditorService.adversarial.test.ts
+++ b/electron/services/__tests__/EditorService.adversarial.test.ts
@@ -517,6 +517,35 @@ describe("EditorService directory targets", () => {
     expect(argsOfFirstLaunch()).toEqual(["", "", WORKTREE]);
   });
 
+  // Only `:` — the form the settings UI documents — is treated as a coordinate
+  // separator. Other punctuation in a hand-written template means whatever the
+  // user's own command says it means.
+  it("leaves a bare vim '+' alone when there is no line to attach to it", async () => {
+    const { openFile } = await loadModule();
+
+    await openFile(
+      WORKTREE,
+      12,
+      5,
+      { id: "custom", customCommand: "gvim", customTemplate: "+{line} {file}" },
+      true
+    );
+
+    expect(argsOfFirstLaunch()).toEqual(["+", WORKTREE]);
+  });
+
+  it("leaves a comma delimiter's empty field in place", async () => {
+    const { openFile } = await loadModule();
+
+    await openFile("/abs/file.ts", 12, undefined, {
+      id: "custom",
+      customCommand: "wrapper",
+      customTemplate: "{line},{col},{file}",
+    });
+
+    expect(argsOfFirstLaunch()).toEqual(["12,,/abs/file.ts"]);
+  });
+
   it("keeps the argv slot for a file opened without a column too", async () => {
     const { openFile } = await loadModule();
 

--- a/electron/services/__tests__/EditorService.adversarial.test.ts
+++ b/electron/services/__tests__/EditorService.adversarial.test.ts
@@ -350,3 +350,241 @@ describe("EditorService adversarial", () => {
     expect(shellMock.openPath).toHaveBeenCalledWith("/abs/file.ts");
   });
 });
+
+// The worktree "Open in Editor" action hands EditorService a folder (#12329).
+// Everything here is about what changes for a directory target — and, just as
+// deliberately, what does not.
+describe("EditorService directory targets", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    originalPATH = process.env.PATH;
+    originalVISUAL = process.env.VISUAL;
+    originalEDITOR = process.env.EDITOR;
+    process.env.PATH = "/usr/local/bin";
+    delete process.env.VISUAL;
+    delete process.env.EDITOR;
+    setPlatform("linux");
+    fsMock.statSync.mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
+    fsMock.accessSync.mockImplementation(() => {
+      throw new Error("EACCES");
+    });
+    shellMock.openPath.mockResolvedValue("");
+    mockExecaChildren(execaMock.execa, ["spawned"]);
+  });
+
+  afterEach(() => {
+    setPlatform(originalPlatform);
+    process.env.PATH = originalPATH;
+    if (originalVISUAL !== undefined) process.env.VISUAL = originalVISUAL;
+    else delete process.env.VISUAL;
+    if (originalEDITOR !== undefined) process.env.EDITOR = originalEDITOR;
+    else delete process.env.EDITOR;
+  });
+
+  const WORKTREE = "/abs/worktrees/feature-x";
+
+  function argsOfFirstLaunch(): string[] {
+    expect(execaMock.execa).toHaveBeenCalled();
+    return execaMock.execa.mock.calls[0][1] as string[];
+  }
+
+  // `--goto` names a file to navigate into; the whole point of the fix.
+  const GOTO_EDITORS = [
+    ["vscode", "code"],
+    ["vscode-insiders", "code-insiders"],
+    ["cursor", "cursor"],
+    ["windsurf", "windsurf"],
+    ["antigravity-ide", "antigravity-ide"],
+  ] as const;
+
+  for (const [id, binary] of GOTO_EDITORS) {
+    it(`${id} opens a directory as a bare path, without --goto`, async () => {
+      mockExistingFiles([`/usr/local/bin/${binary}`]);
+      const { openFile } = await loadModule();
+
+      await openFile(WORKTREE, undefined, undefined, { id }, true);
+
+      expect(execaMock.execa).toHaveBeenCalledWith(
+        `/usr/local/bin/${binary}`,
+        [WORKTREE],
+        expect.objectContaining({ detached: true })
+      );
+    });
+
+    it(`${id} still uses --goto for a file target`, async () => {
+      mockExistingFiles([`/usr/local/bin/${binary}`]);
+      const { openFile } = await loadModule();
+
+      await openFile("/abs/file.ts", 12, 5, { id }, false);
+
+      expect(argsOfFirstLaunch()).toEqual(["--goto", "/abs/file.ts:12:5"]);
+    });
+  }
+
+  // A caller that passes coordinates alongside a folder must not be able to
+  // turn it back into a file target — the folder wins.
+  it("drops coordinates supplied with a directory target", async () => {
+    mockExistingFiles(["/usr/local/bin/code"]);
+    const { openFile } = await loadModule();
+
+    await openFile(WORKTREE, 12, 5, { id: "vscode" }, true);
+
+    expect(argsOfFirstLaunch()).toEqual([WORKTREE]);
+  });
+
+  it("passes a bare directory path to the editors that already take one", async () => {
+    for (const [id, binary] of [
+      ["zed", "zed"],
+      ["sublime", "subl"],
+      ["webstorm", "webstorm"],
+      ["neovim", "nvim"],
+    ] as const) {
+      vi.clearAllMocks();
+      mockExecaChildren(execaMock.execa, ["spawned"]);
+      mockExistingFiles([`/usr/local/bin/${binary}`]);
+      const { openFile } = await loadModule();
+
+      await openFile(WORKTREE, 12, 5, { id }, true);
+
+      expect(argsOfFirstLaunch(), id).toEqual([WORKTREE]);
+    }
+  });
+
+  it("discovered editors are directory-aware too, not just the configured one", async () => {
+    mockExistingFiles(["/usr/local/bin/code"]);
+    const { openFile } = await loadModule();
+
+    // No config at all: the target reaches `code` through the discovery loop.
+    await openFile(WORKTREE, undefined, undefined, null, true);
+
+    expect(argsOfFirstLaunch()).toEqual([WORKTREE]);
+  });
+
+  it("renders the default custom template as a bare directory, not 'dir::'", async () => {
+    const { openFile } = await loadModule();
+
+    await openFile(
+      WORKTREE,
+      12,
+      5,
+      { id: "custom", customCommand: "myeditor", customTemplate: "{file}:{line}:{col}" },
+      true
+    );
+
+    expect(execaMock.execa).toHaveBeenCalledWith(
+      "myeditor",
+      [WORKTREE],
+      expect.objectContaining({ detached: true })
+    );
+  });
+
+  it("keeps the surrounding flags of a custom template when coordinates go away", async () => {
+    const { openFile } = await loadModule();
+
+    await openFile(
+      WORKTREE,
+      12,
+      5,
+      { id: "custom", customCommand: "code", customTemplate: "--reuse-window {file}:{line}:{col}" },
+      true
+    );
+
+    expect(argsOfFirstLaunch()).toEqual(["--reuse-window", WORKTREE]);
+  });
+
+  it("drops a token that exists only to carry a coordinate", async () => {
+    const { openFile } = await loadModule();
+
+    await openFile(
+      WORKTREE,
+      12,
+      undefined,
+      { id: "custom", customCommand: "nvim-qt", customTemplate: "+{line} {file}" },
+      true
+    );
+
+    expect(argsOfFirstLaunch()).toEqual([WORKTREE]);
+  });
+
+  // The same stranded punctuation was already reachable for a file opened with
+  // no line — the settings UI defaults every custom editor to this template.
+  it("renders a file with no line as a bare path under the default template", async () => {
+    const { openFile } = await loadModule();
+
+    await openFile("/abs/file.ts", undefined, undefined, {
+      id: "custom",
+      customCommand: "myeditor",
+      customTemplate: "{file}:{line}:{col}",
+    });
+
+    expect(argsOfFirstLaunch()).toEqual(["/abs/file.ts"]);
+  });
+
+  it("keeps the line but drops the missing column", async () => {
+    const { openFile } = await loadModule();
+
+    await openFile("/abs/file.ts", 12, undefined, {
+      id: "custom",
+      customCommand: "myeditor",
+      customTemplate: "{file}:{line}:{col}",
+    });
+
+    expect(argsOfFirstLaunch()).toEqual(["/abs/file.ts:12"]);
+  });
+
+  it("still renders both coordinates when they are present", async () => {
+    const { openFile } = await loadModule();
+
+    await openFile("/abs/file.ts", 12, 5, {
+      id: "custom",
+      customCommand: "myeditor",
+      customTemplate: "{file}:{line}:{col}",
+    });
+
+    expect(argsOfFirstLaunch()).toEqual(["/abs/file.ts:12:5"]);
+  });
+
+  it("skips the macOS plain-text fallback for a directory and reveals it instead", async () => {
+    setPlatform("darwin");
+    const { openFile } = await loadModule();
+
+    await openFile(WORKTREE, undefined, undefined, null, true);
+
+    expect(execaMock.execa).not.toHaveBeenCalled();
+    expect(shellMock.openPath).toHaveBeenCalledWith(WORKTREE);
+  });
+
+  it("still uses the macOS plain-text fallback for a file", async () => {
+    setPlatform("darwin");
+    const { openFile } = await loadModule();
+
+    await openFile("/abs/file.ts", undefined, undefined, null, false);
+
+    expect(execaMock.execa).toHaveBeenCalledWith(
+      "open",
+      ["-t", "/abs/file.ts"],
+      expect.objectContaining({ detached: true })
+    );
+    expect(shellMock.openPath).not.toHaveBeenCalled();
+  });
+
+  it("reaches shell.openPath for a directory only after every editor has failed", async () => {
+    setPlatform("darwin");
+    mockExistingFiles(["/usr/local/bin/code"]);
+    mockExecaChildren(execaMock.execa, ["enoent"]);
+    const { openFile } = await loadModule();
+
+    await openFile(WORKTREE, undefined, undefined, { id: "vscode" }, true);
+
+    // Configured attempt, then the discovery loop's — both with folder argv,
+    // neither an `open -t`.
+    for (const call of execaMock.execa.mock.calls) {
+      expect(call[0]).toBe("/usr/local/bin/code");
+      expect(call[1]).toEqual([WORKTREE]);
+    }
+    expect(shellMock.openPath).toHaveBeenCalledWith(WORKTREE);
+  });
+});

--- a/electron/services/__tests__/EditorService.adversarial.test.ts
+++ b/electron/services/__tests__/EditorService.adversarial.test.ts
@@ -412,6 +412,10 @@ describe("EditorService directory targets", () => {
         [WORKTREE],
         expect.objectContaining({ detached: true })
       );
+      // A launch that succeeded must end the chain — no discovery pass behind
+      // it, and above all no reveal, which is the bug this fixes.
+      expect(execaMock.execa).toHaveBeenCalledTimes(1);
+      expect(shellMock.openPath).not.toHaveBeenCalled();
     });
 
     it(`${id} still uses --goto for a file target`, async () => {
@@ -479,6 +483,8 @@ describe("EditorService directory targets", () => {
       [WORKTREE],
       expect.objectContaining({ detached: true })
     );
+    expect(execaMock.execa).toHaveBeenCalledTimes(1);
+    expect(shellMock.openPath).not.toHaveBeenCalled();
   });
 
   it("keeps the surrounding flags of a custom template when coordinates go away", async () => {
@@ -495,18 +501,32 @@ describe("EditorService directory targets", () => {
     expect(argsOfFirstLaunch()).toEqual(["--reuse-window", WORKTREE]);
   });
 
-  it("drops a token that exists only to carry a coordinate", async () => {
+  // A token that interpolates away must still be passed, empty: a positional
+  // template would otherwise slide the path into the vacated slot.
+  it("keeps a stranded token's argv slot rather than shifting the ones after it", async () => {
     const { openFile } = await loadModule();
 
     await openFile(
       WORKTREE,
       12,
       undefined,
-      { id: "custom", customCommand: "nvim-qt", customTemplate: "+{line} {file}" },
+      { id: "custom", customCommand: "wrapper", customTemplate: '"{line}" "{col}" "{file}"' },
       true
     );
 
-    expect(argsOfFirstLaunch()).toEqual([WORKTREE]);
+    expect(argsOfFirstLaunch()).toEqual(["", "", WORKTREE]);
+  });
+
+  it("keeps the argv slot for a file opened without a column too", async () => {
+    const { openFile } = await loadModule();
+
+    await openFile("/abs/file.ts", 12, undefined, {
+      id: "custom",
+      customCommand: "wrapper",
+      customTemplate: '"{line}" "{col}" "{file}"',
+    });
+
+    expect(argsOfFirstLaunch()).toEqual(["12", "", "/abs/file.ts"]);
   });
 
   // The same stranded punctuation was already reachable for a file opened with
@@ -579,12 +599,71 @@ describe("EditorService directory targets", () => {
 
     await openFile(WORKTREE, undefined, undefined, { id: "vscode" }, true);
 
-    // Configured attempt, then the discovery loop's — both with folder argv,
-    // neither an `open -t`.
-    for (const call of execaMock.execa.mock.calls) {
-      expect(call[0]).toBe("/usr/local/bin/code");
-      expect(call[1]).toEqual([WORKTREE]);
-    }
+    // Exactly two attempts — the configured editor, then the discovery loop's
+    // — both with folder argv, and no `open -t` between them. Asserting the
+    // count is what stops a reveal-without-trying regression passing here.
+    expect(execaMock.execa.mock.calls).toEqual([
+      ["/usr/local/bin/code", [WORKTREE], expect.objectContaining({ detached: true })],
+      ["/usr/local/bin/code", [WORKTREE], expect.objectContaining({ detached: true })],
+    ]);
     expect(shellMock.openPath).toHaveBeenCalledWith(WORKTREE);
+  });
+
+  it("keeps the directory flag when the configured editor is missing", async () => {
+    // Configured Zed, but only `code` is installed: the configured branch finds
+    // no executable, so discovery answers — still as a folder.
+    mockExistingFiles(["/usr/local/bin/code"]);
+    const { openFile } = await loadModule();
+
+    await openFile(WORKTREE, 12, 5, { id: "zed" }, true);
+
+    expect(execaMock.execa).toHaveBeenCalledTimes(1);
+    expect(argsOfFirstLaunch()).toEqual([WORKTREE]);
+  });
+
+  it("keeps the directory flag when the configured editor fails and another answers", async () => {
+    mockExistingFiles(["/usr/local/bin/code", "/usr/local/bin/subl"]);
+    // The configured launch fails; the discovery loop's first candidate wins.
+    mockExecaChildren(execaMock.execa, ["enoent", "spawned"]);
+    const { openFile } = await loadModule();
+
+    await openFile(WORKTREE, undefined, undefined, { id: "sublime" }, true);
+
+    expect(execaMock.execa.mock.calls[0]![0]).toBe("/usr/local/bin/subl");
+    expect(execaMock.execa.mock.calls[1]).toEqual([
+      "/usr/local/bin/code",
+      [WORKTREE],
+      expect.objectContaining({ detached: true }),
+    ]);
+    expect(shellMock.openPath).not.toHaveBeenCalled();
+  });
+
+  it("appends a directory to $VISUAL without touching its flags", async () => {
+    process.env.VISUAL = "code --reuse-window";
+    const { openFile } = await loadModule();
+
+    await openFile(WORKTREE, 12, 5, null, true);
+
+    expect(execaMock.execa).toHaveBeenCalledWith(
+      "code",
+      ["--reuse-window", WORKTREE],
+      expect.objectContaining({ detached: true })
+    );
+    expect(shellMock.openPath).not.toHaveBeenCalled();
+  });
+
+  it("falls past a terminal-editor $VISUAL to $EDITOR for a directory", async () => {
+    process.env.VISUAL = "vim";
+    process.env.EDITOR = "code";
+    const { openFile } = await loadModule();
+
+    await openFile(WORKTREE, undefined, undefined, null, true);
+
+    expect(execaMock.execa).toHaveBeenCalledTimes(1);
+    expect(execaMock.execa).toHaveBeenCalledWith(
+      "code",
+      [WORKTREE],
+      expect.objectContaining({ detached: true })
+    );
   });
 });

--- a/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
+++ b/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
@@ -6233,7 +6233,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "worktree",
     "danger": "safe",
     "dangerRationale": undefined,
-    "description": "Open a worktree folder in the OS file manager / editor",
+    "description": "Open a worktree folder in the project's configured external editor",
     "examples": undefined,
     "id": "worktree.openEditor",
     "keywords": undefined,

--- a/src/services/actions/definitions/__tests__/worktreeContextActions.openEditor.test.ts
+++ b/src/services/actions/definitions/__tests__/worktreeContextActions.openEditor.test.ts
@@ -1,0 +1,175 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { WorktreeState } from "@/types";
+
+const worktreesMock = vi.hoisted(() => ({ current: new Map<string, Partial<WorktreeState>>() }));
+
+const systemClientMock = vi.hoisted(() => ({
+  openInEditor: vi.fn<(p: Record<string, unknown>) => Promise<void>>(() => Promise.resolve()),
+  openPath: vi.fn<(p: string) => Promise<void>>(() => Promise.resolve()),
+}));
+
+vi.mock("@/store/createWorktreeStore", () => ({
+  getCurrentViewStore: () => ({
+    getState: () => ({ worktrees: worktreesMock.current }),
+  }),
+  getCurrentViewStoreOrNull: () => ({
+    getState: () => ({ worktrees: worktreesMock.current }),
+  }),
+}));
+
+vi.mock("@/clients", () => ({
+  copyTreeClient: { generateAndCopyFile: vi.fn() },
+  systemClient: systemClientMock,
+}));
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: { dispatch: vi.fn() },
+}));
+
+import type { ActionContext } from "@shared/types/actions";
+import type { ActionRegistry, ActionCallbacks } from "../../actionTypes";
+import { registerWorktreeContextActions } from "../worktreeContextActions";
+
+function getAction(id: "worktree.openEditor" | "worktree.reveal") {
+  const actions: ActionRegistry = new Map();
+  // `ActionCallbacks` has ~30 members and neither action here reaches one —
+  // both go straight to `systemClient`. Same stub the sibling suites use.
+  const callbacks = {} as unknown as ActionCallbacks;
+  registerWorktreeContextActions(actions, callbacks);
+  const factory = actions.get(id);
+  if (!factory) throw new Error(`${id} is not registered`);
+  return factory();
+}
+
+function seedWorktree(id: string, path = `/repo/${id}`) {
+  worktreesMock.current.set(id, { id, path });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  worktreesMock.current = new Map();
+  systemClientMock.openInEditor.mockResolvedValue(undefined);
+  systemClientMock.openPath.mockResolvedValue(undefined);
+});
+
+describe("worktree.openEditor", () => {
+  it("registers a renderer-scoped command action", () => {
+    const action = getAction("worktree.openEditor");
+    expect(action.id).toBe("worktree.openEditor");
+    expect(action.kind).toBe("command");
+    expect(action.danger).toBe("safe");
+    expect(action.scope).toBe("renderer");
+  });
+
+  it("accepts an optional worktreeId argument", () => {
+    const action = getAction("worktree.openEditor");
+    expect(action.argsSchema).toBeDefined();
+    expect(() => action.argsSchema!.parse({ worktreeId: "wt-1" })).not.toThrow();
+    expect(() => action.argsSchema!.parse({})).not.toThrow();
+    expect(() => action.argsSchema!.parse(undefined)).not.toThrow();
+  });
+
+  // The bug (#12329): this used to call `openPath`, the OS default handler,
+  // which is what "Reveal Worktree" does — two menu items, one behaviour.
+  it("opens the worktree through the editor pipeline, never the OS handler", async () => {
+    seedWorktree("wt-1", "/repo/wt-1");
+
+    await getAction("worktree.openEditor").run({ worktreeId: "wt-1" }, {
+      projectId: "proj-1",
+    } as ActionContext);
+
+    expect(systemClientMock.openInEditor).toHaveBeenCalledWith({
+      path: "/repo/wt-1",
+      projectId: "proj-1",
+    });
+    expect(systemClientMock.openPath).not.toHaveBeenCalled();
+  });
+
+  // Omitting the project id is what made external editor launches ignore the
+  // preference in #12327 — the main process then has nothing to look up.
+  it("carries the context project id so the right editor preference is read", async () => {
+    seedWorktree("wt-1");
+
+    await getAction("worktree.openEditor").run({ worktreeId: "wt-1" }, {
+      projectId: "proj-42",
+    } as ActionContext);
+
+    expect(systemClientMock.openInEditor.mock.calls[0]![0]).toMatchObject({
+      projectId: "proj-42",
+    });
+  });
+
+  it("forwards an undefined project id rather than inventing one", async () => {
+    seedWorktree("wt-1");
+
+    await getAction("worktree.openEditor").run({ worktreeId: "wt-1" }, {} as ActionContext);
+
+    expect(systemClientMock.openInEditor).toHaveBeenCalledWith({
+      path: "/repo/wt-1",
+      projectId: undefined,
+    });
+  });
+
+  it("falls back to the focused worktree, then the active one", async () => {
+    seedWorktree("wt-focused", "/repo/focused");
+    seedWorktree("wt-active", "/repo/active");
+
+    await getAction("worktree.openEditor").run(undefined, {
+      focusedWorktreeId: "wt-focused",
+      activeWorktreeId: "wt-active",
+      projectId: "proj-1",
+    } as ActionContext);
+
+    expect(systemClientMock.openInEditor).toHaveBeenCalledWith({
+      path: "/repo/focused",
+      projectId: "proj-1",
+    });
+
+    systemClientMock.openInEditor.mockClear();
+
+    await getAction("worktree.openEditor").run(undefined, {
+      activeWorktreeId: "wt-active",
+      projectId: "proj-1",
+    } as ActionContext);
+
+    expect(systemClientMock.openInEditor).toHaveBeenCalledWith({
+      path: "/repo/active",
+      projectId: "proj-1",
+    });
+  });
+
+  it("no-ops when no worktree is selected", async () => {
+    await getAction("worktree.openEditor").run(undefined, {} as ActionContext);
+
+    expect(systemClientMock.openInEditor).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when the selected worktree is gone", async () => {
+    await getAction("worktree.openEditor").run({ worktreeId: "wt-missing" }, {} as ActionContext);
+
+    expect(systemClientMock.openInEditor).not.toHaveBeenCalled();
+  });
+
+  it("propagates a launch failure to the caller", async () => {
+    seedWorktree("wt-1");
+    systemClientMock.openInEditor.mockRejectedValueOnce(new Error("outside root"));
+
+    await expect(
+      getAction("worktree.openEditor").run({ worktreeId: "wt-1" }, {} as ActionContext)
+    ).rejects.toThrow("outside root");
+  });
+});
+
+describe("worktree.reveal", () => {
+  // The sibling action that legitimately wants the OS file manager. It shares
+  // the menu with "Open in Editor" and must keep its own behaviour.
+  it("still reveals through the OS handler", async () => {
+    seedWorktree("wt-1", "/repo/wt-1");
+
+    await getAction("worktree.reveal").run({ worktreeId: "wt-1" }, {} as ActionContext);
+
+    expect(systemClientMock.openPath).toHaveBeenCalledWith("/repo/wt-1");
+    expect(systemClientMock.openInEditor).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/actions/definitions/__tests__/worktreeContextActions.openEditor.test.ts
+++ b/src/services/actions/definitions/__tests__/worktreeContextActions.openEditor.test.ts
@@ -54,14 +54,6 @@ beforeEach(() => {
 });
 
 describe("worktree.openEditor", () => {
-  it("registers a renderer-scoped command action", () => {
-    const action = getAction("worktree.openEditor");
-    expect(action.id).toBe("worktree.openEditor");
-    expect(action.kind).toBe("command");
-    expect(action.danger).toBe("safe");
-    expect(action.scope).toBe("renderer");
-  });
-
   it("accepts an optional worktreeId argument", () => {
     const action = getAction("worktree.openEditor");
     expect(action.argsSchema).toBeDefined();
@@ -111,6 +103,23 @@ describe("worktree.openEditor", () => {
     });
   });
 
+  it("prefers an explicit worktreeId over the focused and active ones", async () => {
+    seedWorktree("wt-explicit", "/repo/explicit");
+    seedWorktree("wt-focused", "/repo/focused");
+    seedWorktree("wt-active", "/repo/active");
+
+    await getAction("worktree.openEditor").run({ worktreeId: "wt-explicit" }, {
+      focusedWorktreeId: "wt-focused",
+      activeWorktreeId: "wt-active",
+      projectId: "proj-1",
+    } as ActionContext);
+
+    expect(systemClientMock.openInEditor).toHaveBeenCalledWith({
+      path: "/repo/explicit",
+      projectId: "proj-1",
+    });
+  });
+
   it("falls back to the focused worktree, then the active one", async () => {
     seedWorktree("wt-focused", "/repo/focused");
     seedWorktree("wt-active", "/repo/active");
@@ -143,12 +152,14 @@ describe("worktree.openEditor", () => {
     await getAction("worktree.openEditor").run(undefined, {} as ActionContext);
 
     expect(systemClientMock.openInEditor).not.toHaveBeenCalled();
+    expect(systemClientMock.openPath).not.toHaveBeenCalled();
   });
 
   it("no-ops when the selected worktree is gone", async () => {
     await getAction("worktree.openEditor").run({ worktreeId: "wt-missing" }, {} as ActionContext);
 
     expect(systemClientMock.openInEditor).not.toHaveBeenCalled();
+    expect(systemClientMock.openPath).not.toHaveBeenCalled();
   });
 
   it("propagates a launch failure to the caller", async () => {

--- a/src/services/actions/definitions/worktreeContextActions.ts
+++ b/src/services/actions/definitions/worktreeContextActions.ts
@@ -544,7 +544,7 @@ export function registerWorktreeContextActions(
     defineAction({
       id: "worktree.openEditor",
       title: "Open in Editor",
-      description: "Open a worktree folder in the OS file manager / editor",
+      description: "Open a worktree folder in the project's configured external editor",
       category: "worktree",
       kind: "command",
       danger: "safe",
@@ -558,7 +558,14 @@ export function registerWorktreeContextActions(
         const worktree = getCurrentViewStore().getState().worktrees.get(targetWorktreeId);
         if (!worktree) return;
 
-        await systemClient.openPath(worktree.path);
+        // `openInEditor`, not `openPath` — the latter is the OS default handler,
+        // which is what made this indistinguishable from "Reveal Worktree"
+        // below (#12329). The project id decides which editor preference the
+        // main process reads; omitting it silently falls back to discovery
+        // order (#12327). `ctx.projectId` resolves through this view's own
+        // workspace id, so it names this view's project rather than whichever
+        // one a sibling window last switched to.
+        await systemClient.openInEditor({ path: worktree.path, projectId: ctx.projectId });
       },
     })
   );


### PR DESCRIPTION
## Summary

- The worktree context menu's "Open in editor" item (`worktree.openEditor`) was calling `systemClient.openPath(worktree.path)`, the OS default file handler, the same call the adjacent "Reveal Worktree" item uses. Two menu items, one behavior; which app opened depended on OS file associations. `terminal.openWorktreeEditor` dispatches the same action, so it inherited the bug too.
- The fix routes the action through the actual editor path and teaches `EditorService` about directories, since folders and files need different argv.
- Found and fixed a related bug in custom editor templates along the way.

Resolves #12329

## Changes

- `worktree.openEditor` now calls `systemClient.openInEditor({ path, projectId })` instead of `openPath`. Passing `ctx.projectId` lets the main process read the correct project's editor preference, resolved through the view's own workspace id rather than the globally-broadcast `currentProject`, so it still names this view's project even if a sibling window has switched. Omitting the project id was a separate fallback-selection bug, #12327, fixed elsewhere.
- `EditorService.openFile` gained an `isDirectory` flag. Coordinates are dropped for a folder, which alone gives Zed, Neovim, JetBrains, and Sublime their correct folder syntax, since their no-coordinate form is already a bare path. Two spots still needed their own handling: the VS Code family's `--goto` flag, which opens a folder as a text buffer rather than a folder, and the macOS `open -t` step, which forces the plain-text UTI handler and can't open a directory at all. `shell.openPath` stays as the genuine last resort.
- The `isDirectory` flag is derived in `handleSystemOpenInEditor` by stat-ing the already-resolved target, no new IPC payload field, no codegen. A stat failure degrades to treating the target as a file, preserving today's behavior, since containment already resolved the real path.
- Related fix: the custom editor template `{file}:{line}:{col}` was rendering a trailing `<path>::` for any target with no line, not just folders. An absent coordinate now takes its preceding `:` with it. Only the colon is treated this way, deliberately, since that's the separator the settings UI documents. A bare `+` is vim's start-at-last-line syntax, and a `,` may be a field delimiter whose empty slot a wrapper still counts. Tokens always keep their argv slot, so a positional template's path can't slide into the column's field.
- Known limitation: a custom template or a `$VISUAL`/`$EDITOR` value that embeds its own file-navigation flag (for example `--goto {file}:{line}:{col}`, or `VISUAL="code --goto"`) still gets file-mode arguments for a folder. Fixing that would mean stripping flags out of a command the user wrote themselves, which would also strip essential options like `open -a "My Editor"`. Those setups can use "Reveal Worktree" instead.

## Testing

2,106 tests across 92 files pass locally, including both `EditorService` test suites, the `systemShell` IPC handler suite, and the full `action-definitions` and `action-manifest` directories. New coverage:

- All five VS Code family editors get bare folder arguments while keeping `--goto` for files.
- Directory launches terminate the fallback chain with one launch and no reveal fallback behind it.
- The macOS `open -t` step is skipped for folders.
- Resolved-target classification is correct through a symlink.
- Custom-template positional and separator contracts.
- Explicit `worktreeId` beats focused/active worktree.
- `worktree.reveal` still uses `openPath`.

The `actionDefinitions.quality` snapshot was regenerated for the action's updated description (a one-line change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015wRi9wzcv4GVumy6kxn8Eq
