### PR TITLE
fix(memory): count the macOS file cache and confirm pressure before evicting cached views

### DIFF
--- a/electron/ipc/handlers/diagnostics.ts
+++ b/electron/ipc/handlers/diagnostics.ts
@@ -198,7 +198,7 @@ function ensureEventLoopHistogram(): IntervalHistogram {
 /**
  * Snapshot total + available physical memory for the diagnostics popover.
  * `systemTotalMB` comes from os.totalmem() (always available). `systemAvailableMB`
- * = free (+ purgeable on macOS) per process.getSystemMemoryInfo(), mirroring
+ * = free (+ purgeable and file-backed on macOS) per process.getSystemMemoryInfo(), mirroring
  * ProcessMemoryMonitor.readAvailableMemoryMb so the two stay in sync; it is
  * omitted when that Chromium API is unavailable (e.g. test mocks), so the
  * renderer hides the row rather than showing 0.

--- a/electron/services/ProcessMemoryMonitor.ts
+++ b/electron/services/ProcessMemoryMonitor.ts
@@ -349,8 +349,8 @@ function getProcessMemoryMb(proc: Electron.ProcessMetric): number {
 
 /**
  * Read system-wide available memory in MB. On macOS, "available" = free +
- * purgeable, because Darwin holds reclaimable pages as purgeable rather than
- * free — using `free` alone would fire false positives on every healthy mac.
+ * purgeable + fileBacked (see readSystemMemorySnapshot) — using `free` alone
+ * would fire false positives on every healthy mac.
  * On Windows/Linux, `free` alone is accurate. Returns null when the Chromium
  * API is unavailable (e.g., under test mocks). Mirrors the pattern in
  * ProjectViewManager.getAvailableMemoryMb so the two memory floors stay in
@@ -540,11 +540,10 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
 
       // System-wide signal uses the reclaim band's critical edge: RAM-relative
       // below ~10 GB, flat at 1 GB above it. Only the band's *warning* edge
-      // widens with RAM (#11926) — this one stays capped, because `availableMb`
-      // is `free + purgeable` and omits Darwin's `fileBacked` file cache, so a
-      // 64–128 GB machine reports far less "available" than it has headroom
-      // for. Raising this edge against that scale would read healthy file-cache
-      // occupancy as critical and hand tier 2 a machine that is fine.
+      // widens with RAM (#11926) — this one is the emergency edge that hands
+      // tier 2 a collapse, and `availableMb` counts Darwin's file cache
+      // (#12363), so on a large Mac it is crossed only once that cache is
+      // spent. See `getSystemMemoryThresholds`.
       const availableMb = readAvailableSystemMemoryMb();
       const systemPressureActive = availableMb !== null && availableMb < systemLowMemoryThresholdMb;
       if (systemPressureActive) {

--- a/electron/services/ResourceProfileService.ts
+++ b/electron/services/ResourceProfileService.ts
@@ -782,8 +782,8 @@ export class ResourceProfileService {
   /**
    * Read system-wide available memory in MB. Mirrors
    * ProjectViewManager.getAvailableMemoryMb(): on macOS "available" =
-   * free + purgeable, because Darwin holds reclaimable pages as purgeable
-   * rather than free. On Windows/Linux, `free` alone is accurate. Returns
+   * free + purgeable + fileBacked (see readSystemMemorySnapshot). On
+   * Windows/Linux, `free` alone is accurate. Returns
    * null when the Chromium API is unavailable (e.g., under test mocks).
    */
   private getAvailableSystemMemoryMb(): number | null {
@@ -981,8 +981,8 @@ export class ResourceProfileService {
     // System-available memory signal. The app-private signal above only sees
     // this process's footprint; if another app on the box is hoarding RAM
     // and the OS is paging, we want to back off even when our own memory
-    // looks fine. Mirrors the (free + purgeable) pattern ProjectViewManager
-    // already uses for cached-view eviction.
+    // looks fine. Reads the same figure ProjectViewManager uses for cached-view
+    // eviction.
     const sysAvailMb = this.getAvailableSystemMemoryMb();
     if (sysAvailMb !== null) {
       let sysScore = 0;

--- a/electron/services/__tests__/ProcessMemoryMonitor.test.ts
+++ b/electron/services/__tests__/ProcessMemoryMonitor.test.ts
@@ -665,14 +665,20 @@ describe("ProcessMemoryMonitor", () => {
       }
     }
 
-    function stubSystemMemoryInfo(freeKb: number, purgeableKb = 0): void {
+    function stubSystemMemoryInfo(freeKb: number, purgeableKb = 0, fileBackedKb = 0): void {
       (
         process as {
-          getSystemMemoryInfo?: () => { free: number; purgeable?: number; total: number };
+          getSystemMemoryInfo?: () => {
+            free: number;
+            purgeable?: number;
+            fileBacked?: number;
+            total: number;
+          };
         }
       ).getSystemMemoryInfo = () => ({
         free: freeKb,
         purgeable: purgeableKb,
+        fileBacked: fileBackedKb,
         total: EIGHT_GB / 1024,
       });
     }
@@ -704,6 +710,19 @@ describe("ProcessMemoryMonitor", () => {
       // 500 MB free + 500 MB purgeable = 1000 MB available, > 819 MB threshold.
       // Without the purgeable summation this would falsely trigger on macOS.
       stubSystemMemoryInfo(500 * 1024, 500 * 1024);
+      mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 100 * 1024, 100)]);
+
+      stop = startAppMetricsMonitor(mockActions);
+      await advancePolls(WARMUP_INTERVALS + PRESSURE_COUNT_TIER2 + 1);
+
+      expect(mockActions.destroyHiddenWebviews).not.toHaveBeenCalled();
+    });
+
+    it("counts the file cache toward available on macOS (#12363)", async () => {
+      // A 64 GB Mac with a warm cache: 600 MB free + purgeable is under the
+      // 1 GB critical edge on every poll, beside 24 GB of file-backed pages.
+      vi.spyOn(os, "totalmem").mockReturnValue(64 * 1024 * 1024 * 1024);
+      stubSystemMemoryInfo(400 * 1024, 200 * 1024, 24 * 1024 * 1024);
       mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 100 * 1024, 100)]);
 
       stop = startAppMetricsMonitor(mockActions);

--- a/electron/services/__tests__/ResourceProfileService.test.ts
+++ b/electron/services/__tests__/ResourceProfileService.test.ts
@@ -1619,10 +1619,16 @@ describe("ResourceProfileService", () => {
       }
     });
 
