### PR TITLE
fix: make overlay items clickable over the toolbar's drag region

### DIFF
--- a/src/components/ui/ReEntrySummary.tsx
+++ b/src/components/ui/ReEntrySummary.tsx
@@ -105,6 +105,10 @@ export function ReEntrySummary({ state }: { state: ReEntrySummaryState }) {
     >
       <div
         className={cn(
+          // Anchored at top-3, so the card overlaps the toolbar's drag band
+          // and its Pin/Dismiss controls are swallowed as window drags. The
+          // opt-out goes here, not on the pointer-events-none wrapper (#12347).
+          "app-no-drag",
           "relative flex flex-col w-full max-w-[360px]",
           "rounded-[var(--radius-sm)] border-l-[3px] border border-tint/[0.08]",
           "bg-surface-panel/85 backdrop-blur-xl",

--- a/src/components/ui/__tests__/FixedDropdown.test.tsx
+++ b/src/components/ui/__tests__/FixedDropdown.test.tsx
@@ -982,3 +982,40 @@ describe("FixedDropdown rAF re-position throttle (issue #9580)", () => {
     expect(rafSpy).not.toHaveBeenCalled();
   });
 });
+
+describe("FixedDropdown drag-region opt-out (issue #12347)", () => {
+  let anchorRef: React.RefObject<HTMLElement | null>;
+
+  beforeEach(() => {
+    _resetForTests();
+    setOverlayStackLength(0);
+    anchorRef = createAnchor();
+    vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({ matches: false }));
+  });
+
+  afterEach(() => {
+    _resetForTests();
+  });
+
+  it("opts the panel out of the drag region without disarming the whole window", () => {
+    // The panel portals to `document.body`, outside the toolbar's
+    // `app-drag-region` subtree, so Chromium never subtracts its rect and
+    // clicks landing over the toolbar are swallowed as window drags. The
+    // opt-out belongs on the panel and nowhere else: the wrapper is
+    // `fixed inset-0`, so marking it would make the entire window
+    // undraggable for as long as any dropdown is open.
+    render(
+      <FixedDropdown open={true} onOpenChange={vi.fn()} anchorRef={anchorRef}>
+        <div data-testid="dropdown-body">Content</div>
+      </FixedDropdown>
+    );
+
+    const panel = document.querySelector('[data-testid="dropdown-body"]')?.parentElement;
+    expect(panel).not.toBeNull();
+    expect(panel?.className.split(/\s+/)).toContain("app-no-drag");
+
+    const viewportWrapper = panel?.parentElement;
+    expect(viewportWrapper?.className).toContain("inset-0");
+    expect(viewportWrapper?.className.split(/\s+/)).not.toContain("app-no-drag");
+  });
+});

--- a/src/components/ui/__tests__/FixedDropdown.test.tsx
+++ b/src/components/ui/__tests__/FixedDropdown.test.tsx
@@ -1010,12 +1010,16 @@ describe("FixedDropdown drag-region opt-out (issue #12347)", () => {
       </FixedDropdown>
     );
 
+    // `?.parentElement` yields undefined, not null, when the query misses —
+    // so assert the element itself rather than leaning on a nullish check that
+    // would wave a missing node through into a confusing downstream failure.
     const panel = document.querySelector('[data-testid="dropdown-body"]')?.parentElement;
-    expect(panel).not.toBeNull();
-    expect(panel?.className.split(/\s+/)).toContain("app-no-drag");
+    if (!(panel instanceof HTMLElement)) throw new Error("FixedDropdown panel not rendered");
+    expect(panel.className.split(/\s+/)).toContain("app-no-drag");
 
-    const viewportWrapper = panel?.parentElement;
-    expect(viewportWrapper?.className).toContain("inset-0");
-    expect(viewportWrapper?.className.split(/\s+/)).not.toContain("app-no-drag");
+    const viewportWrapper = panel.parentElement;
+    if (!(viewportWrapper instanceof HTMLElement)) throw new Error("portal wrapper not rendered");
+    expect(viewportWrapper.className).toContain("inset-0");
+    expect(viewportWrapper.className.split(/\s+/)).not.toContain("app-no-drag");
   });
 });

