### PR TITLE
feat(toolbar): restore hidden buttons from an empty-space context menu

### DIFF
--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -41,6 +41,7 @@ import { ToolbarContextMenuItems } from "./ToolbarContextMenuItems";
 import { ToolbarButtonsContextMenu } from "./ToolbarButtonsContextMenu";
 import {
   buildToolbarVisibilityMenuRows,
+  canListToolbarButton,
   resolveToolbarButtonMetadata,
   type ToolbarSide,
 } from "./toolbarVisibilityMenu";
@@ -1943,18 +1944,20 @@ export function Toolbar({
   );
 
   // Rows for the empty-space menu (#12355), built from the side lists before
-  // the visibility filter. An agent is gated on registry membership rather than
-  // `isAvailable`, which for an agent *is* its visibility and would drop exactly
-  // the hidden rows this menu exists to offer back.
+  // the visibility filter so a hidden button still has one.
   const toolbarMenuRows = useMemo(
     () =>
       buildToolbarVisibilityMenuRows(positionedLeftButtons, positionedRightButtons, {
         resolveMetadata: (id) =>
           resolveToolbarButtonMetadata(id, TOOLBAR_BUTTON_METADATA, dynamicOverflowMeta),
-        canRender: (id) =>
-          isBuiltInAgentId(id)
-            ? Object.hasOwn(buttonRegistry, id)
-            : Boolean(buttonRegistry[id]?.isAvailable) || PROJECT_SCOPED_TOOLBAR_IDS.has(id),
+        canList: (id) =>
+          canListToolbarButton(
+            id,
+            buttonRegistry,
+            PROJECT_SCOPED_TOOLBAR_IDS,
+            effectiveAgentSettings,
+            agentAvailability
+          ),
         isOnToolbar: (id) => isToolbarButtonOnToolbar(id, toolbarPlacementState),
       }),
     [
@@ -1962,6 +1965,8 @@ export function Toolbar({
       positionedRightButtons,
       dynamicOverflowMeta,
       buttonRegistry,
+      effectiveAgentSettings,
+      agentAvailability,
       toolbarPlacementState,
     ]
   );

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -38,6 +38,17 @@ import {
 } from "./toolbarButtonMetadata";
 import { getToolbarDividerAfterIds, orderToolbarButtonsByGroup } from "./toolbarButtonGrouping";
 import { ToolbarContextMenuItems } from "./ToolbarContextMenuItems";
+import { ToolbarButtonsContextMenu } from "./ToolbarButtonsContextMenu";
+import {
+  buildToolbarVisibilityMenuRows,
+  resolveToolbarButtonMetadata,
+  type ToolbarSide,
+} from "./toolbarVisibilityMenu";
+import {
+  isToolbarButtonOnToolbar,
+  setToolbarButtonOnToolbar,
+  type ToolbarButtonPlacementState,
+} from "@/lib/toolbarVisibilityDispatch";
 import { cn } from "@/lib/utils";
 import { isMac, isLinux, isWindows } from "@/lib/platform";
 import { WINDOWS_CAPTION_WIDTH_PX } from "@shared/config/windowChrome";
@@ -669,12 +680,25 @@ export function Toolbar({
   const notificationsEnabled = useNotificationSettingsStore((s) => s.enabled);
   const toolbarLayout = useToolbarPreferencesStore((state) => state.layout);
   const positionAgentButton = useToolbarPreferencesStore((state) => state.positionAgentButton);
+  const toggleButtonVisibility = useToolbarPreferencesStore(
+    (state) => state.toggleButtonVisibility
+  );
+  const setPluginButtonPromoted = useToolbarPreferencesStore(
+    (state) => state.setPluginButtonPromoted
+  );
+  const setPanelButtonOnToolbar = useToolbarPreferencesStore(
+    (state) => state.setPanelButtonOnToolbar
+  );
+  const setLauncherItemOnToolbar = useToolbarPreferencesStore(
+    (state) => state.setLauncherItemOnToolbar
+  );
   // Live subscription so pin/unpin toggles from the launcher immediately
   // update per-agent toolbar button visibility. The `agentSettings` prop is
   // sourced from `useAgentLauncher()`'s local useState which does not react to
   // store mutations, so we prefer the store value when available.
   const liveAgentSettings = useAgentSettingsStore((s) => s.settings);
   const effectiveAgentSettings = liveAgentSettings ?? agentSettings;
+  const setAgentPinned = useAgentSettingsStore((s) => s.setAgentPinned);
 
   const [isFullscreen, setIsFullscreen] = useState(false);
   // Store-derived rather than local click state so every clipboard copy spins
@@ -1630,7 +1654,10 @@ export function Toolbar({
     [pluginConfigs]
   );
 
-  const effectiveLeftButtons = useMemo(() => {
+  // Every button holding a slot on each side, hidden or not. The toolbar draws
+  // the visible subset; its empty-space menu (#12355) lists the whole set, since
+  // hiding never takes a button's position away.
+  const positionedLeftButtons = useMemo(() => {
     // Dedupe defensively so a persisted list holding a repeated id never
     // renders duplicate pills (#10937) — the store also heals this, this is
     // belt-and-suspenders at the render boundary.
@@ -1656,31 +1683,35 @@ export function Toolbar({
     // boundary, so the groups have to actually be contiguous. Ordering here
     // rather than at the render loop means overflow, keyboard roving, and the
     // DOM all see the same canonical sequence.
-    return orderToolbarButtonsByGroup(
-      positioned.filter((id) =>
-        isToolbarButtonVisible(
-          id,
-          pinnedButtons,
-          effectiveAgentSettings,
-          agentAvailability,
-          pluginConfigs.has(id)
-        )
-      ),
-      resolveToolbarGroup
-    );
+    return orderToolbarButtonsByGroup(positioned, resolveToolbarGroup);
   }, [
     toolbarLayout.leftButtons,
     launcherOnRight,
     unpositionedAgentPins,
     unpositionedLauncherItemPins,
-    pinnedButtons,
-    effectiveAgentSettings,
-    agentAvailability,
-    pluginConfigs,
     resolveToolbarGroup,
   ]);
 
-  const effectiveRightButtons = useMemo(() => {
+  const isButtonShownOnToolbar = useCallback(
+    (id: AnyToolbarButtonId) =>
+      isToolbarButtonVisible(
+        id,
+        pinnedButtons,
+        effectiveAgentSettings,
+        agentAvailability,
+        pluginConfigs.has(id)
+      ),
+    [pinnedButtons, effectiveAgentSettings, agentAvailability, pluginConfigs]
+  );
+
+  // Filtering the grouped list yields the same sequence as grouping the filtered
+  // one — grouping is a stable partition.
+  const effectiveLeftButtons = useMemo(
+    () => positionedLeftButtons.filter(isButtonShownOnToolbar),
+    [positionedLeftButtons, isButtonShownOnToolbar]
+  );
+
+  const positionedRightButtons = useMemo(() => {
     // Dedupe the persisted base before appending plugin extras, so duplicate
     // ids (e.g. repeated `forge-stats`, #10937) can't render twice.
     const base = Array.from(new Set(toolbarLayout.rightButtons));
@@ -1703,15 +1734,7 @@ export function Toolbar({
     // replaced. Buttons the user already dragged into a side list keep that
     // position and are filtered on promotion below like any other id.
     const extra = pluginButtonIds.filter((id) => !positioned.has(id) && pinnedButtons[id] === true);
-    return [...base, ...extra].filter((id) =>
-      isToolbarButtonVisible(
-        id,
-        pinnedButtons,
-        effectiveAgentSettings,
-        agentAvailability,
-        pluginConfigs.has(id)
-      )
-    );
+    return [...base, ...extra];
   }, [
     toolbarLayout.rightButtons,
     toolbarLayout.leftButtons,
@@ -1720,10 +1743,12 @@ export function Toolbar({
     unpositionedLauncherItemPins,
     pluginButtonIds,
     pinnedButtons,
-    effectiveAgentSettings,
-    agentAvailability,
-    pluginConfigs,
   ]);
+
+  const effectiveRightButtons = useMemo(
+    () => positionedRightButtons.filter(isButtonShownOnToolbar),
+    [positionedRightButtons, isButtonShownOnToolbar]
+  );
 
   const availableLeftIds = useMemo(
     () =>
@@ -1894,6 +1919,73 @@ export function Toolbar({
       ...buildLauncherToolbarMeta(launcherCatalog),
     }),
     [pluginButtonIds, pluginConfigs, launcherCatalog]
+  );
+
+  // The same bundle Settings → Toolbar hands the placement resolvers, so the
+  // empty-space menu's checkmarks and toggles route exactly as that page does.
+  const toolbarPlacementState = useMemo<ToolbarButtonPlacementState>(
+    () => ({
+      pinnedButtons,
+      leftButtons: toolbarLayout.leftButtons,
+      rightButtons: toolbarLayout.rightButtons,
+      agentSettings: effectiveAgentSettings,
+      agentAvailability,
+      isPluginContribution: (id) => pluginConfigs.has(id),
+    }),
+    [
+      pinnedButtons,
+      toolbarLayout.leftButtons,
+      toolbarLayout.rightButtons,
+      effectiveAgentSettings,
+      agentAvailability,
+      pluginConfigs,
+    ]
+  );
+
+  // Rows for the empty-space menu (#12355), built from the side lists before
+  // the visibility filter. An agent is gated on registry membership rather than
+  // `isAvailable`, which for an agent *is* its visibility and would drop exactly
+  // the hidden rows this menu exists to offer back.
+  const toolbarMenuRows = useMemo(
+    () =>
+      buildToolbarVisibilityMenuRows(positionedLeftButtons, positionedRightButtons, {
+        resolveMetadata: (id) =>
+          resolveToolbarButtonMetadata(id, TOOLBAR_BUTTON_METADATA, dynamicOverflowMeta),
+        canRender: (id) =>
+          isBuiltInAgentId(id)
+            ? Object.hasOwn(buttonRegistry, id)
+            : Boolean(buttonRegistry[id]?.isAvailable) || PROJECT_SCOPED_TOOLBAR_IDS.has(id),
+        isOnToolbar: (id) => isToolbarButtonOnToolbar(id, toolbarPlacementState),
+      }),
+    [
+      positionedLeftButtons,
+      positionedRightButtons,
+      dynamicOverflowMeta,
+      buttonRegistry,
+      toolbarPlacementState,
+    ]
+  );
+
+  const handleToolbarMenuToggle = useCallback(
+    (buttonId: AnyToolbarButtonId, side: ToolbarSide, onToolbar: boolean) => {
+      setToolbarButtonOnToolbar(buttonId, side, onToolbar, toolbarPlacementState, {
+        setAgentPinned,
+        toggleButtonVisibility,
+        positionAgentButton,
+        setPluginButtonPromoted,
+        setPanelButtonOnToolbar,
+        setLauncherItemOnToolbar,
+      });
+    },
+    [
+      toolbarPlacementState,
+      setAgentPinned,
+      toggleButtonVisibility,
+      positionAgentButton,
+      setPluginButtonPromoted,
+      setPanelButtonOnToolbar,
+      setLauncherItemOnToolbar,
+    ]
   );
 
   const overflowActions = useMemo<Partial<Record<AnyToolbarButtonId, () => void>>>(
@@ -2173,263 +2265,269 @@ export function Toolbar({
       {/* Brand marks in the toolbar are painted on the toolbar surface, not on
           whichever surface the theme happens to make hardest. */}
       <BrandSurface surface="surface-toolbar">
-        <div
-          ref={toolbarRef}
-          role="toolbar"
-          aria-label="Main toolbar"
-          onKeyDown={handleToolbarKeyDown}
-          onFocusCapture={handleToolbarFocusCapture}
-          className="@container/toolbar relative z-[60] grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] h-12 items-center px-4 pt-1 shrink-0 app-drag-region surface-toolbar border-b border-divider"
-        >
-          {!isLinux() && <div className="window-resize-strip" />}
-
-          {/* LEFT GROUP */}
+        <ToolbarButtonsContextMenu rows={toolbarMenuRows} onToggle={handleToolbarMenuToggle}>
           <div
-            role="group"
-            aria-label="Navigation and agents"
-            className="flex items-center gap-1.5 z-20"
+            ref={toolbarRef}
+            role="toolbar"
+            aria-label="Main toolbar"
+            onKeyDown={handleToolbarKeyDown}
+            onFocusCapture={handleToolbarFocusCapture}
+            className="@container/toolbar relative z-[60] grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] h-12 items-center px-4 pt-1 shrink-0 app-drag-region surface-toolbar border-b border-divider"
           >
-            {isMac() && (
-              <div
-                data-fullscreen={isFullscreen ? "true" : undefined}
-                className={cn(
-                  "shrink-0 transition-[width] duration-200 data-[fullscreen=true]:duration-120",
-                  isFullscreen ? "w-0" : "w-16"
-                )}
-              />
-            )}
-            {/* Fixed chrome, never part of buttonRegistry/overflow: this is the
+            {!isLinux() && <div className="window-resize-strip" />}
+
+            {/* LEFT GROUP */}
+            <div
+              role="group"
+              aria-label="Navigation and agents"
+              className="flex items-center gap-1.5 z-20"
+            >
+              {isMac() && (
+                <div
+                  data-fullscreen={isFullscreen ? "true" : undefined}
+                  className={cn(
+                    "shrink-0 transition-[width] duration-200 data-[fullscreen=true]:duration-120",
+                    isFullscreen ? "w-0" : "w-16"
+                  )}
+                />
+              )}
+              {/* Fixed chrome, never part of buttonRegistry/overflow: this is the
               recovery surface for the application menu itself, so it must not
               be hideable or reorderable into an overflow popover (#11813).
               Gated here as well as inside the component so macOS doesn't keep
               an empty flex item, which would add a stray gap-1.5 column. */}
-            {!isMac() && (
-              <div className="app-no-drag">
-                <AppMenuButton />
+              {!isMac() && (
+                <div className="app-no-drag">
+                  <AppMenuButton />
+                </div>
+              )}
+              <div className="app-no-drag">{buttonRegistry["sidebar-toggle"]!.render()}</div>
+
+              <div className={toolbarDividerClass} />
+
+              <div
+                ref={leftGroupRef}
+                className="flex flex-1 min-w-0 items-center gap-0.5 overflow-hidden"
+              >
+                {renderLeftButtons(effectiveLeftButtons, leftVisibleSet)}
               </div>
-            )}
-            <div className="app-no-drag">{buttonRegistry["sidebar-toggle"]!.render()}</div>
+              <div className="app-no-drag">
+                {renderOverflowMenu(visibleLeftOverflow, "left", leftOverflowSeverity)}
+              </div>
+            </div>
 
-            <div className={toolbarDividerClass} />
-
+            {/* CENTER GROUP - Grid-centered, shrinks gracefully on narrow windows */}
             <div
-              ref={leftGroupRef}
-              className="flex flex-1 min-w-0 items-center gap-0.5 overflow-hidden"
+              role="group"
+              aria-label="Project"
+              className="app-no-drag relative flex items-center justify-center min-w-0 max-w-full pointer-events-none justify-self-center"
             >
-              {renderLeftButtons(effectiveLeftButtons, leftVisibleSet)}
-            </div>
-            <div className="app-no-drag">
-              {renderOverflowMenu(visibleLeftOverflow, "left", leftOverflowSeverity)}
-            </div>
-          </div>
-
-          {/* CENTER GROUP - Grid-centered, shrinks gracefully on narrow windows */}
-          <div
-            role="group"
-            aria-label="Project"
-            className="app-no-drag relative flex items-center justify-center min-w-0 max-w-full pointer-events-none justify-self-center"
-          >
-            {/* Anchor-only sibling of the pill — see ProjectIdentityEditor. */}
-            {currentProject && (
-              <ProjectIdentityEditor
-                project={currentProject}
-                open={isIdentityEditorOpen}
-                onOpenChange={handleIdentityEditorOpenChange}
-                onCloseAutoFocus={suppressPillTooltipForFocusRestore}
-              />
-            )}
-            <Tooltip
-              open={workspaceIdentity.kind !== "none" ? pillTooltipOpen : false}
-              onOpenChange={
-                workspaceIdentity.kind !== "none" ? handlePillTooltipOpenChange : undefined
-              }
-            >
-              <ContextMenu onOpenChange={handlePillContextMenuOpenChange}>
-                {shouldMountProjectSwitcherDropdown ? (
-                  <Suspense fallback={projectSwitcherTrigger}>
-                    <LazyProjectSwitcherPalette
-                      mode="dropdown"
-                      isOpen={isDropdownOpen}
-                      query={projectSwitcher.query}
-                      results={projectSwitcher.results}
-                      browseBands={projectSwitcher.browseBands}
-                      selectedIndex={projectSwitcher.selectedIndex}
-                      onQueryChange={projectSwitcher.setQuery}
-                      onSelectPrevious={projectSwitcher.selectPrevious}
-                      onSelectNext={projectSwitcher.selectNext}
-                      onSelect={projectSwitcher.selectRow}
-                      onHoverProject={projectSwitcher.onHoverProject}
-                      onHoverProjectEnd={projectSwitcher.onHoverProjectEnd}
-                      fleetLiveness={projectSwitcher.fleetLiveness}
-                      onClose={handlePillDropdownClose}
-                      onDropdownCloseAutoFocus={suppressPillTooltipForFocusRestore}
-                      consumeCloseAutoFocusSuppression={
-                        projectSwitcher.consumeCloseAutoFocusSuppression
-                      }
-                      onAddProject={projectSwitcher.addProject}
-                      onCloneRepo={projectSwitcher.cloneRepo}
-                      onStopProject={handleStopProject}
-                      onCloseProject={handleCloseProject}
-                      onSleepProject={handleSleepProject}
-                      onLocateProject={handleLocateProject}
-                      onMoveOrRenameProject={handleMoveOrRenameProject}
-                      onTogglePinProject={projectSwitcher.togglePinProject}
-                      onCopyPath={projectSwitcher.copyPath}
-                      onOpenProjectSettings={currentProject ? handleOpenProjectSettings : undefined}
-                      onSelectNewWindow={handleSelectNewWindow}
-                      dropdownAlign="center"
-                      removeConfirmProject={projectSwitcher.removeConfirmProject}
-                      onRemoveConfirmClose={handleRemoveConfirmClose}
-                      onConfirmRemove={projectSwitcher.confirmRemoveProject}
-                      isRemovingProject={projectSwitcher.isRemovingProject}
-                      sleepConfirmProject={projectSwitcher.sleepConfirmProject}
-                      onSleepConfirmClose={() => projectSwitcher.setSleepConfirmProject(null)}
-                      onConfirmSleep={projectSwitcher.confirmSleep}
-                      isSleepingProject={projectSwitcher.isSleepingProject}
-                      rankedSearch={projectSwitcher.isRankedSearch}
-                      scratchResults={projectSwitcher.scratchResults}
-                      onCreateScratch={(name) => void projectSwitcher.createScratch(name)}
-                      onSelectScratch={(scratch) => void projectSwitcher.selectScratch(scratch)}
-                      onRequestDeleteScratch={projectSwitcher.requestDeleteScratch}
-                      deleteScratchConfirm={projectSwitcher.deleteScratchConfirm}
-                      onDismissDeleteScratchConfirm={projectSwitcher.dismissDeleteScratchConfirm}
-                      onConfirmDeleteScratch={() => void projectSwitcher.confirmDeleteScratch()}
-                      isDeletingScratch={projectSwitcher.isDeletingScratch}
-                      onRequestDeleteAllScratches={projectSwitcher.requestDeleteAllScratches}
-                      deleteAllScratchesConfirm={projectSwitcher.deleteAllScratchesConfirm}
-                      onDismissDeleteAllScratchesConfirm={
-                        projectSwitcher.dismissDeleteAllScratchesConfirm
-                      }
-                      onConfirmDeleteAllScratches={() =>
-                        void projectSwitcher.confirmDeleteAllScratches()
-                      }
-                      isDeletingAllScratches={projectSwitcher.isDeletingAllScratches}
-                      onRenameScratch={(scratchId, name) =>
-                        void projectSwitcher.renameScratch(scratchId, name)
-                      }
-                      onSaveAsProject={(scratchId) => void projectSwitcher.saveAsProject(scratchId)}
-                      saveAsProjectConfirm={projectSwitcher.saveAsProjectConfirm}
-                      onDismissSaveAsProjectConfirm={projectSwitcher.dismissSaveAsProjectConfirm}
-                      onConfirmDeleteOriginalScratch={() =>
-                        void projectSwitcher.confirmDeleteOriginalScratch()
-                      }
-                      isDeletingOriginalScratch={projectSwitcher.isDeletingOriginalScratch}
+              {/* Anchor-only sibling of the pill — see ProjectIdentityEditor. */}
+              {currentProject && (
+                <ProjectIdentityEditor
+                  project={currentProject}
+                  open={isIdentityEditorOpen}
+                  onOpenChange={handleIdentityEditorOpenChange}
+                  onCloseAutoFocus={suppressPillTooltipForFocusRestore}
+                />
+              )}
+              <Tooltip
+                open={workspaceIdentity.kind !== "none" ? pillTooltipOpen : false}
+                onOpenChange={
+                  workspaceIdentity.kind !== "none" ? handlePillTooltipOpenChange : undefined
+                }
+              >
+                <ContextMenu onOpenChange={handlePillContextMenuOpenChange}>
+                  {shouldMountProjectSwitcherDropdown ? (
+                    <Suspense fallback={projectSwitcherTrigger}>
+                      <LazyProjectSwitcherPalette
+                        mode="dropdown"
+                        isOpen={isDropdownOpen}
+                        query={projectSwitcher.query}
+                        results={projectSwitcher.results}
+                        browseBands={projectSwitcher.browseBands}
+                        selectedIndex={projectSwitcher.selectedIndex}
+                        onQueryChange={projectSwitcher.setQuery}
+                        onSelectPrevious={projectSwitcher.selectPrevious}
+                        onSelectNext={projectSwitcher.selectNext}
+                        onSelect={projectSwitcher.selectRow}
+                        onHoverProject={projectSwitcher.onHoverProject}
+                        onHoverProjectEnd={projectSwitcher.onHoverProjectEnd}
+                        fleetLiveness={projectSwitcher.fleetLiveness}
+                        onClose={handlePillDropdownClose}
+                        onDropdownCloseAutoFocus={suppressPillTooltipForFocusRestore}
+                        consumeCloseAutoFocusSuppression={
+                          projectSwitcher.consumeCloseAutoFocusSuppression
+                        }
+                        onAddProject={projectSwitcher.addProject}
+                        onCloneRepo={projectSwitcher.cloneRepo}
+                        onStopProject={handleStopProject}
+                        onCloseProject={handleCloseProject}
+                        onSleepProject={handleSleepProject}
+                        onLocateProject={handleLocateProject}
+                        onMoveOrRenameProject={handleMoveOrRenameProject}
+                        onTogglePinProject={projectSwitcher.togglePinProject}
+                        onCopyPath={projectSwitcher.copyPath}
+                        onOpenProjectSettings={
+                          currentProject ? handleOpenProjectSettings : undefined
+                        }
+                        onSelectNewWindow={handleSelectNewWindow}
+                        dropdownAlign="center"
+                        removeConfirmProject={projectSwitcher.removeConfirmProject}
+                        onRemoveConfirmClose={handleRemoveConfirmClose}
+                        onConfirmRemove={projectSwitcher.confirmRemoveProject}
+                        isRemovingProject={projectSwitcher.isRemovingProject}
+                        sleepConfirmProject={projectSwitcher.sleepConfirmProject}
+                        onSleepConfirmClose={() => projectSwitcher.setSleepConfirmProject(null)}
+                        onConfirmSleep={projectSwitcher.confirmSleep}
+                        isSleepingProject={projectSwitcher.isSleepingProject}
+                        rankedSearch={projectSwitcher.isRankedSearch}
+                        scratchResults={projectSwitcher.scratchResults}
+                        onCreateScratch={(name) => void projectSwitcher.createScratch(name)}
+                        onSelectScratch={(scratch) => void projectSwitcher.selectScratch(scratch)}
+                        onRequestDeleteScratch={projectSwitcher.requestDeleteScratch}
+                        deleteScratchConfirm={projectSwitcher.deleteScratchConfirm}
+                        onDismissDeleteScratchConfirm={projectSwitcher.dismissDeleteScratchConfirm}
+                        onConfirmDeleteScratch={() => void projectSwitcher.confirmDeleteScratch()}
+                        isDeletingScratch={projectSwitcher.isDeletingScratch}
+                        onRequestDeleteAllScratches={projectSwitcher.requestDeleteAllScratches}
+                        deleteAllScratchesConfirm={projectSwitcher.deleteAllScratchesConfirm}
+                        onDismissDeleteAllScratchesConfirm={
+                          projectSwitcher.dismissDeleteAllScratchesConfirm
+                        }
+                        onConfirmDeleteAllScratches={() =>
+                          void projectSwitcher.confirmDeleteAllScratches()
+                        }
+                        isDeletingAllScratches={projectSwitcher.isDeletingAllScratches}
+                        onRenameScratch={(scratchId, name) =>
+                          void projectSwitcher.renameScratch(scratchId, name)
+                        }
+                        onSaveAsProject={(scratchId) =>
+                          void projectSwitcher.saveAsProject(scratchId)
+                        }
+                        saveAsProjectConfirm={projectSwitcher.saveAsProjectConfirm}
+                        onDismissSaveAsProjectConfirm={projectSwitcher.dismissSaveAsProjectConfirm}
+                        onConfirmDeleteOriginalScratch={() =>
+                          void projectSwitcher.confirmDeleteOriginalScratch()
+                        }
+                        isDeletingOriginalScratch={projectSwitcher.isDeletingOriginalScratch}
+                      >
+                        {projectSwitcherTrigger}
+                      </LazyProjectSwitcherPalette>
+                    </Suspense>
+                  ) : (
+                    projectSwitcherTrigger
+                  )}
+                  {currentProject && (
+                    <ContextMenuContent
+                      className="max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto"
+                      onCloseAutoFocus={handlePillContextMenuCloseAutoFocus}
                     >
-                      {projectSwitcherTrigger}
-                    </LazyProjectSwitcherPalette>
-                  </Suspense>
-                ) : (
-                  projectSwitcherTrigger
-                )}
-                {currentProject && (
-                  <ContextMenuContent
-                    className="max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto"
-                    onCloseAutoFocus={handlePillContextMenuCloseAutoFocus}
-                  >
-                    {/* The display name and emoji. Distinct from the switcher
+                      {/* The display name and emoji. Distinct from the switcher
                         row's "Move or rename project…", which relocates the
                         folder on disk. */}
-                    <ContextMenuItem onSelect={handleEditProjectIdentity}>
-                      <Pencil className="mr-2 h-3.5 w-3.5" />
-                      Edit name and icon…
-                    </ContextMenuItem>
-                    <ContextMenuItem onSelect={handlePillTogglePin}>
-                      {activeSearchableProject?.isPinned ? (
-                        <>
-                          <PinOff className="mr-2 h-3.5 w-3.5" />
-                          Unpin project
-                        </>
-                      ) : (
-                        <>
-                          <Pin className="mr-2 h-3.5 w-3.5" />
-                          Pin project
-                        </>
-                      )}
-                    </ContextMenuItem>
-                    <ContextMenuItem onSelect={handleCopyProjectPath}>
-                      <Clipboard className="mr-2 h-3.5 w-3.5" />
-                      Copy path
-                    </ContextMenuItem>
-                    <ContextMenuSeparator />
-                    <ContextMenuItem onSelect={handleOpenProjectSettings}>
-                      Project settings
-                    </ContextMenuItem>
-                    {activeSearchableProject && activeSearchableProject.processCount > 0 && (
-                      <ContextMenuItem onSelect={() => handleStopProject(currentProject.id)}>
-                        <Square className="mr-2 h-3.5 w-3.5" />
-                        Stop all agents
+                      <ContextMenuItem onSelect={handleEditProjectIdentity}>
+                        <Pencil className="mr-2 h-3.5 w-3.5" />
+                        Edit name and icon…
                       </ContextMenuItem>
-                    )}
-                    <ContextMenuItem
-                      onSelect={() => handleCloseProject(currentProject.id)}
-                      className="text-status-error focus:text-status-error"
-                    >
-                      <X className="mr-2 h-3.5 w-3.5" />
-                      Close project
-                    </ContextMenuItem>
-                  </ContextMenuContent>
+                      <ContextMenuItem onSelect={handlePillTogglePin}>
+                        {activeSearchableProject?.isPinned ? (
+                          <>
+                            <PinOff className="mr-2 h-3.5 w-3.5" />
+                            Unpin project
+                          </>
+                        ) : (
+                          <>
+                            <Pin className="mr-2 h-3.5 w-3.5" />
+                            Pin project
+                          </>
+                        )}
+                      </ContextMenuItem>
+                      <ContextMenuItem onSelect={handleCopyProjectPath}>
+                        <Clipboard className="mr-2 h-3.5 w-3.5" />
+                        Copy path
+                      </ContextMenuItem>
+                      <ContextMenuSeparator />
+                      <ContextMenuItem onSelect={handleOpenProjectSettings}>
+                        Project settings
+                      </ContextMenuItem>
+                      {activeSearchableProject && activeSearchableProject.processCount > 0 && (
+                        <ContextMenuItem onSelect={() => handleStopProject(currentProject.id)}>
+                          <Square className="mr-2 h-3.5 w-3.5" />
+                          Stop all agents
+                        </ContextMenuItem>
+                      )}
+                      <ContextMenuItem
+                        onSelect={() => handleCloseProject(currentProject.id)}
+                        className="text-status-error focus:text-status-error"
+                      >
+                        <X className="mr-2 h-3.5 w-3.5" />
+                        Close project
+                      </ContextMenuItem>
+                    </ContextMenuContent>
+                  )}
+                </ContextMenu>
+                {currentProject && (
+                  <TooltipContent side="bottom" className="max-w-[28rem]">
+                    <div className="flex flex-col gap-0.5">
+                      <div className="text-xs font-medium">
+                        {currentProject.name}
+                        {branchName ? ` · ${branchName}` : ""}
+                      </div>
+                      <div className="text-text-muted font-mono text-2xs truncate">
+                        {currentProject.path}
+                      </div>
+                    </div>
+                  </TooltipContent>
                 )}
-              </ContextMenu>
-              {currentProject && (
-                <TooltipContent side="bottom" className="max-w-[28rem]">
-                  <div className="flex flex-col gap-0.5">
-                    <div className="text-xs font-medium">
-                      {currentProject.name}
-                      {branchName ? ` · ${branchName}` : ""}
+                {!currentProject && currentScratch && (
+                  <TooltipContent side="bottom" className="max-w-[28rem]">
+                    <div className="flex flex-col gap-0.5">
+                      <div className="text-xs font-medium">{currentScratch.name}</div>
+                      <div className="text-text-muted text-2xs">Scratch workspace</div>
                     </div>
-                    <div className="text-text-muted font-mono text-2xs truncate">
-                      {currentProject.path}
-                    </div>
-                  </div>
-                </TooltipContent>
-              )}
-              {!currentProject && currentScratch && (
-                <TooltipContent side="bottom" className="max-w-[28rem]">
-                  <div className="flex flex-col gap-0.5">
-                    <div className="text-xs font-medium">{currentScratch.name}</div>
-                    <div className="text-text-muted text-2xs">Scratch workspace</div>
-                  </div>
-                </TooltipContent>
-              )}
-            </Tooltip>
-          </div>
+                  </TooltipContent>
+                )}
+              </Tooltip>
+            </div>
 
-          {/* RIGHT GROUP */}
-          <div
-            role="group"
-            aria-label="Tools and settings"
-            className="flex items-center justify-end gap-1.5 z-20"
-          >
+            {/* RIGHT GROUP */}
             <div
-              ref={rightGroupRef}
-              className="flex flex-1 min-w-0 items-center gap-0.5 overflow-hidden justify-end"
+              role="group"
+              aria-label="Tools and settings"
+              className="flex items-center justify-end gap-1.5 z-20"
             >
-              {renderButtons(effectiveRightButtons, rightVisibleSet)}
-            </div>
-            <div className="app-no-drag">
-              {renderOverflowMenu(visibleRightOverflow, "right", rightOverflowSeverity)}
-            </div>
-
-            <div className={toolbarDividerClass} />
-
-            <div className="app-no-drag flex items-center gap-0.5">
-              {buttonRegistry["assistant-toggle"]!.render()}
-              {buttonRegistry["portal-toggle"]!.render()}
-            </div>
-
-            {isWindows() && (
               <div
-                aria-hidden="true"
-                data-fullscreen={isFullscreen ? "true" : undefined}
-                className={cn(
-                  "shrink-0 transition-[width] duration-200 data-[fullscreen=true]:duration-120",
-                  isFullscreen && "w-0"
-                )}
-                style={isFullscreen ? undefined : { width: `${WINDOWS_CAPTION_WIDTH_PX}px` }}
-              />
-            )}
+                ref={rightGroupRef}
+                className="flex flex-1 min-w-0 items-center gap-0.5 overflow-hidden justify-end"
+              >
+                {renderButtons(effectiveRightButtons, rightVisibleSet)}
+              </div>
+              <div className="app-no-drag">
+                {renderOverflowMenu(visibleRightOverflow, "right", rightOverflowSeverity)}
+              </div>
+
+              <div className={toolbarDividerClass} />
+
+              <div className="app-no-drag flex items-center gap-0.5">
+                {buttonRegistry["assistant-toggle"]!.render()}
+                {buttonRegistry["portal-toggle"]!.render()}
+              </div>
+
+              {isWindows() && (
+                <div
+                  aria-hidden="true"
+                  data-fullscreen={isFullscreen ? "true" : undefined}
+                  className={cn(
+                    "shrink-0 transition-[width] duration-200 data-[fullscreen=true]:duration-120",
+                    isFullscreen && "w-0"
+                  )}
+                  style={isFullscreen ? undefined : { width: `${WINDOWS_CAPTION_WIDTH_PX}px` }}
+                />
+              )}
+            </div>
           </div>
-        </div>
+        </ToolbarButtonsContextMenu>
       </BrandSurface>
     </header>
   );

--- a/src/components/Layout/ToolbarButtonsContextMenu.tsx
+++ b/src/components/Layout/ToolbarButtonsContextMenu.tsx
@@ -1,4 +1,4 @@
-import { cloneElement, useRef } from "react";
+import { cloneElement, useState } from "react";
 import type React from "react";
 import { BrandSurfaceReset } from "@/components/icons/BrandSurface";
 import {
@@ -48,7 +48,10 @@ export function ToolbarButtonsContextMenu({
   onToggle,
   children,
 }: ToolbarButtonsContextMenuProps) {
-  const triggerRef = useRef<HTMLSpanElement>(null);
+  // State, not a ref: the handler below goes through `cloneElement`, and the
+  // React Compiler reads a ref access inside a function handed to a plain call
+  // as a read during render — an error that fails the dev transform outright.
+  const [trigger, setTrigger] = useState<HTMLSpanElement | null>(null);
   const childOnContextMenu = children.props.onContextMenu;
 
   // Replayed onto a hidden trigger rather than making the root the trigger:
@@ -61,7 +64,8 @@ export function ToolbarButtonsContextMenu({
     if (event.defaultPrevented) return;
     if (!isToolbarEmptySpaceTarget(event.target, event.currentTarget)) return;
     event.preventDefault();
-    triggerRef.current?.dispatchEvent(
+    // Radix anchors the menu to these coordinates, not to the trigger's box.
+    trigger?.dispatchEvent(
       new MouseEvent("contextmenu", {
         bubbles: true,
         cancelable: true,
@@ -95,7 +99,7 @@ export function ToolbarButtonsContextMenu({
         {/* A sibling of the root, not a descendant, so the replayed event can't
             bubble back into the handler that sent it. */}
         <ContextMenuTrigger asChild>
-          <span ref={triggerRef} hidden />
+          <span ref={setTrigger} hidden />
         </ContextMenuTrigger>
         <ContextMenuContent aria-label="Toolbar buttons">
           {/* Context reaches through the portal, so without the reset an agent's

--- a/src/components/Layout/ToolbarButtonsContextMenu.tsx
+++ b/src/components/Layout/ToolbarButtonsContextMenu.tsx
@@ -1,0 +1,98 @@
+import type React from "react";
+import { BrandSurfaceReset } from "@/components/icons/BrandSurface";
+import {
+  ContextMenu,
+  ContextMenuActionItem,
+  ContextMenuCheckboxItem,
+  ContextMenuContent,
+  ContextMenuGroup,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
+import type { AnyToolbarButtonId } from "@/../../shared/types/toolbar";
+import { TOOLBAR_CUSTOMIZE_LABEL } from "./toolbarMenuStrings";
+import {
+  isToolbarEmptySpaceTarget,
+  type ToolbarSide,
+  type ToolbarVisibilityMenuRow,
+  type ToolbarVisibilityMenuRows,
+} from "./toolbarVisibilityMenu";
+
+interface ToolbarButtonsContextMenuProps {
+  rows: ToolbarVisibilityMenuRows;
+  onToggle: (buttonId: AnyToolbarButtonId, side: ToolbarSide, onToolbar: boolean) => void;
+  /** The toolbar root. Slotted, so the menu adds no DOM of its own. */
+  children: React.ReactElement;
+}
+
+/**
+ * The toolbar's empty-space right-click menu (#12355): every button holding a
+ * toolbar slot as a checkbox, so a hidden one comes back from the same surface
+ * it was hidden on, then "Customize toolbar…" for the full editor.
+ *
+ * Opens on empty space only. A button with its own menu already wins, because
+ * Radix composes each trigger's handler to skip an event an inner trigger has
+ * prevented; the filter here covers controls with no menu of their own and
+ * portaled content.
+ *
+ * macOS and Linux deliver this right-click. On Windows the empty space is a
+ * caption drag region, so the OS shows its native window menu there instead and
+ * the page never sees the event.
+ */
+export function ToolbarButtonsContextMenu({
+  rows,
+  onToggle,
+  children,
+}: ToolbarButtonsContextMenuProps) {
+  const handleContextMenu = (event: React.MouseEvent<HTMLElement>) => {
+    if (event.defaultPrevented) return;
+    // Cancelling is how the open is refused — Radix's own handler skips a
+    // prevented event. No native menu goes missing: project views register no
+    // `context-menu` handler.
+    if (!isToolbarEmptySpaceTarget(event.target, event.currentTarget)) {
+      event.preventDefault();
+    }
+  };
+
+  const renderRow = (row: ToolbarVisibilityMenuRow) => {
+    const Icon = row.icon;
+    return (
+      <ContextMenuCheckboxItem
+        key={row.id}
+        checked={row.checked}
+        onCheckedChange={(checked) => onToggle(row.id, row.side, checked)}
+      >
+        <Icon className="mr-2 h-3.5 w-3.5 shrink-0 text-text-secondary" />
+        {row.label}
+      </ContextMenuCheckboxItem>
+    );
+  };
+
+  const hasLeft = rows.left.length > 0;
+  const hasRight = rows.right.length > 0;
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild onContextMenu={handleContextMenu}>
+        {children}
+      </ContextMenuTrigger>
+      <ContextMenuContent aria-label="Toolbar buttons">
+        {/* Context reaches through the portal, so without the reset an agent's
+            brand mark would measure itself against the toolbar surface. */}
+        <BrandSurfaceReset>
+          {hasLeft && (
+            <ContextMenuGroup aria-label="Left side">{rows.left.map(renderRow)}</ContextMenuGroup>
+          )}
+          {hasLeft && hasRight && <ContextMenuSeparator />}
+          {hasRight && (
+            <ContextMenuGroup aria-label="Right side">{rows.right.map(renderRow)}</ContextMenuGroup>
+          )}
+          {(hasLeft || hasRight) && <ContextMenuSeparator />}
+        </BrandSurfaceReset>
+        <ContextMenuActionItem inset actionId="app.settings.openTab" args={{ tab: "toolbar" }}>
+          {TOOLBAR_CUSTOMIZE_LABEL}
+        </ContextMenuActionItem>
+      </ContextMenuContent>
+    </ContextMenu>
+  );
+}

--- a/src/components/Layout/ToolbarButtonsContextMenu.tsx
+++ b/src/components/Layout/ToolbarButtonsContextMenu.tsx
@@ -1,3 +1,4 @@
+import { cloneElement, useRef } from "react";
 import type React from "react";
 import { BrandSurfaceReset } from "@/components/icons/BrandSurface";
 import {
@@ -21,37 +22,53 @@ import {
 interface ToolbarButtonsContextMenuProps {
   rows: ToolbarVisibilityMenuRows;
   onToggle: (buttonId: AnyToolbarButtonId, side: ToolbarSide, onToolbar: boolean) => void;
-  /** The toolbar root. Slotted, so the menu adds no DOM of its own. */
-  children: React.ReactElement;
+  /**
+   * The toolbar root. Cloned with a composed `onContextMenu` — the one prop this
+   * menu needs — so its ref and every other handler stay its own.
+   */
+  children: React.ReactElement<{ onContextMenu?: React.MouseEventHandler<HTMLElement> }>;
 }
 
 /**
  * The toolbar's empty-space right-click menu (#12355): every button holding a
- * toolbar slot as a checkbox, so a hidden one comes back from the same surface
- * it was hidden on, then "Customize toolbar…" for the full editor.
+ * toolbar slot as a checkbox, so a hidden one comes back from the surface it
+ * was hidden on, then "Customize toolbar…" for the full editor.
  *
- * Opens on empty space only. A button with its own menu already wins, because
- * Radix composes each trigger's handler to skip an event an inner trigger has
- * prevented; the filter here covers controls with no menu of their own and
- * portaled content.
+ * Right-click only. Nothing on the toolbar takes focus without being a control,
+ * so there is no keyboard route here; every control's own menu carries
+ * "Customize toolbar…" instead.
  *
- * macOS and Linux deliver this right-click. On Windows the empty space is a
- * caption drag region, so the OS shows its native window menu there instead and
- * the page never sees the event.
+ * macOS and Linux deliver the right-click — Electron forwards secondary clicks
+ * out of a macOS drag region (electron#44761), and Linux windows are framed. On
+ * Windows the empty space is a caption drag region, so the OS shows its native
+ * window menu there and the page never sees the event.
  */
 export function ToolbarButtonsContextMenu({
   rows,
   onToggle,
   children,
 }: ToolbarButtonsContextMenuProps) {
+  const triggerRef = useRef<HTMLSpanElement>(null);
+  const childOnContextMenu = children.props.onContextMenu;
+
+  // Replayed onto a hidden trigger rather than making the root the trigger:
+  // Radix arms a 700ms touch/pen long-press timer on its trigger's pointerdown,
+  // and on the root that timer would fire from every button beneath it — past
+  // this filter, and on top of a button's own menu.
   const handleContextMenu = (event: React.MouseEvent<HTMLElement>) => {
+    childOnContextMenu?.(event);
+    // A control's own menu has already claimed it.
     if (event.defaultPrevented) return;
-    // Cancelling is how the open is refused — Radix's own handler skips a
-    // prevented event. No native menu goes missing: project views register no
-    // `context-menu` handler.
-    if (!isToolbarEmptySpaceTarget(event.target, event.currentTarget)) {
-      event.preventDefault();
-    }
+    if (!isToolbarEmptySpaceTarget(event.target, event.currentTarget)) return;
+    event.preventDefault();
+    triggerRef.current?.dispatchEvent(
+      new MouseEvent("contextmenu", {
+        bubbles: true,
+        cancelable: true,
+        clientX: event.clientX,
+        clientY: event.clientY,
+      })
+    );
   };
 
   const renderRow = (row: ToolbarVisibilityMenuRow) => {
@@ -72,27 +89,34 @@ export function ToolbarButtonsContextMenu({
   const hasRight = rows.right.length > 0;
 
   return (
-    <ContextMenu>
-      <ContextMenuTrigger asChild onContextMenu={handleContextMenu}>
-        {children}
-      </ContextMenuTrigger>
-      <ContextMenuContent aria-label="Toolbar buttons">
-        {/* Context reaches through the portal, so without the reset an agent's
-            brand mark would measure itself against the toolbar surface. */}
-        <BrandSurfaceReset>
-          {hasLeft && (
-            <ContextMenuGroup aria-label="Left side">{rows.left.map(renderRow)}</ContextMenuGroup>
-          )}
-          {hasLeft && hasRight && <ContextMenuSeparator />}
-          {hasRight && (
-            <ContextMenuGroup aria-label="Right side">{rows.right.map(renderRow)}</ContextMenuGroup>
-          )}
-          {(hasLeft || hasRight) && <ContextMenuSeparator />}
-        </BrandSurfaceReset>
-        <ContextMenuActionItem inset actionId="app.settings.openTab" args={{ tab: "toolbar" }}>
-          {TOOLBAR_CUSTOMIZE_LABEL}
-        </ContextMenuActionItem>
-      </ContextMenuContent>
-    </ContextMenu>
+    <>
+      {cloneElement(children, { onContextMenu: handleContextMenu })}
+      <ContextMenu>
+        {/* A sibling of the root, not a descendant, so the replayed event can't
+            bubble back into the handler that sent it. */}
+        <ContextMenuTrigger asChild>
+          <span ref={triggerRef} hidden />
+        </ContextMenuTrigger>
+        <ContextMenuContent aria-label="Toolbar buttons">
+          {/* Context reaches through the portal, so without the reset an agent's
+              brand mark would measure itself against the toolbar surface. */}
+          <BrandSurfaceReset>
+            {hasLeft && (
+              <ContextMenuGroup aria-label="Left side">{rows.left.map(renderRow)}</ContextMenuGroup>
+            )}
+            {hasLeft && hasRight && <ContextMenuSeparator />}
+            {hasRight && (
+              <ContextMenuGroup aria-label="Right side">
+                {rows.right.map(renderRow)}
+              </ContextMenuGroup>
+            )}
+            {(hasLeft || hasRight) && <ContextMenuSeparator />}
+          </BrandSurfaceReset>
+          <ContextMenuActionItem inset actionId="app.settings.openTab" args={{ tab: "toolbar" }}>
+            {TOOLBAR_CUSTOMIZE_LABEL}
+          </ContextMenuActionItem>
+        </ContextMenuContent>
+      </ContextMenu>
+    </>
   );
 }

--- a/src/components/Layout/__tests__/AppLayout.landmarks.test.ts
+++ b/src/components/Layout/__tests__/AppLayout.landmarks.test.ts
@@ -42,8 +42,10 @@ describe("ARIA page landmarks — issue #5416", () => {
       // while sitting between the two tags in source.
       expect(source).toMatch(/<div\s+ref=\{toolbarRef\}\s+role="toolbar"/);
       expect(source).not.toMatch(/<header[^>]*(?:role=|ref=)/);
-      // The banner still has to CONTAIN the toolbar — only a provider, which
-      // renders no DOM, is allowed between the two tags.
+      // The banner still has to CONTAIN the toolbar — only wrappers that render
+      // no DOM of their own (the brand-surface provider, and the empty-space
+      // context menu, whose trigger slots onto the root) are allowed between
+      // the two tags.
       expect(source).toMatch(/<header>[\s\S]{0,400}?<div\s+ref=\{toolbarRef\}\s+role="toolbar"/);
     });
   });

--- a/src/components/Layout/__tests__/AppLayout.landmarks.test.ts
+++ b/src/components/Layout/__tests__/AppLayout.landmarks.test.ts
@@ -42,10 +42,10 @@ describe("ARIA page landmarks — issue #5416", () => {
       // while sitting between the two tags in source.
       expect(source).toMatch(/<div\s+ref=\{toolbarRef\}\s+role="toolbar"/);
       expect(source).not.toMatch(/<header[^>]*(?:role=|ref=)/);
-      // The banner still has to CONTAIN the toolbar — only wrappers that render
-      // no DOM of their own (the brand-surface provider, and the empty-space
-      // context menu, whose trigger slots onto the root) are allowed between
-      // the two tags.
+      // The banner still has to CONTAIN the toolbar — only wrappers that add no
+      // element around it (the brand-surface provider, and the empty-space
+      // context menu, which clones the root rather than wrapping it) are
+      // allowed between the two tags.
       expect(source).toMatch(/<header>[\s\S]{0,400}?<div\s+ref=\{toolbarRef\}\s+role="toolbar"/);
     });
   });

--- a/src/components/Layout/__tests__/Toolbar.layout.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.layout.test.ts
@@ -126,6 +126,28 @@ describe("Toolbar layout — issue #2584 project switcher collision", () => {
     });
   });
 
+  describe("Empty-space context menu — issue #12355", () => {
+    // The menu's behaviour is covered for real in ToolbarButtonsContextMenu and
+    // toolbarVisibilityMenu tests; these only pin Toolbar.tsx's wiring to it.
+    it("wraps the toolbar root itself, so the trigger slots onto it", () => {
+      expect(source).toMatch(
+        /<ToolbarButtonsContextMenu[^>]*>\s*<div\s+ref=\{toolbarRef\}\s+role="toolbar"/
+      );
+    });
+
+    it("builds the rows from the side lists before the visibility filter", () => {
+      // Built from `effective*Buttons` instead, a hidden button would drop out of
+      // the one menu that exists to bring it back.
+      expect(source).toMatch(
+        /buildToolbarVisibilityMenuRows\(\s*positionedLeftButtons,\s*positionedRightButtons/
+      );
+    });
+
+    it("routes a menu toggle through the helper Settings → Toolbar uses", () => {
+      expect(source).toMatch(/setToolbarButtonOnToolbar\(\s*buttonId,\s*side,\s*onToolbar,/);
+    });
+  });
+
   describe("Window resize strip — issue #3273 Linux native title bar", () => {
     it("imports isLinux from platform", () => {
       expect(source).toContain("isLinux");

--- a/src/components/Layout/__tests__/Toolbar.layout.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.layout.test.ts
@@ -129,7 +129,7 @@ describe("Toolbar layout — issue #2584 project switcher collision", () => {
   describe("Empty-space context menu — issue #12355", () => {
     // The menu's behaviour is covered for real in ToolbarButtonsContextMenu and
     // toolbarVisibilityMenu tests; these only pin Toolbar.tsx's wiring to it.
-    it("wraps the toolbar root itself, so the trigger slots onto it", () => {
+    it("hands the menu the toolbar root itself, which it clones rather than wraps", () => {
       expect(source).toMatch(
         /<ToolbarButtonsContextMenu[^>]*>\s*<div\s+ref=\{toolbarRef\}\s+role="toolbar"/
       );

--- a/src/components/Layout/__tests__/ToolbarButtonsContextMenu.test.tsx
+++ b/src/components/Layout/__tests__/ToolbarButtonsContextMenu.test.tsx
@@ -1,0 +1,215 @@
+// @vitest-environment jsdom
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { act, cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { createRef, type ReactNode, type Ref } from "react";
+import { createPortal } from "react-dom";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
+import { primeRadix } from "@/components/ui/radix-loader";
+import { actionService } from "@/services/ActionService";
+import type { AnyToolbarButtonId } from "@/../../shared/types/toolbar";
+import { ToolbarButtonsContextMenu } from "../ToolbarButtonsContextMenu";
+import { TOOLBAR_CUSTOMIZE_LABEL } from "../toolbarMenuStrings";
+import type { ToolbarSide, ToolbarVisibilityMenuRows } from "../toolbarVisibilityMenu";
+
+const Glyph = () => <svg aria-hidden="true" />;
+
+const ROWS: ToolbarVisibilityMenuRows = {
+  left: [{ id: "terminal", side: "left", label: "Terminal", icon: Glyph, checked: true }],
+  right: [
+    { id: "forge-stats", side: "right", label: "Repository stats", icon: Glyph, checked: false },
+  ],
+};
+
+const OWN_MENU_SENTINEL = "Own menu item";
+
+interface HarnessOptions {
+  rows?: ToolbarVisibilityMenuRows;
+  extra?: ReactNode;
+  rootRef?: Ref<HTMLDivElement>;
+  onKeyDown?: () => void;
+  onFocusCapture?: () => void;
+}
+
+function renderToolbar({
+  rows = ROWS,
+  extra,
+  rootRef,
+  onKeyDown,
+  onFocusCapture,
+}: HarnessOptions = {}) {
+  const onToggle =
+    vi.fn<(buttonId: AnyToolbarButtonId, side: ToolbarSide, onToolbar: boolean) => void>();
+  render(
+    <ToolbarButtonsContextMenu rows={rows} onToggle={onToggle}>
+      <div
+        ref={rootRef}
+        role="toolbar"
+        aria-label="Main toolbar"
+        className="app-drag-region"
+        onKeyDown={onKeyDown}
+        onFocusCapture={onFocusCapture}
+      >
+        <div data-testid="group">
+          <div data-toolbar-button-id="terminal" className="app-no-drag">
+            <button type="button" data-toolbar-item="">
+              Terminal
+            </button>
+          </div>
+        </div>
+        <div className="app-no-drag">
+          <button type="button">Toggle sidebar</button>
+        </div>
+        {extra}
+      </div>
+    </ToolbarButtonsContextMenu>
+  );
+  return { onToggle };
+}
+
+// Negative assertions need the open path to have had its chance to commit, and
+// a raw DOM read so an aria-hidden sibling can't mask a menu that did open.
+async function flush() {
+  await act(async () => {});
+}
+
+beforeAll(async () => {
+  await primeRadix();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("ToolbarButtonsContextMenu", () => {
+  it("opens on empty toolbar space with a checkbox per button and the customize entry", async () => {
+    renderToolbar();
+
+    fireEvent.contextMenu(screen.getByTestId("group"));
+
+    const menu = await screen.findByRole("menu", { name: "Toolbar buttons" });
+    expect(
+      within(menu)
+        .getAllByRole("menuitemcheckbox")
+        .map((row) => [row.textContent, row.getAttribute("aria-checked")])
+    ).toEqual([
+      ["Terminal", "true"],
+      ["Repository stats", "false"],
+    ]);
+    expect(
+      within(menu)
+        .getAllByRole("group")
+        .map((group) => group.getAttribute("aria-label"))
+    ).toEqual(["Left side", "Right side"]);
+    expect(within(menu).getByRole("menuitem", { name: TOOLBAR_CUSTOMIZE_LABEL })).toBeTruthy();
+  });
+
+  it("brings a hidden button back with the side it sits on", async () => {
+    const { onToggle } = renderToolbar();
+
+    fireEvent.contextMenu(screen.getByRole("toolbar"));
+    const menu = await screen.findByRole("menu");
+    fireEvent.click(within(menu).getByRole("menuitemcheckbox", { name: "Repository stats" }));
+
+    expect(onToggle).toHaveBeenCalledExactlyOnceWith("forge-stats", "right", true);
+  });
+
+  it("hides a shown button", async () => {
+    const { onToggle } = renderToolbar();
+
+    fireEvent.contextMenu(screen.getByRole("toolbar"));
+    const menu = await screen.findByRole("menu");
+    fireEvent.click(within(menu).getByRole("menuitemcheckbox", { name: "Terminal" }));
+
+    expect(onToggle).toHaveBeenCalledExactlyOnceWith("terminal", "left", false);
+  });
+
+  it("opens the toolbar editor from the customize entry", async () => {
+    const dispatch = vi.spyOn(actionService, "dispatch");
+    renderToolbar();
+
+    fireEvent.contextMenu(screen.getByRole("toolbar"));
+    const menu = await screen.findByRole("menu");
+    fireEvent.click(within(menu).getByRole("menuitem", { name: TOOLBAR_CUSTOMIZE_LABEL }));
+
+    expect(dispatch).toHaveBeenCalledWith(
+      "app.settings.openTab",
+      { tab: "toolbar" },
+      expect.objectContaining({ source: "context-menu" })
+    );
+  });
+
+  it("stays shut for a right-click on a button slot or on fixed chrome", async () => {
+    renderToolbar();
+
+    fireEvent.contextMenu(screen.getByRole("button", { name: "Terminal" }));
+    fireEvent.contextMenu(screen.getByRole("button", { name: "Toggle sidebar" }));
+    await flush();
+
+    expect(document.querySelector("[role='menu']")).toBeNull();
+  });
+
+  it("lets a control's own menu win over the toolbar's", async () => {
+    renderToolbar({
+      extra: (
+        <ContextMenu>
+          <ContextMenuTrigger asChild>
+            <span data-testid="own-menu">Own menu</span>
+          </ContextMenuTrigger>
+          <ContextMenuContent>
+            <ContextMenuItem>{OWN_MENU_SENTINEL}</ContextMenuItem>
+          </ContextMenuContent>
+        </ContextMenu>
+      ),
+    });
+
+    fireEvent.contextMenu(screen.getByTestId("own-menu"));
+
+    expect(await screen.findByRole("menuitem", { name: OWN_MENU_SENTINEL })).toBeTruthy();
+    expect(document.querySelector("[role='menuitemcheckbox']")).toBeNull();
+  });
+
+  it("ignores a right-click that bubbles up from content the toolbar portals out", async () => {
+    renderToolbar({
+      extra: createPortal(<button type="button">Portaled</button>, document.body),
+    });
+
+    fireEvent.contextMenu(screen.getByRole("button", { name: "Portaled" }));
+    await flush();
+
+    expect(document.querySelector("[role='menu']")).toBeNull();
+  });
+
+  it("keeps the toolbar root's own ref and handlers once slotted into the trigger", () => {
+    const rootRef = createRef<HTMLDivElement>();
+    const onKeyDown = vi.fn();
+    const onFocusCapture = vi.fn();
+    renderToolbar({ rootRef, onKeyDown, onFocusCapture });
+
+    const toolbar = screen.getByRole("toolbar");
+    fireEvent.keyDown(toolbar, { key: "ArrowRight" });
+    act(() => {
+      screen.getByRole("button", { name: "Terminal" }).focus();
+    });
+
+    expect(rootRef.current).toBe(toolbar);
+    expect(onKeyDown).toHaveBeenCalledTimes(1);
+    expect(onFocusCapture).toHaveBeenCalled();
+  });
+
+  it("offers only the customize entry, with no stray separators, when no button qualifies", async () => {
+    renderToolbar({ rows: { left: [], right: [] } });
+
+    fireEvent.contextMenu(screen.getByRole("toolbar"));
+    const menu = await screen.findByRole("menu");
+
+    expect(within(menu).queryAllByRole("menuitemcheckbox")).toHaveLength(0);
+    expect(within(menu).queryAllByRole("separator")).toHaveLength(0);
+    expect(within(menu).getByRole("menuitem", { name: TOOLBAR_CUSTOMIZE_LABEL })).toBeTruthy();
+  });
+});

--- a/src/components/Layout/__tests__/ToolbarButtonsContextMenu.test.tsx
+++ b/src/components/Layout/__tests__/ToolbarButtonsContextMenu.test.tsx
@@ -44,7 +44,7 @@ function renderToolbar({
 }: HarnessOptions = {}) {
   const onToggle =
     vi.fn<(buttonId: AnyToolbarButtonId, side: ToolbarSide, onToolbar: boolean) => void>();
-  render(
+  const { container } = render(
     <ToolbarButtonsContextMenu rows={rows} onToggle={onToggle}>
       <div
         ref={rootRef}
@@ -68,7 +68,7 @@ function renderToolbar({
       </div>
     </ToolbarButtonsContextMenu>
   );
-  return { onToggle };
+  return { onToggle, container };
 }
 
 // Negative assertions need the open path to have had its chance to commit, and
@@ -83,6 +83,7 @@ beforeAll(async () => {
 
 afterEach(() => {
   cleanup();
+  vi.useRealTimers();
   vi.restoreAllMocks();
 });
 
@@ -106,6 +107,8 @@ describe("ToolbarButtonsContextMenu", () => {
         .getAllByRole("group")
         .map((group) => group.getAttribute("aria-label"))
     ).toEqual(["Left side", "Right side"]);
+    // One between the sides, one before Customize.
+    expect(within(menu).getAllByRole("separator")).toHaveLength(2);
     expect(within(menu).getByRole("menuitem", { name: TOOLBAR_CUSTOMIZE_LABEL })).toBeTruthy();
   });
 
@@ -119,14 +122,16 @@ describe("ToolbarButtonsContextMenu", () => {
     expect(onToggle).toHaveBeenCalledExactlyOnceWith("forge-stats", "right", true);
   });
 
-  it("hides a shown button", async () => {
+  it("hides a shown button and closes", async () => {
     const { onToggle } = renderToolbar();
 
     fireEvent.contextMenu(screen.getByRole("toolbar"));
     const menu = await screen.findByRole("menu");
     fireEvent.click(within(menu).getByRole("menuitemcheckbox", { name: "Terminal" }));
+    await flush();
 
     expect(onToggle).toHaveBeenCalledExactlyOnceWith("terminal", "left", false);
+    expect(document.querySelector("[role='menu']")).toBeNull();
   });
 
   it("opens the toolbar editor from the customize entry", async () => {
@@ -144,11 +149,14 @@ describe("ToolbarButtonsContextMenu", () => {
     );
   });
 
-  it("stays shut for a right-click on a button slot or on fixed chrome", async () => {
+  it("leaves a right-click on a button slot or on fixed chrome alone", async () => {
     renderToolbar();
 
-    fireEvent.contextMenu(screen.getByRole("button", { name: "Terminal" }));
-    fireEvent.contextMenu(screen.getByRole("button", { name: "Toggle sidebar" }));
+    // `fireEvent` returns false only when a handler cancelled the event.
+    expect(fireEvent.contextMenu(screen.getByRole("button", { name: "Terminal" }))).toBe(true);
+    expect(fireEvent.contextMenu(screen.getByRole("button", { name: "Toggle sidebar" }))).toBe(
+      true
+    );
     await flush();
 
     expect(document.querySelector("[role='menu']")).toBeNull();
@@ -179,17 +187,35 @@ describe("ToolbarButtonsContextMenu", () => {
       extra: createPortal(<button type="button">Portaled</button>, document.body),
     });
 
-    fireEvent.contextMenu(screen.getByRole("button", { name: "Portaled" }));
+    expect(fireEvent.contextMenu(screen.getByRole("button", { name: "Portaled" }))).toBe(true);
     await flush();
 
     expect(document.querySelector("[role='menu']")).toBeNull();
   });
 
-  it("keeps the toolbar root's own ref and handlers once slotted into the trigger", () => {
+  it("never opens from a touch long-press on a button", async () => {
+    renderToolbar();
+
+    // A trigger arms a 700ms long-press timer on any touch pointerdown that
+    // reaches it; the root must not be one.
+    vi.useFakeTimers();
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Terminal" }), {
+      pointerType: "touch",
+    });
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    vi.useRealTimers();
+    await flush();
+
+    expect(document.querySelector("[role='menu']")).toBeNull();
+  });
+
+  it("adds no DOM around the toolbar root and keeps its own ref and handlers", () => {
     const rootRef = createRef<HTMLDivElement>();
     const onKeyDown = vi.fn();
     const onFocusCapture = vi.fn();
-    renderToolbar({ rootRef, onKeyDown, onFocusCapture });
+    const { container } = renderToolbar({ rootRef, onKeyDown, onFocusCapture });
 
     const toolbar = screen.getByRole("toolbar");
     fireEvent.keyDown(toolbar, { key: "ArrowRight" });
@@ -197,6 +223,7 @@ describe("ToolbarButtonsContextMenu", () => {
       screen.getByRole("button", { name: "Terminal" }).focus();
     });
 
+    expect(toolbar.parentElement).toBe(container);
     expect(rootRef.current).toBe(toolbar);
     expect(onKeyDown).toHaveBeenCalledTimes(1);
     expect(onFocusCapture).toHaveBeenCalled();

--- a/src/components/Layout/__tests__/ToolbarButtonsContextMenu.test.tsx
+++ b/src/components/Layout/__tests__/ToolbarButtonsContextMenu.test.tsx
@@ -193,6 +193,21 @@ describe("ToolbarButtonsContextMenu", () => {
     expect(document.querySelector("[role='menu']")).toBeNull();
   });
 
+  it("replays the pointer position, which is what the menu is anchored to", async () => {
+    const { container } = renderToolbar();
+    const trigger = container.querySelector("span[hidden]");
+    if (!trigger) throw new Error("missing the hidden trigger");
+    const replayed: Array<[number, number]> = [];
+    trigger.addEventListener("contextmenu", (event) => {
+      if (event instanceof MouseEvent) replayed.push([event.clientX, event.clientY]);
+    });
+
+    fireEvent.contextMenu(screen.getByTestId("group"), { clientX: 120, clientY: 30 });
+    await screen.findByRole("menu");
+
+    expect(replayed).toEqual([[120, 30]]);
+  });
+
   it("never opens from a touch long-press on a button", async () => {
     renderToolbar();
 

--- a/src/components/Layout/__tests__/toolbarVisibilityMenu.test.ts
+++ b/src/components/Layout/__tests__/toolbarVisibilityMenu.test.ts
@@ -142,6 +142,12 @@ describe("canListToolbarButton", () => {
 
     expect(canListToolbarButton("codex", REGISTRY, PROJECT_SCOPED, null, availability)).toBe(true);
   });
+
+  it("holds back an unpinned agent while CLI availability is still loading", () => {
+    expect(canListToolbarButton("claude", REGISTRY, PROJECT_SCOPED, { agents: {} }, null)).toBe(
+      false
+    );
+  });
 });
 
 describe("resolveToolbarButtonMetadata", () => {

--- a/src/components/Layout/__tests__/toolbarVisibilityMenu.test.ts
+++ b/src/components/Layout/__tests__/toolbarVisibilityMenu.test.ts
@@ -1,9 +1,11 @@
 // @vitest-environment jsdom
 import { describe, it, expect, afterEach } from "vitest";
 import type { AnyToolbarButtonId } from "@/../../shared/types/toolbar";
+import type { AgentSettings, CliAvailability } from "@shared/types";
 import type { ToolbarButtonMetadata } from "../toolbarButtonMetadata";
 import {
   buildToolbarVisibilityMenuRows,
+  canListToolbarButton,
   isToolbarEmptySpaceTarget,
   resolveToolbarButtonMetadata,
   type ToolbarVisibilityMenuRowSource,
@@ -26,7 +28,7 @@ const METADATA: Partial<Record<AnyToolbarButtonId, ToolbarButtonMetadata>> = {
 function source(overrides: Partial<ToolbarVisibilityMenuRowSource> = {}) {
   return {
     resolveMetadata: (id: AnyToolbarButtonId) => resolveToolbarButtonMetadata(id, METADATA, {}),
-    canRender: () => true,
+    canList: () => true,
     isOnToolbar: () => true,
     ...overrides,
   };
@@ -64,11 +66,11 @@ describe("buildToolbarVisibilityMenuRows", () => {
     ]);
   });
 
-  it("drops a button the view cannot draw and one with no name to show", () => {
+  it("drops a button the menu should not list and one with no name to show", () => {
     const rows = buildToolbarVisibilityMenuRows(
       ["terminal", "problems"],
       ["notification-center", "settings"],
-      source({ canRender: (id) => id !== "notification-center" })
+      source({ canList: (id) => id !== "notification-center" })
     );
 
     // `problems` has no metadata in this fixture; notifications are disabled.
@@ -84,13 +86,61 @@ describe("buildToolbarVisibilityMenuRows", () => {
   });
 
   it("returns empty sides when nothing qualifies", () => {
-    const rows = buildToolbarVisibilityMenuRows(
-      ["terminal"],
-      [],
-      source({ canRender: () => false })
-    );
+    const rows = buildToolbarVisibilityMenuRows(["terminal"], [], source({ canList: () => false }));
 
     expect(rows).toEqual({ left: [], right: [] });
+  });
+});
+
+describe("canListToolbarButton", () => {
+  // `isAvailable` here is what each view's button registry would report: for a
+  // built-in whether this view keeps the button, for an agent its visibility.
+  const REGISTRY: Record<string, { isAvailable: boolean }> = {
+    terminal: { isAvailable: true },
+    problems: { isAvailable: false },
+    "forge-stats": { isAvailable: false },
+    claude: { isAvailable: false },
+    gemini: { isAvailable: false },
+    codex: { isAvailable: false },
+  };
+  const PROJECT_SCOPED = new Set<AnyToolbarButtonId>(["forge-stats"]);
+
+  it("lists a built-in the view keeps, and a project-scoped button holding a placeholder", () => {
+    expect(canListToolbarButton("terminal", REGISTRY, PROJECT_SCOPED, null, null)).toBe(true);
+    expect(canListToolbarButton("forge-stats", REGISTRY, PROJECT_SCOPED, null, null)).toBe(true);
+  });
+
+  it("leaves out a built-in this view switched off, and an id with no renderer at all", () => {
+    expect(canListToolbarButton("problems", REGISTRY, PROJECT_SCOPED, null, null)).toBe(false);
+    expect(canListToolbarButton("acme.deploy", REGISTRY, PROJECT_SCOPED, null, null)).toBe(false);
+  });
+
+  it("omits an agent whose CLI is missing and that was never pinned", () => {
+    const availability: CliAvailability = { claude: "missing" };
+
+    expect(
+      canListToolbarButton("claude", REGISTRY, PROJECT_SCOPED, { agents: {} }, availability)
+    ).toBe(false);
+  });
+
+  it("lists an agent the user pinned or hid, whatever its CLI", () => {
+    const agentSettings: AgentSettings = {
+      agents: { claude: { pinned: true }, gemini: { pinned: false } },
+    };
+    const availability: CliAvailability = { claude: "missing", gemini: "missing" };
+
+    expect(
+      canListToolbarButton("claude", REGISTRY, PROJECT_SCOPED, agentSettings, availability)
+    ).toBe(true);
+    expect(
+      canListToolbarButton("gemini", REGISTRY, PROJECT_SCOPED, agentSettings, availability)
+    ).toBe(true);
+  });
+
+  it("lists an installed agent even though its registry entry reads as hidden", () => {
+    const availability: CliAvailability = { codex: "ready" };
+
+    expect(canListToolbarButton("codex", REGISTRY, PROJECT_SCOPED, null, availability)).toBe(true);
   });
 });
 

--- a/src/components/Layout/__tests__/toolbarVisibilityMenu.test.ts
+++ b/src/components/Layout/__tests__/toolbarVisibilityMenu.test.ts
@@ -1,0 +1,174 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from "vitest";
+import type { AnyToolbarButtonId } from "@/../../shared/types/toolbar";
+import type { ToolbarButtonMetadata } from "../toolbarButtonMetadata";
+import {
+  buildToolbarVisibilityMenuRows,
+  isToolbarEmptySpaceTarget,
+  resolveToolbarButtonMetadata,
+  type ToolbarVisibilityMenuRowSource,
+} from "../toolbarVisibilityMenu";
+
+const Icon = () => null;
+
+function meta(label: string): ToolbarButtonMetadata {
+  return { label, icon: Icon, description: `${label} description` };
+}
+
+const METADATA: Partial<Record<AnyToolbarButtonId, ToolbarButtonMetadata>> = {
+  terminal: meta("Terminal"),
+  browser: meta("Browser"),
+  "forge-stats": meta("Repository stats"),
+  "notification-center": meta("Notifications"),
+  settings: meta("Settings"),
+};
+
+function source(overrides: Partial<ToolbarVisibilityMenuRowSource> = {}) {
+  return {
+    resolveMetadata: (id: AnyToolbarButtonId) => resolveToolbarButtonMetadata(id, METADATA, {}),
+    canRender: () => true,
+    isOnToolbar: () => true,
+    ...overrides,
+  };
+}
+
+describe("buildToolbarVisibilityMenuRows", () => {
+  it("keeps each side's order and tags every row with the side it sits on", () => {
+    const rows = buildToolbarVisibilityMenuRows(
+      ["browser", "terminal"],
+      ["settings", "forge-stats"],
+      source()
+    );
+
+    expect(rows.left.map((row) => [row.id, row.side])).toEqual([
+      ["browser", "left"],
+      ["terminal", "left"],
+    ]);
+    expect(rows.right.map((row) => [row.id, row.side])).toEqual([
+      ["settings", "right"],
+      ["forge-stats", "right"],
+    ]);
+  });
+
+  it("draws each checkmark from the placement resolver, so hidden buttons stay listed", () => {
+    const hidden = new Set<AnyToolbarButtonId>(["forge-stats"]);
+    const rows = buildToolbarVisibilityMenuRows(
+      ["terminal"],
+      ["forge-stats"],
+      source({ isOnToolbar: (id) => !hidden.has(id) })
+    );
+
+    expect(rows.left[0]?.checked).toBe(true);
+    expect(rows.right.map((row) => [row.label, row.checked])).toEqual([
+      ["Repository stats", false],
+    ]);
+  });
+
+  it("drops a button the view cannot draw and one with no name to show", () => {
+    const rows = buildToolbarVisibilityMenuRows(
+      ["terminal", "problems"],
+      ["notification-center", "settings"],
+      source({ canRender: (id) => id !== "notification-center" })
+    );
+
+    // `problems` has no metadata in this fixture; notifications are disabled.
+    expect(rows.left.map((row) => row.id)).toEqual(["terminal"]);
+    expect(rows.right.map((row) => row.id)).toEqual(["settings"]);
+  });
+
+  it("lists an id that sits on both sides once, on the side it appears first", () => {
+    const rows = buildToolbarVisibilityMenuRows(["terminal"], ["terminal", "settings"], source());
+
+    expect(rows.left.map((row) => row.id)).toEqual(["terminal"]);
+    expect(rows.right.map((row) => row.id)).toEqual(["settings"]);
+  });
+
+  it("returns empty sides when nothing qualifies", () => {
+    const rows = buildToolbarVisibilityMenuRows(
+      ["terminal"],
+      [],
+      source({ canRender: () => false })
+    );
+
+    expect(rows).toEqual({ left: [], right: [] });
+  });
+});
+
+describe("resolveToolbarButtonMetadata", () => {
+  it("prefers the built-in entry and falls back to the live registry entry", () => {
+    const pluginMeta = meta("Deploy");
+
+    expect(resolveToolbarButtonMetadata("terminal", METADATA, { terminal: meta("Shadow") })).toBe(
+      METADATA.terminal
+    );
+    expect(resolveToolbarButtonMetadata("copy-tree", METADATA, { "copy-tree": pluginMeta })).toBe(
+      pluginMeta
+    );
+  });
+
+  it("ignores entries the lookup tables only inherit", () => {
+    const inherited: Record<string, ToolbarButtonMetadata> = Object.create({
+      "copy-tree": meta("Inherited"),
+    });
+
+    expect(resolveToolbarButtonMetadata("copy-tree", METADATA, inherited)).toBeUndefined();
+  });
+});
+
+describe("isToolbarEmptySpaceTarget", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  function mountToolbar() {
+    // The outer no-drag wrapper proves a match *above* the root never counts.
+    document.body.innerHTML = `
+      <div class="app-no-drag">
+        <div id="root" role="toolbar" class="app-drag-region">
+          <div id="group">
+            <div id="divider"></div>
+            <div data-toolbar-button-id="terminal" class="app-no-drag">
+              <button id="button" data-toolbar-item=""><svg id="glyph"></svg></button>
+            </div>
+          </div>
+          <div class="app-no-drag"><button id="chrome"></button></div>
+          <span id="bare-item" data-toolbar-item=""></span>
+        </div>
+      </div>
+      <div id="portal"><button id="portaled"></button></div>
+    `;
+  }
+
+  function byId(id: string): Element {
+    const element = document.getElementById(id);
+    if (!element) throw new Error(`missing #${id}`);
+    return element;
+  }
+
+  it("treats the root, a group container, and a divider as empty space", () => {
+    mountToolbar();
+    const root = byId("root");
+
+    expect(isToolbarEmptySpaceTarget(root, root)).toBe(true);
+    expect(isToolbarEmptySpaceTarget(byId("group"), root)).toBe(true);
+    expect(isToolbarEmptySpaceTarget(byId("divider"), root)).toBe(true);
+  });
+
+  it("refuses a button slot, anything drawn inside it, fixed chrome, and a bare toolbar item", () => {
+    mountToolbar();
+    const root = byId("root");
+
+    expect(isToolbarEmptySpaceTarget(byId("button"), root)).toBe(false);
+    expect(isToolbarEmptySpaceTarget(byId("glyph"), root)).toBe(false);
+    expect(isToolbarEmptySpaceTarget(byId("chrome"), root)).toBe(false);
+    expect(isToolbarEmptySpaceTarget(byId("bare-item"), root)).toBe(false);
+  });
+
+  it("refuses content outside the toolbar's DOM, such as a portaled menu, and a missing target", () => {
+    mountToolbar();
+    const root = byId("root");
+
+    expect(isToolbarEmptySpaceTarget(byId("portaled"), root)).toBe(false);
+    expect(isToolbarEmptySpaceTarget(null, root)).toBe(false);
+  });
+});

--- a/src/components/Layout/toolbarVisibilityMenu.ts
+++ b/src/components/Layout/toolbarVisibilityMenu.ts
@@ -1,0 +1,101 @@
+import type { ComponentType } from "react";
+import type { AnyToolbarButtonId } from "@/../../shared/types/toolbar";
+import type { ToolbarButtonIconProps, ToolbarButtonMetadata } from "./toolbarButtonMetadata";
+
+export type ToolbarSide = "left" | "right";
+
+export interface ToolbarVisibilityMenuRow {
+  id: AnyToolbarButtonId;
+  side: ToolbarSide;
+  label: string;
+  icon: ComponentType<ToolbarButtonIconProps>;
+  checked: boolean;
+}
+
+export interface ToolbarVisibilityMenuRows {
+  left: ToolbarVisibilityMenuRow[];
+  right: ToolbarVisibilityMenuRow[];
+}
+
+export interface ToolbarVisibilityMenuRowSource {
+  resolveMetadata: (id: AnyToolbarButtonId) => ToolbarButtonMetadata | undefined;
+  /** Whether this view could draw the button at all if it were switched on. */
+  canRender: (id: AnyToolbarButtonId) => boolean;
+  isOnToolbar: (id: AnyToolbarButtonId) => boolean;
+}
+
+/**
+ * Rows for the toolbar's empty-space menu (#12355), one per button that holds a
+ * toolbar slot, in the order the toolbar draws them.
+ *
+ * Takes the side lists *before* the visibility filter. Hiding a button never
+ * removes its position, so those lists are exactly the set a hidden button can
+ * be brought back from — which is the whole job of this menu.
+ *
+ * A row is dropped when the view has nothing to draw for it (Problems without
+ * developer tools, an empty plugin tray) or no name to show it by, because a
+ * checkbox that changes nothing on screen is worse than no checkbox. An id
+ * sitting on both sides keeps its first row only.
+ */
+export function buildToolbarVisibilityMenuRows(
+  leftButtons: readonly AnyToolbarButtonId[],
+  rightButtons: readonly AnyToolbarButtonId[],
+  source: ToolbarVisibilityMenuRowSource
+): ToolbarVisibilityMenuRows {
+  const seen = new Set<AnyToolbarButtonId>();
+  const toRows = (ids: readonly AnyToolbarButtonId[], side: ToolbarSide) => {
+    const rows: ToolbarVisibilityMenuRow[] = [];
+    for (const id of ids) {
+      if (seen.has(id)) continue;
+      seen.add(id);
+      if (!source.canRender(id)) continue;
+      const metadata = source.resolveMetadata(id);
+      if (!metadata) continue;
+      rows.push({
+        id,
+        side,
+        label: metadata.label,
+        icon: metadata.icon,
+        checked: source.isOnToolbar(id),
+      });
+    }
+    return rows;
+  };
+  return { left: toRows(leftButtons, "left"), right: toRows(rightButtons, "right") };
+}
+
+/**
+ * Built-in metadata first, then the live plugin and launcher-item entries.
+ *
+ * Own-property reads, not bracket reads: the ids come from persisted arrays and
+ * live registries, and a plain object literal would hand back an inherited
+ * `Object.prototype` member for a key that happened to match one.
+ */
+export function resolveToolbarButtonMetadata(
+  id: AnyToolbarButtonId,
+  builtIn: Partial<Record<AnyToolbarButtonId, ToolbarButtonMetadata>>,
+  dynamic: Readonly<Record<string, ToolbarButtonMetadata>>
+): ToolbarButtonMetadata | undefined {
+  if (Object.hasOwn(builtIn, id)) return builtIn[id];
+  if (Object.hasOwn(dynamic, id)) return dynamic[id];
+  return undefined;
+}
+
+// Every control region on the toolbar claims a no-drag rect, so "not inside one
+// of these" is the same pixel set as the drag region — the empty space.
+const TOOLBAR_CONTROL_SELECTOR = ".app-no-drag, [data-toolbar-button-id], [data-toolbar-item]";
+
+/**
+ * Whether a right-click landed on the toolbar's own empty space rather than on
+ * a control or inside something the toolbar portals out.
+ *
+ * The containment check is load-bearing, not defensive. React bubbles a
+ * `contextmenu` from portaled content up the component tree, and the toolbar
+ * owns plenty of that — the launcher palette, overflow menus, the plugin tray,
+ * notification history — none of which is a DOM descendant of `root`.
+ */
+export function isToolbarEmptySpaceTarget(target: EventTarget | null, root: Element): boolean {
+  if (!(target instanceof Element) || !root.contains(target)) return false;
+  const control = target.closest(TOOLBAR_CONTROL_SELECTOR);
+  return control === null || !root.contains(control);
+}

--- a/src/components/Layout/toolbarVisibilityMenu.ts
+++ b/src/components/Layout/toolbarVisibilityMenu.ts
@@ -1,5 +1,8 @@
 import type { ComponentType } from "react";
+import { isBuiltInAgentId } from "@shared/config/agentIds";
+import type { AgentSettings, CliAvailability } from "@shared/types";
 import type { AnyToolbarButtonId } from "@/../../shared/types/toolbar";
+import { isAgentInstalled } from "../../../shared/utils/agentAvailability";
 import type { ToolbarButtonIconProps, ToolbarButtonMetadata } from "./toolbarButtonMetadata";
 
 export type ToolbarSide = "left" | "right";
@@ -19,23 +22,22 @@ export interface ToolbarVisibilityMenuRows {
 
 export interface ToolbarVisibilityMenuRowSource {
   resolveMetadata: (id: AnyToolbarButtonId) => ToolbarButtonMetadata | undefined;
-  /** Whether this view could draw the button at all if it were switched on. */
-  canRender: (id: AnyToolbarButtonId) => boolean;
+  /** Whether the button belongs in the menu at all — see `canListToolbarButton`. */
+  canList: (id: AnyToolbarButtonId) => boolean;
   isOnToolbar: (id: AnyToolbarButtonId) => boolean;
 }
 
 /**
- * Rows for the toolbar's empty-space menu (#12355), one per button that holds a
- * toolbar slot, in the order the toolbar draws them.
+ * Rows for the toolbar's empty-space menu (#12355), one per listable button
+ * holding a toolbar slot, in the order the toolbar draws them.
  *
- * Takes the side lists *before* the visibility filter. Hiding a button never
- * removes its position, so those lists are exactly the set a hidden button can
- * be brought back from — which is the whole job of this menu.
+ * Takes the side lists *before* the visibility filter. Hiding a built-in, a
+ * fixed panel button or an agent keeps its position, so those lists are what a
+ * hidden button is brought back from. Launcher items and tray-promoted plugin
+ * buttons are the exception: unchecking one hands it back to the launcher or
+ * the plugin tray that owns it, and it leaves the list along with its slot.
  *
- * A row is dropped when the view has nothing to draw for it (Problems without
- * developer tools, an empty plugin tray) or no name to show it by, because a
- * checkbox that changes nothing on screen is worse than no checkbox. An id
- * sitting on both sides keeps its first row only.
+ * An id sitting on both sides keeps its first row only.
  */
 export function buildToolbarVisibilityMenuRows(
   leftButtons: readonly AnyToolbarButtonId[],
@@ -48,7 +50,7 @@ export function buildToolbarVisibilityMenuRows(
     for (const id of ids) {
       if (seen.has(id)) continue;
       seen.add(id);
-      if (!source.canRender(id)) continue;
+      if (!source.canList(id)) continue;
       const metadata = source.resolveMetadata(id);
       if (!metadata) continue;
       rows.push({
@@ -62,6 +64,38 @@ export function buildToolbarVisibilityMenuRows(
     return rows;
   };
   return { left: toRows(leftButtons, "left"), right: toRows(rightButtons, "right") };
+}
+
+/**
+ * Whether a button holding a toolbar slot belongs in the empty-space menu.
+ *
+ * It needs a renderer this view keeps. A built-in whose registry entry is off
+ * here — Problems without developer tools, disabled notifications, an empty
+ * plugin tray — would be a checkbox that changes nothing, so it drops out. A
+ * project-scoped button stays even while its slot holds a placeholder, because
+ * the preference is real: hiding Repository stats in a scratch workspace still
+ * holds once a repository opens.
+ *
+ * Agents can't be gated on `isAvailable`, which for an agent *is* its
+ * visibility and would drop exactly the hidden rows this menu exists to offer
+ * back. One is listed once the user has pinned or hidden it, or its CLI is
+ * installed. A profile that predates #11680 carries every agent id in its side
+ * arrays, and offering to pin a CLI that isn't there is noise, not recovery.
+ */
+export function canListToolbarButton(
+  id: AnyToolbarButtonId,
+  registry: Readonly<Record<string, { isAvailable: boolean }>>,
+  projectScopedIds: ReadonlySet<AnyToolbarButtonId>,
+  agentSettings: AgentSettings | null | undefined,
+  agentAvailability: CliAvailability | null | undefined
+): boolean {
+  if (!Object.hasOwn(registry, id)) return false;
+  if (isBuiltInAgentId(id)) {
+    return (
+      agentSettings?.agents?.[id]?.pinned !== undefined || isAgentInstalled(agentAvailability?.[id])
+    );
+  }
+  return registry[id]?.isAvailable === true || projectScopedIds.has(id);
 }
 
 /**

--- a/src/components/Settings/ToolbarSettingsTab.tsx
+++ b/src/components/Settings/ToolbarSettingsTab.tsx
@@ -33,7 +33,6 @@ import type {
   AnyToolbarButtonId,
   LauncherItemToolbarButtonId,
   LauncherPanelButtonId,
-  PluginToolbarButtonId,
 } from "@/../../shared/types/toolbar";
 // `@shared/...` because these are value imports — the type-only spelling above
 // is erased at compile time and never has to resolve at runtime.
@@ -42,7 +41,6 @@ import {
   isLauncherItemOnToolbar,
   isLauncherItemToolbarButtonId,
   isPanelButtonOnToolbar,
-  isLauncherPanelButtonId,
 } from "@shared/types/toolbar";
 import {
   subscribeToPanelKindRegistry,
@@ -55,7 +53,7 @@ import {
 import { useRecipeStore } from "@/store/recipeStore";
 import { useUserAgentRegistryStore } from "@/store/userAgentRegistryStore";
 import { resolveLauncherItemMetadata } from "@/components/Layout/launcherToolbarCatalog";
-import { LAUNCHABLE_AGENT_IDS, isBuiltInAgentId } from "@shared/config/agentIds";
+import { LAUNCHABLE_AGENT_IDS } from "@shared/config/agentIds";
 import { isAgentButtonOnToolbar } from "../../../shared/utils/agentPinned";
 import {
   TOOLBAR_BUTTON_METADATA,
@@ -73,7 +71,11 @@ import { DEFAULT_PLUGIN_ICON } from "@/components/icons/pluginIconRegistry";
 import { buildPluginToolbarMeta } from "@/components/Layout/pluginToolbarMeta";
 import { cn } from "@/lib/utils";
 import { DRAG_GHOST_OPACITY, EASE_OUT_EXPO, UI_ANIMATION_DURATION } from "@/lib/animationUtils";
-import { dispatchToolbarVisibility } from "@/lib/toolbarVisibilityDispatch";
+import {
+  isToolbarButtonOnToolbar,
+  setToolbarButtonOnToolbar,
+  type ToolbarButtonPlacementState,
+} from "@/lib/toolbarVisibilityDispatch";
 import { makeSortableAnnouncements } from "@/components/DragDrop/sortableAnnouncements";
 import { SettingsSection } from "./SettingsSection";
 import { SettingsSwitch } from "./SettingsSwitch";
@@ -92,12 +94,6 @@ interface SideLists {
 // a string subset. Narrow in one place so the unavoidable assertion lives here.
 function toButtonId(id: UniqueIdentifier): AnyToolbarButtonId {
   return id as AnyToolbarButtonId;
-}
-
-// Plugin button ids are namespaced `{pluginId}.{buttonId}` by main, so the dot
-// is structural — this narrows without an unsafe assertion.
-function isPluginToolbarButtonId(id: AnyToolbarButtonId): id is PluginToolbarButtonId {
-  return id.includes(".");
 }
 
 interface ToolbarButtonCardProps {
@@ -657,51 +653,30 @@ export function ToolbarSettingsTab() {
     clearDrag();
   };
 
+  // Routed through the same helper as the toolbar's own right-click menu
+  // (#12355), so the two surfaces cannot disagree about which setter owns an id.
   const handleToggle = (buttonId: AnyToolbarButtonId, side: ToolbarSide) => {
-    // A plugin id can still sit in a persisted side array (the v9 migration
-    // deliberately keeps ids a user dragged there). Its switch has to route
-    // through the promotion action: the generic toggle only alternates
-    // `false`/absent, and under tray-default neither of those is promoted, so
-    // the switch could never turn the button on (#11304).
-    if (pluginConfigs.has(buttonId) && isPluginToolbarButtonId(buttonId)) {
-      setPluginButtonPromoted(buttonId, !isVisible(buttonId));
-      return;
-    }
-    // Before the plugin check would have been wrong and after the panel check
-    // would be unreachable: a launcher item's id can carry a dot (a
-    // plugin-contributed recipe is `publisher.name`), and only the registry
-    // membership test above keeps that from reading as a plugin button here.
-    if (isLauncherItemToolbarButtonId(buttonId)) {
-      setLauncherItemOnToolbar(buttonId, !isLauncherItemOn(buttonId));
-      return;
-    }
-    // Launcher panel buttons need the same treatment for a different reason
-    // (#11667). `browser` and `dev-server` are not defaults, so the generic
-    // toggle's "delete the key to show" leaves nothing recording that the user
-    // wants them — and a stale sibling view's write, which replaces the position
-    // arrays wholesale, would then silently un-promote them with nothing left to
-    // rebuild from. `setPanelButtonOnToolbar` writes the explicit `true` that
-    // survives, and positions the button if it has no slot yet.
-    if (isLauncherPanelButtonId(buttonId)) {
-      setPanelButtonOnToolbar(buttonId, !isPanelOnToolbar(buttonId));
-      return;
-    }
-    // The explicit next state comes from the array-aware resolver, not the
-    // dispatcher's own `isAgentToolbarVisible` fallback: since #11680 an
-    // installed-but-unpositioned agent reads as visible to that fallback while
-    // rendering nothing, so the toggle would write `false` on a button the user
-    // is trying to turn on. Non-agent ids ignore the argument.
-    dispatchToolbarVisibility(
+    const placement: ToolbarButtonPlacementState = {
+      pinnedButtons: layout.pinnedButtons,
+      leftButtons: layout.leftButtons,
+      rightButtons: layout.rightButtons,
+      agentSettings,
+      agentAvailability,
+      isPluginContribution: (id) => pluginConfigs.has(id),
+    };
+    setToolbarButtonOnToolbar(
       buttonId,
       side,
+      !isToolbarButtonOnToolbar(buttonId, placement),
+      placement,
       {
-        agentSettings,
-        agentAvailability,
         setAgentPinned,
         toggleButtonVisibility,
         positionAgentButton,
-      },
-      isBuiltInAgentId(buttonId) ? !isAgentOnToolbar(buttonId) : undefined
+        setPluginButtonPromoted,
+        setPanelButtonOnToolbar,
+        setLauncherItemOnToolbar,
+      }
     );
   };
 

--- a/src/lib/__tests__/toolbarVisibilityDispatch.test.ts
+++ b/src/lib/__tests__/toolbarVisibilityDispatch.test.ts
@@ -1,9 +1,17 @@
 import { describe, it, expect, vi } from "vitest";
 import {
   dispatchToolbarVisibility,
+  isToolbarButtonOnToolbar,
+  setToolbarButtonOnToolbar,
+  type ToolbarButtonPlacementActions,
+  type ToolbarButtonPlacementState,
   type ToolbarVisibilityDispatchDeps,
 } from "@/lib/toolbarVisibilityDispatch";
+import { isToolbarButtonVisible } from "@/components/Layout/toolbarButtonMetadata";
+import { launcherItemToolbarButtonId } from "@shared/types/toolbar";
+import type { AnyToolbarButtonId, ToolbarPinnedState } from "@/../../shared/types/toolbar";
 import type { AgentSettings, CliAvailability } from "@shared/types";
+import type { AgentAvailabilityState } from "@shared/types/ipc/system";
 
 function makeDeps(
   overrides: Partial<ToolbarVisibilityDispatchDeps> = {}
@@ -119,5 +127,219 @@ describe("dispatchToolbarVisibility", () => {
     });
     dispatchToolbarVisibility("gemini", "left", deps);
     expect(deps.setAgentPinned).toHaveBeenCalledWith("gemini", true);
+  });
+});
+
+const PLUGIN_ID: AnyToolbarButtonId = "acme.deploy";
+// A plugin-contributed recipe carries a dot of its own (#12217).
+const DOTTED_RECIPE_ID = launcherItemToolbarButtonId("recipe", "publisher.name");
+
+function makeState(
+  overrides: Partial<ToolbarButtonPlacementState> = {}
+): ToolbarButtonPlacementState {
+  return {
+    pinnedButtons: {},
+    leftButtons: [],
+    rightButtons: [],
+    agentSettings: null,
+    agentAvailability: null,
+    isPluginContribution: (id) => id === PLUGIN_ID,
+    ...overrides,
+  };
+}
+
+function makeActions(): ToolbarButtonPlacementActions {
+  return {
+    setAgentPinned: vi.fn<ToolbarButtonPlacementActions["setAgentPinned"]>(),
+    toggleButtonVisibility: vi.fn<ToolbarButtonPlacementActions["toggleButtonVisibility"]>(),
+    positionAgentButton: vi.fn<ToolbarButtonPlacementActions["positionAgentButton"]>(),
+    setPluginButtonPromoted: vi.fn<ToolbarButtonPlacementActions["setPluginButtonPromoted"]>(),
+    setPanelButtonOnToolbar: vi.fn<ToolbarButtonPlacementActions["setPanelButtonOnToolbar"]>(),
+    setLauncherItemOnToolbar: vi.fn<ToolbarButtonPlacementActions["setLauncherItemOnToolbar"]>(),
+  };
+}
+
+describe("isToolbarButtonOnToolbar", () => {
+  const PARITY_IDS: AnyToolbarButtonId[] = [
+    "terminal",
+    "browser",
+    "forge-stats",
+    "launcher",
+    "claude",
+    PLUGIN_ID,
+    launcherItemToolbarButtonId("recipe", "build"),
+  ];
+  const PARITY_CASES = PARITY_IDS.flatMap((id) =>
+    [undefined, true, false].flatMap((pin) =>
+      (["ready", "missing"] satisfies AgentAvailabilityState[]).map(
+        (availability) => [id, pin, availability] as const
+      )
+    )
+  );
+
+  // The toolbar renders from `isToolbarButtonVisible`; its menu draws checkmarks
+  // from this. For a button that holds a slot the two must never disagree, or
+  // the menu would describe a toolbar other than the one on screen.
+  it.each(PARITY_CASES)(
+    "agrees with the toolbar's own filter for positioned %s (pin %s, CLI %s)",
+    (id, pin, availability) => {
+      const pinnedButtons: ToolbarPinnedState = {};
+      const agentSettings: AgentSettings = { agents: {} };
+      if (pin !== undefined) {
+        pinnedButtons[id] = pin;
+        agentSettings.agents[id] = { pinned: pin };
+      }
+      const agentAvailability: CliAvailability = { claude: availability };
+      const state = makeState({
+        pinnedButtons,
+        leftButtons: [id],
+        agentSettings,
+        agentAvailability,
+      });
+
+      expect(isToolbarButtonOnToolbar(id, state)).toBe(
+        isToolbarButtonVisible(
+          id,
+          pinnedButtons,
+          agentSettings,
+          agentAvailability,
+          state.isPluginContribution(id)
+        )
+      );
+    }
+  );
+
+  it("reads an unpositioned panel button as off unless the user promoted it", () => {
+    expect(isToolbarButtonOnToolbar("browser", makeState())).toBe(false);
+    expect(
+      isToolbarButtonOnToolbar("browser", makeState({ pinnedButtons: { browser: true } }))
+    ).toBe(true);
+  });
+
+  it("reads an installed agent with no position as off", () => {
+    const state = makeState({ agentAvailability: { claude: "ready" } });
+
+    expect(isToolbarButtonOnToolbar("claude", state)).toBe(false);
+  });
+
+  it("gives a registered contribution the tray default and an unclaimed dotted id the built-in one", () => {
+    expect(isToolbarButtonOnToolbar(PLUGIN_ID, makeState())).toBe(false);
+    expect(
+      isToolbarButtonOnToolbar(PLUGIN_ID, makeState({ isPluginContribution: () => false }))
+    ).toBe(true);
+  });
+});
+
+describe("setToolbarButtonOnToolbar", () => {
+  it("does nothing when the button already reads as requested", () => {
+    const actions = makeActions();
+
+    setToolbarButtonOnToolbar(
+      "forge-stats",
+      "right",
+      true,
+      makeState({ rightButtons: ["forge-stats"] }),
+      actions
+    );
+    setToolbarButtonOnToolbar(
+      "forge-stats",
+      "right",
+      false,
+      makeState({ rightButtons: ["forge-stats"], pinnedButtons: { "forge-stats": false } }),
+      actions
+    );
+
+    for (const action of Object.values(actions)) {
+      expect(action).not.toHaveBeenCalled();
+    }
+  });
+
+  it("brings a hidden built-in back through the generic toggle on its own side", () => {
+    const actions = makeActions();
+
+    setToolbarButtonOnToolbar(
+      "forge-stats",
+      "right",
+      true,
+      makeState({ rightButtons: ["forge-stats"], pinnedButtons: { "forge-stats": false } }),
+      actions
+    );
+
+    expect(actions.toggleButtonVisibility).toHaveBeenCalledExactlyOnceWith("forge-stats", "right");
+  });
+
+  it("promotes a registered contribution instead of toggling it", () => {
+    const actions = makeActions();
+
+    setToolbarButtonOnToolbar(
+      PLUGIN_ID,
+      "right",
+      true,
+      makeState({ rightButtons: [PLUGIN_ID] }),
+      actions
+    );
+
+    expect(actions.setPluginButtonPromoted).toHaveBeenCalledExactlyOnceWith(PLUGIN_ID, true);
+    expect(actions.toggleButtonVisibility).not.toHaveBeenCalled();
+  });
+
+  it("sends a dotted launcher item to its own setter, not the plugin one", () => {
+    const actions = makeActions();
+
+    setToolbarButtonOnToolbar(
+      DOTTED_RECIPE_ID,
+      "left",
+      true,
+      makeState({ isPluginContribution: () => false }),
+      actions
+    );
+
+    expect(actions.setLauncherItemOnToolbar).toHaveBeenCalledExactlyOnceWith(
+      DOTTED_RECIPE_ID,
+      true
+    );
+    expect(actions.setPluginButtonPromoted).not.toHaveBeenCalled();
+  });
+
+  it("shows a panel button through the panel setter, never the generic toggle", () => {
+    const actions = makeActions();
+
+    setToolbarButtonOnToolbar("browser", "left", true, makeState(), actions);
+
+    expect(actions.setPanelButtonOnToolbar).toHaveBeenCalledExactlyOnceWith("browser", true);
+    expect(actions.toggleButtonVisibility).not.toHaveBeenCalled();
+  });
+
+  it("pins an installed but unpositioned agent and asks for a position", () => {
+    const actions = makeActions();
+
+    setToolbarButtonOnToolbar(
+      "claude",
+      "left",
+      true,
+      makeState({ agentAvailability: { claude: "ready" } }),
+      actions
+    );
+
+    expect(actions.setAgentPinned).toHaveBeenCalledExactlyOnceWith("claude", true);
+    expect(actions.positionAgentButton).toHaveBeenCalledExactlyOnceWith("claude");
+  });
+
+  it("unpins a shown agent and leaves its position alone", () => {
+    const actions = makeActions();
+
+    setToolbarButtonOnToolbar(
+      "claude",
+      "left",
+      false,
+      makeState({
+        leftButtons: ["claude"],
+        agentSettings: { agents: { claude: { pinned: true } } },
+      }),
+      actions
+    );
+
+    expect(actions.setAgentPinned).toHaveBeenCalledExactlyOnceWith("claude", false);
+    expect(actions.positionAgentButton).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/toolbarVisibilityDispatch.ts
+++ b/src/lib/toolbarVisibilityDispatch.ts
@@ -1,7 +1,21 @@
 import { isBuiltInAgentId } from "@shared/config/agentIds";
 import type { AgentSettings, CliAvailability } from "@shared/types";
-import type { AnyToolbarButtonId } from "@/../../shared/types/toolbar";
-import { isAgentToolbarVisible } from "../../shared/utils/agentPinned";
+import type {
+  AnyToolbarButtonId,
+  LauncherItemToolbarButtonId,
+  LauncherPanelButtonId,
+  PluginToolbarButtonId,
+  ToolbarPinnedState,
+} from "@/../../shared/types/toolbar";
+// `@shared/...` because these are value imports — the type-only spelling above
+// is erased at compile time and never has to resolve at runtime.
+import {
+  isLauncherItemOnToolbar,
+  isLauncherItemToolbarButtonId,
+  isLauncherPanelButtonId,
+  isPanelButtonOnToolbar,
+} from "@shared/types/toolbar";
+import { isAgentButtonOnToolbar, isAgentToolbarVisible } from "../../shared/utils/agentPinned";
 
 export interface ToolbarVisibilityDispatchDeps {
   agentSettings: AgentSettings | null | undefined;
@@ -70,4 +84,139 @@ export function dispatchToolbarVisibility(
     return;
   }
   deps.toggleButtonVisibility(buttonId, side);
+}
+
+// Plugin button ids are namespaced `{pluginId}.{buttonId}` by main, so the dot
+// is structural — this narrows without an unsafe assertion. It is only a
+// discriminator alongside registry membership: a launcher item's id can carry a
+// dot too.
+export function isPluginToolbarButtonId(id: AnyToolbarButtonId): id is PluginToolbarButtonId {
+  return id.includes(".");
+}
+
+/** Everything the per-category placement resolvers read. */
+export interface ToolbarButtonPlacementState {
+  pinnedButtons: ToolbarPinnedState;
+  leftButtons: AnyToolbarButtonId[];
+  rightButtons: AnyToolbarButtonId[];
+  agentSettings: AgentSettings | null | undefined;
+  agentAvailability: CliAvailability | null | undefined;
+  /**
+   * Live plugin registry membership — the discriminator for a contribution,
+   * never string-parsing the dotted id (#11304).
+   */
+  isPluginContribution: (buttonId: AnyToolbarButtonId) => boolean;
+}
+
+export interface ToolbarButtonPlacementActions {
+  setAgentPinned: ToolbarVisibilityDispatchDeps["setAgentPinned"];
+  toggleButtonVisibility: ToolbarVisibilityDispatchDeps["toggleButtonVisibility"];
+  positionAgentButton: (buttonId: AnyToolbarButtonId) => void;
+  setPluginButtonPromoted: (buttonId: PluginToolbarButtonId, promoted: boolean) => void;
+  setPanelButtonOnToolbar: (buttonId: LauncherPanelButtonId, onToolbar: boolean) => void;
+  setLauncherItemOnToolbar: (buttonId: LauncherItemToolbarButtonId, onToolbar: boolean) => void;
+}
+
+/**
+ * Whether a button currently has its own top-level toolbar slot, read through
+ * the resolver that owns its category.
+ *
+ * The array-aware resolvers rather than `isToolbarButtonVisible`: away from the
+ * side arrays that predicate's "absent means visible" default reports a fresh
+ * profile's `browser` and an installed-but-unpositioned agent as on while
+ * neither is anywhere on the toolbar (#11667, #11680). For a positioned id the
+ * two agree, which is what lets a surface draw checkmarks from this and still
+ * match the toolbar it describes.
+ */
+export function isToolbarButtonOnToolbar(
+  buttonId: AnyToolbarButtonId,
+  state: ToolbarButtonPlacementState
+): boolean {
+  if (state.isPluginContribution(buttonId) && isPluginToolbarButtonId(buttonId)) {
+    return state.pinnedButtons[buttonId] === true;
+  }
+  if (isLauncherItemToolbarButtonId(buttonId)) {
+    return isLauncherItemOnToolbar(buttonId, state.pinnedButtons);
+  }
+  if (isLauncherPanelButtonId(buttonId)) {
+    return isPanelButtonOnToolbar(
+      buttonId,
+      state.pinnedButtons,
+      state.leftButtons,
+      state.rightButtons
+    );
+  }
+  if (isBuiltInAgentId(buttonId)) {
+    return isAgentButtonOnToolbar(
+      state.agentSettings?.agents?.[buttonId],
+      state.agentAvailability?.[buttonId],
+      state.leftButtons.includes(buttonId) || state.rightButtons.includes(buttonId)
+    );
+  }
+  return state.pinnedButtons[buttonId] !== false;
+}
+
+/**
+ * Give a button its own top-level toolbar slot, or take it away, through the
+ * setter that owns its category. Settings → Toolbar and the toolbar's own
+ * right-click menu (#12355) both route through here so they cannot disagree.
+ *
+ * A no-op when the button already reads as requested: `toggleButtonVisibility`
+ * can only flip, so a caller holding a stale checkmark would otherwise invert
+ * the very state it asked for.
+ */
+export function setToolbarButtonOnToolbar(
+  buttonId: AnyToolbarButtonId,
+  side: "left" | "right",
+  onToolbar: boolean,
+  state: ToolbarButtonPlacementState,
+  actions: ToolbarButtonPlacementActions
+): void {
+  if (isToolbarButtonOnToolbar(buttonId, state) === onToolbar) return;
+
+  // A plugin id can still sit in a persisted side array (the v9 migration
+  // deliberately keeps ids a user dragged there). Its switch has to route
+  // through the promotion action: the generic toggle only alternates
+  // `false`/absent, and under tray-default neither of those is promoted, so
+  // the switch could never turn the button on (#11304).
+  if (state.isPluginContribution(buttonId) && isPluginToolbarButtonId(buttonId)) {
+    actions.setPluginButtonPromoted(buttonId, onToolbar);
+    return;
+  }
+  // Before the plugin check would have been wrong and after the panel check
+  // would be unreachable: a launcher item's id can carry a dot (a
+  // plugin-contributed recipe is `publisher.name`), and only the registry
+  // membership test above keeps that from reading as a plugin button here.
+  if (isLauncherItemToolbarButtonId(buttonId)) {
+    actions.setLauncherItemOnToolbar(buttonId, onToolbar);
+    return;
+  }
+  // Launcher panel buttons need the same treatment for a different reason
+  // (#11667). `browser` and `dev-server` are not defaults, so the generic
+  // toggle's "delete the key to show" leaves nothing recording that the user
+  // wants them — and a stale sibling view's write, which replaces the position
+  // arrays wholesale, would then silently un-promote them with nothing left to
+  // rebuild from. `setPanelButtonOnToolbar` writes the explicit `true` that
+  // survives, and positions the button if it has no slot yet.
+  if (isLauncherPanelButtonId(buttonId)) {
+    actions.setPanelButtonOnToolbar(buttonId, onToolbar);
+    return;
+  }
+  // Agents get the explicit next state rather than the dispatcher's own
+  // `isAgentToolbarVisible` fallback: since #11680 an installed-but-unpositioned
+  // agent reads as visible to that fallback while rendering nothing, so a flip
+  // would write `false` on a button the user is trying to turn on. Non-agent ids
+  // ignore the argument.
+  dispatchToolbarVisibility(
+    buttonId,
+    side,
+    {
+      agentSettings: state.agentSettings,
+      agentAvailability: state.agentAvailability,
+      setAgentPinned: actions.setAgentPinned,
+      toggleButtonVisibility: actions.toggleButtonVisibility,
+      positionAgentButton: actions.positionAgentButton,
+    },
+    isBuiltInAgentId(buttonId) ? onToolbar : undefined
+  );
 }

--- a/src/lib/toolbarVisibilityDispatch.ts
+++ b/src/lib/toolbarVisibilityDispatch.ts
@@ -125,8 +125,9 @@ export interface ToolbarButtonPlacementActions {
  * side arrays that predicate's "absent means visible" default reports a fresh
  * profile's `browser` and an installed-but-unpositioned agent as on while
  * neither is anywhere on the toolbar (#11667, #11680). For a positioned id the
- * two agree, which is what lets a surface draw checkmarks from this and still
- * match the toolbar it describes.
+ * two agree — assistant-only agents aside, which no toolbar surface lists —
+ * and that is what lets a surface draw checkmarks from this and still match the
+ * toolbar it describes.
  */
 export function isToolbarButtonOnToolbar(
   buttonId: AnyToolbarButtonId,


### PR DESCRIPTION
## Summary

- Right-clicking empty toolbar space now opens a menu listing every button holding a toolbar slot as a checkbox, hidden ones unchecked, grouped left and right, plus a "Customize toolbar…" entry that opens settings on the toolbar tab.
- This gives a hidden button a way back from the same place it was hidden. It matters most for `forge-stats`, which has no launcher home to be relaunched from.
- Show/hide routing for each button category is now shared between the settings toggle and this new menu, so both go through the same logic and no-op when a button's already in the requested state.

Resolves #12355

## Changes

- `src/lib/toolbarVisibilityDispatch.ts`: extracted per-category routing into `isToolbarButtonOnToolbar` and `setToolbarButtonOnToolbar` (plugin → `setPluginButtonPromoted`, launcher item → `setLauncherItemOnToolbar`, panel button → `setPanelButtonOnToolbar`, agent/generic → `dispatchToolbarVisibility`). Settings → Toolbar's `handleToggle` now delegates to it, so both surfaces route identically.
- `src/components/Layout/toolbarVisibilityMenu.ts`: a pure row builder. `canListToolbarButton` requires built-ins to have an available renderer or project scope, and requires agents to be pinned, hidden, or CLI-installed before they show up, so a profile with a lot of uninstalled CLIs isn't swamped with rows. `isToolbarEmptySpaceTarget` checks `.app-no-drag` / `[data-toolbar-button-id]` / `[data-toolbar-item]` and DOM containment so the menu never opens over portaled content.
- `src/components/Layout/ToolbarButtonsContextMenu.tsx`: clones the toolbar root with a composed `onContextMenu` and replays empty-space right-clicks onto a hidden sibling Radix trigger. This keeps Radix's touch long-press timer off the toolbar root; buttons with their own context menus still win. The trigger is held in state rather than a ref, because a ref read inside a handler passed through `cloneElement` is a React Compiler error that fails the dev transform.
- `Toolbar.tsx`: split the side lists into `positioned*` (pre-visibility) and `effective*` (rendered, same output as before since grouping is a stable partition) and wired up the rows and toggle.

## Platform notes

- macOS delivers `contextmenu` from a `-webkit-app-region: drag` area (fixed upstream in electron#44761), and Linux windows are framed, so both open the menu.
- On Windows the toolbar's empty space is a caption drag region, so the native system menu appears there instead and this menu isn't reachable. Every button's own menu still has "Customize toolbar…". Bridging it would need a synchronous main-process hit test that knows about the other top-strip drag regions, which I couldn't verify on macOS or CI.
- There's no keyboard route to this menu, since nothing non-interactive in that space is focusable.
- Launcher items and tray-promoted plugin buttons drop off the list when unchecked, since their launcher or tray owns them from there.

## Testing

- Targeted vitest: 24 files / 977 tests, including a new suite for `ToolbarButtonsContextMenu` (real Radix), `toolbarVisibilityMenu`, a dispatch parity table, `ToolbarSettingsTab`, `agentPinSync`, and all `Toolbar.*` source-contract suites.
- `src/config/__tests__`: 504 tests.
- eslint clean on the changed lines, prettier clean, `npm run compiler-budget:critical` shows none of these files.
- Full suite, typecheck, and build run in CI.