### PR TITLE
fix(agents): detect Windows native-install CLIs and stop the check timeout erasing results

### DIFF
--- a/electron/services/CliAvailabilityService.ts
+++ b/electron/services/CliAvailabilityService.ts
@@ -20,6 +20,9 @@ import { store } from "../store.js";
 import { CHANNELS } from "../ipc/channels.js";
 import { broadcastToRenderer } from "../ipc/utils.js";
 import { getDefaultWslDistro } from "../utils/wsl.js";
+import { createLogger } from "../utils/logger.js";
+
+const logger = createLogger("main:CliAvailabilityService");
 
 interface ProbeSuccess {
   status: "found";
@@ -65,6 +68,8 @@ const WINDOWS_EXECUTABLE_PRIORITY = new Map<string, number>([
   [".ps1", 4],
   ["", 5],
 ]);
+
+const WINDOWS_APPENDED_EXTENSIONS = [".cmd", ".exe", ".bat", ".com"];
 
 /**
  * Synthesise probe paths for PyPI-distributed agents. Modern Python tool
@@ -137,6 +142,19 @@ function windowsExecutablePriority(candidatePath: string): number {
   return WINDOWS_EXECUTABLE_PRIORITY.get(pathWin32.extname(candidatePath).toLowerCase()) ?? 6;
 }
 
+/**
+ * `fs.access(X_OK)` is only an existence check on Windows, and the launcher
+ * runs `resolvedPath` verbatim through PowerShell, so an extensionless file
+ * there proves nothing launchable. Probe the executable variants instead, but
+ * leave a path that already names a launchable extension alone so
+ * `goose.exe` never turns into `goose.exe.cmd`.
+ */
+function windowsLaunchCandidates(filePath: string): string[] {
+  const extension = pathWin32.extname(filePath).toLowerCase();
+  if (extension && WINDOWS_EXECUTABLE_PRIORITY.has(extension)) return [filePath];
+  return WINDOWS_APPENDED_EXTENSIONS.map((appended) => `${filePath}${appended}`);
+}
+
 export class CliAvailabilityService {
   private static readonly CHECK_TIMEOUT_MS = 10_000;
   private static readonly AUTH_CHECK_TIMEOUT_MS = 3_000;
@@ -166,63 +184,65 @@ export class CliAvailabilityService {
 
         const entries = Object.entries(getEffectiveRegistry());
 
-        const checksPromise = Promise.allSettled(
+        // Outcomes are recorded as each agent settles, so an agent that
+        // outlives the batch budget can't take the ones that already answered
+        // down with it.
+        const settled = new Map<string, AgentCheckOutcome>();
+        const checksPromise = Promise.all(
           entries.map(async ([id, config]) => {
-            const outcome = await this.checkAgent(config);
-            return [id, outcome] as [string, AgentCheckOutcome];
+            try {
+              settled.set(id, await this.checkAgent(config));
+            } catch (error) {
+              logger.error("Agent CLI check failed", error, { agentId: id });
+              settled.set(id, {
+                state: "missing",
+                detail: { state: "missing", resolvedPath: null, via: null },
+              });
+            }
           })
         );
 
         let timeoutHandle: NodeJS.Timeout | undefined;
-        const timeoutPromise = new Promise<never>((_, reject) => {
-          timeoutHandle = setTimeout(
-            () => reject(new Error("CLI availability check timed out")),
-            CliAvailabilityService.CHECK_TIMEOUT_MS
-          );
+        const timeoutPromise = new Promise<void>((resolve) => {
+          timeoutHandle = setTimeout(() => resolve(), CliAvailabilityService.CHECK_TIMEOUT_MS);
         });
 
-        let outcomeEntries: [string, AgentCheckOutcome][];
         try {
-          const results = await Promise.race([checksPromise, timeoutPromise]);
-          outcomeEntries = results.map((result, index) => {
-            if (result.status === "fulfilled") {
-              return result.value;
-            } else {
-              console.warn(
-                `[CliAvailabilityService] Check failed for ${entries[index][0]}:`,
-                result.reason
-              );
-              return [
-                entries[index][0],
-                {
-                  state: "missing" as AgentAvailabilityState,
-                  detail: {
-                    state: "missing" as AgentAvailabilityState,
-                    resolvedPath: null,
-                    via: null,
-                  },
-                },
-              ];
-            }
-          });
-        } catch (error) {
-          // eslint-disable-next-line no-restricted-syntax -- diagnostic console.warn passes the raw error if not an Error; not a user-visible string.
-          console.warn("[CliAvailabilityService]", error instanceof Error ? error.message : error);
-          outcomeEntries = entries.map(([id]) => [
-            id,
-            {
-              state: "missing" as AgentAvailabilityState,
-              detail: {
-                state: "missing" as AgentAvailabilityState,
-                resolvedPath: null,
-                via: null,
-              },
-            },
-          ]);
+          await Promise.race([checksPromise, timeoutPromise]);
         } finally {
           if (timeoutHandle) {
             clearTimeout(timeoutHandle);
           }
+        }
+
+        const pendingAgentIds: string[] = [];
+        const outcomeEntries = entries.map(([id]): [string, AgentCheckOutcome] => {
+          const outcome = settled.get(id);
+          if (outcome) return [id, outcome];
+          pendingAgentIds.push(id);
+          // Running out of time says nothing about whether the binary is still
+          // there, so keep the last result this agent actually produced.
+          const previous = this.details?.[id];
+          if (previous) return [id, { state: previous.state, detail: previous }];
+          return [
+            id,
+            {
+              state: "missing",
+              detail: {
+                state: "missing",
+                resolvedPath: null,
+                via: null,
+                message: "Detection timed out before this agent could be checked.",
+              },
+            },
+          ];
+        });
+
+        if (pendingAgentIds.length > 0) {
+          logger.warn("CLI availability check timed out", {
+            timeoutMs: CliAvailabilityService.CHECK_TIMEOUT_MS,
+            pendingAgentIds,
+          });
         }
 
         const availability: CliAvailability = Object.fromEntries(
@@ -312,7 +332,7 @@ export class CliAvailabilityService {
     // found nothing), classify as `unauthenticated` — the binary exists but
     // will require login on first launch. The CLI handles auth at runtime.
     const authConfirmed = config.authCheck
-      ? await this.checkAuth(config.name, config.authCheck)
+      ? await this.checkAuth(config.id, config.authCheck)
       : undefined;
 
     const state: AgentAvailabilityState = authConfirmed === false ? "unauthenticated" : "ready";
@@ -334,7 +354,7 @@ export class CliAvailabilityService {
     };
   }
 
-  private async checkAuth(agentName: string, authCheck: AgentAuthCheck): Promise<boolean> {
+  private async checkAuth(agentId: string, authCheck: AgentAuthCheck): Promise<boolean> {
     // Shared flag so the checkPromise knows the timeoutPromise already won
     // the race. Without this, a slow fs.access can later resolve/reject and
     // emit a misleading "auth discovery: no credential found" log for an
@@ -400,11 +420,7 @@ export class CliAvailabilityService {
       }
 
       if (!timedOut) {
-        console.log(
-          `[CliAvailabilityService] ${agentName}: binary found, auth discovery: no credential found (checked: ${
-            checkedPaths.join(", ") || "none"
-          })`
-        );
+        logger.info("Auth discovery found no credential", { agentId, checkedPaths });
       }
       return false;
     })();
@@ -423,6 +439,8 @@ export class CliAvailabilityService {
    *    `missing`).
    * 2. Absolute paths declared in `AgentConfig.nativePaths` — covers native
    *    installer locations not on Electron's PATH (e.g. `~/.local/bin/claude`).
+   *    On Windows an entry without a launchable extension is probed with
+   *    `.cmd`/`.exe`/`.bat`/`.com` appended.
    * 3. npm global bin shim at `$(npm config get prefix)/bin/<cmd>` (POSIX) or
    *    `<prefix>\<cmd>.cmd` (Windows). Only fires when
    *    `AgentConfig.npmGlobalPackage` is set. Positively confirms the binary
@@ -454,9 +472,7 @@ export class CliAvailabilityService {
       return this.probeNativePaths([command]);
     }
     if (!CliAvailabilityService.VALID_COMMAND_RE.test(command)) {
-      console.warn(
-        `[CliAvailabilityService] Command "${command}" contains invalid characters, rejecting`
-      );
+      logger.warn("Rejected agent command with invalid characters", { command });
       return { status: "missing" };
     }
 
@@ -515,7 +531,7 @@ export class CliAvailabilityService {
 
     const commandCandidates =
       process.platform === "win32"
-        ? [`${command}.cmd`, `${command}.exe`, `${command}.bat`, `${command}.com`, command]
+        ? [...WINDOWS_APPENDED_EXTENSIONS.map((extension) => `${command}${extension}`), command]
         : [command];
 
     for (const dir of pathPrefix.split(delimiter).filter(Boolean)) {
@@ -629,27 +645,31 @@ export class CliAvailabilityService {
 
   private async probeNativePaths(paths: string[]): Promise<ProbeResult> {
     const home = homedir();
+    const isWindows = process.platform === "win32";
     for (const raw of paths) {
       const expanded = this.expandPath(raw, home);
       if (!expanded) continue;
-      try {
-        await access(expanded, constants.X_OK);
-        return { status: "found", path: expanded, via: "native" };
-      } catch (err) {
-        const code = (err as NodeJS.ErrnoException | undefined)?.code;
-        if (typeof code === "string" && SECURITY_ERROR_CODES.has(code)) {
-          // File exists but cannot be executed — classify as blocked and
-          // stop probing remaining native paths. Trying other paths would
-          // likely hit the same policy.
-          return {
-            status: "blocked",
-            reason: code === "EACCES" ? "permissions" : "security",
-            path: expanded,
-            via: "native",
-            message: `${expanded} exists but execution failed with ${code} — check file permissions or security software allowlist`,
-          };
+      const candidates = isWindows ? windowsLaunchCandidates(expanded) : [expanded];
+      for (const candidate of candidates) {
+        try {
+          await access(candidate, constants.X_OK);
+          return { status: "found", path: candidate, via: "native" };
+        } catch (err) {
+          const code = (err as NodeJS.ErrnoException | undefined)?.code;
+          if (typeof code === "string" && SECURITY_ERROR_CODES.has(code)) {
+            // File exists but cannot be executed — classify as blocked and
+            // stop probing remaining native paths. Trying other paths would
+            // likely hit the same policy.
+            return {
+              status: "blocked",
+              reason: code === "EACCES" ? "permissions" : "security",
+              path: candidate,
+              via: "native",
+              message: `${candidate} exists but execution failed with ${code} — check file permissions or security software allowlist`,
+            };
+          }
+          // ENOENT (or any other error) — try the next candidate.
         }
-        // ENOENT (or any other error) — try the next candidate.
       }
     }
     return { status: "missing" };
@@ -782,7 +802,7 @@ export class CliAvailabilityService {
       expanded = expandWindowsEnvVars(expanded);
       // On Windows, skip entries that still contain unexpanded %VAR% tokens
       // (env var not set) to avoid probing a literal path like
-      // "%LOCALAPPDATA%\claude-code\bin\claude.exe".
+      // "%LOCALAPPDATA%\Microsoft\WinGet\Links\claude.exe".
       if (expanded.includes("%")) return null;
     } else if (input.includes("\\")) {
       // Windows-only candidates should not be probed on Unix. Inspect the
@@ -835,10 +855,7 @@ export class CliAvailabilityService {
           message: `Active: ${active}. Also found: ${alsoFound}. Pick one install method and remove the others so the most up-to-date version launches.`,
         });
       } catch (err) {
-        console.warn(
-          `[CliAvailabilityService] Failed to broadcast duplicate-install toast for ${agentId}:`,
-          err
-        );
+        logger.error("Failed to broadcast duplicate-install toast", err, { agentId });
         continue;
       }
 
@@ -850,10 +867,7 @@ export class CliAvailabilityService {
       try {
         store.set("orchestrationMilestones", milestones);
       } catch (err) {
-        console.warn(
-          "[CliAvailabilityService] Failed to persist duplicate-install milestone:",
-          err
-        );
+        logger.error("Failed to persist duplicate-install milestone", err);
       }
     }
   }

--- a/electron/services/CliAvailabilityService.ts
+++ b/electron/services/CliAvailabilityService.ts
@@ -60,6 +60,8 @@ interface AgentCheckOutcome {
 
 const SECURITY_ERROR_CODES = new Set(["EACCES", "EPERM"]);
 
+const CHECK_TIMED_OUT_MESSAGE = "The most recent check didn't finish in time.";
+
 const WINDOWS_EXECUTABLE_PRIORITY = new Map<string, number>([
   [".cmd", 0],
   [".exe", 1],
@@ -221,9 +223,19 @@ export class CliAvailabilityService {
           if (outcome) return [id, outcome];
           pendingAgentIds.push(id);
           // Running out of time says nothing about whether the binary is still
-          // there, so keep the last result this agent actually produced.
+          // there, so reuse what the last published check reported and flag
+          // that it wasn't re-confirmed — unless that detail already carries
+          // its own diagnostic, which stays the more useful thing to show.
           const previous = this.details?.[id];
-          if (previous) return [id, { state: previous.state, detail: previous }];
+          if (previous) {
+            return [
+              id,
+              {
+                state: previous.state,
+                detail: { ...previous, message: previous.message ?? CHECK_TIMED_OUT_MESSAGE },
+              },
+            ];
+          }
           return [
             id,
             {
@@ -232,18 +244,11 @@ export class CliAvailabilityService {
                 state: "missing",
                 resolvedPath: null,
                 via: null,
-                message: "Detection timed out before this agent could be checked.",
+                message: CHECK_TIMED_OUT_MESSAGE,
               },
             },
           ];
         });
-
-        if (pendingAgentIds.length > 0) {
-          logger.warn("CLI availability check timed out", {
-            timeoutMs: CliAvailabilityService.CHECK_TIMEOUT_MS,
-            pendingAgentIds,
-          });
-        }
 
         const availability: CliAvailability = Object.fromEntries(
           outcomeEntries.map(([id, outcome]) => [id, outcome.state])
@@ -255,6 +260,14 @@ export class CliAvailabilityService {
         if (this.checkId === currentCheckId) {
           this.availability = availability;
           this.details = details;
+          // Only a published check warns: a superseded one (the setup wizard
+          // re-checks every 3s) would otherwise report results nobody sees.
+          if (pendingAgentIds.length > 0) {
+            logger.warn("CLI availability check timed out", {
+              timeoutMs: CliAvailabilityService.CHECK_TIMEOUT_MS,
+              pendingAgentIds,
+            });
+          }
           this.notifyDuplicateInstalls(outcomeEntries, entries);
         }
 
@@ -420,7 +433,9 @@ export class CliAvailabilityService {
       }
 
       if (!timedOut) {
-        logger.info("Auth discovery found no credential", { agentId, checkedPaths });
+        // Debug, not info: the setup wizard re-checks every 3s, and at info
+        // this repeats into daintree.log's crash-context tail.
+        logger.debug("Auth discovery found no credential", { agentId, checkedPaths });
       }
       return false;
     })();
@@ -467,7 +482,8 @@ export class CliAvailabilityService {
     // Plugin-contributed agents (#10560) resolve a `./`-relative manifest command
     // to an absolute path at registration. Such a command has path separators and
     // would be rejected by VALID_COMMAND_RE below, so probe the file directly
-    // instead — `probeNativePaths` checks existence + executability (X_OK).
+    // instead — `probeNativePaths` checks existence + executability (X_OK),
+    // trying launchable extensions on Windows.
     if (isAbsolute(command)) {
       return this.probeNativePaths([command]);
     }

--- a/electron/services/__tests__/CliAvailabilityService.test.ts
+++ b/electron/services/__tests__/CliAvailabilityService.test.ts
@@ -11,6 +11,8 @@ import { execFile, execFileSync } from "child_process";
 import { refreshPath } from "../../setup/environment.js";
 import { broadcastToRenderer } from "../../ipc/utils.js";
 import { CHANNELS } from "../../ipc/channels.js";
+import { logBuffer } from "../LogBuffer.js";
+import { getLogLevelOverrides, setLogLevelOverrides } from "../../utils/logger.js";
 
 // Mock child_process. The service's probes (shell which/where, npm-global,
 // WSL) all run through async `execFile` — mock it or the probes will call
@@ -120,7 +122,6 @@ describe("CliAvailabilityService", () => {
   let service: CliAvailabilityService;
   const mockedExecFileSync = vi.mocked(execFileSync);
   const mockedExecFile = vi.mocked(execFile);
-  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
   const savedEnv: Record<string, string | undefined> = {};
   // Default platform to darwin so Unix-style path/probe expectations don't
   // diverge on Windows CI. Individual tests that exercise Windows-specific
@@ -169,10 +170,6 @@ describe("CliAvailabilityService", () => {
     // Default async execFile (npm-global / WSL probes) to "not found" —
     // clearAllMocks wipes mock impls, so we reapply the factory default after each clear.
     mockedExecFile.mockImplementation(defaultExecFileImpl as never);
-    // Silence the diagnostic fallback log emitted by checkAuth() so
-    // the test runner output stays clean. Individual tests re-access
-    // the spy via `consoleLogSpy` to assert on log calls.
-    consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -965,6 +962,29 @@ describe("CliAvailabilityService", () => {
   });
 
   describe("diagnostic logging for auth discovery", () => {
+    let savedLogOverrides: Record<string, string>;
+
+    beforeEach(() => {
+      savedLogOverrides = getLogLevelOverrides();
+      // Vitest floors the logger at "debug"; pin production's "info" floor so
+      // a miss logged below it fails here instead of silently never reaching
+      // daintree.log on a user's machine.
+      setLogLevelOverrides({ "*": "info" });
+      logBuffer.clear();
+    });
+
+    afterEach(() => {
+      setLogLevelOverrides(savedLogOverrides);
+      logBuffer.clear();
+    });
+
+    const authMissPaths = (agentId: string): string[][] =>
+      logBuffer
+        .getFiltered({ sources: ["main:CliAvailabilityService"] })
+        .map((entry) => entry.context as { agentId?: unknown; checkedPaths?: unknown } | undefined)
+        .filter((context) => context?.agentId === agentId && Array.isArray(context.checkedPaths))
+        .map((context) => context!.checkedPaths as string[]);
+
     it("logs exactly once when auth discovery finds no credential", async () => {
       mockedExecFileSync.mockImplementation((_file, args) => {
         if (cmdOf(args) === "copilot") return Buffer.from("");
@@ -976,17 +996,11 @@ describe("CliAvailabilityService", () => {
       expect(result.copilot).toBe("unauthenticated");
       expect(service.getDetails()!.copilot?.authConfirmed).toBe(false);
 
-      const copilotLogs = consoleLogSpy.mock.calls.filter((call: unknown[]) =>
-        String(call[0]).includes(
-          "GitHub Copilot: binary found, auth discovery: no credential found"
-        )
-      );
+      const copilotLogs = authMissPaths("copilot");
       // Must fire exactly once — guards against the Promise.race leak where
       // a slow fs.access would log after the timeout branch already resolved.
       expect(copilotLogs).toHaveLength(1);
-      const message = String(copilotLogs[0][0]);
-      expect(message).toContain("[CliAvailabilityService]");
-      expect(message).toContain(join(".copilot", "config.json"));
+      expect(copilotLogs[0].some((p) => p.includes(join(".copilot", "config.json")))).toBe(true);
     });
 
     it("logs Kiro auth discovery miss listing the AWS SSO token path that was checked", async () => {
@@ -1001,12 +1015,11 @@ describe("CliAvailabilityService", () => {
 
       await service.checkAvailability();
 
-      const kiroLog = consoleLogSpy.mock.calls.find((call: unknown[]) =>
-        String(call[0]).includes("Kiro")
-      );
-      expect(kiroLog).toBeDefined();
-      expect(String(kiroLog![0])).toContain(join(".aws", "sso", "cache", "kiro-auth-token.json"));
-      expect(String(kiroLog![0])).toContain("no credential found");
+      const kiroLogs = authMissPaths("kiro");
+      expect(kiroLogs).toHaveLength(1);
+      expect(
+        kiroLogs[0].some((p) => p.includes(join(".aws", "sso", "cache", "kiro-auth-token.json")))
+      ).toBe(true);
     });
 
     it("does NOT log when auth check is short-circuited by envVar (OPENAI_API_KEY)", async () => {
@@ -1020,10 +1033,7 @@ describe("CliAvailabilityService", () => {
       expect(result.codex).toBe("ready");
       expect(service.getDetails()!.codex?.authConfirmed).toBe(true);
 
-      const codexLog = consoleLogSpy.mock.calls.find((call: unknown[]) =>
-        String(call[0]).includes("Codex")
-      );
-      expect(codexLog).toBeUndefined();
+      expect(authMissPaths("codex")).toHaveLength(0);
     });
 
     it("does NOT emit a discovery-miss log when the auth check timed out", async () => {
@@ -1058,13 +1068,8 @@ describe("CliAvailabilityService", () => {
         expect(result.copilot).toBe("unauthenticated");
         expect(service.getDetails()!.copilot?.authConfirmed).toBe(false);
 
-        const copilotLogs = consoleLogSpy.mock.calls.filter((call: unknown[]) =>
-          String(call[0]).includes(
-            "GitHub Copilot: binary found, auth discovery: no credential found"
-          )
-        );
         // No discovery-miss log should fire — the timeout decided the state.
-        expect(copilotLogs).toHaveLength(0);
+        expect(authMissPaths("copilot")).toHaveLength(0);
       } finally {
         vi.useRealTimers();
       }
@@ -1082,10 +1087,7 @@ describe("CliAvailabilityService", () => {
 
       await service.checkAvailability();
 
-      const copilotLog = consoleLogSpy.mock.calls.find((call: unknown[]) =>
-        String(call[0]).includes("GitHub Copilot: binary found, auth discovery")
-      );
-      expect(copilotLog).toBeUndefined();
+      expect(authMissPaths("copilot")).toHaveLength(0);
     });
   });
 
@@ -1233,7 +1235,7 @@ describe("CliAvailabilityService", () => {
       const nativeProbes = mockedAccess.mock.calls.filter(
         (call) =>
           String(call[0]).includes(".local/bin/claude") ||
-          String(call[0]).includes("claude-code\\bin\\claude.exe")
+          String(call[0]).includes("WinGet\\Links\\claude.exe")
       );
       expect(nativeProbes).toHaveLength(0);
     });
@@ -2267,6 +2269,193 @@ describe("CliAvailabilityService", () => {
       } finally {
         clearPluginAgentRegistryForTests();
       }
+    });
+  });
+
+  describe("Windows native path probing (#12352)", () => {
+    const savedWindowsEnv: Record<string, string | undefined> = {};
+
+    beforeEach(() => {
+      Object.defineProperty(process, "platform", { value: "win32", writable: true });
+      for (const name of ["USERPROFILE", "LOCALAPPDATA"]) {
+        savedWindowsEnv[name] = process.env[name];
+        delete process.env[name];
+      }
+      mockedExecFileSync.mockImplementation(() => {
+        throw Object.assign(new Error("not found"), { code: "ENOENT" });
+      });
+    });
+
+    afterEach(() => {
+      for (const [name, value] of Object.entries(savedWindowsEnv)) {
+        if (value === undefined) delete process.env[name];
+        else process.env[name] = value;
+      }
+    });
+
+    const onlyExisting = async (existingPath: string) => {
+      const { access } = await import("fs/promises");
+      const mockedAccess = vi.mocked(access);
+      mockedAccess.mockImplementation(async (p) => {
+        if (String(p) === existingPath) return undefined;
+        throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+      });
+      return mockedAccess;
+    };
+
+    const checkPluginCommand = async (command: string) => {
+      const { registerPluginAgents, clearPluginAgentRegistryForTests } =
+        await import("../../../shared/config/pluginAgentRegistry.js");
+      registerPluginAgents("acme.plugin", [
+        { id: "acme-agent", name: "Acme Agent", command, color: "#3366ff", iconId: "terminal" },
+      ]);
+      try {
+        await service.checkAvailability();
+        return service.getDetails()?.["acme-agent"];
+      } finally {
+        clearPluginAgentRegistryForTests();
+      }
+    };
+
+    it("finds an extensionless native entry through its .exe sibling", async () => {
+      const claudeExe = `${join(homedir(), ".local/bin/claude")}.exe`;
+      await onlyExisting(claudeExe);
+
+      const result = await service.checkAvailability();
+
+      expect(result.claude).toBe("unauthenticated");
+      expect(service.getDetails()!.claude?.via).toBe("native");
+      expect(service.getDetails()!.claude?.resolvedPath).toBe(claudeExe);
+    });
+
+    it("does not accept an extensionless file as a Windows install", async () => {
+      await onlyExisting(join(homedir(), ".local/bin/claude"));
+
+      const result = await service.checkAvailability();
+
+      expect(result.claude).toBe("missing");
+    });
+
+    it("probes an entry that already carries .exe as written", async () => {
+      process.env.USERPROFILE = "C:\\Users\\test";
+      const gooseExe = "C:\\Users\\test\\.local\\bin\\goose.exe";
+      const mockedAccess = await onlyExisting(gooseExe);
+
+      await service.checkAvailability();
+
+      expect(service.getDetails()!.goose?.via).toBe("native");
+      expect(service.getDetails()!.goose?.resolvedPath).toBe(gooseExe);
+      expect(mockedAccess.mock.calls.some(([p]) => String(p).startsWith(`${gooseExe}.`))).toBe(
+        false
+      );
+    });
+
+    it.each(["agent.EXE", "agent.ps1"])(
+      "probes a plugin command already named %s as written",
+      async (fileName) => {
+        const command = `/tmp/daintree-plugins/acme/bin/${fileName}`;
+        await onlyExisting(command);
+
+        const detail = await checkPluginCommand(command);
+
+        expect(detail?.state).toBe("ready");
+        expect(detail?.resolvedPath).toBe(command);
+      }
+    );
+
+    it("resolves an extensionless plugin command to its launchable sibling", async () => {
+      const command = "/tmp/daintree-plugins/acme/bin/agent";
+      await onlyExisting(`${command}.cmd`);
+
+      const detail = await checkPluginCommand(command);
+
+      expect(detail?.state).toBe("ready");
+      expect(detail?.resolvedPath).toBe(`${command}.cmd`);
+    });
+  });
+
+  describe("check timeout (#12352)", () => {
+    let savedLogOverrides: Record<string, string>;
+
+    beforeEach(() => {
+      savedLogOverrides = getLogLevelOverrides();
+      setLogLevelOverrides({ "*": "info" });
+      logBuffer.clear();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+      setLogLevelOverrides(savedLogOverrides);
+      logBuffer.clear();
+    });
+
+    // The hung agent's `which` never calls back, so its check outlives the
+    // batch budget while every other agent settles through microtasks.
+    const hangWhichFor = (hungCommand: string) => {
+      mockedExecFile.mockImplementation(((...args: unknown[]) =>
+        args[0] === "which" && cmdOf(args[1]) === hungCommand
+          ? ({} as never)
+          : defaultExecFileImpl(...args)) as never);
+    };
+
+    const timedOutAgentIds = () =>
+      logBuffer
+        .getFiltered({ sources: ["main:CliAvailabilityService"] })
+        .filter((entry) => entry.level === "warn")
+        .map(
+          (entry) => (entry.context as { pendingAgentIds?: unknown } | undefined)?.pendingAgentIds
+        )
+        .filter((ids) => ids !== undefined);
+
+    it("keeps agents that finished and logs the ones that did not", async () => {
+      mockedExecFileSync.mockImplementation((_file, args) => {
+        if (cmdOf(args) === "claude") return Buffer.from("/usr/local/bin/claude\n");
+        throw Object.assign(new Error("not found"), { code: "ENOENT" });
+      });
+      hangWhichFor("goose");
+
+      vi.useFakeTimers();
+      const checkPromise = service.checkAvailability();
+      await vi.advanceTimersByTimeAsync(60_000);
+      const result = await checkPromise;
+
+      const details = service.getDetails()!;
+      expect(result.claude).toBe("unauthenticated");
+      expect(details.claude?.resolvedPath).toBe("/usr/local/bin/claude");
+      expect(result.goose).toBe("missing");
+      expect(details.goose?.message).toBeDefined();
+      // A real miss carries no timeout message, so the two stay distinguishable.
+      expect(details.gemini?.state).toBe("missing");
+      expect(details.gemini?.message).toBeUndefined();
+      expect(timedOutAgentIds()).toEqual([["goose"]]);
+    });
+
+    it("carries an agent's previous result forward when its re-check times out", async () => {
+      mockedExecFileSync.mockImplementation((_file, args) => {
+        const cmd = cmdOf(args);
+        if (cmd === "claude") return Buffer.from("/usr/local/bin/claude\n");
+        if (cmd === "goose") return Buffer.from("/usr/local/bin/goose\n");
+        throw Object.assign(new Error("not found"), { code: "ENOENT" });
+      });
+      await service.checkAvailability();
+      const previousGoose = service.getDetails()!.goose;
+      expect(previousGoose?.resolvedPath).toBe("/usr/local/bin/goose");
+
+      mockedExecFileSync.mockImplementation((_file, args) => {
+        if (cmdOf(args) === "claude") return Buffer.from("/opt/homebrew/bin/claude\n");
+        throw Object.assign(new Error("not found"), { code: "ENOENT" });
+      });
+      hangWhichFor("goose");
+
+      vi.useFakeTimers();
+      const refreshPromise = service.refresh();
+      await vi.advanceTimersByTimeAsync(60_000);
+      const result = await refreshPromise;
+
+      expect(service.getDetails()!.goose).toEqual(previousGoose);
+      expect(result.goose).toBe(previousGoose?.state);
+      expect(service.getDetails()!.claude?.resolvedPath).toBe("/opt/homebrew/bin/claude");
+      expect(timedOutAgentIds()).toEqual([["goose"]]);
     });
   });
 });

--- a/electron/services/__tests__/CliAvailabilityService.test.ts
+++ b/electron/services/__tests__/CliAvailabilityService.test.ts
@@ -966,10 +966,9 @@ describe("CliAvailabilityService", () => {
 
     beforeEach(() => {
       savedLogOverrides = getLogLevelOverrides();
-      // Vitest floors the logger at "debug"; pin production's "info" floor so
-      // a miss logged below it fails here instead of silently never reaching
-      // daintree.log on a user's machine.
-      setLogLevelOverrides({ "*": "info" });
+      // The miss logs at debug on purpose (see checkAuth); pin that floor so
+      // these assertions don't lean on the ambient default.
+      setLogLevelOverrides({ "*": "debug" });
       logBuffer.clear();
     });
 
@@ -997,8 +996,7 @@ describe("CliAvailabilityService", () => {
       expect(service.getDetails()!.copilot?.authConfirmed).toBe(false);
 
       const copilotLogs = authMissPaths("copilot");
-      // Must fire exactly once — guards against the Promise.race leak where
-      // a slow fs.access would log after the timeout branch already resolved.
+      // One check, one miss — no duplicate log per agent.
       expect(copilotLogs).toHaveLength(1);
       expect(copilotLogs[0].some((p) => p.includes(join(".copilot", "config.json")))).toBe(true);
     });
@@ -1046,22 +1044,22 @@ describe("CliAvailabilityService", () => {
           if (cmdOf(args) === "copilot") return Buffer.from("");
           throw new Error("not found");
         });
-        // Make fs.access hang forever ONLY for copilot's auth config path so
-        // the Copilot auth check race is decided by the timeout branch. Other
-        // agents' fs.access probes (e.g. Claude's native-path probe) must
-        // resolve quickly with ENOENT; otherwise they'd hang forever too and
-        // the outer check timeout would never be reached under fake timers.
+        // Copilot's auth config probe misses only after the auth budget has
+        // decided the race, so the miss path still runs to completion — late,
+        // which is exactly when an unguarded log would fire. Other agents'
+        // fs.access probes must reject straight away or they'd stall the
+        // batch under fake timers.
         const copilotConfig = join(homedir(), ".copilot/config.json");
         mockedAccess.mockImplementation(async (p) => {
           if (String(p) === copilotConfig) {
-            return new Promise(() => {});
+            await new Promise((resolve) => setTimeout(resolve, 5_000));
           }
           throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
         });
 
         const checkPromise = service.checkAvailability();
-        // Advance past AUTH_CHECK_TIMEOUT_MS (3s) to resolve the timeout branch.
-        await vi.advanceTimersByTimeAsync(4_000);
+        // Past both the 3s auth budget and the late 5s miss.
+        await vi.advanceTimersByTimeAsync(6_000);
         const result = await checkPromise;
 
         // Binary found, auth inconclusive due to timeout → unauthenticated.
@@ -2295,12 +2293,10 @@ describe("CliAvailabilityService", () => {
 
     const onlyExisting = async (existingPath: string) => {
       const { access } = await import("fs/promises");
-      const mockedAccess = vi.mocked(access);
-      mockedAccess.mockImplementation(async (p) => {
+      vi.mocked(access).mockImplementation(async (p) => {
         if (String(p) === existingPath) return undefined;
         throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
       });
-      return mockedAccess;
     };
 
     const checkPluginCommand = async (command: string) => {
@@ -2339,15 +2335,21 @@ describe("CliAvailabilityService", () => {
     it("probes an entry that already carries .exe as written", async () => {
       process.env.USERPROFILE = "C:\\Users\\test";
       const gooseExe = "C:\\Users\\test\\.local\\bin\\goose.exe";
-      const mockedAccess = await onlyExisting(gooseExe);
+      await onlyExisting(gooseExe);
 
       await service.checkAvailability();
 
       expect(service.getDetails()!.goose?.via).toBe("native");
       expect(service.getDetails()!.goose?.resolvedPath).toBe(gooseExe);
-      expect(mockedAccess.mock.calls.some(([p]) => String(p).startsWith(`${gooseExe}.`))).toBe(
-        false
-      );
+    });
+
+    it("never appends a second extension to an entry that already carries one", async () => {
+      process.env.USERPROFILE = "C:\\Users\\test";
+      await onlyExisting("C:\\Users\\test\\.local\\bin\\goose.exe.cmd");
+
+      const result = await service.checkAvailability();
+
+      expect(result.goose).toBe("missing");
     });
 
     it.each(["agent.EXE", "agent.ps1"])(
@@ -2363,14 +2365,34 @@ describe("CliAvailabilityService", () => {
       }
     );
 
-    it("resolves an extensionless plugin command to its launchable sibling", async () => {
-      const command = "/tmp/daintree-plugins/acme/bin/agent";
-      await onlyExisting(`${command}.cmd`);
+    it.each(["agent", "agent-2.1"])(
+      "resolves a plugin command named %s to its launchable sibling",
+      async (fileName) => {
+        const command = `/tmp/daintree-plugins/acme/bin/${fileName}`;
+        await onlyExisting(`${command}.cmd`);
 
-      const detail = await checkPluginCommand(command);
+        const detail = await checkPluginCommand(command);
 
-      expect(detail?.state).toBe("ready");
-      expect(detail?.resolvedPath).toBe(`${command}.cmd`);
+        expect(detail?.state).toBe("ready");
+        expect(detail?.resolvedPath).toBe(`${command}.cmd`);
+      }
+    );
+
+    it("reports the launch candidate that was denied, not the extensionless entry", async () => {
+      const { access } = await import("fs/promises");
+      const claudeExe = `${join(homedir(), ".local/bin/claude")}.exe`;
+      vi.mocked(access).mockImplementation(async (p) => {
+        const code = String(p) === claudeExe ? "EACCES" : "ENOENT";
+        throw Object.assign(new Error(code), { code });
+      });
+
+      await service.checkAvailability();
+
+      expect(service.getDetails()!.claude).toMatchObject({
+        state: "blocked",
+        via: "native",
+        resolvedPath: claudeExe,
+      });
     });
   });
 
@@ -2416,6 +2438,7 @@ describe("CliAvailabilityService", () => {
 
       vi.useFakeTimers();
       const checkPromise = service.checkAvailability();
+      // Comfortably past the batch budget without pinning its exact value.
       await vi.advanceTimersByTimeAsync(60_000);
       const result = await checkPromise;
 
@@ -2440,6 +2463,7 @@ describe("CliAvailabilityService", () => {
       await service.checkAvailability();
       const previousGoose = service.getDetails()!.goose;
       expect(previousGoose?.resolvedPath).toBe("/usr/local/bin/goose");
+      expect(previousGoose?.message).toBeUndefined();
 
       mockedExecFileSync.mockImplementation((_file, args) => {
         if (cmdOf(args) === "claude") return Buffer.from("/opt/homebrew/bin/claude\n");
@@ -2452,10 +2476,56 @@ describe("CliAvailabilityService", () => {
       await vi.advanceTimersByTimeAsync(60_000);
       const result = await refreshPromise;
 
-      expect(service.getDetails()!.goose).toEqual(previousGoose);
+      // Same observation as last time, flagged as not re-confirmed.
+      expect(service.getDetails()!.goose).toEqual({
+        ...previousGoose,
+        message: expect.any(String),
+      });
       expect(result.goose).toBe(previousGoose?.state);
       expect(service.getDetails()!.claude?.resolvedPath).toBe("/opt/homebrew/bin/claude");
       expect(timedOutAgentIds()).toEqual([["goose"]]);
+    });
+
+    it("keeps a carried agent's own diagnostic instead of the timeout note", async () => {
+      mockedExecFileSync.mockImplementation((_file, args) => {
+        if (cmdOf(args) === "goose") {
+          throw Object.assign(new Error("operation not permitted"), { code: "EPERM" });
+        }
+        throw Object.assign(new Error("not found"), { code: "ENOENT" });
+      });
+      await service.checkAvailability();
+      const blockedGoose = service.getDetails()!.goose;
+      expect(blockedGoose?.state).toBe("blocked");
+      expect(blockedGoose?.message).toBeDefined();
+
+      hangWhichFor("goose");
+      vi.useFakeTimers();
+      const refreshPromise = service.refresh();
+      await vi.advanceTimersByTimeAsync(60_000);
+      await refreshPromise;
+
+      expect(service.getDetails()!.goose).toEqual(blockedGoose);
+    });
+
+    it("isolates an agent whose check throws from the rest of the batch", async () => {
+      mockedExecFileSync.mockImplementation((_file, args) => {
+        if (cmdOf(args) === "claude") return Buffer.from("/usr/local/bin/claude\n");
+        throw Object.assign(new Error("not found"), { code: "ENOENT" });
+      });
+      mockedExecFile.mockImplementation(((...args: unknown[]) => {
+        if (args[0] === "which" && cmdOf(args[1]) === "goose") throw new Error("spawn EBADF");
+        return defaultExecFileImpl(...args);
+      }) as never);
+
+      const result = await service.checkAvailability();
+
+      expect(result.goose).toBe("missing");
+      expect(service.getDetails()!.claude?.resolvedPath).toBe("/usr/local/bin/claude");
+      const failedAgentIds = logBuffer
+        .getFiltered({ sources: ["main:CliAvailabilityService"] })
+        .filter((entry) => entry.level === "error")
+        .map((entry) => (entry.context as { agentId?: unknown } | undefined)?.agentId);
+      expect(failedAgentIds).toEqual(["goose"]);
     });
   });
 });

--- a/electron/services/__tests__/CliAvailabilityService.test.ts
+++ b/electron/services/__tests__/CliAvailabilityService.test.ts
@@ -2504,6 +2504,9 @@ describe("CliAvailabilityService", () => {
       await vi.advanceTimersByTimeAsync(60_000);
       await refreshPromise;
 
+      // A fresh re-check would rebuild the same blocked detail, so pin that
+      // goose really was carried rather than re-probed.
+      expect(timedOutAgentIds()).toEqual([["goose"]]);
       expect(service.getDetails()!.goose).toEqual(blockedGoose);
     });
 

--- a/shared/config/agentRegistry.ts
+++ b/shared/config/agentRegistry.ts
@@ -761,13 +761,16 @@ export interface AgentConfig {
    * Absolute filesystem paths to probe when PATH-based lookup (`which`/`where`)
    * fails. Used to detect agents installed by native installers into locations
    * the Electron process may not inherit in PATH — notably `~/.local/bin/claude`
-   * for Anthropic's native installer on macOS/Linux, and
-   * `%LOCALAPPDATA%\claude-code\bin\claude.exe` on Windows.
+   * for Anthropic's native installer, and WinGet's
+   * `%LOCALAPPDATA%\Microsoft\WinGet\Links\claude.exe` on Windows.
    *
    * Tilde (`~`) is expanded to `os.homedir()` and Windows `%VAR%` tokens are
    * expanded against `process.env` by CliAvailabilityService before probing
-   * (see `expandWindowsEnvVars()` in electron/setup/environment.ts). Paths are
-   * tried in listed order; first accessible file wins.
+   * (see `expandWindowsEnvVars()` in electron/setup/environment.ts). On Windows
+   * an entry without a launchable extension is probed with `.cmd`, `.exe`,
+   * `.bat` and `.com` appended instead of as written, so a POSIX-style entry
+   * also covers a Windows install that shares its layout. Paths are tried in
+   * listed order; first accessible file wins.
    */
   nativePaths?: string[];
   /**

--- a/shared/config/agents/claude.ts
+++ b/shared/config/agents/claude.ts
@@ -6,12 +6,13 @@ export const config: AgentConfig = {
   name: "Claude",
   command: "claude",
   // Anthropic's native installer places the symlink at ~/.local/bin/claude
-  // on macOS/Linux and a versioned binary under ~/.local/share/claude.
-  // Windows native installer places the binary under
-  // %LOCALAPPDATA%\claude-code\bin\claude.exe. Detect both so users who
-  // install via the native installer are not mis-reported as "missing"
-  // when ~/.local/bin isn't inherited by the Electron process PATH.
-  nativePaths: ["~/.local/bin/claude", "%LOCALAPPDATA%\\claude-code\\bin\\claude.exe"],
+  // on macOS/Linux (with a versioned binary under ~/.local/share/claude) and
+  // the binary at %USERPROFILE%\.local\bin\claude.exe on Windows. The first
+  // entry covers both: `~` is the user profile on Windows and the probe
+  // appends executable extensions there. WinGet links claude.exe into its own
+  // Links directory instead. Probing these keeps users from being reported
+  // "missing" when neither directory is on the Electron process PATH.
+  nativePaths: ["~/.local/bin/claude", "%LOCALAPPDATA%\\Microsoft\\WinGet\\Links\\claude.exe"],
   npmGlobalPackage: "@anthropic-ai/claude-code",
   color: "#CC785C",
   iconId: "claude",

--- a/shared/config/agents/claude.ts
+++ b/shared/config/agents/claude.ts
@@ -9,10 +9,15 @@ export const config: AgentConfig = {
   // on macOS/Linux (with a versioned binary under ~/.local/share/claude) and
   // the binary at %USERPROFILE%\.local\bin\claude.exe on Windows. The first
   // entry covers both: `~` is the user profile on Windows and the probe
-  // appends executable extensions there. WinGet links claude.exe into its own
-  // Links directory instead. Probing these keeps users from being reported
-  // "missing" when neither directory is on the Electron process PATH.
-  nativePaths: ["~/.local/bin/claude", "%LOCALAPPDATA%\\Microsoft\\WinGet\\Links\\claude.exe"],
+  // appends executable extensions there. WinGet links claude.exe into its
+  // user-scope or machine-scope Links directory instead. Probing these keeps
+  // users from being reported "missing" when none of them is on the Electron
+  // process PATH.
+  nativePaths: [
+    "~/.local/bin/claude",
+    "%LOCALAPPDATA%\\Microsoft\\WinGet\\Links\\claude.exe",
+    "%ProgramFiles%\\WinGet\\Links\\claude.exe",
+  ],
   npmGlobalPackage: "@anthropic-ai/claude-code",
   color: "#CC785C",
   iconId: "claude",


### PR DESCRIPTION
## Summary
- On Windows, `probeNativePaths` checked each `nativePaths` entry literally with `fs.access(X_OK)`, which is only an existence check there, so every extensionless entry (`~/.local/bin/claude`, amp, crush, grok, opencode, qwen, cursor, goose) could never match the real `.exe`.
- Separately, `checkAvailability` raced all agents against one shared 10 second budget, and on timeout it mapped every agent to missing, including ones that had already resolved, with nothing reaching the log because the service never used `createLogger`.
- This fixes both, adds logging, updates Claude's manifest, and adds tests.

Resolves #12352

## Changes
- Windows probing: entries without a launchable extension are now probed as `.cmd`, `.exe`, `.bat`, or `.com` in turn (never bare, since the launcher runs `resolvedPath` verbatim through PowerShell). Entries that already end in a launchable extension, including `.ps1` (which PowerShell's `&` runs), are probed as written, so `goose.exe` never becomes `goose.exe.cmd`. Applies to plugin absolute commands too; `probePrependedCliPath` behaviour is unchanged.
- Timeout handling: each agent's outcome is kept as it settles. Agents still pending at the budget reuse the last published detail, flagged with "The most recent check didn't finish in time." (unless the detail already carries its own diagnostic), or become missing with that message if there's no prior result. One warn log with the pending agent ids is written for checks that publish.
- Logging: all `CliAvailabilityService` diagnostics now go through `createLogger('main:CliAvailabilityService')`. The auth-discovery miss is logged at debug level, since the setup wizard re-checks every 3 seconds.
- Claude manifest: replaced the never-real `%LOCALAPPDATA%\claude-code\bin\claude.exe` with WinGet's user-scope `%LOCALAPPDATA%\Microsoft\WinGet\Links\claude.exe` and machine-scope `%ProgramFiles%\WinGet\Links\claude.exe`. `~/.local/bin/claude` now also covers the native installer's `%USERPROFILE%\.local\bin\claude.exe`.
- Tests: new mocked-win32 suite (extensionless entries resolving to a `.exe` sibling, a bare file rejected, an existing extension probed as written and never double-appended, case-insensitive `.EXE` and `.ps1` plugin commands, dotted plugin names, a blocked result reporting the probed candidate), plus a check-timeout suite (finished agents kept, pending ids logged at the production info floor, previous result carried with the note, an agent's own diagnostic preserved, a throwing agent isolated from the batch). Auth-discovery logging tests migrated from a console spy to `logBuffer`. Three of the new tests are mutation-checked, so breaking the guard each one pins turns it red.

## Testing
- `npm test --` on CliAvailabilityService, agentRegistry, AgentVersionService.resilience, serviceRefs, appLifecycle, menu, agentActions.adversarial: 7 files, 684 passed, 1 pre-existing win32-only skip as expected.
- eslint and prettier clean on the 4 changed files.
- Full suite, typecheck, and build left to CI.

Follow-ups noted but out of scope: the setup wizard polls `refresh()` every 3 seconds without awaiting it, so on a slow host no check publishes while it's open; a plugin command with a non-launchable extension (e.g. `agent.js`) now reads as missing rather than explaining why.
