### PR TITLE
fix(assistant): resume native engine after involuntary teardown

### DIFF
--- a/e2e/helpers/captureAssistantStates.mts
+++ b/e2e/helpers/captureAssistantStates.mts
@@ -196,6 +196,7 @@ async function capture(spec: Capture): Promise<AssistantSessionState> {
     pendingQuestion: s.pendingQuestion,
     awaitingLocalCommand: s.awaitingLocalCommand,
     stoppedReason: s.stoppedReason,
+    resumed: s.resumed,
     error: s.error,
     turns: s.turns,
     toolCalls: s.toolCalls,

--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -799,6 +799,10 @@ export const CHANNELS = {
   ASSISTANT_HOST_START: "assistant-host:start",
   ASSISTANT_HOST_SEND: "assistant-host:send",
   ASSISTANT_HOST_STOP: "assistant-host:stop",
+  /** The lanes with a conversation their next start would continue (#12365). */
+  ASSISTANT_HOST_LIST_RESUMABLE: "assistant-host:list-resumable",
+  /** Forgets the conversation a lane would continue: Stop, and closing its tab. */
+  ASSISTANT_HOST_DISCARD_RESUME: "assistant-host:discard-resume",
   /** One validated protocol event from the engine. */
   ASSISTANT_HOST_EVENT: "assistant-host:event",
   /**

--- a/electron/ipc/handlers/__tests__/assistantHost.ownership.test.ts
+++ b/electron/ipc/handlers/__tests__/assistantHost.ownership.test.ts
@@ -19,6 +19,8 @@ const start = vi.fn(async (_opts: Record<string, unknown>) => ({
   replay: [],
   mcpUnavailableReason: null,
 }));
+const listResumable = vi.fn(async (_projectId: string) => [{ slot: 1, panelWasOpen: true }]);
+const discardResume = vi.fn(async (_projectId: string, _slot: number) => undefined);
 
 vi.mock("../../../services/assistant-host/AssistantHostService.js", () => ({
   assistantHostService: {
@@ -26,10 +28,13 @@ vi.mock("../../../services/assistant-host/AssistantHostService.js", () => ({
     send: vi.fn(),
     stop: vi.fn(),
     isOwnedBy: vi.fn(() => true),
+    listResumable,
+    discardResume,
   },
 }));
 
 vi.mock("electron", () => ({
+  app: { getPath: () => "/tmp", isPackaged: false },
   ipcMain: { handle: vi.fn(), removeHandler: vi.fn() },
   webContents: { fromId: () => undefined },
 }));
@@ -40,9 +45,18 @@ const handler = assistantHostNamespace.ops.start.handler as (
   ctx: IpcContext,
   payload: unknown
 ) => Promise<unknown>;
+const listHandler = assistantHostNamespace.ops.listResumable.handler as (
+  ctx: IpcContext,
+  projectId: unknown
+) => Promise<unknown>;
+const discardHandler = assistantHostNamespace.ops.discardResume.handler as (
+  ctx: IpcContext,
+  projectId: unknown,
+  slot: unknown
+) => Promise<unknown>;
 
-function context(senderWindow: { id: number } | null): IpcContext {
-  return { webContentsId: 7, senderWindow } as unknown as IpcContext;
+function context(senderWindow: { id: number } | null, projectId: string | null = "p1"): IpcContext {
+  return { webContentsId: 7, senderWindow, projectId } as unknown as IpcContext;
 }
 
 const PAYLOAD = { projectId: "p1", cwd: "/tmp/project" };
@@ -75,5 +89,55 @@ describe("assistantHost.start ownership", () => {
     // The point of refusing rather than defaulting: nothing was spawned, so there is no
     // unreclaimable session and no held lease.
     expect(start).not.toHaveBeenCalled();
+  });
+});
+
+describe("assistantHost.start and the lane's conversation (#12365)", () => {
+  beforeEach(() => {
+    start.mockClear();
+  });
+
+  it("continues the conversation unless the renderer asks for a new one", async () => {
+    await handler(context({ id: 42 }), PAYLOAD);
+    await handler(context({ id: 42 }), { ...PAYLOAD, fresh: true });
+    // Only a real `true` declines it. A malformed flag keeps the conversation rather than
+    // throwing it away.
+    await handler(context({ id: 42 }), { ...PAYLOAD, fresh: "yes" });
+
+    expect(start.mock.calls.map(([opts]) => opts.fresh)).toEqual([false, true, false]);
+  });
+
+  it("never lets the renderer name the conversation to continue", async () => {
+    await handler(context({ id: 42 }), { ...PAYLOAD, resumeSessionId: "ses_someone_else" });
+    expect(start.mock.calls[0]![0]).not.toHaveProperty("resumeSessionId");
+  });
+});
+
+describe("assistantHost resume records belong to one workspace (#12365)", () => {
+  beforeEach(() => {
+    listResumable.mockClear();
+    discardResume.mockClear();
+  });
+
+  it("lists only the calling view's own workspace", async () => {
+    expect(await listHandler(context({ id: 42 }, "p1"), "p1")).toEqual([
+      { slot: 1, panelWasOpen: true },
+    ]);
+    expect(await listHandler(context({ id: 42 }, "p1"), "p2")).toEqual([]);
+    expect(await listHandler(context({ id: 42 }, null), "p1")).toEqual([]);
+    expect(listResumable.mock.calls).toEqual([["p1"]]);
+  });
+
+  it("discards only its own workspace's lanes, and only a lane that exists", async () => {
+    expect(await discardHandler(context({ id: 42 }, "p1"), "p1", 2)).toEqual({ discarded: true });
+    expect(await discardHandler(context({ id: 42 }, "p1"), "p2", 0)).toEqual({
+      discarded: false,
+    });
+    // Resolved down to lane 0 the way a start's slot is, this would throw away a
+    // conversation the caller never named.
+    expect(await discardHandler(context({ id: 42 }, "p1"), "p1", 9)).toEqual({
+      discarded: false,
+    });
+    expect(discardResume.mock.calls).toEqual([["p1", 2]]);
   });
 });

--- a/electron/ipc/handlers/__tests__/assistantHost.ownership.test.ts
+++ b/electron/ipc/handlers/__tests__/assistantHost.ownership.test.ts
@@ -20,7 +20,9 @@ const start = vi.fn(async (_opts: Record<string, unknown>) => ({
   mcpUnavailableReason: null,
 }));
 const listResumable = vi.fn(async (_projectId: string) => [{ slot: 1, panelWasOpen: true }]);
-const discardResume = vi.fn(async (_projectId: string, _slot: number) => undefined);
+const discardResume = vi.fn(
+  async (_projectId: string, _slot: number, _webContentsId: number) => true
+);
 
 vi.mock("../../../services/assistant-host/AssistantHostService.js", () => ({
   assistantHostService: {
@@ -55,10 +57,24 @@ const discardHandler = assistantHostNamespace.ops.discardResume.handler as (
   slot: unknown
 ) => Promise<unknown>;
 
-function context(senderWindow: { id: number } | null, projectId: string | null = "p1"): IpcContext {
-  return { webContentsId: 7, senderWindow, projectId } as unknown as IpcContext;
+/**
+ * An IPC context. `url` is the sender's document URL, which only the startup-restore
+ * renderer carries a `?projectId=` on.
+ */
+function context(
+  senderWindow: { id: number } | null,
+  projectId: string | null = "p1",
+  url?: string
+): IpcContext {
+  return {
+    webContentsId: 7,
+    senderWindow,
+    projectId,
+    ...(url ? { event: { sender: { getURL: () => url } } } : {}),
+  } as unknown as IpcContext;
 }
 
+const STARTUP_URL = "app://daintree/index.html?projectId=p1";
 const PAYLOAD = { projectId: "p1", cwd: "/tmp/project" };
 
 describe("assistantHost.start ownership", () => {
@@ -111,6 +127,18 @@ describe("assistantHost.start and the lane's conversation (#12365)", () => {
     await handler(context({ id: 42 }), { ...PAYLOAD, resumeSessionId: "ses_someone_else" });
     expect(start.mock.calls[0]![0]).not.toHaveProperty("resumeSessionId");
   });
+
+  it("lets only the workspace's own view keep that workspace's conversation", async () => {
+    await handler(context({ id: 42 }, "p1"), PAYLOAD);
+    await handler(context({ id: 42 }, "p2"), PAYLOAD);
+    // Still coming up: not bound yet, and known only by the startup URL it was loaded with.
+    await handler(context({ id: 42 }, null, STARTUP_URL), PAYLOAD);
+    await handler(context({ id: 42 }, null), PAYLOAD);
+
+    // Every one of them still starts — a foreign view always could — but only the owners
+    // may continue, discard or overwrite the conversation.
+    expect(start.mock.calls.map(([opts]) => opts.recordable)).toEqual([true, false, true, false]);
+  });
 });
 
 describe("assistantHost resume records belong to one workspace (#12365)", () => {
@@ -128,6 +156,17 @@ describe("assistantHost resume records belong to one workspace (#12365)", () => 
     expect(listResumable.mock.calls).toEqual([["p1"]]);
   });
 
+  it("answers a view still coming up by its startup URL, and a bound view by its binding", async () => {
+    // A panel coming back cold asks before main has registered its view. Refused there,
+    // every restored conversation would stay behind.
+    expect(await listHandler(context({ id: 42 }, null, STARTUP_URL), "p1")).toEqual([
+      { slot: 1, panelWasOpen: true },
+    ]);
+    expect(await listHandler(context({ id: 42 }, null, STARTUP_URL), "p2")).toEqual([]);
+    // Once bound, the binding is the answer: a stale query string never overrides it.
+    expect(await listHandler(context({ id: 42 }, "p2", STARTUP_URL), "p1")).toEqual([]);
+  });
+
   it("discards only its own workspace's lanes, and only a lane that exists", async () => {
     expect(await discardHandler(context({ id: 42 }, "p1"), "p1", 2)).toEqual({ discarded: true });
     expect(await discardHandler(context({ id: 42 }, "p1"), "p2", 0)).toEqual({
@@ -138,6 +177,15 @@ describe("assistantHost resume records belong to one workspace (#12365)", () => 
     expect(await discardHandler(context({ id: 42 }, "p1"), "p1", 9)).toEqual({
       discarded: false,
     });
-    expect(discardResume.mock.calls).toEqual([["p1", 2]]);
+    // The asking surface comes from the context, so main can tell it from the others
+    // still watching the lane.
+    expect(discardResume.mock.calls).toEqual([["p1", 2, 7]]);
+  });
+
+  it("reports a discard main refused", async () => {
+    discardResume.mockResolvedValueOnce(false);
+    expect(await discardHandler(context({ id: 42 }, "p1"), "p1", 0)).toEqual({
+      discarded: false,
+    });
   });
 });

--- a/electron/ipc/handlers/assistantHost.preload.ts
+++ b/electron/ipc/handlers/assistantHost.preload.ts
@@ -12,6 +12,8 @@ export const ASSISTANT_HOST_METHOD_CHANNELS = {
   start: "assistant-host:start",
   send: "assistant-host:send",
   stop: "assistant-host:stop",
+  listResumable: "assistant-host:list-resumable",
+  discardResume: "assistant-host:discard-resume",
 } as const satisfies Record<string, keyof IpcInvokeMap>;
 
 type Methods = typeof ASSISTANT_HOST_METHOD_CHANNELS;

--- a/electron/ipc/handlers/assistantHost.ts
+++ b/electron/ipc/handlers/assistantHost.ts
@@ -4,6 +4,7 @@ import { assistantHostService } from "../../services/assistant-host/AssistantHos
 import { parseAssistantHostCommand } from "../../schemas/ipc.js";
 import { isValidAssistantSlot } from "../../../shared/config/assistantSlots.js";
 import { createLogger } from "../../utils/logger.js";
+import { getProjectIdFromSenderUrl } from "../senderIdentity.js";
 import type { IpcContext } from "../types.js";
 import type {
   AssistantHostResumableLane,
@@ -12,6 +13,21 @@ import type {
 } from "../../../shared/types/ipc/assistantHostIpc.js";
 
 const logger = createLogger("main:ipc:assistantHost");
+
+/**
+ * The workspace the calling view belongs to.
+ *
+ * The registry's binding first, and the startup renderer's `?projectId=` only while that
+ * binding does not exist yet: main loads the restored view before it registers it, and a
+ * panel coming back cold asks for its lanes inside that gap — refusing it there would
+ * leave every restored conversation behind. A bound view is never overridden by its URL,
+ * and no answer at all stays an identity rather than a wildcard.
+ */
+function callerWorkspaceId(ctx: IpcContext): string | null {
+  if (ctx.projectId) return ctx.projectId;
+  const sender = ctx.event?.sender;
+  return sender ? getProjectIdFromSenderUrl(sender) : null;
+}
 
 /**
  * Whether the calling view IS the workspace it names.
@@ -25,7 +41,7 @@ function callerOwnsWorkspace(
   operation: string
 ): projectId is string {
   if (typeof projectId !== "string" || !projectId) return false;
-  if (ctx.projectId === projectId) return true;
+  if (callerWorkspaceId(ctx) === projectId) return true;
   logger.warn(`${operation}: projectId mismatch — refusing a cross-workspace call`, {
     requested: projectId,
     fromView: ctx.projectId,
@@ -82,6 +98,10 @@ export const assistantHostNamespace = defineIpcNamespace({
           // Strictly `true`: anything else continues the lane's conversation, which is
           // the default a malformed payload should fall back to rather than discarding it.
           fresh: payload.fresh === true,
+          // A view that is not the workspace it names may still start an engine there, as
+          // it always could — but it may not continue, discard or overwrite that
+          // workspace's conversation (#12365).
+          recordable: callerWorkspaceId(ctx) === payload.projectId,
           // BOTH identities come from the IPC CONTEXT, never the payload. A renderer
           // must not be able to nominate which view an assistant session — and
           // therefore its approval prompts — gets delivered to.
@@ -168,8 +188,11 @@ export const assistantHostNamespace = defineIpcNamespace({
       async (ctx, projectId: string, slot: number): Promise<{ discarded: boolean }> => {
         if (!callerOwnsWorkspace(ctx, projectId, "discardResume")) return { discarded: false };
         if (!isValidAssistantSlot(slot)) return { discarded: false };
-        await assistantHostService.discardResume(projectId, slot);
-        return { discarded: true };
+        // The asking surface, from the context: a discard is refused while another surface
+        // is still watching the lane's engine, and only main can tell the two apart.
+        return {
+          discarded: await assistantHostService.discardResume(projectId, slot, ctx.webContentsId),
+        };
       },
       { withContext: true }
     ),

--- a/electron/ipc/handlers/assistantHost.ts
+++ b/electron/ipc/handlers/assistantHost.ts
@@ -2,17 +2,45 @@ import { defineIpcNamespace, op } from "../define.js";
 import { ASSISTANT_HOST_METHOD_CHANNELS } from "./assistantHost.preload.js";
 import { assistantHostService } from "../../services/assistant-host/AssistantHostService.js";
 import { parseAssistantHostCommand } from "../../schemas/ipc.js";
+import { isValidAssistantSlot } from "../../../shared/config/assistantSlots.js";
+import { createLogger } from "../../utils/logger.js";
+import type { IpcContext } from "../types.js";
 import type {
+  AssistantHostResumableLane,
   AssistantHostStartPayload,
   AssistantHostStartResult,
 } from "../../../shared/types/ipc/assistantHostIpc.js";
 
+const logger = createLogger("main:ipc:assistantHost");
+
+/**
+ * Whether the calling view IS the workspace it names.
+ *
+ * A lane's recorded conversation belongs to one workspace, so a view may only read or
+ * forget its own — the guard the PTY hibernation handlers put on their resume tokens.
+ */
+function callerOwnsWorkspace(
+  ctx: IpcContext,
+  projectId: unknown,
+  operation: string
+): projectId is string {
+  if (typeof projectId !== "string" || !projectId) return false;
+  if (ctx.projectId === projectId) return true;
+  logger.warn(`${operation}: projectId mismatch — refusing a cross-workspace call`, {
+    requested: projectId,
+    fromView: ctx.projectId,
+    webContentsId: ctx.webContentsId,
+  });
+  return false;
+}
+
 /**
  * IPC surface for the native assistant engine.
  *
- * Deliberately thin: three commands in, an event stream out on push channels. All the
- * lifecycle (one engine per project, pinned delivery, displacement) lives in
- * `AssistantHostService`, so this layer only validates and routes.
+ * Deliberately thin: commands in, an event stream out on push channels. All the
+ * lifecycle (one engine per project, pinned delivery, displacement, which conversation a
+ * lane continues) lives in `AssistantHostService`, so this layer only validates and
+ * routes.
  */
 export const assistantHostNamespace = defineIpcNamespace({
   name: "assistantHost",
@@ -51,6 +79,9 @@ export const assistantHostNamespace = defineIpcNamespace({
           // name — it is a piece of the window's own layout, not a permission — and
           // `startLocked` resolves anything out of range down to the default lane.
           slot: payload.slot,
+          // Strictly `true`: anything else continues the lane's conversation, which is
+          // the default a malformed payload should fall back to rather than discarding it.
+          fresh: payload.fresh === true,
           // BOTH identities come from the IPC CONTEXT, never the payload. A renderer
           // must not be able to nominate which view an assistant session — and
           // therefore its approval prompts — gets delivered to.
@@ -105,6 +136,40 @@ export const assistantHostNamespace = defineIpcNamespace({
         // engine stops when the last surface leaves.
         assistantHostService.detachSession(sessionId, ctx.webContentsId, attachmentId);
         return { stopped: true };
+      },
+      { withContext: true }
+    ),
+
+    /**
+     * The lanes of this workspace whose conversation a start would continue (#12365).
+     *
+     * Slot numbers and whether each one's panel was open — the conversation ids stay in
+     * main.
+     */
+    listResumable: op(
+      ASSISTANT_HOST_METHOD_CHANNELS.listResumable,
+      async (ctx, projectId: string): Promise<AssistantHostResumableLane[]> => {
+        if (!callerOwnsWorkspace(ctx, projectId, "listResumable")) return [];
+        return assistantHostService.listResumable(projectId);
+      },
+      { withContext: true }
+    ),
+
+    /**
+     * Forgets the conversation a lane would continue, so its next start is a new one.
+     *
+     * What Stop and closing a lane's tab mean, both confirmed in the panel when there is
+     * anything to lose. An out-of-range slot is refused rather than resolved down to lane
+     * 0 the way a start's is: resolving a DISCARD would throw away a conversation the
+     * caller never named.
+     */
+    discardResume: op(
+      ASSISTANT_HOST_METHOD_CHANNELS.discardResume,
+      async (ctx, projectId: string, slot: number): Promise<{ discarded: boolean }> => {
+        if (!callerOwnsWorkspace(ctx, projectId, "discardResume")) return { discarded: false };
+        if (!isValidAssistantSlot(slot)) return { discarded: false };
+        await assistantHostService.discardResume(projectId, slot);
+        return { discarded: true };
       },
       { withContext: true }
     ),

--- a/electron/services/HelpSessionService.ts
+++ b/electron/services/HelpSessionService.ts
@@ -485,6 +485,17 @@ export class HelpSessionService {
     return this.panelVisibleByProjectId.get(projectId) === true;
   }
 
+  /**
+   * Whether this workspace's assistant panel is open, as last reported by its
+   * renderer. The native engine's teardown reads it to decide whether a view
+   * coming back cold should reopen the panel (#12365) — the question the PTY
+   * capture answers from the same map.
+   */
+  isPanelOpen(projectId: string): boolean {
+    if (!projectId) return false;
+    return this.panelOpenByProjectId.get(projectId) === true;
+  }
+
   validateToken(token: string): HelpAssistantTier | false {
     if (!token) return false;
     const record = this.sessionsByToken.get(token);

--- a/electron/services/__tests__/HelpSessionService.test.ts
+++ b/electron/services/__tests__/HelpSessionService.test.ts
@@ -2207,6 +2207,7 @@ describe("HelpSessionService", () => {
       service.reportPanelOpen("proj-toggle", true);
       // User closed the panel before switching away.
       service.reportPanelOpen("proj-toggle", false);
+      expect(service.isPanelOpen("proj-toggle")).toBe(false);
 
       await service.revokeByWebContentsId(97);
       await Promise.resolve();

--- a/electron/services/assistant-host/AssistantHostService.ts
+++ b/electron/services/assistant-host/AssistantHostService.ts
@@ -60,6 +60,13 @@ export interface StartSessionOptions {
    * "+ New session" is the only caller that means it.
    */
   fresh?: boolean;
+  /**
+   * Whether this start may read, clear or write the lane's recorded conversation. The IPC
+   * layer sets it false for a view that is not the workspace it names: that view can still
+   * start an engine there, but cannot continue, discard or overwrite the workspace's
+   * conversation. Defaults to true.
+   */
+  recordable?: boolean;
   windowId: number;
   /** The renderer that owns this session. Events are pinned to it. */
   webContentsId: number;
@@ -71,11 +78,15 @@ interface LiveSession {
   /** The lane this engine occupies. `(projectId, slot)` is its identity. */
   slot: number;
   /**
-   * Whether the lane's recorded conversation is this session's — see
-   * `recordConversation`. Cleared by a discard while the session runs, so an engine
-   * another window is still using records itself again on its next turn.
+   * Whether this session may keep the lane's recorded conversation (#12365). False for a
+   * start from a view that is not the workspace it named, and once the conversation has
+   * been discarded — a late turn from an engine on its way out must not bring it back.
    */
+  recordable: boolean;
+  /** Whether it has written the lane's record. See `recordConversation`. */
   recorded: boolean;
+  /** Conversation activity seen before `host:ready`, recorded once readiness lands. */
+  activeBeforeReady: boolean;
   host: AssistantHostProcess;
   /**
    * Every surface watching this session: WebContents id → its attachment.
@@ -190,6 +201,26 @@ const READY_PROGRESS_MS = 10_000;
  * the fallback — a signal — is not a bad outcome for a process being torn down anyway.
  */
 const SHUTDOWN_GRACE_MS = 2_000;
+
+/**
+ * How old a lane's record may get while its conversation is in use before it is written
+ * again. The store drops records older than two weeks when it loads, and an engine that
+ * stays up longer than that would otherwise still carry the age of its first turn.
+ */
+const RECORD_REFRESH_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Events that mean a lane is having a conversation worth continuing (#12365). A turn is
+ * the obvious one, but a wake's first phase lands before its turn opens, and an
+ * interjection folds into a turn already running. `turn:token` is left out: it only
+ * follows a `turn:start`, and it arrives many times a second.
+ */
+const CONVERSATION_EVENTS: ReadonlySet<string> = new Set([
+  "turn:start",
+  "turn:phase",
+  "turn:interjection",
+  "turn:end",
+]);
 
 /**
  * engine sessionId → the help-session id holding its MCP bearer.
@@ -416,9 +447,25 @@ export class AssistantHostService {
     // it and times out — and it must not displace the first, which is what shipped
     // before: opening a project in a second window silently tore down the conversation
     // the first window was showing.
+    const recordable = opts.recordable !== false;
+    // Only a start that may touch the lane's record can decline it.
+    const fresh = recordable && opts.fresh === true;
     const existing = this.bySlotKey.get(slotKey);
     if (existing && !existing.host.hasExited()) {
-      return this.attach(existing, opts, elapsedMs());
+      // A FRESH start does not join (#12365). "+ New session" asks for a new conversation
+      // on the lane, and joining would hand back the one it is replacing — from a start
+      // still in flight on this very panel, or from another window sharing the engine. It
+      // displaces the running engine instead, and tells the other surfaces on it that the
+      // session ended, because a displaced engine's own exit reaches only its starter.
+      if (!fresh) return this.attach(existing, opts, elapsedMs());
+      for (const webContentsId of [...existing.subscribers.keys()]) {
+        if (webContentsId === opts.webContentsId) continue;
+        this.deliver(webContentsId, CHANNELS.ASSISTANT_HOST_EXIT, {
+          sessionId: existing.sessionId,
+          code: null,
+          signal: null,
+        });
+      }
     }
 
     // Only a session belonging to THIS lane is displaced — a view re-running its
@@ -433,8 +480,9 @@ export class AssistantHostService {
     // does fail cannot hand the declined conversation to the next one.
     const resumeStore = getNativeAssistantResumeStore();
     await resumeStore.load();
-    if (opts.fresh) await resumeStore.clear(slotKey);
-    const resumeSessionId = opts.fresh ? undefined : resumeStore.get(slotKey)?.resumeSessionId;
+    if (fresh) await resumeStore.clear(slotKey);
+    const resumeSessionId =
+      recordable && !fresh ? resumeStore.get(slotKey)?.resumeSessionId : undefined;
 
     // Logged as well as thrown. The renderer surfaces this one, but a resolution failure
     // names a build step someone has to run, and the main log is where they will look for
@@ -650,7 +698,7 @@ export class AssistantHostService {
         ...(mcp?.url ? { DAINTREE_MCP_URL: mcp.url, DAINTREE_MCP_TOKEN: mcp.token } : {}),
       },
       onEvent: (event) => {
-        if (event.type === "turn:start") this.recordConversation(sessionId);
+        if (CONVERSATION_EVENTS.has(event.type)) this.recordConversation(sessionId);
         this.broadcast(sessionId, CHANNELS.ASSISTANT_HOST_EVENT, event);
       },
       onSequenceGap: (info) =>
@@ -690,7 +738,9 @@ export class AssistantHostService {
       sessionId,
       projectId: opts.projectId,
       slot,
+      recordable,
       recorded: false,
+      activeBeforeReady: false,
       host,
       provisionerWebContentsId: opts.webContentsId,
       subscribers: new Map([[opts.webContentsId, { windowId: opts.windowId, attachmentId }]]),
@@ -758,8 +808,11 @@ export class AssistantHostService {
       }
       // A continued conversation is already recorded under the id it continues. Recording
       // it again refreshes its age and clears the panel state its last loss noted, which
-      // has now done its job.
-      if (ready?.resumedSessionId) this.recordConversation(sessionId);
+      // has now done its job. So does a conversation that began before readiness did — a
+      // wake can open a turn in the moment before `host:ready` is written.
+      if (ready?.resumedSessionId || session.activeBeforeReady) {
+        this.recordConversation(sessionId);
+      }
       logger.info("engine ready", {
         sessionId,
         pid: host.getPid(),
@@ -830,6 +883,7 @@ export class AssistantHostService {
     // one engine diverge on the first message either of them sends, one showing a
     // question with no answer and the other an answer with no question.
     session.host.recordPrompt(command.text);
+    this.recordConversation(session.sessionId);
     for (const webContentsId of [...session.subscribers.keys()]) {
       if (webContentsId === fromWebContentsId) continue;
       this.deliver(webContentsId, CHANNELS.ASSISTANT_HOST_PEER_PROMPT, {
@@ -1024,6 +1078,14 @@ export class AssistantHostService {
     // ones already draining from an earlier displacement or eviction, which the session
     // maps no longer know about at all.
     await Promise.all([...this.spawnedHosts].map((host) => host.waitForExit(graceMs)));
+
+    // A conversation recorded moments before quit may still be on its way to disk. Waited
+    // for within the same budget, never beyond it: a stuck write costs one conversation its
+    // continuity, where a hung quit costs everything else its cleanup.
+    await Promise.race([
+      getNativeAssistantResumeStore().flush(),
+      new Promise((resolve) => setTimeout(resolve, graceMs).unref?.()),
+    ]);
   }
 
   /** Tears down every session without waiting. Retained for non-shutdown callers. */
@@ -1100,22 +1162,35 @@ export class AssistantHostService {
 
   /**
    * Forgets the conversation a lane would continue, so its next start is a new one
-   * (#12365) — what Stop and closing a lane's tab mean.
+   * (#12365) — what Stop and closing a lane's tab mean, asked by the surface at
+   * `webContentsId`.
    *
    * It does not end the engine; the panel's own teardown does that. It runs behind the
    * lane's queue, so a start already on its way records first and is then forgotten,
-   * rather than recording after this and bringing the conversation straight back. An
-   * engine still running on the lane — another window can be watching it — is marked
-   * unrecorded, so it records itself again if anyone goes on using it.
+   * rather than recording after this and bringing the conversation straight back.
+   *
+   * Refused while another surface is still watching the lane's engine: that surface is
+   * still having the conversation — the asker leaving ends only its own attachment — and
+   * forgetting it under them would lose it to their next eviction. Otherwise the running
+   * engine is barred from recording again, because the asker's detach is still on its way
+   * and a turn landing before it must not undo the discard.
+   *
+   * Resolves to whether the record was forgotten.
    */
-  discardResume(projectId: string, slot: number): Promise<void> {
+  discardResume(projectId: string, slot: number, webContentsId: number): Promise<boolean> {
     const slotKey = assistantSlotKey(projectId, slot);
     return this.onLane(slotKey, async () => {
+      const live = this.bySlotKey.get(slotKey);
+      const shared =
+        live !== undefined &&
+        !live.host.hasExited() &&
+        [...live.subscribers.keys()].some((id) => id !== webContentsId);
+      if (shared) return false;
       const store = getNativeAssistantResumeStore();
       await store.load();
-      const live = this.bySlotKey.get(slotKey);
-      if (live) live.recorded = false;
+      if (live) live.recordable = false;
       await store.clear(slotKey);
+      return true;
     });
   }
 
@@ -1135,19 +1210,28 @@ export class AssistantHostService {
    * once a lane has been continued even once; continuing from it opens an empty
    * conversation without an error anywhere.
    *
-   * Written on a session's first turn rather than at readiness, so a lane nobody spoke in
-   * leaves nothing behind — and a view coming back cold neither reopens its panel nor
-   * starts an engine for a conversation that never happened.
+   * Written at the session's first sign of conversation — a prompt, a turn, a wake's phase
+   * — rather than at readiness, so a lane nobody spoke in leaves nothing behind, and a view
+   * coming back cold neither reopens its panel nor restores a tab for a conversation that
+   * never happened. Written again once the record is a day old, so a conversation in
+   * steady use never ages out as abandoned.
    */
   private recordConversation(sessionId: string): void {
     const session = this.bySession.get(sessionId);
-    const ready = session?.host.getReadyEvent();
-    if (!session || !ready || session.recorded) return;
+    if (!session?.recordable) return;
+    const ready = session.host.getReadyEvent();
+    if (!ready) {
+      session.activeBeforeReady = true;
+      return;
+    }
+    const store = getNativeAssistantResumeStore();
+    const slotKey = assistantSlotKey(session.projectId, session.slot);
+    const existing = store.get(slotKey);
+    if (session.recorded && existing && Date.now() - existing.capturedAt < RECORD_REFRESH_MS) {
+      return;
+    }
     session.recorded = true;
-    void getNativeAssistantResumeStore().set(
-      assistantSlotKey(session.projectId, session.slot),
-      ready.resumedSessionId ?? session.sessionId
-    );
+    void store.set(slotKey, ready.resumedSessionId ?? session.sessionId);
   }
 
   /**
@@ -1156,6 +1240,7 @@ export class AssistantHostService {
    * is still standing: a lost view sends no parting report.
    */
   private rememberPanelState(session: LiveSession): void {
+    if (!session.recordable) return;
     const store = getNativeAssistantResumeStore();
     const slotKey = assistantSlotKey(session.projectId, session.slot);
     if (!store.get(slotKey)) return;

--- a/electron/services/assistant-host/AssistantHostService.ts
+++ b/electron/services/assistant-host/AssistantHostService.ts
@@ -78,11 +78,17 @@ interface LiveSession {
   /** The lane this engine occupies. `(projectId, slot)` is its identity. */
   slot: number;
   /**
-   * Whether this session may keep the lane's recorded conversation (#12365). False for a
-   * start from a view that is not the workspace it named, and once the conversation has
-   * been discarded — a late turn from an engine on its way out must not bring it back.
+   * Whether this session may keep the lane's recorded conversation (#12365): false while
+   * only a view that is not the workspace it named has used it. The workspace's own view
+   * joining makes it true.
    */
   recordable: boolean;
+  /**
+   * The lane's conversation was discarded while this engine was still up. It never records
+   * again and is never joined — a late turn, or a start landing before the asker's detach,
+   * must not carry on a conversation Stop ended.
+   */
+  discarded: boolean;
   /** Whether it has written the lane's record. See `recordConversation`. */
   recorded: boolean;
   /** Conversation activity seen before `host:ready`, recorded once readiness lands. */
@@ -457,7 +463,15 @@ export class AssistantHostService {
       // still in flight on this very panel, or from another window sharing the engine. It
       // displaces the running engine instead, and tells the other surfaces on it that the
       // session ended, because a displaced engine's own exit reaches only its starter.
-      if (!fresh) return this.attach(existing, opts, elapsedMs());
+      //
+      // Nor does anything join an engine whose conversation was discarded: the asker's
+      // detach can still be on its way when the lane is armed again.
+      if (!fresh && !existing.discarded) {
+        // The workspace's own view joining an engine a foreign view started makes it the
+        // lane's conversation from here on.
+        if (recordable) existing.recordable = true;
+        return this.attach(existing, opts, elapsedMs());
+      }
       for (const webContentsId of [...existing.subscribers.keys()]) {
         if (webContentsId === opts.webContentsId) continue;
         this.deliver(webContentsId, CHANNELS.ASSISTANT_HOST_EXIT, {
@@ -739,6 +753,7 @@ export class AssistantHostService {
       projectId: opts.projectId,
       slot,
       recordable,
+      discarded: false,
       recorded: false,
       activeBeforeReady: false,
       host,
@@ -883,7 +898,6 @@ export class AssistantHostService {
     // one engine diverge on the first message either of them sends, one showing a
     // question with no answer and the other an answer with no question.
     session.host.recordPrompt(command.text);
-    this.recordConversation(session.sessionId);
     for (const webContentsId of [...session.subscribers.keys()]) {
       if (webContentsId === fromWebContentsId) continue;
       this.deliver(webContentsId, CHANNELS.ASSISTANT_HOST_PEER_PROMPT, {
@@ -1007,6 +1021,15 @@ export class AssistantHostService {
         webContentsId,
         strandedSubscribers: session.subscribers.size,
       });
+      // Told here rather than by `onExit`: `stop` deregisters the session first, so the
+      // process's own exit would reach only the surface that started it — the one leaving.
+      for (const remaining of [...session.subscribers.keys()]) {
+        this.deliver(remaining, CHANNELS.ASSISTANT_HOST_EXIT, {
+          sessionId: session.sessionId,
+          code: null,
+          signal: null,
+        });
+      }
     } else {
       logger.info("last surface left; stopping the engine", {
         sessionId: session.sessionId,
@@ -1172,8 +1195,8 @@ export class AssistantHostService {
    * Refused while another surface is still watching the lane's engine: that surface is
    * still having the conversation — the asker leaving ends only its own attachment — and
    * forgetting it under them would lose it to their next eviction. Otherwise the running
-   * engine is barred from recording again, because the asker's detach is still on its way
-   * and a turn landing before it must not undo the discard.
+   * engine is marked discarded, because the asker's detach is still on its way, and neither
+   * a turn nor a start landing before it may carry the conversation on.
    *
    * Resolves to whether the record was forgotten.
    */
@@ -1188,7 +1211,7 @@ export class AssistantHostService {
       if (shared) return false;
       const store = getNativeAssistantResumeStore();
       await store.load();
-      if (live) live.recordable = false;
+      if (live) live.discarded = true;
       await store.clear(slotKey);
       return true;
     });
@@ -1210,15 +1233,16 @@ export class AssistantHostService {
    * once a lane has been continued even once; continuing from it opens an empty
    * conversation without an error anywhere.
    *
-   * Written at the session's first sign of conversation — a prompt, a turn, a wake's phase
-   * — rather than at readiness, so a lane nobody spoke in leaves nothing behind, and a view
+   * Written when the engine first reports conversation — a turn, a wake's phase — rather
+   * than at readiness or on a prompt it may yet refuse, so a lane nobody spoke in leaves
+   * nothing behind, and a view
    * coming back cold neither reopens its panel nor restores a tab for a conversation that
    * never happened. Written again once the record is a day old, so a conversation in
    * steady use never ages out as abandoned.
    */
   private recordConversation(sessionId: string): void {
     const session = this.bySession.get(sessionId);
-    if (!session?.recordable) return;
+    if (!session?.recordable || session.discarded) return;
     const ready = session.host.getReadyEvent();
     if (!ready) {
       session.activeBeforeReady = true;
@@ -1240,7 +1264,7 @@ export class AssistantHostService {
    * is still standing: a lost view sends no parting report.
    */
   private rememberPanelState(session: LiveSession): void {
-    if (!session.recordable) return;
+    if (!session.recordable || session.discarded) return;
     const store = getNativeAssistantResumeStore();
     const slotKey = assistantSlotKey(session.projectId, session.slot);
     if (!store.get(slotKey)) return;

--- a/electron/services/assistant-host/AssistantHostService.ts
+++ b/electron/services/assistant-host/AssistantHostService.ts
@@ -2,6 +2,7 @@ import { app, webContents, type WebContents } from "electron";
 import path from "node:path";
 import { randomBytes } from "node:crypto";
 import { AssistantHostProcess } from "./AssistantHostProcess.js";
+import { getNativeAssistantResumeStore } from "./NativeAssistantResumeStore.js";
 import { resolveAssistantBinary, ASSISTANT_BIN_ENV } from "./resolveAssistantBinary.js";
 import { assistantPlatformSupport } from "../../../shared/config/assistantPlatform.js";
 import { assistantChildEnv } from "./assistantChildEnv.js";
@@ -20,7 +21,10 @@ import {
   assistantSlotKey,
   isValidAssistantSlot,
 } from "../../../shared/config/assistantSlots.js";
-import type { AssistantHostStartResult } from "../../../shared/types/ipc/assistantHostIpc.js";
+import type {
+  AssistantHostResumableLane,
+  AssistantHostStartResult,
+} from "../../../shared/types/ipc/assistantHostIpc.js";
 import { createLogger } from "../../utils/logger.js";
 
 /**
@@ -51,6 +55,11 @@ export interface StartSessionOptions {
    * one session a project used to have.
    */
   slot?: number;
+  /**
+   * Start a new conversation instead of continuing the lane's recorded one (#12365).
+   * "+ New session" is the only caller that means it.
+   */
+  fresh?: boolean;
   windowId: number;
   /** The renderer that owns this session. Events are pinned to it. */
   webContentsId: number;
@@ -61,6 +70,12 @@ interface LiveSession {
   projectId: string;
   /** The lane this engine occupies. `(projectId, slot)` is its identity. */
   slot: number;
+  /**
+   * Whether the lane's recorded conversation is this session's — see
+   * `recordConversation`. Cleared by a discard while the session runs, so an engine
+   * another window is still using records itself again on its next turn.
+   */
+  recorded: boolean;
   host: AssistantHostProcess;
   /**
    * Every surface watching this session: WebContents id → its attachment.
@@ -351,9 +366,19 @@ export class AssistantHostService {
     // empty-lane check, both spawning, and the loser left in `bySession` only: an engine
     // holding lane 0's lease that no later start can find or displace.
     const slot = isValidAssistantSlot(opts.slot) ? opts.slot : DEFAULT_ASSISTANT_SLOT;
-    const slotKey = assistantSlotKey(opts.projectId, slot);
+    return this.onLane(assistantSlotKey(opts.projectId, slot), () =>
+      this.startLocked({ ...opts, slot })
+    );
+  }
+
+  /**
+   * Runs `work` behind everything already queued on a lane — the serialization `start`
+   * describes, shared with `discardResume` so a discard lands in the order it was asked
+   * for relative to the starts around it.
+   */
+  private onLane<T>(slotKey: string, work: () => Promise<T>): Promise<T> {
     const prior = this.startQueue.get(slotKey) ?? Promise.resolve();
-    const run = prior.catch(() => undefined).then(() => this.startLocked({ ...opts, slot }));
+    const run = prior.catch(() => undefined).then(work);
     const settled = run.catch(() => undefined);
     this.startQueue.set(slotKey, settled);
     // Identity-checked so a later start that already replaced this tail is not
@@ -400,6 +425,16 @@ export class AssistantHostService {
     // start effect, or switching projects, must be able to replace its own engine,
     // and must not reach a sibling lane's.
     await this.stopSlot(slotKey);
+
+    // The lane's conversation outlives any one engine: the engine stores it under the id
+    // it was first started with and continues it when handed that id back (#12365). Read
+    // behind the lane's queue, so a discard or a fresh start asked for earlier has already
+    // landed. A fresh start forgets it before anything here can fail, so a start that then
+    // does fail cannot hand the declined conversation to the next one.
+    const resumeStore = getNativeAssistantResumeStore();
+    await resumeStore.load();
+    if (opts.fresh) await resumeStore.clear(slotKey);
+    const resumeSessionId = opts.fresh ? undefined : resumeStore.get(slotKey)?.resumeSessionId;
 
     // Logged as well as thrown. The renderer surfaces this one, but a resolution failure
     // names a build step someone has to run, and the main log is where they will look for
@@ -541,6 +576,7 @@ export class AssistantHostService {
         cwd: opts.cwd,
         tier: engineTier,
         protocolVersion: ASSISTANT_HOST_PROTOCOL_VERSION,
+        ...(resumeSessionId ? { resumeSessionId } : {}),
       },
       env: {
         // Inherited MINUS the control variables — see `assistantChildEnv`.
@@ -613,7 +649,10 @@ export class AssistantHostService {
         // honest "no control plane" it already knows how to degrade around.
         ...(mcp?.url ? { DAINTREE_MCP_URL: mcp.url, DAINTREE_MCP_TOKEN: mcp.token } : {}),
       },
-      onEvent: (event) => this.broadcast(sessionId, CHANNELS.ASSISTANT_HOST_EVENT, event),
+      onEvent: (event) => {
+        if (event.type === "turn:start") this.recordConversation(sessionId);
+        this.broadcast(sessionId, CHANNELS.ASSISTANT_HOST_EVENT, event);
+      },
       onSequenceGap: (info) =>
         this.broadcast(sessionId, CHANNELS.ASSISTANT_HOST_GAP, { sessionId, ...info }),
       onDiagnostic: (line) => {
@@ -651,6 +690,7 @@ export class AssistantHostService {
       sessionId,
       projectId: opts.projectId,
       slot,
+      recorded: false,
       host,
       provisionerWebContentsId: opts.webContentsId,
       subscribers: new Map([[opts.webContentsId, { windowId: opts.windowId, attachmentId }]]),
@@ -696,6 +736,7 @@ export class AssistantHostService {
         binaryPath,
         cwd: opts.cwd,
         tier: engineTier,
+        resuming: resumeSessionId !== undefined,
         elapsedMs: elapsedMs(),
       });
       await host.waitForReady();
@@ -715,6 +756,10 @@ export class AssistantHostService {
           stateDir: ready.stateDir,
         });
       }
+      // A continued conversation is already recorded under the id it continues. Recording
+      // it again refreshes its age and clears the panel state its last loss noted, which
+      // has now done its job.
+      if (ready?.resumedSessionId) this.recordConversation(sessionId);
       logger.info("engine ready", {
         sessionId,
         pid: host.getPid(),
@@ -873,8 +918,17 @@ export class AssistantHostService {
    * panel re-running its start effect resolves the new attach before the old one's
    * teardown runs, so an unqualified detach would remove the live attachment and stop
    * an engine that something is still using.
+   *
+   * `lost` is a surface that went away without asking — its view evicted or crashed, its
+   * window closed. When that ends the engine, the lane notes whether its panel was open,
+   * so the view coming back cold can reopen it (#12365).
    */
-  private detach(session: LiveSession, webContentsId: number, attachmentId?: string): void {
+  private detach(
+    session: LiveSession,
+    webContentsId: number,
+    attachmentId?: string,
+    lost = false
+  ): void {
     const subscriber = session.subscribers.get(webContentsId);
     if (!subscriber) return;
     if (attachmentId !== undefined && subscriber.attachmentId !== attachmentId) return;
@@ -905,6 +959,7 @@ export class AssistantHostService {
         webContentsId,
       });
     }
+    if (lost) this.rememberPanelState(session);
     this.stop(session.sessionId);
   }
 
@@ -1015,7 +1070,9 @@ export class AssistantHostService {
    */
   stopByWebContents(webContentsId: number): void {
     this.departedSurfaces.add(webContentsId);
-    for (const session of [...this.bySession.values()]) this.detach(session, webContentsId);
+    for (const session of [...this.bySession.values()]) {
+      this.detach(session, webContentsId, undefined, true);
+    }
   }
 
   /**
@@ -1035,10 +1092,74 @@ export class AssistantHostService {
       for (const [webContentsId, subscriber] of [...session.subscribers]) {
         if (subscriber.windowId === windowId) {
           this.departedSurfaces.add(webContentsId);
-          this.detach(session, webContentsId);
+          this.detach(session, webContentsId, undefined, true);
         }
       }
     }
+  }
+
+  /**
+   * Forgets the conversation a lane would continue, so its next start is a new one
+   * (#12365) — what Stop and closing a lane's tab mean.
+   *
+   * It does not end the engine; the panel's own teardown does that. It runs behind the
+   * lane's queue, so a start already on its way records first and is then forgotten,
+   * rather than recording after this and bringing the conversation straight back. An
+   * engine still running on the lane — another window can be watching it — is marked
+   * unrecorded, so it records itself again if anyone goes on using it.
+   */
+  discardResume(projectId: string, slot: number): Promise<void> {
+    const slotKey = assistantSlotKey(projectId, slot);
+    return this.onLane(slotKey, async () => {
+      const store = getNativeAssistantResumeStore();
+      await store.load();
+      const live = this.bySlotKey.get(slotKey);
+      if (live) live.recorded = false;
+      await store.clear(slotKey);
+    });
+  }
+
+  /** The lanes of a workspace with a conversation to continue, lowest slot first. */
+  async listResumable(projectId: string): Promise<AssistantHostResumableLane[]> {
+    const store = getNativeAssistantResumeStore();
+    await store.load();
+    return store.lanesFor(projectId);
+  }
+
+  /**
+   * Records the conversation a lane is having, so its next start continues it (#12365).
+   *
+   * The id is the one the engine STORES the conversation under: the resume id it was
+   * handed, else the session id it was started with — read off `host:ready`. Never off
+   * `host:shutdown`, whose resume handle names the launch rather than the conversation
+   * once a lane has been continued even once; continuing from it opens an empty
+   * conversation without an error anywhere.
+   *
+   * Written on a session's first turn rather than at readiness, so a lane nobody spoke in
+   * leaves nothing behind — and a view coming back cold neither reopens its panel nor
+   * starts an engine for a conversation that never happened.
+   */
+  private recordConversation(sessionId: string): void {
+    const session = this.bySession.get(sessionId);
+    const ready = session?.host.getReadyEvent();
+    if (!session || !ready || session.recorded) return;
+    session.recorded = true;
+    void getNativeAssistantResumeStore().set(
+      assistantSlotKey(session.projectId, session.slot),
+      ready.resumedSessionId ?? session.sessionId
+    );
+  }
+
+  /**
+   * Notes whether a recorded lane's panel was open as its engine went down with its view
+   * (#12365). Read from the open state the renderer last reported for the workspace, which
+   * is still standing: a lost view sends no parting report.
+   */
+  private rememberPanelState(session: LiveSession): void {
+    const store = getNativeAssistantResumeStore();
+    const slotKey = assistantSlotKey(session.projectId, session.slot);
+    if (!store.get(slotKey)) return;
+    store.markPanelWasOpen(slotKey, helpSessionService.isPanelOpen(session.projectId));
   }
 
   /** True when `webContentsId` is one of the surfaces watching `sessionId`. */

--- a/electron/services/assistant-host/NativeAssistantResumeStore.ts
+++ b/electron/services/assistant-host/NativeAssistantResumeStore.ts
@@ -1,0 +1,190 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { app } from "electron";
+import { resilientAtomicWriteFile } from "../../utils/fs.js";
+import { createLogger } from "../../utils/logger.js";
+import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
+import {
+  isValidAssistantSlot,
+  projectIdFromSlotKey,
+} from "../../../shared/config/assistantSlots.js";
+import type { AssistantHostResumableLane } from "../../../shared/types/ipc/assistantHostIpc.js";
+
+const logger = createLogger("main:AssistantResume");
+
+const FILE_NAME = "assistant-native-resume.json";
+const FILE_VERSION = 1;
+/**
+ * Older than this on read is dropped. The engine would still continue the conversation,
+ * but the panel cannot show what was said in it, and picking up weeks-old context behind
+ * an empty transcript is not what someone reopening a forgotten project expects. The same
+ * two weeks the PTY resume tokens get.
+ */
+const STALE_AFTER_MS = 14 * 24 * 60 * 60 * 1000;
+/** The engine refuses a descriptor whose `resumeSessionId` is longer than this. */
+const MAX_RESUME_ID_BYTES = 256;
+
+export interface NativeAssistantResumeRecord {
+  /** The id the engine stores this lane's conversation under. */
+  resumeSessionId: string;
+  capturedAt: number;
+  /**
+   * Whether the panel was open when the lane's engine went down with its view. In memory
+   * only, like the PTY store's flag of the same name: a record read back from disk after
+   * a restart describes an earlier run of the app, and must never reopen a panel.
+   */
+  panelWasOpen?: boolean;
+}
+
+type PersistedRecord = Omit<NativeAssistantResumeRecord, "panelWasOpen">;
+
+interface FileShape {
+  version: number;
+  entries: Record<string, PersistedRecord>;
+}
+
+function isPersistedRecord(value: unknown): value is PersistedRecord {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.resumeSessionId === "string" &&
+    v.resumeSessionId !== "" &&
+    Buffer.byteLength(v.resumeSessionId, "utf8") <= MAX_RESUME_ID_BYTES &&
+    typeof v.capturedAt === "number" &&
+    Number.isFinite(v.capturedAt) &&
+    // A future stamp would never age out.
+    v.capturedAt <= Date.now()
+  );
+}
+
+function slotFromSlotKey(slotKey: string): number | null {
+  const at = slotKey.lastIndexOf("\u0000");
+  if (at === -1) return null;
+  const slot = Number(slotKey.slice(at + 1));
+  return isValidAssistantSlot(slot) ? slot : null;
+}
+
+/**
+ * Which conversation each native assistant lane is having, by
+ * `assistantSlotKey(workspaceId, slot)` (#12365).
+ *
+ * The engine keeps a conversation in its own database for as long as it is asked to
+ * continue it, but only the host can ask — and the renderer that knew the id is the
+ * thing an eviction or a crash destroys. So main keeps it, beside the service that
+ * starts the engines, and on disk so an app restart does not lose it either.
+ *
+ * Kept apart from `PendingHelpHibernationStore` on purpose. Those entries are one-shot
+ * resume tokens for a CLI agent, taken by the launch that uses them and read by paths
+ * that launch whatever agent the entry names; a native record is a standing pointer that
+ * every start of the lane reads and only an explicit discard removes.
+ */
+export class NativeAssistantResumeStore {
+  private readonly entries = new Map<string, NativeAssistantResumeRecord>();
+  /**
+   * One read, shared. Starts on different lanes are not serialized with each other, so a
+   * load that marked itself done before its read resolved would hand the second caller an
+   * empty map — and it would start a fresh conversation over a recorded one.
+   */
+  private loading: Promise<void> | null = null;
+  private writeChain: Promise<void> = Promise.resolve();
+
+  constructor(private readonly explicitFilePath?: string) {}
+
+  load(): Promise<void> {
+    this.loading ??= this.read();
+    return this.loading;
+  }
+
+  get(slotKey: string): NativeAssistantResumeRecord | null {
+    return this.entries.get(slotKey) ?? null;
+  }
+
+  set(slotKey: string, resumeSessionId: string): Promise<void> {
+    this.entries.set(slotKey, { resumeSessionId, capturedAt: Date.now() });
+    return this.persist();
+  }
+
+  clear(slotKey: string): Promise<void> {
+    if (!this.entries.delete(slotKey)) return Promise.resolve();
+    return this.persist();
+  }
+
+  /** Stamps a recorded lane's panel state. In memory only; a lane with no record is left alone. */
+  markPanelWasOpen(slotKey: string, panelWasOpen: boolean): void {
+    const entry = this.entries.get(slotKey);
+    if (entry) this.entries.set(slotKey, { ...entry, panelWasOpen });
+  }
+
+  /** The recorded lanes of one workspace, lowest slot first. */
+  lanesFor(projectId: string): AssistantHostResumableLane[] {
+    const lanes: AssistantHostResumableLane[] = [];
+    for (const [slotKey, entry] of this.entries) {
+      if (projectIdFromSlotKey(slotKey) !== projectId) continue;
+      const slot = slotFromSlotKey(slotKey);
+      if (slot === null) continue;
+      lanes.push({ slot, panelWasOpen: entry.panelWasOpen === true });
+    }
+    return lanes.sort((a, b) => a.slot - b.slot);
+  }
+
+  private filePath(): string {
+    return this.explicitFilePath ?? path.join(app.getPath("userData"), FILE_NAME);
+  }
+
+  private async read(): Promise<void> {
+    try {
+      const parsed = JSON.parse(await fs.readFile(this.filePath(), "utf-8")) as Partial<FileShape>;
+      if (!parsed || typeof parsed !== "object" || parsed.version !== FILE_VERSION) return;
+      if (!parsed.entries || typeof parsed.entries !== "object") return;
+      const cutoff = Date.now() - STALE_AFTER_MS;
+      for (const [slotKey, entry] of Object.entries(parsed.entries)) {
+        if (slotFromSlotKey(slotKey) === null || !isPersistedRecord(entry)) continue;
+        if (entry.capturedAt < cutoff) continue;
+        // Rebuilt field by field so nothing else on disk — a `panelWasOpen` included —
+        // survives into memory.
+        this.entries.set(slotKey, {
+          resumeSessionId: entry.resumeSessionId,
+          capturedAt: entry.capturedAt,
+        });
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+      logger.warn("Failed to load native assistant resume records", {
+        error: formatErrorMessage(error, "unknown"),
+      });
+    }
+  }
+
+  private persist(): Promise<void> {
+    // Snapshotted now, written in order: a clear queued behind a set must land last.
+    const entries: Record<string, PersistedRecord> = {};
+    for (const [slotKey, { resumeSessionId, capturedAt }] of this.entries) {
+      entries[slotKey] = { resumeSessionId, capturedAt };
+    }
+    const body = `${JSON.stringify({ version: FILE_VERSION, entries } satisfies FileShape, null, 2)}\n`;
+    const work = this.writeChain.then(async () => {
+      try {
+        await resilientAtomicWriteFile(this.filePath(), body, "utf-8", { mode: 0o600 });
+      } catch (error) {
+        logger.warn("Failed to persist native assistant resume records", {
+          error: formatErrorMessage(error, "unknown"),
+        });
+      }
+    });
+    this.writeChain = work;
+    return work;
+  }
+}
+
+let instance: NativeAssistantResumeStore | null = null;
+
+export function getNativeAssistantResumeStore(): NativeAssistantResumeStore {
+  instance ??= new NativeAssistantResumeStore();
+  return instance;
+}
+
+export function __resetNativeAssistantResumeStoreForTests(
+  store: NativeAssistantResumeStore | null = null
+): void {
+  instance = store;
+}

--- a/electron/services/assistant-host/NativeAssistantResumeStore.ts
+++ b/electron/services/assistant-host/NativeAssistantResumeStore.ts
@@ -127,6 +127,11 @@ export class NativeAssistantResumeStore {
     return lanes.sort((a, b) => a.slot - b.slot);
   }
 
+  /** Resolves once every write asked for so far has landed or failed. */
+  flush(): Promise<void> {
+    return this.writeChain;
+  }
+
   private filePath(): string {
     return this.explicitFilePath ?? path.join(app.getPath("userData"), FILE_NAME);
   }

--- a/electron/services/assistant-host/__tests__/NativeAssistantResumeStore.test.ts
+++ b/electron/services/assistant-host/__tests__/NativeAssistantResumeStore.test.ts
@@ -1,0 +1,129 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("electron", () => ({ app: { getPath: () => "/nonexistent-userdata" } }));
+
+import { NativeAssistantResumeStore } from "../NativeAssistantResumeStore.js";
+import { assistantSlotKey } from "../../../../shared/config/assistantSlots.js";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+describe("NativeAssistantResumeStore", () => {
+  let tmpDir: string;
+  let filePath: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "native-resume-"));
+    filePath = path.join(tmpDir, "resume.json");
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  async function writeRaw(entries: Record<string, unknown>, version = 1): Promise<void> {
+    await fs.writeFile(filePath, JSON.stringify({ version, entries }), "utf-8");
+  }
+
+  async function reread(): Promise<NativeAssistantResumeStore> {
+    const store = new NativeAssistantResumeStore(filePath);
+    await store.load();
+    return store;
+  }
+
+  it("keeps a lane's conversation across a restart, but never its panel state", async () => {
+    const store = await reread();
+    await store.set(assistantSlotKey("p1", 1), "ses_a");
+    store.markPanelWasOpen(assistantSlotKey("p1", 1), true);
+    expect(store.lanesFor("p1")).toEqual([{ slot: 1, panelWasOpen: true }]);
+    // Another write AFTER the stamp, so a persist that carried the flag would put it on disk.
+    await store.set(assistantSlotKey("p2", 0), "ses_b");
+
+    const restarted = await reread();
+    expect(restarted.get(assistantSlotKey("p1", 1))?.resumeSessionId).toBe("ses_a");
+    // A restart is an earlier run of the app: its panel must not reopen on its own.
+    expect(restarted.lanesFor("p1")).toEqual([{ slot: 1, panelWasOpen: false }]);
+    expect(await fs.readFile(filePath, "utf-8")).not.toContain("panelWasOpen");
+  });
+
+  it("hands a load that arrives mid-read what the read found", async () => {
+    await writeRaw({
+      [assistantSlotKey("p1", 0)]: { resumeSessionId: "ses_a", capturedAt: Date.now() },
+    });
+    const store = new NativeAssistantResumeStore(filePath);
+
+    // Starts on different lanes are not serialized with each other. A second load that
+    // resolved before the first read did would see an empty map, and its start would
+    // open a new conversation over the recorded one.
+    const first = store.load();
+    await store.load();
+    expect(store.get(assistantSlotKey("p1", 0))?.resumeSessionId).toBe("ses_a");
+    await first;
+  });
+
+  it("drops entries it cannot trust on read", async () => {
+    const now = Date.now();
+    await writeRaw({
+      [assistantSlotKey("p1", 0)]: { resumeSessionId: "ses_ok", capturedAt: now },
+      [assistantSlotKey("p1", 1)]: { resumeSessionId: "ses_stale", capturedAt: now - 15 * DAY_MS },
+      [assistantSlotKey("p1", 2)]: { resumeSessionId: "", capturedAt: now },
+      // Past the engine's own descriptor limit, which would refuse the whole start.
+      [assistantSlotKey("p2", 0)]: { resumeSessionId: "x".repeat(257), capturedAt: now },
+      // A future stamp never ages out.
+      [assistantSlotKey("p3", 0)]: { resumeSessionId: "ses_future", capturedAt: now + DAY_MS },
+      [assistantSlotKey("p4", 9)]: { resumeSessionId: "ses_no_such_lane", capturedAt: now },
+      "p5-without-a-slot": { resumeSessionId: "ses_unkeyed", capturedAt: now },
+    });
+
+    const store = await reread();
+    expect(store.lanesFor("p1")).toEqual([{ slot: 0, panelWasOpen: false }]);
+    for (const project of ["p2", "p3", "p4", "p5-without-a-slot"]) {
+      expect(store.lanesFor(project)).toEqual([]);
+    }
+  });
+
+  it("ignores a file written by a version it does not know", async () => {
+    await writeRaw(
+      { [assistantSlotKey("p1", 0)]: { resumeSessionId: "ses_a", capturedAt: Date.now() } },
+      2
+    );
+    expect((await reread()).get(assistantSlotKey("p1", 0))).toBeNull();
+  });
+
+  it("lists one workspace's lanes, lowest first", async () => {
+    const store = await reread();
+    await store.set(assistantSlotKey("p1", 2), "ses_c");
+    // A workspace whose id another one's is a prefix of.
+    await store.set(assistantSlotKey("p10", 0), "ses_other");
+    await store.set(assistantSlotKey("p1", 0), "ses_a");
+
+    expect(store.lanesFor("p1").map((lane) => lane.slot)).toEqual([0, 2]);
+  });
+
+  it("forgets a cleared lane on disk and leaves its siblings", async () => {
+    const store = await reread();
+    await store.set(assistantSlotKey("p1", 0), "ses_a");
+    await store.set(assistantSlotKey("p1", 1), "ses_b");
+    await store.clear(assistantSlotKey("p1", 0));
+
+    expect((await reread()).lanesFor("p1")).toEqual([{ slot: 1, panelWasOpen: false }]);
+  });
+
+  it("lands writes in the order they were asked for", async () => {
+    const store = await reread();
+    // Not awaited in between: a clear queued behind a set must be what reaches disk.
+    const set = store.set(assistantSlotKey("p1", 0), "ses_a");
+    const clear = store.clear(assistantSlotKey("p1", 0));
+    await Promise.all([set, clear]);
+
+    expect((await reread()).get(assistantSlotKey("p1", 0))).toBeNull();
+  });
+
+  it("stamps panel state only on a lane that has a conversation", async () => {
+    const store = await reread();
+    store.markPanelWasOpen(assistantSlotKey("p1", 0), true);
+    expect(store.lanesFor("p1")).toEqual([]);
+  });
+});

--- a/electron/services/assistant-host/__tests__/multiSurface.test.ts
+++ b/electron/services/assistant-host/__tests__/multiSurface.test.ts
@@ -133,6 +133,7 @@ const { AssistantHostService } = await import("../AssistantHostService.js");
 const { NativeAssistantResumeStore, __resetNativeAssistantResumeStoreForTests } = await import(
   "../NativeAssistantResumeStore.js"
 );
+const { CHANNELS } = await import("../../../ipc/channels.js");
 
 const PROJECT = "p1";
 const CWD = "/tmp/project";
@@ -249,6 +250,9 @@ describe("a project open on more than one surface", () => {
     // answers and cannot act. They get an ordinary exit instead.
     service.stopByWebContents(10);
     expect(hosts[0]?.disposed).toBe(true);
+    // …and told so now. The process's own exit arrives after the session is deregistered,
+    // and would reach only the surface that left.
+    expect(deliveriesTo(11).map((d) => d.channel)).toEqual([CHANNELS.ASSISTANT_HOST_EXIT]);
   });
 
   it("ignores a stale detach that names a superseded attachment", async () => {

--- a/electron/services/assistant-host/__tests__/multiSurface.test.ts
+++ b/electron/services/assistant-host/__tests__/multiSurface.test.ts
@@ -1,4 +1,7 @@
-import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach, afterEach } from "vitest";
 
 /**
  * One project, one engine, many surfaces.
@@ -122,10 +125,14 @@ vi.mock("../../HelpSessionService.js", () => ({
     getDebugLogging: () => false,
     getBypassPermissions: () => false,
     revokeSession: () => Promise.resolve(),
+    isPanelOpen: () => false,
   },
 }));
 
 const { AssistantHostService } = await import("../AssistantHostService.js");
+const { NativeAssistantResumeStore, __resetNativeAssistantResumeStoreForTests } = await import(
+  "../NativeAssistantResumeStore.js"
+);
 
 const PROJECT = "p1";
 const CWD = "/tmp/project";
@@ -134,10 +141,23 @@ const deliveriesTo = (id: number) => delivered.get(id) ?? [];
 const peerPromptsTo = (id: number) =>
   deliveriesTo(id).filter((d) => d.channel === "assistant-host:peer-prompt");
 
-beforeEach(() => {
+// Each test gets its own conversation records (#12365). The service records a lane's
+// conversation on its first turn, and one store shared across the file would hand a later
+// test's start a conversation to continue that an earlier test left behind.
+let resumeDir: string;
+beforeEach(async () => {
   hosts.length = 0;
   delivered.clear();
   destroyed.clear();
+  resumeDir = await mkdtemp(join(tmpdir(), "daintree-multisurface-resume-"));
+  __resetNativeAssistantResumeStoreForTests(
+    new NativeAssistantResumeStore(join(resumeDir, "resume.json"))
+  );
+});
+
+afterEach(async () => {
+  __resetNativeAssistantResumeStoreForTests();
+  await rm(resumeDir, { recursive: true, force: true });
 });
 
 async function twoSurfaces() {

--- a/electron/services/assistant-host/__tests__/multiSurface.test.ts
+++ b/electron/services/assistant-host/__tests__/multiSurface.test.ts
@@ -130,9 +130,8 @@ vi.mock("../../HelpSessionService.js", () => ({
 }));
 
 const { AssistantHostService } = await import("../AssistantHostService.js");
-const { NativeAssistantResumeStore, __resetNativeAssistantResumeStoreForTests } = await import(
-  "../NativeAssistantResumeStore.js"
-);
+const { NativeAssistantResumeStore, __resetNativeAssistantResumeStoreForTests } =
+  await import("../NativeAssistantResumeStore.js");
 const { CHANNELS } = await import("../../../ipc/channels.js");
 
 const PROJECT = "p1";

--- a/electron/services/assistant-host/__tests__/multiSurface.test.ts
+++ b/electron/services/assistant-host/__tests__/multiSurface.test.ts
@@ -145,17 +145,19 @@ const peerPromptsTo = (id: number) =>
 // conversation on its first turn, and one store shared across the file would hand a later
 // test's start a conversation to continue that an earlier test left behind.
 let resumeDir: string;
+let resumeStore: InstanceType<typeof NativeAssistantResumeStore>;
 beforeEach(async () => {
   hosts.length = 0;
   delivered.clear();
   destroyed.clear();
   resumeDir = await mkdtemp(join(tmpdir(), "daintree-multisurface-resume-"));
-  __resetNativeAssistantResumeStoreForTests(
-    new NativeAssistantResumeStore(join(resumeDir, "resume.json"))
-  );
+  resumeStore = new NativeAssistantResumeStore(join(resumeDir, "resume.json"));
+  __resetNativeAssistantResumeStoreForTests(resumeStore);
 });
 
 afterEach(async () => {
+  // Writes the service queued are drained before their directory goes.
+  await resumeStore.flush();
   __resetNativeAssistantResumeStoreForTests();
   await rm(resumeDir, { recursive: true, force: true });
 });

--- a/electron/services/assistant-host/__tests__/ownershipBoundary.contract.test.ts
+++ b/electron/services/assistant-host/__tests__/ownershipBoundary.contract.test.ts
@@ -96,6 +96,17 @@ const ASSISTANT_CHANNEL_SURFACE = new Map<string, string>([
   [CHANNELS.ASSISTANT_HOST_START, "Starts an engine process for this window. Transport."],
   [CHANNELS.ASSISTANT_HOST_SEND, "One typed command into the running engine. Transport."],
   [CHANNELS.ASSISTANT_HOST_STOP, "Ends the session. Transport."],
+  [
+    CHANNELS.ASSISTANT_HOST_LIST_RESUMABLE,
+    "Which of this workspace's lanes have a conversation a start would continue, and " +
+      "whether each one's panel was open when its engine was lost. Slot numbers and a " +
+      "flag — the conversation ids stay in main. Lifecycle.",
+  ],
+  [
+    CHANNELS.ASSISTANT_HOST_DISCARD_RESUME,
+    "Forgets the conversation a lane would continue, for Stop and closing its tab. A " +
+      "workspace and a slot in, whether it ran out. Lifecycle.",
+  ],
   [CHANNELS.ASSISTANT_HOST_EVENT, "One validated protocol event back. Transport."],
   [CHANNELS.ASSISTANT_HOST_GAP, "A hole in the engine's sequence. Transport integrity."],
   [CHANNELS.ASSISTANT_HOST_EXIT, "The engine process ended. Lifecycle."],

--- a/electron/services/assistant-host/__tests__/resumeLifecycle.test.ts
+++ b/electron/services/assistant-host/__tests__/resumeLifecycle.test.ts
@@ -124,9 +124,8 @@ vi.mock("../../HelpSessionService.js", () => ({
 }));
 
 const { AssistantHostService } = await import("../AssistantHostService.js");
-const { NativeAssistantResumeStore, __resetNativeAssistantResumeStoreForTests } = await import(
-  "../NativeAssistantResumeStore.js"
-);
+const { NativeAssistantResumeStore, __resetNativeAssistantResumeStoreForTests } =
+  await import("../NativeAssistantResumeStore.js");
 const { assistantSlotKey } = await import("../../../../shared/config/assistantSlots.js");
 const { CHANNELS } = await import("../../../ipc/channels.js");
 
@@ -151,8 +150,7 @@ describe("native assistant resume lifecycle", () => {
   let tmpDir: string;
   let store: InstanceType<typeof NativeAssistantResumeStore>;
 
-  const recorded = (slot = 0) =>
-    store.get(assistantSlotKey("p1", slot))?.resumeSessionId ?? null;
+  const recorded = (slot = 0) => store.get(assistantSlotKey("p1", slot))?.resumeSessionId ?? null;
 
   beforeEach(async () => {
     hosts.length = 0;

--- a/electron/services/assistant-host/__tests__/resumeLifecycle.test.ts
+++ b/electron/services/assistant-host/__tests__/resumeLifecycle.test.ts
@@ -15,26 +15,35 @@ import { describe, it, expect, vi, beforeEach, afterEach, beforeAll, afterAll } 
 interface FakeHost {
   descriptor: { sessionId: string; resumeSessionId?: string };
   onEvent: (event: Record<string, unknown>) => void;
+  disposed: boolean;
 }
 
 const hosts: FakeHost[] = [];
 /** When true, the next engines never reach `host:ready`. */
 let failReady = false;
+/** An event each new engine emits after it is up but before the host has its ready frame. */
+let preReadyEvent: ((sessionId: string) => Record<string, unknown>) | null = null;
 /** Workspaces whose assistant panel their renderer last reported open. */
 const panelOpen = new Set<string>();
+const delivered: Array<{ webContentsId: number; channel: string; payload: unknown }> = [];
 
 vi.mock("../AssistantHostProcess.js", () => ({
   AssistantHostProcess: class {
     private readonly record: FakeHost;
-    constructor(opts: FakeHost) {
-      this.record = { descriptor: opts.descriptor, onEvent: opts.onEvent };
+    private isReady = false;
+    constructor(opts: Pick<FakeHost, "descriptor" | "onEvent">) {
+      this.record = { descriptor: opts.descriptor, onEvent: opts.onEvent, disposed: false };
       hosts.push(this.record);
     }
     start() {}
     waitForReady() {
-      return failReady ? Promise.reject(new Error("engine never became ready")) : Promise.resolve();
+      if (failReady) return Promise.reject(new Error("engine never became ready"));
+      if (preReadyEvent) this.record.onEvent(preReadyEvent(this.record.descriptor.sessionId));
+      this.isReady = true;
+      return Promise.resolve();
     }
     getReadyEvent() {
+      if (!this.isReady) return null;
       // The engine's own echo (internal/host/host.go): `resumedSessionId` is present
       // exactly when the descriptor carried a `resumeSessionId`.
       const { sessionId, resumeSessionId } = this.record.descriptor;
@@ -59,7 +68,13 @@ vi.mock("../AssistantHostProcess.js", () => ({
     getTranscript() {
       return { events: [], prompts: [], truncated: false };
     }
-    dispose() {}
+    send() {
+      return true;
+    }
+    recordPrompt() {}
+    dispose() {
+      this.record.disposed = true;
+    }
     waitForExit() {
       return Promise.resolve();
     }
@@ -82,7 +97,14 @@ vi.mock("../resolveAssistantBinary.js", () => ({
 
 vi.mock("electron", () => ({
   app: { getPath: () => "/nonexistent-userdata", isPackaged: false },
-  webContents: { fromId: () => ({ isDestroyed: () => false, send: () => {} }) },
+  webContents: {
+    fromId: (webContentsId: number) => ({
+      isDestroyed: () => false,
+      send: (channel: string, payload: unknown) => {
+        delivered.push({ webContentsId, channel, payload });
+      },
+    }),
+  },
 }));
 
 vi.mock("../../../ipc/handlers/helpAssistant.js", () => ({
@@ -106,8 +128,11 @@ const { NativeAssistantResumeStore, __resetNativeAssistantResumeStoreForTests } 
   "../NativeAssistantResumeStore.js"
 );
 const { assistantSlotKey } = await import("../../../../shared/config/assistantSlots.js");
+const { CHANNELS } = await import("../../../ipc/channels.js");
 
 const VIEW = { projectId: "p1", cwd: "/tmp/p1", webContentsId: 7, windowId: 1 };
+const OTHER_WINDOW = { ...VIEW, webContentsId: 8, windowId: 2 };
+const DAY_MS = 24 * 60 * 60 * 1000;
 
 /** The engine opens a turn — the moment a lane has a conversation worth continuing. */
 function speak(host: FakeHost): void {
@@ -130,7 +155,9 @@ describe("native assistant resume lifecycle", () => {
 
   beforeEach(async () => {
     hosts.length = 0;
+    delivered.length = 0;
     failReady = false;
+    preReadyEvent = null;
     panelOpen.clear();
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "native-resume-lifecycle-"));
     store = new NativeAssistantResumeStore(path.join(tmpDir, "resume.json"));
@@ -138,6 +165,9 @@ describe("native assistant resume lifecycle", () => {
   });
 
   afterEach(async () => {
+    vi.useRealTimers();
+    // Writes the service queued are drained before their directory goes.
+    await store.flush();
     __resetNativeAssistantResumeStoreForTests();
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
@@ -174,6 +204,49 @@ describe("native assistant resume lifecycle", () => {
     expect(await service.listResumable("p1")).toEqual([]);
   });
 
+  it("records a conversation from the prompt that begins it", async () => {
+    const service = new AssistantHostService();
+    const first = await service.start(VIEW);
+    expect(recorded()).toBeNull();
+
+    service.send(
+      { type: "prompt", sessionId: first.sessionId, text: "hello" } as never,
+      VIEW.webContentsId
+    );
+    expect(recorded()).toBe(first.sessionId);
+  });
+
+  it("records a conversation that began before the host had the engine's ready frame", async () => {
+    // A wake can open in the moment between the engine becoming ready and `host:ready`
+    // being written. Asked then, the host cannot yet say which id the conversation is
+    // stored under — and no later turn may come to ask again before the view is lost.
+    preReadyEvent = (sessionId) => ({
+      type: "turn:phase",
+      sessionId,
+      seq: 2,
+      phase: "Waking",
+      wake: true,
+    });
+    const service = new AssistantHostService();
+    const first = await service.start(VIEW);
+
+    expect(recorded()).toBe(first.sessionId);
+  });
+
+  it("keeps the record's age current while the conversation is in use", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    const service = new AssistantHostService();
+    await service.start(VIEW);
+    speak(hosts[0]!);
+    const firstAt = store.get(assistantSlotKey("p1", 0))!.capturedAt;
+
+    // An engine up for longer than the store's staleness cutoff would otherwise still
+    // carry its first turn's age, and be dropped on the next launch as abandoned.
+    vi.setSystemTime(firstAt + DAY_MS + 1);
+    speak(hosts[0]!);
+    expect(store.get(assistantSlotKey("p1", 0))!.capturedAt).toBe(firstAt + DAY_MS + 1);
+  });
+
   it("keeps the conversation through a start that fails", async () => {
     const service = new AssistantHostService();
     const first = await service.start(VIEW);
@@ -202,6 +275,29 @@ describe("native assistant resume lifecycle", () => {
     expect(recorded()).toBeNull();
   });
 
+  it("replaces a running engine on a fresh start rather than joining it", async () => {
+    const service = new AssistantHostService();
+    const first = await service.start(VIEW);
+    speak(hosts[0]!);
+    await service.start(OTHER_WINDOW);
+    expect(hosts).toHaveLength(1);
+    delivered.length = 0;
+
+    const fresh = await service.start({ ...VIEW, fresh: true });
+
+    // Joining would have handed "+ New session" the very conversation it replaces.
+    expect(hosts).toHaveLength(2);
+    expect(hosts[0]!.disposed).toBe(true);
+    expect(fresh.sessionId).not.toBe(first.sessionId);
+    expect(hosts[1]!.descriptor).not.toHaveProperty("resumeSessionId");
+    // The other window is told its session ended, rather than left typing into it.
+    expect(delivered).toContainEqual({
+      webContentsId: OTHER_WINDOW.webContentsId,
+      channel: CHANNELS.ASSISTANT_HOST_EXIT,
+      payload: { sessionId: first.sessionId, code: null, signal: null },
+    });
+  });
+
   it("discards one lane, and only after a start already on its way", async () => {
     const service = new AssistantHostService();
     await service.start(VIEW);
@@ -214,18 +310,43 @@ describe("native assistant resume lifecycle", () => {
     // records it again at readiness, so a discard that jumped the queue would either be
     // undone by it or keep it from resuming at all.
     const restarting = service.start(VIEW);
-    const discarding = service.discardResume("p1", 0);
+    const discarding = service.discardResume("p1", 0, VIEW.webContentsId);
     await restarting;
-    await discarding;
+    expect(await discarding).toBe(true);
 
     expect(hosts[2]!.descriptor.resumeSessionId).toBe(hosts[0]!.descriptor.sessionId);
     expect(recorded(0)).toBeNull();
     expect(recorded(1)).toBe(hosts[1]!.descriptor.sessionId);
 
-    // The engine that was running when it was discarded is still somebody's conversation
-    // (another window can be watching it), so using it records it again.
+    // The engine is still up until the asker's own detach lands. A turn arriving in that
+    // gap must not bring back what was just discarded.
     speak(hosts[2]!);
-    expect(recorded(0)).toBe(hosts[0]!.descriptor.sessionId);
+    expect(recorded(0)).toBeNull();
+  });
+
+  it("refuses to discard a conversation another window is still having", async () => {
+    const service = new AssistantHostService();
+    const first = await service.start(VIEW);
+    speak(hosts[0]!);
+    await service.start(OTHER_WINDOW);
+
+    // Stop in one window ends only that window's attachment; the other is still talking,
+    // and would lose the conversation to its next eviction.
+    expect(await service.discardResume("p1", 0, VIEW.webContentsId)).toBe(false);
+    expect(recorded()).toBe(first.sessionId);
+  });
+
+  it("lets a view that is not the workspace neither continue, discard nor overwrite it", async () => {
+    const service = new AssistantHostService();
+    const first = await service.start(VIEW);
+    speak(hosts[0]!);
+    service.stopByWebContents(VIEW.webContentsId);
+
+    await service.start({ ...VIEW, webContentsId: 9, windowId: 3, recordable: false, fresh: true });
+    expect(hosts[1]!.descriptor).not.toHaveProperty("resumeSessionId");
+    speak(hosts[1]!);
+
+    expect(recorded()).toBe(first.sessionId);
   });
 
   it("remembers whether the panel was open only when the engine went down with its view", async () => {

--- a/electron/services/assistant-host/__tests__/resumeLifecycle.test.ts
+++ b/electron/services/assistant-host/__tests__/resumeLifecycle.test.ts
@@ -132,6 +132,7 @@ const { CHANNELS } = await import("../../../ipc/channels.js");
 
 const VIEW = { projectId: "p1", cwd: "/tmp/p1", webContentsId: 7, windowId: 1 };
 const OTHER_WINDOW = { ...VIEW, webContentsId: 8, windowId: 2 };
+const FOREIGN_VIEW = { ...VIEW, webContentsId: 9, windowId: 3, recordable: false };
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 /** The engine opens a turn — the moment a lane has a conversation worth continuing. */
@@ -166,6 +167,7 @@ describe("native assistant resume lifecycle", () => {
 
   afterEach(async () => {
     vi.useRealTimers();
+    vi.restoreAllMocks();
     // Writes the service queued are drained before their directory goes.
     await store.flush();
     __resetNativeAssistantResumeStoreForTests();
@@ -204,15 +206,19 @@ describe("native assistant resume lifecycle", () => {
     expect(await service.listResumable("p1")).toEqual([]);
   });
 
-  it("records a conversation from the prompt that begins it", async () => {
+  it("waits for the engine to report a turn rather than counting a prompt it may refuse", async () => {
     const service = new AssistantHostService();
     const first = await service.start(VIEW);
-    expect(recorded()).toBeNull();
 
     service.send(
       { type: "prompt", sessionId: first.sessionId, text: "hello" } as never,
       VIEW.webContentsId
     );
+    // Taken by the pipe is not taken by the engine: a prompt refused as busy stores
+    // nothing, and a lane restored for it would announce a conversation that never began.
+    expect(recorded()).toBeNull();
+
+    speak(hosts[0]!);
     expect(recorded()).toBe(first.sessionId);
   });
 
@@ -324,6 +330,23 @@ describe("native assistant resume lifecycle", () => {
     expect(recorded(0)).toBeNull();
   });
 
+  it("starts a new engine rather than joining one whose conversation was discarded", async () => {
+    const service = new AssistantHostService();
+    await service.start(VIEW);
+    speak(hosts[0]!);
+    expect(await service.discardResume("p1", 0, VIEW.webContentsId)).toBe(true);
+
+    // Armed again before Stop's own detach landed, while the discarded engine is still up.
+    // Joining it would carry on the conversation Stop ended, and never record it again.
+    const again = await service.start(VIEW);
+    expect(hosts).toHaveLength(2);
+    expect(hosts[0]!.disposed).toBe(true);
+    expect(hosts[1]!.descriptor).not.toHaveProperty("resumeSessionId");
+
+    speak(hosts[1]!);
+    expect(recorded()).toBe(again.sessionId);
+  });
+
   it("refuses to discard a conversation another window is still having", async () => {
     const service = new AssistantHostService();
     const first = await service.start(VIEW);
@@ -342,11 +365,25 @@ describe("native assistant resume lifecycle", () => {
     speak(hosts[0]!);
     service.stopByWebContents(VIEW.webContentsId);
 
-    await service.start({ ...VIEW, webContentsId: 9, windowId: 3, recordable: false, fresh: true });
+    await service.start({ ...FOREIGN_VIEW, fresh: true });
     expect(hosts[1]!.descriptor).not.toHaveProperty("resumeSessionId");
     speak(hosts[1]!);
 
     expect(recorded()).toBe(first.sessionId);
+  });
+
+  it("makes a foreign view's engine the lane's conversation once the workspace joins it", async () => {
+    const service = new AssistantHostService();
+    const foreign = await service.start(FOREIGN_VIEW);
+    speak(hosts[0]!);
+    expect(recorded()).toBeNull();
+
+    // The workspace's own view is now having this conversation. Left unrecorded, its next
+    // eviction would lose it.
+    await service.start(VIEW);
+    expect(hosts).toHaveLength(1);
+    speak(hosts[0]!);
+    expect(recorded()).toBe(foreign.sessionId);
   });
 
   it("remembers whether the panel was open only when the engine went down with its view", async () => {
@@ -385,5 +422,37 @@ describe("native assistant resume lifecycle", () => {
 
     await service.shutdown(10);
     expect(recorded()).toBe(first.sessionId);
+  });
+
+  it("waits at quit for a conversation still on its way to disk", async () => {
+    let release!: () => void;
+    vi.spyOn(store, "flush").mockReturnValue(
+      new Promise<void>((resolve) => {
+        release = resolve;
+      })
+    );
+    const service = new AssistantHostService();
+    await service.start(VIEW);
+
+    let settled = false;
+    const done = service.shutdown(5_000).then(() => {
+      settled = true;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(settled).toBe(false);
+
+    release();
+    await done;
+    expect(settled).toBe(true);
+  });
+
+  it("does not let a stuck write hold quit past its budget", async () => {
+    vi.spyOn(store, "flush").mockReturnValue(new Promise<void>(() => {}));
+    const service = new AssistantHostService();
+    await service.start(VIEW);
+
+    // Resolves at all: a write that never lands costs one conversation its continuity, not
+    // the whole quit.
+    await service.shutdown(20);
   });
 });

--- a/electron/services/assistant-host/__tests__/resumeLifecycle.test.ts
+++ b/electron/services/assistant-host/__tests__/resumeLifecycle.test.ts
@@ -1,0 +1,268 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, it, expect, vi, beforeEach, afterEach, beforeAll, afterAll } from "vitest";
+
+/**
+ * Which conversation a native lane continues (#12365).
+ *
+ * The engine keeps a conversation in its own database and continues it when handed its
+ * id back, so an engine that went down with its view — evicted, crashed, its window
+ * closed — has lost nothing but the host's knowledge of that id. These are the rules for
+ * keeping it: which id, when it is written, what forgets it, and what never may.
+ */
+
+interface FakeHost {
+  descriptor: { sessionId: string; resumeSessionId?: string };
+  onEvent: (event: Record<string, unknown>) => void;
+}
+
+const hosts: FakeHost[] = [];
+/** When true, the next engines never reach `host:ready`. */
+let failReady = false;
+/** Workspaces whose assistant panel their renderer last reported open. */
+const panelOpen = new Set<string>();
+
+vi.mock("../AssistantHostProcess.js", () => ({
+  AssistantHostProcess: class {
+    private readonly record: FakeHost;
+    constructor(opts: FakeHost) {
+      this.record = { descriptor: opts.descriptor, onEvent: opts.onEvent };
+      hosts.push(this.record);
+    }
+    start() {}
+    waitForReady() {
+      return failReady ? Promise.reject(new Error("engine never became ready")) : Promise.resolve();
+    }
+    getReadyEvent() {
+      // The engine's own echo (internal/host/host.go): `resumedSessionId` is present
+      // exactly when the descriptor carried a `resumeSessionId`.
+      const { sessionId, resumeSessionId } = this.record.descriptor;
+      return {
+        type: "host:ready",
+        sessionId,
+        seq: 1,
+        protocolVersion: 4,
+        autoApprove: false,
+        ...(resumeSessionId ? { resumedSessionId: resumeSessionId } : {}),
+      };
+    }
+    getPid() {
+      return null;
+    }
+    takePreReadyEvents() {
+      return [];
+    }
+    hasExited() {
+      return false;
+    }
+    getTranscript() {
+      return { events: [], prompts: [], truncated: false };
+    }
+    dispose() {}
+    waitForExit() {
+      return Promise.resolve();
+    }
+  },
+}));
+
+const REAL_PLATFORM = process.platform;
+beforeAll(() => {
+  Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
+});
+afterAll(() => {
+  Object.defineProperty(process, "platform", { value: REAL_PLATFORM, configurable: true });
+});
+
+vi.mock("../resolveAssistantBinary.js", () => ({
+  ASSISTANT_BIN_ENV: "DAINTREE_ASSISTANT_BIN",
+  resolveAssistantBinary: () =>
+    Promise.resolve({ path: "/nonexistent/daintree-assistant", source: "repo" }),
+}));
+
+vi.mock("electron", () => ({
+  app: { getPath: () => "/nonexistent-userdata", isPackaged: false },
+  webContents: { fromId: () => ({ isDestroyed: () => false, send: () => {} }) },
+}));
+
+vi.mock("../../../ipc/handlers/helpAssistant.js", () => ({
+  getHelpAssistantSettings: () => ({ tier: "action" }),
+}));
+
+vi.mock("../../HelpSessionService.js", () => ({
+  helpSessionService: {
+    provisionSession: () => Promise.resolve(null),
+    markEngineSession: () => true,
+    getDebugLoggingPreference: () => false,
+    getDebugLogging: () => false,
+    getBypassPermissions: () => false,
+    revokeSession: () => Promise.resolve(),
+    isPanelOpen: (projectId: string) => panelOpen.has(projectId),
+  },
+}));
+
+const { AssistantHostService } = await import("../AssistantHostService.js");
+const { NativeAssistantResumeStore, __resetNativeAssistantResumeStoreForTests } = await import(
+  "../NativeAssistantResumeStore.js"
+);
+const { assistantSlotKey } = await import("../../../../shared/config/assistantSlots.js");
+
+const VIEW = { projectId: "p1", cwd: "/tmp/p1", webContentsId: 7, windowId: 1 };
+
+/** The engine opens a turn — the moment a lane has a conversation worth continuing. */
+function speak(host: FakeHost): void {
+  host.onEvent({
+    type: "turn:start",
+    sessionId: host.descriptor.sessionId,
+    seq: 2,
+    turnId: "t1",
+    role: "assistant",
+    startedAt: 1,
+  });
+}
+
+describe("native assistant resume lifecycle", () => {
+  let tmpDir: string;
+  let store: InstanceType<typeof NativeAssistantResumeStore>;
+
+  const recorded = (slot = 0) =>
+    store.get(assistantSlotKey("p1", slot))?.resumeSessionId ?? null;
+
+  beforeEach(async () => {
+    hosts.length = 0;
+    failReady = false;
+    panelOpen.clear();
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "native-resume-lifecycle-"));
+    store = new NativeAssistantResumeStore(path.join(tmpDir, "resume.json"));
+    __resetNativeAssistantResumeStoreForTests(store);
+  });
+
+  afterEach(async () => {
+    __resetNativeAssistantResumeStoreForTests();
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("continues the conversation a lane first had, however many engines later", async () => {
+    const service = new AssistantHostService();
+    const first = await service.start(VIEW);
+    speak(hosts[0]!);
+    expect(recorded()).toBe(first.sessionId);
+
+    service.stopByWebContents(VIEW.webContentsId);
+    await service.start(VIEW);
+    expect(hosts[1]!.descriptor.resumeSessionId).toBe(first.sessionId);
+    // A new engine, with a wire id of its own…
+    expect(hosts[1]!.descriptor.sessionId).not.toBe(first.sessionId);
+    speak(hosts[1]!);
+
+    service.stopByWebContents(VIEW.webContentsId);
+    await service.start(VIEW);
+    // …which is NOT what the third one continues. The conversation is stored under the id
+    // it began with; the second engine's own id — what its `host:shutdown` names as the
+    // resume handle — holds nothing, and continuing from it opens an empty conversation
+    // without an error anywhere.
+    expect(hosts[2]!.descriptor.resumeSessionId).toBe(first.sessionId);
+  });
+
+  it("leaves nothing to continue for a lane nobody spoke in", async () => {
+    const service = new AssistantHostService();
+    await service.start(VIEW);
+    service.stopByWebContents(VIEW.webContentsId);
+
+    await service.start(VIEW);
+    expect(hosts[1]!.descriptor).not.toHaveProperty("resumeSessionId");
+    expect(await service.listResumable("p1")).toEqual([]);
+  });
+
+  it("keeps the conversation through a start that fails", async () => {
+    const service = new AssistantHostService();
+    const first = await service.start(VIEW);
+    speak(hosts[0]!);
+    service.stopByWebContents(VIEW.webContentsId);
+
+    failReady = true;
+    await expect(service.start(VIEW)).rejects.toThrow(/ready/);
+    failReady = false;
+
+    await service.start(VIEW);
+    expect(hosts[2]!.descriptor.resumeSessionId).toBe(first.sessionId);
+  });
+
+  it("declines the conversation on a fresh start, even one that then fails", async () => {
+    const service = new AssistantHostService();
+    await service.start(VIEW);
+    speak(hosts[0]!);
+    service.stopByWebContents(VIEW.webContentsId);
+
+    failReady = true;
+    await expect(service.start({ ...VIEW, fresh: true })).rejects.toThrow(/ready/);
+    expect(hosts[1]!.descriptor).not.toHaveProperty("resumeSessionId");
+    // The user asked for a new conversation. A failure to start one must not quietly hand
+    // them the old one on the next attempt.
+    expect(recorded()).toBeNull();
+  });
+
+  it("discards one lane, and only after a start already on its way", async () => {
+    const service = new AssistantHostService();
+    await service.start(VIEW);
+    speak(hosts[0]!);
+    await service.start({ ...VIEW, slot: 1 });
+    speak(hosts[1]!);
+    service.stopByWebContents(VIEW.webContentsId);
+
+    // Queued behind a start of the same lane. That start continues the conversation and
+    // records it again at readiness, so a discard that jumped the queue would either be
+    // undone by it or keep it from resuming at all.
+    const restarting = service.start(VIEW);
+    const discarding = service.discardResume("p1", 0);
+    await restarting;
+    await discarding;
+
+    expect(hosts[2]!.descriptor.resumeSessionId).toBe(hosts[0]!.descriptor.sessionId);
+    expect(recorded(0)).toBeNull();
+    expect(recorded(1)).toBe(hosts[1]!.descriptor.sessionId);
+
+    // The engine that was running when it was discarded is still somebody's conversation
+    // (another window can be watching it), so using it records it again.
+    speak(hosts[2]!);
+    expect(recorded(0)).toBe(hosts[0]!.descriptor.sessionId);
+  });
+
+  it("remembers whether the panel was open only when the engine went down with its view", async () => {
+    const service = new AssistantHostService();
+    panelOpen.add("p1");
+    await service.start(VIEW);
+    speak(hosts[0]!);
+
+    service.stopByWebContents(VIEW.webContentsId);
+    expect(await service.listResumable("p1")).toEqual([{ slot: 0, panelWasOpen: true }]);
+
+    // Continuing the conversation is what that note was for; once it has, it is spent.
+    const again = await service.start(VIEW);
+    expect(await service.listResumable("p1")).toEqual([{ slot: 0, panelWasOpen: false }]);
+
+    // The panel ending its own attachment is not a loss: the view is still there, with
+    // nothing to come back to.
+    service.detachSession(again.sessionId, VIEW.webContentsId, again.attachmentId);
+    expect(await service.listResumable("p1")).toEqual([{ slot: 0, panelWasOpen: false }]);
+  });
+
+  it("treats a closed window as a lost view too", async () => {
+    const service = new AssistantHostService();
+    panelOpen.add("p1");
+    await service.start(VIEW);
+    speak(hosts[0]!);
+
+    service.stopByWindow(VIEW.windowId);
+    expect(await service.listResumable("p1")).toEqual([{ slot: 0, panelWasOpen: true }]);
+  });
+
+  it("keeps every lane's conversation through a quit", async () => {
+    const service = new AssistantHostService();
+    const first = await service.start(VIEW);
+    speak(hosts[0]!);
+
+    await service.shutdown(10);
+    expect(recorded()).toBe(first.sessionId);
+  });
+});

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1961,6 +1961,16 @@ export interface ElectronAPI extends GeneratedElectronAPI {
      * live surface is still using.
      */
     stop(sessionId: string, attachmentId: string): Promise<{ stopped: boolean }>;
+    /**
+     * The lanes of this workspace with a conversation their next start would continue,
+     * and whether each one's panel was open when its engine went down with the view
+     * (#12365).
+     */
+    listResumable(
+      projectId: string
+    ): Promise<import("./assistantHostIpc.js").AssistantHostResumableLane[]>;
+    /** Forgets the conversation a lane would continue. What Stop and closing its tab mean. */
+    discardResume(projectId: string, slot: number): Promise<{ discarded: boolean }>;
     /** One validated protocol event from the engine. */
     onEvent(callback: (event: import("./assistantHost.js").AssistantHostEvent) => void): () => void;
     /**

--- a/shared/types/ipc/assistantHostIpc.ts
+++ b/shared/types/ipc/assistantHostIpc.ts
@@ -61,6 +61,26 @@ export interface AssistantHostStartPayload {
    * project used to have.
    */
   slot?: number;
+  /**
+   * Start a new conversation instead of continuing the lane's recorded one (#12365).
+   *
+   * Every other start continues it, which is what brings a view back to the conversation
+   * it lost to an eviction or a crash; only "+ New session" sets this. The id being
+   * continued never crosses the bridge — main looks it up — so a renderer can decline a
+   * conversation but never name one.
+   */
+  fresh?: boolean;
+}
+
+/** A lane with a conversation main would continue on its next start (#12365). */
+export interface AssistantHostResumableLane {
+  slot: number;
+  /**
+   * Whether the assistant panel was open when this lane's engine went down with its
+   * view. Only ever true in the app run that lost it: the flag is not persisted, so a
+   * restart never reopens a panel on its own.
+   */
+  panelWasOpen: boolean;
 }
 
 /**

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -188,6 +188,14 @@ export interface GeneratedIpcInvokeMap {
     args: [options: import("./agent.js").SaveArtifactOptions];
     result: import("./agent.js").SaveArtifactResult | null;
   };
+  "assistant-host:discard-resume": {
+    args: [projectId: string, slot: number];
+    result: { discarded: boolean };
+  };
+  "assistant-host:list-resumable": {
+    args: [projectId: string];
+    result: import("./assistantHostIpc.js").AssistantHostResumableLane[];
+  };
   "assistant-host:send": {
     args: [raw: unknown];
     result: { delivered: boolean };

--- a/src/components/AssistantPanel/AssistantPanel.tsx
+++ b/src/components/AssistantPanel/AssistantPanel.tsx
@@ -147,6 +147,7 @@ export function AssistantPanel({
       awaitingLocalCommand: s.awaitingLocalCommand,
       autoApprove: s.autoApprove,
       stoppedReason: s.stoppedReason,
+      resumed: s.resumed,
       error: s.error,
       turns: s.turns,
       toolCalls: s.toolCalls,

--- a/src/components/AssistantPanel/__preview__/capturedStates.ts
+++ b/src/components/AssistantPanel/__preview__/capturedStates.ts
@@ -75,6 +75,7 @@ export const CAPTURED_STATES = {
     pendingQuestion: null,
     awaitingLocalCommand: false,
     stoppedReason: null,
+    resumed: false,
     error: null,
     turns: [],
     toolCalls: {},
@@ -149,18 +150,19 @@ export const CAPTURED_STATES = {
     toolGrants: {},
     queuedInterjections: [],
     retractedDraft: null,
-    lastActivityAt: 1788070816429,
-    turnStartedAt: 1788070815531,
+    lastActivityAt: 1789096799342,
+    turnStartedAt: 1789096798461,
     phaseIsWake: false,
     pendingQuestion: null,
     awaitingLocalCommand: false,
     stoppedReason: "exit",
+    resumed: false,
     error: null,
     turns: [
       {
-        turnId: "local_7c6b068d-7c10-4a50-80c9-03dda365a40d",
+        turnId: "local_73688160-d625-416b-8554-3f327022339b",
         role: "user",
-        startedAt: 1788070815530,
+        startedAt: 1789096798460,
         segments: [
           {
             kind: "text",
@@ -175,14 +177,14 @@ export const CAPTURED_STATES = {
       {
         turnId: "turn_1",
         role: "assistant",
-        startedAt: 1788070815530,
+        startedAt: 1789096798461,
         segments: [
           {
             kind: "text",
-            text: "1. Step 1 — a line of explanation that wraps at panel width.\n2. Step 2 — a line of explanation that wraps at panel width.\n3. Step 3 — a line of explanation that wraps at panel width.\n4. Step 4 — a line of explanation that wraps at panel width.\n5. Step 5 — a line of explanation that wraps at panel width.\n6. Step 6 — a line of explanation that wraps at panel width.\n7. Step 7 — a line of explanation that wraps at panel width.\n8. Step 8 — a line of explanation that wraps at panel width.\n9. Step 9 — a line of explanation that wraps at panel width.\n10. Step 10 — a line of explanation that wraps at panel width.\n11. Step 11 — a line of explanation that wraps at panel width.\n12. Step 12 — a line of explanation that wraps at panel width.\n13. Step 13 — a line of explanation that wraps at panel width.\n14. Step 14 — a line of explanation that wraps at panel width.\n15. Step 15 — a line of explanation that wraps at panel width.\n16. Step 16 — a line of explanation that wraps at panel width.\n17. Step 17 — a line of explanation that wraps at panel width.\n18. Step 18 — a line of explanation that wraps at panel width.\n19. Step 19 — a line of explanation that wraps at panel width.\n20. Step 20 — a line of explanation that wraps at panel width.\n21. Step 21 — a line of explanation that wraps at panel width.\n22. Step 22 — a line of explanation that wraps at panel width.\n23. Step 23 — a line of explanation that wraps at panel width.\n24. Step 24 — a line of explanation that wraps at",
+            text: "1. Step 1 — a line of explanation that wraps at panel width.\n2. Step 2 — a line of explanation that wraps at panel width.\n3. Step 3 — a line of explanation that wraps at panel width.\n4. Step 4 — a line of explanation that wraps at panel width.\n5. Step 5 — a line of explanation that wraps at panel width.\n6. Step 6 — a line of explanation that wraps at panel width.\n7. Step 7 — a line of explanation that wraps at panel width.\n8. Step 8 — a line of explanation that wraps at panel width.\n9. Step 9 — a line of explanation that wraps at panel width.\n10. Step 10 — a line of explanation that wraps at panel width.\n11. Step 11 — a line of explanation that wraps at panel width.\n12. Step 12 — a line of explanation that wraps at panel width.\n13. Step 13 — a line of explanation that wraps at panel width.\n14. Step 14 — a line of explanation that wraps at panel width.\n15. Step 15 — a line of explanation that wraps at panel width.\n16. Step 16 — a line of explanation that wraps at panel width.\n17. Step 17 — a line of explanation that wraps at panel width.\n18. Step 18 — a line of explanation that wraps at panel width.\n19. Step 19 — a line of explanation that wraps at panel width.\n20. Step 20 — a line of explanation that wraps at panel width.\n21. Step 21 — a line of explanation that wraps at panel width.\n22. Step 22 — a line of explanation that wraps at panel width.\n23. Step 23 — a line of explanat",
           },
         ],
-        text: "1. Step 1 — a line of explanation that wraps at panel width.\n2. Step 2 — a line of explanation that wraps at panel width.\n3. Step 3 — a line of explanation that wraps at panel width.\n4. Step 4 — a line of explanation that wraps at panel width.\n5. Step 5 — a line of explanation that wraps at panel width.\n6. Step 6 — a line of explanation that wraps at panel width.\n7. Step 7 — a line of explanation that wraps at panel width.\n8. Step 8 — a line of explanation that wraps at panel width.\n9. Step 9 — a line of explanation that wraps at panel width.\n10. Step 10 — a line of explanation that wraps at panel width.\n11. Step 11 — a line of explanation that wraps at panel width.\n12. Step 12 — a line of explanation that wraps at panel width.\n13. Step 13 — a line of explanation that wraps at panel width.\n14. Step 14 — a line of explanation that wraps at panel width.\n15. Step 15 — a line of explanation that wraps at panel width.\n16. Step 16 — a line of explanation that wraps at panel width.\n17. Step 17 — a line of explanation that wraps at panel width.\n18. Step 18 — a line of explanation that wraps at panel width.\n19. Step 19 — a line of explanation that wraps at panel width.\n20. Step 20 — a line of explanation that wraps at panel width.\n21. Step 21 — a line of explanation that wraps at panel width.\n22. Step 22 — a line of explanation that wraps at panel width.\n23. Step 23 — a line of explanation that wraps at panel width.\n24. Step 24 — a line of explanation that wraps at",
+        text: "1. Step 1 — a line of explanation that wraps at panel width.\n2. Step 2 — a line of explanation that wraps at panel width.\n3. Step 3 — a line of explanation that wraps at panel width.\n4. Step 4 — a line of explanation that wraps at panel width.\n5. Step 5 — a line of explanation that wraps at panel width.\n6. Step 6 — a line of explanation that wraps at panel width.\n7. Step 7 — a line of explanation that wraps at panel width.\n8. Step 8 — a line of explanation that wraps at panel width.\n9. Step 9 — a line of explanation that wraps at panel width.\n10. Step 10 — a line of explanation that wraps at panel width.\n11. Step 11 — a line of explanation that wraps at panel width.\n12. Step 12 — a line of explanation that wraps at panel width.\n13. Step 13 — a line of explanation that wraps at panel width.\n14. Step 14 — a line of explanation that wraps at panel width.\n15. Step 15 — a line of explanation that wraps at panel width.\n16. Step 16 — a line of explanation that wraps at panel width.\n17. Step 17 — a line of explanation that wraps at panel width.\n18. Step 18 — a line of explanation that wraps at panel width.\n19. Step 19 — a line of explanation that wraps at panel width.\n20. Step 20 — a line of explanation that wraps at panel width.\n21. Step 21 — a line of explanation that wraps at panel width.\n22. Step 22 — a line of explanation that wraps at panel width.\n23. Step 23 — a line of explanat",
         toolCallIds: [],
         interjections: [],
         complete: false,
@@ -266,12 +268,13 @@ export const CAPTURED_STATES = {
     pendingQuestion: null,
     awaitingLocalCommand: false,
     stoppedReason: "exit",
+    resumed: false,
     error: null,
     turns: [
       {
-        turnId: "local_18dca55b-ef38-453a-9317-989cbd33728d",
+        turnId: "local_65adb792-0762-48fc-a4cf-de6172b6271f",
         role: "user",
-        startedAt: 1788070816470,
+        startedAt: 1789096799412,
         segments: [
           {
             kind: "text",
@@ -286,7 +289,7 @@ export const CAPTURED_STATES = {
       {
         turnId: "turn_1",
         role: "assistant",
-        startedAt: 1788070816470,
+        startedAt: 1789096799412,
         segments: [
           {
             kind: "tools",
@@ -301,7 +304,7 @@ export const CAPTURED_STATES = {
         toolCallIds: ["c1", "c2"],
         interjections: [],
         complete: true,
-        endedAt: 1788070816481,
+        endedAt: 1789096799425,
         outcome: "answered",
       },
     ],
@@ -313,7 +316,7 @@ export const CAPTURED_STATES = {
         danger: false,
         verb: "Listed worktrees",
         state: "done",
-        startedAt: 1788070816472,
+        startedAt: 1789096799414,
         progress: "reading",
         durationMs: 240,
         severity: "info",
@@ -326,7 +329,7 @@ export const CAPTURED_STATES = {
         verb: "Read git state",
         target: "wt_forge",
         state: "done",
-        startedAt: 1788070816473,
+        startedAt: 1789096799415,
         progress: "reading",
         durationMs: 240,
         severity: "info",
@@ -415,18 +418,19 @@ export const CAPTURED_STATES = {
     toolGrants: {},
     queuedInterjections: [],
     retractedDraft: null,
-    lastActivityAt: 1788070816533,
-    turnStartedAt: 1788070816533,
+    lastActivityAt: 1789096799475,
+    turnStartedAt: 1789096799475,
     phaseIsWake: false,
     pendingQuestion: null,
     awaitingLocalCommand: false,
     stoppedReason: "exit",
+    resumed: false,
     error: null,
     turns: [
       {
-        turnId: "local_de2f2174-2da6-45ae-b426-fdb7573e04d5",
+        turnId: "local_e96ce482-7d3e-4fcb-bc92-d4029fef5279",
         role: "user",
-        startedAt: 1788070816533,
+        startedAt: 1789096799474,
         segments: [
           {
             kind: "text",
@@ -441,7 +445,7 @@ export const CAPTURED_STATES = {
       {
         turnId: "turn_1",
         role: "assistant",
-        startedAt: 1788070816533,
+        startedAt: 1789096799475,
         segments: [
           {
             kind: "tools",
@@ -474,7 +478,7 @@ export const CAPTURED_STATES = {
         needsTypedConfirm: true,
         rememberable: false,
         grantKey: "git.push",
-        requestedAt: 1788070816533,
+        requestedAt: 1789096799475,
       },
     ],
     notices: [],
@@ -547,18 +551,19 @@ export const CAPTURED_STATES = {
     toolGrants: {},
     queuedInterjections: [],
     retractedDraft: null,
-    lastActivityAt: 1788070816594,
-    turnStartedAt: 1788070816594,
+    lastActivityAt: 1789096799540,
+    turnStartedAt: 1789096799540,
     phaseIsWake: false,
     pendingQuestion: null,
     awaitingLocalCommand: false,
     stoppedReason: "exit",
+    resumed: false,
     error: null,
     turns: [
       {
-        turnId: "local_53a2035a-fea2-439a-b581-a77f9e3059b6",
+        turnId: "local_5c28b9b8-b7b0-45c1-82ba-75c3ac10ed54",
         role: "user",
-        startedAt: 1788070816594,
+        startedAt: 1789096799540,
         segments: [
           {
             kind: "text",
@@ -573,7 +578,7 @@ export const CAPTURED_STATES = {
       {
         turnId: "turn_1",
         role: "assistant",
-        startedAt: 1788070816594,
+        startedAt: 1789096799540,
         segments: [],
         text: "",
         toolCallIds: [],
@@ -592,7 +597,7 @@ export const CAPTURED_STATES = {
         needsTypedConfirm: false,
         rememberable: true,
         grantKey: "terminal.sendCommand",
-        requestedAt: 1788070816594,
+        requestedAt: 1789096799540,
       },
     ],
     notices: [],
@@ -665,8 +670,8 @@ export const CAPTURED_STATES = {
     toolGrants: {},
     queuedInterjections: [],
     retractedDraft: null,
-    lastActivityAt: 1788070816654,
-    turnStartedAt: 1788070816654,
+    lastActivityAt: 1789096799600,
+    turnStartedAt: 1789096799600,
     phaseIsWake: false,
     pendingQuestion: {
       questionId: "qst_1",
@@ -688,16 +693,17 @@ export const CAPTURED_STATES = {
         },
       ],
       defaultIndex: 0,
-      requestedAt: 1788070816654,
+      requestedAt: 1789096799600,
     },
     awaitingLocalCommand: false,
     stoppedReason: "exit",
+    resumed: false,
     error: null,
     turns: [
       {
-        turnId: "local_c3dee15f-bb70-448c-a794-b7af1a183ae6",
+        turnId: "local_36149c41-948a-425f-bb25-e0c56763c559",
         role: "user",
-        startedAt: 1788070816654,
+        startedAt: 1789096799599,
         segments: [
           {
             kind: "text",
@@ -712,7 +718,7 @@ export const CAPTURED_STATES = {
       {
         turnId: "turn_1",
         role: "assistant",
-        startedAt: 1788070816654,
+        startedAt: 1789096799599,
         segments: [],
         text: "",
         toolCallIds: [],
@@ -792,8 +798,8 @@ export const CAPTURED_STATES = {
     toolGrants: {},
     queuedInterjections: [],
     retractedDraft: null,
-    lastActivityAt: 1788070816715,
-    turnStartedAt: 1788070816715,
+    lastActivityAt: 1789096799661,
+    turnStartedAt: 1789096799661,
     phaseIsWake: false,
     pendingQuestion: {
       questionId: "qst_1",
@@ -835,16 +841,17 @@ export const CAPTURED_STATES = {
         },
       ],
       defaultIndex: 2,
-      requestedAt: 1788070816715,
+      requestedAt: 1789096799661,
     },
     awaitingLocalCommand: false,
     stoppedReason: "exit",
+    resumed: false,
     error: null,
     turns: [
       {
-        turnId: "local_6e118ffa-c4ee-4e9b-97e3-31eaef8a809c",
+        turnId: "local_e2e89431-5e42-46d1-befc-fd4728e99d10",
         role: "user",
-        startedAt: 1788070816714,
+        startedAt: 1789096799661,
         segments: [
           {
             kind: "text",
@@ -859,7 +866,7 @@ export const CAPTURED_STATES = {
       {
         turnId: "turn_1",
         role: "assistant",
-        startedAt: 1788070816715,
+        startedAt: 1789096799661,
         segments: [],
         text: "",
         toolCallIds: [],
@@ -945,12 +952,13 @@ export const CAPTURED_STATES = {
     pendingQuestion: null,
     awaitingLocalCommand: false,
     stoppedReason: "exit",
+    resumed: false,
     error: null,
     turns: [
       {
-        turnId: "local_74f6b463-c2fe-4e54-bd40-c3230bd140a4",
+        turnId: "local_7c908258-f2db-411b-b72b-37d0226e6e47",
         role: "user",
-        startedAt: 1788070816775,
+        startedAt: 1789096799725,
         segments: [
           {
             kind: "text",
@@ -965,7 +973,7 @@ export const CAPTURED_STATES = {
       {
         turnId: "turn_1",
         role: "assistant",
-        startedAt: 1788070816776,
+        startedAt: 1789096799725,
         segments: [
           {
             kind: "tools",
@@ -980,7 +988,7 @@ export const CAPTURED_STATES = {
         toolCallIds: ["c1"],
         interjections: [],
         complete: true,
-        endedAt: 1788070816784,
+        endedAt: 1789096799735,
         outcome: "answered",
       },
     ],
@@ -1078,12 +1086,13 @@ export const CAPTURED_STATES = {
     pendingQuestion: null,
     awaitingLocalCommand: false,
     stoppedReason: "exit",
+    resumed: false,
     error: null,
     turns: [
       {
-        turnId: "local_c7dba4c1-7dc8-411a-b6a1-a3d7dadd986c",
+        turnId: "local_08a158a3-9b41-4253-89d4-5ee28749f1e3",
         role: "user",
-        startedAt: 1788070816836,
+        startedAt: 1789096799784,
         segments: [
           {
             kind: "text",
@@ -1098,7 +1107,7 @@ export const CAPTURED_STATES = {
       {
         turnId: "turn_1",
         role: "assistant",
-        startedAt: 1788070816836,
+        startedAt: 1789096799784,
         segments: [
           {
             kind: "tools",
@@ -1113,7 +1122,7 @@ export const CAPTURED_STATES = {
         toolCallIds: ["c1"],
         interjections: [],
         complete: true,
-        endedAt: 1788070816845,
+        endedAt: 1789096799792,
         outcome: "hedged",
       },
     ],
@@ -1136,7 +1145,7 @@ export const CAPTURED_STATES = {
         id: "n1",
         level: "warning",
         message: "MCP connection degraded — orchestration tools are offline.",
-        at: 1788070816837,
+        at: 1789096799784,
         turnId: "turn_1",
         afterTurnId: "turn_1",
       },
@@ -1219,12 +1228,13 @@ export const CAPTURED_STATES = {
     pendingQuestion: null,
     awaitingLocalCommand: false,
     stoppedReason: "exit",
+    resumed: false,
     error: null,
     turns: [
       {
-        turnId: "local_4db710d9-fd77-4830-8192-60cd427f3299",
+        turnId: "local_7179a212-c497-4ce7-882f-9e18951be1b6",
         role: "user",
-        startedAt: 1788070816897,
+        startedAt: 1789096799844,
         segments: [
           {
             kind: "text",
@@ -1239,7 +1249,7 @@ export const CAPTURED_STATES = {
       {
         turnId: "turn_1",
         role: "assistant",
-        startedAt: 1788070816897,
+        startedAt: 1789096799844,
         segments: [
           {
             kind: "text",
@@ -1250,7 +1260,7 @@ export const CAPTURED_STATES = {
         toolCallIds: [],
         interjections: [],
         complete: true,
-        endedAt: 1788070816897,
+        endedAt: 1789096799844,
         outcome: "answered",
       },
     ],
@@ -1261,7 +1271,7 @@ export const CAPTURED_STATES = {
         id: "n2",
         level: "warning",
         message: "1 update were lost in transit. This part of the conversation may be incomplete.",
-        at: 1788070816897,
+        at: 1789096799844,
         turnId: null,
         afterTurnId: "turn_1",
       },
@@ -1341,12 +1351,13 @@ export const CAPTURED_STATES = {
     pendingQuestion: null,
     awaitingLocalCommand: false,
     stoppedReason: "exit",
+    resumed: false,
     error: null,
     turns: [
       {
-        turnId: "local_33b7b38e-9488-41f6-b5e2-46f66bc25316",
+        turnId: "local_9c85f259-0d78-4cdb-94fb-6556f634ae14",
         role: "user",
-        startedAt: 1788070816958,
+        startedAt: 1789096799904,
         segments: [
           {
             kind: "text",
@@ -1361,13 +1372,13 @@ export const CAPTURED_STATES = {
       {
         turnId: "turn_1",
         role: "assistant",
-        startedAt: 1788070816958,
+        startedAt: 1789096799904,
         segments: [],
         text: "",
         toolCallIds: [],
         interjections: [],
         complete: true,
-        endedAt: 1788070816959,
+        endedAt: 1789096799905,
         outcome: "unknown",
       },
     ],
@@ -1378,7 +1389,7 @@ export const CAPTURED_STATES = {
         id: "n3",
         level: "error",
         message: "The model provider is unavailable. Try again shortly.",
-        at: 1788070816959,
+        at: 1789096799906,
         turnId: null,
         code: "upstream_unavailable",
         afterTurnId: "turn_1",

--- a/src/components/AssistantPanel/__preview__/proseSpecimen.ts
+++ b/src/components/AssistantPanel/__preview__/proseSpecimen.ts
@@ -105,6 +105,7 @@ export const PROSE_SPECIMEN: AssistantSessionState = {
   pendingQuestion: null,
   awaitingLocalCommand: false,
   stoppedReason: null,
+  resumed: false,
   error: null,
   turns: [
     {

--- a/src/components/AssistantPanel/__tests__/useAssistantSession.lifecycle.test.tsx
+++ b/src/components/AssistantPanel/__tests__/useAssistantSession.lifecycle.test.tsx
@@ -427,4 +427,24 @@ describe("useAssistantSession — which conversation a start continues (#12365)"
     expect(state.resumed).toBe(false);
     expect(state.notices).toEqual([]);
   });
+
+  it("does not read a lane's nonce going back to zero as a restart", async () => {
+    // Closing a lane drops its nonce while the slot's panel can stay mounted. That reset,
+    // carried into whichever workspace the slot next starts in, must not throw away THAT
+    // workspace's conversation.
+    const { rerender } = renderHook((props: Props) => useAssistantSession(props), {
+      initialProps: { ...OPTS, restartNonce: 2 },
+    });
+    await waitFor(() => expect(start).toHaveBeenCalledTimes(1));
+
+    rerender({ ...OPTS, enabled: false, restartNonce: 0 });
+    rerender({ ...OPTS, projectId: "proj-2", cwd: "/other", restartNonce: 0 });
+    await waitFor(() => expect(start).toHaveBeenCalledTimes(2));
+    expect(start.mock.calls[1]![0]).not.toHaveProperty("fresh");
+
+    // A genuine restart after it still starts fresh.
+    rerender({ ...OPTS, projectId: "proj-2", cwd: "/other", restartNonce: 1 });
+    await waitFor(() => expect(start).toHaveBeenCalledTimes(3));
+    expect(start.mock.calls[2]![0]).toMatchObject({ fresh: true });
+  });
 });

--- a/src/components/AssistantPanel/__tests__/useAssistantSession.lifecycle.test.tsx
+++ b/src/components/AssistantPanel/__tests__/useAssistantSession.lifecycle.test.tsx
@@ -33,7 +33,7 @@ let releaseStart: (result: {
   sessionId: string;
   /** The surface's attachment, which is what a detach names — see `AssistantHostService`. */
   attachmentId: string;
-  ready: null;
+  ready: Record<string, unknown> | null;
   replay?: Record<string, unknown>[];
 }) => void;
 
@@ -343,5 +343,88 @@ describe("useAssistantSession — a mid-turn message main refuses", () => {
     expect(send).toHaveBeenLastCalledWith(
       expect.objectContaining({ type: "question:answer", questionId: "q1", choiceIndex: 1 })
     );
+  });
+});
+
+describe("useAssistantSession — which conversation a start continues (#12365)", () => {
+  type Props = typeof OPTS & { restartNonce?: number };
+
+  it("declines the lane's conversation only when the restart nonce moves", async () => {
+    const { rerender } = renderHook((props: Props) => useAssistantSession(props), {
+      initialProps: { ...OPTS, restartNonce: 3 },
+    });
+    await waitFor(() => expect(start).toHaveBeenCalledTimes(1));
+    // Mounting under a nonce that moved long ago is not a restart: a lane remounted after
+    // its view came back continues its conversation.
+    expect(start.mock.calls[0]![0]).not.toHaveProperty("fresh");
+
+    rerender({ ...OPTS, restartNonce: 4 });
+    await waitFor(() => expect(start).toHaveBeenCalledTimes(2));
+    expect(start.mock.calls[1]![0]).toMatchObject({ fresh: true });
+
+    // Anything else re-running the start — here the project folder moving — picks the
+    // conversation back up.
+    rerender({ ...OPTS, cwd: "/moved", restartNonce: 4 });
+    await waitFor(() => expect(start).toHaveBeenCalledTimes(3));
+    expect(start.mock.calls[2]![0]).not.toHaveProperty("fresh");
+  });
+
+  it("still starts fresh after a restart asked for while the lane was not running", async () => {
+    const { rerender } = renderHook((props: Props) => useAssistantSession(props), {
+      initialProps: { ...OPTS, enabled: false, restartNonce: 0 },
+    });
+    rerender({ ...OPTS, enabled: false, restartNonce: 1 });
+    expect(start).not.toHaveBeenCalled();
+
+    rerender({ ...OPTS, enabled: true, restartNonce: 1 });
+    await waitFor(() => expect(start).toHaveBeenCalledTimes(1));
+    expect(start.mock.calls[0]![0]).toMatchObject({ fresh: true });
+  });
+
+  it("says so when the engine continued a conversation the panel cannot show", async () => {
+    renderHook(() => useAssistantSession(OPTS));
+    await waitFor(() => expect(start).toHaveBeenCalledTimes(1));
+    await act(async () => {
+      releaseStart({
+        sessionId: "ses_new",
+        attachmentId: "att_test",
+        ready: {
+          type: "host:ready",
+          sessionId: "ses_new",
+          seq: 1,
+          protocolVersion: 4,
+          autoApprove: false,
+          resumedSessionId: "ses_old",
+        },
+      });
+    });
+
+    const state = useAssistantStore.getState();
+    // Counted as a conversation, so Stop and "+ New session" ask before discarding it…
+    expect(state.resumed).toBe(true);
+    // …and named on screen, because nothing else on screen shows it exists.
+    expect(state.notices.map((notice) => notice.level)).toEqual(["info"]);
+  });
+
+  it("says nothing of the kind about a conversation that is new", async () => {
+    renderHook(() => useAssistantSession(OPTS));
+    await waitFor(() => expect(start).toHaveBeenCalledTimes(1));
+    await act(async () => {
+      releaseStart({
+        sessionId: "ses_new",
+        attachmentId: "att_test",
+        ready: {
+          type: "host:ready",
+          sessionId: "ses_new",
+          seq: 1,
+          protocolVersion: 4,
+          autoApprove: false,
+        },
+      });
+    });
+
+    const state = useAssistantStore.getState();
+    expect(state.resumed).toBe(false);
+    expect(state.notices).toEqual([]);
   });
 });

--- a/src/components/AssistantPanel/useAssistantSession.ts
+++ b/src/components/AssistantPanel/useAssistantSession.ts
@@ -352,11 +352,14 @@ export function useAssistantSession(opts: AssistantSessionOptions): AssistantSes
       return;
     }
 
-    // A newer nonce is "+ New session", the one start that must not continue the lane's
+    // A RISING nonce is "+ New session", the one start that must not continue the lane's
     // recorded conversation. Anything else re-running this effect — a remount, a moved
-    // folder, the lane armed again — picks it back up (#12365). Consumed only here, so a
-    // bump made while the lane was disabled still starts fresh when it next runs.
-    const fresh = restartNonce !== startedNonceRef.current;
+    // folder, the lane armed again — picks it back up (#12365). Rising, not merely
+    // different: closing a lane resets its nonce to zero while this hook can stay mounted
+    // for the slot, and reading that reset as a restart would wipe the conversation of
+    // whichever workspace the slot next starts in. Consumed only here, so a bump made
+    // while the lane was disabled still starts fresh when it next runs.
+    const fresh = restartNonce > startedNonceRef.current;
     startedNonceRef.current = restartNonce;
 
     const state = store.getState();

--- a/src/components/AssistantPanel/useAssistantSession.ts
+++ b/src/components/AssistantPanel/useAssistantSession.ts
@@ -148,6 +148,11 @@ export function useAssistantSession(opts: AssistantSessionOptions): AssistantSes
    * is still using, or the one this panel has just re-attached to.
    */
   const attachmentIdRef = useRef<string | null>(null);
+  /**
+   * The restart nonce the last start ran under. A start under a newer one is "+ New
+   * session" — the only start that declines the lane's recorded conversation.
+   */
+  const startedNonceRef = useRef(opts.restartNonce ?? 0);
   /** Non-null while a start is in flight, so stray frames can be told apart from noise. */
   const pendingSessionRef = useRef<number | null>(null);
   /** Frames that arrived before this hook learned its session id. */
@@ -347,6 +352,13 @@ export function useAssistantSession(opts: AssistantSessionOptions): AssistantSes
       return;
     }
 
+    // A newer nonce is "+ New session", the one start that must not continue the lane's
+    // recorded conversation. Anything else re-running this effect — a remount, a moved
+    // folder, the lane armed again — picks it back up (#12365). Consumed only here, so a
+    // bump made while the lane was disabled still starts fresh when it next runs.
+    const fresh = restartNonce !== startedNonceRef.current;
+    startedNonceRef.current = restartNonce;
+
     const state = store.getState();
     state.reset(null);
     state.setConnection("starting", null);
@@ -355,7 +367,7 @@ export function useAssistantSession(opts: AssistantSessionOptions): AssistantSes
 
     safeFireAndForget(
       window.electron.assistantHost
-        .start({ projectId, cwd, slot })
+        .start({ projectId, cwd, slot, ...(fresh ? { fresh: true } : {}) })
         .then((started) => {
           const {
             sessionId,
@@ -427,11 +439,23 @@ export function useAssistantSession(opts: AssistantSessionOptions): AssistantSes
           }
           preAdoptionRef.current = new Map();
           pendingSessionRef.current = null;
-          // This panel joined a conversation already running elsewhere, and main's
-          // replay buffer no longer reaches its beginning. Say so: a transcript that
-          // silently starts in the middle reads as a conversation that began there, and
-          // the user would go looking for messages that are not missing at all.
-          if (replayTruncated) {
+          if (ready?.resumedSessionId) {
+            // The engine continued a conversation this panel never saw (#12365): the view
+            // that showed it was lost, and the transcript with it, while the conversation
+            // lived on in the engine's own database. It is in the assistant's context and
+            // nowhere on screen — say so, rather than show an empty panel the assistant
+            // then talks about as though it were not.
+            store
+              .getState()
+              .pushNotice(
+                "info",
+                "Picked up your previous conversation. Earlier messages aren't shown here."
+              );
+          } else if (replayTruncated) {
+            // This panel joined a conversation already running elsewhere, and main's
+            // replay buffer no longer reaches its beginning. Say so: a transcript that
+            // silently starts in the middle reads as a conversation that began there, and
+            // the user would go looking for messages that are not missing at all.
             store
               .getState()
               .pushNotice(

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -59,6 +59,7 @@ import { terminalClient } from "@/clients";
 import { logWarn } from "@/utils/logger";
 import { safeFireAndForget } from "@/utils/safeFireAndForget";
 import { DAINTREE_ASSISTANT_AGENT_ID } from "@shared/config/agentRegistry";
+import type { AssistantHostResumableLane } from "@shared/types/ipc/assistantHostIpc";
 import { assistantPlatformSupport } from "@shared/config/assistantPlatform";
 import { InlineStatusBanner } from "@/components/Terminal/InlineStatusBanner";
 import { isBuiltInAgentId } from "@shared/config/agentIds";
@@ -355,23 +356,32 @@ export function HelpPanel({
   const [nativeSessionNonceBySlot, setNativeSessionNonceBySlot] = useState<Record<number, number>>(
     {}
   );
-  // Lanes main holds a conversation for, restored by this view and not yet shown, by the
-  // workspace they belong to (#12365). Until such a lane starts its store is empty — no
-  // turns, nothing resumed — so without this a restored conversation could be stopped or
-  // closed on one silent click.
-  const [savedNativeLaneBySlot, setSavedNativeLaneBySlot] = useState<Record<number, string>>({});
+  // The native lanes main holds a conversation for, as it last answered for a workspace
+  // (#12365). Read each time a workspace becomes active, not only on a cold view: it is what
+  // says a lane has something to lose before its engine has started — its store is empty
+  // until then, and a same-renderer switch released it — so a stale answer would let Stop
+  // or a close forget a conversation on one silent click.
+  const [resumableLanes, setResumableLanes] = useState<{
+    workspaceId: string;
+    lanes: AssistantHostResumableLane[];
+  } | null>(null);
+  // Counts only until the lane adopts a session. From then its own store — turns, a resumed
+  // conversation, live state — is the answer, and main may have replaced the conversation
+  // since it was listed.
   const laneHasSavedConversation = useCallback(
     (slot: number) =>
-      activeWorkspaceId !== null && savedNativeLaneBySlot[slot] === activeWorkspaceId,
-    [activeWorkspaceId, savedNativeLaneBySlot]
+      resumableLanes !== null &&
+      resumableLanes.workspaceId === activeWorkspaceId &&
+      resumableLanes.lanes.some((lane) => lane.slot === slot) &&
+      assistantStoreForSlot(slot).getState().sessionId === null,
+    [resumableLanes, activeWorkspaceId]
   );
   const forgetSavedNativeLane = useCallback((slot: number) => {
-    setSavedNativeLaneBySlot((prev) => {
-      if (!(slot in prev)) return prev;
-      const next = { ...prev };
-      delete next[slot];
-      return next;
-    });
+    setResumableLanes((prev) =>
+      prev?.lanes.some((lane) => lane.slot === slot)
+        ? { ...prev, lanes: prev.lanes.filter((lane) => lane.slot !== slot) }
+        : prev
+    );
   }, []);
   /**
    * The Daintree Assistant renders NATIVELY; every other help agent keeps the xterm pane.
@@ -1452,32 +1462,32 @@ export function HelpPanel({
   // lane, and main hands it its conversation. Lanes nobody selects start nothing.
   //
   // The native half of the restore above, under the same conditions: once per workspace,
-  // and only while the view is genuinely cold, so it never fights the user's own tabs.
-  const restoredNativeWorkspaceRef = useRef<string | null>(null);
+  // and only while the view is genuinely cold, so it never fights the user's own tabs. It
+  // reads the listing below rather than asking again.
+  const restoredNativeWorkspacesRef = useRef<Set<string>>(new Set());
   useEffect(() => {
-    if (!activeWorkspaceId || restoredNativeWorkspaceRef.current === activeWorkspaceId) return;
-    if (!useNativeAssistant) return;
+    if (!activeWorkspaceId || resumableLanes?.workspaceId !== activeWorkspaceId) return;
+    if (restoredNativeWorkspacesRef.current.has(activeWorkspaceId)) return;
+    restoredNativeWorkspacesRef.current.add(activeWorkspaceId);
     if (openSlots.length > 1 || terminalId) return;
+    const store = useHelpPanelStore.getState();
+    for (const { slot } of resumableLanes.lanes) store.ensureSlot(slot);
+    const reopen = resumableLanes.lanes.find((lane) => lane.panelWasOpen);
+    if (!reopen || store.isOpen) return;
+    store.setActiveSlot(reopen.slot);
+    setOpen(true);
+  }, [resumableLanes, activeWorkspaceId, openSlots.length, terminalId, setOpen]);
+
+  // Ask main which of this workspace's native lanes hold a conversation, each time the
+  // workspace becomes active (#12365). See `resumableLanes`.
+  useEffect(() => {
+    if (!activeWorkspaceId || !useNativeAssistant) return;
     const listing = window.electron.assistantHost.listResumable?.(activeWorkspaceId);
     if (!listing) return;
     let cancelled = false;
     void listing
       .then((lanes) => {
-        if (cancelled || restoredNativeWorkspaceRef.current === activeWorkspaceId) return;
-        restoredNativeWorkspaceRef.current = activeWorkspaceId;
-        const store = useHelpPanelStore.getState();
-        for (const { slot } of lanes) store.ensureSlot(slot);
-        if (lanes.length > 0) {
-          setSavedNativeLaneBySlot((prev) => {
-            const next = { ...prev };
-            for (const { slot } of lanes) next[slot] = activeWorkspaceId;
-            return next;
-          });
-        }
-        const reopen = lanes.find((lane) => lane.panelWasOpen);
-        if (!reopen || store.isOpen) return;
-        store.setActiveSlot(reopen.slot);
-        setOpen(true);
+        if (!cancelled) setResumableLanes({ workspaceId: activeWorkspaceId, lanes });
       })
       .catch((err) => {
         logWarn("HelpPanel: failed to list resumable native lanes", err);
@@ -1485,7 +1495,7 @@ export function HelpPanel({
     return () => {
       cancelled = true;
     };
-  }, [activeWorkspaceId, openSlots.length, terminalId, useNativeAssistant, setOpen]);
+  }, [activeWorkspaceId, useNativeAssistant]);
 
   const handleOpenParallelSession = useCallback(() => {
     const slot = useHelpPanelStore.getState().openSlot();

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -355,6 +355,24 @@ export function HelpPanel({
   const [nativeSessionNonceBySlot, setNativeSessionNonceBySlot] = useState<Record<number, number>>(
     {}
   );
+  // Lanes main holds a conversation for, restored by this view and not yet shown, by the
+  // workspace they belong to (#12365). Until such a lane starts its store is empty — no
+  // turns, nothing resumed — so without this a restored conversation could be stopped or
+  // closed on one silent click.
+  const [savedNativeLaneBySlot, setSavedNativeLaneBySlot] = useState<Record<number, string>>({});
+  const laneHasSavedConversation = useCallback(
+    (slot: number) =>
+      activeWorkspaceId !== null && savedNativeLaneBySlot[slot] === activeWorkspaceId,
+    [activeWorkspaceId, savedNativeLaneBySlot]
+  );
+  const forgetSavedNativeLane = useCallback((slot: number) => {
+    setSavedNativeLaneBySlot((prev) => {
+      if (!(slot in prev)) return prev;
+      const next = { ...prev };
+      delete next[slot];
+      return next;
+    });
+  }, []);
   /**
    * The Daintree Assistant renders NATIVELY; every other help agent keeps the xterm pane.
    *
@@ -459,6 +477,12 @@ export function HelpPanel({
     // would wipe a conversation restored into slot 0 before this component mounted.
     if (previous === null) return;
     for (const slot of ASSISTANT_SLOTS) releaseAssistantStore(slot);
+    // A confirmation names the conversation it was asked about. Confirmed after a switch,
+    // the same button would act on the new workspace's lane instead — for a native lane,
+    // forgetting a conversation nobody was asked about (#12365).
+    setPendingCloseSlot(null);
+    setShowEndSessionConfirm(false);
+    setShowNewSessionConfirm(false);
   }, [activeWorkspaceId]);
 
   // Moving the agent preference to a terminal agent converts the lane the user is
@@ -1443,6 +1467,13 @@ export function HelpPanel({
         restoredNativeWorkspaceRef.current = activeWorkspaceId;
         const store = useHelpPanelStore.getState();
         for (const { slot } of lanes) store.ensureSlot(slot);
+        if (lanes.length > 0) {
+          setSavedNativeLaneBySlot((prev) => {
+            const next = { ...prev };
+            for (const { slot } of lanes) next[slot] = activeWorkspaceId;
+            return next;
+          });
+        }
         const reopen = lanes.find((lane) => lane.panelWasOpen);
         if (!reopen || store.isOpen) return;
         store.setActiveSlot(reopen.slot);
@@ -1494,10 +1525,11 @@ export function HelpPanel({
   const discardNativeConversation = useCallback(
     (slot: number) => {
       if (!activeWorkspaceId) return;
+      forgetSavedNativeLane(slot);
       const discarded = window.electron.assistantHost.discardResume?.(activeWorkspaceId, slot);
       if (discarded) safeFireAndForget(discarded, { context: "HelpPanel.discardResume" });
     },
-    [activeWorkspaceId]
+    [activeWorkspaceId, forgetSavedNativeLane]
   );
 
   const closeSlotNow = useCallback(
@@ -1562,20 +1594,24 @@ export function HelpPanel({
   // Same "something to lose" gate the Stop control uses, but evaluated against
   // the lane BEING CLOSED rather than the one on screen — a background lane is
   // exactly where a working agent goes unnoticed.
-  const laneNeedsCloseConfirm = useCallback((slot: number) => {
-    const lane = useHelpPanelStore.getState().sessions[slot];
-    if (lane?.conversationTouched) return true;
-    if (lane?.terminalId) {
-      const panel = usePanelStore.getState().panelsById[lane.terminalId];
-      const agentState = panel && isPtyPanel(panel) ? panel.agentState : undefined;
-      if (agentState !== undefined && CLOSE_CONFIRM_AGENT_STATES.has(agentState)) return true;
-    }
-    // The native lane keeps its whole conversation in its own store, so "something to
-    // lose" is read from there. Asked of the lane rather than of the panel's current
-    // mode, so a background native session cannot be closed on one silent click just
-    // because the tab on screen is a terminal.
-    return nativeLaneHasSomethingToLose(slot);
-  }, []);
+  const laneNeedsCloseConfirm = useCallback(
+    (slot: number) => {
+      const lane = useHelpPanelStore.getState().sessions[slot];
+      if (lane?.conversationTouched) return true;
+      if (lane?.terminalId) {
+        const panel = usePanelStore.getState().panelsById[lane.terminalId];
+        const agentState = panel && isPtyPanel(panel) ? panel.agentState : undefined;
+        if (agentState !== undefined && CLOSE_CONFIRM_AGENT_STATES.has(agentState)) return true;
+      }
+      // The native lane keeps its whole conversation in its own store, so "something to
+      // lose" is read from there — or, for a lane restored but not started yet, from what
+      // main said it holds (#12365). Asked of the lane rather than of the panel's current
+      // mode, so a background native session cannot be closed on one silent click just
+      // because the tab on screen is a terminal.
+      return nativeLaneHasSomethingToLose(slot) || laneHasSavedConversation(slot);
+    },
+    [laneHasSavedConversation]
+  );
 
   const handleCloseSlot = useCallback(
     (slot: number) => {
@@ -1613,8 +1649,8 @@ export function HelpPanel({
    * identical PTY action asked first.
    */
   const nativeLaneHasConversation = useCallback(
-    () => nativeLaneHasSomethingToLose(activeSlot),
-    [activeSlot]
+    () => nativeLaneHasSomethingToLose(activeSlot) || laneHasSavedConversation(activeSlot),
+    [activeSlot, laneHasSavedConversation]
   );
 
   /** Restart the lane on screen. The deck is a reading of the session that just ended,
@@ -1622,11 +1658,13 @@ export function HelpPanel({
    *  over a fresh one. */
   const restartNativeLane = useCallback(() => {
     setOperationsOpen(false);
+    // The fresh start this triggers is what forgets the saved conversation, in main.
+    forgetSavedNativeLane(activeSlot);
     setNativeSessionNonceBySlot((prev) => ({
       ...prev,
       [activeSlot]: (prev[activeSlot] ?? 0) + 1,
     }));
-  }, [activeSlot]);
+  }, [activeSlot, forgetSavedNativeLane]);
 
   /** Stop the lane on screen. Disarms THIS LANE only: a parallel session the user did
    *  not stop keeps running, exactly as "Stop" reads. Disarming ends the engine through

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -33,10 +33,12 @@ import {
 /**
  * Whether a native lane holds something a restart, a stop or a close would destroy.
  *
- * Two readings, because a lane can be worth protecting before anybody has said
- * anything: `turns` is the conversation, and the lane state is the engine mid-flight —
- * a wake's first phase lands BEFORE its turn opens, so a transcript test alone would
- * wave through a Stop on a lane that is actively working.
+ * Three readings, because a lane can be worth protecting before anybody has said
+ * anything here: `turns` is the conversation, and the lane state is the engine
+ * mid-flight — a wake's first phase lands BEFORE its turn opens, so a transcript test
+ * alone would wave through a Stop on a lane that is actively working. `resumed` is a
+ * conversation the transcript cannot show: an engine that picked one back up after its
+ * view was lost (#12365) holds it in context behind an empty panel.
  *
  * The same test for all three controls on purpose. They discard the same thing, and
  * three answers to one question is how "+ New session" ended up asking while Stop did
@@ -44,7 +46,7 @@ import {
  */
 function nativeLaneHasSomethingToLose(slot: number): boolean {
   const state = assistantStoreForSlot(slot).getState();
-  return state.turns.length > 0 || selectAssistantLaneState(state) !== null;
+  return state.turns.length > 0 || state.resumed || selectAssistantLaneState(state) !== null;
 }
 import { MissingCliGate } from "@/components/Terminal/MissingCliGate";
 import {
@@ -1417,6 +1419,43 @@ export function HelpPanel({
     };
   }, [activeWorkspaceId, openSlots.length, terminalId, useNativeAssistant]);
 
+  // Bring back the native lanes whose engines went down with this view (#12365).
+  //
+  // Main records which conversation each lane was having and continues it on the lane's
+  // next start, but a cold view knows nothing of either: lanes 1+ have no tab, and the
+  // panel comes back closed. So put the tabs back, and when the panel was open as the view
+  // was lost, reopen it on the first lane that was — the arm effect above then starts that
+  // lane, and main hands it its conversation. Lanes nobody selects start nothing.
+  //
+  // The native half of the restore above, under the same conditions: once per workspace,
+  // and only while the view is genuinely cold, so it never fights the user's own tabs.
+  const restoredNativeWorkspaceRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!activeWorkspaceId || restoredNativeWorkspaceRef.current === activeWorkspaceId) return;
+    if (!useNativeAssistant) return;
+    if (openSlots.length > 1 || terminalId) return;
+    const listing = window.electron.assistantHost.listResumable?.(activeWorkspaceId);
+    if (!listing) return;
+    let cancelled = false;
+    void listing
+      .then((lanes) => {
+        if (cancelled || restoredNativeWorkspaceRef.current === activeWorkspaceId) return;
+        restoredNativeWorkspaceRef.current = activeWorkspaceId;
+        const store = useHelpPanelStore.getState();
+        for (const { slot } of lanes) store.ensureSlot(slot);
+        const reopen = lanes.find((lane) => lane.panelWasOpen);
+        if (!reopen || store.isOpen) return;
+        store.setActiveSlot(reopen.slot);
+        setOpen(true);
+      })
+      .catch((err) => {
+        logWarn("HelpPanel: failed to list resumable native lanes", err);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [activeWorkspaceId, openSlots.length, terminalId, useNativeAssistant, setOpen]);
+
   const handleOpenParallelSession = useCallback(() => {
     const slot = useHelpPanelStore.getState().openSlot();
     if (slot === null) return;
@@ -1445,6 +1484,20 @@ export function HelpPanel({
       if (!laneUsesNativeAssistant(slot)) useHelpPanelStore.getState().requestFocus();
     },
     [laneUsesNativeAssistant]
+  );
+
+  /**
+   * Forgets a native lane's recorded conversation, so its next start is a new one
+   * (#12365). Stop and closing the lane mean that. A view merely going away does not, and
+   * never reaches here — which is what lets main bring that conversation back.
+   */
+  const discardNativeConversation = useCallback(
+    (slot: number) => {
+      if (!activeWorkspaceId) return;
+      const discarded = window.electron.assistantHost.discardResume?.(activeWorkspaceId, slot);
+      if (discarded) safeFireAndForget(discarded, { context: "HelpPanel.discardResume" });
+    },
+    [activeWorkspaceId]
   );
 
   const closeSlotNow = useCallback(
@@ -1476,9 +1529,11 @@ export function HelpPanel({
 
       // The native half, which has no PTY and no controller session to end. Disarming
       // is what stops its engine — through the same effect cleanup a project change
-      // uses — and releasing its store is what stops the next occupant of this slot
-      // number inheriting a conversation. Both are no-ops for a lane that never ran the
-      // native assistant, so this needs no mode test of its own.
+      // uses — and releasing its store and forgetting its recorded conversation are what
+      // stop the next occupant of this slot number inheriting one, from this renderer or
+      // from main (#12365). All three are no-ops for a lane that never ran the native
+      // assistant, so this needs no mode test of its own.
+      discardNativeConversation(slot);
       setArmedWorkspaceBySlot((prev) => {
         if (!(slot in prev)) return prev;
         const next = { ...prev };
@@ -1501,7 +1556,7 @@ export function HelpPanel({
       }
       state.closeSlot(slot);
     },
-    [setOpen]
+    [setOpen, discardNativeConversation]
   );
 
   // Same "something to lose" gate the Stop control uses, but evaluated against
@@ -1575,16 +1630,18 @@ export function HelpPanel({
 
   /** Stop the lane on screen. Disarms THIS LANE only: a parallel session the user did
    *  not stop keeps running, exactly as "Stop" reads. Disarming ends the engine through
-   *  the same effect cleanup a project change uses; re-selecting the tab arms it again. */
+   *  the same effect cleanup a project change uses; re-selecting the tab arms it again,
+   *  on a new conversation, because Stop also forgets this one (#12365). */
   const stopNativeLane = useCallback(() => {
     setOperationsOpen(false);
+    discardNativeConversation(activeSlot);
     setArmedWorkspaceBySlot((prev) => {
       if (!(activeSlot in prev)) return prev;
       const next = { ...prev };
       delete next[activeSlot];
       return next;
     });
-  }, [activeSlot]);
+  }, [activeSlot, discardNativeConversation]);
 
   const handleNewSession = useCallback(() => {
     if (useNativeAssistant) {

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.sessionResetStop.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.sessionResetStop.test.tsx
@@ -1720,4 +1720,47 @@ describe("HelpPanel — native lanes and the conversations main keeps for them (
     expect(queryByTestId("confirm-dialog")).toBe(null);
     expect(assistantHost().discardResume).not.toHaveBeenCalled();
   });
+
+  it("reads again which lanes hold a conversation each time the workspace comes back", async () => {
+    nativeMode();
+    Object.assign(helpPanelState, { ensureSlot: vi.fn() });
+    const listResumable = assistantHost().listResumable!;
+    const { container, rerender, getByTestId } = render(<HelpPanel width={380} />);
+    await act(async () => {});
+
+    // Away and back in the same renderer. The lane stores are released on the way out, so
+    // only main's answer, read again on return, says lane 0 has something to lose.
+    projectStoreState.currentProject = { id: "proj-2", path: "/other" };
+    await act(async () => {
+      rerender(<HelpPanel width={380} />);
+    });
+    listResumable.mockResolvedValue([{ slot: 0, panelWasOpen: false }]);
+    projectStoreState.currentProject = { id: "proj-1", path: "/repo" };
+    await act(async () => {
+      rerender(<HelpPanel width={380} />);
+    });
+
+    fireEvent.click(queryStopItem(container)!);
+    expect(listResumable).toHaveBeenLastCalledWith("proj-1");
+    expect(getByTestId("dialog-title").textContent).toBe("Stop assistant?");
+  });
+
+  it("stops counting a restored lane as saved once it has adopted a session", async () => {
+    nativeMode();
+    Object.assign(helpPanelState, { ensureSlot: vi.fn() });
+    assistantHost().listResumable!.mockResolvedValue([{ slot: 0, panelWasOpen: false }]);
+    const { container, queryByTestId } = render(<HelpPanel width={380} />);
+    await act(async () => {});
+
+    // It adopted a new, empty session: another window replaced the conversation meanwhile.
+    act(() => {
+      assistantStoreForSlot(0).getState().reset("ses_replacement");
+    });
+    act(() => {
+      fireEvent.click(queryStopItem(container)!);
+    });
+
+    expect(queryByTestId("confirm-dialog")).toBe(null);
+    expect(assistantHost().discardResume).toHaveBeenCalledWith("proj-1", 0);
+  });
 });

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.sessionResetStop.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.sessionResetStop.test.tsx
@@ -629,6 +629,8 @@ beforeEach(() => {
           start: vi.fn().mockResolvedValue({ sessionId: "assistant-test-session" }),
           send: vi.fn().mockResolvedValue({ delivered: true }),
           stop: vi.fn().mockResolvedValue({ stopped: true }),
+          listResumable: vi.fn().mockResolvedValue([]),
+          discardResume: vi.fn().mockResolvedValue({ discarded: true }),
           onEvent: vi.fn(() => () => {}),
           onPeerPrompt: () => () => {},
           onSequenceGap: vi.fn(() => () => {}),
@@ -1547,5 +1549,131 @@ describe("HelpPanel — the native assistant's destructive controls", () => {
     });
     expect(queryByTestId("confirm-dialog")).toBeNull();
     expect(nativePanelProps.at(-1)?.active).toBe(false);
+  });
+});
+
+/**
+ * A native lane whose engine went down with its view (#12365).
+ *
+ * Main keeps which conversation each lane was having and continues it on the lane's next
+ * start, so a cold view only has to put the lanes back where the user can reach them —
+ * and the panel back on screen when it was open as the view was lost. What it must NOT
+ * do is let an ordinary teardown forget that conversation, which is why only Stop and
+ * closing a lane ask main to.
+ */
+describe("HelpPanel — native lanes and the conversations main keeps for them (#12365)", () => {
+  type HostMock = Record<string, ReturnType<typeof vi.fn>>;
+
+  function nativeMode() {
+    projectStoreState.currentProject = { id: "proj-1", path: "/repo" };
+    helpPanelState.terminalId = null;
+    helpPanelState.agentId = null;
+    helpPanelState.preferredAgentId = null;
+  }
+
+  function assistantHost(): HostMock {
+    return (window as unknown as { electron: { assistantHost: HostMock } }).electron
+      .assistantHost;
+  }
+
+  function queryStopItem(container: HTMLElement): HTMLButtonElement | null {
+    return (
+      [
+        ...container.querySelectorAll<HTMLButtonElement>("[data-testid='overflow-menu'] button"),
+      ].find((b) => b.textContent?.includes("Stop assistant")) ?? null
+    );
+  }
+
+  afterEach(() => {
+    for (const slot of [0, 1, 2]) releaseAssistantStore(slot);
+    nativePanelProps.length = 0;
+  });
+
+  it("puts the lanes back and reopens the panel on one lost while it was open", async () => {
+    nativeMode();
+    helpPanelState.isOpen = false;
+    const ensureSlot = vi.fn();
+    Object.assign(helpPanelState, { ensureSlot });
+    assistantHost().listResumable!.mockResolvedValue([
+      { slot: 0, panelWasOpen: false },
+      { slot: 2, panelWasOpen: true },
+    ]);
+
+    await act(async () => {
+      render(<HelpPanel width={380} />);
+    });
+
+    expect(assistantHost().listResumable).toHaveBeenCalledWith("proj-1");
+    expect(ensureSlot.mock.calls).toEqual([[0], [2]]);
+    // Onto the conversation, not whichever lane a cold view happens to come up on.
+    expect(helpPanelState.setActiveSlot).toHaveBeenCalledWith(2);
+    expect(helpPanelState.setOpen).toHaveBeenCalledWith(true);
+  });
+
+  it("puts the lanes back but leaves a panel closed that was closed", async () => {
+    nativeMode();
+    helpPanelState.isOpen = false;
+    const ensureSlot = vi.fn();
+    Object.assign(helpPanelState, { ensureSlot });
+    assistantHost().listResumable!.mockResolvedValue([{ slot: 1, panelWasOpen: false }]);
+
+    await act(async () => {
+      render(<HelpPanel width={380} />);
+    });
+
+    expect(ensureSlot).toHaveBeenCalledWith(1);
+    expect(helpPanelState.setOpen).not.toHaveBeenCalledWith(true);
+    expect(helpPanelState.setActiveSlot).not.toHaveBeenCalled();
+  });
+
+  it("asks main for nothing while a terminal agent has the panel", async () => {
+    // The reset's preference: a terminal-backed agent, whose lanes restore through the
+    // PTY hibernation entries instead.
+    projectStoreState.currentProject = { id: "proj-1", path: "/repo" };
+    await act(async () => {
+      render(<HelpPanel width={380} />);
+    });
+    expect(assistantHost().listResumable).not.toHaveBeenCalled();
+  });
+
+  it("forgets the lane's conversation when it is stopped", () => {
+    nativeMode();
+    const { container } = render(<HelpPanel width={380} />);
+    act(() => {
+      fireEvent.click(queryStopItem(container)!);
+    });
+    expect(assistantHost().discardResume).toHaveBeenCalledWith("proj-1", 0);
+  });
+
+  it("forgets a closed lane's conversation, and no other lane's", () => {
+    nativeMode();
+    helpPanelState.openSlots = [0, 1];
+    const { container } = render(<HelpPanel width={380} />);
+    const close = container.querySelector<HTMLButtonElement>('button[title="Close Session 2"]');
+    expect(close).not.toBe(null);
+
+    act(() => {
+      fireEvent.click(close!);
+    });
+    expect(assistantHost().discardResume.mock.calls).toEqual([["proj-1", 1]]);
+  });
+
+  it("asks before Stop discards a conversation the lane picked back up but cannot show", () => {
+    nativeMode();
+    assistantStoreForSlot(0).getState().reset("ses_native");
+    assistantStoreForSlot(0).getState().applyEvent({
+      type: "host:ready",
+      sessionId: "ses_native",
+      seq: 1,
+      protocolVersion: 4,
+      autoApprove: false,
+      resumedSessionId: "ses_before",
+    });
+    const { container, getByTestId } = render(<HelpPanel width={380} />);
+
+    fireEvent.click(queryStopItem(container)!);
+    // An empty transcript, and a whole conversation in the assistant's context.
+    expect(getByTestId("dialog-title").textContent).toBe("Stop assistant?");
+    expect(assistantHost().discardResume).not.toHaveBeenCalled();
   });
 });

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.sessionResetStop.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.sessionResetStop.test.tsx
@@ -1572,8 +1572,7 @@ describe("HelpPanel — native lanes and the conversations main keeps for them (
   }
 
   function assistantHost(): HostMock {
-    return (window as unknown as { electron: { assistantHost: HostMock } }).electron
-      .assistantHost;
+    return (window as unknown as { electron: { assistantHost: HostMock } }).electron.assistantHost;
   }
 
   function queryStopItem(container: HTMLElement): HTMLButtonElement | null {

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.sessionResetStop.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.sessionResetStop.test.tsx
@@ -1676,4 +1676,48 @@ describe("HelpPanel — native lanes and the conversations main keeps for them (
     expect(getByTestId("dialog-title").textContent).toBe("Stop assistant?");
     expect(assistantHost().discardResume).not.toHaveBeenCalled();
   });
+
+  it("asks before closing a restored lane that has not started yet", async () => {
+    nativeMode();
+    const ensureSlot = vi.fn((slot: number) => {
+      if (!helpPanelState.openSlots.includes(slot)) {
+        helpPanelState.openSlots = [...helpPanelState.openSlots, slot];
+      }
+    });
+    Object.assign(helpPanelState, { ensureSlot });
+    assistantHost().listResumable!.mockResolvedValue([{ slot: 1, panelWasOpen: false }]);
+
+    const { container, rerender, getByTestId } = render(<HelpPanel width={380} />);
+    await act(async () => {});
+    act(() => {
+      rerender(<HelpPanel width={380} />);
+    });
+    const close = container.querySelector<HTMLButtonElement>('button[title="Close Session 2"]');
+    expect(close).not.toBe(null);
+
+    act(() => {
+      fireEvent.click(close!);
+    });
+    // Its store is empty until it starts, but main is holding a conversation for it.
+    expect(getByTestId("dialog-title").textContent).toBe("Close Session 2?");
+    expect(assistantHost().discardResume).not.toHaveBeenCalled();
+  });
+
+  it("drops an open confirmation when the workspace changes under it", () => {
+    nativeMode();
+    assistantStoreForSlot(0).getState().reset("ses_native");
+    assistantStoreForSlot(0).getState().appendUserTurn("something worth keeping");
+    const { container, rerender, queryByTestId } = render(<HelpPanel width={380} />);
+    fireEvent.click(queryStopItem(container)!);
+    expect(queryByTestId("confirm-dialog")).not.toBe(null);
+
+    projectStoreState.currentProject = { id: "proj-2", path: "/other" };
+    act(() => {
+      rerender(<HelpPanel width={380} />);
+    });
+
+    // Confirmed now, Stop would forget proj-2's conversation — which nobody was asked about.
+    expect(queryByTestId("confirm-dialog")).toBe(null);
+    expect(assistantHost().discardResume).not.toHaveBeenCalled();
+  });
 });

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.sessionResetStop.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.sessionResetStop.test.tsx
@@ -11,6 +11,8 @@ const {
   mockProvisionSession,
   mockRevokeSession,
   mockTakePendingHibernation,
+  mockListResumable,
+  mockDiscardResume,
   mockGetAssistantSupportedAgentIds,
   mockGetHelpAssistantSettings,
   mockGetAgentVersion,
@@ -38,6 +40,8 @@ const {
   mockProvisionSession: vi.fn().mockResolvedValue(null),
   mockRevokeSession: vi.fn().mockResolvedValue(undefined),
   mockTakePendingHibernation: vi.fn().mockResolvedValue(null),
+  mockListResumable: vi.fn().mockResolvedValue([]),
+  mockDiscardResume: vi.fn().mockResolvedValue({ discarded: true }),
   mockGetAssistantSupportedAgentIds: vi.fn(() => ["claude"]),
   mockGetHelpAssistantSettings: vi.fn().mockResolvedValue({
     docSearch: true,
@@ -556,6 +560,10 @@ function resetState() {
   mockRevokeSession.mockResolvedValue(undefined);
   mockTakePendingHibernation.mockReset();
   mockTakePendingHibernation.mockResolvedValue(null);
+  mockListResumable.mockReset();
+  mockListResumable.mockResolvedValue([]);
+  mockDiscardResume.mockReset();
+  mockDiscardResume.mockResolvedValue({ discarded: true });
   mockGetAssistantSupportedAgentIds.mockReset();
   mockGetAssistantSupportedAgentIds.mockReturnValue(["claude"]);
   mockGetHelpAssistantSettings.mockReset();
@@ -629,8 +637,8 @@ beforeEach(() => {
           start: vi.fn().mockResolvedValue({ sessionId: "assistant-test-session" }),
           send: vi.fn().mockResolvedValue({ delivered: true }),
           stop: vi.fn().mockResolvedValue({ stopped: true }),
-          listResumable: vi.fn().mockResolvedValue([]),
-          discardResume: vi.fn().mockResolvedValue({ discarded: true }),
+          listResumable: mockListResumable,
+          discardResume: mockDiscardResume,
           onEvent: vi.fn(() => () => {}),
           onPeerPrompt: () => () => {},
           onSequenceGap: vi.fn(() => () => {}),
@@ -1562,17 +1570,11 @@ describe("HelpPanel — the native assistant's destructive controls", () => {
  * closing a lane ask main to.
  */
 describe("HelpPanel — native lanes and the conversations main keeps for them (#12365)", () => {
-  type HostMock = Record<string, ReturnType<typeof vi.fn>>;
-
   function nativeMode() {
     projectStoreState.currentProject = { id: "proj-1", path: "/repo" };
     helpPanelState.terminalId = null;
     helpPanelState.agentId = null;
     helpPanelState.preferredAgentId = null;
-  }
-
-  function assistantHost(): HostMock {
-    return (window as unknown as { electron: { assistantHost: HostMock } }).electron.assistantHost;
   }
 
   function queryStopItem(container: HTMLElement): HTMLButtonElement | null {
@@ -1593,7 +1595,7 @@ describe("HelpPanel — native lanes and the conversations main keeps for them (
     helpPanelState.isOpen = false;
     const ensureSlot = vi.fn();
     Object.assign(helpPanelState, { ensureSlot });
-    assistantHost().listResumable!.mockResolvedValue([
+    mockListResumable.mockResolvedValue([
       { slot: 0, panelWasOpen: false },
       { slot: 2, panelWasOpen: true },
     ]);
@@ -1602,7 +1604,7 @@ describe("HelpPanel — native lanes and the conversations main keeps for them (
       render(<HelpPanel width={380} />);
     });
 
-    expect(assistantHost().listResumable).toHaveBeenCalledWith("proj-1");
+    expect(mockListResumable).toHaveBeenCalledWith("proj-1");
     expect(ensureSlot.mock.calls).toEqual([[0], [2]]);
     // Onto the conversation, not whichever lane a cold view happens to come up on.
     expect(helpPanelState.setActiveSlot).toHaveBeenCalledWith(2);
@@ -1614,7 +1616,7 @@ describe("HelpPanel — native lanes and the conversations main keeps for them (
     helpPanelState.isOpen = false;
     const ensureSlot = vi.fn();
     Object.assign(helpPanelState, { ensureSlot });
-    assistantHost().listResumable!.mockResolvedValue([{ slot: 1, panelWasOpen: false }]);
+    mockListResumable.mockResolvedValue([{ slot: 1, panelWasOpen: false }]);
 
     await act(async () => {
       render(<HelpPanel width={380} />);
@@ -1632,7 +1634,7 @@ describe("HelpPanel — native lanes and the conversations main keeps for them (
     await act(async () => {
       render(<HelpPanel width={380} />);
     });
-    expect(assistantHost().listResumable).not.toHaveBeenCalled();
+    expect(mockListResumable).not.toHaveBeenCalled();
   });
 
   it("forgets the lane's conversation when it is stopped", () => {
@@ -1641,7 +1643,7 @@ describe("HelpPanel — native lanes and the conversations main keeps for them (
     act(() => {
       fireEvent.click(queryStopItem(container)!);
     });
-    expect(assistantHost().discardResume).toHaveBeenCalledWith("proj-1", 0);
+    expect(mockDiscardResume).toHaveBeenCalledWith("proj-1", 0);
   });
 
   it("forgets a closed lane's conversation, and no other lane's", () => {
@@ -1654,7 +1656,7 @@ describe("HelpPanel — native lanes and the conversations main keeps for them (
     act(() => {
       fireEvent.click(close!);
     });
-    expect(assistantHost().discardResume.mock.calls).toEqual([["proj-1", 1]]);
+    expect(mockDiscardResume.mock.calls).toEqual([["proj-1", 1]]);
   });
 
   it("asks before Stop discards a conversation the lane picked back up but cannot show", () => {
@@ -1673,7 +1675,7 @@ describe("HelpPanel — native lanes and the conversations main keeps for them (
     fireEvent.click(queryStopItem(container)!);
     // An empty transcript, and a whole conversation in the assistant's context.
     expect(getByTestId("dialog-title").textContent).toBe("Stop assistant?");
-    expect(assistantHost().discardResume).not.toHaveBeenCalled();
+    expect(mockDiscardResume).not.toHaveBeenCalled();
   });
 
   it("asks before closing a restored lane that has not started yet", async () => {
@@ -1684,7 +1686,7 @@ describe("HelpPanel — native lanes and the conversations main keeps for them (
       }
     });
     Object.assign(helpPanelState, { ensureSlot });
-    assistantHost().listResumable!.mockResolvedValue([{ slot: 1, panelWasOpen: false }]);
+    mockListResumable.mockResolvedValue([{ slot: 1, panelWasOpen: false }]);
 
     const { container, rerender, getByTestId } = render(<HelpPanel width={380} />);
     await act(async () => {});
@@ -1699,7 +1701,7 @@ describe("HelpPanel — native lanes and the conversations main keeps for them (
     });
     // Its store is empty until it starts, but main is holding a conversation for it.
     expect(getByTestId("dialog-title").textContent).toBe("Close Session 2?");
-    expect(assistantHost().discardResume).not.toHaveBeenCalled();
+    expect(mockDiscardResume).not.toHaveBeenCalled();
   });
 
   it("drops an open confirmation when the workspace changes under it", () => {
@@ -1717,13 +1719,13 @@ describe("HelpPanel — native lanes and the conversations main keeps for them (
 
     // Confirmed now, Stop would forget proj-2's conversation — which nobody was asked about.
     expect(queryByTestId("confirm-dialog")).toBe(null);
-    expect(assistantHost().discardResume).not.toHaveBeenCalled();
+    expect(mockDiscardResume).not.toHaveBeenCalled();
   });
 
   it("reads again which lanes hold a conversation each time the workspace comes back", async () => {
     nativeMode();
     Object.assign(helpPanelState, { ensureSlot: vi.fn() });
-    const listResumable = assistantHost().listResumable!;
+    const listResumable = mockListResumable;
     const { container, rerender, getByTestId } = render(<HelpPanel width={380} />);
     await act(async () => {});
 
@@ -1747,7 +1749,7 @@ describe("HelpPanel — native lanes and the conversations main keeps for them (
   it("stops counting a restored lane as saved once it has adopted a session", async () => {
     nativeMode();
     Object.assign(helpPanelState, { ensureSlot: vi.fn() });
-    assistantHost().listResumable!.mockResolvedValue([{ slot: 0, panelWasOpen: false }]);
+    mockListResumable.mockResolvedValue([{ slot: 0, panelWasOpen: false }]);
     const { container, queryByTestId } = render(<HelpPanel width={380} />);
     await act(async () => {});
 
@@ -1760,6 +1762,6 @@ describe("HelpPanel — native lanes and the conversations main keeps for them (
     });
 
     expect(queryByTestId("confirm-dialog")).toBe(null);
-    expect(assistantHost().discardResume).toHaveBeenCalledWith("proj-1", 0);
+    expect(mockDiscardResume).toHaveBeenCalledWith("proj-1", 0);
   });
 });

--- a/src/store/assistantStore.ts
+++ b/src/store/assistantStore.ts
@@ -432,6 +432,12 @@ export interface AssistantSessionState {
   autoApprove: boolean;
   /** Why the engine stopped, when it did. */
   stoppedReason: string | null;
+  /**
+   * True when the engine continued a conversation this panel never saw (#12365). The
+   * transcript is empty but the conversation is not, so it counts as something a restart
+   * or a stop would discard.
+   */
+  resumed: boolean;
   /** Fatal error that prevented (or ended) the session. */
   error: string | null;
 
@@ -556,6 +562,7 @@ const EMPTY: AssistantSessionState = {
   awaitingLocalCommand: false,
   autoApprove: false,
   stoppedReason: null,
+  resumed: false,
   error: null,
   turns: [],
   toolCalls: {},
@@ -945,6 +952,7 @@ const assistantStoreCreator: StateCreator<AssistantStore> = (set, get) => ({
           routing: event.routing ?? null,
           logFile: event.logFile ?? null,
           commands: event.commands ?? [],
+          resumed: Boolean(event.resumedSessionId),
           error: null,
         });
         return;

--- a/src/store/assistantStore.ts
+++ b/src/store/assistantStore.ts
@@ -1507,6 +1507,9 @@ const assistantStoreCreator: StateCreator<AssistantStore> = (set, get) => ({
             lastActivityAt: null,
             pendingQuestion: null,
             awaitingLocalCommand: false,
+            // Nothing is left of a conversation this panel was continuing, so nothing is left
+            // for Stop or a restart to ask about (#12365).
+            resumed: false,
             // A gap belongs to a transcript. Cleared with it, or the panel keeps
             // reporting frames missing from a conversation nobody can read.
             droppedFrames: 0,


### PR DESCRIPTION
## Summary

When the native Daintree Assistant engine went down involuntarily (view eviction, renderer crash, window close), the next cold view came back with the panel closed and empty. The conversation was still sitting on disk in the engine's `state.db`, but nothing in the app knew it existed.

This change has main track which conversation each lane is having and continue it the next time that lane starts. A cold view restores the lanes and reopens the panel if it had been open.

Resolves #12365

## How it works

- **`NativeAssistantResumeStore`** (new, `electron/services/assistant-host/`): writes `assistant-native-resume.json` in userData, keyed by (workspace, slot). Records the id the engine stores the conversation under: `ready.resumedSessionId ?? sessionId`, never `host:shutdown`'s handle, since that names the launch after the first resume. `panelWasOpen` is in-memory only, so an app restart never reopens a panel on its own (same rule as the PTY hibernation store, #10815). Shared load, ordered writes, 14-day staleness, validated entries, bounded flush at quit.
- **`AssistantHostService`**: every non-fresh start of a lane passes `resumeSessionId`. A lane gets recorded when the engine first reports conversation (turn events, pre-ready activity), and refreshed daily while in use, so a lane nobody spoke in leaves nothing behind. "+ New session" sends `fresh`: it clears the record and replaces a running engine rather than joining the conversation it replaces (other windows get an exit). A failed start keeps the record. Losing a view or window stamps whether the panel was open. `discardResume` (Stop, closing a lane) runs on the lane's start queue, is refused while another window still watches the engine, and marks a discarded engine so it's neither joined nor recorded again. The provisioning surface leaving now tells the remaining windows the session ended.
- **IPC**: `assistantHost.listResumable(workspaceId)` and `assistantHost.discardResume(workspaceId, slot)`, guarded to the caller's own workspace (registry binding, falling back to the startup renderer's `?projectId=` only while unbound). `start` accepts `fresh`, and only the workspace's own view can continue, discard, or overwrite its conversation. The renderer never supplies a conversation id.
- **Renderer**: `useAssistantSession` sends `fresh` only when the lane's restart nonce rises, and shows an info notice when a start picked up a previous conversation ("Earlier messages aren't shown here"). `HelpPanel` lists resumable lanes on each workspace activation, restores tabs and reopens the panel on a genuinely cold view, forgets a lane's conversation on native Stop and lane close, confirms before discarding a resumed or restored-but-unstarted conversation, and closes open confirmations on a workspace switch. `assistantStore` gains `resumed` (cleared by `/clear`).
- `captureAssistantStates.mts` now captures `resumed`; `__preview__/capturedStates.ts` was regenerated with it, so its timestamps and local turn ids changed as a side effect.

## Known limitations

- The visible transcript isn't repainted after the engine process restarts. The engine has no history query, so the panel says so.
- The startup-URL identity fallback trusts the sender's current URL, the same trust `terminal:reconnect` already places in it. A main-owned startup binding would harden every handler that uses it.
- Native lanes aren't restored while the global agent preference is a terminal agent (their records are kept).
- Panel-open state is per workspace with last-reporter-wins, same as the PTY capture. Sleeping the on-screen project and later destroying its retained view doesn't auto-reopen the panel.
- No engine (Go) or `DAINTREE_HOST.md` change needed. The protocol already carried `resumeSessionId` / `resumedSessionId`.

## Testing

New `NativeAssistantResumeStore.test.ts` and `resumeLifecycle.test.ts`. Extended `assistantHost.ownership.test.ts`, `multiSurface.test.ts`, `ownershipBoundary.contract.test.ts`, `HelpSessionService.test.ts`, `useAssistantSession.lifecycle.test.tsx`, `HelpPanel.helpLaunch.sessionResetStop.test.tsx`.

Locally green: electron assistant-host/IPC/help-session suites (317 passed, 15 skipped), AssistantPanel/HelpPanel/store suites (903 passed), `check:ipc`, `check:ipc-renderer`, `check:channels`, `check:ipc-handwritten`. Own-file prettier and a per-rule eslint comparison against base show no increase. PR-triggered CI does not run for PRs into this base branch, so `ci.yml` was dispatched on the head commit instead: check, build, all four test shards and ci-ok passed ([run 34559986096](https://github.com/daintreehq/daintree/actions/runs/34559986096)).
