### PR TITLE
fix(worktree): break focus-follow oscillation and make active-worktree switches traceable

### DIFF
--- a/electron/workspace-host.ts
+++ b/electron/workspace-host.ts
@@ -128,7 +128,9 @@ async function handleWorktreePortRequest(
 
       case "set-active": {
         const requestId = `port-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-        workspaceService.setActiveWorktree(requestId, msg.payload.worktreeId);
+        workspaceService.setActiveWorktree(requestId, msg.payload.worktreeId, {
+          origin: msg.payload.origin,
+        });
         result = { ok: true };
         break;
       }

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -2516,7 +2516,11 @@ export class WorkspaceService {
     });
   }
 
-  setActiveWorktree(requestId: string, worktreeId: string, options?: { silent?: boolean }): void {
+  setActiveWorktree(
+    requestId: string,
+    worktreeId: string,
+    options?: { silent?: boolean; origin?: string }
+  ): void {
     // Reject unknown worktree ids with success:false. Pre-PR, an unknown id
     // would mutate `this.activeWorktreeId` to a value the renderer could not
     // resolve; the new `worktree-activated` emit would propagate that miss
@@ -2593,6 +2597,7 @@ export class WorkspaceService {
       epoch: this.epoch,
       seq: this.nextSeq(),
       silent: options?.silent,
+      origin: options?.origin,
     });
 
     this.sendEvent({ type: "set-active-result", requestId, success: true });

--- a/electron/workspace-host/__tests__/WorkspaceService.activeWorktreeEvents.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.activeWorktreeEvents.test.ts
@@ -254,6 +254,33 @@ describe("WorkspaceService active-worktree event emission (#9945)", () => {
     expect(activatedDefault?.silent).toBeUndefined();
   });
 
+  it("echoes the set-active request's origin and leaves it unset for host-originated activations (#12370)", () => {
+    createAndRegisterMonitor({
+      id: pathResolve("/test/main"),
+      path: pathResolve("/test/main"),
+      isMainWorktree: true,
+    });
+    service["activeWorktreeId"] = null;
+    const activatedEvents = () =>
+      sentEvents.filter(
+        (e): e is Extract<WorkspaceHostEvent, { type: "worktree-activated" }> =>
+          e.type === "worktree-activated"
+      );
+
+    service["setActiveWorktree"]("port-1", pathResolve("/test/main"), {
+      origin: "renderer-abc123",
+    });
+    expect(activatedEvents().at(-1)?.origin).toBe("renderer-abc123");
+    // Origin is independent of the legacy silent contract.
+    expect(activatedEvents().at(-1)?.silent).toBeUndefined();
+
+    // The auto-switch paths call without options — the renderer must be able
+    // to tell those apart from its own echoes by the absence of an origin.
+    service["setActiveWorktree"]("topology-reconcile-auto-switch", pathResolve("/test/main"));
+    expect(activatedEvents()).toHaveLength(2);
+    expect(activatedEvents().at(-1)?.origin).toBeUndefined();
+  });
+
   it("rejects unknown worktree ids with success:false and does not emit worktree-activated", () => {
     createAndRegisterMonitor({
       id: pathResolve("/test/main"),

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -821,12 +821,15 @@ export type WorkspaceHostEvent =
   // that explicitly marked the activation silent (the renderer IPC path)
   // do not double-notify subscribers that the legacy
   // `CHANNELS.WORKTREE_ACTIVATED` path already suppresses.
+  // `origin` echoes the `set-active` request's origin tag, when it carried one,
+  // so a view can recognise the echo of its own selection (#12370).
   | {
       type: "worktree-activated";
       worktreeId: string;
       epoch: string;
       seq: number;
       silent?: boolean;
+      origin?: string;
     }
   // Per-worktree lifecycle setup failure surfaced to the renderer's error
   // banner. Emitted from sites that previously swallowed errors to

--- a/shared/types/worktree-port.ts
+++ b/shared/types/worktree-port.ts
@@ -47,7 +47,10 @@ export interface WorktreePortProtocol {
     } & WorktreeEventVersion;
   };
   "set-active": {
-    payload: { worktreeId: string };
+    // `origin` is echoed back on the resulting `worktree-activated` event so
+    // the requesting view can skip the echo of a selection it already applied
+    // locally, while still applying host-originated activations (#12370).
+    payload: { worktreeId: string; origin?: string };
     result: { ok: true };
   };
   // Full-replacement set of worktree IDs that currently have an agent

--- a/src/contexts/WorktreeStoreContext.tsx
+++ b/src/contexts/WorktreeStoreContext.tsx
@@ -33,6 +33,7 @@ import { actionService } from "@/services/ActionService";
 import { logDebug } from "@/utils/logger";
 import {
   RENDERER_ACTIVATION_ORIGIN,
+  latestActivationRequest,
   markHostActivationApplied,
 } from "@/store/worktreeActivationOrigin";
 
@@ -654,6 +655,24 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
         // B, echoed A then B) into a loop that persists and rewrites the MRU
         // on every hop (#12370). Host-originated activations carry no origin.
         if (event.origin === RENDERER_ACTIVATION_ORIGIN) {
+          // One exception: the ack of this view's *latest* request landing
+          // after another window's activation displaced it. Two windows
+          // picking different worktrees in the same round trip would
+          // otherwise settle on different answers, with nothing left in
+          // flight to reconcile them. Re-asserting sends one more
+          // `set-active`, which every view then sees as already active.
+          const displaced =
+            event.worktreeId === latestActivationRequest() &&
+            useWorktreeSelectionStore.getState().activeWorktreeId !== event.worktreeId &&
+            store.getState().worktrees.has(event.worktreeId);
+          if (displaced) {
+            logDebug("[WorktreeStore] worktree-activated re-applied: own request displaced", {
+              worktreeId: event.worktreeId,
+              ...version,
+            });
+            useWorktreeSelectionStore.getState().selectWorktree(event.worktreeId);
+            return;
+          }
           logDebug("[WorktreeStore] worktree-activated ignored: own echo", {
             worktreeId: event.worktreeId,
             ...version,

--- a/src/contexts/WorktreeStoreContext.tsx
+++ b/src/contexts/WorktreeStoreContext.tsx
@@ -31,7 +31,10 @@ import { scheduleRevealTextReraster } from "@/utils/revealTextReraster";
 import { notify } from "@/lib/notify";
 import { actionService } from "@/services/ActionService";
 import { logDebug } from "@/utils/logger";
-import { RENDERER_ACTIVATION_ORIGIN } from "@/store/worktreeActivationOrigin";
+import {
+  RENDERER_ACTIVATION_ORIGIN,
+  markHostActivationApplied,
+} from "@/store/worktreeActivationOrigin";
 
 // How long the topology watcher may stay dark before we escalate from the
 // Tier-1 ambient pip to a Tier-3 low-priority inbox notification (#9908). The
@@ -697,6 +700,9 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
           to: event.worktreeId,
           ...version,
         });
+        // The host is the author of this selection; the sync hook must not
+        // send it back as a `set-active` of our own.
+        markHostActivationApplied(event.worktreeId);
         selectionStore.setPendingWorktree(event.worktreeId);
         selectionStore.selectWorktree(event.worktreeId);
         if (store.getState().worktrees.has(event.worktreeId)) {

--- a/src/contexts/WorktreeStoreContext.tsx
+++ b/src/contexts/WorktreeStoreContext.tsx
@@ -636,6 +636,14 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
     // topology. They get their own high-water mark so a replayed or reordered
     // activation cannot re-select a worktree this view has moved past.
     let lastActivation: WorktreeEventVersion | null = null;
+    // This view's latest request at the moment a foreign activation was
+    // applied over it, with the selection generation right after that apply.
+    // Consumed by the own-echo branch below.
+    let displacedRequest: {
+      worktreeId: string;
+      durable: boolean;
+      generation: number;
+    } | null = null;
     cleanups.push(
       worktreePort.onEvent("worktree-activated", (data) => {
         const event = data as WorktreeActivatedEvent;
@@ -655,22 +663,34 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
         // B, echoed A then B) into a loop that persists and rewrites the MRU
         // on every hop (#12370). Host-originated activations carry no origin.
         if (event.origin === RENDERER_ACTIVATION_ORIGIN) {
-          // One exception: the ack of this view's *latest* request landing
-          // after another window's activation displaced it. Two windows
-          // picking different worktrees in the same round trip would
-          // otherwise settle on different answers, with nothing left in
-          // flight to reconcile them. Re-asserting sends one more
-          // `set-active`, which every view then sees as already active.
-          const displaced =
-            event.worktreeId === latestActivationRequest() &&
-            useWorktreeSelectionStore.getState().activeWorktreeId !== event.worktreeId &&
-            store.getState().worktrees.has(event.worktreeId);
-          if (displaced) {
+          // One exception: the ack of this view's latest request landing
+          // after another window's activation was applied over it, with no
+          // selection of any kind since (the generation check — a local pick
+          // in between, including a ghost row that sends nothing, wins). Two
+          // windows picking different worktrees in the same round trip would
+          // otherwise settle on different answers with nothing left in
+          // flight to reconcile them. This is a catch-up to what the host
+          // already holds, never a re-send: marked host-applied so the sync
+          // hook stays quiet, and made with the source the pick had.
+          const selection = useWorktreeSelectionStore.getState();
+          const displaced = displacedRequest;
+          if (
+            displaced &&
+            displaced.worktreeId === event.worktreeId &&
+            displaced.generation === selection._policyGeneration &&
+            selection.activeWorktreeId !== event.worktreeId &&
+            store.getState().worktrees.has(event.worktreeId)
+          ) {
+            displacedRequest = null;
             logDebug("[WorktreeStore] worktree-activated re-applied: own request displaced", {
               worktreeId: event.worktreeId,
+              durable: displaced.durable,
               ...version,
             });
-            useWorktreeSelectionStore.getState().selectWorktree(event.worktreeId);
+            markHostActivationApplied(event.worktreeId);
+            selection.selectWorktree(event.worktreeId, {
+              source: displaced.durable ? "user" : "focus",
+            });
             return;
           }
           logDebug("[WorktreeStore] worktree-activated ignored: own echo", {
@@ -727,6 +747,11 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
         if (store.getState().worktrees.has(event.worktreeId)) {
           selectionStore.applyPendingWorktreeSelection(event.worktreeId);
         }
+        const latest = latestActivationRequest();
+        displacedRequest =
+          latest && latest.worktreeId !== event.worktreeId
+            ? { ...latest, generation: useWorktreeSelectionStore.getState()._policyGeneration }
+            : null;
       })
     );
 

--- a/src/contexts/WorktreeStoreContext.tsx
+++ b/src/contexts/WorktreeStoreContext.tsx
@@ -30,6 +30,8 @@ import { markSwitch, setActiveSwitchTrace } from "@/utils/switchTrace";
 import { scheduleRevealTextReraster } from "@/utils/revealTextReraster";
 import { notify } from "@/lib/notify";
 import { actionService } from "@/services/ActionService";
+import { logDebug } from "@/utils/logger";
+import { RENDERER_ACTIVATION_ORIGIN } from "@/store/worktreeActivationOrigin";
 
 // How long the topology watcher may stay dark before we escalate from the
 // Tier-1 ambient pip to a Tier-3 low-priority inbox notification (#9908). The
@@ -135,6 +137,10 @@ function overlayVersion(current: WorktreeEventVersion): WorktreeEventVersion {
 interface WorktreeActivatedEvent {
   type: "worktree-activated";
   worktreeId: string;
+  epoch: string;
+  seq: number;
+  silent?: boolean;
+  origin?: string;
 }
 
 export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
@@ -621,9 +627,36 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
       })
     );
 
+    // Activations are stamped from the same `(epoch, seq)` counter as the
+    // topology events but never advance the store's version — they carry no
+    // topology. They get their own high-water mark so a replayed or reordered
+    // activation cannot re-select a worktree this view has moved past.
+    let lastActivation: WorktreeEventVersion | null = null;
     cleanups.push(
       worktreePort.onEvent("worktree-activated", (data) => {
         const event = data as WorktreeActivatedEvent;
+        const version = { epoch: event.epoch, seq: event.seq };
+        if (lastActivation && compareVersion(version, lastActivation) < 0) {
+          logDebug("[WorktreeStore] worktree-activated ignored: stale", {
+            worktreeId: event.worktreeId,
+            ...version,
+          });
+          return;
+        }
+        lastActivation = version;
+        // The echo of this view's own `set-active`. The selection was applied
+        // locally before the request went out, and by the time the echo lands
+        // the view may already have moved on — re-selecting it here with the
+        // default "user" source is what turns two overlapping requests (A then
+        // B, echoed A then B) into a loop that persists and rewrites the MRU
+        // on every hop (#12370). Host-originated activations carry no origin.
+        if (event.origin === RENDERER_ACTIVATION_ORIGIN) {
+          logDebug("[WorktreeStore] worktree-activated ignored: own echo", {
+            worktreeId: event.worktreeId,
+            ...version,
+          });
+          return;
+        }
         const selectionStore = useWorktreeSelectionStore.getState();
         // Skip the worktree-activated handler if the active id already
         // matches the event's id. The host's MessagePort echoes
@@ -659,6 +692,11 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
             return;
           }
         }
+        logDebug("[WorktreeStore] worktree-activated applied", {
+          from: activeId,
+          to: event.worktreeId,
+          ...version,
+        });
         selectionStore.setPendingWorktree(event.worktreeId);
         selectionStore.selectWorktree(event.worktreeId);
         if (store.getState().worktrees.has(event.worktreeId)) {

--- a/src/contexts/__tests__/WorktreeStoreContext.worktreeActivated.test.tsx
+++ b/src/contexts/__tests__/WorktreeStoreContext.worktreeActivated.test.tsx
@@ -5,6 +5,7 @@ import { useContext } from "react";
 
 import { useProjectStore } from "@/store/projectStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
+import { RENDERER_ACTIVATION_ORIGIN } from "@/store/worktreeActivationOrigin";
 import type { WorktreeSnapshot } from "@shared/types";
 import type { Project } from "@shared/types/project";
 
@@ -130,6 +131,8 @@ describe("WorktreeStoreProvider worktree-activated handler (#9945)", () => {
       emit("worktree-activated", {
         type: "worktree-activated",
         worktreeId: "wt-main",
+        epoch: "test",
+        seq: 3,
       });
     });
 
@@ -181,6 +184,8 @@ describe("WorktreeStoreProvider worktree-activated handler (#9945)", () => {
       emit("worktree-activated", {
         type: "worktree-activated",
         worktreeId: "wt-main",
+        epoch: "test",
+        seq: 4,
       });
     });
 
@@ -265,6 +270,8 @@ describe("WorktreeStoreProvider worktree-activated handler (#9945)", () => {
       emit("worktree-activated", {
         type: "worktree-activated",
         worktreeId: "wt-main",
+        epoch: "test",
+        seq: 2,
       });
     });
 
@@ -278,5 +285,125 @@ describe("WorktreeStoreProvider worktree-activated handler (#9945)", () => {
     // already-active branch.
     expect(after.restoreWorktreeId).toBe(restoreBefore);
     expect(after.pendingWorktreeId).toBe(pendingBefore);
+  });
+});
+
+describe("WorktreeStoreProvider worktree-activated origin and version gates (#12370)", () => {
+  async function renderWithWorktrees(ids: string[]) {
+    const store = await renderProvider();
+    act(() => {
+      ids.forEach((id, i) => {
+        store
+          .getState()
+          .applyUpdate(makeWorktree(id, { isMainWorktree: i === 0, branch: `b/${id}` }), {
+            epoch: "test",
+            seq: i + 1,
+          });
+      });
+    });
+    return store;
+  }
+
+  it("ignores the echo of this view's own set-active once the view has moved on", async () => {
+    await renderWithWorktrees(["wt-a", "wt-b"]);
+    // The view selected A, then B, and sent set-active for both. B is the
+    // current selection when A's echo lands; re-applying A here is the first
+    // hop of the A/B echo loop.
+    act(() => {
+      useWorktreeSelectionStore.setState({
+        activeWorktreeId: "wt-b",
+        restoreWorktreeId: "wt-b",
+        pendingWorktreeId: null,
+      });
+    });
+
+    act(() => {
+      emit("worktree-activated", {
+        type: "worktree-activated",
+        worktreeId: "wt-a",
+        epoch: "test",
+        seq: 3,
+        origin: RENDERER_ACTIVATION_ORIGIN,
+      });
+    });
+
+    const after = useWorktreeSelectionStore.getState();
+    expect(after.activeWorktreeId).toBe("wt-b");
+    expect(after.restoreWorktreeId).toBe("wt-b");
+    expect(after.pendingWorktreeId).toBeNull();
+  });
+
+  it("still applies an activation carrying some other origin", async () => {
+    await renderWithWorktrees(["wt-a", "wt-b"]);
+    act(() => {
+      useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-b" });
+    });
+
+    act(() => {
+      emit("worktree-activated", {
+        type: "worktree-activated",
+        worktreeId: "wt-a",
+        epoch: "test",
+        seq: 3,
+        origin: "renderer-someone-else",
+      });
+    });
+
+    expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-a");
+  });
+
+  it("ignores an activation older than the newest one it has seen in the same epoch", async () => {
+    await renderWithWorktrees(["wt-main", "wt-active", "wt-other"]);
+    act(() => {
+      useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-active" });
+    });
+
+    act(() => {
+      emit("worktree-activated", {
+        type: "worktree-activated",
+        worktreeId: "wt-main",
+        epoch: "test",
+        seq: 5,
+      });
+    });
+    expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-main");
+
+    act(() => {
+      emit("worktree-activated", {
+        type: "worktree-activated",
+        worktreeId: "wt-other",
+        epoch: "test",
+        seq: 4,
+      });
+    });
+    expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-main");
+  });
+
+  it("accepts an activation from a new epoch regardless of its seq", async () => {
+    await renderWithWorktrees(["wt-main", "wt-active", "wt-other"]);
+    act(() => {
+      useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-active" });
+    });
+
+    act(() => {
+      emit("worktree-activated", {
+        type: "worktree-activated",
+        worktreeId: "wt-main",
+        epoch: "e1",
+        seq: 5,
+      });
+    });
+    expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-main");
+
+    // A host restart resets the counter; its first activation must win.
+    act(() => {
+      emit("worktree-activated", {
+        type: "worktree-activated",
+        worktreeId: "wt-other",
+        epoch: "e2",
+        seq: 1,
+      });
+    });
+    expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-other");
   });
 });

--- a/src/contexts/__tests__/WorktreeStoreContext.worktreeActivated.test.tsx
+++ b/src/contexts/__tests__/WorktreeStoreContext.worktreeActivated.test.tsx
@@ -5,7 +5,11 @@ import { useContext } from "react";
 
 import { useProjectStore } from "@/store/projectStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
-import { RENDERER_ACTIVATION_ORIGIN } from "@/store/worktreeActivationOrigin";
+import {
+  RENDERER_ACTIVATION_ORIGIN,
+  consumeHostAppliedActivation,
+  _resetHostAppliedActivationForTesting,
+} from "@/store/worktreeActivationOrigin";
 import type { WorktreeSnapshot } from "@shared/types";
 import type { Project } from "@shared/types/project";
 
@@ -37,6 +41,7 @@ function setCurrentProject(path: string | null): void {
 
 beforeEach(() => {
   listeners.clear();
+  _resetHostAppliedActivationForTesting();
   setCurrentProject("/repo/proj");
   // Reset the selection store so per-test state doesn't leak.
   useWorktreeSelectionStore.setState({
@@ -331,6 +336,29 @@ describe("WorktreeStoreProvider worktree-activated origin and version gates (#12
     expect(after.activeWorktreeId).toBe("wt-b");
     expect(after.restoreWorktreeId).toBe("wt-b");
     expect(after.pendingWorktreeId).toBeNull();
+    // Nothing was applied, so there is nothing for the sync hook to withhold.
+    expect(consumeHostAppliedActivation("wt-a")).toBe(false);
+  });
+
+  it("marks a host-pushed selection so the sync hook does not answer it with a set-active", async () => {
+    await renderWithWorktrees(["wt-a", "wt-b"]);
+    act(() => {
+      useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-b" });
+    });
+
+    act(() => {
+      emit("worktree-activated", {
+        type: "worktree-activated",
+        worktreeId: "wt-a",
+        epoch: "test",
+        seq: 3,
+      });
+    });
+
+    expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-a");
+    // With two windows on one project, echoing the host's own activation back
+    // is the next hop of a loop: each view applies the other's and re-sends.
+    expect(consumeHostAppliedActivation("wt-a")).toBe(true);
   });
 
   it("still applies an activation carrying some other origin", async () => {

--- a/src/contexts/__tests__/WorktreeStoreContext.worktreeActivated.test.tsx
+++ b/src/contexts/__tests__/WorktreeStoreContext.worktreeActivated.test.tsx
@@ -8,6 +8,7 @@ import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import {
   RENDERER_ACTIVATION_ORIGIN,
   consumeHostAppliedActivation,
+  markActivationRequested,
   _resetHostAppliedActivationForTesting,
 } from "@/store/worktreeActivationOrigin";
 import type { WorktreeSnapshot } from "@shared/types";
@@ -321,6 +322,7 @@ describe("WorktreeStoreProvider worktree-activated origin and version gates (#12
         pendingWorktreeId: null,
       });
     });
+    markActivationRequested("wt-b");
 
     act(() => {
       emit("worktree-activated", {
@@ -338,6 +340,60 @@ describe("WorktreeStoreProvider worktree-activated origin and version gates (#12
     expect(after.pendingWorktreeId).toBeNull();
     // Nothing was applied, so there is nothing for the sync hook to withhold.
     expect(consumeHostAppliedActivation("wt-a")).toBe(false);
+  });
+
+  it("leaves a focus-promoted selection alone when its own echo is already active", async () => {
+    await renderWithWorktrees(["wt-a", "wt-b"]);
+    // wt-b became active by focus promotion (restore target still wt-a), and
+    // the sync hook sent set-active for it. Its echo must not re-select with
+    // the "user" source and pin wt-b as the restore target (#9512).
+    act(() => {
+      useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-b", restoreWorktreeId: "wt-a" });
+    });
+    markActivationRequested("wt-b");
+
+    act(() => {
+      emit("worktree-activated", {
+        type: "worktree-activated",
+        worktreeId: "wt-b",
+        epoch: "test",
+        seq: 3,
+        origin: RENDERER_ACTIVATION_ORIGIN,
+      });
+    });
+
+    const after = useWorktreeSelectionStore.getState();
+    expect(after.activeWorktreeId).toBe("wt-b");
+    expect(after.restoreWorktreeId).toBe("wt-a");
+  });
+
+  it("re-asserts its latest own request when another window's activation displaced it", async () => {
+    const store = await renderWithWorktrees(["wt-a", "wt-b", "wt-c"]);
+    // This window asked for C; the other window asked for B in the same
+    // round trip. The host processed B first, so B's foreign activation
+    // landed here and was applied — then C's own echo arrives. Ignoring it
+    // would leave this window on B while the host and the other window sit
+    // on C, with nothing left in flight to reconcile them.
+    act(() => {
+      useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-b" });
+    });
+    markActivationRequested("wt-c");
+
+    act(() => {
+      emit("worktree-activated", {
+        type: "worktree-activated",
+        worktreeId: "wt-c",
+        epoch: "test",
+        seq: 5,
+        origin: RENDERER_ACTIVATION_ORIGIN,
+      });
+    });
+
+    expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-c");
+    // Not a host-pushed selection: the sync hook must send it, so the host
+    // and the other window converge on C too.
+    expect(consumeHostAppliedActivation("wt-c")).toBe(false);
+    expect(store.getState().worktrees.has("wt-c")).toBe(true);
   });
 
   it("marks a host-pushed selection so the sync hook does not answer it with a set-active", async () => {

--- a/src/contexts/__tests__/WorktreeStoreContext.worktreeActivated.test.tsx
+++ b/src/contexts/__tests__/WorktreeStoreContext.worktreeActivated.test.tsx
@@ -322,7 +322,7 @@ describe("WorktreeStoreProvider worktree-activated origin and version gates (#12
         pendingWorktreeId: null,
       });
     });
-    markActivationRequested("wt-b");
+    markActivationRequested("wt-b", true);
 
     act(() => {
       emit("worktree-activated", {
@@ -350,7 +350,7 @@ describe("WorktreeStoreProvider worktree-activated origin and version gates (#12
     act(() => {
       useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-b", restoreWorktreeId: "wt-a" });
     });
-    markActivationRequested("wt-b");
+    markActivationRequested("wt-b", true);
 
     act(() => {
       emit("worktree-activated", {
@@ -367,33 +367,101 @@ describe("WorktreeStoreProvider worktree-activated origin and version gates (#12
     expect(after.restoreWorktreeId).toBe("wt-a");
   });
 
-  it("re-asserts its latest own request when another window's activation displaced it", async () => {
-    const store = await renderWithWorktrees(["wt-a", "wt-b", "wt-c"]);
+  describe("own request displaced by another window", () => {
+    function emitActivated(worktreeId: string, seq: number, origin?: string) {
+      act(() => {
+        emit("worktree-activated", {
+          type: "worktree-activated",
+          worktreeId,
+          epoch: "test",
+          seq,
+          ...(origin ? { origin } : {}),
+        });
+      });
+    }
+
     // This window asked for C; the other window asked for B in the same
     // round trip. The host processed B first, so B's foreign activation
-    // landed here and was applied — then C's own echo arrives. Ignoring it
+    // lands here and is applied — then C's own echo arrives. Ignoring it
     // would leave this window on B while the host and the other window sit
     // on C, with nothing left in flight to reconcile them.
-    act(() => {
-      useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-b" });
-    });
-    markActivationRequested("wt-c");
-
-    act(() => {
-      emit("worktree-activated", {
-        type: "worktree-activated",
-        worktreeId: "wt-c",
-        epoch: "test",
-        seq: 5,
-        origin: RENDERER_ACTIVATION_ORIGIN,
+    async function displaceOwnPick(durable: boolean) {
+      await renderWithWorktrees(["wt-a", "wt-b", "wt-c"]);
+      act(() => {
+        useWorktreeSelectionStore.setState({
+          activeWorktreeId: "wt-c",
+          restoreWorktreeId: durable ? "wt-c" : "wt-a",
+        });
       });
+      markActivationRequested("wt-c", durable);
+      emitActivated("wt-b", 4);
+      expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-b");
+      expect(consumeHostAppliedActivation("wt-b")).toBe(true);
+    }
+
+    it("catches up to its displaced latest request without sending it again", async () => {
+      await displaceOwnPick(true);
+
+      emitActivated("wt-c", 5, RENDERER_ACTIVATION_ORIGIN);
+
+      const after = useWorktreeSelectionStore.getState();
+      expect(after.activeWorktreeId).toBe("wt-c");
+      expect(after.restoreWorktreeId).toBe("wt-c");
+      // The host already holds C — it just said so. A re-send would be the
+      // next hop of a two-window echo loop.
+      expect(consumeHostAppliedActivation("wt-c")).toBe(true);
     });
 
-    expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-c");
-    // Not a host-pushed selection: the sync hook must send it, so the host
-    // and the other window converge on C too.
-    expect(consumeHostAppliedActivation("wt-c")).toBe(false);
-    expect(store.getState().worktrees.has("wt-c")).toBe(true);
+    it("keeps a focus-promoted pick incidental when catching up", async () => {
+      await displaceOwnPick(false);
+      expect(useWorktreeSelectionStore.getState().restoreWorktreeId).toBe("wt-b");
+
+      emitActivated("wt-c", 5, RENDERER_ACTIVATION_ORIGIN);
+
+      const after = useWorktreeSelectionStore.getState();
+      expect(after.activeWorktreeId).toBe("wt-c");
+      // Catching up with the "user" source would pin C as the restore target
+      // even though the user never chose it (#9512).
+      expect(after.restoreWorktreeId).toBe("wt-b");
+    });
+
+    it("does not catch up once anything was selected after the foreign activation", async () => {
+      await displaceOwnPick(true);
+      // A ghost row sends no set-active, so the latest request is still C —
+      // but the user's newer intent must win over C's late echo.
+      act(() => {
+        useWorktreeSelectionStore.getState().selectWorktree("wt-ghost", { source: "focus" });
+      });
+
+      emitActivated("wt-c", 5, RENDERER_ACTIVATION_ORIGIN);
+
+      expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-ghost");
+    });
+
+    it("still catches up when a superseded own echo lands in between", async () => {
+      await displaceOwnPick(true);
+
+      // The echo of an older request of ours (X, sent before C) is ignored
+      // and must not spoil the pending catch-up.
+      emitActivated("wt-a", 5, RENDERER_ACTIVATION_ORIGIN);
+      expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-b");
+      emitActivated("wt-c", 6, RENDERER_ACTIVATION_ORIGIN);
+
+      expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-c");
+    });
+
+    it("ignores its own echo when nothing foreign was applied since the request", async () => {
+      await renderWithWorktrees(["wt-a", "wt-b"]);
+      // Selected B locally after C's request went out; C's echo is just late.
+      act(() => {
+        useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-b" });
+      });
+      markActivationRequested("wt-a", true);
+
+      emitActivated("wt-a", 3, RENDERER_ACTIVATION_ORIGIN);
+
+      expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-b");
+    });
   });
 
   it("marks a host-pushed selection so the sync hook does not answer it with a set-active", async () => {

--- a/src/hooks/app/__tests__/useActiveWorktreeSync.test.ts
+++ b/src/hooks/app/__tests__/useActiveWorktreeSync.test.ts
@@ -15,6 +15,7 @@ const mocks = vi.hoisted(() => ({
   useWorktrees: vi.fn(),
   selectionState: {
     activeWorktreeId: null as string | null,
+    restoreWorktreeId: null as string | null,
     selectWorktree: vi.fn(),
     setActiveWorktree: vi.fn(),
     // Only unread today because every active id here is also a live worktree,
@@ -209,6 +210,7 @@ describe("useActiveWorktreeSync host sync", () => {
     request().mockClear();
     _resetHostAppliedActivationForTesting();
     mocks.selectionState.activeWorktreeId = worktree.id;
+    mocks.selectionState.restoreWorktreeId = null;
     mocks.selectionState.deletedWorktrees = new Map();
     mocks.projectState.currentProject = { id: "p1", path: "/repo" };
     mocks.scratchState.currentScratch = null;
@@ -228,8 +230,15 @@ describe("useActiveWorktreeSync host sync", () => {
       origin: RENDERER_ACTIVATION_ORIGIN,
     });
     // Remembered so the echo handler can tell the ack of the latest request
-    // from a superseded one.
-    expect(latestActivationRequest()).toBe(worktree.id);
+    // from a superseded one, and keep its source if it has to catch up.
+    expect(latestActivationRequest()).toEqual({ worktreeId: worktree.id, durable: false });
+  });
+
+  it("records the request as durable when the pick is the restore target", () => {
+    mocks.selectionState.restoreWorktreeId = worktree.id;
+    renderHook(() => useActiveWorktreeSync());
+
+    expect(latestActivationRequest()).toEqual({ worktreeId: worktree.id, durable: true });
   });
 
   it("drops a host mark when the selection clears, so it cannot swallow a later pick", () => {

--- a/src/hooks/app/__tests__/useActiveWorktreeSync.test.ts
+++ b/src/hooks/app/__tests__/useActiveWorktreeSync.test.ts
@@ -3,6 +3,7 @@
 import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useActiveWorktreeSync } from "../useActiveWorktreeSync";
+import { RENDERER_ACTIVATION_ORIGIN } from "@/store/worktreeActivationOrigin";
 
 const mocks = vi.hoisted(() => ({
   useWorktrees: vi.fn(),
@@ -185,6 +186,28 @@ describe("useActiveWorktreeSync defaultTerminalCwd", () => {
       rerender();
 
       expect(result.current.defaultTerminalCwd).toBe("/scratches/s1");
+    });
+  });
+});
+
+describe("useActiveWorktreeSync host sync", () => {
+  beforeEach(() => {
+    vi.mocked(window.electron.worktreePort.request).mockClear();
+    mocks.selectionState.activeWorktreeId = worktree.id;
+    mocks.selectionState.deletedWorktrees = new Map();
+    mocks.projectState.currentProject = { id: "p1", path: "/repo" };
+    mocks.scratchState.currentScratch = null;
+    mocks.homeDir.homeDir = "/home/user";
+    mocks.useWorktrees.mockReturnValue({ worktrees: [worktree], isInitialized: true });
+  });
+
+  it("tags its set-active request with this view's origin so the host's echo is recognisable (#12370)", () => {
+    renderHook(() => useActiveWorktreeSync());
+
+    expect(window.electron.worktreePort.request).toHaveBeenCalledTimes(1);
+    expect(window.electron.worktreePort.request).toHaveBeenCalledWith("set-active", {
+      worktreeId: worktree.id,
+      origin: RENDERER_ACTIVATION_ORIGIN,
     });
   });
 });

--- a/src/hooks/app/__tests__/useActiveWorktreeSync.test.ts
+++ b/src/hooks/app/__tests__/useActiveWorktreeSync.test.ts
@@ -3,7 +3,11 @@
 import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useActiveWorktreeSync } from "../useActiveWorktreeSync";
-import { RENDERER_ACTIVATION_ORIGIN } from "@/store/worktreeActivationOrigin";
+import {
+  RENDERER_ACTIVATION_ORIGIN,
+  markHostActivationApplied,
+  _resetHostAppliedActivationForTesting,
+} from "@/store/worktreeActivationOrigin";
 
 const mocks = vi.hoisted(() => ({
   useWorktrees: vi.fn(),
@@ -191,23 +195,77 @@ describe("useActiveWorktreeSync defaultTerminalCwd", () => {
 });
 
 describe("useActiveWorktreeSync host sync", () => {
+  const otherWorktree = {
+    id: "wt-2",
+    name: "other",
+    path: "/repo-worktrees/other",
+    isMainWorktree: false,
+  };
+  const request = () => vi.mocked(window.electron.worktreePort.request);
+
   beforeEach(() => {
-    vi.mocked(window.electron.worktreePort.request).mockClear();
+    request().mockClear();
+    _resetHostAppliedActivationForTesting();
     mocks.selectionState.activeWorktreeId = worktree.id;
     mocks.selectionState.deletedWorktrees = new Map();
     mocks.projectState.currentProject = { id: "p1", path: "/repo" };
     mocks.scratchState.currentScratch = null;
     mocks.homeDir.homeDir = "/home/user";
-    mocks.useWorktrees.mockReturnValue({ worktrees: [worktree], isInitialized: true });
+    mocks.useWorktrees.mockReturnValue({
+      worktrees: [worktree, otherWorktree],
+      isInitialized: true,
+    });
   });
 
   it("tags its set-active request with this view's origin so the host's echo is recognisable (#12370)", () => {
     renderHook(() => useActiveWorktreeSync());
 
-    expect(window.electron.worktreePort.request).toHaveBeenCalledTimes(1);
-    expect(window.electron.worktreePort.request).toHaveBeenCalledWith("set-active", {
+    expect(request()).toHaveBeenCalledTimes(1);
+    expect(request()).toHaveBeenCalledWith("set-active", {
       worktreeId: worktree.id,
       origin: RENDERER_ACTIVATION_ORIGIN,
     });
+  });
+
+  it("does not answer a selection the host itself pushed, then sends the next local one as usual", () => {
+    markHostActivationApplied(worktree.id);
+    const { rerender } = renderHook(() => useActiveWorktreeSync());
+    expect(request()).not.toHaveBeenCalled();
+
+    mocks.selectionState.activeWorktreeId = otherWorktree.id;
+    rerender();
+    expect(request()).toHaveBeenCalledTimes(1);
+    expect(request()).toHaveBeenLastCalledWith(
+      "set-active",
+      expect.objectContaining({ worktreeId: otherWorktree.id })
+    );
+
+    // The mark was single-shot: coming back to the same id is ours to send.
+    mocks.selectionState.activeWorktreeId = worktree.id;
+    rerender();
+    expect(request()).toHaveBeenCalledTimes(2);
+    expect(request()).toHaveBeenLastCalledWith(
+      "set-active",
+      expect.objectContaining({ worktreeId: worktree.id })
+    );
+  });
+
+  it("clears a stale host mark on the next selection change instead of swallowing a later local pick", () => {
+    // The host pushed wt-2, but the user picked wt-1 before the effect ran.
+    markHostActivationApplied(otherWorktree.id);
+    const { rerender } = renderHook(() => useActiveWorktreeSync());
+    expect(request()).toHaveBeenCalledTimes(1);
+    expect(request()).toHaveBeenLastCalledWith(
+      "set-active",
+      expect.objectContaining({ worktreeId: worktree.id })
+    );
+
+    mocks.selectionState.activeWorktreeId = otherWorktree.id;
+    rerender();
+    expect(request()).toHaveBeenCalledTimes(2);
+    expect(request()).toHaveBeenLastCalledWith(
+      "set-active",
+      expect.objectContaining({ worktreeId: otherWorktree.id })
+    );
   });
 });

--- a/src/hooks/app/__tests__/useActiveWorktreeSync.test.ts
+++ b/src/hooks/app/__tests__/useActiveWorktreeSync.test.ts
@@ -5,6 +5,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useActiveWorktreeSync } from "../useActiveWorktreeSync";
 import {
   RENDERER_ACTIVATION_ORIGIN,
+  consumeHostAppliedActivation,
+  latestActivationRequest,
   markHostActivationApplied,
   _resetHostAppliedActivationForTesting,
 } from "@/store/worktreeActivationOrigin";
@@ -225,6 +227,18 @@ describe("useActiveWorktreeSync host sync", () => {
       worktreeId: worktree.id,
       origin: RENDERER_ACTIVATION_ORIGIN,
     });
+    // Remembered so the echo handler can tell the ack of the latest request
+    // from a superseded one.
+    expect(latestActivationRequest()).toBe(worktree.id);
+  });
+
+  it("drops a host mark when the selection clears, so it cannot swallow a later pick", () => {
+    markHostActivationApplied(worktree.id);
+    mocks.selectionState.activeWorktreeId = null;
+    renderHook(() => useActiveWorktreeSync());
+
+    expect(request()).not.toHaveBeenCalled();
+    expect(consumeHostAppliedActivation(worktree.id)).toBe(false);
   });
 
   it("does not answer a selection the host itself pushed, then sends the next local one as usual", () => {

--- a/src/hooks/app/useActiveWorktreeSync.ts
+++ b/src/hooks/app/useActiveWorktreeSync.ts
@@ -5,6 +5,7 @@ import { useProjectStore } from "@/store";
 import { useScratchStore } from "@/store/scratchStore";
 import { useHomeDir } from "@/hooks/app/useHomeDir";
 import { resolveWorkspaceCwd } from "@/utils/workspaceCwd";
+import { RENDERER_ACTIVATION_ORIGIN } from "@/store/worktreeActivationOrigin";
 
 export function useActiveWorktreeSync() {
   const { worktrees, isInitialized } = useWorktrees();
@@ -90,8 +91,14 @@ export function useActiveWorktreeSync() {
     }
 
     lastSyncedActiveRef.current = { projectId, worktreeId: selectedWorktreeId };
+    // The selection is already applied locally; the origin tag lets the
+    // `worktree-activated` echo be skipped instead of re-selecting an id this
+    // view may have moved past by the time it lands (#12370).
     window.electron.worktreePort
-      .request("set-active", { worktreeId: selectedWorktreeId })
+      .request("set-active", {
+        worktreeId: selectedWorktreeId,
+        origin: RENDERER_ACTIVATION_ORIGIN,
+      })
       .catch(() => {
         if (
           lastSyncedActiveRef.current.projectId === projectId &&

--- a/src/hooks/app/useActiveWorktreeSync.ts
+++ b/src/hooks/app/useActiveWorktreeSync.ts
@@ -7,7 +7,9 @@ import { useHomeDir } from "@/hooks/app/useHomeDir";
 import { resolveWorkspaceCwd } from "@/utils/workspaceCwd";
 import {
   RENDERER_ACTIVATION_ORIGIN,
+  clearHostAppliedActivation,
   consumeHostAppliedActivation,
+  markActivationRequested,
 } from "@/store/worktreeActivationOrigin";
 
 export function useActiveWorktreeSync() {
@@ -78,6 +80,7 @@ export function useActiveWorktreeSync() {
 
     if (!projectId || !selectedWorktreeId) {
       lastSyncedActiveRef.current = { projectId, worktreeId: null };
+      clearHostAppliedActivation();
       return;
     }
 
@@ -105,6 +108,7 @@ export function useActiveWorktreeSync() {
     // The selection is already applied locally; the origin tag lets the
     // `worktree-activated` echo be skipped instead of re-selecting an id this
     // view may have moved past by the time it lands (#12370).
+    markActivationRequested(selectedWorktreeId);
     window.electron.worktreePort
       .request("set-active", {
         worktreeId: selectedWorktreeId,

--- a/src/hooks/app/useActiveWorktreeSync.ts
+++ b/src/hooks/app/useActiveWorktreeSync.ts
@@ -15,6 +15,7 @@ import {
 export function useActiveWorktreeSync() {
   const { worktrees, isInitialized } = useWorktrees();
   const activeWorktreeId = useWorktreeSelectionStore((s) => s.activeWorktreeId);
+  const restoreWorktreeId = useWorktreeSelectionStore((s) => s.restoreWorktreeId);
   const selectWorktree = useWorktreeSelectionStore((s) => s.selectWorktree);
   const setActiveWorktree = useWorktreeSelectionStore((s) => s.setActiveWorktree);
   const deletedWorktrees = useWorktreeSelectionStore((s) => s.deletedWorktrees);
@@ -26,6 +27,8 @@ export function useActiveWorktreeSync() {
     projectId: null,
     worktreeId: null,
   });
+  const restoreRef = useRef(restoreWorktreeId);
+  restoreRef.current = restoreWorktreeId;
 
   const activeWorktree = useMemo(
     () => worktrees.find((w) => w.id === activeWorktreeId) ?? null,
@@ -107,8 +110,11 @@ export function useActiveWorktreeSync() {
     lastSyncedActiveRef.current = { projectId, worktreeId: selectedWorktreeId };
     // The selection is already applied locally; the origin tag lets the
     // `worktree-activated` echo be skipped instead of re-selecting an id this
-    // view may have moved past by the time it lands (#12370).
-    markActivationRequested(selectedWorktreeId);
+    // view may have moved past by the time it lands (#12370). Whether it was
+    // the durable pick is captured now, so a later catch-up re-apply can keep
+    // the source it was made with. Read at send time on purpose — a change to
+    // the restore target alone must not resend.
+    markActivationRequested(selectedWorktreeId, restoreRef.current === selectedWorktreeId);
     window.electron.worktreePort
       .request("set-active", {
         worktreeId: selectedWorktreeId,

--- a/src/hooks/app/useActiveWorktreeSync.ts
+++ b/src/hooks/app/useActiveWorktreeSync.ts
@@ -5,7 +5,10 @@ import { useProjectStore } from "@/store";
 import { useScratchStore } from "@/store/scratchStore";
 import { useHomeDir } from "@/hooks/app/useHomeDir";
 import { resolveWorkspaceCwd } from "@/utils/workspaceCwd";
-import { RENDERER_ACTIVATION_ORIGIN } from "@/store/worktreeActivationOrigin";
+import {
+  RENDERER_ACTIVATION_ORIGIN,
+  consumeHostAppliedActivation,
+} from "@/store/worktreeActivationOrigin";
 
 export function useActiveWorktreeSync() {
   const { worktrees, isInitialized } = useWorktrees();
@@ -75,6 +78,14 @@ export function useActiveWorktreeSync() {
 
     if (!projectId || !selectedWorktreeId) {
       lastSyncedActiveRef.current = { projectId, worktreeId: null };
+      return;
+    }
+
+    // A selection the host pushed to us (auto-switch, another window) is
+    // already the host's active id — answering with a `set-active` would only
+    // start another round of activations for every attached view (#12370).
+    if (consumeHostAppliedActivation(selectedWorktreeId)) {
+      lastSyncedActiveRef.current = { projectId, worktreeId: selectedWorktreeId };
       return;
     }
 

--- a/src/store/__tests__/focusFollowBreaker.test.ts
+++ b/src/store/__tests__/focusFollowBreaker.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest";
+import { createFocusFollowBreaker } from "../focusFollowBreaker";
+
+function makeClock(start = 1_000) {
+  let t = start;
+  return {
+    now: () => t,
+    advance: (ms: number) => {
+      t += ms;
+    },
+  };
+}
+
+// A→B→A→B: the two-state toggle the incident showed.
+function promotion(n: number) {
+  return n % 2 === 0
+    ? { from: "wt-a", to: "wt-b", panelId: "term-b" }
+    : { from: "wt-b", to: "wt-a", panelId: "term-a" };
+}
+
+function makeBreaker(clock: ReturnType<typeof makeClock>) {
+  return createFocusFollowBreaker({
+    threshold: 4,
+    windowMs: 1_000,
+    cooldownMs: 500,
+    now: clock.now,
+  });
+}
+
+describe("createFocusFollowBreaker (#12370)", () => {
+  it("allows promotions below the threshold and blocks the one that reaches it", () => {
+    const clock = makeClock();
+    const breaker = makeBreaker(clock);
+
+    expect([0, 1, 2].map((n) => breaker.record(promotion(n)))).toEqual(["allow", "allow", "allow"]);
+    expect(breaker.snapshot().tripped).toBe(false);
+
+    expect(breaker.record(promotion(3))).toBe("tripped");
+    const snap = breaker.snapshot();
+    expect(snap.tripped).toBe(true);
+    expect(snap.history.map((p) => p.to)).toEqual(["wt-b", "wt-a", "wt-b", "wt-a"]);
+    expect(snap.history.every((p) => p.at === clock.now())).toBe(true);
+  });
+
+  it("forgets promotions that fall outside the window", () => {
+    const clock = makeClock();
+    const breaker = makeBreaker(clock);
+
+    for (let n = 0; n < 3; n++) breaker.record(promotion(n));
+    clock.advance(1_001);
+    // The three above are now older than the window, so this one starts over.
+    expect(breaker.record(promotion(3))).toBe("allow");
+    expect(breaker.snapshot().history).toHaveLength(1);
+
+    expect(breaker.record(promotion(4))).toBe("allow");
+    expect(breaker.record(promotion(5))).toBe("allow");
+    expect(breaker.record(promotion(6))).toBe("tripped");
+  });
+
+  it("suppresses every attempt during the hold and extends the hold on each one", () => {
+    const clock = makeClock();
+    const breaker = makeBreaker(clock);
+    for (let n = 0; n < 4; n++) breaker.record(promotion(n));
+
+    // Each attempt lands inside the previous attempt's cooldown, so the hold
+    // never elapses even though 1.2 s > cooldownMs has passed since the trip.
+    clock.advance(400);
+    expect(breaker.record(promotion(4))).toBe("suppressed");
+    clock.advance(400);
+    expect(breaker.record(promotion(5))).toBe("suppressed");
+    clock.advance(400);
+    expect(breaker.record(promotion(6))).toBe("suppressed");
+
+    const snap = breaker.snapshot();
+    expect(snap.tripped).toBe(true);
+    expect(snap.suppressedCount).toBe(3);
+    // Suppressed attempts are not added to the ring.
+    expect(snap.history).toHaveLength(4);
+  });
+
+  it("releases after a quiet cooldown, reports the release once, and starts a fresh window", () => {
+    const clock = makeClock();
+    const breaker = makeBreaker(clock);
+    for (let n = 0; n < 4; n++) breaker.record(promotion(n));
+    clock.advance(200);
+    breaker.record(promotion(4));
+    expect(breaker.snapshot().suppressedCount).toBe(1);
+
+    clock.advance(501);
+    expect(breaker.record(promotion(5))).toBe("recovered");
+    const snap = breaker.snapshot();
+    expect(snap.tripped).toBe(false);
+    expect(snap.history).toHaveLength(1);
+    // Still reports the hold that just ended, for the release log line.
+    expect(snap.suppressedCount).toBe(1);
+
+    // A second burst counts from the recovery promotion, not from zero.
+    expect(breaker.record(promotion(6))).toBe("allow");
+    expect(breaker.record(promotion(7))).toBe("allow");
+    expect(breaker.record(promotion(8))).toBe("tripped");
+    expect(breaker.snapshot().suppressedCount).toBe(0);
+  });
+
+  it("reset clears the window, the hold, and the counters", () => {
+    const clock = makeClock();
+    const breaker = makeBreaker(clock);
+    for (let n = 0; n < 5; n++) breaker.record(promotion(n));
+    expect(breaker.snapshot().tripped).toBe(true);
+
+    breaker.reset();
+    expect(breaker.snapshot()).toEqual({ tripped: false, history: [], suppressedCount: 0 });
+    expect(breaker.record(promotion(0))).toBe("allow");
+  });
+});

--- a/src/store/__tests__/focusFollowBreaker.test.ts
+++ b/src/store/__tests__/focusFollowBreaker.test.ts
@@ -11,7 +11,8 @@ function makeClock(start = 1_000) {
   };
 }
 
-// A→B→A→B: the two-state toggle the incident showed.
+// A→B→A→B: the two-state toggle the incident showed. Only the first hop is
+// fresh; every later one revisits.
 function promotion(n: number) {
   return n % 2 === 0
     ? { from: "wt-a", to: "wt-b", panelId: "term-b" }
@@ -27,88 +28,150 @@ function makeBreaker(clock: ReturnType<typeof makeClock>) {
   });
 }
 
+function trip(breaker: ReturnType<typeof makeBreaker>) {
+  for (let n = 0; n < 5; n++) breaker.record(promotion(n));
+  expect(breaker.snapshot().tripped).toBe(true);
+}
+
 describe("createFocusFollowBreaker (#12370)", () => {
-  it("allows promotions below the threshold and blocks the one that reaches it", () => {
+  it("allows revisits below the threshold and blocks the one that reaches it", () => {
     const clock = makeClock();
     const breaker = makeBreaker(clock);
 
-    expect([0, 1, 2].map((n) => breaker.record(promotion(n)))).toEqual(["allow", "allow", "allow"]);
+    expect([0, 1, 2, 3].map((n) => breaker.record(promotion(n)))).toEqual([
+      "allow",
+      "allow",
+      "allow",
+      "allow",
+    ]);
     expect(breaker.snapshot().tripped).toBe(false);
 
-    expect(breaker.record(promotion(3))).toBe("tripped");
+    expect(breaker.record(promotion(4))).toBe("tripped");
     const snap = breaker.snapshot();
     expect(snap.tripped).toBe(true);
-    expect(snap.history.map((p) => p.to)).toEqual(["wt-b", "wt-a", "wt-b", "wt-a"]);
+    expect(snap.history.map((p) => p.to)).toEqual(["wt-b", "wt-a", "wt-b", "wt-a", "wt-b"]);
+    expect(snap.history.map((p) => p.revisit)).toEqual([false, true, true, true, true]);
     expect(snap.history.every((p) => p.at === clock.now())).toBe(true);
+  });
+
+  it("does not count a one-way tour, however long", () => {
+    const clock = makeClock();
+    const breaker = makeBreaker(clock);
+
+    for (let i = 1; i <= 12; i++) {
+      expect(breaker.record({ from: `wt-${i}`, to: `wt-${i + 1}`, panelId: `t${i}` })).toBe(
+        "allow"
+      );
+    }
+    expect(breaker.snapshot().tripped).toBe(false);
+    // Bounded at twice the threshold so a pathological tour cannot grow it.
+    expect(breaker.snapshot().history).toHaveLength(8);
+  });
+
+  it("counts a return to either end of an earlier hop, so a three-way cycle still trips", () => {
+    const clock = makeClock();
+    const breaker = makeBreaker(clock);
+    const cycle = [
+      { from: "wt-a", to: "wt-b", panelId: "tb" },
+      { from: "wt-b", to: "wt-c", panelId: "tc" },
+      { from: "wt-c", to: "wt-a", panelId: "ta" },
+    ];
+
+    const outcomes = [0, 1, 2, 3, 4, 5].map((n) => breaker.record(cycle[n % 3]!));
+
+    // Hops 1–2 are fresh; hop 3 returns to wt-a; hops 4–6 revisit too.
+    expect(outcomes).toEqual(["allow", "allow", "allow", "allow", "allow", "tripped"]);
+    expect(breaker.snapshot().history.map((p) => p.revisit)).toEqual([
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+    ]);
   });
 
   it("forgets promotions that fall outside the window", () => {
     const clock = makeClock();
     const breaker = makeBreaker(clock);
 
-    for (let n = 0; n < 3; n++) breaker.record(promotion(n));
+    for (let n = 0; n < 4; n++) breaker.record(promotion(n));
     clock.advance(1_001);
-    // The three above are now older than the window, so this one starts over.
-    expect(breaker.record(promotion(3))).toBe("allow");
-    expect(breaker.snapshot().history).toHaveLength(1);
-
+    // Everything above is now older than the window, so this hop is fresh.
     expect(breaker.record(promotion(4))).toBe("allow");
-    expect(breaker.record(promotion(5))).toBe("allow");
-    expect(breaker.record(promotion(6))).toBe("tripped");
+    expect(breaker.snapshot().history).toHaveLength(1);
+    expect(breaker.snapshot().history[0]!.revisit).toBe(false);
+
+    for (let n = 5; n < 8; n++) expect(breaker.record(promotion(n))).toBe("allow");
+    expect(breaker.record(promotion(8))).toBe("tripped");
   });
 
   it("suppresses every attempt during the hold and extends the hold on each one", () => {
     const clock = makeClock();
     const breaker = makeBreaker(clock);
-    for (let n = 0; n < 4; n++) breaker.record(promotion(n));
+    trip(breaker);
 
     // Each attempt lands inside the previous attempt's cooldown, so the hold
     // never elapses even though 1.2 s > cooldownMs has passed since the trip.
     clock.advance(400);
-    expect(breaker.record(promotion(4))).toBe("suppressed");
-    clock.advance(400);
     expect(breaker.record(promotion(5))).toBe("suppressed");
+    expect(breaker.holdRemainingMs()).toBe(500);
     clock.advance(400);
     expect(breaker.record(promotion(6))).toBe("suppressed");
+    clock.advance(400);
+    expect(breaker.record(promotion(7))).toBe("suppressed");
 
     const snap = breaker.snapshot();
     expect(snap.tripped).toBe(true);
     expect(snap.suppressedCount).toBe(3);
     // Suppressed attempts are not added to the ring.
-    expect(snap.history).toHaveLength(4);
+    expect(snap.history).toHaveLength(5);
+  });
+
+  it("reports how long the hold has left, and zero once it has lapsed or was never held", () => {
+    const clock = makeClock();
+    const breaker = makeBreaker(clock);
+    expect(breaker.holdRemainingMs()).toBe(0);
+
+    trip(breaker);
+    expect(breaker.holdRemainingMs()).toBe(500);
+    clock.advance(200);
+    expect(breaker.holdRemainingMs()).toBe(300);
+    clock.advance(400);
+    expect(breaker.holdRemainingMs()).toBe(0);
   });
 
   it("releases after a quiet cooldown, reports the release once, and starts a fresh window", () => {
     const clock = makeClock();
     const breaker = makeBreaker(clock);
-    for (let n = 0; n < 4; n++) breaker.record(promotion(n));
+    trip(breaker);
     clock.advance(200);
-    breaker.record(promotion(4));
+    breaker.record(promotion(5));
     expect(breaker.snapshot().suppressedCount).toBe(1);
 
     clock.advance(501);
-    expect(breaker.record(promotion(5))).toBe("recovered");
+    expect(breaker.record(promotion(6))).toBe("recovered");
     const snap = breaker.snapshot();
     expect(snap.tripped).toBe(false);
     expect(snap.history).toHaveLength(1);
+    expect(snap.history[0]!.revisit).toBe(false);
     // Still reports the hold that just ended, for the release log line.
     expect(snap.suppressedCount).toBe(1);
 
     // A second burst counts from the recovery promotion, not from zero.
-    expect(breaker.record(promotion(6))).toBe("allow");
-    expect(breaker.record(promotion(7))).toBe("allow");
-    expect(breaker.record(promotion(8))).toBe("tripped");
+    for (let n = 7; n < 10; n++) expect(breaker.record(promotion(n))).toBe("allow");
+    expect(breaker.record(promotion(10))).toBe("tripped");
     expect(breaker.snapshot().suppressedCount).toBe(0);
   });
 
   it("reset clears the window, the hold, and the counters", () => {
     const clock = makeClock();
     const breaker = makeBreaker(clock);
-    for (let n = 0; n < 5; n++) breaker.record(promotion(n));
-    expect(breaker.snapshot().tripped).toBe(true);
+    trip(breaker);
 
     breaker.reset();
     expect(breaker.snapshot()).toEqual({ tripped: false, history: [], suppressedCount: 0 });
+    expect(breaker.holdRemainingMs()).toBe(0);
     expect(breaker.record(promotion(0))).toBe("allow");
   });
 });

--- a/src/store/__tests__/focusFollowBreaker.test.ts
+++ b/src/store/__tests__/focusFollowBreaker.test.ts
@@ -24,6 +24,7 @@ function makeBreaker(clock: ReturnType<typeof makeClock>) {
     threshold: 4,
     windowMs: 1_000,
     cooldownMs: 500,
+    maxCooldownMs: 1_500,
     now: clock.now,
   });
 }
@@ -64,8 +65,7 @@ describe("createFocusFollowBreaker (#12370)", () => {
       );
     }
     expect(breaker.snapshot().tripped).toBe(false);
-    // Bounded at twice the threshold so a pathological tour cannot grow it.
-    expect(breaker.snapshot().history).toHaveLength(8);
+    expect(breaker.snapshot().history).toHaveLength(12);
   });
 
   it("counts a return to either end of an earlier hop, so a three-way cycle still trips", () => {
@@ -89,6 +89,25 @@ describe("createFocusFollowBreaker (#12370)", () => {
       true,
       true,
     ]);
+  });
+
+  it("is bounded by time only, so a cycle wider than any count-based ring still trips", () => {
+    const clock = makeClock();
+    const breaker = makeBreaker(clock);
+    const width = 18;
+    const hop = (n: number) => ({
+      from: `wt-${n % width}`,
+      to: `wt-${(n + 1) % width}`,
+      panelId: `t${(n + 1) % width}`,
+    });
+
+    // The last hop of the first rotation already returns to the start
+    // worktree (it was the `from` of the first hop), and every hop after it
+    // revisits too, so the trip comes on the (width + threshold − 1)th
+    // promotion — well past any count-based ring of 2×threshold.
+    for (let n = 0; n < width + 2; n++) expect(breaker.record(hop(n))).toBe("allow");
+    expect(breaker.record(hop(width + 2))).toBe("tripped");
+    expect(breaker.snapshot().history).toHaveLength(width + 3);
   });
 
   it("forgets promotions that fall outside the window", () => {
@@ -164,13 +183,70 @@ describe("createFocusFollowBreaker (#12370)", () => {
     expect(breaker.snapshot().suppressedCount).toBe(0);
   });
 
-  it("reset clears the window, the hold, and the counters", () => {
+  it("doubles the hold when a trip follows a release inside the window, up to the ceiling", () => {
     const clock = makeClock();
     const breaker = makeBreaker(clock);
     trip(breaker);
+    expect(breaker.snapshot().holdMs).toBe(500);
+
+    // A writer that only reacts to switches goes quiet while held and
+    // restarts the moment the release promotes again: the recovery hop plus
+    // the burst re-trip immediately.
+    const retripAfterRelease = () => {
+      clock.advance(breaker.holdRemainingMs() + 1);
+      expect(breaker.record(promotion(0))).toBe("recovered");
+      for (let n = 1; n < 4; n++) expect(breaker.record(promotion(n))).toBe("allow");
+      expect(breaker.record(promotion(4))).toBe("tripped");
+    };
+
+    retripAfterRelease();
+    expect(breaker.snapshot().holdMs).toBe(1_000);
+    expect(breaker.holdRemainingMs()).toBe(1_000);
+    retripAfterRelease();
+    expect(breaker.snapshot().holdMs).toBe(1_500);
+    retripAfterRelease();
+    expect(breaker.snapshot().holdMs).toBe(1_500);
+
+    // Suppressed attempts extend by the backed-off hold, not the base one.
+    clock.advance(100);
+    expect(breaker.record(promotion(5))).toBe("suppressed");
+    expect(breaker.holdRemainingMs()).toBe(1_500);
+  });
+
+  it("goes back to the base hold once a release sticks for a full window", () => {
+    const clock = makeClock();
+    const breaker = makeBreaker(clock);
+    trip(breaker);
+    clock.advance(501);
+    expect(breaker.record(promotion(0))).toBe("recovered");
+    for (let n = 1; n < 5; n++) breaker.record(promotion(n));
+    expect(breaker.snapshot().holdMs).toBe(1_000);
+
+    // Release, then nothing for longer than the window: the writer is gone.
+    clock.advance(1_001);
+    expect(breaker.record(promotion(0))).toBe("recovered");
+    clock.advance(1_001);
+    for (let n = 1; n < 6; n++) breaker.record(promotion(n));
+    expect(breaker.snapshot().tripped).toBe(true);
+    expect(breaker.snapshot().holdMs).toBe(500);
+  });
+
+  it("reset clears the window, the hold, the backoff, and the counters", () => {
+    const clock = makeClock();
+    const breaker = makeBreaker(clock);
+    trip(breaker);
+    clock.advance(501);
+    breaker.record(promotion(0));
+    for (let n = 1; n < 5; n++) breaker.record(promotion(n));
+    expect(breaker.snapshot().holdMs).toBe(1_000);
 
     breaker.reset();
-    expect(breaker.snapshot()).toEqual({ tripped: false, history: [], suppressedCount: 0 });
+    expect(breaker.snapshot()).toEqual({
+      tripped: false,
+      holdMs: 500,
+      history: [],
+      suppressedCount: 0,
+    });
     expect(breaker.holdRemainingMs()).toBe(0);
     expect(breaker.record(promotion(0))).toBe("allow");
   });

--- a/src/store/__tests__/rendererStoreOrchestrator.test.ts
+++ b/src/store/__tests__/rendererStoreOrchestrator.test.ts
@@ -77,7 +77,18 @@ vi.mock("../worktreeStore", async (importOriginal) => {
   };
 });
 
+vi.mock("@/utils/logger", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/utils/logger")>();
+  return {
+    ...actual,
+    logDebug: vi.fn(),
+    logInfo: vi.fn(),
+    logWarn: vi.fn(),
+  };
+});
+
 const { usePanelStore } = await import("../panelStore");
+const { logDebug, logInfo, logWarn } = await import("@/utils/logger");
 const { useWorktreeSelectionStore, persistMruList, suppressMruRecording } =
   await import("../worktreeStore");
 const { useTerminalInputStore } = await import("../terminalInputStore");
@@ -1363,6 +1374,172 @@ describe("rendererStoreOrchestrator", () => {
 
     // Worktree should NOT have been switched since orchestrator is destroyed
     expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-1");
+  });
+
+  describe("focus-follow breaker (#12370)", () => {
+    const panel = (id: string, worktreeId: string) => ({
+      id,
+      title: id,
+      kind: "terminal" as const,
+      cwd: "/test",
+      cols: 80,
+      rows: 24,
+      location: "grid" as const,
+      worktreeId,
+    });
+
+    function seedTwoWorktrees() {
+      useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-1", restoreWorktreeId: "wt-1" });
+      usePanelStore.setState({
+        panelsById: { "term-1": panel("term-1", "wt-1"), "term-2": panel("term-2", "wt-2") },
+        panelIds: ["term-1", "term-2"],
+        focusedId: "term-1",
+      });
+    }
+
+    // Two writers disagreeing about focus, as the incident's persisted state
+    // showed: focus alternates across the worktree boundary and each flip
+    // asks the orchestrator to follow. Returns the active id after each flip.
+    function pingPong(flips: number): Array<string | null> {
+      const seen: Array<string | null> = [];
+      for (let i = 0; i < flips; i++) {
+        usePanelStore.setState({ focusedId: i % 2 === 0 ? "term-2" : "term-1" });
+        seen.push(useWorktreeSelectionStore.getState().activeWorktreeId);
+      }
+      return seen;
+    }
+
+    // Focus is on the other worktree's terminal once the breaker holds, so a
+    // fresh attempt needs a same-worktree hop first; only the second write
+    // crosses the boundary.
+    function crossFlip() {
+      usePanelStore.setState({ focusedId: "term-2" });
+      usePanelStore.setState({ focusedId: "term-1" });
+    }
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("stops following focus at the eighth cross-worktree promotion inside the window", () => {
+      seedTwoWorktrees();
+
+      const seen = pingPong(10);
+
+      expect(seen.slice(0, 7)).toEqual(["wt-2", "wt-1", "wt-2", "wt-1", "wt-2", "wt-1", "wt-2"]);
+      // The eighth trips and is dropped; everything after is suppressed.
+      expect(seen.slice(7)).toEqual(["wt-2", "wt-2", "wt-2"]);
+
+      expect(logWarn).toHaveBeenCalledTimes(1);
+      const [message, context] = vi.mocked(logWarn).mock.calls[0]!;
+      expect(message).toContain("breaker tripped");
+      // The warning carries the whole window — the A→B→A pattern plus the
+      // writer's stack for every hop — so an incident log is diagnosable
+      // without a live capture.
+      const hop = (from: string, to: string) =>
+        expect.objectContaining({ from, to, stack: expect.any(String) });
+      expect(context).toEqual(
+        expect.objectContaining({
+          from: "wt-2",
+          to: "wt-1",
+          panelId: "term-1",
+          promotions: [
+            hop("wt-1", "wt-2"),
+            hop("wt-2", "wt-1"),
+            hop("wt-1", "wt-2"),
+            hop("wt-2", "wt-1"),
+            hop("wt-1", "wt-2"),
+            hop("wt-2", "wt-1"),
+            hop("wt-1", "wt-2"),
+            hop("wt-2", "wt-1"),
+          ],
+        })
+      );
+      // Once held, focus sits on wt-1's terminal while wt-2 stays active, so
+      // only every other flip crosses the boundary: flips 9 and 10 are one
+      // same-worktree hop and one suppressed attempt.
+      expect(logDebug).toHaveBeenCalledWith(
+        expect.stringContaining("suppressed"),
+        expect.objectContaining({ from: "wt-2", to: "wt-1", suppressedCount: 1 })
+      );
+
+      // Focus-sourced switches never touch the durable selection or record a
+      // worktree MRU entry — the property that made the incident invisible in
+      // persisted state, and the property the breaker must preserve.
+      expect(useWorktreeSelectionStore.getState().restoreWorktreeId).toBe("wt-1");
+      expect(usePanelStore.getState().mruList.some((e) => e.startsWith("worktree:"))).toBe(false);
+    });
+
+    it("keeps holding while attempts keep arriving, even past the cooldown length", () => {
+      vi.useFakeTimers();
+      seedTwoWorktrees();
+      pingPong(8);
+      expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-2");
+
+      vi.advanceTimersByTime(1_500);
+      crossFlip();
+      expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-2");
+
+      // 3 s since the trip, but only 1.5 s since the last attempt.
+      vi.advanceTimersByTime(1_500);
+      crossFlip();
+      expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-2");
+      expect(logInfo).not.toHaveBeenCalled();
+    });
+
+    it("follows focus again once the writer has been quiet for the cooldown", () => {
+      vi.useFakeTimers();
+      seedTwoWorktrees();
+      // Eight flips trip the breaker; the tenth is a suppressed attempt.
+      pingPong(10);
+      expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-2");
+
+      vi.advanceTimersByTime(2_001);
+      crossFlip();
+
+      expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-1");
+      expect(logInfo).toHaveBeenCalledWith(
+        expect.stringContaining("released"),
+        expect.objectContaining({ suppressedCount: 1 })
+      );
+    });
+
+    it("starts each orchestrator lifetime with an open breaker", () => {
+      seedTwoWorktrees();
+      pingPong(8);
+      expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-2");
+
+      destroyStoreOrchestrator();
+      initStoreOrchestrator();
+      crossFlip();
+
+      expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-1");
+    });
+
+    it("does not promote on a callback whose focus a nested write already moved", () => {
+      destroyStoreOrchestrator();
+      seedTwoWorktrees();
+      // Registered before the orchestrator so it runs first in dispatch order
+      // and yanks focus back inside the same setState. The orchestrator's
+      // callback for the outer write still describes term-2; promoting on it
+      // would leave the active worktree disagreeing with the real focus —
+      // exactly the two-writer shape that sustains a ping-pong.
+      const unsubscribe = usePanelStore.subscribe(
+        (state) => state.focusedId,
+        (focusedId) => {
+          if (focusedId === "term-2") usePanelStore.setState({ focusedId: "term-1" });
+        }
+      );
+      initStoreOrchestrator();
+
+      try {
+        usePanelStore.setState({ focusedId: "term-2" });
+        expect(usePanelStore.getState().focusedId).toBe("term-1");
+        expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-1");
+      } finally {
+        unsubscribe();
+      }
+    });
   });
 
   describe("availability → agent-settings sync (issue #5158)", () => {

--- a/src/store/__tests__/rendererStoreOrchestrator.test.ts
+++ b/src/store/__tests__/rendererStoreOrchestrator.test.ts
@@ -1420,6 +1420,9 @@ describe("rendererStoreOrchestrator", () => {
     }
 
     afterEach(() => {
+      // Dispose the timer owner while the clock it armed against is still the
+      // fake one, so cancellation is real rather than a clock swap.
+      destroyStoreOrchestrator();
       vi.useRealTimers();
     });
 
@@ -1554,10 +1557,16 @@ describe("rendererStoreOrchestrator", () => {
       vi.useFakeTimers();
       seedTwoWorktrees();
       pingPong(9);
+      // Let the terminal-MRU persist debounce fire so the release timer is
+      // the only one left pending.
+      vi.advanceTimersByTime(1_000);
+      expect(vi.getTimerCount()).toBe(1);
 
       destroyStoreOrchestrator();
-      vi.advanceTimersByTime(3_000);
 
+      // Cancelled outright, not merely neutered by the liveness flag.
+      expect(vi.getTimerCount()).toBe(0);
+      vi.advanceTimersByTime(3_000);
       expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-1");
       expect(logInfo).not.toHaveBeenCalled();
     });

--- a/src/store/__tests__/rendererStoreOrchestrator.test.ts
+++ b/src/store/__tests__/rendererStoreOrchestrator.test.ts
@@ -1409,26 +1409,38 @@ describe("rendererStoreOrchestrator", () => {
       return seen;
     }
 
-    // Focus is on the other worktree's terminal once the breaker holds, so a
+    // The first flip is a fresh hop and every flip after it revisits, so the
+    // ninth flip is the eighth revisit and trips. Flip 8 landed on wt-1, so
+    // once held the active worktree is wt-1 with focus parked on term-2 — a
     // fresh attempt needs a same-worktree hop first; only the second write
     // crosses the boundary.
     function crossFlip() {
-      usePanelStore.setState({ focusedId: "term-2" });
       usePanelStore.setState({ focusedId: "term-1" });
+      usePanelStore.setState({ focusedId: "term-2" });
     }
 
     afterEach(() => {
       vi.useRealTimers();
     });
 
-    it("stops following focus at the eighth cross-worktree promotion inside the window", () => {
+    it("stops following focus once eight promotions in the window revisit worktrees already passed through", () => {
       seedTwoWorktrees();
 
-      const seen = pingPong(10);
+      const seen = pingPong(11);
 
-      expect(seen.slice(0, 7)).toEqual(["wt-2", "wt-1", "wt-2", "wt-1", "wt-2", "wt-1", "wt-2"]);
-      // The eighth trips and is dropped; everything after is suppressed.
-      expect(seen.slice(7)).toEqual(["wt-2", "wt-2", "wt-2"]);
+      expect(seen.slice(0, 8)).toEqual([
+        "wt-2",
+        "wt-1",
+        "wt-2",
+        "wt-1",
+        "wt-2",
+        "wt-1",
+        "wt-2",
+        "wt-1",
+      ]);
+      // The ninth trips and is dropped. Flip 10 lands back inside the active
+      // worktree; flip 11 is a suppressed attempt.
+      expect(seen.slice(8)).toEqual(["wt-1", "wt-1", "wt-1"]);
 
       expect(logWarn).toHaveBeenCalledTimes(1);
       const [message, context] = vi.mocked(logWarn).mock.calls[0]!;
@@ -1436,31 +1448,29 @@ describe("rendererStoreOrchestrator", () => {
       // The warning carries the whole window — the A→B→A pattern plus the
       // writer's stack for every hop — so an incident log is diagnosable
       // without a live capture.
-      const hop = (from: string, to: string) =>
-        expect.objectContaining({ from, to, stack: expect.any(String) });
+      const hop = (from: string, to: string, revisit: boolean) =>
+        expect.objectContaining({ from, to, revisit, stack: expect.any(String) });
       expect(context).toEqual(
         expect.objectContaining({
-          from: "wt-2",
-          to: "wt-1",
-          panelId: "term-1",
+          from: "wt-1",
+          to: "wt-2",
+          panelId: "term-2",
           promotions: [
-            hop("wt-1", "wt-2"),
-            hop("wt-2", "wt-1"),
-            hop("wt-1", "wt-2"),
-            hop("wt-2", "wt-1"),
-            hop("wt-1", "wt-2"),
-            hop("wt-2", "wt-1"),
-            hop("wt-1", "wt-2"),
-            hop("wt-2", "wt-1"),
+            hop("wt-1", "wt-2", false),
+            hop("wt-2", "wt-1", true),
+            hop("wt-1", "wt-2", true),
+            hop("wt-2", "wt-1", true),
+            hop("wt-1", "wt-2", true),
+            hop("wt-2", "wt-1", true),
+            hop("wt-1", "wt-2", true),
+            hop("wt-2", "wt-1", true),
+            hop("wt-1", "wt-2", true),
           ],
         })
       );
-      // Once held, focus sits on wt-1's terminal while wt-2 stays active, so
-      // only every other flip crosses the boundary: flips 9 and 10 are one
-      // same-worktree hop and one suppressed attempt.
       expect(logDebug).toHaveBeenCalledWith(
         expect.stringContaining("suppressed"),
-        expect.objectContaining({ from: "wt-2", to: "wt-1", suppressedCount: 1 })
+        expect.objectContaining({ from: "wt-1", to: "wt-2", suppressedCount: 1 })
       );
 
       // Focus-sourced switches never touch the durable selection or record a
@@ -1470,75 +1480,98 @@ describe("rendererStoreOrchestrator", () => {
       expect(usePanelStore.getState().mruList.some((e) => e.startsWith("worktree:"))).toBe(false);
     });
 
+    it("never trips on a one-way tour across many worktrees", () => {
+      // Cycling agents with the keyboard visits a fresh worktree every hop;
+      // nine cross-worktree promotions in a burst, and only the return to the
+      // first is a revisit.
+      const ids = Array.from({ length: 8 }, (_, i) => `wt-${i + 1}`);
+      useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-1" });
+      usePanelStore.setState({
+        panelsById: Object.fromEntries(ids.map((id) => [`term-${id}`, panel(`term-${id}`, id)])),
+        panelIds: ids.map((id) => `term-${id}`),
+        focusedId: "term-wt-1",
+      });
+
+      for (const id of ids.slice(1)) {
+        usePanelStore.setState({ focusedId: `term-${id}` });
+        expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe(id);
+      }
+      usePanelStore.setState({ focusedId: "term-wt-1" });
+
+      expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-1");
+      expect(logWarn).not.toHaveBeenCalled();
+    });
+
     it("keeps holding while attempts keep arriving, even past the cooldown length", () => {
       vi.useFakeTimers();
       seedTwoWorktrees();
-      pingPong(8);
-      expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-2");
+      pingPong(9);
+      expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-1");
 
       vi.advanceTimersByTime(1_500);
       crossFlip();
-      expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-2");
+      expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-1");
 
       // 3 s since the trip, but only 1.5 s since the last attempt.
       vi.advanceTimersByTime(1_500);
       crossFlip();
-      expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-2");
+      expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-1");
       expect(logInfo).not.toHaveBeenCalled();
     });
 
-    it("follows focus again once the writer has been quiet for the cooldown", () => {
+    it("catches the grid up to the parked focus once the writer has been quiet for the cooldown", () => {
       vi.useFakeTimers();
       seedTwoWorktrees();
-      // Eight flips trip the breaker; the tenth is a suppressed attempt.
-      pingPong(10);
-      expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-2");
-
-      vi.advanceTimersByTime(2_001);
-      crossFlip();
-
+      // Nine flips trip the breaker; the eleventh is a suppressed attempt that
+      // leaves focus parked on term-2 while wt-1 stays active.
+      pingPong(11);
       expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-1");
+
+      // No further focus write: re-activating the parked panel is invisible to
+      // the subscription, so the release timer has to do this on its own.
+      vi.advanceTimersByTime(2_001);
+
+      expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-2");
       expect(logInfo).toHaveBeenCalledWith(
         expect.stringContaining("released"),
         expect.objectContaining({ suppressedCount: 1 })
       );
     });
 
+    it("leaves the grid alone at release when focus is already back inside the active worktree", () => {
+      vi.useFakeTimers();
+      seedTwoWorktrees();
+      pingPong(9);
+      usePanelStore.setState({ focusedId: "term-1" });
+
+      vi.advanceTimersByTime(2_001);
+
+      expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-1");
+      expect(logInfo).not.toHaveBeenCalled();
+    });
+
+    it("drops the release timer with the orchestrator", () => {
+      vi.useFakeTimers();
+      seedTwoWorktrees();
+      pingPong(9);
+
+      destroyStoreOrchestrator();
+      vi.advanceTimersByTime(3_000);
+
+      expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-1");
+      expect(logInfo).not.toHaveBeenCalled();
+    });
+
     it("starts each orchestrator lifetime with an open breaker", () => {
       seedTwoWorktrees();
-      pingPong(8);
-      expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-2");
+      pingPong(9);
+      expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-1");
 
       destroyStoreOrchestrator();
       initStoreOrchestrator();
       crossFlip();
 
-      expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-1");
-    });
-
-    it("does not promote on a callback whose focus a nested write already moved", () => {
-      destroyStoreOrchestrator();
-      seedTwoWorktrees();
-      // Registered before the orchestrator so it runs first in dispatch order
-      // and yanks focus back inside the same setState. The orchestrator's
-      // callback for the outer write still describes term-2; promoting on it
-      // would leave the active worktree disagreeing with the real focus —
-      // exactly the two-writer shape that sustains a ping-pong.
-      const unsubscribe = usePanelStore.subscribe(
-        (state) => state.focusedId,
-        (focusedId) => {
-          if (focusedId === "term-2") usePanelStore.setState({ focusedId: "term-1" });
-        }
-      );
-      initStoreOrchestrator();
-
-      try {
-        usePanelStore.setState({ focusedId: "term-2" });
-        expect(usePanelStore.getState().focusedId).toBe("term-1");
-        expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-1");
-      } finally {
-        unsubscribe();
-      }
+      expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-2");
     });
   });
 

--- a/src/store/__tests__/rendererStoreOrchestrator.visibility.test.ts
+++ b/src/store/__tests__/rendererStoreOrchestrator.visibility.test.ts
@@ -72,6 +72,26 @@ vi.mock("@/services/SemanticAnalysisService", () => ({
   semanticAnalysisService: { unregisterTerminal: vi.fn() },
 }));
 
+// A controllable stand-in for main's view-lifecycle signals: a cached view
+// keeps reporting `document.visibilityState === "visible"`, so this is the
+// only way the orchestrator can learn nobody is looking.
+type LifecyclePhase = "cached" | "active" | "revealed";
+const viewCache = vi.hoisted(() => ({
+  cached: false,
+  listeners: new Set<(phase: "cached" | "active" | "revealed") => void>(),
+}));
+vi.mock("@/lib/viewCacheState", () => ({
+  isProjectViewCached: () => viewCache.cached,
+  subscribeProjectViewLifecycle: (listener: (phase: LifecyclePhase) => void) => {
+    viewCache.listeners.add(listener);
+    return () => viewCache.listeners.delete(listener);
+  },
+  __resetProjectViewCacheStateForTests: vi.fn(),
+}));
+function emitPhase(phase: LifecyclePhase): void {
+  for (const listener of Array.from(viewCache.listeners)) listener(phase);
+}
+
 const { initStoreOrchestrator, destroyStoreOrchestrator } =
   await import("../rendererStoreOrchestrator");
 const { usePanelStore } = await import("../panelStore");
@@ -115,6 +135,34 @@ describe("rendererStoreOrchestrator — focus-follow release while hidden (#1237
     destroyStoreOrchestrator();
     vi.useRealTimers();
     setHidden(false);
+    viewCache.cached = false;
+    viewCache.listeners.clear();
+  });
+
+  it("holds the release while the view is cached and runs it on reveal", () => {
+    viewCache.cached = true;
+    vi.advanceTimersByTime(2_001);
+    expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-1");
+
+    viewCache.cached = false;
+    emitPhase("revealed");
+
+    expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-2");
+  });
+
+  it("re-arms on warm activation, so a switch rollback that never reveals still releases", () => {
+    viewCache.cached = true;
+    vi.advanceTimersByTime(2_001);
+    expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-1");
+
+    viewCache.cached = false;
+    emitPhase("active");
+    // Not run on the signal itself — the view may still sit behind the
+    // anti-flash bridge — but on a fresh timer that re-checks.
+    expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-1");
+    vi.advanceTimersByTime(1);
+
+    expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-2");
   });
 
   it("holds the release while the document is hidden and runs it once shown again", () => {

--- a/src/store/__tests__/rendererStoreOrchestrator.visibility.test.ts
+++ b/src/store/__tests__/rendererStoreOrchestrator.visibility.test.ts
@@ -31,6 +31,7 @@ vi.mock("@/clients", () => ({
     onExit: vi.fn(),
     onAgentStateChanged: vi.fn(),
     onBroadcastResult: vi.fn().mockReturnValue(() => {}),
+    setFocusedTerminal: vi.fn(),
   },
   appClient: { setState: vi.fn().mockResolvedValue(undefined) },
   projectClient: {
@@ -73,10 +74,79 @@ vi.mock("@/services/SemanticAnalysisService", () => ({
 
 const { initStoreOrchestrator, destroyStoreOrchestrator } =
   await import("../rendererStoreOrchestrator");
+const { usePanelStore } = await import("../panelStore");
+const { useWorktreeSelectionStore } = await import("../worktreeStore");
 
 function setHidden(hidden: boolean): void {
   Object.defineProperty(document, "hidden", { configurable: true, value: hidden });
 }
+
+describe("rendererStoreOrchestrator — focus-follow release while hidden (#12370)", () => {
+  const panel = (id: string, worktreeId: string) => ({
+    id,
+    title: id,
+    kind: "terminal" as const,
+    cwd: "/test",
+    cols: 80,
+    rows: 24,
+    location: "grid" as const,
+    worktreeId,
+  });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    destroyStoreOrchestrator();
+    initStoreOrchestrator();
+    useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-1", restoreWorktreeId: "wt-1" });
+    usePanelStore.setState({
+      panelsById: { "term-1": panel("term-1", "wt-1"), "term-2": panel("term-2", "wt-2") },
+      panelIds: ["term-1", "term-2"],
+      focusedId: "term-1",
+    });
+    // Nine alternating flips: eight revisits, the ninth trips with wt-1
+    // active and focus parked on term-2.
+    for (let i = 0; i < 9; i++) {
+      usePanelStore.setState({ focusedId: i % 2 === 0 ? "term-2" : "term-1" });
+    }
+    expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-1");
+  });
+
+  afterEach(() => {
+    destroyStoreOrchestrator();
+    vi.useRealTimers();
+    setHidden(false);
+  });
+
+  it("holds the release while the document is hidden and runs it once shown again", () => {
+    setHidden(true);
+    vi.advanceTimersByTime(2_001);
+    // Switching a workspace nobody can see would re-run the terminal policy
+    // and push a set-active for nothing.
+    expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-1");
+
+    setHidden(false);
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-2");
+  });
+
+  it("runs the release straight away when the document is visible", () => {
+    vi.advanceTimersByTime(2_001);
+
+    expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-2");
+  });
+
+  it("forgets a pending release on destroy", () => {
+    setHidden(true);
+    vi.advanceTimersByTime(2_001);
+    destroyStoreOrchestrator();
+
+    setHidden(false);
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-1");
+  });
+});
 
 describe("rendererStoreOrchestrator — MRU flush on hide (#9914)", () => {
   beforeEach(() => {

--- a/src/store/focusFollowBreaker.ts
+++ b/src/store/focusFollowBreaker.ts
@@ -7,8 +7,10 @@
  * terminal policy and repaints the grid — and because the switches are
  * focus-sourced they leave no trace in persisted state. The seed writer is
  * not known, so the guard is rate-based rather than a re-entrancy flag: a
- * burst of cross-worktree promotions inside a short window is a fault, not a
- * state to keep serving.
+ * burst of promotions back onto worktrees the window already passed through
+ * (A→B→A, or A→B→C→A) is a fault, not a state to keep serving. A one-way tour
+ * across many worktrees — cycling agents with the keyboard — never revisits
+ * and never counts.
  *
  * Pure and clock-injected; no timers. Once tripped, every further attempt
  * extends the hold, so a sustained oscillator keeps the breaker open and it
@@ -24,12 +26,14 @@ export interface FocusPromotion {
 
 export interface RecordedFocusPromotion extends FocusPromotion {
   at: number;
+  /** The destination was already an end of a hop inside the window. */
+  revisit: boolean;
 }
 
 export type FocusFollowOutcome = "allow" | "recovered" | "tripped" | "suppressed";
 
 export interface FocusFollowBreakerOptions {
-  /** Promotions inside `windowMs` that trip the breaker; the Nth is blocked. */
+  /** Revisits inside `windowMs` that trip the breaker; the Nth is blocked. */
   threshold?: number;
   windowMs?: number;
   /** Quiet period with no attempts before promotions are served again. */
@@ -39,6 +43,8 @@ export interface FocusFollowBreakerOptions {
 
 export interface FocusFollowBreaker {
   record: (promotion: FocusPromotion) => FocusFollowOutcome;
+  /** Milliseconds until the hold lapses on its own; 0 when not held. */
+  holdRemainingMs: () => number;
   snapshot: () => {
     tripped: boolean;
     history: readonly RecordedFocusPromotion[];
@@ -65,9 +71,11 @@ export function createFocusFollowBreaker(
   // construction (fake timers) is honoured.
   const now = options.now ?? (() => Date.now());
 
-  // Never longer than `threshold`: recording stops at the trip and the window
-  // is cleared on release. The ring exists to show the A→B→A pattern and the
-  // writer stacks in the trip warning, not to keep an audit trail.
+  // Every promotion inside the window, revisit or not — a later hop needs
+  // the earlier ones to recognise a return, and the trip warning shows the
+  // whole pattern with the writer stacks. Bounded well above the trip point
+  // so a pathological tour cannot grow it; cleared on release.
+  const maxHistory = threshold * 2;
   const history: RecordedFocusPromotion[] = [];
   let holdUntil: number | null = null;
   let suppressedCount = 0;
@@ -87,14 +95,21 @@ export function createFocusFollowBreaker(
       }
 
       while (history.length > 0 && at - history[0]!.at > windowMs) history.shift();
-      history.push({ ...promotion, at });
+      const revisit = history.some((p) => p.to === promotion.to || p.from === promotion.to);
+      history.push({ ...promotion, at, revisit });
+      if (history.length > maxHistory) history.shift();
 
-      if (history.length >= threshold) {
+      let revisits = 0;
+      for (const p of history) if (p.revisit) revisits++;
+      if (revisits >= threshold) {
         holdUntil = at + cooldownMs;
         suppressedCount = 0;
         return "tripped";
       }
       return recovered ? "recovered" : "allow";
+    },
+    holdRemainingMs() {
+      return holdUntil === null ? 0 : Math.max(0, holdUntil - now());
     },
     snapshot() {
       return { tripped: holdUntil !== null, history: [...history], suppressedCount };

--- a/src/store/focusFollowBreaker.ts
+++ b/src/store/focusFollowBreaker.ts
@@ -1,0 +1,108 @@
+/**
+ * Rate breaker for the focus-follow worktree promotion (#12370).
+ *
+ * Focusing a terminal in another worktree promotes that worktree to active.
+ * Two `focusedId` writers that disagree about which terminal owns focus turn
+ * that promotion into a workspace-wide oscillation — every switch re-runs the
+ * terminal policy and repaints the grid — and because the switches are
+ * focus-sourced they leave no trace in persisted state. The seed writer is
+ * not known, so the guard is rate-based rather than a re-entrancy flag: a
+ * burst of cross-worktree promotions inside a short window is a fault, not a
+ * state to keep serving.
+ *
+ * Pure and clock-injected; no timers. Once tripped, every further attempt
+ * extends the hold, so a sustained oscillator keeps the breaker open and it
+ * only releases after the writer has been quiet for `cooldownMs`.
+ */
+
+export interface FocusPromotion {
+  from: string | null;
+  to: string;
+  panelId: string;
+  stack?: string;
+}
+
+export interface RecordedFocusPromotion extends FocusPromotion {
+  at: number;
+}
+
+export type FocusFollowOutcome = "allow" | "recovered" | "tripped" | "suppressed";
+
+export interface FocusFollowBreakerOptions {
+  /** Promotions inside `windowMs` that trip the breaker; the Nth is blocked. */
+  threshold?: number;
+  windowMs?: number;
+  /** Quiet period with no attempts before promotions are served again. */
+  cooldownMs?: number;
+  now?: () => number;
+}
+
+export interface FocusFollowBreaker {
+  record: (promotion: FocusPromotion) => FocusFollowOutcome;
+  snapshot: () => {
+    tripped: boolean;
+    history: readonly RecordedFocusPromotion[];
+    suppressedCount: number;
+  };
+  reset: () => void;
+}
+
+export const FOCUS_FOLLOW_BREAKER_DEFAULTS = {
+  threshold: 8,
+  windowMs: 5_000,
+  cooldownMs: 2_000,
+} as const;
+
+export function createFocusFollowBreaker(
+  options: FocusFollowBreakerOptions = {}
+): FocusFollowBreaker {
+  const threshold = options.threshold ?? FOCUS_FOLLOW_BREAKER_DEFAULTS.threshold;
+  const windowMs = options.windowMs ?? FOCUS_FOLLOW_BREAKER_DEFAULTS.windowMs;
+  const cooldownMs = options.cooldownMs ?? FOCUS_FOLLOW_BREAKER_DEFAULTS.cooldownMs;
+  // Wall clock on purpose: the `at` stamps in the trip warning line up with
+  // the rest of the log, and a wake-from-sleep jump only ever releases early.
+  // Resolved per call rather than captured, so a clock swapped in after
+  // construction (fake timers) is honoured.
+  const now = options.now ?? (() => Date.now());
+
+  // Never longer than `threshold`: recording stops at the trip and the window
+  // is cleared on release. The ring exists to show the A→B→A pattern and the
+  // writer stacks in the trip warning, not to keep an audit trail.
+  const history: RecordedFocusPromotion[] = [];
+  let holdUntil: number | null = null;
+  let suppressedCount = 0;
+
+  return {
+    record(promotion) {
+      const at = now();
+      if (holdUntil !== null && at < holdUntil) {
+        holdUntil = at + cooldownMs;
+        suppressedCount++;
+        return "suppressed";
+      }
+      const recovered = holdUntil !== null;
+      if (recovered) {
+        holdUntil = null;
+        history.length = 0;
+      }
+
+      while (history.length > 0 && at - history[0]!.at > windowMs) history.shift();
+      history.push({ ...promotion, at });
+
+      if (history.length >= threshold) {
+        holdUntil = at + cooldownMs;
+        suppressedCount = 0;
+        return "tripped";
+      }
+      return recovered ? "recovered" : "allow";
+    },
+    snapshot() {
+      return { tripped: holdUntil !== null, history: [...history], suppressedCount };
+    },
+    reset() {
+      history.length = 0;
+      holdUntil = null;
+      suppressedCount = 0;
+    },
+  };
+}

--- a/src/store/focusFollowBreaker.ts
+++ b/src/store/focusFollowBreaker.ts
@@ -14,7 +14,11 @@
  *
  * Pure and clock-injected; no timers. Once tripped, every further attempt
  * extends the hold, so a sustained oscillator keeps the breaker open and it
- * only releases after the writer has been quiet for `cooldownMs`.
+ * only releases after the writer has been quiet for the hold length. A trip
+ * that follows a release within the window means the writer only went quiet
+ * because promotions had stopped; each such failed recovery doubles the next
+ * hold, up to `maxCooldownMs`, so a switch-reactive writer decays to a burst a
+ * minute instead of one every few seconds.
  */
 
 export interface FocusPromotion {
@@ -38,6 +42,8 @@ export interface FocusFollowBreakerOptions {
   windowMs?: number;
   /** Quiet period with no attempts before promotions are served again. */
   cooldownMs?: number;
+  /** Ceiling for the doubled hold after repeated failed recoveries. */
+  maxCooldownMs?: number;
   now?: () => number;
 }
 
@@ -47,6 +53,8 @@ export interface FocusFollowBreaker {
   holdRemainingMs: () => number;
   snapshot: () => {
     tripped: boolean;
+    /** Length of the current (or most recent) hold, after backoff. */
+    holdMs: number;
     history: readonly RecordedFocusPromotion[];
     suppressedCount: number;
   };
@@ -57,6 +65,7 @@ export const FOCUS_FOLLOW_BREAKER_DEFAULTS = {
   threshold: 8,
   windowMs: 5_000,
   cooldownMs: 2_000,
+  maxCooldownMs: 60_000,
 } as const;
 
 export function createFocusFollowBreaker(
@@ -65,6 +74,7 @@ export function createFocusFollowBreaker(
   const threshold = options.threshold ?? FOCUS_FOLLOW_BREAKER_DEFAULTS.threshold;
   const windowMs = options.windowMs ?? FOCUS_FOLLOW_BREAKER_DEFAULTS.windowMs;
   const cooldownMs = options.cooldownMs ?? FOCUS_FOLLOW_BREAKER_DEFAULTS.cooldownMs;
+  const maxCooldownMs = options.maxCooldownMs ?? FOCUS_FOLLOW_BREAKER_DEFAULTS.maxCooldownMs;
   // Wall clock on purpose: the `at` stamps in the trip warning line up with
   // the rest of the log, and a wake-from-sleep jump only ever releases early.
   // Resolved per call rather than captured, so a clock swapped in after
@@ -73,36 +83,41 @@ export function createFocusFollowBreaker(
 
   // Every promotion inside the window, revisit or not — a later hop needs
   // the earlier ones to recognise a return, and the trip warning shows the
-  // whole pattern with the writer stacks. Bounded well above the trip point
-  // so a pathological tour cannot grow it; cleared on release.
-  const maxHistory = threshold * 2;
+  // whole pattern with the writer stacks. Bounded by time alone: with a
+  // finite set of worktrees every hop past the first visit to each is a
+  // revisit, so the ring cannot outgrow (worktrees + threshold) before it
+  // trips, and it is cleared on release.
   const history: RecordedFocusPromotion[] = [];
   let holdUntil: number | null = null;
+  let holdMs = cooldownMs;
+  let lastRecoveryAt: number | null = null;
   let suppressedCount = 0;
 
   return {
     record(promotion) {
       const at = now();
       if (holdUntil !== null && at < holdUntil) {
-        holdUntil = at + cooldownMs;
+        holdUntil = at + holdMs;
         suppressedCount++;
         return "suppressed";
       }
       const recovered = holdUntil !== null;
       if (recovered) {
         holdUntil = null;
+        lastRecoveryAt = at;
         history.length = 0;
       }
 
       while (history.length > 0 && at - history[0]!.at > windowMs) history.shift();
       const revisit = history.some((p) => p.to === promotion.to || p.from === promotion.to);
       history.push({ ...promotion, at, revisit });
-      if (history.length > maxHistory) history.shift();
 
       let revisits = 0;
       for (const p of history) if (p.revisit) revisits++;
       if (revisits >= threshold) {
-        holdUntil = at + cooldownMs;
+        const failedRecovery = lastRecoveryAt !== null && at - lastRecoveryAt <= windowMs;
+        holdMs = failedRecovery ? Math.min(holdMs * 2, maxCooldownMs) : cooldownMs;
+        holdUntil = at + holdMs;
         suppressedCount = 0;
         return "tripped";
       }
@@ -112,11 +127,13 @@ export function createFocusFollowBreaker(
       return holdUntil === null ? 0 : Math.max(0, holdUntil - now());
     },
     snapshot() {
-      return { tripped: holdUntil !== null, history: [...history], suppressedCount };
+      return { tripped: holdUntil !== null, holdMs, history: [...history], suppressedCount };
     },
     reset() {
       history.length = 0;
       holdUntil = null;
+      holdMs = cooldownMs;
+      lastRecoveryAt = null;
       suppressedCount = 0;
     },
   };

--- a/src/store/rendererStoreOrchestrator.ts
+++ b/src/store/rendererStoreOrchestrator.ts
@@ -37,8 +37,10 @@ import { getCurrentViewStoreOrNull } from "./createWorktreeStore";
 import { setActiveContextAccessors } from "@/lib/notify";
 import { debounce } from "@/utils/debounce";
 import { DisposableStore, toDisposable } from "@/utils/disposable";
+import { logDebug, logInfo, logWarn } from "@/utils/logger";
 import { isPtyPanel } from "@shared/types/panel";
 import { terminalClient } from "@/clients";
+import { createFocusFollowBreaker } from "./focusFollowBreaker";
 
 // Thunk form: read the live mruList at fire time, not at schedule time. A
 // snapshot captured at schedule time could be stale by the time the debounce
@@ -145,21 +147,67 @@ export function initStoreOrchestrator(): () => void {
   );
 
   // 1b. Active worktree switch: focusing a terminal that lives in a
-  //     different worktree promotes that worktree to active.
+  //     different worktree promotes that worktree to active. Rate-limited by
+  //     a breaker: two `focusedId` writers that disagree would otherwise
+  //     ping-pong the whole workspace through here at whatever cadence they
+  //     run, and focus-sourced switches leave no trace in persisted state
+  //     (#12370). One breaker per orchestrator lifetime — the subscription
+  //     that owns it is disposed with the rest.
+  const focusFollowBreaker = createFocusFollowBreaker();
   disposables.add(
     toDisposable(
       usePanelStore.subscribe(
         (state) => state.focusedId,
         (focusedId) => {
           if (!focusedId) return;
-          const terminal = usePanelStore.getState().panelsById[focusedId];
+          const panelState = usePanelStore.getState();
+          // A nested write during listener dispatch can leave this callback
+          // describing a focus that has already moved on. Promoting on it
+          // would make this subscription the second writer of a ping-pong.
+          if (panelState.focusedId !== focusedId) return;
+          const terminal = panelState.panelsById[focusedId];
           if (!terminal?.worktreeId) return;
           const worktreeState = useWorktreeSelectionStore.getState();
-          if (terminal.worktreeId !== worktreeState.activeWorktreeId) {
-            // Focus promotion is incidental, not a deliberate selection: mark it
-            // so it doesn't become the persisted restore target (#9512).
-            worktreeState.selectWorktree(terminal.worktreeId, { source: "focus" });
+          const from = worktreeState.activeWorktreeId;
+          const to = terminal.worktreeId;
+          if (to === from) return;
+
+          // Recorded before the switch so a synchronous nested promotion sees
+          // the updated count. The stack is captured inside Zustand's
+          // synchronous dispatch, so the frames above this listener are the
+          // writer that moved focus — the thing an incident log needs.
+          const outcome = focusFollowBreaker.record({
+            from,
+            to,
+            panelId: focusedId,
+            stack: new Error().stack,
+          });
+          if (outcome === "tripped") {
+            logWarn("[StoreOrchestrator] focus-follow oscillation detected — breaker tripped", {
+              from,
+              to,
+              panelId: focusedId,
+              promotions: focusFollowBreaker.snapshot().history,
+            });
+            return;
           }
+          if (outcome === "suppressed") {
+            logDebug("[StoreOrchestrator] focus promotion suppressed by breaker", {
+              from,
+              to,
+              panelId: focusedId,
+              suppressedCount: focusFollowBreaker.snapshot().suppressedCount,
+            });
+            return;
+          }
+          if (outcome === "recovered") {
+            logInfo("[StoreOrchestrator] focus-follow breaker released", {
+              suppressedCount: focusFollowBreaker.snapshot().suppressedCount,
+            });
+          }
+          // Focus promotion is incidental, not a deliberate selection: mark it
+          // so it doesn't become the persisted restore target (#9512).
+          worktreeState.selectWorktree(to, { source: "focus", focusedPanelId: focusedId });
         }
       )
     )

--- a/src/store/rendererStoreOrchestrator.ts
+++ b/src/store/rendererStoreOrchestrator.ts
@@ -151,63 +151,93 @@ export function initStoreOrchestrator(): () => void {
   //     a breaker: two `focusedId` writers that disagree would otherwise
   //     ping-pong the whole workspace through here at whatever cadence they
   //     run, and focus-sourced switches leave no trace in persisted state
-  //     (#12370). One breaker per orchestrator lifetime — the subscription
-  //     that owns it is disposed with the rest.
+  //     (#12370). One breaker per orchestrator lifetime, disposed with the
+  //     subscriptions.
+  //
+  //     While held, focus can sit on a terminal in a worktree that is not
+  //     active — hidden by the terminal policy — and nothing rewrites
+  //     `focusedId` just because time passed, so re-activating that same
+  //     panel is invisible to the subscription. The release timer re-runs the
+  //     promotion for whatever is focused once the hold lapses, so a burst of
+  //     deliberate cross-worktree navigation costs a short stall, not a stuck
+  //     grid.
   const focusFollowBreaker = createFocusFollowBreaker();
+  let focusFollowLive = true;
+  let focusFollowReleaseTimer: ReturnType<typeof setTimeout> | null = null;
+  const clearFocusFollowReleaseTimer = () => {
+    if (focusFollowReleaseTimer !== null) clearTimeout(focusFollowReleaseTimer);
+    focusFollowReleaseTimer = null;
+  };
+  const armFocusFollowRelease = () => {
+    clearFocusFollowReleaseTimer();
+    focusFollowReleaseTimer = setTimeout(() => {
+      focusFollowReleaseTimer = null;
+      // Guarded in the callback: a timer the event loop already picked up
+      // survives the clearTimeout in dispose.
+      if (!focusFollowLive) return;
+      const focusedId = usePanelStore.getState().focusedId;
+      if (focusedId) followFocusedWorktree(focusedId);
+    }, focusFollowBreaker.holdRemainingMs() + 1);
+  };
+  function followFocusedWorktree(focusedId: string): void {
+    const terminal = usePanelStore.getState().panelsById[focusedId];
+    if (!terminal?.worktreeId) return;
+    const worktreeState = useWorktreeSelectionStore.getState();
+    const from = worktreeState.activeWorktreeId;
+    const to = terminal.worktreeId;
+    if (to === from) return;
+
+    // Recorded before the switch so a synchronous nested promotion sees the
+    // updated count. The stack is captured inside Zustand's synchronous
+    // dispatch, so the frames above this listener are the writer that moved
+    // focus — the thing an incident log needs.
+    const outcome = focusFollowBreaker.record({
+      from,
+      to,
+      panelId: focusedId,
+      stack: new Error().stack,
+    });
+    if (outcome === "tripped") {
+      logWarn("[StoreOrchestrator] focus-follow oscillation detected — breaker tripped", {
+        from,
+        to,
+        panelId: focusedId,
+        promotions: focusFollowBreaker.snapshot().history,
+      });
+      armFocusFollowRelease();
+      return;
+    }
+    if (outcome === "suppressed") {
+      logDebug("[StoreOrchestrator] focus promotion suppressed by breaker", {
+        from,
+        to,
+        panelId: focusedId,
+        suppressedCount: focusFollowBreaker.snapshot().suppressedCount,
+      });
+      armFocusFollowRelease();
+      return;
+    }
+    if (outcome === "recovered") {
+      logInfo("[StoreOrchestrator] focus-follow breaker released", {
+        suppressedCount: focusFollowBreaker.snapshot().suppressedCount,
+      });
+    }
+    // Focus promotion is incidental, not a deliberate selection: mark it so
+    // it doesn't become the persisted restore target (#9512).
+    worktreeState.selectWorktree(to, { source: "focus", focusedPanelId: focusedId });
+  }
+  disposables.add(
+    toDisposable(() => {
+      focusFollowLive = false;
+      clearFocusFollowReleaseTimer();
+    })
+  );
   disposables.add(
     toDisposable(
       usePanelStore.subscribe(
         (state) => state.focusedId,
         (focusedId) => {
-          if (!focusedId) return;
-          const panelState = usePanelStore.getState();
-          // A nested write during listener dispatch can leave this callback
-          // describing a focus that has already moved on. Promoting on it
-          // would make this subscription the second writer of a ping-pong.
-          if (panelState.focusedId !== focusedId) return;
-          const terminal = panelState.panelsById[focusedId];
-          if (!terminal?.worktreeId) return;
-          const worktreeState = useWorktreeSelectionStore.getState();
-          const from = worktreeState.activeWorktreeId;
-          const to = terminal.worktreeId;
-          if (to === from) return;
-
-          // Recorded before the switch so a synchronous nested promotion sees
-          // the updated count. The stack is captured inside Zustand's
-          // synchronous dispatch, so the frames above this listener are the
-          // writer that moved focus — the thing an incident log needs.
-          const outcome = focusFollowBreaker.record({
-            from,
-            to,
-            panelId: focusedId,
-            stack: new Error().stack,
-          });
-          if (outcome === "tripped") {
-            logWarn("[StoreOrchestrator] focus-follow oscillation detected — breaker tripped", {
-              from,
-              to,
-              panelId: focusedId,
-              promotions: focusFollowBreaker.snapshot().history,
-            });
-            return;
-          }
-          if (outcome === "suppressed") {
-            logDebug("[StoreOrchestrator] focus promotion suppressed by breaker", {
-              from,
-              to,
-              panelId: focusedId,
-              suppressedCount: focusFollowBreaker.snapshot().suppressedCount,
-            });
-            return;
-          }
-          if (outcome === "recovered") {
-            logInfo("[StoreOrchestrator] focus-follow breaker released", {
-              suppressedCount: focusFollowBreaker.snapshot().suppressedCount,
-            });
-          }
-          // Focus promotion is incidental, not a deliberate selection: mark it
-          // so it doesn't become the persisted restore target (#9512).
-          worktreeState.selectWorktree(to, { source: "focus", focusedPanelId: focusedId });
+          if (focusedId) followFocusedWorktree(focusedId);
         }
       )
     )

--- a/src/store/rendererStoreOrchestrator.ts
+++ b/src/store/rendererStoreOrchestrator.ts
@@ -267,7 +267,16 @@ export function initStoreOrchestrator(): () => void {
   disposables.add(
     toDisposable(
       subscribeProjectViewLifecycle((phase) => {
-        if (phase === "revealed") runPendingFocusFollowRelease();
+        if (!focusFollowReleasePending) return;
+        if (phase === "revealed") {
+          runPendingFocusFollowRelease();
+        } else if (phase === "active") {
+          // Re-attached but possibly still behind the anti-flash bridge, and
+          // a switch rollback restores a view with only this signal. Re-arm
+          // rather than run, so the release lands once the view is
+          // observable (the callback re-checks).
+          armFocusFollowRelease();
+        }
       })
     )
   );

--- a/src/store/rendererStoreOrchestrator.ts
+++ b/src/store/rendererStoreOrchestrator.ts
@@ -41,6 +41,7 @@ import { logDebug, logInfo, logWarn } from "@/utils/logger";
 import { isPtyPanel } from "@shared/types/panel";
 import { terminalClient } from "@/clients";
 import { createFocusFollowBreaker } from "./focusFollowBreaker";
+import { isProjectViewCached, subscribeProjectViewLifecycle } from "@/lib/viewCacheState";
 
 // Thunk form: read the live mruList at fire time, not at schedule time. A
 // snapshot captured at schedule time could be stale by the time the debounce
@@ -160,24 +161,42 @@ export function initStoreOrchestrator(): () => void {
   //     panel is invisible to the subscription. The release timer re-runs the
   //     promotion for whatever is focused once the hold lapses, so a burst of
   //     deliberate cross-worktree navigation costs a short stall, not a stuck
-  //     grid.
+  //     grid. A view nobody can see (window hidden, or the view cached by
+  //     ProjectViewManager — which keeps reporting `visible`) holds the
+  //     release until it is shown again: switching a parked workspace would
+  //     re-run the terminal policy and push a `set-active` for nothing.
   const focusFollowBreaker = createFocusFollowBreaker();
   let focusFollowLive = true;
+  let focusFollowReleasePending = false;
   let focusFollowReleaseTimer: ReturnType<typeof setTimeout> | null = null;
   const clearFocusFollowReleaseTimer = () => {
     if (focusFollowReleaseTimer !== null) clearTimeout(focusFollowReleaseTimer);
     focusFollowReleaseTimer = null;
   };
+  const isViewUnobservable = () =>
+    (typeof document !== "undefined" && document.hidden) || isProjectViewCached();
+  const releaseFocusFollow = () => {
+    if (!focusFollowLive) return;
+    if (isViewUnobservable()) {
+      focusFollowReleasePending = true;
+      return;
+    }
+    focusFollowReleasePending = false;
+    const focusedId = usePanelStore.getState().focusedId;
+    if (focusedId) followFocusedWorktree(focusedId);
+  };
   const armFocusFollowRelease = () => {
     clearFocusFollowReleaseTimer();
+    focusFollowReleasePending = false;
     focusFollowReleaseTimer = setTimeout(() => {
       focusFollowReleaseTimer = null;
       // Guarded in the callback: a timer the event loop already picked up
       // survives the clearTimeout in dispose.
-      if (!focusFollowLive) return;
-      const focusedId = usePanelStore.getState().focusedId;
-      if (focusedId) followFocusedWorktree(focusedId);
+      releaseFocusFollow();
     }, focusFollowBreaker.holdRemainingMs() + 1);
+  };
+  const runPendingFocusFollowRelease = () => {
+    if (focusFollowReleasePending) releaseFocusFollow();
   };
   function followFocusedWorktree(focusedId: string): void {
     const terminal = usePanelStore.getState().panelsById[focusedId];
@@ -198,11 +217,13 @@ export function initStoreOrchestrator(): () => void {
       stack: new Error().stack,
     });
     if (outcome === "tripped") {
+      const { holdMs, history } = focusFollowBreaker.snapshot();
       logWarn("[StoreOrchestrator] focus-follow oscillation detected — breaker tripped", {
         from,
         to,
         panelId: focusedId,
-        promotions: focusFollowBreaker.snapshot().history,
+        holdMs,
+        promotions: history,
       });
       armFocusFollowRelease();
       return;
@@ -229,6 +250,7 @@ export function initStoreOrchestrator(): () => void {
   disposables.add(
     toDisposable(() => {
       focusFollowLive = false;
+      focusFollowReleasePending = false;
       clearFocusFollowReleaseTimer();
     })
   );
@@ -242,6 +264,24 @@ export function initStoreOrchestrator(): () => void {
       )
     )
   );
+  disposables.add(
+    toDisposable(
+      subscribeProjectViewLifecycle((phase) => {
+        if (phase === "revealed") runPendingFocusFollowRelease();
+      })
+    )
+  );
+  if (typeof document !== "undefined") {
+    const handleFocusFollowVisibility = () => {
+      if (!document.hidden) runPendingFocusFollowRelease();
+    };
+    document.addEventListener("visibilitychange", handleFocusFollowVisibility);
+    disposables.add(
+      toDisposable(() =>
+        document.removeEventListener("visibilitychange", handleFocusFollowVisibility)
+      )
+    );
+  }
 
   // 1c. Terminal MRU recording: append the newly focused terminal to the
   //     MRU list and persist it (debounced) unless suppressed. Only PTY

--- a/src/store/worktreeActivationOrigin.ts
+++ b/src/store/worktreeActivationOrigin.ts
@@ -6,18 +6,24 @@
 // own V8 context, so module scope is per view.
 export const RENDERER_ACTIVATION_ORIGIN = `renderer-${crypto.randomUUID()}`;
 
-// The last id this view asked the host for. An own echo is normally
-// redundant, but the echo of the *latest* request landing while another
-// window's activation has displaced it is the ack of this view's intent, and
-// re-asserting it is what brings both windows and the host back together.
-let latestRequestedWorktreeId: string | null = null;
-
-export function markActivationRequested(worktreeId: string): void {
-  latestRequestedWorktreeId = worktreeId;
+export interface ActivationRequest {
+  worktreeId: string;
+  /** The selection was the durable restore target when it was sent. */
+  durable: boolean;
 }
 
-export function latestActivationRequest(): string | null {
-  return latestRequestedWorktreeId;
+// The last request this view sent. An own echo is normally redundant, but
+// when another window's activation has displaced this view's latest request,
+// the echo of that request is the host telling us it holds our pick after
+// all — re-applying it locally (never re-sending) brings the views together.
+let latestRequest: ActivationRequest | null = null;
+
+export function markActivationRequested(worktreeId: string, durable: boolean): void {
+  latestRequest = { worktreeId, durable };
+}
+
+export function latestActivationRequest(): ActivationRequest | null {
+  return latestRequest;
 }
 
 // The selection the host itself just pushed, if any. The host already holds
@@ -44,5 +50,5 @@ export function clearHostAppliedActivation(): void {
 
 export function _resetHostAppliedActivationForTesting(): void {
   hostAppliedWorktreeId = null;
-  latestRequestedWorktreeId = null;
+  latestRequest = null;
 }

--- a/src/store/worktreeActivationOrigin.ts
+++ b/src/store/worktreeActivationOrigin.ts
@@ -1,6 +1,29 @@
 // Identity stamped on the renderer's own `set-active` requests so the host's
 // `worktree-activated` echo of a selection this view already applied can be
 // told apart from a host-originated activation (auto-switch after a delete,
-// topology reconcile, Main-originated IPC) that it must still apply (#12370).
-// Each project view runs in its own V8 context, so module scope is per view.
+// topology reconcile, Main-originated IPC, another window on the same
+// project) that it must still apply (#12370). Each project view runs in its
+// own V8 context, so module scope is per view.
 export const RENDERER_ACTIVATION_ORIGIN = `renderer-${crypto.randomUUID()}`;
+
+// The selection the host itself just pushed, if any. The host already holds
+// it, so `useActiveWorktreeSync` must not answer with a `set-active` — with
+// two windows on one project that answer is the next hop of an echo loop:
+// each view applies the other's activation and sends it back under its own
+// origin, seq climbing forever. Single-slot: the sync effect consumes it on
+// the very next selection change, matching or not.
+let hostAppliedWorktreeId: string | null = null;
+
+export function markHostActivationApplied(worktreeId: string): void {
+  hostAppliedWorktreeId = worktreeId;
+}
+
+export function consumeHostAppliedActivation(worktreeId: string): boolean {
+  const matched = hostAppliedWorktreeId === worktreeId;
+  hostAppliedWorktreeId = null;
+  return matched;
+}
+
+export function _resetHostAppliedActivationForTesting(): void {
+  hostAppliedWorktreeId = null;
+}

--- a/src/store/worktreeActivationOrigin.ts
+++ b/src/store/worktreeActivationOrigin.ts
@@ -1,0 +1,6 @@
+// Identity stamped on the renderer's own `set-active` requests so the host's
+// `worktree-activated` echo of a selection this view already applied can be
+// told apart from a host-originated activation (auto-switch after a delete,
+// topology reconcile, Main-originated IPC) that it must still apply (#12370).
+// Each project view runs in its own V8 context, so module scope is per view.
+export const RENDERER_ACTIVATION_ORIGIN = `renderer-${crypto.randomUUID()}`;

--- a/src/store/worktreeActivationOrigin.ts
+++ b/src/store/worktreeActivationOrigin.ts
@@ -6,12 +6,26 @@
 // own V8 context, so module scope is per view.
 export const RENDERER_ACTIVATION_ORIGIN = `renderer-${crypto.randomUUID()}`;
 
+// The last id this view asked the host for. An own echo is normally
+// redundant, but the echo of the *latest* request landing while another
+// window's activation has displaced it is the ack of this view's intent, and
+// re-asserting it is what brings both windows and the host back together.
+let latestRequestedWorktreeId: string | null = null;
+
+export function markActivationRequested(worktreeId: string): void {
+  latestRequestedWorktreeId = worktreeId;
+}
+
+export function latestActivationRequest(): string | null {
+  return latestRequestedWorktreeId;
+}
+
 // The selection the host itself just pushed, if any. The host already holds
 // it, so `useActiveWorktreeSync` must not answer with a `set-active` — with
 // two windows on one project that answer is the next hop of an echo loop:
 // each view applies the other's activation and sends it back under its own
-// origin, seq climbing forever. Single-slot: the sync effect consumes it on
-// the very next selection change, matching or not.
+// origin, seq climbing forever. Single-slot: the next run of the sync effect
+// consumes it, matching or not, so a stale mark never swallows a later pick.
 let hostAppliedWorktreeId: string | null = null;
 
 export function markHostActivationApplied(worktreeId: string): void {
@@ -24,6 +38,11 @@ export function consumeHostAppliedActivation(worktreeId: string): boolean {
   return matched;
 }
 
+export function clearHostAppliedActivation(): void {
+  hostAppliedWorktreeId = null;
+}
+
 export function _resetHostAppliedActivationForTesting(): void {
   hostAppliedWorktreeId = null;
+  latestRequestedWorktreeId = null;
 }

--- a/src/store/worktreeStore.ts
+++ b/src/store/worktreeStore.ts
@@ -11,6 +11,7 @@ import type { FleetScopeToken } from "@shared/types/worktree";
 import { useFocusStore } from "@/store/focusStore";
 import { usePanelStore } from "@/store/panelStore";
 import { logErrorWithContext } from "@/utils/errorContext";
+import { logDebug } from "@/utils/logger";
 import { PERF_MARKS } from "@shared/perf/marks";
 import { isRendererPerfCaptureEnabled, markRendererPerformance } from "@/utils/performance";
 import { getFleetArmedIds, getFleetLastArmedId } from "./storeAccessors";
@@ -311,7 +312,14 @@ interface WorktreeSelectionState {
    */
   setActiveWorktree: (id: string | null, options?: { persist?: boolean }) => void;
   setFocusedWorktree: (id: string | null) => void;
-  selectWorktree: (id: string, options?: { source?: "user" | "focus" }) => void;
+  /**
+   * `focusedPanelId` is diagnostic only — the panel whose focus triggered a
+   * `"focus"`-sourced promotion, so the switch trace can name it (#12370).
+   */
+  selectWorktree: (
+    id: string,
+    options?: { source?: "user" | "focus"; focusedPanelId?: string }
+  ) => void;
   setPendingWorktree: (id: string | null) => void;
   applyPendingWorktreeSelection: (worktreeId: string) => void;
   addPendingCreation: (path: string, meta: { branch: string }) => void;
@@ -721,6 +729,7 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
     const previousId = get().activeWorktreeId;
     const generation = get()._policyGeneration + 1;
     const switchStartedAt = Date.now();
+    logDebug("[WorktreeStore] setActiveWorktree", { from: previousId, to: id, persist });
     markRendererPerformance(PERF_MARKS.WORKTREE_SWITCH_START, {
       fromWorktreeId: previousId ?? null,
       toWorktreeId: id ?? null,
@@ -812,16 +821,33 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
       // A deliberate re-selection of the already-active worktree still confirms
       // it as the durable restore target (it may have been activated only via
       // focus promotion before).
-      if (source === "user" && get().restoreWorktreeId !== id) {
+      const confirmedRestore = source === "user" && get().restoreWorktreeId !== id;
+      if (confirmedRestore) {
         set({ restoreWorktreeId: id });
         persistActiveWorktree(id);
       }
+      logDebug("[WorktreeStore] selectWorktree", {
+        outcome: "already-active",
+        source,
+        id,
+        confirmedRestore,
+      });
       return;
     }
 
     const previousId = get().activeWorktreeId;
     const generation = get()._policyGeneration + 1;
     const switchStartedAt = Date.now();
+    // Every switch is traceable with its source: focus-sourced promotions
+    // leave nothing in persisted state, so without this a focus ping-pong
+    // shows up only as its symptoms (#12370).
+    logDebug("[WorktreeStore] selectWorktree", {
+      outcome: "switched",
+      source,
+      from: previousId,
+      to: id,
+      focusedPanelId: options?.focusedPanelId,
+    });
     markRendererPerformance(PERF_MARKS.WORKTREE_SWITCH_START, {
       fromWorktreeId: previousId ?? null,
       toWorktreeId: id,

--- a/src/store/worktreeStore.ts
+++ b/src/store/worktreeStore.ts
@@ -826,9 +826,11 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
         set({ restoreWorktreeId: id });
         persistActiveWorktree(id);
       }
+      // `selectionSource`, not `source`: the main-process log sink stamps
+      // `source: "Renderer"` over every renderer context.
       logDebug("[WorktreeStore] selectWorktree", {
         outcome: "already-active",
-        source,
+        selectionSource: source,
         id,
         confirmedRestore,
       });
@@ -843,7 +845,7 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
     // shows up only as its symptoms (#12370).
     logDebug("[WorktreeStore] selectWorktree", {
       outcome: "switched",
-      source,
+      selectionSource: source,
       from: previousId,
       to: id,
       focusedPanelId: options?.focusedPanelId,


### PR DESCRIPTION
## Summary

After a post-eviction cold start, the active worktree oscillated at 2 Hz for 25 minutes (#12370). The switches were focus-sourced, so persisted state showed nothing, and the seed writer never got identified. The issue asked for the loop to be made impossible and diagnosable rather than reproduced on demand. This PR does the three things the issue's follow-up comment asked for, plus a multi-window echo hazard that turned up during review.

Resolves #12370

## Changes

1. Oscillation breaker on the focus-follow subscription (`src/store/rendererStoreOrchestrator.ts`, pure helper in `src/store/focusFollowBreaker.ts`). It counts only *revisits*, promotions back onto a worktree the 5 s window already passed through (A→B→A, A→B→C→A), so a one-way keyboard tour across many worktrees never counts. Eight revisits trip it and the eighth is dropped. While held, every further attempt extends the hold, and it releases after 2 s of quiet. A trip that follows a release inside the window counts as a failed recovery and doubles the next hold (capped at 60 s), so a writer that only reacts to switches decays to a burst a minute. The trip warning carries the whole window with each hop's writer stack. A release timer re-runs the promotion for whatever is focused once the hold lapses (re-activating the same parked panel is invisible to the subscription), gated on `document.hidden` and `isProjectViewCached()` and re-armed on view lifecycle `active`/`revealed`, so a hidden or cached view never switches for nothing.
2. Debug trace on every switch: `selectWorktree` (both branches, logging `selectionSource` since `source` gets overwritten by the main log sink, plus the focused panel id for focus promotions) and `setActiveWorktree`.
3. `worktree-activated` echo handling in `src/contexts/WorktreeStoreContext.tsx`. The renderer's `set-active` requests now carry a per-view `origin` (`src/store/worktreeActivationOrigin.ts`), threaded through `shared/types/worktree-port.ts`, `electron/workspace-host.ts`, and `WorkspaceService.setActiveWorktree` onto the event, so the view skips echoes of selections it already applied instead of re-selecting an id it may have moved past (the A-then-B echo loop). Activations also get their own `epoch`/`seq` high-water mark. A host-pushed selection (auto-switch, another window) is marked so `useActiveWorktreeSync` does not answer it with another `set-active`; with two windows on one project, that answer was the next hop of a loop. The one exception: the echo of this view's latest request landing after another window's activation displaced it is applied as a host-applied catch-up (never re-sent), only when nothing was selected since, and with the source the pick was made with.

Not changed:

- `TerminalReconciliationWatchdog.repairStoreVisibility` (the issue names it as an amplifier, not the cause)
- `useWorktrees().setActive` (no consumers)

## Testing

New `focusFollowBreaker.test.ts` covers revisit semantics, a time-only window with an 18-wide cycle, hold extension, and backoff doubling/cap/reset. `rendererStoreOrchestrator.test.ts` drives the issue's oracle: two panels in two worktrees, alternating `focusedId`, tripping at the ninth flip, `restoreWorktreeId` and the worktree MRU untouched, a one-way tour that never trips, hold extension, the timer healing after quiet, and the timer cancelled on destroy. jsdom cases cover hidden/cached deferral and rollback re-arm. `WorktreeStoreContext.worktreeActivated.test.tsx` covers the A-then-B echo oracle, stale same-epoch replay, new-epoch acceptance, the host-mark, and the displaced catch-up variants. Host and hook tests cover origin propagation and the host-mark.

Locally: 20 files / 464 tests pass across the touched areas. eslint is 0 errors with no new warnings on added lines. prettier is clean.

Known trade-off: nine rapid `focusAlternate` toggles across two worktrees inside 5 s still trip the breaker. The cost is a stall of at most 2 s before the grid catches up, and explicit sidebar selection is never gated.