--- a/src/components/ui/__tests__/overlay-drag-region.test.tsx
+++ b/src/components/ui/__tests__/overlay-drag-region.test.tsx
@@ -156,8 +156,8 @@ describe("no ui/ surface portals over the toolbar without opting out", () => {
     "AppPaletteDialog.tsx": "same as AppDialog.tsx — pt-[15vh] panel, modal",
   };
 
-  // Named per file, so adding a third portaled surface to one of these forces
-  // a deliberate edit here instead of riding along on a sibling's stamp.
+  // Named, not counted, so extending one of these files is a deliberate edit
+  // here rather than a number that silently still matches.
   const STAMPED: Record<string, string[]> = {
     "context-menu.tsx": ["ContextMenuContent", "ContextMenuSubContent"],
     "dropdown-menu.tsx": ["DropdownMenuContent", "DropdownMenuSubContent"],
@@ -185,7 +185,12 @@ describe("no ui/ surface portals over the toolbar without opting out", () => {
     // Only inside a string literal, which is the only place a class can take
     // effect — matched loosely enough to survive being folded into a longer
     // class list.
-    return code.match(new RegExp(`"[^"\n]*\\b${NO_DRAG}\\b[^"\n]*"`, "g"))?.length ?? 0;
+    // Delimited by quote or space, so `data-testid="app-no-drag-probe"` does
+    // not read as a stamp, and never an attribute value (`="…"`), which is the
+    // only false-green direction — the misses all under-count and fail loudly.
+    return (
+      code.match(new RegExp(`(?<![=\\w])"(?:[^"\n]* )?${NO_DRAG}(?: [^"\n]*)?"`, "g"))?.length ?? 0
+    );
   }
 
   const portaling = readdirSync(UI_DIR)
@@ -217,8 +222,10 @@ describe("no ui/ surface portals over the toolbar without opting out", () => {
   });
 
   it.each(Object.entries(STAMPED))("%s stamps each of its portaled surfaces", (file, surfaces) => {
-    // A file-level "does it appear anywhere" check passes while a second or
-    // third portaled surface in the same module goes unstamped.
+    // A deletion ratchet, and only that: it fails if one of the named surfaces
+    // loses its stamp. A newly *added* portaled surface in an already-listed
+    // file still needs the author to extend the table above — which is why the
+    // surfaces are named rather than counted.
     expect(stampCount(file), `expected one stamp per surface: ${surfaces.join(", ")}`).toBe(
       surfaces.length
     );

--- a/src/components/ui/__tests__/overlay-drag-region.test.tsx
+++ b/src/components/ui/__tests__/overlay-drag-region.test.tsx
@@ -111,16 +111,16 @@ describe("portaled overlay content opts out of the OS drag region — issue #123
     }
   );
 
-  it.each([
-    ["ContextMenuContent", renderContextMenu],
-    ["DropdownMenuContent", renderDropdownMenu],
-    ["PopoverContent", renderPopover],
-  ])("%s keeps the opt-out when a caller supplies its own classes", (_name, mount) => {
-    // `cn()` runs tailwind-merge, which is free to drop a token it believes a
-    // later class supersedes. A consumer passing layout classes is the common
-    // case, and it must not be able to hand the toolbar back its dead zone.
-    mount("w-80 p-0 absolute");
-    expect(classTokens(probe(".probe-content"))).toContain(NO_DRAG);
+  it("composes the opt-out with a caller className rather than being replaced by it", () => {
+    // Deliberately not a tailwind-merge claim: `app-no-drag` belongs to no
+    // conflict group, so twMerge would never drop it and such a test could not
+    // fail. What this pins is the composition — a primitive rewritten to use
+    // the caller's `className` in place of its own base list, rather than
+    // merging the two, hands the toolbar back its dead zone.
+    renderPopover("w-80 p-0 absolute");
+    const tokens = classTokens(probe(".probe-content"));
+    expect(tokens).toContain(NO_DRAG);
+    expect(tokens).toContain("w-80");
   });
 });
 
@@ -131,32 +131,96 @@ describe("the opt-out stays wired to a real rule", () => {
     // descendant half is what carries the opt-out to the menu items, which
     // never carry the class themselves.
     const css = readFileSync(path.join(UI_DIR, "..", "..", "index.css"), "utf8");
-    const rule = /\.app-no-drag,\s*\n\s*\.app-no-drag \*\s*\{([^}]*)\}/.exec(css);
-    expect(rule, "`.app-no-drag, .app-no-drag *` rule missing from src/index.css").not.toBeNull();
+    // Built from NO_DRAG, not spelled again: renaming the class in the
+    // primitives and here, but not in the stylesheet, would otherwise ship a
+    // class with no rule behind it and leave this suite green.
+    const rule = new RegExp(`\\.${NO_DRAG},\\s*\\n\\s*\\.${NO_DRAG} \\*\\s*\\{([^}]*)\\}`).exec(
+      css
+    );
+    expect(rule, `\`.${NO_DRAG}, .${NO_DRAG} *\` rule missing from src/index.css`).not.toBeNull();
     const declarations = rule?.[1] ?? "";
     expect(declarations).toMatch(/-webkit-app-region:\s*no-drag/);
     expect(declarations).toMatch(/(?<!-)\bapp-region:\s*no-drag/);
   });
 });
 
-describe("no ui/ primitive portals over the toolbar without opting out", () => {
-  // Deliberately exempt. Tooltips are non-interactive, so they have no dead
-  // click zone to fix — and marking them no-drag would instead carve a dead
-  // *drag* zone out of the title bar for as long as one is showing.
-  const EXEMPT = new Set(["tooltip.tsx"]);
+describe("no ui/ surface portals over the toolbar without opting out", () => {
+  // Every exemption is a geometry claim, and each one is why this list is
+  // spelled out rather than inferred.
+  const EXEMPT: Record<string, string> = {
+    "tooltip.tsx":
+      "non-interactive, so there is no dead click zone to fix — and opting it out would carve a dead *drag* zone out of the title bar for as long as one shows",
+    "ShortcutHint.tsx": "pointer-events-none and aria-hidden — nothing in it is clickable",
+    "AppDialog.tsx":
+      "centred modal panel; it only reaches the drag band on a short window with a global banner up, and whether a window should drag at all behind an open modal is a separate call",
+    "AppPaletteDialog.tsx": "same as AppDialog.tsx — pt-[15vh] panel, modal",
+  };
 
-  it("every module rendering a Radix Portal stamps the opt-out", () => {
-    // The failure this exists for: a sixth anchored surface is added next to
-    // these five, portals to `document.body` like the rest, and reintroduces
-    // the bug on its own — invisibly, because no existing test renders it.
-    const offenders = readdirSync(UI_DIR)
-      .filter((file) => file.endsWith(".tsx") && !EXEMPT.has(file))
-      .filter((file) => {
-        const src = readFileSync(path.join(UI_DIR, file), "utf8");
-        return /radix\.\w+\.Portal\b/.test(src) && !src.includes(NO_DRAG);
-      });
-    expect(offenders, `add "${NO_DRAG}" to the portaled content, or exempt with a reason`).toEqual(
-      []
+  // Named per file, so adding a third portaled surface to one of these forces
+  // a deliberate edit here instead of riding along on a sibling's stamp.
+  const STAMPED: Record<string, string[]> = {
+    "context-menu.tsx": ["ContextMenuContent", "ContextMenuSubContent"],
+    "dropdown-menu.tsx": ["DropdownMenuContent", "DropdownMenuSubContent"],
+    "popover.tsx": ["PopoverContent"],
+    "select.tsx": ["SelectContent"],
+    "fixed-dropdown.tsx": ["FixedDropdown panel"],
+    "toaster.tsx": ["Toast", "OverflowPill"],
+    "ReEntrySummary.tsx": ["summary card"],
+  };
+
+  function readModule(file: string): string {
+    return readFileSync(path.join(UI_DIR, file), "utf8");
+  }
+
+  // Comments are stripped before counting. The stamp sites carry a `#12347`
+  // note that names the class, and a substring search over raw source is
+  // satisfied by that prose alone — the class could be deleted outright and
+  // the scan would stay green.
+  function stripComments(source: string): string {
+    return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/[^\n]*/g, "");
+  }
+
+  function stampCount(file: string): number {
+    const code = stripComments(readModule(file));
+    // Only inside a string literal, which is the only place a class can take
+    // effect — matched loosely enough to survive being folded into a longer
+    // class list.
+    return code.match(new RegExp(`"[^"\n]*\\b${NO_DRAG}\\b[^"\n]*"`, "g"))?.length ?? 0;
+  }
+
+  const portaling = readdirSync(UI_DIR)
+    .filter((file) => file.endsWith(".tsx"))
+    .filter((file) => {
+      const code = stripComments(readModule(file));
+      // Both idioms: the deferred Radix loader, and raw react-dom portals.
+      return /radix\.\w+\.Portal\b/.test(code) || /\bcreatePortal\(/.test(code);
+    });
+
+  it("scans a non-empty set of portaling modules", () => {
+    // Without this the guard below is one refactor away from silently
+    // scanning nothing and passing forever.
+    expect(portaling.length).toBeGreaterThan(0);
+    const unaccounted = portaling.filter((file) => !(file in EXEMPT) && !(file in STAMPED));
+    expect(unaccounted, "new portaling module: stamp it, or exempt it with a reason").toEqual([]);
+    const vanished = [...Object.keys(STAMPED), ...Object.keys(EXEMPT)].filter(
+      (file) => !portaling.includes(file)
+    );
+    expect(vanished, "listed here but no longer portals — drop the entry").toEqual([]);
+  });
+
+  it("stamps every portaled surface that is not exempt", () => {
+    const offenders = portaling.filter((file) => !(file in EXEMPT) && stampCount(file) === 0);
+    expect(
+      offenders,
+      `add "${NO_DRAG}" to the portaled content, or exempt it with a reason`
+    ).toEqual([]);
+  });
+
+  it.each(Object.entries(STAMPED))("%s stamps each of its portaled surfaces", (file, surfaces) => {
+    // A file-level "does it appear anywhere" check passes while a second or
+    // third portaled surface in the same module goes unstamped.
+    expect(stampCount(file), `expected one stamp per surface: ${surfaces.join(", ")}`).toBe(
+      surfaces.length
     );
   });
 });

--- a/src/components/ui/__tests__/overlay-drag-region.test.tsx
+++ b/src/components/ui/__tests__/overlay-drag-region.test.tsx
@@ -1,0 +1,162 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import * as ContextMenuPrimitive from "@radix-ui/react-context-menu";
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
+import * as PopoverPrimitive from "@radix-ui/react-popover";
+import { ContextMenuContent, ContextMenuSubContent } from "../context-menu";
+import { DropdownMenuContent, DropdownMenuSubContent } from "../dropdown-menu";
+import { PopoverContent } from "../popover";
+import { primeRadix } from "../radix-loader";
+
+/**
+ * Issue #12347 — overlay content portals to `document.body`, outside the
+ * toolbar's `app-drag-region` subtree. Chromium derives the OS draggable
+ * region geometrically (drag rects minus no-drag rects), so a portaled
+ * surface that claims no no-drag rect leaves the toolbar's `drag` showing
+ * through wherever the two overlap, and clicks on the items painted there
+ * are swallowed as window drags.
+ *
+ * jsdom resolves no `-webkit-app-region`, so there is no browser-behaviour
+ * claim here. What these pin is that the opt-out reaches the DOM node that
+ * actually paints over the toolbar, survives `cn()`, and stays wired to a
+ * real CSS rule.
+ */
+
+const UI_DIR = path.join(__dirname, "..");
+const NO_DRAG = "app-no-drag";
+
+beforeAll(async () => {
+  await primeRadix();
+});
+
+afterEach(cleanup);
+
+function probe(selector: string): HTMLElement {
+  const el = document.querySelector(selector);
+  if (!(el instanceof HTMLElement)) {
+    throw new Error(
+      `${selector}: expected a rendered HTMLElement, got ${el === null ? "null" : typeof el}`
+    );
+  }
+  return el;
+}
+
+function classTokens(el: HTMLElement): Set<string> {
+  return new Set(el.className.split(/\s+/));
+}
+
+function renderContextMenu(callerClass = "") {
+  const { container } = render(
+    <ContextMenuPrimitive.Root>
+      <ContextMenuPrimitive.Trigger data-testid="trigger">trigger</ContextMenuPrimitive.Trigger>
+      <ContextMenuContent className={`probe-content ${callerClass}`}>
+        <ContextMenuPrimitive.Sub open>
+          <ContextMenuPrimitive.SubTrigger>more</ContextMenuPrimitive.SubTrigger>
+          <ContextMenuSubContent className="probe-sub">item</ContextMenuSubContent>
+        </ContextMenuPrimitive.Sub>
+      </ContextMenuContent>
+    </ContextMenuPrimitive.Root>
+  );
+  // Context menus have no `open` on the root — the gesture is what mounts the
+  // portal, so fire it rather than forcing the content.
+  fireEvent.contextMenu(probeIn(container, "[data-testid='trigger']"));
+}
+
+function renderDropdownMenu(callerClass = "") {
+  render(
+    <DropdownMenuPrimitive.Root open>
+      <DropdownMenuPrimitive.Trigger>trigger</DropdownMenuPrimitive.Trigger>
+      <DropdownMenuContent className={`probe-content ${callerClass}`}>
+        <DropdownMenuPrimitive.Sub open>
+          <DropdownMenuPrimitive.SubTrigger>more</DropdownMenuPrimitive.SubTrigger>
+          <DropdownMenuSubContent className="probe-sub">item</DropdownMenuSubContent>
+        </DropdownMenuPrimitive.Sub>
+      </DropdownMenuContent>
+    </DropdownMenuPrimitive.Root>
+  );
+}
+
+function renderPopover(callerClass = "") {
+  render(
+    <PopoverPrimitive.Root open>
+      <PopoverPrimitive.Trigger>trigger</PopoverPrimitive.Trigger>
+      <PopoverContent forceMount className={`probe-content ${callerClass}`}>
+        content
+      </PopoverContent>
+    </PopoverPrimitive.Root>
+  );
+}
+
+function probeIn(container: HTMLElement, selector: string): HTMLElement {
+  const el = container.querySelector(selector);
+  if (!(el instanceof HTMLElement)) throw new Error(`${selector} not found`);
+  return el;
+}
+
+describe("portaled overlay content opts out of the OS drag region — issue #12347", () => {
+  it.each([
+    ["ContextMenuContent", renderContextMenu, ".probe-content"],
+    ["ContextMenuSubContent", renderContextMenu, ".probe-sub"],
+    ["DropdownMenuContent", renderDropdownMenu, ".probe-content"],
+    ["DropdownMenuSubContent", renderDropdownMenu, ".probe-sub"],
+    ["PopoverContent", renderPopover, ".probe-content"],
+  ])(
+    "%s carries the opt-out on the element that paints over the toolbar",
+    (_name, mount, selector) => {
+      mount();
+      expect(classTokens(probe(selector))).toContain(NO_DRAG);
+    }
+  );
+
+  it.each([
+    ["ContextMenuContent", renderContextMenu],
+    ["DropdownMenuContent", renderDropdownMenu],
+    ["PopoverContent", renderPopover],
+  ])("%s keeps the opt-out when a caller supplies its own classes", (_name, mount) => {
+    // `cn()` runs tailwind-merge, which is free to drop a token it believes a
+    // later class supersedes. A consumer passing layout classes is the common
+    // case, and it must not be able to hand the toolbar back its dead zone.
+    mount("w-80 p-0 absolute");
+    expect(classTokens(probe(".probe-content"))).toContain(NO_DRAG);
+  });
+});
+
+describe("the opt-out stays wired to a real rule", () => {
+  it("`.app-no-drag` sets both spellings of the OS property, for itself and its descendants", () => {
+    // Without this rule the class the primitives stamp is decoration, and
+    // every assertion above passes while the bug is fully back. The
+    // descendant half is what carries the opt-out to the menu items, which
+    // never carry the class themselves.
+    const css = readFileSync(path.join(UI_DIR, "..", "..", "index.css"), "utf8");
+    const rule = /\.app-no-drag,\s*\n\s*\.app-no-drag \*\s*\{([^}]*)\}/.exec(css);
+    expect(rule, "`.app-no-drag, .app-no-drag *` rule missing from src/index.css").not.toBeNull();
+    const declarations = rule?.[1] ?? "";
+    expect(declarations).toMatch(/-webkit-app-region:\s*no-drag/);
+    expect(declarations).toMatch(/(?<!-)\bapp-region:\s*no-drag/);
+  });
+});
+
+describe("no ui/ primitive portals over the toolbar without opting out", () => {
+  // Deliberately exempt. Tooltips are non-interactive, so they have no dead
+  // click zone to fix — and marking them no-drag would instead carve a dead
+  // *drag* zone out of the title bar for as long as one is showing.
+  const EXEMPT = new Set(["tooltip.tsx"]);
+
+  it("every module rendering a Radix Portal stamps the opt-out", () => {
+    // The failure this exists for: a sixth anchored surface is added next to
+    // these five, portals to `document.body` like the rest, and reintroduces
+    // the bug on its own — invisibly, because no existing test renders it.
+    const offenders = readdirSync(UI_DIR)
+      .filter((file) => file.endsWith(".tsx") && !EXEMPT.has(file))
+      .filter((file) => {
+        const src = readFileSync(path.join(UI_DIR, file), "utf8");
+        return /radix\.\w+\.Portal\b/.test(src) && !src.includes(NO_DRAG);
+      });
+    expect(offenders, `add "${NO_DRAG}" to the portaled content, or exempt with a reason`).toEqual(
+      []
+    );
+  });
+});

--- a/src/components/ui/__tests__/reentry-summary.test.tsx
+++ b/src/components/ui/__tests__/reentry-summary.test.tsx
@@ -666,3 +666,28 @@ describe("ReEntrySummary", () => {
     });
   });
 });
+
+describe("re-entry summary drag-region opt-out (issue #12347)", () => {
+  it("opts the card out of the drag region, not its pointer-events-none wrapper", () => {
+    // top-3 plus the wrapper's p-4 puts the card's header at y≈28px — inside
+    // the toolbar's 48px drag band with no banner needed — so Pin and Dismiss
+    // are swallowed as window drags. The wrapper is full-width and always
+    // mounted, so the opt-out must sit on the card instead.
+    render(<ReEntrySummary state={makeState({ rows: [makeRow()] })} />);
+
+    const dismiss = screen.getByRole("button", { name: "Dismiss summary" });
+    const stamped = dismiss.closest(".app-no-drag");
+    if (!(stamped instanceof HTMLElement)) throw new Error("no opt-out above the dismiss control");
+
+    // Located independently of the stamp, so moving the opt-out up onto the
+    // wrapper fails here rather than quietly satisfying a relative lookup.
+    // Deliberately not a pointer-events check: the card itself carries
+    // `pointer-events-none` until its entry animation runs.
+    const wrapper = document.querySelector(".fixed.top-3");
+    if (!(wrapper instanceof HTMLElement)) throw new Error("summary wrapper not rendered");
+    expect(wrapper.className).toContain("pointer-events-none");
+    expect(wrapper.className.split(/\s+/)).not.toContain("app-no-drag");
+    expect(wrapper.contains(stamped)).toBe(true);
+    expect(stamped).not.toBe(wrapper);
+  });
+});

--- a/src/components/ui/__tests__/toaster.test.tsx
+++ b/src/components/ui/__tests__/toaster.test.tsx
@@ -1928,3 +1928,31 @@ describe("Toast stack motion (issue #9618)", () => {
     expect(card.className).not.toContain("motion-reduce:transition-none");
   });
 });
