### PR TITLE
fix(plugins): quieter host chrome above a plugin's empty canvas

### DIFF
--- a/e2e/screenshots/project-surface-strip-review.spec.ts
+++ b/e2e/screenshots/project-surface-strip-review.spec.ts
@@ -1,0 +1,587 @@
+/**
+ * Project-surface strip visual-review harness.
+ *
+ * Drives `ProjectSurfaceFrame` — the host chrome Daintree keeps above a project
+ * plugin's `emptyCanvas` surface — through every state that carries design
+ * weight, and writes a PNG of the canvas for each.
+ *
+ * This strip only exists when a project-local plugin claims the empty-canvas
+ * slot, so it can only be judged in that context: it is thin host chrome framing
+ * someone else's full-bleed view, and the question it has to answer is whether
+ * it stays subordinate to the content below it. The first-show consent notice is
+ * the same story at a different scale — it renders once, stacked on a 32px bar,
+ * and its proportion against that bar is the whole design problem.
+ *
+ * Sibling of `canvas-home-review.spec.ts`, which owns the stock canvas this
+ * strip switches back to.
+ *
+ * NOT covered, both for the same reason — the state cannot be reached from the
+ * renderer, so a capture of it would have to be staged rather than driven:
+ *
+ *   - A plugin view that fails to load. That path replaces the region with the
+ *     host's own error content and never renders the strip's surface half, so it
+ *     is a different surface.
+ *   - The failed-save banner. It needs `plugin.setProjectSurfaceChoice` to
+ *     reject, and the bridge is a contextBridge object: neither assignment nor
+ *     `defineProperty` takes, and every route that does not go through the
+ *     bridge stages the banner into a shape the app cannot actually reach. It is
+ *     reviewed from source, and owned by
+ *     `src/components/Plugin/__tests__/ProjectSurfaceFrame.test.tsx`.
+ *
+ * Opt-in only: skips itself unless DAINTREE_SHOT_THEME is set, so neither the
+ * marketing screenshots workflow nor a bare `--project=screenshots` runs it.
+ *
+ *   DAINTREE_SHOT_THEME=daintree npx playwright test --project=screenshots project-surface-strip-review
+ *
+ * Env knobs:
+ *   DAINTREE_SHOT_THEME  required — theme id to render (e.g. daintree, bondi)
+ *   DAINTREE_SHOT_DIR    optional absolute output dir (default artifacts/…)
+ *   DAINTREE_SHOT_TAG    optional suffix to keep before/after rounds side by side
+ *   DAINTREE_SHOT_ONLY   comma-separated step filter (see STEPS below)
+ *   DAINTREE_SCREENSHOT_SCALE  device scale factor (default 2)
+ *
+ * Output: <dir>/<theme>/<NN-slug>[-tag].png plus a `-strip` tight crop of the
+ * chrome itself for each full-canvas shot (gitignored).
+ */
+
+import { expect, test, type Page } from "@playwright/test";
+import { createHash } from "crypto";
+import { mkdirSync, rmSync, existsSync, readdirSync, readFileSync, writeFileSync } from "fs";
+import { mkdtempSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+import { launchApp, closeApp, type AppContext } from "../helpers/launch";
+import { openAndOnboardProject } from "../helpers/project";
+import { dismissBlockingPalette } from "../helpers/overlays";
+import { setAppTheme } from "../helpers/theme";
+import { createFixtureRepo, type FixtureRepo } from "../helpers/fixtures";
+import { SEL } from "../helpers/selectors";
+import { T_LONG } from "../helpers/timeouts";
+
+const THEME = process.env.DAINTREE_SHOT_THEME ?? "";
+const TAG = process.env.DAINTREE_SHOT_TAG ? `-${process.env.DAINTREE_SHOT_TAG}` : "";
+const SCALE = process.env.DAINTREE_SCREENSHOT_SCALE ?? "2";
+const OUTPUT_DIR = path.join(
+  process.env.DAINTREE_SHOT_DIR ?? path.resolve(process.cwd(), "artifacts", "surface-strip-shots"),
+  THEME || "unset"
+);
+
+const CANVAS = "#panel-grid";
+const STRIP = '[data-testid="project-surface-strip"]';
+const FRAME = '[data-testid="project-surface-frame"]';
+
+const WIDE = { width: 1680, height: 1050 };
+
+const PLUGIN_ID = "acme.mission-control";
+
+/**
+ * Every shot this harness owes, in capture order. Kept as data rather than
+ * spelled only inside the steps so the run can count what actually landed on
+ * disk against what was promised — an exit code alone has never been evidence
+ * that a capture harness produced anything.
+ */
+const STEPS = [
+  { name: "first-show", slug: "01-first-show" },
+  { name: "rest", slug: "02-rest-surface" },
+  { name: "stock", slug: "03-stock-launcher" },
+  { name: "focus", slug: "04-focus-switch" },
+  { name: "narrow", slug: "05-narrow" },
+  { name: "long-name", slug: "06-long-name" },
+  { name: "narrow-long-name", slug: "07-narrow-long-name" },
+  { name: "forced-colors", slug: "08-forced-colors" },
+  { name: "contrast-more", slug: "09-contrast-more" },
+  { name: "narrow-notice", slug: "10-narrow-notice" },
+] as const;
+
+// Freeze animations and hide carets so captures are deterministic. The segment
+// thumb slides between segments on every switch, and a mid-transition frame
+// reads as a misaligned control that isn't.
+const POLISH_CSS = `
+  ::-webkit-scrollbar { display: none !important; width: 0 !important; height: 0 !important; }
+  *, *::before, *::after {
+    animation-duration: 0s !important;
+    animation-delay: 0s !important;
+    transition-duration: 0s !important;
+    transition-delay: 0s !important;
+    caret-color: transparent !important;
+  }
+`;
+
+/**
+ * A project-local plugin claiming the empty-canvas slot.
+ *
+ * The panel deliberately draws its own full-bleed content AND pins a toolbar
+ * into its top-right corner. That corner is the documented hazard this strip
+ * exists to stay out of, and a fixture whose plugin draws nothing there would
+ * photograph a collision that cannot happen. `panelName` is a parameter because
+ * the switch's first segment carries it, and a name that always fits hides the
+ * truncation the 32-char cap is for.
+ */
+function writeSurfacePlugin(projectDir: string, panelName: string): void {
+  const root = path.join(projectDir, ".daintree", "plugins", PLUGIN_ID);
+  mkdirSync(path.join(root, "dist"), { recursive: true });
+  writeFileSync(path.join(root, "package.json"), JSON.stringify({ type: "module", private: true }));
+  writeFileSync(
+    path.join(root, "plugin.json"),
+    JSON.stringify(
+      {
+        name: PLUGIN_ID,
+        version: "0.1.0",
+        scope: "project",
+        displayName: "Mission Control",
+        description: "The project's own canvas.",
+        main: "dist/index.js",
+        engines: { daintree: ">=0.11.0" },
+        capabilities: [],
+        contributes: {
+          panels: [
+            {
+              id: "overview",
+              name: panelName,
+              iconId: "monitor-play",
+              color: "var(--theme-category-rose)",
+              hasPty: false,
+              canRestart: false,
+              canConvert: false,
+              showInPalette: true,
+            },
+          ],
+          views: [{ id: "overview", componentPath: "dist/panel.js", location: "panel" }],
+          surfaces: { emptyCanvas: { viewId: "overview" } },
+        },
+      },
+      null,
+      2
+    )
+  );
+  writeFileSync(
+    path.join(root, "dist/index.js"),
+    "export async function activate() { return () => {}; }"
+  );
+  // Plain ESM, no build step: the view loader takes the module as written.
+  writeFileSync(
+    path.join(root, "dist/panel.js"),
+    `
+    import { createElement as h } from "react";
+    const card = (title, meta, tone) =>
+      h("div", {
+        key: title,
+        style: {
+          border: "1px solid rgba(128,128,128,0.22)", borderRadius: 10, padding: "14px 16px",
+          display: "flex", flexDirection: "column", gap: 8, minHeight: 96,
+          background: "rgba(128,128,128,0.06)",
+        },
+      },
+        h("div", { style: { fontSize: 13, fontWeight: 600, opacity: 0.92 } }, title),
+        h("div", { style: { fontSize: 11, opacity: 0.55 } }, meta),
+        h("div", { style: { marginTop: "auto", height: 4, borderRadius: 2, background: tone } })
+      );
+    export default function Panel() {
+      return h("div", {
+        "data-testid": "plugin-surface",
+        style: { position: "absolute", inset: 0, display: "flex", flexDirection: "column", overflow: "hidden" },
+      },
+        h("div", {
+          style: {
+            display: "flex", alignItems: "center", justifyContent: "space-between",
+            padding: "18px 24px 10px",
+          },
+        },
+          h("div", { style: { fontSize: 20, fontWeight: 600 } }, "Mission Control"),
+          h("div", { style: { display: "flex", gap: 8 } },
+            h("button", { type: "button", style: { fontSize: 12, padding: "5px 10px", borderRadius: 6, border: "1px solid rgba(128,128,128,0.28)", background: "transparent", color: "inherit" } }, "Refresh"),
+            h("button", { type: "button", style: { fontSize: 12, padding: "5px 10px", borderRadius: 6, border: "1px solid rgba(128,128,128,0.28)", background: "transparent", color: "inherit" } }, "New run")
+          )
+        ),
+        h("div", {
+          style: {
+            display: "grid", gap: 12, padding: "6px 24px 24px",
+            gridTemplateColumns: "repeat(auto-fill, minmax(240px, 1fr))", overflow: "auto",
+          },
+        },
+          card("Device flow refresh", "staged · 3 gates green", "rgba(110,190,130,0.8)"),
+          card("Retry backoff jitter", "drafting · 1 gate red", "rgba(220,150,90,0.8)"),
+          card("Pulse heatmap alignment", "final · shipped", "rgba(120,160,220,0.8)"),
+          card("Palette density pass", "staged · 2 gates green", "rgba(110,190,130,0.8)"),
+          card("Worktree rail spacing", "drafting", "rgba(150,150,150,0.6)"),
+          card("Forced-colors sweep", "queued", "rgba(150,150,150,0.6)")
+        )
+      );
+    }
+  `
+  );
+}
+
+async function settle(page: Page, ms = 350): Promise<void> {
+  await page.evaluate(
+    () => new Promise<void>((r) => requestAnimationFrame(() => requestAnimationFrame(() => r())))
+  );
+  await page.waitForTimeout(ms);
+}
+
+/**
+ * Wait until the plugin's panel kind is registered.
+ *
+ * A project plugin is discovered, activated and registered out of process, and
+ * the surface claim is only published once its view has a resolvable panel
+ * kind behind it. None of that is instant, and until it lands the region draws
+ * the stock canvas — which is a perfectly plausible screenshot of the wrong
+ * thing. So gate on the kind, not on a timeout.
+ */
+async function waitForPluginKind(page: Page): Promise<void> {
+  await expect
+    .poll(
+      async () =>
+        (await page.evaluate(() => window.electron.plugin.getPanelKinds())).some((kind) =>
+          kind.extensionId?.includes(PLUGIN_ID)
+        ),
+      { timeout: 90_000, message: `${PLUGIN_ID} never registered its panel kind` }
+    )
+    .toBe(true);
+}
+
+/**
+ * Wait for the frame to be what the canvas region is drawing. The frame's own
+ * testid is the marker: the strip is inside it, and the stock canvas renders
+ * neither, so this distinguishes "the plugin claimed the slot" from "the claim
+ * has not arrived yet" — which look identical if you wait on the canvas alone.
+ */
+async function waitForFrame(page: Page): Promise<void> {
+  await page.locator(CANVAS).waitFor({ state: "visible", timeout: T_LONG });
+  await waitForPluginKind(page);
+  await page.locator(FRAME).waitFor({ state: "visible", timeout: T_LONG });
+  await page.locator(STRIP).waitFor({ state: "visible", timeout: T_LONG });
+  await settle(page, 600);
+}
+
+async function reload(page: Page): Promise<void> {
+  await page.reload({ waitUntil: "domcontentloaded" });
+  await page.locator(SEL.toolbar.toggleSidebar).waitFor({ state: "visible", timeout: T_LONG });
+  await page.addStyleTag({ content: POLISH_CSS }).catch(() => {});
+  await dismissBlockingPalette(page);
+  await waitForFrame(page);
+}
+
+/**
+ * Clip to the canvas region — the box the frame is handed and has to compose
+ * within. Judging the strip needs the content under it in shot: its whole job
+ * is to stay quieter than that content, which an element-tight crop of the
+ * strip alone cannot show. A second tight crop of the strip goes out beside it
+ * for the detail the wide shot loses.
+ *
+ * Throws when a file did not land. A harness that writes a success artifact it
+ * has not verified is worse than one that fails.
+ */
+async function snap(page: Page, slug: string): Promise<void> {
+  await settle(page);
+  const box = await page.locator(CANVAS).first().boundingBox();
+  if (!box) throw new Error(`no bounding box for ${CANVAS}`);
+  const file = path.join(OUTPUT_DIR, `${slug}${TAG}.png`);
+  await page.screenshot({
+    path: file,
+    type: "png",
+    animations: "disabled",
+    caret: "hide",
+    clip: { x: box.x, y: box.y, width: box.width, height: box.height },
+  });
+  if (!existsSync(file)) throw new Error(`screenshot did not land at ${file}`);
+
+  const strip = await page.locator(STRIP).first().boundingBox();
+  if (strip) {
+    // Two strip heights of context below the chrome: enough to read the seam
+    // between host and plugin, which is where visual weight is actually judged.
+    const stripFile = path.join(OUTPUT_DIR, `${slug}${TAG}-strip.png`);
+    await page.screenshot({
+      path: stripFile,
+      type: "png",
+      animations: "disabled",
+      caret: "hide",
+      clip: {
+        x: box.x,
+        y: strip.y,
+        width: box.width,
+        height: Math.min(strip.height * 6, box.y + box.height - strip.y),
+      },
+    });
+    if (!existsSync(stripFile)) throw new Error(`strip crop did not land at ${stripFile}`);
+  }
+}
+
+/** Answer the first-show question through the store's own seam. */
+async function setChoice(page: Page, choice: "surface" | "stock" | null): Promise<void> {
+  await page.evaluate(async (next) => {
+    await window.electron.plugin.setProjectSurfaceChoice("emptyCanvas", next);
+  }, choice);
+  await settle(page, 500);
+}
+
+/**
+ * Assert which half of the switch is showing before photographing it.
+ *
+ * The duplicate-hash check at the end catches a step that drove nothing at all,
+ * but not a step that drove the WRONG thing: a capture of the stock launcher
+ * when the plugin's surface was meant to be up differs from every other frame,
+ * so it sails through the hash check and looks entirely plausible on disk. This
+ * caught exactly that — three states silently captured against the stock canvas
+ * because a stub never took.
+ */
+async function expectShowing(page: Page, mode: "surface" | "stock"): Promise<void> {
+  const pressed = await page
+    .locator(`${STRIP} button[aria-pressed="true"]`)
+    .first()
+    .textContent()
+    .catch(() => null);
+  if (pressed === null) throw new Error(`no pressed segment in the strip (wanted ${mode})`);
+  const isStock = pressed.trim() === "Launcher";
+  const showing = isStock ? "stock" : "surface";
+  if (showing !== mode) throw new Error(`strip is showing "${showing}", wanted "${mode}"`);
+}
+
+const ONLY = (process.env.DAINTREE_SHOT_ONLY ?? "").split(",").filter(Boolean);
+const stepFailures: string[] = [];
+
+/**
+ * Run a capture step. A failure never stops the remaining shots — one missing
+ * state should not cost the whole sweep — but it IS recorded, and the test
+ * fails at the end.
+ */
+async function step(name: string, fn: () => Promise<void>): Promise<void> {
+  if (ONLY.length > 0 && !ONLY.includes(name)) return;
+  try {
+    await fn();
+  } catch (error) {
+    const detail = String(error).split("\n")[0];
+    console.warn(`[surface-strip-shots] step "${name}" FAILED:`, detail);
+    stepFailures.push(`${name}: ${detail}`);
+  }
+}
+
+test("project surface strip review — host chrome above a plugin's canvas", async () => {
+  test.info().annotations.push({
+    type: "conditional-skip",
+    description: "DAINTREE_SHOT_THEME is required for the project-surface-strip capture",
+  });
+  test.skip(!THEME, "Set DAINTREE_SHOT_THEME to run the project-surface-strip capture");
+  // Nine states, each with a settle, and two of them reload the whole app to
+  // pick up a rewritten manifest. Plugin activation alone can take most of a
+  // minute on a loaded machine.
+  test.setTimeout(600_000);
+
+  mkdirSync(OUTPUT_DIR, { recursive: true });
+  let repo: FixtureRepo | undefined;
+  // Prefix deliberately avoids "daintree-e2e" — launchApp's pre-launch hygiene
+  // pkills that pattern, and parallel theme captures would SIGKILL each other.
+  const userDataDir = mkdtempSync(path.join(tmpdir(), "daintree-stripshot-"));
+
+  let ctx: AppContext | undefined;
+  try {
+    repo = createFixtureRepo({ name: "mission-control" });
+    writeSurfacePlugin(repo.dir, "Videos");
+
+    ctx = await launchApp({
+      userDataDir,
+      screenshotScale: SCALE,
+      windowSize: WIDE,
+      extraArgs: ["--disable-gpu", "--in-process-gpu", "--disable-breakpad", "--noerrdialogs"],
+    });
+
+    const page = await openAndOnboardProject(ctx.app, ctx.window, repo.dir, "Mission Control");
+    // Project plugins are trust-gated and load for nobody until the project is
+    // trusted. Without this the region draws the stock canvas forever and every
+    // capture is a picture of the surface this harness is not about.
+    await page.evaluate(() => window.electron.plugin.setProjectPluginTrust("enabled"));
+    await setAppTheme(page, THEME);
+    await page.addStyleTag({ content: POLISH_CSS }).catch(() => {});
+    await dismissBlockingPalette(page);
+    await waitForFrame(page);
+    await dismissBlockingPalette(page);
+
+    // 1. The first-show consent notice, unanswered. This is what a project sees
+    // exactly once, and it is the state the strip is stacked under.
+    await step("first-show", async () => {
+      await expectShowing(page, "surface");
+      await snap(page, "01-first-show");
+    });
+
+    // 2. Answered "keep it": the strip at rest over the plugin's canvas. The
+    // state every subsequent session of this project opens in, and the one the
+    // strip is actually judged on.
+    await step("rest", async () => {
+      await setChoice(page, "surface");
+      await waitForFrame(page);
+      await expectShowing(page, "surface");
+      await snap(page, "02-rest-surface");
+    });
+
+    // 3. Switched back to the stock launcher. The strip loses its status text
+    // and its palette entry here, because the canvas below carries both — so
+    // this is where the chrome is at its emptiest and any leftover weight shows.
+    await step("stock", async () => {
+      await setChoice(page, "stock");
+      await settle(page, 700);
+      await expectShowing(page, "stock");
+      await snap(page, "03-stock-launcher");
+      await setChoice(page, "surface");
+      await waitForFrame(page);
+    });
+
+    // 4. Keyboard focus on the switch. This region is reached by keyboard as
+    // often as by pointer and the ring is the only thing that says where you
+    // landed. Tabbed, never `.focus()`: Chromium only sets `:focus-visible` for
+    // keyboard-driven focus, so a programmatic focus photographs the rest state
+    // and calls it a focus ring.
+    await step("focus", async () => {
+      await page.locator(CANVAS).click({ position: { x: 8, y: 8 } });
+      let reached = false;
+      for (let press = 0; press < 40 && !reached; press++) {
+        await page.keyboard.press("Tab");
+        reached = await page
+          .locator(`${STRIP} button`)
+          .first()
+          .evaluate((el) => el === document.activeElement)
+          .catch(() => false);
+      }
+      if (!reached) throw new Error("Tab never reached the strip's first control");
+      await settle(page, 300);
+      await expectShowing(page, "surface");
+      await snap(page, "04-focus-switch");
+      await page.keyboard.press("Escape").catch(() => {});
+      await settle(page, 200);
+    });
+
+    // 5. A narrow canvas. Everything in the strip competes for one row, so this
+    // is where the status text and the palette entry either survive or clip.
+    await step("narrow", async () => {
+      await page.setViewportSize({ width: 900, height: WIDE.height });
+      await settle(page, 900);
+      await expectShowing(page, "surface");
+      await snap(page, "05-narrow");
+      await page.setViewportSize(WIDE);
+      await settle(page, 600);
+    });
+
+    // 6. A panel name at the 32-character cap. The manifest sets no length
+    // limit, and the segment carrying the name is half of the way back.
+    await step("long-name", async () => {
+      writeSurfacePlugin(repo!.dir, "Mission Control — Slate, Gates & Final Artifacts");
+      await reload(page);
+      await expectShowing(page, "surface");
+      await snap(page, "06-long-name");
+      writeSurfacePlugin(repo!.dir, "Videos");
+      await reload(page);
+    });
+
+    // 7. The combination, which is the only state where the width guard is
+    // actually load-bearing: a name at the character cap AND a window too narrow
+    // to hold it. Either alone fits, so either alone proves nothing — the cap
+    // bounds characters, not rendered width, and it is this pairing that decides
+    // whether the Launcher segment, the way back, survives.
+    await step("narrow-long-name", async () => {
+      writeSurfacePlugin(repo!.dir, "Mission Control — Slate, Gates & Final Artifacts");
+      await reload(page);
+      await page.setViewportSize({ width: 720, height: WIDE.height });
+      await settle(page, 900);
+      await expectShowing(page, "surface");
+      // The way back has to still be there, and still be pressable.
+      const launcher = page.locator(`${STRIP} button`).nth(1);
+      const box = await launcher.boundingBox();
+      if (!box || box.width < 8)
+        throw new Error("the Launcher segment was squeezed out of the row");
+      await snap(page, "07-narrow-long-name");
+      await page.setViewportSize(WIDE);
+      await settle(page, 600);
+      writeSurfacePlugin(repo!.dir, "Videos");
+      await reload(page);
+    });
+
+    // 8-9. The two accessibility media modes. `forced-colors: active` throws the
+    // theme's tokens away and redraws from system keywords — the segment thumb
+    // is a background fill, which is exactly what does not survive there — and
+    // `prefers-contrast: more` swaps in the high-contrast block.
+    await step("forced-colors", async () => {
+      await expectShowing(page, "surface");
+      await page.emulateMedia({ forcedColors: "active" });
+      await settle(page, 600);
+      await snap(page, "08-forced-colors");
+      await page.emulateMedia({ forcedColors: "none" });
+      await settle(page, 400);
+    });
+
+    await step("contrast-more", async () => {
+      await expectShowing(page, "surface");
+      await page.emulateMedia({ contrast: "more" });
+      await settle(page, 600);
+      await snap(page, "09-contrast-more");
+      await page.emulateMedia({ contrast: "no-preference" });
+      await settle(page, 400);
+    });
+
+    // 10. The first-show question, unanswered, at a narrow width, with a long
+    // plugin name. This is the notice's worst case and the only state where its
+    // wrap behaviour is load-bearing: the question and both answers cannot share
+    // one line here, and the two ways to lose are overflowing the answers
+    // off-canvas or truncating the question away to a bare plugin name. Every
+    // other capture answers the question long before it gets narrow, so without
+    // this step the row's hardest moment is never photographed.
+    await step("narrow-notice", async () => {
+      writeSurfacePlugin(repo!.dir, "Mission Control — Slate, Gates & Final Artifacts");
+      await reload(page);
+      await setChoice(page, null);
+      await page.setViewportSize({ width: 720, height: WIDE.height });
+      await settle(page, 900);
+      await waitForFrame(page);
+      // Addressed by role, not a testid: the notice is an `InlineStatusBanner`,
+      // whose props are a closed set — `role="status"` IS its handle. Scoped to
+      // a direct child of the frame, because the running app has several other
+      // live regions and a bare role lookup matches all of them.
+      const notice = page.locator(`${FRAME} > [role="status"]`);
+      await notice.waitFor({ state: "visible", timeout: T_LONG });
+      // Both answers still have to be on screen and pressable. Overflowing them
+      // off the canvas is the failure this state exists to catch, and it looks
+      // perfectly fine in a screenshot cropped to the canvas.
+      const canvas = await page.locator(CANVAS).first().boundingBox();
+      for (const label of ["Keep it", "Use the launcher"]) {
+        const box = await notice.getByRole("button", { name: label }).boundingBox();
+        if (!box || !canvas) throw new Error(`no box for the ${label} answer`);
+        if (box.x < canvas.x || box.x + box.width > canvas.x + canvas.width + 1) {
+          throw new Error(`the ${label} answer overflowed the canvas`);
+        }
+      }
+      await snap(page, "10-narrow-notice");
+      await page.setViewportSize(WIDE);
+      await settle(page, 600);
+    });
+
+    // Count what landed against what was promised. The exit code says only that
+    // no step threw; this says the sweep actually produced its artifacts.
+    const expected = STEPS.filter((s) => ONLY.length === 0 || ONLY.includes(s.name)).map(
+      (s) => `${s.slug}${TAG}.png`
+    );
+    const present = new Set(readdirSync(OUTPUT_DIR));
+    const missing = expected.filter((f) => !present.has(f));
+
+    // Two states that render byte-identically mean one of them never actually
+    // happened — a step that drove nothing still writes a perfectly plausible
+    // PNG of the state before it, which is the worst artifact a capture harness
+    // can produce. Same-viewport states only: a resize changes every pixel, so
+    // cross-size pairs can never collide and would only add noise.
+    const SAME_VIEWPORT = expected.filter((f) => !/^(0[57]|10)-/.test(f));
+    const byHash = new Map<string, string[]>();
+    for (const file of SAME_VIEWPORT) {
+      if (!present.has(file)) continue;
+      const hash = createHash("sha256")
+        .update(readFileSync(path.join(OUTPUT_DIR, file)))
+        .digest("hex");
+      byHash.set(hash, [...(byHash.get(hash) ?? []), file]);
+    }
+    const duplicates = [...byHash.values()].filter((files) => files.length > 1);
+
+    expect(stepFailures, `surface-strip capture steps failed in "${THEME}"`).toEqual([]);
+    expect(missing, `surface-strip captures missing from ${OUTPUT_DIR}`).toEqual([]);
+    expect(duplicates, `identical surface-strip captures — a step drove nothing`).toEqual([]);
+  } finally {
+    if (ctx?.app) await closeApp(ctx.app);
+    repo?.cleanup();
+    rmSync(userDataDir, { recursive: true, force: true });
+  }
+});

--- a/src/components/Plugin/ProjectSurfaceFrame.tsx
+++ b/src/components/Plugin/ProjectSurfaceFrame.tsx
@@ -1,10 +1,11 @@
-import { useRef, type MouseEvent, type ReactNode } from "react";
+import { useRef, type ReactNode } from "react";
 import { AlertCircle, Puzzle, Search } from "lucide-react";
 import type { ProjectSurfaceChoice } from "@shared/types/plugin";
 import { InlineStatusBanner } from "@/components/Terminal/InlineStatusBanner";
 import { Button } from "@/components/ui/button";
 import { SegmentedToggle } from "@/components/ui/SegmentedToggle";
 import { SurfaceHeader } from "@/components/ui/SurfaceHeader";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useRenderableSurfaceClaim } from "@/hooks/useRenderableSurfaceClaim";
 import { actionService } from "@/services/ActionService";
 import {
@@ -15,9 +16,13 @@ import {
 import { useProjectPluginStore } from "@/store/projectPluginStore";
 
 /**
- * A manifest's panel name has no length cap, and the switch cannot shrink: an
- * uncapped name could push the Launcher segment — the way back — out of a
- * narrow canvas.
+ * A manifest's panel name has no length cap, so the strip caps it twice over.
+ *
+ * This is the coarse half, and it bounds the accessible name and the tooltip as
+ * much as the pixels. It cannot be the only half: 32 characters of "WWWW" are
+ * not 32 characters of "llll", so a character count alone can never promise the
+ * Launcher segment — the way back — still fits. The switch is also allowed to
+ * shrink in the strip, which is what actually holds that promise at any width.
  */
 const PANEL_LABEL_MAX_CHARS = 32;
 
@@ -41,8 +46,16 @@ const SEGMENT_INDEX: Record<ProjectSurfaceChoice, number> = { surface: 0, stock:
  * On its own a claimed surface looks like one more panel — even to the person
  * who wrote the manifest. So the host keeps a strip of its own chrome above the
  * region: a switch naming the plugin's panel and the stock launcher, and while
- * the surface shows, "No panels open" and the launcher's palette entry, so the
- * region still says nothing is open and still offers a way to start something.
+ * the surface shows, the launcher's palette entry, so the region still offers a
+ * way to start something.
+ *
+ * The strip carries those two things and nothing else. It is 32px of chrome
+ * framing a full-bleed view someone else drew, so anything in it is competing
+ * with that view for the same glance — which is why the switch is the only thing
+ * with a fill, and why the palette entry is an icon rather than the sentence it
+ * used to be. A "No panels open" label lived here too and was cut: it was not
+ * actionable, it was not a degraded state, and sitting flush against the switch
+ * with no separator it read as a third, disabled segment.
  *
  * The strip sits ABOVE the region, in flow, never floated over it. Plugins draw
  * their own toolbars, most often top-right, and a control pinned into that
@@ -69,6 +82,18 @@ export function ProjectSurfaceFrame({ children }: { children: ReactNode }) {
     (s) => s.plugins.find((p) => p.instanceId === claimPluginId)?.displayName
   );
   const stripRef = useRef<HTMLDivElement>(null);
+  /**
+   * Whether the last input that reached this frame was a pointer.
+   *
+   * A banner action's `onClick` carries no event, so the usual tell — a
+   * keyboard press arrives as a synthetic click with `detail === 0` — is not
+   * available here. Tracked on the frame instead, in the capture phase so it is
+   * already correct by the time the click handler runs. Only a pointer press
+   * suppresses the ring; anything else, including the initial render, is
+   * treated as keyboard, which is the safe default: a stray ring costs a mouse
+   * user nothing, a missing one strands a keyboard user.
+   */
+  const viaPointerRef = useRef(false);
 
   // `useProjectSurface`'s own test. Without it the strip could offer a surface
   // the region will not draw, or show it pressed while the stock canvas is what
@@ -86,18 +111,33 @@ export function ProjectSurfaceFrame({ children }: { children: ReactNode }) {
     if (next === showing) return;
     void setSurfaceChoice("emptyCanvas", next);
   };
-  const answer = async (next: ProjectSurfaceChoice, event: MouseEvent<HTMLButtonElement>) => {
-    // A keyboard press is a synthetic click with no detail; only it earns a ring.
-    const viaKeyboard = event.detail === 0;
-    await setSurfaceChoice("emptyCanvas", next);
-    // The pressed button leaves with the notice, and focus left on the body
-    // strands a keyboard user. The switch's segments never unmount, so the one
-    // now showing is a stable place to land.
+  /**
+   * Land focus on the segment now showing.
+   *
+   * Every control in a notice row destroys its own row by succeeding — an
+   * answer, a retry that lands, a dismissal — and focus left on the body strands
+   * a keyboard user mid-task. The switch's segments never unmount, so the one
+   * now showing is the stable place to put them.
+   */
+  const restoreFocus = () => {
     const now =
       selectSurfaceChoice(usePluginProjectSurfacesStore.getState(), "emptyCanvas") ?? "surface";
     stripRef.current
       ?.querySelectorAll<HTMLButtonElement>("button")
-      [SEGMENT_INDEX[now]]?.focus({ preventScroll: true, focusVisible: viaKeyboard });
+      [SEGMENT_INDEX[now]]?.focus({ preventScroll: true, focusVisible: !viaPointerRef.current });
+  };
+  const answer = async (next: ProjectSurfaceChoice) => {
+    await setSurfaceChoice("emptyCanvas", next);
+    restoreFocus();
+  };
+  const retryFailedSave = async (next: ProjectSurfaceChoice | null) => {
+    await setSurfaceChoice("emptyCanvas", next);
+    // Only on success. A retry that fails again leaves the row — and this
+    // button — standing, and moving focus off it would be taking the control
+    // away at the moment the user most wants to press it a second time.
+    if (selectFailedSave(usePluginProjectSurfacesStore.getState(), "emptyCanvas") === null) {
+      restoreFocus();
+    }
   };
   const panelLabel = capLabel(config.name);
 
@@ -105,6 +145,12 @@ export function ProjectSurfaceFrame({ children }: { children: ReactNode }) {
     <div
       className="flex h-full w-full min-h-0 min-w-0 flex-col"
       data-testid="project-surface-frame"
+      onPointerDownCapture={() => {
+        viaPointerRef.current = true;
+      }}
+      onKeyDownCapture={() => {
+        viaPointerRef.current = false;
+      }}
     >
       <SurfaceHeader
         ref={stripRef}
@@ -114,8 +160,20 @@ export function ProjectSurfaceFrame({ children }: { children: ReactNode }) {
         className="gap-3 px-2"
         data-testid="project-surface-strip"
       >
-        <div className="flex min-w-0 items-center gap-2.5">
+        {/* `shrink` AND `min-w-0`, both load-bearing and neither sufficient
+            alone: `min-w-0` only lowers the floor a flex item may shrink TO,
+            while the control's own `shrink-0` says it never shrinks at all.
+            tailwind-merge resolves the pair to the caller's `shrink`, so this
+            is the one place the switch is allowed to give way.
+
+            It has to be able to. The label is capped by character count, which
+            cannot know how wide those characters render — 32 wide glyphs in a
+            narrow window would otherwise push the Launcher segment, the way
+            back, off the end of the row. */}
+        <div className="flex min-w-0 items-center">
           <SegmentedToggle
+            className="min-w-0 shrink"
+            density="compact"
             options={[
               {
                 value: "surface",
@@ -127,73 +185,79 @@ export function ProjectSurfaceFrame({ children }: { children: ReactNode }) {
             value={showing}
             onChange={choose}
           />
-          {showing === "surface" && (
-            <span className="truncate text-xs text-text-secondary">No panels open</span>
-          )}
         </div>
         {/* The stock launcher carries this same entry as its anchor, so the strip
-            only repeats it while the plugin's surface is standing in for it. */}
+            only repeats it while the plugin's surface is standing in for it.
+            Icon-only: at 32px the label is the widest thing in the strip and it
+            says nothing the icon and its tooltip do not. */}
         {showing === "surface" && (
-          <Button
-            variant="ghost"
-            size="xs"
-            className="shrink-0"
-            onClick={() => {
-              void actionService.dispatch("panel.palette", undefined, { source: "user" });
-            }}
-          >
-            <Search aria-hidden="true" />
-            Search agents &amp; panels…
-          </Button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="inline-flex shrink-0">
+                <Button
+                  variant="ghost"
+                  size="icon-xs"
+                  aria-label="Search agents &amp; panels…"
+                  onClick={() => {
+                    void actionService.dispatch("panel.palette", undefined, { source: "user" });
+                  }}
+                >
+                  <Search aria-hidden="true" />
+                </Button>
+              </span>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">Search agents &amp; panels…</TooltipContent>
+          </Tooltip>
         )}
       </SurfaceHeader>
+      {/* Both notices are single-line by construction: a `title` and no
+          `description`, which is the layout `InlineStatusBanner` already draws
+          for that shape — one 40px row, not the 112px card this surface used to
+          stack on a 32px strip. The description slot is what made it a card, so
+          the rule is simply never to pass one here. */}
       {failedSave !== null ? (
-        <div className="shrink-0 px-2 pt-2">
-          <InlineStatusBanner
-            icon={AlertCircle}
-            title="Couldn't save the canvas choice"
-            description="Daintree couldn't record it, so the canvas hasn't changed."
-            severity="error"
-            action={{
-              id: "retry",
-              label: "Retry",
-              variant: "primary",
-              onClick: () => void setSurfaceChoice("emptyCanvas", failedSave.choice),
-            }}
-            onClose={dismissFailedSave}
-            className="mx-auto w-full max-w-2xl"
-          />
-        </div>
+        <InlineStatusBanner
+          icon={AlertCircle}
+          title="Couldn't save the canvas choice"
+          severity="error"
+          role="alert"
+          action={{
+            id: "retry",
+            label: "Retry",
+            variant: "primary",
+            onClick: () => void retryFailedSave(failedSave.choice),
+          }}
+          onClose={() => {
+            dismissFailedSave();
+            restoreFocus();
+          }}
+        />
       ) : (
         choice === null && (
-          <div className="shrink-0 px-2 pt-2">
-            <InlineStatusBanner
-              icon={Puzzle}
-              title={`${pluginDisplayName ?? config.name} replaced the launcher`}
-              description="This project's plugin draws the canvas when no panels are open. You can switch back any time with Launcher above."
-              descriptionExtras={
-                <div className="mt-3 flex flex-wrap gap-2">
-                  <Button
-                    size="sm"
-                    variant="secondary"
-                    onClick={(event) => void answer("surface", event)}
-                  >
-                    Keep it
-                  </Button>
-                  <Button
-                    size="sm"
-                    variant="ghost"
-                    onClick={(event) => void answer("stock", event)}
-                  >
-                    Use the launcher
-                  </Button>
-                </div>
-              }
-              severity="neutral"
-              role="status"
-              className="mx-auto w-full max-w-2xl rounded-lg border border-border-default bg-surface-panel"
-            />
-          </div>
+          <InlineStatusBanner
+            icon={Puzzle}
+            title={`${pluginDisplayName ?? config.name} replaced the launcher`}
+            severity="neutral"
+            role="status"
+            // Equal weight, deliberately: one variant, one size, both answers.
+            // Each is a single click from being reversed — the switch directly
+            // above, and the reset in project plugin settings — so promoting
+            // either one is picking for the user.
+            actions={[
+              {
+                id: "keep",
+                label: "Keep it",
+                variant: "primary",
+                onClick: () => void answer("surface"),
+              },
+              {
+                id: "stock",
+                label: "Use the launcher",
+                variant: "primary",
+                onClick: () => void answer("stock"),
+              },
+            ]}
+          />
         )
       )}
       <div className="relative min-h-0 min-w-0 flex-1" data-testid="project-surface-region">

--- a/src/components/Plugin/__tests__/ProjectSurfaceFrame.test.tsx
+++ b/src/components/Plugin/__tests__/ProjectSurfaceFrame.test.tsx
@@ -32,6 +32,7 @@ vi.mock("@/components/Plugin/PluginViewContent", () => ({
   ),
 }));
 
+import { TooltipProvider } from "@/components/ui/tooltip";
 import { ProjectSurfaceFrame } from "../ProjectSurfaceFrame";
 import {
   ProjectSurfaceView,
@@ -173,8 +174,15 @@ describe("ProjectSurfaceFrame", () => {
     });
   });
 
+  // The strip's palette entry is icon-only and carries a tooltip, so it needs
+  // the provider App.tsx mounts at the root. Same wrapper the file-viewer tests
+  // use for the same reason.
   const renderFrame = (children: React.ReactNode = <div data-testid="surface" />) =>
-    render(<ProjectSurfaceFrame>{children}</ProjectSurfaceFrame>);
+    render(
+      <TooltipProvider>
+        <ProjectSurfaceFrame>{children}</ProjectSurfaceFrame>
+      </TooltipProvider>
+    );
 
   const strip = () => screen.getByRole("group", { name: "Empty canvas" });
   const stripButton = (name: string) => within(strip()).getByRole("button", { name });
@@ -220,9 +228,53 @@ describe("ProjectSurfaceFrame", () => {
 
     renderFrame();
 
-    expect(strip().textContent).toContain("No panels open");
     expect(stripButton("Mission Control").getAttribute("aria-pressed")).toBe("true");
     expect(stripButton("Launcher").getAttribute("aria-pressed")).toBe("false");
+  });
+
+  it("puts nothing in the strip that is not a control", () => {
+    registerSurfaceKind();
+    setClaim(answer("surface"));
+
+    renderFrame();
+
+    // 32px of host chrome framing a full-bleed view someone else drew. Every
+    // glance it costs is a glance taken from that view, so the strip earns its
+    // place by carrying only things the user can act on. A status label here
+    // reads as a third, disabled segment — which is what "No panels open" did.
+    //
+    // The rule, not the label: any text in the strip belongs to a control.
+    let stray = strip().textContent ?? "";
+    for (const button of within(strip()).getAllByRole("button")) {
+      stray = stray.replace(button.textContent ?? "", "");
+    }
+    expect(stray.trim()).toBe("");
+  });
+
+  it("keeps both notices on one row, never on a card", async () => {
+    registerSurfaceKind();
+    setClaim();
+
+    renderFrame();
+
+    // This surface stacks its notices directly on a 32px chrome strip, and the
+    // known way to get that wrong is scale mismatch — a multi-line card on a
+    // thin bar inverts the hierarchy and makes host onboarding the loudest
+    // thing on a canvas the plugin owns. It shipped that way once: a title, a
+    // description and a separate action row, 112px of it.
+    //
+    // The rule, not the pixel height: `InlineStatusBanner` draws a single row
+    // when it has no `description` and a stacked card when it has one, so the
+    // invariant is simply that this surface never passes one. Give either
+    // notice a description and this fails.
+    expect(notice().className).not.toMatch(/\bflex-col\b/);
+    expect(notice().className).toMatch(/\bitems-center\b/);
+
+    failNextSave = true;
+    await press(stripButton("Launcher"));
+    const failed = screen.getByRole("alert");
+    expect(failed.className).not.toMatch(/\bflex-col\b/);
+    expect(failed.className).toMatch(/\bitems-center\b/);
   });
 
   it("lays the strip out above the plugin's contained box, never over it", async () => {
@@ -282,7 +334,7 @@ describe("ProjectSurfaceFrame", () => {
     expect(notice()).toBeTruthy();
   });
 
-  it("keeps the palette entry and the empty-canvas label only while the surface stands in", async () => {
+  it("keeps the palette entry only while the surface stands in", async () => {
     registerSurfaceKind();
     setClaim(answer("surface"));
     renderFrame();
@@ -293,7 +345,6 @@ describe("ProjectSurfaceFrame", () => {
     // The stock launcher is its own empty state, anchor included.
     await press(stripButton("Launcher"));
     expect(within(strip()).queryByRole("button", { name: PALETTE_ENTRY })).toBeNull();
-    expect(strip().textContent).not.toContain("No panels open");
   });
 
   it("caps a long panel name so the way back stays in reach", () => {
@@ -335,7 +386,10 @@ describe("ProjectSurfaceFrame", () => {
     setClaim();
     renderFrame();
 
-    expect(notice().textContent).toContain("Acme Dashboard replaced the launcher");
+    // The plugin's DISPLAY name, not its manifest id and not the panel's name:
+    // the question is "do you want this plugin drawing your canvas", and the
+    // only name that answers it is the one the user sees in settings.
+    expect(notice().textContent).toContain("Acme Dashboard");
     // Unanswered is the manifest's own intent: the surface is already showing.
     expect(stripButton("Mission Control").getAttribute("aria-pressed")).toBe("true");
 
@@ -361,6 +415,36 @@ describe("ProjectSurfaceFrame", () => {
 
     expect(screen.queryByRole("status")).toBeNull();
     expect(document.activeElement).toBe(stripButton("Launcher"));
+  });
+
+  it("keeps the ring for a keyboard answer and drops it for a pointer one", async () => {
+    registerSurfaceKind();
+    setClaim();
+    renderFrame();
+
+    // A banner action's onClick carries no event, so the usual tell — a
+    // keyboard press arriving as a click with `detail === 0` — is not available
+    // and the frame tracks the modality itself. The direction is the whole
+    // point and it is easy to get backwards: a keyboard user who loses the ring
+    // is stranded with no idea where focus went, while a stray ring costs a
+    // mouse user nothing.
+    const keyboardTarget = stripButton("Launcher");
+    const keyboardSpy = vi.spyOn(keyboardTarget, "focus");
+    await press(within(notice()).getByRole("button", { name: "Use the launcher" }));
+    expect(keyboardSpy).toHaveBeenCalledWith({ preventScroll: true, focusVisible: true });
+
+    // Same answer, reached by pointer this time.
+    setClaim();
+    await flush();
+    const pointerTarget = stripButton("Launcher");
+    const pointerSpy = vi.spyOn(pointerTarget, "focus");
+    const answerButton = within(notice()).getByRole("button", { name: "Use the launcher" });
+    await act(async () => {
+      fireEvent.pointerDown(answerButton);
+      answerButton.click();
+      await settle();
+    });
+    expect(pointerSpy).toHaveBeenCalledWith({ preventScroll: true, focusVisible: false });
   });
 
   it("remembers using the launcher across a reload", async () => {
@@ -424,6 +508,25 @@ describe("ProjectSurfaceFrame", () => {
 
     expect(canvasChoice()).toBe("stock");
     expect(screen.queryByText(SAVE_FAILED)).toBeNull();
+    // A retry that lands destroys the row holding the button that was pressed.
+    // Every control in a notice row does — an answer, a retry, a dismissal — so
+    // each one owes the same handoff: focus lands on the segment now showing,
+    // never on the body.
+    expect(document.activeElement).toBe(stripButton("Launcher"));
+  });
+
+  it("hands focus back to the strip when a failed save is dismissed", async () => {
+    registerSurfaceKind();
+    setClaim();
+    renderFrame();
+
+    failNextSave = true;
+    await press(stripButton("Launcher"));
+    await press(screen.getByRole("button", { name: "Dismiss" }));
+
+    expect(screen.queryByText(SAVE_FAILED)).toBeNull();
+    // Dismissing recorded no answer, so the surface is still what is showing.
+    expect(document.activeElement).toBe(stripButton("Mission Control"));
   });
 
   it("asks the new owner instead of offering a retry once the slot changes hands", async () => {

--- a/src/components/ui/SegmentedToggle.tsx
+++ b/src/components/ui/SegmentedToggle.tsx
@@ -26,16 +26,46 @@ export function SegmentedToggle<T extends string>({
   options,
   value,
   onChange,
+  className,
+  density = "default",
 }: {
   options: SegmentedToggleOption<T>[];
   value: T;
   onChange: (value: T) => void;
+  /**
+   * `compact` for a 32px host-chrome strip.
+   *
+   * The default is 28px tall, which is right in a panel header and wrong in a
+   * 32px bar: it leaves 2px of clearance, the bottom 1px of which is the bar's
+   * own divider, so the control reads as a tab welded to the bottom edge rather
+   * than a button sitting in a row. `compact` is 24px — real clearance top and
+   * bottom, and the same height as an `icon-xs` button, so a strip carrying both
+   * has one control height instead of two.
+   */
+  density?: "default" | "compact";
+  /**
+   * Escape hatch for a caller that cannot afford `shrink-0` — host chrome whose
+   * label comes from a plugin manifest, where the widest option is not known
+   * until runtime.
+   *
+   * Pass **both** `min-w-0` and `shrink` to let the labels truncate instead of
+   * pushing the last segment out of the row. Neither alone is enough: `min-w-0`
+   * only lowers the floor a flex item may shrink to, while the `shrink-0` in the
+   * base says it never shrinks at all. tailwind-merge resolves the pair to the
+   * caller's `shrink`.
+   */
+  className?: string;
 }) {
   const thumbLayoutId = `${useId()}-segmented-thumb`;
   const thumbTransition = useUiMotionTransition();
 
   return (
-    <div className="relative isolate flex bg-surface-sidebar rounded p-0.5 shrink-0">
+    <div
+      className={cn(
+        "relative isolate flex bg-surface-sidebar rounded-lg p-0.5 shrink-0",
+        className
+      )}
+    >
       {options.map((option) => {
         const isActive = value === option.value;
 
@@ -48,10 +78,12 @@ export function SegmentedToggle<T extends string>({
             aria-label={option.ariaLabel}
             aria-pressed={isActive}
             className={cn(
-              "relative px-2.5 py-1 text-xs font-medium rounded transition-colors",
+              "relative min-w-0 text-xs font-medium rounded-lg transition-colors",
+              density === "compact" ? "px-2 py-0.5" : "px-2.5 py-1",
               "disabled:cursor-not-allowed disabled:pointer-events-none",
-              isActive ? "text-text-primary" : "text-muted-foreground hover:text-text-primary"
+              isActive ? "text-text-primary" : "text-text-secondary hover:text-text-primary"
             )}
+            title={option.ariaLabel}
           >
             {isActive && (
               <m.div
@@ -60,13 +92,29 @@ export function SegmentedToggle<T extends string>({
                 layoutId={thumbLayoutId}
                 layoutCrossfade={false}
                 transition={thumbTransition}
-                // `rounded` tracks the theme (it resolves to --theme-radius-scale), which an
+                // `rounded-lg` tracks the theme (it resolves to --theme-radius-scale), which an
                 // inline pixel radius would not. framer can only scale-correct a radius it
                 // reads from `style`, so the corners stretch slightly while the thumb morphs
                 // between segments of different widths — a frame or two, and worth it to stay
                 // theme-correct at rest.
+                //
+                // The fill alone cannot say which segment is selected: it sits about 1.3:1
+                // against the surface behind it, deliberately quiet, and no neutral token in
+                // this system reaches the 3:1 non-text floor without turning chrome into the
+                // loudest thing on screen. The text step does not rescue it either — hovering
+                // the UNSELECTED segment lifts its label to primary too, and at that moment
+                // the 1.3:1 fill is all that is left distinguishing them. So the state is
+                // carried by a hairline: one pixel of ink reads at a glance for a fraction
+                // of a compliant fill's weight, and stays distinct from the focus ring,
+                // which is 2px, accent-coloured and offset.
+                //
+                // `text-secondary`, NOT `text-muted`. `text-muted` measures 5.65:1 on
+                // daintree and would look like it clears the floor easily, but it has no
+                // dark-theme contrast floor at all — 2.22:1 on namib, 2.50:1 on redwoods —
+                // so a load-bearing cue drawn in it fails on the themes nobody checked.
                 className={cn(
-                  "absolute inset-0 z-0 rounded bg-border-default pointer-events-none",
+                  "absolute inset-0 z-0 rounded-lg bg-border-default pointer-events-none",
+                  "border border-text-secondary",
                   option.disabled && "opacity-40"
                 )}
                 aria-hidden="true"
@@ -74,8 +122,14 @@ export function SegmentedToggle<T extends string>({
             )}
             {/* Dimming a disabled segment has to happen on its contents, never on the
                 button: opacity below 1 would make the button a stacking context and trap
-                this label beneath a thumb sliding across it from a sibling. */}
-            <span className={cn("relative z-10", option.disabled && "opacity-40")}>
+                this label beneath a thumb sliding across it from a sibling.
+
+                `block truncate` rather than the inline default: an inline span has no
+                width of its own to overflow, so a shrinking button would clip its label
+                mid-glyph instead of ellipsing it. Callers that stay `shrink-0` never
+                reach this — the label is only ever as narrow as its button is allowed
+                to get. */}
+            <span className={cn("relative z-10 block truncate", option.disabled && "opacity-40")}>
               {option.label}
             </span>
           </button>

--- a/src/index.css
+++ b/src/index.css
@@ -2414,6 +2414,17 @@ body[data-performance-mode="true"] [class*="backdrop-blur"] {
     border-color: ButtonText;
   }
 
+  /* A segmented toggle marks its selection with one filled thumb, and a fill is
+     exactly what forced-colors strips — leaving two identically-outlined
+     segments and no way to see which view you are actually on. Same problem and
+     same remedy as [data-highlighted] below: repaint the selection as a border,
+     which the UA leaves alone. ButtonText rather than Highlight, because
+     Highlight is spoken for by :focus-visible two rules up and a selected
+     segment that is not focused must not claim the focus cue. */
+  [data-slot="segmented-thumb"] {
+    border: 2px solid ButtonText;
+  }
+
   /* Radix highlighted items rely on background-color which is stripped here.
      Fall back to a system outline so the active menu/select row stays visible. */
   [data-highlighted] {
@@ -2824,6 +2835,18 @@ body[data-performance-mode="true"] [class*="backdrop-blur"] {
      forced-colors rule on purpose — author colours survive here, so the fill
      still does its job and only the outline is missing. */
   [data-notification-filter="true"][aria-pressed="true"] {
+    outline: 1px solid var(--color-border-strong);
+    outline-offset: -1px;
+  }
+
+  /* Segmented toggles have the same shape of problem as those filter chips, and
+     take the same remedy. The selected thumb is a fill roughly 1.3:1 against the
+     surface behind it — deliberate quiet chrome at normal contrast, but in a
+     mode whose whole request is "more contrast" a 1.3:1 step is not an answer.
+     Outline the thumb rather than brighten it: a hairline reads at a glance
+     without turning quiet host chrome into the loudest thing on the surface it
+     frames. Inset so it sits inside the thumb rather than growing it. */
+  [data-slot="segmented-thumb"] {
     outline: 1px solid var(--color-border-strong);
     outline-offset: -1px;
   }


### PR DESCRIPTION
## Summary
- The strip Daintree draws above a project plugin's empty-canvas surface was louder than the view it frames, and its first-show notice was a 112px card stacked on a 32px bar.
- Both notices now use InlineStatusBanner's single-row mode (112px to 40px), "No panels open" is gone, the palette entry is an icon button, and the switch sits with equal clearance above and below instead of reading as a tab welded to the divider.
- SegmentedToggle gets a visible selection cue (a hairline, plus forced-colors and prefers-contrast fallbacks), an opt-in compact density, and the ability to shrink so a long plugin name can't push Launcher off the row.

## What changed
- `ProjectSurfaceFrame.tsx`: single-row notices, icon-only palette entry, equal-weight consent answers, shared focus handoff for Retry and Dismiss, input-modality tracking for the focus ring.
- `SegmentedToggle.tsx` and `index.css`: selection hairline in `text-secondary`, ButtonText border under forced-colors, inset outline under prefers-contrast, `density="compact"`, `className` passthrough. Three bare `rounded` and one `text-muted-foreground` retired (lint ratchet 3048 to 3045).
- New `e2e/screenshots/project-surface-strip-review.spec.ts`: 10 states x 2 themes, with assertions that the way back and both consent answers stay on canvas at narrow widths.

## Design review
Score 6.0 to 8.8 over three rounds against proportion, hierarchy, orientation, density and robustness. The consistency survey found the round-2 private notice chassis was an outlier against 79 InlineStatusBanner call sites, so it was reverted to the shared component's existing single-row mode. The compact toggle density is used only here; the other five call sites all sit in taller toolbars and keep the default.

## Testing
- `npm test`: 58,327 passed, exit 0.
- `npm run check`: typecheck and every guard passed except `check:sample-views`, which fails on a pre-existing stale `plugins/sample/file-tree/view/file-tree-view.js` unrelated to this change. The six steps after it were run individually and all pass.
- Four new invariants in `ProjectSurfaceFrame.test.tsx`, each mutation-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0188yYcBvDLd8wUGr5Dg2hpP