### PR TITLE
fix(toolbar): label the forge stats button "Repository activity"

### DIFF
--- a/src/components/Layout/toolbarButtonMetadata.ts
+++ b/src/components/Layout/toolbarButtonMetadata.ts
@@ -95,7 +95,7 @@ export const TOOLBAR_BUTTON_METADATA: Partial<Record<AnyToolbarButtonId, Toolbar
     description: "Persistent dictation indicator shown while recording is active",
   },
   "forge-stats": {
-    label: "Repository stats",
+    label: "Repository activity",
     icon: GitPullRequest,
     description: "Issues, PRs, and commits",
   },


### PR DESCRIPTION
## Summary

- Renamed the `forge-stats` toolbar button's label in `src/components/Layout/toolbarButtonMetadata.ts` from `Repository stats` to `Repository activity`. The description (`Issues, PRs, and commits`), the id, and the icon are all unchanged.
- `Stats` reads as a passive analytics display, but this button is the main entry point for browsing open issues, open PRs, and recent commits. The customizer list is the only way back to a hidden button (#12355), so the label needs to name what it actually opens.
- Left the data-layer `repository stats` vocabulary alone on purpose (the `forge.getRepoStats` action title, IPC type docs, the `useRepositoryStats` fetch-error string). Those name the fetch, not the button.

Resolves #12356

## Changes

- Settings toolbar customizer rows pick up the new label, both the visible text and the composed aria-labels (`Reorder …`, `Toggle … visibility`, `Show … in toolbar`).
- The label-sorted hidden-button list picks it up too. Sort position is unchanged.
- The forge-stats overflow dropdown entry doesn't use this label at all, it renders its own provider-named group (Issues / Pull Requests / Commits), so that's unaffected.
- No test added. `.claude/rules/testing.md` bans tautological assertions that just copy a literal from its source of truth, and the existing registry test already asserts every entry has a non-empty label.

## Testing

- `npm test` on the 13 test files that cover this: `toolbarButtonMetadata`, `toolbarButtonGrouping`, `pluginToolbarMeta`, `Toolbar.overflow`, `launcherToolbarCatalog`, `ToolbarContextMenuItems`, four `ForgeStatsToolbarButton` files, `ToolbarSettingsTab`, `LauncherQuickActions`, `useToolbarOverflow`. 245 passed, exit 0.
- `prettier --check` and `eslint` on the changed file. Clean, exit 0.