+
+describe("Toast drag-region opt-out (issue #12347)", () => {
+  beforeEach(() => {
+    useNotificationStore.getState().reset();
+  });
+
+  it("opts the toast out of the drag region, not its pointer-events-none column", () => {
+    // A global banner renders above the toolbar, pushing the drag band below
+    // this column's top-14 origin, so toast controls land inside it. Which
+    // element carries the opt-out is the whole fix: the column is full-width
+    // and always mounted, so stamping it would hold a no-drag rect across the
+    // title bar with no toast showing.
+    render(<Toaster />);
+    act(() => {
+      addToast({ message: "Drag region probe" });
+    });
+
+    const dismiss = screen.getByRole("button", { name: "Dismiss notification" });
+    const stamped = dismiss.closest(".app-no-drag");
+    if (!(stamped instanceof HTMLElement)) throw new Error("no opt-out above the dismiss control");
+    expect(stamped.className).toContain("pointer-events-auto");
+    expect(stamped.className).not.toContain("pointer-events-none");
+
+    const column = document.querySelector('[aria-label="Notifications"]');
+    expect(column?.className).toContain("pointer-events-none");
+    expect(column?.className.split(/\s+/)).not.toContain("app-no-drag");
+  });
+});

--- a/src/components/ui/context-menu.tsx
+++ b/src/components/ui/context-menu.tsx
@@ -227,6 +227,8 @@ const ContextMenuSubContent = React.forwardRef<
         collisionPadding={collisionPadding}
         style={{ transformOrigin: "var(--radix-context-menu-content-transform-origin)", ...style }}
         className={cn(
+          // Escapes the toolbar's drag region via the portal — see `.app-no-drag` (#12347).
+          "app-no-drag",
           "relative z-[var(--z-popover)] min-w-[10rem] max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto rounded-[var(--radius-lg)] surface-overlay shadow-overlay p-1 text-text-primary",
           OVERLAY_MOTION_CLASS,
           className
@@ -317,6 +319,8 @@ const ContextMenuContent = React.forwardRef<
             ...style,
           }}
           className={cn(
+            // Escapes the toolbar's drag region via the portal — see `.app-no-drag` (#12347).
+            "app-no-drag",
             "relative z-[var(--z-popover)] min-w-[10rem] max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto rounded-[var(--radius-lg)] surface-overlay shadow-overlay p-1 text-text-primary",
             OVERLAY_MOTION_CLASS,
             className

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -279,6 +279,8 @@ const DropdownMenuSubContent = React.forwardRef<
         collisionPadding={collisionPadding}
         style={{ transformOrigin: "var(--radix-dropdown-menu-content-transform-origin)", ...style }}
         className={cn(
+          // Escapes the toolbar's drag region via the portal — see `.app-no-drag` (#12347).
+          "app-no-drag",
           "relative z-[var(--z-popover)] min-w-[10rem] max-h-[var(--radix-dropdown-menu-content-available-height)] overflow-y-auto rounded-[var(--radius-lg)] surface-overlay shadow-overlay p-1 text-text-primary",
           OVERLAY_MOTION_CLASS,
           className
@@ -375,6 +377,8 @@ const DropdownMenuContent = React.forwardRef<
               ...style,
             }}
             className={cn(
+              // Escapes the toolbar's drag region via the portal — see `.app-no-drag` (#12347).
+              "app-no-drag",
               "relative z-[var(--z-popover)] min-w-[10rem] max-h-[var(--radix-dropdown-menu-content-available-height)] overflow-y-auto rounded-[var(--radius-lg)] surface-overlay shadow-overlay p-1 text-text-primary",
               OVERLAY_MOTION_CLASS,
               className

--- a/src/components/ui/fixed-dropdown.tsx
+++ b/src/components/ui/fixed-dropdown.tsx
@@ -245,6 +245,8 @@ export function FixedDropdown({
     <div
       ref={contentRef}
       className={cn(
+        // Escapes the toolbar's drag region via the portal — see `.app-no-drag` (#12347).
+        "app-no-drag",
         "absolute pointer-events-auto overflow-hidden rounded-[var(--radius-lg)] surface-overlay shadow-overlay text-text-primary",
         // Tailwind v4 translate-*/scale-* emit the individual `translate` and
         // `scale` properties, which `transform` in a transition list does NOT

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -310,6 +310,8 @@ const PopoverContent = React.forwardRef<
             collisionBoundary={collisionBoundary ?? boundary ?? undefined}
             style={{ transformOrigin: "var(--radix-popover-content-transform-origin)", ...style }}
             className={cn(
+              // Escapes the toolbar's drag region via the portal — see `.app-no-drag` (#12347).
+              "app-no-drag",
               "z-[var(--z-popover)] overflow-hidden rounded-[var(--radius-lg)] surface-overlay shadow-overlay text-text-primary",
               OVERLAY_MOTION_CLASS,
               className

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -241,6 +241,8 @@ const SelectContent = React.forwardRef<
           }}
           style={{ transformOrigin: "var(--radix-select-content-transform-origin)", ...style }}
           className={cn(
+            // Escapes the toolbar's drag region via the portal — see `.app-no-drag` (#12347).
+            "app-no-drag",
             "relative z-[var(--z-popover)] overflow-hidden rounded-[var(--radius-lg)] surface-overlay shadow-overlay text-text-primary",
             OVERLAY_MOTION_CLASS,
             position === "popper" &&

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -365,6 +365,11 @@ function Toast({
     <div
       ref={toastRef}
       className={cn(
+        // A global banner pushes the toolbar's drag band below this
+        // column's top-14 origin, so toast controls land inside it — stamp the
+        // toast, not the pointer-events-none column, which would hold a rect
+        // over the title bar even with nothing showing (#12347).
+        "app-no-drag",
         "pointer-events-auto relative w-full min-w-[240px] max-w-[360px]",
         "transition-[transform,opacity]",
         "motion-reduce:transition-none motion-reduce:duration-0",
@@ -696,6 +701,7 @@ function OverflowPill({ count }: { count: number }) {
       aria-label={label}
       data-testid="toast-overflow-pill"
       className={cn(
+        "app-no-drag",
         "pointer-events-auto self-end",
         "inline-flex items-center gap-1 rounded-full",
         "bg-surface-panel/85 backdrop-blur-xl",

--- a/src/index.css
+++ b/src/index.css
@@ -2186,7 +2186,15 @@ body[data-performance-mode="true"] .forge-status-error {
 /* Non-draggable interactive elements (Buttons, Inputs).
    Descendants opt out too — nested wrappers inside an interactive control
    would otherwise inherit `drag` from the toolbar parent and re-introduce
-   dead-click zones over the children. */
+   dead-click zones over the children.
+
+   Overlay content portaled to `document.body` (menus, popovers, selects,
+   dropdowns) needs this class as well. Chromium derives the OS drag region
+   geometrically, as drag rects minus no-drag rects, so a portaled surface
+   that never claims a no-drag rect has the toolbar's `drag` showing through
+   wherever the two overlap — and every item painted over the toolbar is
+   swallowed as a window drag instead of being clickable (#12347). The
+   descendant selector then carries the opt-out to the items inside. */
 .app-no-drag,
 .app-no-drag * {
   -webkit-app-region: no-drag;


### PR DESCRIPTION
## Summary

Right-clicking the project pill opened a context menu whose items were unclickable wherever they painted over the toolbar. The toolbar root carries `app-drag-region` (`-webkit-app-region: drag`), and Chromium derives the OS draggable region geometrically as drag rects minus no-drag rects. Radix portals its content to `document.body`, outside the toolbar's subtree, where it claimed no no-drag rect, so the toolbar's drag region showed through the overlap and every click there was swallowed as a window drag. Items falling below the toolbar's bottom edge worked fine, which is what made this look like a menu bug rather than a window chrome one.

Resolves #12347

## The fix

Stamp the existing `app-no-drag` class on the portaled content of every interactive overlay primitive, at the shared `src/components/ui/` layer rather than at each call site. That covers the toolbar, the plugin manager header, and the title bar mode status banner all at once. `.app-no-drag *` already carries the opt-out down to the items themselves.

Surfaces touched:

- ContextMenu `Content` and `SubContent`
- DropdownMenu `Content` and `SubContent`
- `PopoverContent` (which also covers `AppPalettePopover`)
- `SelectContent`
- the `FixedDropdown` panel
- the toast and its overflow pill
- the re-entry summary card

## Two surfaces review caught

The toaster and the re-entry summary card were nearly excluded on the assumption that their `top-14` / `top-3` origins clear the 48px toolbar. That assumption is wrong. A global banner renders above the toolbar in `AppLayout`'s flex column, so the drag band doesn't start at `y=0`, which is exactly why `OVERLAY_TOP_OFFSET` exists, and the banner itself is a drag region with no bounded height. The re-entry card overlaps the band unconditionally, banner or not: its header lands at about `y=28px`, putting Pin and Dismiss inside it.

## Placement matters

In every case the opt-out goes on the interactive child, never on the `pointer-events-none` full-viewport or full-width container. Stamping a container would hold a no-drag rect across the whole title bar with nothing visibly interactive there, and for `FixedDropdown`'s `fixed inset-0` wrapper it would make the entire window undraggable whenever a dropdown is open. Tests pin this by locating the container independently and asserting it stays unstamped.

## Deliberately excluded

- `tooltip.tsx`: tooltips are non-interactive, so there's no dead click zone. Opting it out would instead carve a dead drag zone out of the title bar while a tooltip is showing.
- `ShortcutHint.tsx`: pointer-events-none and aria-hidden.
- `AppDialog` / `AppPaletteDialog`: their `fixed inset-0` scrims mean click-outside-to-dismiss is still dead over the toolbar strip, but whether a window should drag at all behind an open modal is a separate product call. Noting it as a follow-up rather than deciding it here.

Also considered and rejected: a global CSS rule on `[data-radix-popper-content-wrapper]`. It depends on a Radix-internal selector (see the fragility lesson from #8216), does nothing for the non-Radix `createPortal` surfaces, and would blanket tooltips too.

## Tests

Added `overlay-drag-region.test.tsx`, which renders the real primitives and asserts the opt-out reaches the DOM node that actually paints over the toolbar, plus a composition test, a check that the class still maps to a live CSS rule, and a sweep over `src/components/ui/` that fails if a portaled surface is neither stamped nor exempt with a documented reason. The sweep strips comments before scanning, since the stamp comments name the class and a naive substring scan would be satisfied by its own prose. One honest limit: the sweep's per-surface count is a deletion ratchet, so it can't catch a newly added unstamped surface in a file that's already on its list.

## Verification

- `src/components/ui/__tests__`: 993 tests / 59 files
- Toolbar + AppLayout + `useReEntrySummary` suites: 139 tests / 5 files
- `src/config/__tests__`: 504 tests / 24 files

All passing. `prettier` clean, `eslint` 0 errors across all 12 changed files, and 0 warnings on any line this branch added. jsdom doesn't resolve `-webkit-app-region`, so nothing here claims to verify real browser drag behavior, that limit is stated directly in the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VoHgMNBYcYyQRiC7JDuyqk
