### PR TITLE
fix(assistant): keep a live native engine's view out of eviction

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -81,6 +81,9 @@ import {
   setStopDiskSpaceMonitor,
   getMainProcessWatchdogClientRef,
 } from "./window/windowServices.js";
+// After windowServices on purpose: its IPC handlers already evaluate this module,
+// so importing it here adds no boot work and moves nothing in the init order.
+import { assistantHostService } from "./services/assistant-host/AssistantHostService.js";
 import { getMcpServerServiceRef, getResourceProfileService } from "./window/serviceRefs.js";
 import {
   setupPowerMonitor,
@@ -418,6 +421,11 @@ if (!gotTheLock) {
       // async, and a shard that times out comes back as an empty list, which
       // would read as "the assistant is gone" and unprotect a live one.
       isTerminalLive: (terminalId) => getPtyClient()?.hasTerminal(terminalId) === true,
+      // The native engine's half (#12364). It never binds a PTY, so the pair above
+      // cannot see it, and `onViewEvicted` below stops it outright. The service
+      // answers from the same rule its teardown applies, keyed by the view alone.
+      wouldEndNativeAssistant: (webContentsId) =>
+        assistantHostService.wouldEndLiveEngine(webContentsId),
       // Keeps a workspace an MCP session is bound to out of the freeze sweep,
       // and out of eviction entirely while a dispatch is in flight (#11790).
       // A bound session drives a *background* workspace by design, and a frozen

--- a/electron/services/assistant-host/AssistantHostService.ts
+++ b/electron/services/assistant-host/AssistantHostService.ts
@@ -109,6 +109,22 @@ function newAttachmentId(): string {
   return `att_${randomBytes(6).toString("hex")}`;
 }
 
+/**
+ * Whether losing `webContentsId` ENDS `session`, rather than merely detaching one of
+ * its surfaces.
+ *
+ * Decided in one place because two callers need the same answer: `detach` acts on it,
+ * and `wouldEndLiveEngine` predicts it for view eviction (#12364). Kept apart, the
+ * eviction floor could drift from the teardown it exists to prevent — protecting a
+ * view whose loss kills nothing, or releasing one whose loss still does.
+ *
+ * Asked BEFORE the subscriber is removed, so a sole subscriber reads as the last one.
+ */
+function departureEndsSession(session: LiveSession, webContentsId: number): boolean {
+  if (!session.subscribers.has(webContentsId)) return false;
+  return session.subscribers.size === 1 || webContentsId === session.provisionerWebContentsId;
+}
+
 /** The roster id the MCP tier policy is keyed on for this surface. */
 const ASSISTANT_AGENT_ID = "daintree-assistant";
 
@@ -850,7 +866,8 @@ export class AssistantHostService {
   }
 
   /**
-   * Detaches one surface, stopping the engine when the last one leaves.
+   * Detaches one surface, stopping the engine when the last one leaves — or when the
+   * one leaving is the surface the control plane is pinned to.
    *
    * `attachmentId`, when given, must match the CURRENT attachment for that surface. A
    * panel re-running its start effect resolves the new attach before the old one's
@@ -861,9 +878,10 @@ export class AssistantHostService {
     const subscriber = session.subscribers.get(webContentsId);
     if (!subscriber) return;
     if (attachmentId !== undefined && subscriber.attachmentId !== attachmentId) return;
+    const ends = departureEndsSession(session, webContentsId);
     session.subscribers.delete(webContentsId);
 
-    if (session.subscribers.size > 0 && webContentsId !== session.provisionerWebContentsId) {
+    if (!ends) {
       logger.info("surface left the project's engine; others remain", {
         sessionId: session.sessionId,
         webContentsId,
@@ -881,11 +899,12 @@ export class AssistantHostService {
         webContentsId,
         strandedSubscribers: session.subscribers.size,
       });
+    } else {
+      logger.info("last surface left; stopping the engine", {
+        sessionId: session.sessionId,
+        webContentsId,
+      });
     }
-    logger.info("last surface left; stopping the engine", {
-      sessionId: session.sessionId,
-      webContentsId,
-    });
     this.stop(session.sessionId);
   }
 
@@ -987,7 +1006,8 @@ export class AssistantHostService {
    * Detaches a renderer from every session it was watching (destroyed view, crashed view).
    *
    * Named `stop*` for its callers, who mean "this surface is gone" — but a surface
-   * going away only ENDS the engine when no other window is still showing it.
+   * going away only ENDS the engine when it was the last one showing it, or the one
+   * holding the control plane.
    *
    * The surface is also recorded as departed, because one of its own starts may still
    * be queued behind another project's: registering it afterwards would leave a
@@ -1024,6 +1044,31 @@ export class AssistantHostService {
   /** True when `webContentsId` is one of the surfaces watching `sessionId`. */
   isOwnedBy(sessionId: string, webContentsId: number): boolean {
     return this.bySession.get(sessionId)?.subscribers.has(webContentsId) ?? false;
+  }
+
+  /**
+   * True when losing this surface would end a live engine — the question view eviction
+   * has to ask first, because destroying a view runs `stopByWebContents` (#12364).
+   *
+   * Keyed by WebContents alone, across every session, because that is how the teardown
+   * it predicts is keyed. A cached view's key is a workspace id that nothing guarantees
+   * is the project id a session was started under, so filtering by project could miss a
+   * view the teardown would still find.
+   *
+   * Live means registered and not yet exited: from before the child is even spawned,
+   * through the whole readiness wait, until the session is stopped or its child dies. A
+   * stopped session whose child is still draining does not count — it has already left
+   * routing and lost its bearer, so keeping its view would save nothing.
+   *
+   * A joining window's view does not qualify. Losing it only detaches that window, which
+   * can rejoin with a replay when its view comes back — the same shape as the PTY floor,
+   * which protects only the view a session pinned.
+   */
+  wouldEndLiveEngine(webContentsId: number): boolean {
+    for (const session of this.bySession.values()) {
+      if (!session.host.hasExited() && departureEndsSession(session, webContentsId)) return true;
+    }
+    return false;
   }
 }
 

--- a/electron/services/assistant-host/__tests__/engineEvictionProtection.test.ts
+++ b/electron/services/assistant-host/__tests__/engineEvictionProtection.test.ts
@@ -154,13 +154,17 @@ describe("which surfaces a live native engine cannot lose (#12364)", () => {
     // The floor is only as good as this prediction. Each case asks, then does what
     // eviction does, on a fresh engine — so a change to `detach` the query did not follow
     // fails here instead of in somebody's lost conversation.
+    //
+    // Each case also carries its own expected answer, because prediction and teardown
+    // share one rule: agreement alone would pass if that rule were wrong for both.
     const cases = [
-      { surfaces: [10], lose: 10 },
-      { surfaces: [10, 11], lose: 10 },
-      { surfaces: [10, 11], lose: 11 },
-      { surfaces: [10, 11, 12], lose: 12 },
+      { surfaces: [10], lose: 10, ends: true },
+      { surfaces: [10, 11], lose: 10, ends: true },
+      { surfaces: [10, 11], lose: 11, ends: false },
+      { surfaces: [10, 11, 12], lose: 10, ends: true },
+      { surfaces: [10, 11, 12], lose: 12, ends: false },
     ];
-    for (const { surfaces, lose } of cases) {
+    for (const { surfaces, lose, ends } of cases) {
       hosts.length = 0;
       const service = new AssistantHostService();
       for (const [index, webContentsId] of surfaces.entries()) {
@@ -170,10 +174,11 @@ describe("which surfaces a live native engine cannot lose (#12364)", () => {
       const predicted = service.wouldEndLiveEngine(lose);
       service.stopByWebContents(lose);
 
-      expect({ surfaces, lose, ended: hosts[0]?.disposed }).toEqual({
+      expect({ surfaces, lose, predicted, ended: hosts[0]?.disposed }).toEqual({
         surfaces,
         lose,
-        ended: predicted,
+        predicted: ends,
+        ended: ends,
       });
     }
   });
@@ -251,6 +256,21 @@ describe("which surfaces a live native engine cannot lose (#12364)", () => {
 
     expect(service.wouldEndLiveEngine(10)).toBe(false);
     expect(service.wouldEndLiveEngine(20)).toBe(true);
+  });
+
+  it("keeps a view that started two lanes protected until both engines have ended", async () => {
+    // One view, two engines. An answer taken from the first session that names the view
+    // would release it the moment that lane exits, with the other still running.
+    const service = new AssistantHostService();
+    await startSurface(service, 10, 1, 0);
+    await startSurface(service, 10, 1, 1);
+    expect(hosts).toHaveLength(2);
+
+    hosts[0]!.exited = true;
+    expect(service.wouldEndLiveEngine(10)).toBe(true);
+
+    hosts[1]!.exited = true;
+    expect(service.wouldEndLiveEngine(10)).toBe(false);
   });
 
   it("says the control plane left when it did, not that the last surface did", async () => {

--- a/electron/services/assistant-host/__tests__/engineEvictionProtection.test.ts
+++ b/electron/services/assistant-host/__tests__/engineEvictionProtection.test.ts
@@ -1,0 +1,277 @@
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from "vitest";
+
+/**
+ * Which surfaces a live engine cannot afford to lose (#12364).
+ *
+ * View eviction destroys a cached project view and then runs `stopByWebContents` on it.
+ * The native engine never binds a PTY, so the eviction floor that protects PTY
+ * assistants never saw it, and every reclaimed view took its conversation along.
+ * `wouldEndLiveEngine` is that floor's native half: it has to say yes for exactly the
+ * views whose loss ends an engine, and for exactly as long as there is an engine to end.
+ */
+
+interface FakeHost {
+  disposed: boolean;
+  exited: boolean;
+  /** Settles the readiness wait while `deferReady` holds it open. */
+  ready: { resolve: () => void; reject: (error: Error) => void } | null;
+}
+
+const hosts: FakeHost[] = [];
+/** When true, `waitForReady` hangs until the test settles it. */
+let deferReady = false;
+/** Runs inside `host.start()` — the moment the child would be spawned. */
+let onSpawn: (() => void) | null = null;
+
+vi.mock("../AssistantHostProcess.js", () => ({
+  AssistantHostProcess: class {
+    private readonly record: FakeHost = { disposed: false, exited: false, ready: null };
+    constructor() {
+      hosts.push(this.record);
+    }
+    start() {
+      onSpawn?.();
+    }
+    waitForReady() {
+      if (!deferReady) return Promise.resolve();
+      return new Promise<void>((resolve, reject) => {
+        this.record.ready = { resolve, reject };
+      });
+    }
+    getReadyEvent() {
+      return null;
+    }
+    getTranscript() {
+      return { events: [], prompts: [], truncated: false };
+    }
+    getPid() {
+      return null;
+    }
+    takePreReadyEvents() {
+      return [];
+    }
+    hasExited() {
+      return this.record.exited;
+    }
+    dispose() {
+      this.record.disposed = true;
+    }
+    waitForExit() {
+      return Promise.resolve();
+    }
+  },
+}));
+
+const REAL_PLATFORM = process.platform;
+beforeAll(() => {
+  Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
+});
+afterAll(() => {
+  Object.defineProperty(process, "platform", { value: REAL_PLATFORM, configurable: true });
+});
+
+vi.mock("../resolveAssistantBinary.js", () => ({
+  ASSISTANT_BIN_ENV: "DAINTREE_ASSISTANT_BIN",
+  resolveAssistantBinary: () =>
+    Promise.resolve({ path: "/nonexistent/daintree-assistant", source: "repo" }),
+}));
+
+vi.mock("electron", () => ({
+  app: { getPath: () => "/tmp/daintree-eviction-protection-test", isPackaged: false },
+  webContents: { fromId: () => ({ isDestroyed: () => false, send: () => {} }) },
+}));
+
+vi.mock("../../../ipc/handlers/helpAssistant.js", () => ({
+  getHelpAssistantSettings: () => ({ tier: "action" }),
+}));
+
+vi.mock("../../HelpSessionService.js", () => ({
+  helpSessionService: {
+    provisionSession: () =>
+      Promise.resolve({
+        sessionId: "help_1",
+        sessionPath: "/tmp/daintree-eviction-protection-test/help_1",
+        token: "tok",
+        tier: "action",
+        mcpUrl: "http://127.0.0.1:1/mcp",
+        windowId: 1,
+      }),
+    markEngineSession: () => true,
+    getDebugLoggingPreference: () => false,
+    getDebugLogging: () => false,
+    getBypassPermissions: () => false,
+    revokeSession: () => Promise.resolve(),
+  },
+}));
+
+const logger = vi.hoisted(() => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock("../../../utils/logger.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../utils/logger.js")>()),
+  createLogger: () => logger,
+}));
+
+const { AssistantHostService } = await import("../AssistantHostService.js");
+
+type Service = InstanceType<typeof AssistantHostService>;
+
+function startSurface(service: Service, webContentsId: number, windowId: number, slot?: number) {
+  return service.start({ projectId: "p1", cwd: "/tmp/project", webContentsId, windowId, slot });
+}
+
+/** A macrotask boundary: every microtask a start chains before its readiness wait has run. */
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+beforeEach(() => {
+  hosts.length = 0;
+  deferReady = false;
+  onSpawn = null;
+  vi.clearAllMocks();
+});
+
+describe("which surfaces a live native engine cannot lose (#12364)", () => {
+  it("names the view holding the control plane, not a window that joined it", async () => {
+    const service = new AssistantHostService();
+    await startSurface(service, 10, 1);
+    await startSurface(service, 11, 2);
+
+    expect(service.wouldEndLiveEngine(10)).toBe(true);
+    // Losing a joiner only detaches it — the engine keeps running for surface 10.
+    expect(service.wouldEndLiveEngine(11)).toBe(false);
+    expect(service.wouldEndLiveEngine(99)).toBe(false);
+
+    service.stopByWebContents(11);
+    expect(hosts[0]?.disposed).toBe(false);
+    expect(service.wouldEndLiveEngine(10)).toBe(true);
+  });
+
+  it("agrees with what losing each surface actually does", async () => {
+    // The floor is only as good as this prediction. Each case asks, then does what
+    // eviction does, on a fresh engine — so a change to `detach` the query did not follow
+    // fails here instead of in somebody's lost conversation.
+    const cases = [
+      { surfaces: [10], lose: 10 },
+      { surfaces: [10, 11], lose: 10 },
+      { surfaces: [10, 11], lose: 11 },
+      { surfaces: [10, 11, 12], lose: 12 },
+    ];
+    for (const { surfaces, lose } of cases) {
+      hosts.length = 0;
+      const service = new AssistantHostService();
+      for (const [index, webContentsId] of surfaces.entries()) {
+        await startSurface(service, webContentsId, index + 1);
+      }
+
+      const predicted = service.wouldEndLiveEngine(lose);
+      service.stopByWebContents(lose);
+
+      expect({ surfaces, lose, ended: hosts[0]?.disposed }).toEqual({
+        surfaces,
+        lose,
+        ended: predicted,
+      });
+    }
+  });
+
+  it("covers the engine from registration, before it is spawned or ready", async () => {
+    // The session is registered before the child is spawned, and the readiness wait can
+    // run for 90 seconds — long enough for a background view to be reclaimed mid-boot.
+    deferReady = true;
+    const service = new AssistantHostService();
+    let atSpawn: boolean | null = null;
+    onSpawn = () => {
+      atSpawn = service.wouldEndLiveEngine(10);
+    };
+
+    const pending = startSurface(service, 10, 1);
+    await flush();
+
+    expect(atSpawn).toBe(true);
+    expect(hosts[0]?.ready).not.toBe(null);
+    expect(service.wouldEndLiveEngine(10)).toBe(true);
+
+    hosts[0]?.ready?.resolve();
+    await pending;
+    expect(service.wouldEndLiveEngine(10)).toBe(true);
+  });
+
+  it("releases the view once the engine's child has exited", async () => {
+    const service = new AssistantHostService();
+    await startSurface(service, 10, 1);
+    expect(service.wouldEndLiveEngine(10)).toBe(true);
+
+    // Flipped WITHOUT the exit callback that deregisters the session: liveness is read
+    // from the child, not inferred from the session still being on file.
+    hosts[0]!.exited = true;
+
+    expect(service.wouldEndLiveEngine(10)).toBe(false);
+  });
+
+  it("releases the view as soon as the session is stopped, while its child still drains", async () => {
+    // `stop` leaves routing and revokes the bearer at once, then gives the child a grace
+    // period. There is nothing left to keep alive, so there is nothing to protect.
+    const service = new AssistantHostService();
+    const { sessionId } = await startSurface(service, 10, 1);
+
+    service.stop(sessionId);
+
+    expect(hosts[0]?.disposed).toBe(true);
+    expect(hosts[0]?.exited).toBe(false);
+    expect(service.wouldEndLiveEngine(10)).toBe(false);
+  });
+
+  it("does not hold a view for a start that failed", async () => {
+    deferReady = true;
+    const service = new AssistantHostService();
+    const pending = startSurface(service, 10, 1);
+    await flush();
+
+    hosts[0]?.ready?.reject(new Error("engine never became ready"));
+
+    await expect(pending).rejects.toThrow(/never became ready/);
+    expect(service.wouldEndLiveEngine(10)).toBe(false);
+  });
+
+  it("keeps each lane's owner to itself", async () => {
+    // Lanes of one project run separate engines (#12108), here started from different
+    // windows. A dead lane must not borrow its sibling's liveness, nor lend its own.
+    const service = new AssistantHostService();
+    await startSurface(service, 10, 1, 0);
+    await startSurface(service, 20, 2, 1);
+    expect(hosts).toHaveLength(2);
+    expect(service.wouldEndLiveEngine(10)).toBe(true);
+    expect(service.wouldEndLiveEngine(20)).toBe(true);
+
+    hosts[0]!.exited = true;
+
+    expect(service.wouldEndLiveEngine(10)).toBe(false);
+    expect(service.wouldEndLiveEngine(20)).toBe(true);
+  });
+
+  it("says the control plane left when it did, not that the last surface did", async () => {
+    // A provisioner leaving with windows still attached ends the session too, and the log
+    // used to follow the right line with the wrong one.
+    const messages = () => logger.info.mock.calls.map(([message]) => String(message));
+    const logged = (pattern: RegExp) => messages().some((message) => pattern.test(message));
+
+    const shared = new AssistantHostService();
+    await startSurface(shared, 10, 1);
+    await startSurface(shared, 11, 2);
+    logger.info.mockClear();
+    shared.stopByWebContents(10);
+    expect(logged(/control plane left/)).toBe(true);
+    expect(logged(/last surface left/)).toBe(false);
+
+    const solo = new AssistantHostService();
+    await startSurface(solo, 20, 3);
+    logger.info.mockClear();
+    solo.stopByWebContents(20);
+    expect(logged(/last surface left/)).toBe(true);
+    expect(logged(/control plane left/)).toBe(false);
+  });
+});

--- a/electron/window/ProjectViewEvictionController.ts
+++ b/electron/window/ProjectViewEvictionController.ts
@@ -41,7 +41,16 @@ function readProcessMemoryKb(proc: Electron.ProcessMetric): number {
 /**
  * Whether destroying `entry` would kill a running Daintree Assistant (#11157).
  *
- * Three conditions, all load-bearing:
+ * A native engine (#12364) is asked about first, and separately. It is a child
+ * process of main that never binds a PTY, so the PTY backends below are empty
+ * for it — and that empty list used to return false before anything else was
+ * consulted, putting the engine's view in the ordinary pool. Destroying the
+ * view runs `stopByWebContents`; `wouldEndNativeAssistant` answers whether that
+ * would end a live engine, from the service that makes the decision, so it
+ * names only the view whose loss stops one (its sole surface, or the surface
+ * its control plane is pinned to).
+ *
+ * A PTY-backed assistant needs three conditions, all load-bearing:
  *
  * 1. HelpSessionService has an unrevoked session for the project with a spawned
  *    PTY bound to it.
@@ -67,10 +76,10 @@ function hasLiveAssistantBackend(
   projectId: string,
   entry: ViewEntry
 ): boolean {
-  const backends = host.assistantBackendsForProject?.(projectId) ?? [];
-  if (backends.length === 0) return false;
   const wc = entry.view.webContents;
   if (wc.isDestroyed()) return false;
+  if (host.wouldEndNativeAssistant?.(wc.id) === true) return true;
+  const backends = host.assistantBackendsForProject?.(projectId) ?? [];
   // All three conditions must hold for the SAME lane (#12108): a dead lane
   // must not borrow a live sibling's liveness, and a lane pinned to another
   // window must not protect this view. Checking them per backend rather than
@@ -338,7 +347,8 @@ export function evictStaleViews(
   // `onViewEvicted` → `revokeByWebContentsId` → `gracefulKill`, which kills the
   // assistant's whole PTY process tree, so every sub-agent and background shell
   // it spawned dies with no completion record. Only the transcript's resume id
-  // survives. An ordinary grid terminal has no such coupling — its PTY lives in
+  // survives. A native engine dies the same way through `stopByWebContents`,
+  // taking its conversation with it (#12364). An ordinary grid terminal has no such coupling — its PTY lives in
   // the pty-host and reconnects on switch-back — which is why the floor is
   // scoped to assistant backends and not to `hasActiveAgent()` at large, whose
   // views are safe to evict and whose projects would otherwise pin the cache
@@ -353,13 +363,16 @@ export function evictStaleViews(
   // never a `<webview>` guest and never appears in `app.getAppMetrics()`, so
   // the `gracefulKill` that follows the teardown recovers nothing this pass can
   // measure. Admitting the view bought no memory the ordinary tiers could not,
-  // and cost the user every running sub-agent.
+  // and cost the user every running sub-agent. The native engine is no
+  // different: a plain `child_process` of main, which `app.getAppMetrics()`
+  // does not list either.
   //
-  // Cache growth stays bounded by construction: only the single `webContentsId`
-  // a live session pinned is protected, HelpSessionService enforces one backend
-  // per project, and another window's view of the same project remains an
-  // ordinary candidate. The ceiling is the number of assistants actually
-  // running — reported below so the over-cap cache is attributable.
+  // Cache growth stays bounded by construction: only the single view a live
+  // session pinned is protected — for a native engine, the one whose loss would
+  // end it — there is at most one backend per lane, and another window's view
+  // of the same project remains an ordinary candidate. The ceiling is the number
+  // of assistants actually running — reported below so the over-cap cache is
+  // attributable.
   //
   // A view backing a live-but-idle MCP session binding sits between the two
   // (#11790): evicting it breaks the binding with no recovery path, so it

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -218,6 +218,14 @@ export interface ProjectViewManagerOptions {
    */
   isTerminalLive?: (terminalId: string) => boolean;
   /**
+   * Whether destroying the view with this WebContents would end a live native
+   * Daintree Assistant engine (#12364). The native engine is a child process of
+   * main that never binds a PTY, so the pair above cannot see it — and eviction
+   * stops it outright. Injected from the composition root for the same reason as
+   * that pair. Absent, no view reads as backing a native engine.
+   */
+  wouldEndNativeAssistant?: (webContentsId: number) => boolean;
+  /**
    * Why MCP needs this view kept running right now (#11790) — a live session
    * binding, an in-flight dispatch, or neither. Injected from the composition
    * root for the same reason as `assistantBackendsForProject`: electron/window/
@@ -300,6 +308,7 @@ export class ProjectViewManager {
     webContentsId: number;
   }>;
   isTerminalLive?: (terminalId: string) => boolean;
+  wouldEndNativeAssistant?: (webContentsId: number) => boolean;
   mcpViewActivity?: (workspaceId: string, webContentsId: number) => McpViewActivity | null;
   windowRegistry?: import("./WindowRegistry.js").WindowRegistry;
   private switchChain: Promise<void> = Promise.resolve();
@@ -385,6 +394,7 @@ export class ProjectViewManager {
     this.onViewCrashed = opts.onViewCrashed;
     this.assistantBackendsForProject = opts.assistantBackendsForProject;
     this.isTerminalLive = opts.isTerminalLive;
+    this.wouldEndNativeAssistant = opts.wouldEndNativeAssistant;
     this.mcpViewActivity = opts.mcpViewActivity;
     this.windowRegistry = opts.windowRegistry;
     if (opts.cachedProjectViews != null) {

--- a/electron/window/__tests__/ProjectViewManager.eviction.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.eviction.test.ts
@@ -1000,8 +1000,16 @@ describe("ProjectViewManager — eviction safety", () => {
   // here, because an empty backend list is exactly what used to decide the
   // answer before the engine was ever asked about.
   describe("live native assistant engines (#12364)", () => {
-    function makeManager(cachedProjectViews: number, onViewEvicted?: (id: number) => void) {
-      return new ProjectViewManager(win as never, {
+    let managers: ProjectViewManager[] = [];
+
+    function makeManager(
+      cachedProjectViews: number,
+      hooks: {
+        onViewEvicted?: (id: number) => void;
+        wouldEndNativeAssistant?: (id: number) => boolean;
+      } = {}
+    ) {
+      const mgr = new ProjectViewManager(win as never, {
         dirname: "/test",
         paintGateTimeoutMs: 0,
         paintGateHardTimeoutMs: 0,
@@ -1010,10 +1018,19 @@ describe("ProjectViewManager — eviction safety", () => {
         cachedProjectViews,
         assistantBackendsForProject,
         isTerminalLive,
-        wouldEndNativeAssistant,
-        onViewEvicted,
+        wouldEndNativeAssistant: hooks.wouldEndNativeAssistant ?? wouldEndNativeAssistant,
+        onViewEvicted: hooks.onViewEvicted,
       });
+      managers.push(mgr);
+      return mgr;
     }
+
+    afterEach(() => {
+      // Each manager starts a randomly-phased memory sampler; a tick left running
+      // could write into the shared logInfo mock during a later test.
+      for (const mgr of managers) mgr.dispose();
+      managers = [];
+    });
 
     const evictedProjectIds = () =>
       vi
@@ -1040,7 +1057,7 @@ describe("ProjectViewManager — eviction safety", () => {
       // false and the engine's view — the LRU one — was reclaimed like any other.
       // No agent-state seed either: an engine waiting on its user is still an engine.
       const onViewEvicted = vi.fn();
-      const managerWithLimit = makeManager(2, onViewEvicted);
+      const managerWithLimit = makeManager(2, { onViewEvicted });
       const wcA = registerA(managerWithLimit);
 
       await managerWithLimit.switchTo("proj-b", "/path/b");
@@ -1135,7 +1152,8 @@ describe("ProjectViewManager — eviction safety", () => {
     });
 
     it("keeps a native engine's view through the forced tier-2 reclaim (#11477)", async () => {
-      const managerWithLimit = makeManager(3);
+      const onViewEvicted = vi.fn();
+      const managerWithLimit = makeManager(3, { onViewEvicted });
       const wcA = registerA(managerWithLimit);
 
       await managerWithLimit.switchTo("proj-b", "/path/b");
@@ -1144,6 +1162,7 @@ describe("ProjectViewManager — eviction safety", () => {
       await flushImmediates();
 
       nativeEngineViews.add(wcA.id);
+      const wcB = webContentsOf(managerWithLimit, "proj-b");
 
       managerWithLimit.reclaimCachedViewsUnderPressure();
 
@@ -1155,6 +1174,8 @@ describe("ProjectViewManager — eviction safety", () => {
       ).toEqual(["proj-a", "proj-c"]);
       expect(evictedProjectIds()).toEqual(["proj-b"]);
       expect(wcA.close).not.toHaveBeenCalled();
+      expect(onViewEvicted).toHaveBeenCalledWith(wcB.id);
+      expect(onViewEvicted).not.toHaveBeenCalledWith(wcA.id);
       expect(vi.mocked(logInfo)).toHaveBeenCalledWith(
         "projectview.eviction-skipped",
         expect.objectContaining({
@@ -1164,6 +1185,26 @@ describe("ProjectViewManager — eviction safety", () => {
           protectedProjectIds: ["proj-a"],
         })
       );
+    });
+
+    it("never asks about, or keeps, a view whose renderer is already gone", async () => {
+      // The service can still name a dead surface until something reaps it. Asking
+      // before the destroyed guard would pin a dead entry over the cap indefinitely.
+      const asked = vi.fn(wouldEndNativeAssistant);
+      const managerWithLimit = makeManager(2, { wouldEndNativeAssistant: asked });
+      const wcA = registerA(managerWithLimit);
+
+      await managerWithLimit.switchTo("proj-b", "/path/b");
+      await flushImmediates();
+      nativeEngineViews.add(wcA.id);
+      wcA.isDestroyed.mockReturnValue(true);
+
+      await managerWithLimit.switchTo("proj-c", "/path/c");
+      await flushImmediates();
+
+      expect(managerWithLimit.getAllViews().map((v) => v.projectId)).not.toContain("proj-a");
+      expect(evictedProjectIds()).toContain("proj-a");
+      expect(asked).not.toHaveBeenCalledWith(wcA.id);
     });
   });
 

--- a/electron/window/__tests__/ProjectViewManager.eviction.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.eviction.test.ts
@@ -221,6 +221,11 @@ const assistantBackendsForProject = (projectId: string) => {
   return backend ? [backend] : [];
 };
 const isTerminalLive = (terminalId: string): boolean => liveTerminals.has(terminalId);
+// The native engine's half (#12364): the views whose loss would end a live
+// engine, keyed by WebContents id alone — the way the teardown it predicts is.
+const nativeEngineViews = new Set<number>();
+const wouldEndNativeAssistant = (webContentsId: number): boolean =>
+  nativeEngineViews.has(webContentsId);
 
 import { ProjectViewManager } from "../ProjectViewManager.js";
 import { events } from "../../services/events.js";
@@ -277,6 +282,7 @@ describe("ProjectViewManager — eviction safety", () => {
     mockGetAppMetrics.mockReturnValue([]);
     assistantBackends.clear();
     liveTerminals.clear();
+    nativeEngineViews.clear();
     win = createMockWindow();
     manager = new ProjectViewManager(win as never, {
       dirname: "/test",
@@ -983,6 +989,181 @@ describe("ProjectViewManager — eviction safety", () => {
 
       expect(wcB.close).toHaveBeenCalled();
       expect(managerWithLimit.getAllViews().map((v) => v.projectId)).not.toContain("proj-b");
+    });
+  });
+
+  // ── Native assistant engines share the floor (issue #12364) ──
+  //
+  // The native engine is a child process of main, not a PTY, so the backends
+  // above never see it — and evicting its view runs `stopByWebContents`, which
+  // ends the engine and its conversation. The PTY pair stays wired but empty
+  // here, because an empty backend list is exactly what used to decide the
+  // answer before the engine was ever asked about.
+  describe("live native assistant engines (#12364)", () => {
+    function makeManager(cachedProjectViews: number, onViewEvicted?: (id: number) => void) {
+      return new ProjectViewManager(win as never, {
+        dirname: "/test",
+        paintGateTimeoutMs: 0,
+        paintGateHardTimeoutMs: 0,
+        warmPaintGateTimeoutMs: 0,
+        warmPaintGateHardTimeoutMs: 0,
+        cachedProjectViews,
+        assistantBackendsForProject,
+        isTerminalLive,
+        wouldEndNativeAssistant,
+        onViewEvicted,
+      });
+    }
+
+    const evictedProjectIds = () =>
+      vi
+        .mocked(logInfo)
+        .mock.calls.filter(([event]) => event === "projectview.eviction")
+        .map(([, ctx]) => (ctx as { projectId: string }).projectId);
+
+    const webContentsOf = (mgr: ProjectViewManager, projectId: string) =>
+      mgr.getAllViews().find((v) => v.projectId === projectId)!.view
+        .webContents as unknown as ReturnType<typeof createMockWebContents>;
+
+    function registerA(mgr: ProjectViewManager) {
+      const wcA = createMockWebContents();
+      mgr.registerInitialView(
+        { webContents: wcA, setBounds: vi.fn() } as never,
+        "proj-a",
+        "/path/a"
+      );
+      return wcA;
+    }
+
+    it("keeps a native engine's view out of LRU eviction with no PTY backend at all", async () => {
+      // The reported bug. Nothing bound a PTY, so the empty backend list returned
+      // false and the engine's view — the LRU one — was reclaimed like any other.
+      // No agent-state seed either: an engine waiting on its user is still an engine.
+      const onViewEvicted = vi.fn();
+      const managerWithLimit = makeManager(2, onViewEvicted);
+      const wcA = registerA(managerWithLimit);
+
+      await managerWithLimit.switchTo("proj-b", "/path/b");
+      await flushImmediates();
+      nativeEngineViews.add(wcA.id);
+      const wcB = webContentsOf(managerWithLimit, "proj-b");
+
+      await managerWithLimit.switchTo("proj-c", "/path/c");
+      await flushImmediates();
+
+      const remaining = managerWithLimit.getAllViews().map((v) => v.projectId);
+      expect(remaining).toContain("proj-a");
+      expect(remaining).not.toContain("proj-b");
+      expect(wcA.close).not.toHaveBeenCalled();
+      expect(wcB.close).toHaveBeenCalled();
+      // `onViewEvicted` is what stops the engine in the product.
+      expect(onViewEvicted).toHaveBeenCalledWith(wcB.id);
+      expect(onViewEvicted).not.toHaveBeenCalledWith(wcA.id);
+    });
+
+    it("holds the cache over its limit for a native engine beside a PTY assistant", async () => {
+      // The halves are OR'd: neither kind of assistant may mask the other.
+      const managerWithLimit = makeManager(2);
+      const wcA = registerA(managerWithLimit);
+
+      await managerWithLimit.switchTo("proj-b", "/path/b");
+      await flushImmediates();
+
+      nativeEngineViews.add(wcA.id);
+      const wcB = webContentsOf(managerWithLimit, "proj-b");
+      assistantBackends.set("proj-b", { terminalId: "t-help-b", webContentsId: wcB.id });
+      liveTerminals.add("t-help-b");
+
+      await managerWithLimit.switchTo("proj-c", "/path/c");
+      await flushImmediates();
+
+      expect(
+        managerWithLimit
+          .getAllViews()
+          .map((v) => v.projectId)
+          .sort()
+      ).toEqual(["proj-a", "proj-b", "proj-c"]);
+      expect(wcA.close).not.toHaveBeenCalled();
+      expect(wcB.close).not.toHaveBeenCalled();
+      expect(vi.mocked(logInfo)).toHaveBeenCalledWith(
+        "projectview.eviction-skipped",
+        expect.objectContaining({
+          reason: "lru",
+          overflow: 1,
+          protectedProjectIds: ["proj-a", "proj-b"],
+        })
+      );
+    });
+
+    it("stops protecting the view once losing it would no longer end an engine", async () => {
+      // The engine exited or its session was stopped, so the service stops naming
+      // the view. The floor is re-read on every pass, and the next one takes it.
+      const managerWithLimit = makeManager(2);
+      const wcA = registerA(managerWithLimit);
+
+      await managerWithLimit.switchTo("proj-b", "/path/b");
+      await flushImmediates();
+      nativeEngineViews.add(wcA.id);
+
+      await managerWithLimit.switchTo("proj-c", "/path/c");
+      await flushImmediates();
+      expect(wcA.close).not.toHaveBeenCalled();
+
+      nativeEngineViews.delete(wcA.id);
+      await managerWithLimit.switchTo("proj-d", "/path/d");
+      await flushImmediates();
+
+      expect(managerWithLimit.getAllViews().map((v) => v.projectId)).not.toContain("proj-a");
+      expect(wcA.close).toHaveBeenCalled();
+    });
+
+    it("protects only the view whose loss would end the engine", async () => {
+      // A window that merely joined the engine detaches without harm and can rejoin,
+      // so the service does not name its view and it stays an ordinary candidate.
+      const managerWithLimit = makeManager(2);
+      const wcA = registerA(managerWithLimit);
+
+      await managerWithLimit.switchTo("proj-b", "/path/b");
+      await flushImmediates();
+      nativeEngineViews.add(wcA.id + 5000);
+
+      await managerWithLimit.switchTo("proj-c", "/path/c");
+      await flushImmediates();
+
+      expect(managerWithLimit.getAllViews().map((v) => v.projectId)).not.toContain("proj-a");
+      expect(wcA.close).toHaveBeenCalled();
+    });
+
+    it("keeps a native engine's view through the forced tier-2 reclaim (#11477)", async () => {
+      const managerWithLimit = makeManager(3);
+      const wcA = registerA(managerWithLimit);
+
+      await managerWithLimit.switchTo("proj-b", "/path/b");
+      await flushImmediates();
+      await managerWithLimit.switchTo("proj-c", "/path/c");
+      await flushImmediates();
+
+      nativeEngineViews.add(wcA.id);
+
+      managerWithLimit.reclaimCachedViewsUnderPressure();
+
+      expect(
+        managerWithLimit
+          .getAllViews()
+          .map((v) => v.projectId)
+          .sort()
+      ).toEqual(["proj-a", "proj-c"]);
+      expect(evictedProjectIds()).toEqual(["proj-b"]);
+      expect(wcA.close).not.toHaveBeenCalled();
+      expect(vi.mocked(logInfo)).toHaveBeenCalledWith(
+        "projectview.eviction-skipped",
+        expect.objectContaining({
+          reason: "pressure",
+          forced: true,
+          protectedCount: 1,
+          protectedProjectIds: ["proj-a"],
+        })
+      );
     });
   });
 
@@ -2484,6 +2665,7 @@ describe("ProjectViewManager — low-memory eviction", () => {
     mockGetAppMetrics.mockReturnValue([]);
     assistantBackends.clear();
     liveTerminals.clear();
+    nativeEngineViews.clear();
     win = createMockWindow();
     manager = new ProjectViewManager(win as never, {
       dirname: "/test",
@@ -3006,6 +3188,7 @@ describe("ProjectViewManager — graduated memory reclaim (#11469)", () => {
     mockGetAppMetrics.mockReturnValue([]);
     assistantBackends.clear();
     liveTerminals.clear();
+    nativeEngineViews.clear();
     win = createMockWindow();
     manager = makeManager(3);
     manager.setMemoryPressurePolicy(BAND);


### PR DESCRIPTION
## Summary

- The native Daintree Assistant engine is a `child_process` of main, and it was getting killed every time its cached project view got evicted. `hasLiveAssistantBackend` in `electron/window/ProjectViewEvictionController.ts` only recognized PTY-backed assistants (via `HelpSessionService` bindings plus `PtyClient` liveness), so for a native-only project the backend list came back empty, the predicate returned false, and the view fell into the ordinary LRU/pressure pool. From there `onViewEvicted` called `assistantHostService.stopByWebContents`, which called `detach`, which called `stop` and killed the engine.
- The PTY-backed help agents already get an unconditional eviction floor. This brings the native engine in line with that.

Resolves #12364

## Changes

- `AssistantHostService` gains `departureEndsSession(session, webContentsId)`: true when the session is subscribed and either it's the sole subscriber or the departing surface is the control-plane provisioner. Both `detach()` and a new public `wouldEndLiveEngine(webContentsId)` use it. `wouldEndLiveEngine` is true iff a registered session whose child hasn't exited would be ended by losing that surface, keyed by WebContents alone (same as `stopByWebContents`). It's live from registration, before spawn, through the readiness wait, until the session stops or the child exits. A joining window's view isn't protected, since losing it only detaches that window rather than ending the session.
- `ProjectViewManager` gets a new optional `wouldEndNativeAssistant` option, consulted in `hasLiveAssistantBackend` right after the destroyed-WebContents guard and before the PTY backend check, OR'd with the existing PTY floor. So the native engine now gets the same unconditional floor across LRU eviction, limit overflow, and gradual and forced tier-2 pressure.
- Wired up in `electron/main.ts` with a static import placed after `windowServices`, which already evaluates the module through the IPC handlers.
- `detach()` no longer logs "last surface left" after a control-plane departure that already logged it ended the shared session. That misleading double log line is what the issue's evidence section was pointing at.

## Testing

- Added `electron/services/assistant-host/__tests__/engineEvictionProtection.test.ts`: provisioner vs. joiner behavior, prediction agreeing with actual teardown (checked independently), protection before spawn and before readiness, release on child exit, release on stop mid-drain, failed start, per-lane isolation, one view hosting two lanes, and exclusive departure logging.
- Added a "live native assistant engines (#12364)" block to `electron/window/__tests__/ProjectViewManager.eviction.test.ts`: no-PTY view survives LRU with `onViewEvicted` never naming the protected view, native and PTY protection OR'd together over the cap, release after the engine ends, only the ending view gets protected, forced tier-2 reclaim still respects the floor, and a destroyed view is never asked about and gets reclaimed regardless.
- Ran a targeted vitest pass over 11 files (assistant-host suites including `ownershipBoundary.contract`, plus `ProjectViewManager` eviction/adversarial/lifecycle/recovery/freeze, plus `globalServicesInit.order`): 360 tests passed. `eslint` and `prettier --check` are clean on all 6 changed files. Full suite, typecheck, and build are left to CI.

One adjacent gap I checked but is out of scope here: `IdleBackgroundAutoCloseService` (opt-in, default off) floors PTY assistants but not native engines, since its `closeProject` revokes the project's bearers and evicts the renderer directly. With idle auto-close turned on, a background project's native engine can still get closed that way. I also checked `HibernationService` and it doesn't touch native engines, since it only evicts renderers for user-initiated hibernation. Session recovery after a teardown is a separate gap, already tracked as #12365.