-    function stubSystemMemory(freeKb: number, purgeableKb: number, totalKb: number): void {
+    function stubSystemMemory(
+      freeKb: number,
+      purgeableKb: number,
+      totalKb: number,
+      fileBackedKb = 0
+    ): void {
       (process as { getSystemMemoryInfo?: unknown }).getSystemMemoryInfo = vi.fn(() => ({
         free: freeKb,
         purgeable: purgeableKb,
+        fileBacked: fileBackedKb,
         total: totalKb,
       }));
     }
@@ -1689,6 +1695,25 @@ describe("ResourceProfileService", () => {
       // Asserting "performance" only passes if purgeable was added — without it
       // the score would jump to +2 (sys mem critical).
       stubSystemMemory(200 * 1024, 4 * 1024 * 1024, EIGHT_GB / 1024);
+
+      const deps = createDeps();
+      const service = new ResourceProfileService(deps);
+      service.start();
+
+      mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 200)]);
+      mockIsOnBatteryPower.mockReturnValue(false);
+
+      vi.advanceTimersByTime(60_000 + 30_000 + 30_000 + 30_000 + 30_000);
+      expect(service.getProfile()).toBe("performance");
+
+      service.stop();
+    });
+
+    it("includes the file cache in the 'available' calculation (#12363)", () => {
+      // Same shape as the purgeable case: 200 MB free alone is below the 10%
+      // floor, and 4 GB of file-backed pages lifts it above 20%. "performance"
+      // only holds if fileBacked was added.
+      stubSystemMemory(200 * 1024, 0, EIGHT_GB / 1024, 4 * 1024 * 1024);
 
       const deps = createDeps();
       const service = new ResourceProfileService(deps);

--- a/electron/utils/__tests__/systemMemory.test.ts
+++ b/electron/utils/__tests__/systemMemory.test.ts
@@ -34,10 +34,9 @@ describe("systemMemory thresholds", () => {
 
   it("holds the critical edge flat above the knee while the warning edge keeps widening", () => {
     // The asymmetry IS the fix. `criticalMb` gates tier-2 collapse, the
-    // efficiency latch and OOM classification, and is measured against a
-    // `free + purgeable` figure that omits Darwin's file cache — so it stays
-    // put. `warningMb` only starts the one-view-per-tick ladder, so it is the
-    // edge allowed to scale with the machine.
+    // efficiency latch and OOM classification, so it stays put. `warningMb`
+    // only starts the one-view-per-tick ladder, so it is the edge allowed to
+    // scale with the machine.
     const knee = getSystemMemoryThresholds(10 * 1024);
     let previousWarning = knee.warningMb;
     // Strictly increasing only up to the saturation point; past it the band is
@@ -143,7 +142,12 @@ describe("systemMemory thresholds", () => {
 
 describe("readSystemMemorySnapshot", () => {
   const proc = process as unknown as {
-    getSystemMemoryInfo?: () => { free: number; purgeable?: number; total: number };
+    getSystemMemoryInfo?: () => {
+      free: number;
+      purgeable?: number;
+      fileBacked?: number;
+      total: number;
+    };
   };
   const original = proc.getSystemMemoryInfo;
 
@@ -161,7 +165,7 @@ describe("readSystemMemorySnapshot", () => {
   it("treats a zero total as an API artifact rather than critical pressure", () => {
     // A transiently zeroed struct must not read as "no memory available" — that
     // would collapse every cached view and downgrade the profile on a glitch.
-    stub(() => ({ free: 0, purgeable: 0, total: 8 * 1024 * 1024 }));
+    stub(() => ({ free: 0, purgeable: 0, fileBacked: 0, total: 8 * 1024 * 1024 }));
     expect(readAvailableSystemMemoryMb()).toBeNull();
   });
 
@@ -195,5 +199,42 @@ describe("readSystemMemorySnapshot", () => {
 
     stub(() => ({ free: 512 * 1024, purgeable: Number.NaN, total: 8 * 1024 * 1024 }));
     expect(readAvailableSystemMemoryMb()).toBe(512);
+  });
+
+  it("counts Darwin's file cache as available, so a warm-cache Mac is not read as short (#12363)", () => {
+    // The issue's machine: 64 GB with ~600 MB free, ~1 GB purgeable and ~24 GB
+    // of file cache. Free + purgeable alone sits under the 64 GB warning edge,
+    // which is what had the ladder evicting cached views on every tick.
+    const band = getSystemMemoryThresholds(64 * 1024);
+    stub(() => ({
+      free: 600 * 1024,
+      purgeable: 1024 * 1024,
+      fileBacked: 24 * 1024 * 1024,
+      total: 64 * 1024 * 1024,
+    }));
+    const snapshot = readSystemMemorySnapshot();
+    expect(snapshot).toMatchObject({ freeMb: 600, purgeableMb: 1024, fileBackedMb: 24 * 1024 });
+    expect(snapshot!.availableMb).toBe(600 + 1024 + 24 * 1024);
+    expect(snapshot!.freeMb + snapshot!.purgeableMb).toBeLessThan(band.warningMb);
+    expect(snapshot!.availableMb).toBeGreaterThan(band.warningMb);
+  });
+
+  it("ignores an absent or malformed fileBacked figure, as Windows and Linux report none", () => {
+    for (const fileBacked of [undefined, Number.NaN, Number.POSITIVE_INFINITY, -4096, "lots"]) {
+      stub(() => ({ free: 512 * 1024, purgeable: 256 * 1024, fileBacked, total: 8 * 1024 * 1024 }));
+      expect(readSystemMemorySnapshot()).toMatchObject({ fileBackedMb: 0, availableMb: 768 });
+    }
+  });
+
+  it("still rejects a malformed free reading however much file cache comes with it", () => {
+    // Same reasoning as a plausible purgeable: a component must not launder a
+    // broken reading into a healthy-looking one.
+    stub(() => ({
+      free: -1024,
+      purgeable: 0,
+      fileBacked: 24 * 1024 * 1024,
+      total: 8 * 1024 * 1024,
+    }));
+    expect(readAvailableSystemMemoryMb()).toBeNull();
   });
 });

--- a/electron/utils/systemMemory.ts
+++ b/electron/utils/systemMemory.ts
@@ -98,18 +98,20 @@ function darwinComponentMb(kb: unknown): number {
 }
 
 /**
- * `availableMb` is what the OS can hand back cheaply: `free`, plus on Darwin
- * `purgeable` and `fileBacked`, which Electron reports only there — Windows and
- * Linux read `free` alone.
+ * `availableMb` is free memory plus, on Darwin, what Activity Monitor calls
+ * Cached Files: `fileBacked` + `purgeable`, which Electron reports only there,
+ * so Windows and Linux read `free` alone. That is the line macOS itself draws
+ * between reclaimable memory and Memory Used (app + wired + compressed).
  *
- * `fileBacked` is the file cache, and on a large Mac it is most of the
- * reclaimable memory: a 64 GB machine with a warm cache routinely shows ~1.5 GB
- * free + purgeable beside ~24 GB of it. Leaving it out read that machine as
- * permanently short and evicted its cached views around the clock (#12363).
+ * On a large Mac the file cache is most of it: a 64 GB machine with a warm
+ * cache routinely shows ~1.5 GB free + purgeable beside ~24 GB of `fileBacked`.
+ * Leaving that out read the machine as permanently short and evicted its cached
+ * views around the clock (#12363).
  *
- * The figure errs optimistic in one place — a cache under heavy churn costs
- * more to reclaim than a clean one. Pressure Daintree causes itself still
- * reaches ProcessMemoryMonitor's own-process RSS tiers, which never read this.
+ * The figure errs optimistic in one place: `fileBacked` counts active file
+ * pages as well as idle cache, and pages under heavy churn cost more to reclaim
+ * than clean ones. Pressure Daintree causes itself still reaches
+ * ProcessMemoryMonitor's own-process RSS tiers, which never read this.
  */
 export function readSystemMemorySnapshot(): SystemMemorySnapshot | null {
   const totalMb = os.totalmem() / 1024 / 1024;

--- a/electron/utils/systemMemory.ts
+++ b/electron/utils/systemMemory.ts
@@ -35,6 +35,7 @@ export interface SystemMemorySnapshot {
   totalMb: number;
   freeMb: number;
   purgeableMb: number;
+  fileBackedMb: number;
   availableMb: number;
 }
 
@@ -54,13 +55,11 @@ export interface SystemMemoryThresholds {
  * window — assistant-backed views stay protected at any band),
  * scores `+3` on the profile — enough to latch efficiency alone — and lets a
  * contemporaneous renderer `crashed`/`killed` be classified as probable OOM.
- * It is capped flat above the knee and stays that way. `availableMb` is
- * `free + purgeable`, which on Darwin omits `fileBacked` — the file cache, and
- * the bulk of what the OS would actually reclaim first. A large-RAM machine
- * therefore reports a far smaller "available" figure than it has headroom for,
- * and raising this edge against that scale would manufacture emergencies on
- * healthy machines. That measurement is the real ceiling on how far the band
- * can move and is worth fixing on its own; it is not this change.
+ * It is capped flat above the knee and stays that way. Since #12363
+ * `availableMb` counts Darwin's file cache, so on a large Mac this edge is
+ * crossed only once that cache is spent — which is what an emergency is.
+ * Raising it would move the collapse ahead of that point with nothing measured
+ * to say where.
  *
  * `warningMb` is the proactive edge: crossing it starts the graduated ladder,
  * which sheds at most one renderer per 30s sample per window and restores the
@@ -92,6 +91,26 @@ export function getSystemMemoryThresholds(totalMb: number): SystemMemoryThreshol
   };
 }
 
+/** A Darwin-only component (KB) as MB. Absent on Windows and Linux; a malformed
+ *  figure contributes nothing rather than failing a reading `free` vouches for. */
+function darwinComponentMb(kb: unknown): number {
+  return typeof kb === "number" && Number.isFinite(kb) && kb > 0 ? kb / 1024 : 0;
+}
+
+/**
+ * `availableMb` is what the OS can hand back cheaply: `free`, plus on Darwin
+ * `purgeable` and `fileBacked`, which Electron reports only there — Windows and
+ * Linux read `free` alone.
+ *
+ * `fileBacked` is the file cache, and on a large Mac it is most of the
+ * reclaimable memory: a 64 GB machine with a warm cache routinely shows ~1.5 GB
+ * free + purgeable beside ~24 GB of it. Leaving it out read that machine as
+ * permanently short and evicted its cached views around the clock (#12363).
+ *
+ * The figure errs optimistic in one place — a cache under heavy churn costs
+ * more to reclaim than a clean one. Pressure Daintree causes itself still
+ * reaches ProcessMemoryMonitor's own-process RSS tiers, which never read this.
+ */
 export function readSystemMemorySnapshot(): SystemMemorySnapshot | null {
   const totalMb = os.totalmem() / 1024 / 1024;
   if (!Number.isFinite(totalMb) || totalMb <= 0) return null;
@@ -102,14 +121,19 @@ export function readSystemMemorySnapshot(): SystemMemorySnapshot | null {
   if (getIsE2EFaultMode() || getIsE2EMode()) {
     const availableMb = Number(process.env.DAINTREE_E2E_SYSTEM_AVAILABLE_MEMORY_MB);
     if (Number.isFinite(availableMb) && availableMb > 0) {
-      return { totalMb, freeMb: availableMb, purgeableMb: 0, availableMb };
+      return { totalMb, freeMb: availableMb, purgeableMb: 0, fileBackedMb: 0, availableMb };
     }
   }
 
   try {
     const getInfo = (
       process as {
-        getSystemMemoryInfo?: () => { free: number; purgeable?: number; total: number };
+        getSystemMemoryInfo?: () => {
+          free: number;
+          purgeable?: number;
+          fileBacked?: number;
+          total: number;
+        };
       }
     ).getSystemMemoryInfo;
     if (typeof getInfo !== "function") return null;
@@ -119,17 +143,15 @@ export function readSystemMemorySnapshot(): SystemMemorySnapshot | null {
     // sum back into a healthy-looking figure.
     if (typeof info.free !== "number" || !Number.isFinite(info.free) || info.free < 0) return null;
     const freeMb = info.free / 1024;
-    const purgeableMb =
-      typeof info.purgeable === "number" && Number.isFinite(info.purgeable) && info.purgeable > 0
-        ? info.purgeable / 1024
-        : 0;
-    const availableMb = freeMb + purgeableMb;
+    const purgeableMb = darwinComponentMb(info.purgeable);
+    const fileBackedMb = darwinComponentMb(info.fileBacked);
+    const availableMb = freeMb + purgeableMb + fileBackedMb;
     // A zero total is treated as an API artifact, not a maximally-critical
     // reading: a transiently zeroed struct must not collapse every cached view
     // and downgrade the profile. Genuine exhaustion is caught by
     // ProcessMemoryMonitor's own-process RSS tiers.
     if (availableMb <= 0) return null;
-    return { totalMb, freeMb, purgeableMb, availableMb };
+    return { totalMb, freeMb, purgeableMb, fileBackedMb, availableMb };
   } catch {
     return null;
   }

--- a/electron/window/ProjectViewEvictionController.ts
+++ b/electron/window/ProjectViewEvictionController.ts
@@ -29,6 +29,23 @@ type EvictionCandidate = {
 };
 
 /**
+ * Consecutive sampler readings below the warning edge before a pressure pass
+ * may destroy anything (#12363). At the sampler's 30s cadence, two means the
+ * reading was still low half a minute later — enough to tell a dip from a trend
+ * while keeping the reaction to real pressure inside a minute.
+ */
+export const PRESSURE_SAMPLES_TO_CONFIRM = 2;
+
+/**
+ * How long a view must have sat unused before a gradual pressure pass may take
+ * it (#12363). The view the user just left is the likeliest next switch, so
+ * destroying it trades a ~60ms warm reveal for a cold reload exactly while they
+ * are moving between projects. Measured from `lastUsed`, the stamp LRU order
+ * already sorts on.
+ */
+export const MIN_PRESSURE_EVICTION_AGE_MS = 60_000;
+
+/**
  * workingSetSize is the only cross-platform field — privateBytes is
  * Windows-only and reports 0 (not undefined) on macOS/Linux, so a
  * `privateBytes ?? workingSetSize` fallback never fires there and silently
@@ -444,9 +461,26 @@ export function evictStaleViews(
 
   let evictedCount = 0;
   while (host.views.size > effectiveMax && candidates.length > 0 && evictedCount < evictionBudget) {
+    const next = candidates[0];
+    const ageMs = Date.now() - next.entry.lastUsed;
+    // Ends the pass rather than skipping to the next candidate. The queue is
+    // tier-ordered, so passing over a young ordinary view would hand its
+    // eviction to an older one the tiers deliberately rank as costlier to lose
+    // — an agent's, a bound session's, or a workspace the user granted
+    // residency. Gradual passes only: the forced reclaim is the OOM escape
+    // hatch, and LRU and limit-change passes enforce a cap the user chose.
+    if (gradualPressure && ageMs < MIN_PRESSURE_EVICTION_AGE_MS) {
+      logInfo("projectview.eviction-deferred", {
+        projectId: next.projectId,
+        reason: effectiveReason,
+        ageMs,
+        minimumAgeMs: MIN_PRESSURE_EVICTION_AGE_MS,
+      });
+      break;
+    }
+    candidates.shift();
     const { projectId, entry, activeAgent, liveAssistantBackend, boundMcpSession, keepResident } =
-      candidates.shift()!;
-    const ageMs = Date.now() - entry.lastUsed;
+      next;
     const memoryKb = memoryFor(entry);
     const guestMemoryKb = guestMemoryFor(entry);
     const ctx: Record<string, unknown> = {
@@ -608,29 +642,38 @@ export function sampleCachedViewMemory(host: ProjectViewManager): void {
  * path that performs banded contraction, so gating it on `criticalMb` would
  * leave the graduated ladder unreachable (#11469).
  *
+ * One reading below that edge destroys nothing; it takes
+ * PRESSURE_SAMPLES_TO_CONFIRM consecutive ones (#12363). A reading is one
+ * instant of a figure the OS is constantly rebalancing, and acting on the first
+ * low one let a machine hovering near the edge shed a renderer on every tick it
+ * happened to dip. Once confirmed the streak holds, so sustained pressure still
+ * converges a view per tick rather than a view per confirmation. A tick that is
+ * not a readable low sample — at or above the edge, unreadable, unarmed, or
+ * with nothing cached to take — starts the count over.
+ *
  * Never escalates to a one-pass collapse, at any band. This sampler is
- * per-window and fires off an instantaneous availability reading with no
- * consecutive-poll count, no cooldown, and no view of whether a cheaper
+ * per-window, holds no cooldown, and has no view of whether a cheaper
  * mitigation is already in flight — the combination that let it destroy a
  * live assistant's view 560ms into a tier-1 pass that resolved the pressure
  * without it (#11477). Collapse is `ProcessMemoryMonitor`'s tier 2 alone,
  * which owns all of that state globally and arrives via `forcePressure`.
  */
 export function maybeEvictUnderPressure(host: ProjectViewManager): void {
-  if (host.views.size <= 1) return;
   const policy = host.memoryPressurePolicy;
-  if (policy == null) return;
-  const availableMb = getAvailableMemoryMb();
-  if (availableMb == null || availableMb >= policy.warningMb) return;
+  const availableMb = policy != null && host.views.size > 1 ? getAvailableMemoryMb() : null;
+  if (policy == null || availableMb == null || availableMb >= policy.warningMb) {
+    host.pressureSampleStreak = 0;
+    return;
+  }
+  host.pressureSampleStreak = Math.min(host.pressureSampleStreak + 1, PRESSURE_SAMPLES_TO_CONFIRM);
+  if (host.pressureSampleStreak < PRESSURE_SAMPLES_TO_CONFIRM) return;
   evictStaleViews(host, "pressure");
 }
 
 /**
- * Read system-wide available memory in MB. On macOS, "available" = free +
- * purgeable, because Darwin holds reclaimable pages as purgeable rather
- * than free — using `free` alone would fire false positives on every
- * healthy mac. On Windows/Linux, `free` alone is accurate. Returns null
- * when the Chromium API is unavailable (e.g., under test mocks).
+ * Read system-wide available memory in MB — see `readSystemMemorySnapshot` for
+ * what "available" counts on each platform. Returns null when the Chromium API
+ * is unavailable (e.g., under test mocks).
  */
 export function getAvailableMemoryMb(): number | null {
   return readAvailableSystemMemoryMb();

--- a/electron/window/ProjectViewEvictionController.ts
+++ b/electron/window/ProjectViewEvictionController.ts
@@ -32,7 +32,8 @@ type EvictionCandidate = {
  * Consecutive sampler readings below the warning edge before a pressure pass
  * may destroy anything (#12363). At the sampler's 30s cadence, two means the
  * reading was still low half a minute later — enough to tell a dip from a trend
- * while keeping the reaction to real pressure inside a minute.
+ * while confirming real pressure inside a minute. A view the user only just left
+ * also waits out MIN_PRESSURE_EVICTION_AGE_MS on top of that.
  */
 export const PRESSURE_SAMPLES_TO_CONFIRM = 2;
 
@@ -176,14 +177,20 @@ export function backgroundRestoreCapacity(
 export function evictStaleViews(
   host: ProjectViewManager,
   reason: EvictionReason,
-  forcePressure = false
+  forcePressure = false,
+  sampledAvailableMb?: number
 ): number {
   // Override the user-configured cap when system memory is low so we can
   // reclaim Chromium renderers (~100–500 MB each) before the OS hits
   // compressed-RAM throttling. The override is per-pass — `maxCachedViews`
   // is never mutated, so once pressure subsides the user's setting takes
   // effect on the next eviction.
-  const availableMb = getAvailableMemoryMb();
+  //
+  // The sampler hands over the reading that confirmed the pass, so the pass acts
+  // on the figure it counted. A fresh read landing above the warning edge would
+  // turn its one-view gradual pass into an unbudgeted trim to the configured cap
+  // that skips the minimum age (#12363).
+  const availableMb = sampledAvailableMb ?? getAvailableMemoryMb();
   const policy = host.memoryPressurePolicy;
   const { level, targetMax } =
     policy != null && availableMb != null
@@ -667,7 +674,7 @@ export function maybeEvictUnderPressure(host: ProjectViewManager): void {
   }
   host.pressureSampleStreak = Math.min(host.pressureSampleStreak + 1, PRESSURE_SAMPLES_TO_CONFIRM);
   if (host.pressureSampleStreak < PRESSURE_SAMPLES_TO_CONFIRM) return;
-  evictStaleViews(host, "pressure");
+  evictStaleViews(host, "pressure", false, availableMb);
 }
 
 /**

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -107,9 +107,9 @@ const DEFAULT_VIEW_LOAD_HARD_TIMEOUT_MS = 30_000;
  * matches `ProcessMemoryMonitor` and keeps the synchronous `app.getAppMetrics()`
  * call (5–50 ms per invocation) out of the budget that would risk main-thread
  * jank. Each tick also evaluates the low-memory pressure floor (see
- * `maybeEvictUnderPressure`), which acts only on consecutive low readings, so
- * pressure-eviction latency is a couple of sample periods and needs no new
- * timer.
+ * `maybeEvictUnderPressure`), which acts only on consecutive low readings and
+ * spares a view used within the last minute, so pressure-eviction latency is a
+ * few sample periods and needs no new timer.
  */
 const CACHED_VIEW_MEMORY_SAMPLE_INTERVAL_MS = 30_000;
 

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -107,8 +107,9 @@ const DEFAULT_VIEW_LOAD_HARD_TIMEOUT_MS = 30_000;
  * matches `ProcessMemoryMonitor` and keeps the synchronous `app.getAppMetrics()`
  * call (5–50 ms per invocation) out of the budget that would risk main-thread
  * jank. Each tick also evaluates the low-memory pressure floor (see
- * `maybeEvictUnderPressure`), bounding pressure-eviction latency to one
- * sample period without a new timer.
+ * `maybeEvictUnderPressure`), which acts only on consecutive low readings, so
+ * pressure-eviction latency is a couple of sample periods and needs no new
+ * timer.
  */
 const CACHED_VIEW_MEMORY_SAMPLE_INTERVAL_MS = 30_000;
 
@@ -288,6 +289,8 @@ export class ProjectViewManager {
   activeProjectId: string | null = null;
   maxCachedViews = 1;
   memoryPressurePolicy: MemoryPressurePolicy | null = null;
+  /** Consecutive sampler readings below the warning edge — see `maybeEvictUnderPressure`. */
+  pressureSampleStreak = 0;
   win: BrowserWindow;
   dirname: string;
   onRecreateWindow?: () => Promise<void>;
@@ -1102,6 +1105,8 @@ export class ProjectViewManager {
    * an inverted or non-finite edge disables rather than half-arms the policy.
    */
   setMemoryPressurePolicy(policy: MemoryPressurePolicy | null): void {
+    // Readings counted against the previous band say nothing about this one.
+    this.pressureSampleStreak = 0;
     if (
       policy == null ||
       !Number.isFinite(policy.criticalMb) ||
@@ -1128,6 +1133,7 @@ export class ProjectViewManager {
    * cache in a single pass.
    */
   setLowMemoryFreeThresholdMb(mb: number | null): void {
+    this.pressureSampleStreak = 0;
     if (mb == null || !Number.isFinite(mb) || mb <= 0) {
       this.memoryPressurePolicy = null;
     } else {

--- a/electron/window/__tests__/ProjectViewManager.eviction.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.eviction.test.ts
@@ -232,6 +232,7 @@ import {
   unthrottleCpuWebContents,
 } from "../../utils/webContentsLifecycle.js";
 import { resetAppMetricsSnapshotForTesting } from "../../utils/appMetricsSnapshot.js";
+import { MIN_PRESSURE_EVICTION_AGE_MS } from "../ProjectViewEvictionController.js";
 
 // The shared snapshot is module-level state; without a reset, a test could be
 // served metrics cached by the previous test's differently-mocked sweep.
@@ -247,6 +248,27 @@ beforeEach(() => {
 });
 
 const flushImmediates = () => new Promise<void>((resolve) => setImmediate(resolve));
+
+/**
+ * Backdate every view past the pressure ladder's minimum age, keeping their
+ * relative LRU order. These fixtures switch milliseconds apart, so without it
+ * every gradual pass would defer on a view the user "just left" (#12363).
+ */
+function ageViewsPastPressureFloor(mgr: ProjectViewManager): void {
+  for (const entry of mgr.views.values()) entry.lastUsed -= MIN_PRESSURE_EVICTION_AGE_MS;
+}
+
+/**
+ * Age the cache and take the one low reading that on its own confirms nothing
+ * (#12363), asserting it destroyed nothing — so the ticks that follow exercise a
+ * confirmed pass. Call with memory already reading low.
+ */
+function armPressureLadder(mgr: ProjectViewManager): void {
+  ageViewsPastPressureFloor(mgr);
+  const before = mgr.views.size;
+  mgr.maybeEvictUnderPressure();
+  expect(mgr.views.size).toBe(before);
+}
 
 function createMockWindow() {
   return {
@@ -2447,7 +2469,7 @@ describe("ProjectViewManager — low-memory eviction", () => {
 
   // Helper for mocking process.getSystemMemoryInfo. Chromium-extended API not in
   // the default Node typings, so spy via a cast and restore in afterEach.
-  type MemInfo = { free: number; purgeable?: number; total: number };
+  type MemInfo = { free: number; purgeable?: number; fileBacked?: number; total: number };
   function stubSystemMemoryInfo(info: MemInfo | (() => MemInfo) | "throw" | "missing") {
     const proc = process as unknown as { getSystemMemoryInfo?: () => MemInfo };
     if (info === "missing") {
@@ -2558,6 +2580,7 @@ describe("ProjectViewManager — low-memory eviction", () => {
     // The switches themselves hold the user's cap of 3 — an LRU pass no longer
     // inherits pressure (#11477). The sampler is what converges on 1.
     expect(manager.getAllViews().length).toBe(3);
+    armPressureLadder(manager);
     tickPressureCheck(manager);
     tickPressureCheck(manager);
 
@@ -2620,6 +2643,7 @@ describe("ProjectViewManager — low-memory eviction", () => {
     // tick's pressure check must reclaim without waiting for a switch — one
     // view per tick, converging on the active view (#11477).
     freeKb = 128 * 1024;
+    armPressureLadder(manager);
     tickPressureCheck(manager);
     expect(manager.getAllViews().map((v) => v.projectId)).toEqual(["proj-b", "proj-c"]);
     expect(wcA.close).toHaveBeenCalled();
@@ -2637,14 +2661,18 @@ describe("ProjectViewManager — low-memory eviction", () => {
     await manager.switchTo("proj-b", "/path/b");
     await flushImmediates();
 
+    // Aged, and ticked past confirmation, so neither case can pass merely
+    // because a single sample never evicts (#12363).
+    ageViewsPastPressureFloor(manager);
+
     // Null threshold (performance profile): pressure check must not run.
-    (manager as unknown as { maybeEvictUnderPressure(): void }).maybeEvictUnderPressure();
+    for (let tick = 0; tick < 3; tick++) tickPressureCheck(manager);
     expect(manager.getAllViews().length).toBe(2);
 
     // Threshold set but memory healthy: still a no-op.
     stubSystemMemoryInfo({ free: 2 * 1024 * 1024, purgeable: 0, total: 8 * 1024 * 1024 });
     manager.setLowMemoryFreeThresholdMb(768);
-    (manager as unknown as { maybeEvictUnderPressure(): void }).maybeEvictUnderPressure();
+    for (let tick = 0; tick < 3; tick++) tickPressureCheck(manager);
     expect(manager.getAllViews().length).toBe(2);
     expect(wcA.close).not.toHaveBeenCalled();
   });
@@ -2668,9 +2696,44 @@ describe("ProjectViewManager — low-memory eviction", () => {
     await manager.switchTo("proj-c", "/path/c");
     await flushImmediates();
 
-    // 50 + 2*1024*1024 KB ≈ 2050 MB > 768 → no override.
+    // 50 + 2*1024*1024 KB ≈ 2050 MB > 768 → no override, however long it holds.
+    ageViewsPastPressureFloor(manager);
+    for (let tick = 0; tick < 3; tick++) tickPressureCheck(manager);
     expect(manager.getAllViews().length).toBe(3);
     expect(wcA.close).not.toHaveBeenCalled();
+  });
+
+  it("counts the file cache as available on macOS, so a warm-cache Mac keeps its views (#12363)", async () => {
+    // The issue's 64 GB machine and band: ~600 MB free and ~1 GB purgeable
+    // beside ~24 GB of file cache. Free + purgeable alone reads inside the band.
+    let fileBackedKb = 24 * 1024 * 1024;
+    stubSystemMemoryInfo(() => ({
+      free: 600 * 1024,
+      purgeable: 1024 * 1024,
+      fileBacked: fileBackedKb,
+      total: 64 * 1024 * 1024,
+    }));
+    manager.setMemoryPressurePolicy({ criticalMb: 1024, warningMb: 3072 });
+
+    const wcA = createMockWebContents();
+    const viewA = { webContents: wcA, setBounds: vi.fn() };
+    manager.registerInitialView(viewA as never, "proj-a", "/path/a");
+    await manager.switchTo("proj-b", "/path/b");
+    await flushImmediates();
+    await manager.switchTo("proj-c", "/path/c");
+    await flushImmediates();
+    ageViewsPastPressureFloor(manager);
+
+    for (let tick = 0; tick < 3; tick++) tickPressureCheck(manager);
+    expect(manager.getAllViews().length).toBe(3);
+
+    // The same machine with its cache spent is genuinely short, and the ladder
+    // still answers — the fix moved the measurement, not the band.
+    fileBackedKb = 0;
+    tickPressureCheck(manager);
+    tickPressureCheck(manager);
+    expect(manager.getAllViews().length).toBe(2);
+    expect(wcA.close).toHaveBeenCalled();
   });
 
   it("does not mutate maxCachedViews — user limit returns when pressure subsides", async () => {
@@ -2686,6 +2749,7 @@ describe("ProjectViewManager — low-memory eviction", () => {
     await manager.switchTo("proj-c", "/path/c");
     await flushImmediates();
     // Sampler ticks converge on 1 (the switches hold the user's cap, #11477).
+    armPressureLadder(manager);
     tickPressureCheck(manager);
     tickPressureCheck(manager);
     expect(manager.getAllViews().length).toBe(1);
@@ -2715,6 +2779,7 @@ describe("ProjectViewManager — low-memory eviction", () => {
     await flushImmediates();
     await manager.switchTo("proj-c", "/path/c");
     await flushImmediates();
+    armPressureLadder(manager);
     tickPressureCheck(manager);
 
     expect(vi.mocked(logInfo)).toHaveBeenCalledWith(
@@ -2840,6 +2905,7 @@ describe("ProjectViewManager — low-memory eviction", () => {
 
     // The reading is what's under test, so drive the sampler — the switches
     // above no longer inherit pressure themselves (#11477).
+    armPressureLadder(manager);
     tickPressureCheck(manager);
     expect(manager.getAllViews().length).toBe(2);
     expect(wcA.close).toHaveBeenCalled();
@@ -2860,6 +2926,7 @@ describe("ProjectViewManager — low-memory eviction", () => {
 
     // Driven to its settled target one view per tick, and then some — however
     // long pressure lasts, the active view is never a candidate.
+    armPressureLadder(manager);
     tickPressureCheck(manager);
     tickPressureCheck(manager);
     tickPressureCheck(manager);
@@ -2896,6 +2963,7 @@ describe("ProjectViewManager — low-memory eviction", () => {
 
     // 4 views, override targets 1 → 3 evictions, callback fires for each. One
     // per sampler tick since #11477, so drive it to the settled target.
+    armPressureLadder(pressureManager);
     tickPressureCheck(pressureManager);
     tickPressureCheck(pressureManager);
     tickPressureCheck(pressureManager);
@@ -3024,8 +3092,11 @@ describe("ProjectViewManager — graduated memory reclaim (#11469)", () => {
     expect(manager.getAllViews().length).toBe(3);
 
     // Deep in the soft band the settled target is 1, but a single pass must
-    // still take only one view — this is the whole point of #11469.
+    // still take only one view — this is the whole point of #11469. Once
+    // confirmed the streak holds, so it is one per tick rather than one per
+    // confirmation (#12363).
     setAvailableMb(1200);
+    armPressureLadder(manager);
     tickPressureCheck(manager);
     expect(manager.getAllViews().map((v) => v.projectId)).toEqual(["proj-b", "proj-c"]);
 
@@ -3042,6 +3113,7 @@ describe("ProjectViewManager — graduated memory reclaim (#11469)", () => {
     await seedThreeViews(manager);
 
     setAvailableMb(1200);
+    armPressureLadder(manager);
     tickPressureCheck(manager);
     expect(manager.getAllViews().length).toBe(2);
 
@@ -3057,9 +3129,11 @@ describe("ProjectViewManager — graduated memory reclaim (#11469)", () => {
     await seedThreeViews(manager);
 
     // A critical reading targets the active view alone — but the sampler is
-    // per-window and ungated, so it walks there a view at a time rather than
-    // pre-empting ProcessMemoryMonitor's cooldown-gated ladder in one pass.
+    // per-window and holds no cooldown, so it walks there a view at a time
+    // rather than pre-empting ProcessMemoryMonitor's cooldown-gated ladder in
+    // one pass.
     setAvailableMb(BAND.criticalMb - 1);
+    armPressureLadder(manager);
     tickPressureCheck(manager);
     expect(manager.getAllViews().map((v) => v.projectId)).toEqual(["proj-b", "proj-c"]);
     tickPressureCheck(manager);
@@ -3075,7 +3149,9 @@ describe("ProjectViewManager — graduated memory reclaim (#11469)", () => {
     setAvailableMb(2500);
     await seedThreeViews(mgr);
 
-    // Ample memory: `forcePressure` alone drives it, not the sampled band.
+    // Ample memory: `forcePressure` alone drives it, not the sampled band. The
+    // views are seconds old and no tick has confirmed anything, so neither the
+    // sampler's streak nor its age floor reaches this path (#12363).
     expect(mgr.reclaimCachedViewsUnderPressure()).toBe(2);
     expect(mgr.getAllViews().map((v) => v.projectId)).toEqual(["proj-c"]);
   });
@@ -3132,6 +3208,7 @@ describe("ProjectViewManager — graduated memory reclaim (#11469)", () => {
     liveTerminals.add("t-help-a");
 
     setAvailableMb(1200);
+    armPressureLadder(mgr);
     tickPressureCheck(mgr);
 
     expect(mgr.getAllViews().length).toBe(3);
@@ -3163,6 +3240,7 @@ describe("ProjectViewManager — graduated memory reclaim (#11469)", () => {
     (mgr as unknown as { maxCachedViews: number }).maxCachedViews = 2;
 
     setAvailableMb(1200);
+    armPressureLadder(mgr);
     tickPressureCheck(mgr);
 
     expect(mgr.getAllViews().map((v) => v.projectId)).toEqual(["proj-b", "proj-c", "proj-d"]);
@@ -3184,6 +3262,7 @@ describe("ProjectViewManager — graduated memory reclaim (#11469)", () => {
     }
 
     setAvailableMb(1200);
+    armPressureLadder(mgr);
     tickPressureCheck(mgr);
 
     expect(mgr.getAllViews().length).toBe(3);
@@ -3205,11 +3284,14 @@ describe("ProjectViewManager — graduated memory reclaim (#11469)", () => {
     setAvailableMb(2500);
     await seedThreeViews(manager);
 
+    ageViewsPastPressureFloor(manager);
     setAvailableMb(BAND.warningMb);
+    tickPressureCheck(manager);
     tickPressureCheck(manager);
     expect(manager.getAllViews().length).toBe(3);
 
     setAvailableMb(BAND.warningMb - 1);
+    armPressureLadder(manager);
     tickPressureCheck(manager);
     expect(manager.getAllViews().length).toBe(2);
   });
@@ -3219,6 +3301,7 @@ describe("ProjectViewManager — graduated memory reclaim (#11469)", () => {
     await seedThreeViews(manager);
 
     setAvailableMb(1200);
+    armPressureLadder(manager);
     tickPressureCheck(manager);
 
     expect(vi.mocked(logInfo)).toHaveBeenCalledWith(
@@ -3246,6 +3329,7 @@ describe("ProjectViewManager — graduated memory reclaim (#11469)", () => {
     expect(manager.getAllViews().length).toBe(3);
 
     setAvailableMb(1499);
+    armPressureLadder(manager);
     tickPressureCheck(manager);
     expect(manager.getAllViews().map((v) => v.projectId)).toEqual(["proj-b", "proj-c"]);
 
@@ -3266,6 +3350,7 @@ describe("ProjectViewManager — graduated memory reclaim (#11469)", () => {
 
     // Far below the critical edge — the old code took everything here.
     setAvailableMb(1);
+    armPressureLadder(manager);
     tickPressureCheck(manager);
     expect(manager.getAllViews().length).toBe(2);
 
@@ -3300,8 +3385,10 @@ describe("ProjectViewManager — graduated memory reclaim (#11469)", () => {
     manager.setMemoryPressurePolicy(null);
     setAvailableMb(50);
     await seedThreeViews(manager);
+    ageViewsPastPressureFloor(manager);
 
-    tickPressureCheck(manager);
+    // However long the pressure lasts: a null policy is the E2E escape hatch.
+    for (let tick = 0; tick < 3; tick++) tickPressureCheck(manager);
     expect(manager.getAllViews().length).toBe(3);
     expect(manager.getLowMemoryFreeThresholdMb()).toBeNull();
   });
@@ -3339,6 +3426,126 @@ describe("ProjectViewManager — graduated memory reclaim (#11469)", () => {
 
     expect(manager.reclaimCachedViewsUnderPressure()).toBe(2);
     expect(manager.getAllViews().map((v) => v.projectId)).toEqual(["proj-c"]);
+  });
+
+  describe("sustained pressure and the minimum age (#12363)", () => {
+    const viewOf = (projectId: string) => manager.views.get(projectId)!;
+
+    const deferredLogs = () =>
+      vi
+        .mocked(logInfo)
+        .mock.calls.filter(([event]) => event === "projectview.eviction-deferred")
+        .map(([, ctx]) => ctx as Record<string, unknown>);
+
+    it("destroys nothing on one low reading, however low — it has to hold to the next tick", async () => {
+      setAvailableMb(2500);
+      await seedThreeViews(manager);
+      ageViewsPastPressureFloor(manager);
+
+      setAvailableMb(1);
+      tickPressureCheck(manager);
+      expect(manager.getAllViews().length).toBe(3);
+      expect(evictedProjectIds()).toEqual([]);
+
+      tickPressureCheck(manager);
+      expect(evictedProjectIds()).toEqual(["proj-a"]);
+    });
+
+    it("starts the count over on a reading at the edge, or one it cannot read", async () => {
+      setAvailableMb(2500);
+      await seedThreeViews(manager);
+      ageViewsPastPressureFloor(manager);
+
+      // Low, then exactly at the edge: the next low reading is a first again.
+      setAvailableMb(1200);
+      tickPressureCheck(manager);
+      setAvailableMb(BAND.warningMb);
+      tickPressureCheck(manager);
+      setAvailableMb(1200);
+      tickPressureCheck(manager);
+      expect(manager.getAllViews().length).toBe(3);
+
+      // Low, then unreadable — which is no evidence the pressure persisted.
+      Object.defineProperty(process, "getSystemMemoryInfo", {
+        configurable: true,
+        value: undefined,
+      });
+      tickPressureCheck(manager);
+      setAvailableMb(1200);
+      tickPressureCheck(manager);
+      expect(manager.getAllViews().length).toBe(3);
+
+      tickPressureCheck(manager);
+      expect(manager.getAllViews().length).toBe(2);
+    });
+
+    it("starts the count over when either setter re-arms the band", async () => {
+      setAvailableMb(2500);
+      await seedThreeViews(manager);
+      ageViewsPastPressureFloor(manager);
+      setAvailableMb(1200);
+
+      tickPressureCheck(manager);
+      manager.setMemoryPressurePolicy(BAND);
+      tickPressureCheck(manager);
+      expect(manager.getAllViews().length).toBe(3);
+
+      manager.setLowMemoryFreeThresholdMb(BAND.warningMb);
+      tickPressureCheck(manager);
+      expect(manager.getAllViews().length).toBe(3);
+
+      tickPressureCheck(manager);
+      expect(manager.getAllViews().length).toBe(2);
+    });
+
+    it("will not take a view the user left under a minute ago, and takes it once it has aged", async () => {
+      setAvailableMb(2500);
+      await seedThreeViews(manager);
+      // proj-a went cold long ago; proj-b was left moments before pressure hit.
+      viewOf("proj-a").lastUsed -= MIN_PRESSURE_EVICTION_AGE_MS;
+
+      setAvailableMb(1200);
+      tickPressureCheck(manager);
+      tickPressureCheck(manager);
+      expect(evictedProjectIds()).toEqual(["proj-a"]);
+
+      tickPressureCheck(manager);
+      expect(manager.getAllViews().map((v) => v.projectId)).toEqual(["proj-b", "proj-c"]);
+      const deferred = deferredLogs();
+      expect(deferred.map((ctx) => ctx.projectId)).toEqual(["proj-b"]);
+      expect(deferred[0].ageMs as number).toBeLessThan(MIN_PRESSURE_EVICTION_AGE_MS);
+      // Held back by age, not by protection — reporting it as the latter would
+      // misattribute the over-target cache.
+      expect(vi.mocked(logInfo)).not.toHaveBeenCalledWith(
+        "projectview.eviction-skipped",
+        expect.anything()
+      );
+
+      // Eligible from exactly a minute unused.
+      viewOf("proj-b").lastUsed = Date.now() - MIN_PRESSURE_EVICTION_AGE_MS;
+      tickPressureCheck(manager);
+      expect(manager.getAllViews().map((v) => v.projectId)).toEqual(["proj-c"]);
+    });
+
+    it("holds the pass rather than handing a young view's eviction to an older, costlier one", async () => {
+      // An agent's view ranks after ordinary ones. Skipping past a young
+      // ordinary view would evict the older agent view in its place, turning
+      // the age floor into a way around the tier order.
+      setAvailableMb(2500);
+      await seedThreeViews(manager);
+      mockGetAllTerminals.mockResolvedValue([
+        { id: "t-a", projectId: "proj-a", agentState: "working" },
+      ]);
+      await manager.initAgentStateCache(mockPtyClient as never);
+      viewOf("proj-a").lastUsed -= MIN_PRESSURE_EVICTION_AGE_MS;
+
+      setAvailableMb(1200);
+      for (let tick = 0; tick < 3; tick++) tickPressureCheck(manager);
+
+      expect(manager.getAllViews().length).toBe(3);
+      expect(evictedProjectIds()).toEqual([]);
+      expect(deferredLogs().map((ctx) => ctx.projectId)).toEqual(["proj-b", "proj-b"]);
+    });
   });
 });
 
@@ -3618,6 +3825,7 @@ describe("ProjectViewManager — MCP bound sessions and dispatch leases (#11790)
       boundWorkspaces.add("proj-a");
 
       setAvailableMb(1200);
+      armPressureLadder(mgr);
       tickPressureCheck(mgr);
       expect(mgr.getAllViews().map((v) => v.projectId)).toEqual(["proj-a", "proj-c"]);
 

--- a/electron/window/__tests__/ProjectViewManager.eviction.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.eviction.test.ts
@@ -265,6 +265,9 @@ function ageViewsPastPressureFloor(mgr: ProjectViewManager): void {
  */
 function armPressureLadder(mgr: ProjectViewManager): void {
   ageViewsPastPressureFloor(mgr);
+  // From a clean count: the manager's own randomly-phased sampler is live, and
+  // may already have taken a low reading while the fixture awaited its switches.
+  mgr.pressureSampleStreak = 0;
   const before = mgr.views.size;
   mgr.maybeEvictUnderPressure();
   expect(mgr.views.size).toBe(before);
@@ -2520,6 +2523,9 @@ describe("ProjectViewManager — low-memory eviction", () => {
   });
 
   afterEach(() => {
+    // Stops this manager's randomly-phased sampler from ticking into a later
+    // test's memory stub and the shared logInfo mock.
+    manager.dispose();
     Object.defineProperty(process, "getSystemMemoryInfo", {
       configurable: true,
       value: originalSystemMemoryInfo,
@@ -3041,8 +3047,11 @@ describe("ProjectViewManager — graduated memory reclaim (#11469)", () => {
   const tickPressureCheck = (mgr: ProjectViewManager) =>
     (mgr as unknown as { maybeEvictUnderPressure(): void }).maybeEvictUnderPressure();
 
+  /** Every manager built here, so the randomly-phased sampler each one starts is torn down. */
+  const managers: ProjectViewManager[] = [];
+
   function makeManager(cachedProjectViews: number) {
-    return new ProjectViewManager(win as never, {
+    const mgr = new ProjectViewManager(win as never, {
       dirname: "/test",
       paintGateTimeoutMs: 0,
       paintGateHardTimeoutMs: 0,
@@ -3052,6 +3061,8 @@ describe("ProjectViewManager — graduated memory reclaim (#11469)", () => {
       assistantBackendsForProject,
       isTerminalLive,
     });
+    managers.push(mgr);
+    return mgr;
   }
 
   /** Three views (proj-a, proj-b oldest-first; proj-c active). */
@@ -3080,6 +3091,7 @@ describe("ProjectViewManager — graduated memory reclaim (#11469)", () => {
   });
 
   afterEach(() => {
+    for (const mgr of managers.splice(0)) mgr.dispose();
     Object.defineProperty(process, "getSystemMemoryInfo", {
       configurable: true,
       value: originalSystemMemoryInfo,
@@ -3477,6 +3489,41 @@ describe("ProjectViewManager — graduated memory reclaim (#11469)", () => {
 
       tickPressureCheck(manager);
       expect(manager.getAllViews().length).toBe(2);
+
+      // And from confirmed pressure, not only a pending count: recovery wipes
+      // the streak, so the next dip needs two readings of its own.
+      setAvailableMb(BAND.warningMb);
+      tickPressureCheck(manager);
+      setAvailableMb(1200);
+      tickPressureCheck(manager);
+      expect(manager.getAllViews().length).toBe(2);
+      tickPressureCheck(manager);
+      expect(manager.getAllViews().length).toBe(1);
+    });
+
+    it("needs fresh confirmation once the cache has held only the active view", async () => {
+      // With nothing cached to take, a tick has no reading to count, so it
+      // cannot carry an old confirmation over to a view cached afterwards.
+      setAvailableMb(2500);
+      await seedThreeViews(manager);
+      setAvailableMb(1200);
+      armPressureLadder(manager);
+      tickPressureCheck(manager);
+      tickPressureCheck(manager);
+      expect(manager.getAllViews().map((v) => v.projectId)).toEqual(["proj-c"]);
+      tickPressureCheck(manager);
+
+      // Healthy while switching, so a live sampler tick can only reset the count.
+      setAvailableMb(2500);
+      await manager.switchTo("proj-d", "/path/d");
+      await flushImmediates();
+      ageViewsPastPressureFloor(manager);
+
+      setAvailableMb(1200);
+      tickPressureCheck(manager);
+      expect(manager.getAllViews().length).toBe(2);
+      tickPressureCheck(manager);
+      expect(manager.getAllViews().map((v) => v.projectId)).toEqual(["proj-d"]);
     });
 
     it("starts the count over when either setter re-arms the band", async () => {
@@ -3521,10 +3568,86 @@ describe("ProjectViewManager — graduated memory reclaim (#11469)", () => {
         expect.anything()
       );
 
-      // Eligible from exactly a minute unused.
-      viewOf("proj-b").lastUsed = Date.now() - MIN_PRESSURE_EVICTION_AGE_MS;
+      // The boundary, on a pinned clock: a millisecond short still defers, and
+      // exactly a minute unused is old enough.
+      const leftAt = viewOf("proj-b").lastUsed;
+      const clock = vi.spyOn(Date, "now");
+      try {
+        clock.mockReturnValue(leftAt + MIN_PRESSURE_EVICTION_AGE_MS - 1);
+        tickPressureCheck(manager);
+        expect(manager.getAllViews().length).toBe(2);
+        expect(deferredLogs().at(-1)).toEqual({
+          projectId: "proj-b",
+          reason: "pressure",
+          ageMs: MIN_PRESSURE_EVICTION_AGE_MS - 1,
+          minimumAgeMs: MIN_PRESSURE_EVICTION_AGE_MS,
+        });
+
+        clock.mockReturnValue(leftAt + MIN_PRESSURE_EVICTION_AGE_MS);
+        tickPressureCheck(manager);
+        expect(manager.getAllViews().map((v) => v.projectId)).toEqual(["proj-c"]);
+      } finally {
+        clock.mockRestore();
+      }
+    });
+
+    it("spares the view the user just left while pressure stays confirmed", async () => {
+      // The issue's symptom end to end: a real switch stamps the outgoing view,
+      // and a confirmed ladder must not take it on the very next tick.
+      setAvailableMb(2500);
+      await seedThreeViews(manager);
+      setAvailableMb(1200);
+      armPressureLadder(manager);
       tickPressureCheck(manager);
-      expect(manager.getAllViews().map((v) => v.projectId)).toEqual(["proj-c"]);
+      expect(evictedProjectIds()).toEqual(["proj-a"]);
+
+      await manager.switchTo("proj-b", "/path/b");
+      await flushImmediates();
+      tickPressureCheck(manager);
+
+      expect(
+        manager
+          .getAllViews()
+          .map((v) => v.projectId)
+          .sort()
+      ).toEqual(["proj-b", "proj-c"]);
+      expect(evictedProjectIds()).toEqual(["proj-a"]);
+      expect(deferredLogs().at(-1)).toMatchObject({ projectId: "proj-c", reason: "pressure" });
+    });
+
+    it("acts on the reading that confirmed the pass, not a second read that crossed back", async () => {
+      // Over its cap, a pass that re-read memory and landed above the edge would
+      // stop being gradual: an unbudgeted trim to the cap that skips the minimum
+      // age. The confirming reading is the one the pass has to act on.
+      const mgr = makeManager(4);
+      mgr.setMemoryPressurePolicy(BAND);
+      setAvailableMb(2500);
+      const wcA = createMockWebContents();
+      mgr.registerInitialView(
+        { webContents: wcA, setBounds: vi.fn() } as never,
+        "proj-a",
+        "/path/a"
+      );
+      for (const id of ["proj-b", "proj-c", "proj-d"]) {
+        await mgr.switchTo(id, `/path/${id}`);
+        await flushImmediates();
+      }
+      (mgr as unknown as { maxCachedViews: number }).maxCachedViews = 2;
+      ageViewsPastPressureFloor(mgr);
+
+      const readingsMb = [1200, 1200, 2500];
+      Object.defineProperty(process, "getSystemMemoryInfo", {
+        configurable: true,
+        value: () => ({
+          free: (readingsMb.shift() ?? 2500) * 1024,
+          purgeable: 0,
+          total: 8 * 1024 * 1024,
+        }),
+      });
+      tickPressureCheck(mgr);
+      tickPressureCheck(mgr);
+
+      expect(mgr.getAllViews().map((v) => v.projectId)).toEqual(["proj-b", "proj-c", "proj-d"]);
     });
 
     it("holds the pass rather than handing a young view's eviction to an older, costlier one", async () => {

--- a/electron/window/__tests__/ProjectViewManager.eviction.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.eviction.test.ts
@@ -2857,6 +2857,7 @@ describe("ProjectViewManager — low-memory eviction", () => {
       "projectview.eviction",
       expect.objectContaining({ projectId: "proj-a", reason: "lru" })
     );
+    managerWithLimit.dispose();
   });
 
   it("falls back to normal LRU behavior when getSystemMemoryInfo throws", async () => {
@@ -2975,6 +2976,7 @@ describe("ProjectViewManager — low-memory eviction", () => {
     tickPressureCheck(pressureManager);
     expect(pressureManager.getAllViews().length).toBe(1);
     expect(onViewEvicted).toHaveBeenCalledTimes(3);
+    pressureManager.dispose();
   });
 
   it("setLowMemoryFreeThresholdMb(null) clears a previously set threshold", async () => {
@@ -3512,6 +3514,9 @@ describe("ProjectViewManager — graduated memory reclaim (#11469)", () => {
       tickPressureCheck(manager);
       expect(manager.getAllViews().map((v) => v.projectId)).toEqual(["proj-c"]);
       tickPressureCheck(manager);
+      // Checked here, before any await: a live sampler tick during the switch
+      // below would reset the count too, and hide a tick that failed to.
+      expect(manager.pressureSampleStreak).toBe(0);
 
       // Healthy while switching, so a live sampler tick can only reset the count.
       setAvailableMb(2500);

--- a/electron/window/__tests__/ProjectViewManager.lifecycle.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.lifecycle.test.ts
@@ -684,6 +684,9 @@ describe("ProjectViewManager — lifecycle invariants", () => {
       tick.call(manager);
       tick.call(manager);
       tick.call(manager);
+      // One more with only the bridge left to offer: aged like the rest, so its
+      // exclusion is the only thing that can spare it now.
+      tick.call(manager);
 
       // The bridge (C) and the incoming active view (D) survive; A and B go.
       expect(setup.onViewEvicted).toHaveBeenCalledWith(initialWc.id);
@@ -1178,6 +1181,24 @@ describe("ProjectViewManager — background restore", () => {
     expect(result).toEqual({ status: "deferred", reason: "capacity" });
     expect(setup.manager.views.has("proj-b")).toBe(false);
     expect(setup.manager.views.has("proj-a")).toBe(true);
+  });
+
+  it("defers under pressure on the first low reading, without the ladder's confirmation", async () => {
+    // Admission reads the same target the ladder converges on, but it gates
+    // creating a renderer rather than destroying one — so it refuses on the
+    // reading in hand instead of waiting for a second (#12363). The cap has room,
+    // so pressure is the only reason to refuse.
+    const setup = createManager({ cachedProjectViews: 3 });
+    setup.manager.setMemoryPressurePolicy({ criticalMb: 1000, warningMb: 2000 });
+    stubSystemMemoryInfo({ free: 500 * 1024, total: 8 * 1024 * 1024 });
+    try {
+      const result = await setup.manager.restoreInBackground("proj-b", "/b", { lastUsed: 1 });
+      expect(result).toEqual({ status: "deferred", reason: "pressure" });
+      expect(setup.manager.views.has("proj-b")).toBe(false);
+      expect(setup.manager.pressureSampleStreak).toBe(0);
+    } finally {
+      restoreSystemMemoryInfo();
+    }
   });
 
   it("abandons an in-flight restore when the user switches to that project", async () => {

--- a/electron/window/__tests__/ProjectViewManager.lifecycle.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.lifecycle.test.ts
@@ -246,6 +246,7 @@ vi.mock("../../utils/logger.js", () => ({
 
 import { ProjectViewManager } from "../ProjectViewManager.js";
 import { BACKGROUND_HYDRATION_TIMEOUT_MS } from "../ProjectViewRestoreController.js";
+import { MIN_PRESSURE_EVICTION_AGE_MS } from "../ProjectViewEvictionController.js";
 import { logWarn } from "../../utils/logger.js";
 import {
   registerAppView,
@@ -673,11 +674,14 @@ describe("ProjectViewManager — lifecycle invariants", () => {
       // Free RAM collapses below the profile floor while the gate is open.
       manager.setLowMemoryFreeThresholdMb(1024);
       stubSystemMemoryInfo({ free: 100 * 1024, total: 8 * 1024 * 1024 });
-      // Two ticks, because the sampler sheds one view per pass at every band
-      // since #11477 — what matters here is WHICH views it is willing to take,
-      // not how fast, so drive it to its settled target.
+      // Three ticks: one to confirm the pressure (#12363), then one view per pass
+      // at every band since #11477 — what matters here is WHICH views it is
+      // willing to take, not how fast, so drive it to its settled target. Aged
+      // past the ladder's minimum so recency is not what spares a view.
+      for (const entry of manager.views.values()) entry.lastUsed -= MIN_PRESSURE_EVICTION_AGE_MS;
       const tick = (manager as unknown as { maybeEvictUnderPressure: () => void })
         .maybeEvictUnderPressure;
+      tick.call(manager);
       tick.call(manager);
       tick.call(manager);
 
@@ -713,12 +717,15 @@ describe("ProjectViewManager — lifecycle invariants", () => {
       await coldSwitch(setup, "proj-d", "/d");
       expect(manager.getAllViews()).toHaveLength(3);
 
-      // Low-memory passes converge on 1 without rewriting the preference. Two
-      // ticks: the sampler sheds one view per pass at every band (#11477).
+      // Low-memory passes converge on 1 without rewriting the preference. Three
+      // ticks: one to confirm the pressure (#12363), then one view per pass at
+      // every band (#11477), with the views aged past the ladder's minimum.
       manager.setLowMemoryFreeThresholdMb(1024);
       stubSystemMemoryInfo({ free: 100 * 1024, total: 8 * 1024 * 1024 });
+      for (const entry of manager.views.values()) entry.lastUsed -= MIN_PRESSURE_EVICTION_AGE_MS;
       const tick = (manager as unknown as { maybeEvictUnderPressure: () => void })
         .maybeEvictUnderPressure;
+      tick.call(manager);
       tick.call(manager);
       tick.call(manager);
       expect(manager.getAllViews().map((entry) => entry.projectId)).toEqual(["proj-d"]);

--- a/scripts/perf/__tests__/projectSwitch.test.ts
+++ b/scripts/perf/__tests__/projectSwitch.test.ts
@@ -158,6 +158,8 @@ describe("project-view perf scenarios", () => {
     // (#11477), and never nothing (#11469).
     expect(metrics.pressureEvictionCount).toBe(2);
     expect(metrics.pressureLadderMisses).toBe(0);
+    // The tick before those two confirms the pressure and takes nothing (#12363).
+    expect(metrics.pressureConfirmationMisses).toBe(0);
     expect(metrics.pressureBudgetMisses).toBe(0);
     // A healthy reading must move nothing at all.
     expect(metrics.healthyBandMisses).toBe(0);

--- a/scripts/perf/lib/projectViewFixture.ts
+++ b/scripts/perf/lib/projectViewFixture.ts
@@ -843,6 +843,15 @@ export class ProjectViewHarness {
     };
   }
 
+  /**
+   * Backdate every view's recency stamp by `ms`, keeping their order. The
+   * pressure ladder will not take a view used within the last minute (#12363),
+   * which is not something a scenario can sit out.
+   */
+  ageViews(ms: number): void {
+    for (const entry of this.manager.getAllViews()) entry.lastUsed -= ms;
+  }
+
   /** The forced tier-2 reclaim — a one-pass collapse to the active view. */
   forcedReclaim(): { evicted: string[]; wcIds: number[]; reported: number } {
     const before = this.viewSnapshot();

--- a/scripts/perf/scenarios/projectSwitch.ts
+++ b/scripts/perf/scenarios/projectSwitch.ts
@@ -565,31 +565,36 @@ const projectViewScenarios: PerfScenario[] = [
         // (#12363). Done first, so no pass below can pass on recency alone.
         harness.ageViews(PRESSURE_VIEW_AGE_MS);
 
+        // A reading deep in the band only starts the count, and a healthy one
+        // has to wipe it, so neither low pass around the healthy one may take
+        // anything (#12363). Anything taken means the sampler is acting on a
+        // single reading again, or carried the first one across the recovery.
+        let pressureConfirmationMisses = harness.pressurePass(PRESSURE_SAMPLE_AVAILABLE_MB).evicted
+          .length;
+
         // A healthy reading must move nothing. Without this the whole ladder
         // could be firing unconditionally and every other number here would
-        // still look correct. Two passes: one alone never evicts (#12363), so
-        // a single healthy pass would read clean even with the band ignored.
-        let healthyBandMisses = 0;
-        for (let pass = 0; pass < 2; pass++) {
-          healthyBandMisses += harness.pressurePass(HEALTHY_AVAILABLE_MB).evicted.length;
-        }
+        // still look correct. It follows a low reading, so a ladder that
+        // ignored the band would confirm and evict right here.
+        const healthyBandMisses = harness.pressurePass(HEALTHY_AVAILABLE_MB).evicted.length;
 
-        // The first reading deep in the band only starts the count: pressure
-        // has to still be there on the next tick (#12363). Anything taken here
-        // means the sampler is acting on a single reading again.
-        const pressureConfirmationMisses = harness.pressurePass(PRESSURE_SAMPLE_AVAILABLE_MB)
-          .evicted.length;
+        pressureConfirmationMisses += harness.pressurePass(PRESSURE_SAMPLE_AVAILABLE_MB).evicted
+          .length;
 
         // Two sampler ticks deep in the band. The settled target is ONE view,
         // but a periodic pass may only shed one per tick (#11477) — a pass
-        // that collapses the cache instead is the regression this counts.
+        // that collapses the cache instead is the regression this counts. Each
+        // pass must also shed one: a ladder that paused between evictions would
+        // still have shed something overall.
         let pressureBudgetMisses = 0;
+        let pressureLadderMisses = 0;
         let pressureEvictionCount = 0;
         const gradualEvicted: string[] = [];
         for (let pass = 0; pass < 2; pass++) {
           const result = harness.pressurePass(PRESSURE_SAMPLE_AVAILABLE_MB);
           pressureEvictionCount += result.evicted.length;
           pressureBudgetMisses += Math.max(0, result.evicted.length - 1);
+          if (result.evicted.length === 0) pressureLadderMisses++;
           gradualEvicted.push(...result.evicted);
           evictedWcIds.push(...result.wcIds);
           evictedProjects.push(...result.evicted);
@@ -625,10 +630,10 @@ const projectViewScenarios: PerfScenario[] = [
           durationMs: 0,
           metrics: {
             pressureEvictionCount,
-            // Zero here means the graduated ladder shed nothing at a reading
-            // deep inside the band — the #11469/#11926 failure mode, where
-            // reclaim quietly becomes emergency-only.
-            pressureLadderMisses: pressureEvictionCount > 0 ? 0 : 1,
+            // Counts gradual passes that shed nothing at a reading deep inside
+            // the band — the #11469/#11926 failure mode, where reclaim quietly
+            // becomes emergency-only.
+            pressureLadderMisses,
             pressureConfirmationMisses,
             pressureBudgetMisses,
             healthyBandMisses,

--- a/scripts/perf/scenarios/projectSwitch.ts
+++ b/scripts/perf/scenarios/projectSwitch.ts
@@ -310,6 +310,8 @@ const PRESSURE_POLICY = { criticalMb: 500, warningMb: 2000 };
 const PRESSURE_SAMPLE_AVAILABLE_MB = 600;
 /** Comfortably above `warningMb`, so the ladder must decline to act. */
 const HEALTHY_AVAILABLE_MB = 8_000;
+/** Well past the ladder's one-minute floor on how recently a view was used. */
+const PRESSURE_VIEW_AGE_MS = 5 * 60_000;
 
 /** Includes a return to a project already in the burst, so the queue has to
  *  resolve both a cold start and a cache hit without draining in between. */
@@ -526,6 +528,7 @@ const projectViewScenarios: PerfScenario[] = [
     warmups: 1,
     correctness: [
       "pressureLadderMisses",
+      "pressureConfirmationMisses",
       "pressureBudgetMisses",
       "healthyBandMisses",
       "forcedConvergenceMisses",
@@ -557,11 +560,25 @@ const projectViewScenarios: PerfScenario[] = [
         const evictedWcIds: number[] = [];
         const evictedProjects: string[] = [];
 
+        // The ladder takes nothing used within the last minute, and a scenario
+        // cannot wait that out — so the prefill is aged past it, in order
+        // (#12363). Done first, so no pass below can pass on recency alone.
+        harness.ageViews(PRESSURE_VIEW_AGE_MS);
+
         // A healthy reading must move nothing. Without this the whole ladder
         // could be firing unconditionally and every other number here would
-        // still look correct.
-        const healthyPass = harness.pressurePass(HEALTHY_AVAILABLE_MB);
-        const healthyBandMisses = healthyPass.evicted.length;
+        // still look correct. Two passes: one alone never evicts (#12363), so
+        // a single healthy pass would read clean even with the band ignored.
+        let healthyBandMisses = 0;
+        for (let pass = 0; pass < 2; pass++) {
+          healthyBandMisses += harness.pressurePass(HEALTHY_AVAILABLE_MB).evicted.length;
+        }
+
+        // The first reading deep in the band only starts the count: pressure
+        // has to still be there on the next tick (#12363). Anything taken here
+        // means the sampler is acting on a single reading again.
+        const pressureConfirmationMisses = harness.pressurePass(PRESSURE_SAMPLE_AVAILABLE_MB)
+          .evicted.length;
 
         // Two sampler ticks deep in the band. The settled target is ONE view,
         // but a periodic pass may only shed one per tick (#11477) — a pass
@@ -612,6 +629,7 @@ const projectViewScenarios: PerfScenario[] = [
             // deep inside the band — the #11469/#11926 failure mode, where
             // reclaim quietly becomes emergency-only.
             pressureLadderMisses: pressureEvictionCount > 0 ? 0 : 1,
+            pressureConfirmationMisses,
             pressureBudgetMisses,
             healthyBandMisses,
             forcedEvictionCount: forced.evicted.length,

--- a/scripts/perf/scenarios/projectSwitch.ts
+++ b/scripts/perf/scenarios/projectSwitch.ts
@@ -574,8 +574,10 @@ const projectViewScenarios: PerfScenario[] = [
 
         // A healthy reading must move nothing. Without this the whole ladder
         // could be firing unconditionally and every other number here would
-        // still look correct. It follows a low reading, so a ladder that
-        // ignored the band would confirm and evict right here.
+        // still look correct. It also has to wipe the count the low reading
+        // started: a sampler that took it for another low one would confirm and
+        // take a view on the next low pass, which `pressureConfirmationMisses`
+        // reports.
         const healthyBandMisses = harness.pressurePass(HEALTHY_AVAILABLE_MB).evicted.length;
 
         pressureConfirmationMisses += harness.pressurePass(PRESSURE_SAMPLE_AVAILABLE_MB).evicted

--- a/shared/types/ipc/system.ts
+++ b/shared/types/ipc/system.ts
@@ -285,7 +285,7 @@ export interface DiagnosticsInfo {
   eventLoopP99Ms: number;
   /** Total physical RAM (MB) from os.totalmem(); omitted when unreadable. */
   systemTotalMB?: number;
-  /** Available physical RAM (MB) — free (+ purgeable on macOS) from process.getSystemMemoryInfo(); omitted when unreadable. */
+  /** Available physical RAM (MB) — free (+ purgeable and file-backed on macOS) from process.getSystemMemoryInfo(); omitted when unreadable. */
   systemAvailableMB?: number;
 }
 


### PR DESCRIPTION
Summary — On a 64 GB Mac with a warm file cache the per-window cached-view sampler was evicting views almost continuously (some 13–20 s old) while the OS had ~24 GB reclaimable. Two things compounded: the macOS availability estimate left out the file cache, and the ladder acted on a single instantaneous reading with no minimum age.

Changes:
- `electron/utils/systemMemory.ts`: Darwin `availableMb` is now `free + purgeable + fileBacked` (Electron's darwin-only `fileBacked`, KB). That is free memory plus what Activity Monitor calls Cached Files (`external_page_count + purgeable_count`). Malformed/absent `fileBacked` contributes 0, so Windows/Linux arithmetic is unchanged. Band thresholds (`getSystemMemoryThresholds`) are unchanged. The corrected figure also reaches ProcessMemoryMonitor's system-pressure flag, ResourceProfileService scoring, probable-OOM classification and diagnostics, all of which the issue named as working from the undercount.
- `electron/window/ProjectViewEvictionController.ts` + `ProjectViewManager.ts`: `maybeEvictUnderPressure` needs `PRESSURE_SAMPLES_TO_CONFIRM = 2` consecutive readings below the warning edge before the ladder contracts (per-window `pressureSampleStreak`; reset by a reading at/above the edge, an unreadable reading, a null policy, ≤1 view, or either policy setter). Once confirmed it stays one view per tick. The sampler passes its confirming reading into `evictStaleViews` so a second read can't flip the pass into an unbudgeted trim.
- Gradual pressure passes (sampler only) now defer on a head candidate used within `MIN_PRESSURE_EVICTION_AGE_MS = 60_000` and log `projectview.eviction-deferred` ({ projectId, reason, ageMs, minimumAgeMs }). The pass stops rather than skipping ahead, so a young ordinary view never hands its eviction to an older active-agent / bound-session / resident view.
- Unchanged by design: tier-2 forced reclaim (`reclaimCachedViewsUnderPressure`) stays a one-pass collapse; `setLowMemoryFreeThresholdMb(null)` still disables sampler eviction for E2E; LRU and limit-change passes are unaffected; `backgroundRestoreCapacity` still refuses on the instantaneous reading (it gates creation, not destruction).

Tradeoff worth knowing: `fileBacked` counts active file pages as well as idle cache, so on a Mac under genuine pressure from other apps the estimate is optimistic. Pressure Daintree causes itself still reaches ProcessMemoryMonitor's own-process RSS tiers, which don't read this figure. A kernel pressure signal (`kern.memorystatus_vm_pressure_level`) would need a subprocess or native bridge and was left out of scope.

Testing:
- New/updated vitest coverage: `electron/utils/__tests__/systemMemory.test.ts` (fileBacked reader cases), `electron/window/__tests__/ProjectViewManager.eviction.test.ts` (confirmation streak, resets incl. from confirmed pressure and active-only cache, 60 s boundary on a pinned clock, a real switch sparing the view just left, single-snapshot pass, warm-cache Mac keeps its views; existing sampler tests now take one confirming tick with aged fixtures; memory suites dispose their managers), `electron/window/__tests__/ProjectViewManager.lifecycle.test.ts` (mid-gate bridge exclusion actually exercised; background restore defers under pressure on the first reading), `electron/services/__tests__/ProcessMemoryMonitor.test.ts` and `ResourceProfileService.test.ts` (file cache counted), `scripts/perf` PERF-076 (confirmation/healthy-reset flow, one eviction required per gradual pass).
- Locally: 18 targeted test files, 711 tests passing after rebase; prettier and eslint clean on changed files (no new warnings). Full suite, typecheck and build left to CI.

Resolves #12363