### PR TITLE
fix(terminal): start untouched Claude panes fresh instead of resuming a missing session

### DIFF
--- a/electron/ipc/handlers/terminal/__tests__/lifecycle.bookmarks.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/lifecycle.bookmarks.test.ts
@@ -32,7 +32,7 @@ const m = vi.hoisted(() => ({
   renameBookmark: vi.fn(),
   deleteBookmark: vi.fn(),
   listBookmarks: vi.fn(() => []),
-  listAgentSessions: vi.fn(() => []),
+  listAgentSessions: vi.fn((): Array<{ sessionId: string; agentId: string }> => []),
   dropClaudeSessionsWithoutTranscript: vi.fn(async (records: unknown[]) => records),
   readSessionHistorySync: vi.fn<() => { sessionId: string; projectId: string | null }[]>(() => []),
   // Typed so the evicted-ledger case (mockReturnValue(undefined)) type-checks.
@@ -61,7 +61,9 @@ vi.mock("../../../../services/pty/agentSessionRetention.js", () => ({
 }));
 vi.mock("../../../../services/claude/ClaudeSessionStore.js", () => ({
   CLAUDE_TRANSCRIPT_LOOKUP_TIMEOUT_MS: 1_500,
-  resolveClaudeProjectsRoot: vi.fn(() => null),
+  CLAUDE_STORE_UNREACHABLE_COOLDOWN_MS: 60_000,
+  resolvePaneClaudeProjectsRoot: vi.fn(() => null),
+  __resetClaudeSessionStoreForTests: vi.fn(),
   observeClaudeTranscript: vi.fn(async () => "unknown"),
   findUntouchedClaudeSession: vi.fn().mockResolvedValue(undefined),
   isClaudeSessionWithoutTranscript: vi.fn(async () => false),
@@ -436,12 +438,14 @@ describe("bookmark mutator handlers", () => {
   it("session list returns only what survives the transcript filter", async () => {
     register();
     const list = handlerFor(CHANNELS.AGENT_SESSION_LIST);
-    const kept = { sessionId: "kept", agentId: "codex" };
-    m.dropClaudeSessionsWithoutTranscript.mockResolvedValueOnce([kept]);
+    const retrieved = [
+      { sessionId: "untouched", agentId: "claude" },
+      { sessionId: "kept", agentId: "codex" },
+    ];
+    m.listAgentSessions.mockReturnValueOnce(retrieved);
+    m.dropClaudeSessionsWithoutTranscript.mockResolvedValueOnce([retrieved[1]]);
 
-    await expect(list({}, {})).resolves.toEqual([kept]);
-    expect(m.dropClaudeSessionsWithoutTranscript).toHaveBeenLastCalledWith(
-      m.listAgentSessions.mock.results.at(-1)?.value
-    );
+    await expect(list({}, {})).resolves.toEqual([retrieved[1]]);
+    expect(m.dropClaudeSessionsWithoutTranscript).toHaveBeenLastCalledWith(retrieved);
   });
 });

--- a/electron/ipc/handlers/terminal/__tests__/lifecycle.bookmarks.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/lifecycle.bookmarks.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { CHANNELS } from "../../../channels.js";
 import type { HandlerDependencies } from "../../../types.js";
-import { projectStore } from "../../../../services/ProjectStore.js";
 
 // Focused coverage of the bookmark IPC handlers in registerTerminalLifecycleHandlers:
 // error-code mapping, the generation freeze/recheck, and the prepare-before-remove
@@ -33,12 +32,7 @@ const m = vi.hoisted(() => ({
   renameBookmark: vi.fn(),
   deleteBookmark: vi.fn(),
   listBookmarks: vi.fn(() => []),
-  listAgentSessions: vi.fn(
-    (): Array<{ sessionId: string; agentId: string; projectId?: string | null }> => []
-  ),
-  dropClaudeSessionsWithoutTranscript: vi.fn(
-    async (records: unknown[], _options?: unknown) => records
-  ),
+  listAgentSessions: vi.fn(() => []),
   readSessionHistorySync: vi.fn<() => { sessionId: string; projectId: string | null }[]>(() => []),
   // Typed so the evicted-ledger case (mockReturnValue(undefined)) type-checks.
   currentGeneration: vi.fn<() => number | undefined>(() => 1),
@@ -63,17 +57,6 @@ vi.mock("../../../../services/pty/agentSessionJournal.js", () => ({
 }));
 vi.mock("../../../../services/pty/agentSessionRetention.js", () => ({
   getAgentSessionRetentionDays: vi.fn(() => 30),
-}));
-vi.mock("../../../../services/claude/ClaudeSessionStore.js", () => ({
-  CLAUDE_TRANSCRIPT_LOOKUP_TIMEOUT_MS: 1_500,
-  CLAUDE_STORE_UNREACHABLE_COOLDOWN_MS: 60_000,
-  resolvePaneClaudeProjectsRoot: vi.fn(() => null),
-  __resetClaudeSessionStoreForTests: vi.fn(),
-  rememberClaudePaneStore: vi.fn(),
-  observeClaudeTranscript: vi.fn(async () => "unknown"),
-  findUntouchedClaudeSession: vi.fn().mockResolvedValue(undefined),
-  isClaudeSessionWithoutTranscript: vi.fn(async () => false),
-  dropClaudeSessionsWithoutTranscript: m.dropClaudeSessionsWithoutTranscript,
 }));
 vi.mock("../../../../services/pty/lifecycleLedger.js", () => ({
   getLifecycleLedger: () => ({
@@ -438,58 +421,5 @@ describe("bookmark mutator handlers", () => {
       30,
       undefined
     );
-  });
-
-  // #12371 — the list must not offer Claude sessions that have no conversation.
-  it("session list returns only what survives the transcript filter", async () => {
-    register();
-    const list = handlerFor(CHANNELS.AGENT_SESSION_LIST);
-    const retrieved = [
-      { sessionId: "untouched", agentId: "claude" },
-      { sessionId: "kept", agentId: "codex" },
-    ];
-    m.listAgentSessions.mockReturnValueOnce(retrieved);
-    m.dropClaudeSessionsWithoutTranscript.mockResolvedValueOnce([retrieved[1]]);
-
-    await expect(list({}, {})).resolves.toEqual([retrieved[1]]);
-    expect(m.dropClaudeSessionsWithoutTranscript).toHaveBeenLastCalledWith(
-      retrieved,
-      expect.objectContaining({ keep: expect.any(Function) })
-    );
-  });
-
-  it("session list keeps records whose pane may have read another Claude store", async () => {
-    register();
-    const list = handlerFor(CHANNELS.AGENT_SESSION_LIST);
-    vi.mocked(projectStore.getProjectSettings).mockImplementation(async (projectId: string) => {
-      if (projectId === "proj-shell") return { terminalSettings: { shell: "/bin/bash" } } as never;
-      if (projectId === "proj-env") {
-        return { environmentVariables: { CLAUDE_CONFIG_DIR: "/work/claude" } } as never;
-      }
-      if (projectId === "proj-broken") throw new Error("unreadable settings");
-      // An icon that happens to contain the name is not an environment setting.
-      return { projectIconSvg: "<svg><title>CLAUDE_CONFIG_DIR</title></svg>" } as never;
-    });
-    const record = (sessionId: string, projectId: string | null) => ({
-      sessionId,
-      agentId: "claude",
-      projectId,
-    });
-    const retrieved = [
-      record("plain", "proj-plain"),
-      record("own-shell", "proj-shell"),
-      record("own-store", "proj-env"),
-      record("unreadable", "proj-broken"),
-      record("no-project", null),
-    ];
-    m.listAgentSessions.mockReturnValueOnce(retrieved);
-
-    await list({}, {});
-
-    const [, options] = m.dropClaudeSessionsWithoutTranscript.mock.calls.at(-1) as [
-      unknown,
-      { keep: (record: unknown) => boolean },
-    ];
-    expect(retrieved.map((entry) => options.keep(entry))).toEqual([false, true, true, true, true]);
   });
 });

--- a/electron/ipc/handlers/terminal/__tests__/lifecycle.bookmarks.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/lifecycle.bookmarks.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { CHANNELS } from "../../../channels.js";
 import type { HandlerDependencies } from "../../../types.js";
+import { projectStore } from "../../../../services/ProjectStore.js";
 
 // Focused coverage of the bookmark IPC handlers in registerTerminalLifecycleHandlers:
 // error-code mapping, the generation freeze/recheck, and the prepare-before-remove
@@ -32,8 +33,12 @@ const m = vi.hoisted(() => ({
   renameBookmark: vi.fn(),
   deleteBookmark: vi.fn(),
   listBookmarks: vi.fn(() => []),
-  listAgentSessions: vi.fn((): Array<{ sessionId: string; agentId: string }> => []),
-  dropClaudeSessionsWithoutTranscript: vi.fn(async (records: unknown[]) => records),
+  listAgentSessions: vi.fn(
+    (): Array<{ sessionId: string; agentId: string; projectId?: string | null }> => []
+  ),
+  dropClaudeSessionsWithoutTranscript: vi.fn(
+    async (records: unknown[], _options?: unknown) => records
+  ),
   readSessionHistorySync: vi.fn<() => { sessionId: string; projectId: string | null }[]>(() => []),
   // Typed so the evicted-ledger case (mockReturnValue(undefined)) type-checks.
   currentGeneration: vi.fn<() => number | undefined>(() => 1),
@@ -64,6 +69,7 @@ vi.mock("../../../../services/claude/ClaudeSessionStore.js", () => ({
   CLAUDE_STORE_UNREACHABLE_COOLDOWN_MS: 60_000,
   resolvePaneClaudeProjectsRoot: vi.fn(() => null),
   __resetClaudeSessionStoreForTests: vi.fn(),
+  rememberClaudePaneStore: vi.fn(),
   observeClaudeTranscript: vi.fn(async () => "unknown"),
   findUntouchedClaudeSession: vi.fn().mockResolvedValue(undefined),
   isClaudeSessionWithoutTranscript: vi.fn(async () => false),
@@ -446,6 +452,44 @@ describe("bookmark mutator handlers", () => {
     m.dropClaudeSessionsWithoutTranscript.mockResolvedValueOnce([retrieved[1]]);
 
     await expect(list({}, {})).resolves.toEqual([retrieved[1]]);
-    expect(m.dropClaudeSessionsWithoutTranscript).toHaveBeenLastCalledWith(retrieved);
+    expect(m.dropClaudeSessionsWithoutTranscript).toHaveBeenLastCalledWith(
+      retrieved,
+      expect.objectContaining({ keep: expect.any(Function) })
+    );
+  });
+
+  it("session list keeps records whose pane may have read another Claude store", async () => {
+    register();
+    const list = handlerFor(CHANNELS.AGENT_SESSION_LIST);
+    vi.mocked(projectStore.getProjectSettings).mockImplementation(async (projectId: string) => {
+      if (projectId === "proj-shell") return { terminalSettings: { shell: "/bin/bash" } } as never;
+      if (projectId === "proj-env") {
+        return { environmentVariables: { CLAUDE_CONFIG_DIR: "/work/claude" } } as never;
+      }
+      if (projectId === "proj-broken") throw new Error("unreadable settings");
+      // An icon that happens to contain the name is not an environment setting.
+      return { projectIconSvg: "<svg><title>CLAUDE_CONFIG_DIR</title></svg>" } as never;
+    });
+    const record = (sessionId: string, projectId: string | null) => ({
+      sessionId,
+      agentId: "claude",
+      projectId,
+    });
+    const retrieved = [
+      record("plain", "proj-plain"),
+      record("own-shell", "proj-shell"),
+      record("own-store", "proj-env"),
+      record("unreadable", "proj-broken"),
+      record("no-project", null),
+    ];
+    m.listAgentSessions.mockReturnValueOnce(retrieved);
+
+    await list({}, {});
+
+    const [, options] = m.dropClaudeSessionsWithoutTranscript.mock.calls.at(-1) as [
+      unknown,
+      { keep: (record: unknown) => boolean },
+    ];
+    expect(retrieved.map((entry) => options.keep(entry))).toEqual([false, true, true, true, true]);
   });
 });

--- a/electron/ipc/handlers/terminal/__tests__/lifecycle.bookmarks.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/lifecycle.bookmarks.test.ts
@@ -33,6 +33,7 @@ const m = vi.hoisted(() => ({
   deleteBookmark: vi.fn(),
   listBookmarks: vi.fn(() => []),
   listAgentSessions: vi.fn(() => []),
+  dropClaudeSessionsWithoutTranscript: vi.fn(async (records: unknown[]) => records),
   readSessionHistorySync: vi.fn<() => { sessionId: string; projectId: string | null }[]>(() => []),
   // Typed so the evicted-ledger case (mockReturnValue(undefined)) type-checks.
   currentGeneration: vi.fn<() => number | undefined>(() => 1),
@@ -57,6 +58,14 @@ vi.mock("../../../../services/pty/agentSessionJournal.js", () => ({
 }));
 vi.mock("../../../../services/pty/agentSessionRetention.js", () => ({
   getAgentSessionRetentionDays: vi.fn(() => 30),
+}));
+vi.mock("../../../../services/claude/ClaudeSessionStore.js", () => ({
+  CLAUDE_TRANSCRIPT_LOOKUP_TIMEOUT_MS: 1_500,
+  resolveClaudeProjectsRoot: vi.fn(() => null),
+  observeClaudeTranscript: vi.fn(async () => "unknown"),
+  findUntouchedClaudeSession: vi.fn().mockResolvedValue(undefined),
+  isClaudeSessionWithoutTranscript: vi.fn(async () => false),
+  dropClaudeSessionsWithoutTranscript: m.dropClaudeSessionsWithoutTranscript,
 }));
 vi.mock("../../../../services/pty/lifecycleLedger.js", () => ({
   getLifecycleLedger: () => ({
@@ -420,6 +429,19 @@ describe("bookmark mutator handlers", () => {
       expect.any(String),
       30,
       undefined
+    );
+  });
+
+  // #12371 — the list must not offer Claude sessions that have no conversation.
+  it("session list returns only what survives the transcript filter", async () => {
+    register();
+    const list = handlerFor(CHANNELS.AGENT_SESSION_LIST);
+    const kept = { sessionId: "kept", agentId: "codex" };
+    m.dropClaudeSessionsWithoutTranscript.mockResolvedValueOnce([kept]);
+
+    await expect(list({}, {})).resolves.toEqual([kept]);
+    expect(m.dropClaudeSessionsWithoutTranscript).toHaveBeenLastCalledWith(
+      m.listAgentSessions.mock.results.at(-1)?.value
     );
   });
 });

--- a/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
@@ -87,7 +87,6 @@ vi.mock("../../../../services/claude/ClaudeSessionStore.js", () => ({
   observeClaudeTranscript: vi.fn(async () => "unknown"),
   findUntouchedClaudeSession: findUntouchedClaudeSessionMock,
   isClaudeSessionWithoutTranscript: vi.fn(async () => false),
-  dropClaudeSessionsWithoutTranscript: vi.fn(async (records: unknown[]) => records),
 }));
 
 type SafeParseable = {

--- a/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
@@ -74,7 +74,9 @@ const findUntouchedClaudeSessionMock = vi.hoisted(() =>
 // that omits an export throws for every consumer that reaches it.
 vi.mock("../../../../services/claude/ClaudeSessionStore.js", () => ({
   CLAUDE_TRANSCRIPT_LOOKUP_TIMEOUT_MS: 1_500,
-  resolveClaudeProjectsRoot: vi.fn(() => null),
+  CLAUDE_STORE_UNREACHABLE_COOLDOWN_MS: 60_000,
+  resolvePaneClaudeProjectsRoot: vi.fn(() => null),
+  __resetClaudeSessionStoreForTests: vi.fn(),
   observeClaudeTranscript: vi.fn(async () => "unknown"),
   findUntouchedClaudeSession: findUntouchedClaudeSessionMock,
   isClaudeSessionWithoutTranscript: vi.fn(async () => false),
@@ -1674,6 +1676,35 @@ describe("terminal spawn handler - help session detection (#6524)", () => {
     // Canonical flag is present as a standalone token.
     expect(spawnArgs.command).toMatch(/(^|\s)--dangerously-skip-permissions(\s|$)/);
     expect(spawnArgs.command).toContain("--resume abc");
+  });
+
+  it("keeps a help launch's enrichment when an untouched session starts fresh (#12371)", async () => {
+    mockValidateToken.mockImplementation((token) => (token === "bypass-token" ? "action" : false));
+    mockGetBypassPermissions.mockImplementation((token) => token === "bypass-token");
+    const session = "006fdfc0-67bf-4df0-ad82-48ebfe4df184";
+    findUntouchedClaudeSessionMock.mockResolvedValueOnce(session);
+
+    const deps = { ptyClient } as unknown as HandlerDependencies;
+    registerTerminalLifecycleHandlers(deps);
+
+    const handler = getSpawnHandler();
+    await handler(
+      {} as Electron.IpcMainInvokeEvent,
+      {
+        cols: 80,
+        rows: 24,
+        cwd: tmpDir,
+        command: `claude --resume ${session}`,
+        launchAgentId: "claude",
+        env: { DAINTREE_MCP_TOKEN: "bypass-token" },
+      } as unknown as Parameters<typeof handler>[1]
+    );
+
+    const spawnArgs = ptyClient.spawn.mock.calls[0][1];
+    expect(spawnArgs.command).toMatch(/(^|\s)--dangerously-skip-permissions(\s|$)/);
+    expect(spawnArgs.command).toContain(`--session-id ${session}`);
+    expect(spawnArgs.command).not.toContain("--resume");
+    expect(spawnArgs.agentSessionId).toBe(session);
   });
 
   it("refuses to spawn when DAINTREE_MCP_TOKEN is present but invalid for an assistant-supported launch (#7509)", async () => {

--- a/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
@@ -70,12 +70,19 @@ vi.mock("../../../../services/pty/agentSessionRetention.js", () => ({
 const findUntouchedClaudeSessionMock = vi.hoisted(() =>
   vi.fn<(...args: unknown[]) => Promise<string | undefined>>(async () => undefined)
 );
+const claudeStoreMocks = vi.hoisted(() => ({
+  resolvePaneClaudeProjectsRoot: vi.fn<(...args: unknown[]) => string | null>(
+    () => "/claude-store/projects"
+  ),
+  rememberClaudePaneStore: vi.fn(),
+}));
 // Full surface: the real session journal imports this module too, and a factory
 // that omits an export throws for every consumer that reaches it.
 vi.mock("../../../../services/claude/ClaudeSessionStore.js", () => ({
   CLAUDE_TRANSCRIPT_LOOKUP_TIMEOUT_MS: 1_500,
   CLAUDE_STORE_UNREACHABLE_COOLDOWN_MS: 60_000,
-  resolvePaneClaudeProjectsRoot: vi.fn(() => null),
+  resolvePaneClaudeProjectsRoot: claudeStoreMocks.resolvePaneClaudeProjectsRoot,
+  rememberClaudePaneStore: claudeStoreMocks.rememberClaudePaneStore,
   __resetClaudeSessionStoreForTests: vi.fn(),
   observeClaudeTranscript: vi.fn(async () => "unknown"),
   findUntouchedClaudeSession: findUntouchedClaudeSessionMock,
@@ -888,6 +895,7 @@ describe("terminal spawn handler - cwd fallback (#5139: worktree is now renderer
 
   describe("untouched Claude sessions (#12371)", () => {
     const SESSION = "006fdfc0-67bf-4df0-ad82-48ebfe4df184";
+    const CLAUDE_STORE = "/claude-store/projects";
 
     async function spawnClaude(options: Record<string, unknown>) {
       const deps = { ptyClient } as unknown as HandlerDependencies;
@@ -919,7 +927,14 @@ describe("terminal spawn handler - cwd fallback (#5139: worktree is now renderer
       expect(findUntouchedClaudeSessionMock).toHaveBeenCalledWith(
         `claude --resume ${SESSION}`,
         "claude",
-        expect.objectContaining({ cwd, agentSessionId: SESSION })
+        expect.objectContaining({ cwd, agentSessionId: SESSION, projectsRoot: CLAUDE_STORE })
+      );
+      expect(claudeStoreMocks.resolvePaneClaudeProjectsRoot).toHaveBeenCalledWith(
+        expect.objectContaining({ shell: "/usr/bin/nu" })
+      );
+      expect(claudeStoreMocks.rememberClaudePaneStore).toHaveBeenCalledWith(
+        expect.any(String),
+        CLAUDE_STORE
       );
       expect(spawnArgs.command).toContain(`--session-id ${SESSION}`);
       expect(spawnArgs.command).not.toContain("--resume");
@@ -964,6 +979,13 @@ describe("terminal spawn handler - cwd fallback (#5139: worktree is now renderer
 
       expect(ptyClient.spawn).toHaveBeenCalledTimes(1);
       expect(spawnArgs.command).toContain(`--resume ${SESSION}`);
+    });
+
+    it("resolves and remembers no Claude store for a launch that isn't Claude", async () => {
+      await spawnClaude({ launchAgentId: "codex", command: "codex", shell: "/usr/bin/nu" });
+
+      expect(claudeStoreMocks.resolvePaneClaudeProjectsRoot).not.toHaveBeenCalled();
+      expect(claudeStoreMocks.rememberClaudePaneStore).not.toHaveBeenCalled();
     });
   });
 });

--- a/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
@@ -65,6 +65,22 @@ vi.mock("../../../../services/pty/agentSessionRetention.js", () => ({
   getAgentSessionRetentionDays: vi.fn(() => 30),
 }));
 
+// The real lookup reads the developer's own Claude store; no case here should
+// depend on what happens to be on this machine.
+const findUntouchedClaudeSessionMock = vi.hoisted(() =>
+  vi.fn<(...args: unknown[]) => Promise<string | undefined>>(async () => undefined)
+);
+// Full surface: the real session journal imports this module too, and a factory
+// that omits an export throws for every consumer that reaches it.
+vi.mock("../../../../services/claude/ClaudeSessionStore.js", () => ({
+  CLAUDE_TRANSCRIPT_LOOKUP_TIMEOUT_MS: 1_500,
+  resolveClaudeProjectsRoot: vi.fn(() => null),
+  observeClaudeTranscript: vi.fn(async () => "unknown"),
+  findUntouchedClaudeSession: findUntouchedClaudeSessionMock,
+  isClaudeSessionWithoutTranscript: vi.fn(async () => false),
+  dropClaudeSessionsWithoutTranscript: vi.fn(async (records: unknown[]) => records),
+}));
+
 type SafeParseable = {
   safeParse: (v: unknown) => { success: true; data: unknown } | { success: false; error: unknown };
 };
@@ -867,6 +883,87 @@ describe("terminal spawn handler - cwd fallback (#5139: worktree is now renderer
       expect(spawnArgs.args?.join(" ")).toContain("claude --resume s-1");
     }
   );
+
+  describe("untouched Claude sessions (#12371)", () => {
+    const SESSION = "006fdfc0-67bf-4df0-ad82-48ebfe4df184";
+
+    async function spawnClaude(options: Record<string, unknown>) {
+      const deps = { ptyClient } as unknown as HandlerDependencies;
+      registerTerminalLifecycleHandlers(deps);
+      const handler = getSpawnHandler();
+      const os = await import("os");
+      await handler(
+        {} as Electron.IpcMainInvokeEvent,
+        {
+          cwd: os.homedir(),
+          cols: 80,
+          rows: 24,
+          launchAgentId: "claude",
+          command: `claude --resume ${SESSION}`,
+          ...options,
+        } as unknown as Parameters<typeof handler>[1]
+      );
+      return { spawnArgs: ptyClient.spawn.mock.calls[0][1], cwd: os.homedir() };
+    }
+
+    it("starts a fresh conversation under the same id instead of a resume that can't open", async () => {
+      findUntouchedClaudeSessionMock.mockResolvedValueOnce(SESSION);
+
+      const { spawnArgs, cwd } = await spawnClaude({
+        shell: "/usr/bin/nu",
+        agentSessionId: SESSION,
+      });
+
+      expect(findUntouchedClaudeSessionMock).toHaveBeenCalledWith(
+        `claude --resume ${SESSION}`,
+        "claude",
+        expect.objectContaining({ cwd, agentSessionId: SESSION })
+      );
+      expect(spawnArgs.command).toContain(`--session-id ${SESSION}`);
+      expect(spawnArgs.command).not.toContain("--resume");
+      expect(spawnArgs.postSpawnInput).toBe(`${spawnArgs.command}\r`);
+      expect(spawnArgs.agentSessionId).toBe(SESSION);
+    });
+
+    it.skipIf(process.platform === "win32")(
+      "rebuilds the shell wrapper from the swapped command",
+      async () => {
+        findUntouchedClaudeSessionMock.mockResolvedValueOnce(SESSION);
+
+        const { spawnArgs } = await spawnClaude({ shell: "/bin/bash", agentSessionId: SESSION });
+
+        const wrapped = spawnArgs.args?.join(" ") ?? "";
+        expect(wrapped).toContain(`--session-id ${SESSION}`);
+        expect(wrapped).not.toContain(`--resume ${SESSION}`);
+      }
+    );
+
+    it("records the assigned id for a caller that only had the command", async () => {
+      findUntouchedClaudeSessionMock.mockResolvedValueOnce(SESSION);
+
+      const { spawnArgs } = await spawnClaude({ shell: "/usr/bin/nu" });
+
+      expect(spawnArgs.command).toContain(`--session-id ${SESSION}`);
+      expect(spawnArgs.agentSessionId).toBe(SESSION);
+    });
+
+    it("leaves the resume untouched when the conversation exists or can't be checked", async () => {
+      const { spawnArgs } = await spawnClaude({ shell: "/usr/bin/nu", agentSessionId: SESSION });
+
+      expect(spawnArgs.command).toContain(`--resume ${SESSION}`);
+      expect(spawnArgs.command).not.toContain("--session-id");
+      expect(spawnArgs.agentSessionId).toBe(SESSION);
+    });
+
+    it("still spawns the resume when the lookup throws", async () => {
+      findUntouchedClaudeSessionMock.mockRejectedValueOnce(new Error("store unreadable"));
+
+      const { spawnArgs } = await spawnClaude({ shell: "/usr/bin/nu", agentSessionId: SESSION });
+
+      expect(ptyClient.spawn).toHaveBeenCalledTimes(1);
+      expect(spawnArgs.command).toContain(`--resume ${SESSION}`);
+    });
+  });
 });
 
 describe("terminal spawn shell-injection hardening (#6065)", () => {

--- a/electron/ipc/handlers/terminal/lifecycle.ts
+++ b/electron/ipc/handlers/terminal/lifecycle.ts
@@ -16,6 +16,8 @@ import { isAssistantTerminalRecord } from "../../../services/assistantTerminal.j
 import {
   dropClaudeSessionsWithoutTranscript,
   findUntouchedClaudeSession,
+  rememberClaudePaneStore,
+  resolvePaneClaudeProjectsRoot,
 } from "../../../services/claude/ClaudeSessionStore.js";
 import type { HandlerDependencies, IpcContext } from "../../types.js";
 import {
@@ -53,6 +55,42 @@ import {
 import type * as PluginServiceModule from "../../../services/PluginService.js";
 
 type ValidatedTerminalSpawnOptions = z.output<typeof TerminalSpawnOptionsSchema>;
+
+/**
+ * Which history records may come from a pane that read a different Claude store
+ * than a default pane does (#12371): every record once an agent preset mentions
+ * `CLAUDE_CONFIG_DIR`; otherwise those from a project that sets its own shell or
+ * mentions it in its settings, and those with no project to check. The resume
+ * list leaves them alone rather than judge them against the wrong store.
+ */
+async function findRecordsOffDefaultClaudeStore(
+  records: readonly AgentSessionRecord[]
+): Promise<(record: AgentSessionRecord) => boolean> {
+  const mentionsClaudeStore = (value: unknown): boolean =>
+    JSON.stringify(value ?? null).includes("CLAUDE_CONFIG_DIR");
+  if (mentionsClaudeStore(store.get("agentSettings"))) return () => true;
+  const projectIds = new Set(
+    records.flatMap((record) =>
+      record.agentId === "claude" && record.projectId ? [record.projectId] : []
+    )
+  );
+  const offDefault = new Set<string>();
+  await Promise.all(
+    [...projectIds].map(async (projectId) => {
+      try {
+        // The icon can be a quarter of a megabyte and says nothing about env.
+        const { projectIconSvg: _icon, ...settings } =
+          await projectStore.getProjectSettings(projectId);
+        if (settings.terminalSettings?.shell || mentionsClaudeStore(settings)) {
+          offDefault.add(projectId);
+        }
+      } catch {
+        offDefault.add(projectId);
+      }
+    })
+  );
+  return (record) => !record.projectId || offDefault.has(record.projectId);
+}
 
 const TERMINAL_SPAWN_INTERVAL_MS = 1_000;
 const TERMINAL_SPAWN_BURST = 6;
@@ -499,17 +537,24 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
       });
     }
 
-    // An untouched Claude pane comes back as `--resume <id>` for an id Claude
-    // Code never wrote a conversation for, and the CLI exits on it (#12371).
-    // Every way a pane resumes (relaunch, restart, sleep/wake, eviction, the
-    // resume list) funnels through this spawn, so this is where to look. Awaited
-    // above the resource bindings for the same reason as the PATH refresh, and
-    // applied below to the finished command the launch carriers are built from.
-    // Enrichment too: a lookup that fails leaves the resume exactly as it was.
+    // Which Claude store this pane will read, decided from what it launches with
+    // (#12371). Remembered for the close that journals it, and needed right here:
+    // an untouched Claude pane comes back as `--resume <id>` for an id Claude Code
+    // never wrote a conversation for, and the CLI exits on it. Every way a pane
+    // resumes (relaunch, restart, sleep/wake, eviction, the resume list) funnels
+    // through this spawn, so this is where to look. Awaited above the resource
+    // bindings for the same reason as the PATH refresh, and applied below to the
+    // finished command the launch carriers are built from. Enrichment too: a
+    // lookup that fails leaves the resume exactly as it was.
+    const claudePaneStore =
+      launchAgentId === "claude"
+        ? resolvePaneClaudeProjectsRoot({ shell: quotingShell, env: spawnEnv })
+        : undefined;
+    if (claudePaneStore !== undefined) rememberClaudePaneStore(id, claudePaneStore);
     const untouchedSessionId = await findUntouchedClaudeSession(safeCommand, launchAgentId, {
       cwd,
       agentSessionId: validatedOptions.agentSessionId,
-      env: spawnEnv,
+      projectsRoot: claudePaneStore ?? null,
     }).catch(() => undefined);
 
     if (isHelpLaunch && launchAgentId) {
@@ -1029,14 +1074,15 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
 
   const handleAgentSessionList = async (payload: { worktreeId?: string; projectId?: string }) => {
     const { app } = await import("electron");
-    return dropClaudeSessionsWithoutTranscript(
-      listAgentSessions(
-        payload?.worktreeId,
-        app.getPath("userData"),
-        getAgentSessionRetentionDays(),
-        payload?.projectId
-      )
+    const records = listAgentSessions(
+      payload?.worktreeId,
+      app.getPath("userData"),
+      getAgentSessionRetentionDays(),
+      payload?.projectId
     );
+    return dropClaudeSessionsWithoutTranscript(records, {
+      keep: await findRecordsOffDefaultClaudeStore(records),
+    });
   };
 
   const handleAgentSessionClear = async (payload: { worktreeId?: string }): Promise<void> => {

--- a/electron/ipc/handlers/terminal/lifecycle.ts
+++ b/electron/ipc/handlers/terminal/lifecycle.ts
@@ -14,7 +14,6 @@ import { mcpPaneConfigService } from "../../../services/McpPaneConfigService.js"
 import { helpSessionService } from "../../../services/HelpSessionService.js";
 import { isAssistantTerminalRecord } from "../../../services/assistantTerminal.js";
 import {
-  dropClaudeSessionsWithoutTranscript,
   findUntouchedClaudeSession,
   rememberClaudePaneStore,
   resolvePaneClaudeProjectsRoot,
@@ -55,42 +54,6 @@ import {
 import type * as PluginServiceModule from "../../../services/PluginService.js";
 
 type ValidatedTerminalSpawnOptions = z.output<typeof TerminalSpawnOptionsSchema>;
-
-/**
- * Which history records may come from a pane that read a different Claude store
- * than a default pane does (#12371): every record once an agent preset mentions
- * `CLAUDE_CONFIG_DIR`; otherwise those from a project that sets its own shell or
- * mentions it in its settings, and those with no project to check. The resume
- * list leaves them alone rather than judge them against the wrong store.
- */
-async function findRecordsOffDefaultClaudeStore(
-  records: readonly AgentSessionRecord[]
-): Promise<(record: AgentSessionRecord) => boolean> {
-  const mentionsClaudeStore = (value: unknown): boolean =>
-    JSON.stringify(value ?? null).includes("CLAUDE_CONFIG_DIR");
-  if (mentionsClaudeStore(store.get("agentSettings"))) return () => true;
-  const projectIds = new Set(
-    records.flatMap((record) =>
-      record.agentId === "claude" && record.projectId ? [record.projectId] : []
-    )
-  );
-  const offDefault = new Set<string>();
-  await Promise.all(
-    [...projectIds].map(async (projectId) => {
-      try {
-        // The icon can be a quarter of a megabyte and says nothing about env.
-        const { projectIconSvg: _icon, ...settings } =
-          await projectStore.getProjectSettings(projectId);
-        if (settings.terminalSettings?.shell || mentionsClaudeStore(settings)) {
-          offDefault.add(projectId);
-        }
-      } catch {
-        offDefault.add(projectId);
-      }
-    })
-  );
-  return (record) => !record.projectId || offDefault.has(record.projectId);
-}
 
 const TERMINAL_SPAWN_INTERVAL_MS = 1_000;
 const TERMINAL_SPAWN_BURST = 6;
@@ -1074,15 +1037,12 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
 
   const handleAgentSessionList = async (payload: { worktreeId?: string; projectId?: string }) => {
     const { app } = await import("electron");
-    const records = listAgentSessions(
+    return listAgentSessions(
       payload?.worktreeId,
       app.getPath("userData"),
       getAgentSessionRetentionDays(),
       payload?.projectId
     );
-    return dropClaudeSessionsWithoutTranscript(records, {
-      keep: await findRecordsOffDefaultClaudeStore(records),
-    });
   };
 
   const handleAgentSessionClear = async (payload: { worktreeId?: string }): Promise<void> => {

--- a/electron/ipc/handlers/terminal/lifecycle.ts
+++ b/electron/ipc/handlers/terminal/lifecycle.ts
@@ -13,6 +13,10 @@ import type * as McpServerServiceModule from "../../../services/McpServerService
 import { mcpPaneConfigService } from "../../../services/McpPaneConfigService.js";
 import { helpSessionService } from "../../../services/HelpSessionService.js";
 import { isAssistantTerminalRecord } from "../../../services/assistantTerminal.js";
+import {
+  dropClaudeSessionsWithoutTranscript,
+  findUntouchedClaudeSession,
+} from "../../../services/claude/ClaudeSessionStore.js";
 import type { HandlerDependencies, IpcContext } from "../../types.js";
 import {
   TerminalSpawnOptionsSchema,
@@ -33,6 +37,7 @@ import { resolveDaintreeMcpTier } from "../../../../shared/types/project.js";
 import { normalizeTerminalGridDimension } from "../../../../shared/types/terminal.js";
 import {
   DEFAULT_DANGEROUS_ARGS,
+  relaunchResumeAsAssignedSession,
   supportsExactSessionCapture,
 } from "../../../../shared/types/agentSettings.js";
 import {
@@ -494,6 +499,19 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
       });
     }
 
+    // An untouched Claude pane comes back as `--resume <id>` for an id Claude
+    // Code never wrote a conversation for, and the CLI exits on it (#12371).
+    // Every way a pane resumes (relaunch, restart, sleep/wake, eviction, the
+    // resume list) funnels through this spawn, so this is where to look. Awaited
+    // above the resource bindings for the same reason as the PATH refresh, and
+    // applied below to the finished command the launch carriers are built from.
+    // Enrichment too: a lookup that fails leaves the resume exactly as it was.
+    const untouchedSessionId = await findUntouchedClaudeSession(safeCommand, launchAgentId, {
+      cwd,
+      agentSessionId: validatedOptions.agentSessionId,
+      env: spawnEnv,
+    }).catch(() => undefined);
+
     if (isHelpLaunch && launchAgentId) {
       const dangerous = DEFAULT_DANGEROUS_ARGS[launchAgentId];
       const bypassPermissions = helpSessionService.getBypassPermissions(helpToken);
@@ -774,6 +792,21 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
     // intentionally leave `spawnShell` as the original undefined-when-unset
     // value (no `getDefaultShell()` fallback) so the PTY pool can match —
     // see `acquirePtyProcess` in `terminalSpawn.ts`.
+    let spawnAgentSessionId = validatedOptions.agentSessionId;
+    if (untouchedSessionId) {
+      const relaunch = relaunchResumeAsAssignedSession(safeCommand, launchAgentId);
+      if (relaunch?.sessionId === untouchedSessionId) {
+        safeCommand = relaunch.command;
+        // A caller that only had the command still gets the id on the record, so
+        // teardown hands it back like any other assigned launch.
+        spawnAgentSessionId ??= untouchedSessionId;
+        console.info(
+          `[TerminalSpawn] Terminal ${id.slice(0, 8)} has no Claude conversation to resume; ` +
+            "starting a fresh one under its assigned session id"
+        );
+      }
+    }
+
     const commandLaunchShell = buildCommandLaunchShell(safeCommand, quotingShell);
     const resolvedArgs = commandLaunchShell ? commandLaunchShell.args : projectArgs;
     const spawnShell = commandLaunchShell
@@ -827,7 +860,7 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
         isAssistantTerminal: isHelpLaunch || helpSessionService.isHelpTerminal(id),
         agentLaunchFlags: validatedOptions.agentLaunchFlags,
         agentModelId: validatedOptions.agentModelId,
-        agentSessionId: validatedOptions.agentSessionId,
+        agentSessionId: spawnAgentSessionId,
         worktreeId: spawnWorktreeId,
         agentPresetId: validatedOptions.agentPresetId,
         agentPresetColor: validatedOptions.agentPresetColor,
@@ -996,11 +1029,13 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
 
   const handleAgentSessionList = async (payload: { worktreeId?: string; projectId?: string }) => {
     const { app } = await import("electron");
-    return listAgentSessions(
-      payload?.worktreeId,
-      app.getPath("userData"),
-      getAgentSessionRetentionDays(),
-      payload?.projectId
+    return dropClaudeSessionsWithoutTranscript(
+      listAgentSessions(
+        payload?.worktreeId,
+        app.getPath("userData"),
+        getAgentSessionRetentionDays(),
+        payload?.projectId
+      )
     );
   };
 

--- a/electron/services/claude/ClaudeSessionStore.ts
+++ b/electron/services/claude/ClaudeSessionStore.ts
@@ -58,10 +58,13 @@ const PANE_STORE_MEMORY = 1_024;
 /** Claude Code only accepts a UUID as a session id, so nothing else can name a transcript it wrote. */
 const SESSION_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 /**
- * The titles a Claude pane carries before its first message: Daintree's label
- * for the agent and Claude Code's idle title, with or without its status glyph.
+ * Shells a pane starts the way the startup probe does, as an interactive login
+ * shell, so the user's profile reaches both alike. Other POSIX shells launch
+ * without `-l` (see `buildCommandLaunchShell`) and read different startup files.
  */
-const UNTOUCHED_TITLE_PATTERN = /^(?:[^\p{L}\p{N}\s]\s*)?Claude(?: Code)?$/u;
+const LOGIN_PROBED_SHELLS = new Set(["zsh", "bash"]);
+/** Pane-level overrides that move the store or change which startup files a shell reads. */
+const STARTUP_ENV_VARS = [CONFIG_DIR_VAR, "HOME", "ZDOTDIR", "ENV", "BASH_ENV"];
 
 type EnvLike = Readonly<Record<string, string | undefined>>;
 
@@ -115,8 +118,10 @@ function isAbsence(error: unknown): boolean {
  *
  * A pane's shell sources the user's profile, which can export, change, or unset
  * `CLAUDE_CONFIG_DIR`, and main never sees the result. Certainty therefore needs
- * the pane to start from exactly what the startup probe saw: the same shell, and
- * no `CLAUDE_CONFIG_DIR` of its own for that profile to treat differently. Its
+ * the pane to start from exactly what the startup probe saw: the same shell,
+ * started the same way (zsh and bash are the shells a pane runs as an
+ * interactive login shell, like the probe), and no override of its own for
+ * `CLAUDE_CONFIG_DIR` or the variables that choose a shell's startup files. Its
  * profile then does to the pane whatever it did to the probe. Anything else — a
  * different shell, a pane-level override, no probe yet — is unknown, and so is
  * Windows, whose PowerShell and cmd profiles are never probed.
@@ -128,10 +133,12 @@ export function resolvePaneClaudeProjectsRoot(
   context: ClaudeStoreContext = {}
 ): string | null {
   if ((context.platform ?? process.platform) === "win32") return null;
-  if (pane.env && hasEnvVar(pane.env, CONFIG_DIR_VAR)) return null;
+  const paneEnv = pane.env;
+  if (paneEnv && STARTUP_ENV_VARS.some((name) => hasEnvVar(paneEnv, name))) return null;
   const observation = (context.readShellObservation ?? getShellEnvironmentObservation)();
   const shell = pane.shell ?? getEnvVar(context.env ?? process.env, "SHELL");
   if (!observation || !shell || shell !== observation.shell) return null;
+  if (!LOGIN_PROBED_SHELLS.has(path.basename(shell))) return null;
   const configDir = observation.env[CONFIG_DIR_VAR];
   if (configDir === undefined) return path.join(os.homedir(), ".claude", "projects");
   // Empty or relative: what the CLI makes of either is not something to guess at.
@@ -360,52 +367,6 @@ export async function isClaudeSessionWithoutTranscript(
     options
   );
   return observation === "missing";
-}
-
-type SessionRecordFacts = Pick<AgentSessionRecord, "agentId" | "sessionId" | "bookmark" | "title">;
-
-/**
- * A history record that could be an untouched pane: an unbookmarked Claude
- * session still wearing Claude's pre-conversation title. A record outlives the
- * spawn that knew its pane's store, so an old one has to look untouched as well
- * before it is judged at all.
- */
-function couldBeUntouchedClaudeSession(record: SessionRecordFacts): boolean {
-  if (record.agentId !== CLAUDE_AGENT_ID || record.bookmark !== undefined) return false;
-  if (!SESSION_ID_PATTERN.test(record.sessionId)) return false;
-  const title = record.title?.trim();
-  return !title || UNTOUCHED_TITLE_PATTERN.test(title);
-}
-
-export interface DropClaudeSessionsOptions<T> extends ClaudeStoreOptions {
-  /** Records the caller knows may have run against a different store. Always kept. */
-  keep?: (record: T) => boolean;
-}
-
-/**
- * Drops untouched Claude sessions from a history list, so the resume list stops
- * offering conversations `--resume` can never open. Only records that could
- * have come from a default pane are judged, against the store such a pane reads,
- * and the caller's `keep` vetoes any it knows were launched differently.
- * Read-side only: the journal on disk is untouched, and a store that can't be
- * pinned down or read in full filters nothing.
- */
-export async function dropClaudeSessionsWithoutTranscript<T extends SessionRecordFacts>(
-  records: T[],
-  options: DropClaudeSessionsOptions<T> = {}
-): Promise<T[]> {
-  const judged = (record: T): boolean =>
-    couldBeUntouchedClaudeSession(record) && !options.keep?.(record);
-  if (!records.some(judged)) return records;
-  const projectsRoot = resolvePaneClaudeProjectsRoot({}, options);
-  if (!projectsRoot || isCoolingDown(projectsRoot)) return records;
-  const ids = await readTranscriptIndex(
-    projectsRoot,
-    options.fs ?? nodeFs,
-    options.timeoutMs ?? CLAUDE_TRANSCRIPT_LOOKUP_TIMEOUT_MS
-  );
-  if (!ids) return records;
-  return records.filter((record) => !judged(record) || ids.has(record.sessionId.toLowerCase()));
 }
 
 export function __resetClaudeSessionStoreForTests(): void {

--- a/electron/services/claude/ClaudeSessionStore.ts
+++ b/electron/services/claude/ClaudeSessionStore.ts
@@ -10,9 +10,10 @@
  * side of the #4100 boundary `ClaudeSubagentReader` sits on.
  *
  * Claude Code writes nothing else keyed by the id before that first message, so
- * absence can only ever be proven in one store at a time. Everything here starts
- * by asking which store that is, and answers `unknown` when it can't be sure:
- * reading the wrong one would call a live conversation missing.
+ * absence can only ever be proven in one store. Everything here starts by asking
+ * which store a pane reads, and answers `unknown` unless that is certain:
+ * reading the wrong one would call a live conversation missing, and a relaunch
+ * built on that is rejected by the CLI as already in use.
  *
  * Every answer is one observation at one moment and is never kept: the first
  * message can create the transcript right after a `missing`.
@@ -24,10 +25,10 @@ import path from "path";
 import { relaunchResumeAsAssignedSession } from "../../../shared/types/agentSettings.js";
 import type { AgentSessionRecord } from "../../../shared/types/ipc/agentSessionHistory.js";
 import {
-  getShellObservedEnv,
-  type ShellObservedEnv,
+  getShellEnvironmentObservation,
+  type ShellEnvironmentObservation,
 } from "../../setup/shellEnvironmentObservation.js";
-import { getEnvVar } from "../pty/EnvironmentFilter.js";
+import { getEnvVar, hasEnvVar } from "../pty/EnvironmentFilter.js";
 import { deriveProjectSlug } from "./ClaudeSubagentReader.js";
 
 /**
@@ -52,12 +53,13 @@ const CONFIG_DIR_VAR = "CLAUDE_CONFIG_DIR";
 const TRANSCRIPT_SUFFIX = ".jsonl";
 /** Concurrent project-directory reads during a scan. */
 const SCAN_CONCURRENCY = 8;
+/** Terminals whose store is remembered from their spawn; the oldest go first. */
+const PANE_STORE_MEMORY = 1_024;
 /** Claude Code only accepts a UUID as a session id, so nothing else can name a transcript it wrote. */
 const SESSION_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 /**
  * The titles a Claude pane carries before its first message: Daintree's label
  * for the agent and Claude Code's idle title, with or without its status glyph.
- * Claude Code retitles the terminal after the conversation it starts.
  */
 const UNTOUCHED_TITLE_PATTERN = /^(?:[^\p{L}\p{N}\s]\s*)?Claude(?: Code)?$/u;
 
@@ -71,8 +73,9 @@ export interface ClaudeStoreFs {
 
 /** Where a pane's store is decided from. Defaults are this process's own. */
 export interface ClaudeStoreContext {
+  /** Daintree's own environment, for the shell a terminal gets by default. */
   env?: EnvLike;
-  readShellEnv?: () => ShellObservedEnv | undefined;
+  readShellObservation?: () => ShellEnvironmentObservation | undefined;
   platform?: NodeJS.Platform;
 }
 
@@ -97,44 +100,43 @@ function within<T>(promise: Promise<T>, ms: number): Promise<T | typeof TIMED_OU
   return Promise.race([promise, expiry]).finally(() => clearTimeout(timer));
 }
 
+function errorCode(error: unknown): unknown {
+  return (error as { code?: unknown } | null)?.code;
+}
+
 function isAbsence(error: unknown): boolean {
-  const code = (error as { code?: unknown } | null)?.code;
+  const code = errorCode(error);
   return code === "ENOENT" || code === "ENOTDIR";
 }
 
-function readConfigDir(env: EnvLike | undefined): string | undefined {
-  return (env && getEnvVar(env, CONFIG_DIR_VAR)?.trim()) || undefined;
-}
-
-function projectsRootFor(configDir: string | undefined): string | null {
-  if (!configDir) return path.join(os.homedir(), ".claude", "projects");
-  // A relative value resolves against the CLI's own cwd, which differs per pane.
-  return path.isAbsolute(configDir) ? path.join(configDir, "projects") : null;
-}
-
 /**
- * The `projects/` directory a Claude pane launched with `spawnEnv` reads, or
- * null when that can't be pinned to one place.
+ * The `projects/` directory a Claude pane will read, or null unless that is
+ * certain.
  *
- * A pane's shell sources the user's profile, and main copies only `PATH` out of
- * the startup shell probe, so a `CLAUDE_CONFIG_DIR` exported from `.zshrc`
- * reaches every pane but never this process. The probe's own observation fills
- * that in; without one, a POSIX pane's store is unknowable. Windows panes don't
- * source a login profile, so what they inherit is what they get. A profile that
- * exports a different value from the one the pane inherits may or may not win,
- * depending on how it is written, so that is unknown too.
+ * A pane's shell sources the user's profile, which can export, change, or unset
+ * `CLAUDE_CONFIG_DIR`, and main never sees the result. Certainty therefore needs
+ * the pane to start from exactly what the startup probe saw: the same shell, and
+ * no `CLAUDE_CONFIG_DIR` of its own for that profile to treat differently. Its
+ * profile then does to the pane whatever it did to the probe. Anything else — a
+ * different shell, a pane-level override, no probe yet — is unknown, and so is
+ * Windows, whose PowerShell and cmd profiles are never probed.
+ *
+ * `pane.shell` defaults to the shell a terminal gets when nothing names one.
  */
 export function resolvePaneClaudeProjectsRoot(
-  spawnEnv?: EnvLike,
+  pane: { shell?: string; env?: EnvLike } = {},
   context: ClaudeStoreContext = {}
 ): string | null {
-  const platform = context.platform ?? process.platform;
-  const shellEnv = platform === "win32" ? {} : (context.readShellEnv ?? getShellObservedEnv)();
-  if (!shellEnv) return null;
-  const inherited = readConfigDir(spawnEnv) ?? readConfigDir(context.env ?? process.env);
-  const exported = readConfigDir(shellEnv);
-  if (inherited && exported && inherited !== exported) return null;
-  return projectsRootFor(exported ?? inherited);
+  if ((context.platform ?? process.platform) === "win32") return null;
+  if (pane.env && hasEnvVar(pane.env, CONFIG_DIR_VAR)) return null;
+  const observation = (context.readShellObservation ?? getShellEnvironmentObservation)();
+  const shell = pane.shell ?? getEnvVar(context.env ?? process.env, "SHELL");
+  if (!observation || !shell || shell !== observation.shell) return null;
+  const configDir = observation.env[CONFIG_DIR_VAR];
+  if (configDir === undefined) return path.join(os.homedir(), ".claude", "projects");
+  // Empty or relative: what the CLI makes of either is not something to guess at.
+  const trimmed = configDir.trim();
+  return trimmed && path.isAbsolute(trimmed) ? path.join(trimmed, "projects") : null;
 }
 
 const unreachableUntil = new Map<string, number>();
@@ -148,7 +150,11 @@ function isCoolingDown(projectsRoot: string): boolean {
 }
 
 function markUnreachable(projectsRoot: string): void {
-  unreachableUntil.set(projectsRoot, Date.now() + CLAUDE_STORE_UNREACHABLE_COOLDOWN_MS);
+  const now = Date.now();
+  for (const [root, until] of unreachableUntil) {
+    if (until <= now) unreachableUntil.delete(root);
+  }
+  unreachableUntil.set(projectsRoot, now + CLAUDE_STORE_UNREACHABLE_COOLDOWN_MS);
 }
 
 /**
@@ -170,7 +176,7 @@ async function scanTranscriptIds(
   try {
     projectDirs = await fs.readdir(projectsRoot);
   } catch (error) {
-    if ((error as { code?: unknown } | null)?.code !== "ENOENT") return null;
+    if (errorCode(error) !== "ENOENT" || isCancelled()) return null;
     try {
       await fs.lstat(path.dirname(projectsRoot));
       return new Set();
@@ -291,60 +297,62 @@ export async function observeClaudeTranscript(
  * conversation Claude Code never wrote (#12371), or undefined when the command
  * should run exactly as given.
  *
- * Only a proven absence in the store this pane will actually read changes
- * anything. Reassigning an id that does have a conversation is rejected by the
- * CLI as already in use, so `unknown` keeps the resume that would have run
- * before this check existed. `env` is the spawn's own overrides.
+ * Only a proven absence in `pane.projectsRoot` — the store this pane will read,
+ * from {@link resolvePaneClaudeProjectsRoot} — changes anything, so an uncertain
+ * store or an `unknown` keeps the resume that would have run before this check.
  */
 export async function findUntouchedClaudeSession(
   command: string,
   launchAgentId: string | undefined,
-  pane: { cwd: string; agentSessionId?: string; env?: EnvLike },
-  options: ClaudeStoreOptions = {}
+  pane: { cwd: string; agentSessionId?: string; projectsRoot: string | null },
+  options: Pick<ClaudeStoreOptions, "fs" | "timeoutMs"> = {}
 ): Promise<string | undefined> {
-  if (launchAgentId !== CLAUDE_AGENT_ID) return undefined;
+  if (launchAgentId !== CLAUDE_AGENT_ID || !pane.projectsRoot) return undefined;
   const relaunch = relaunchResumeAsAssignedSession(command, launchAgentId);
   if (!relaunch) return undefined;
   // A pane on record under a different id than the one its command resumes is
   // not a shape Daintree builds. Leave it to the CLI rather than reassign the
   // wrong conversation's id.
   if (pane.agentSessionId && pane.agentSessionId !== relaunch.sessionId) return undefined;
-  const projectsRoot = resolvePaneClaudeProjectsRoot(pane.env, options);
   const observation = await observeClaudeTranscript(
     relaunch.sessionId,
     pane.cwd,
-    projectsRoot,
+    pane.projectsRoot,
     options
   );
   return observation === "missing" ? relaunch.sessionId : undefined;
 }
 
-type SessionRecordFacts = Pick<AgentSessionRecord, "agentId" | "sessionId" | "bookmark" | "title">;
+const paneStores = new Map<string, string | null>();
 
 /**
- * A history record that could be an untouched pane: an unbookmarked Claude
- * session still wearing Claude's pre-conversation title. A record doesn't say
- * which store its pane read — a preset can relocate it — so the title is what
- * keeps a real conversation, in a store this process can't see, from being
- * judged against the wrong one.
+ * Remember which store a Claude terminal was launched against, so its close is
+ * judged by the pane's own store. A history record says nothing about the
+ * environment its pane had; the spawn is the one place that knew.
  */
-function couldBeUntouchedClaudeSession(record: SessionRecordFacts): boolean {
-  if (record.agentId !== CLAUDE_AGENT_ID || record.bookmark !== undefined) return false;
-  if (!SESSION_ID_PATTERN.test(record.sessionId)) return false;
-  const title = record.title?.trim();
-  return !title || UNTOUCHED_TITLE_PATTERN.test(title);
+export function rememberClaudePaneStore(terminalId: string, projectsRoot: string | null): void {
+  paneStores.delete(terminalId);
+  paneStores.set(terminalId, projectsRoot);
+  if (paneStores.size > PANE_STORE_MEMORY) {
+    const oldest = paneStores.keys().next().value;
+    if (oldest !== undefined) paneStores.delete(oldest);
+  }
 }
 
 /**
- * True only for a record that could be an untouched pane and whose transcript is
- * proven missing — the journal's cue not to record a session nobody can resume.
+ * True only for an unbookmarked Claude session whose transcript is proven
+ * missing from the store its terminal was launched against — the journal's cue
+ * not to record a session nobody can resume. A terminal whose store was never
+ * remembered, or wasn't certain, never qualifies.
  */
 export async function isClaudeSessionWithoutTranscript(
-  record: SessionRecordFacts & Pick<AgentSessionRecord, "cwd">,
-  options: ClaudeStoreOptions = {}
+  record: Pick<AgentSessionRecord, "agentId" | "sessionId" | "bookmark" | "cwd">,
+  terminalId: string,
+  options: Pick<ClaudeStoreOptions, "fs" | "timeoutMs"> = {}
 ): Promise<boolean> {
-  if (!couldBeUntouchedClaudeSession(record)) return false;
-  const projectsRoot = resolvePaneClaudeProjectsRoot(undefined, options);
+  if (record.agentId !== CLAUDE_AGENT_ID || record.bookmark !== undefined) return false;
+  const projectsRoot = paneStores.get(terminalId);
+  if (!projectsRoot) return false;
   const observation = await observeClaudeTranscript(
     record.sessionId,
     record.cwd,
@@ -354,18 +362,42 @@ export async function isClaudeSessionWithoutTranscript(
   return observation === "missing";
 }
 
+type SessionRecordFacts = Pick<AgentSessionRecord, "agentId" | "sessionId" | "bookmark" | "title">;
+
+/**
+ * A history record that could be an untouched pane: an unbookmarked Claude
+ * session still wearing Claude's pre-conversation title. A record outlives the
+ * spawn that knew its pane's store, so an old one has to look untouched as well
+ * before it is judged at all.
+ */
+function couldBeUntouchedClaudeSession(record: SessionRecordFacts): boolean {
+  if (record.agentId !== CLAUDE_AGENT_ID || record.bookmark !== undefined) return false;
+  if (!SESSION_ID_PATTERN.test(record.sessionId)) return false;
+  const title = record.title?.trim();
+  return !title || UNTOUCHED_TITLE_PATTERN.test(title);
+}
+
+export interface DropClaudeSessionsOptions<T> extends ClaudeStoreOptions {
+  /** Records the caller knows may have run against a different store. Always kept. */
+  keep?: (record: T) => boolean;
+}
+
 /**
  * Drops untouched Claude sessions from a history list, so the resume list stops
- * offering conversations `--resume` can never open. Read-side only: the journal
- * on disk is untouched, bookmarks and retitled sessions always stay, and a store
- * that can't be pinned down or read in full filters nothing.
+ * offering conversations `--resume` can never open. Only records that could
+ * have come from a default pane are judged, against the store such a pane reads,
+ * and the caller's `keep` vetoes any it knows were launched differently.
+ * Read-side only: the journal on disk is untouched, and a store that can't be
+ * pinned down or read in full filters nothing.
  */
 export async function dropClaudeSessionsWithoutTranscript<T extends SessionRecordFacts>(
   records: T[],
-  options: ClaudeStoreOptions = {}
+  options: DropClaudeSessionsOptions<T> = {}
 ): Promise<T[]> {
-  if (!records.some(couldBeUntouchedClaudeSession)) return records;
-  const projectsRoot = resolvePaneClaudeProjectsRoot(undefined, options);
+  const judged = (record: T): boolean =>
+    couldBeUntouchedClaudeSession(record) && !options.keep?.(record);
+  if (!records.some(judged)) return records;
+  const projectsRoot = resolvePaneClaudeProjectsRoot({}, options);
   if (!projectsRoot || isCoolingDown(projectsRoot)) return records;
   const ids = await readTranscriptIndex(
     projectsRoot,
@@ -373,12 +405,11 @@ export async function dropClaudeSessionsWithoutTranscript<T extends SessionRecor
     options.timeoutMs ?? CLAUDE_TRANSCRIPT_LOOKUP_TIMEOUT_MS
   );
   if (!ids) return records;
-  return records.filter(
-    (record) => !couldBeUntouchedClaudeSession(record) || ids.has(record.sessionId.toLowerCase())
-  );
+  return records.filter((record) => !judged(record) || ids.has(record.sessionId.toLowerCase()));
 }
 
 export function __resetClaudeSessionStoreForTests(): void {
   inFlightScans.clear();
   unreachableUntil.clear();
+  paneStores.clear();
 }

--- a/electron/services/claude/ClaudeSessionStore.ts
+++ b/electron/services/claude/ClaudeSessionStore.ts
@@ -9,8 +9,13 @@
  * the only answer, so this reads the store — and only reads it, the same narrow
  * side of the #4100 boundary `ClaudeSubagentReader` sits on.
  *
- * Every answer is one observation of one store at one moment and is never kept:
- * the first message can create the transcript right after a `missing`.
+ * Claude Code writes nothing else keyed by the id before that first message, so
+ * absence can only ever be proven in one store at a time. Everything here starts
+ * by asking which store that is, and answers `unknown` when it can't be sure:
+ * reading the wrong one would call a live conversation missing.
+ *
+ * Every answer is one observation at one moment and is never kept: the first
+ * message can create the transcript right after a `missing`.
  */
 
 import { lstat, readdir } from "fs/promises";
@@ -18,26 +23,43 @@ import os from "os";
 import path from "path";
 import { relaunchResumeAsAssignedSession } from "../../../shared/types/agentSettings.js";
 import type { AgentSessionRecord } from "../../../shared/types/ipc/agentSessionHistory.js";
-import { getEnvVar, hasEnvVar } from "../pty/EnvironmentFilter.js";
-import { withTimeout } from "../../utils/withTimeout.js";
+import {
+  getShellObservedEnv,
+  type ShellObservedEnv,
+} from "../../setup/shellEnvironmentObservation.js";
+import { getEnvVar } from "../pty/EnvironmentFilter.js";
 import { deriveProjectSlug } from "./ClaudeSubagentReader.js";
 
 /**
  * `unknown` covers everything that isn't proof either way: a store that can't be
- * located or read in full, a lookup that ran out of time, an id that can't be one
- * of Claude's. Callers treat it as "do what you did before".
+ * pinned down or read in full, a lookup that ran out of time, an id that can't be
+ * one of Claude's. Callers treat it as "do what you did before".
  */
 export type ClaudeTranscriptObservation = "present" | "missing" | "unknown";
 
-/** Budget for one lookup, fallback scan included. A dead network mount must not hold up a launch. */
+/** Budget for one caller's lookup, fallback scan included. A dead mount must not hold up a launch. */
 export const CLAUDE_TRANSCRIPT_LOOKUP_TIMEOUT_MS = 1_500;
 
+/**
+ * How long a store that timed out is left alone. A dead mount answers every
+ * lookup the same way, and each one would spend the whole budget again — on app
+ * quit, once per pane, against a fixed shutdown deadline.
+ */
+export const CLAUDE_STORE_UNREACHABLE_COOLDOWN_MS = 60_000;
+
 const CLAUDE_AGENT_ID = "claude";
+const CONFIG_DIR_VAR = "CLAUDE_CONFIG_DIR";
 const TRANSCRIPT_SUFFIX = ".jsonl";
 /** Concurrent project-directory reads during a scan. */
 const SCAN_CONCURRENCY = 8;
 /** Claude Code only accepts a UUID as a session id, so nothing else can name a transcript it wrote. */
 const SESSION_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+/**
+ * The titles a Claude pane carries before its first message: Daintree's label
+ * for the agent and Claude Code's idle title, with or without its status glyph.
+ * Claude Code retitles the terminal after the conversation it starts.
+ */
+const UNTOUCHED_TITLE_PATTERN = /^(?:[^\p{L}\p{N}\s]\s*)?Claude(?: Code)?$/u;
 
 type EnvLike = Readonly<Record<string, string | undefined>>;
 
@@ -47,8 +69,14 @@ export interface ClaudeStoreFs {
   readdir(target: string): Promise<string[]>;
 }
 
-export interface ClaudeStoreOptions {
+/** Where a pane's store is decided from. Defaults are this process's own. */
+export interface ClaudeStoreContext {
   env?: EnvLike;
+  readShellEnv?: () => ShellObservedEnv | undefined;
+  platform?: NodeJS.Platform;
+}
+
+export interface ClaudeStoreOptions extends ClaudeStoreContext {
   timeoutMs?: number;
   fs?: ClaudeStoreFs;
 }
@@ -58,30 +86,74 @@ const nodeFs: ClaudeStoreFs = {
   readdir: (target) => readdir(target),
 };
 
-function errorCode(error: unknown): unknown {
-  return (error as { code?: unknown } | null)?.code;
+const TIMED_OUT = Symbol("timed out");
+
+function within<T>(promise: Promise<T>, ms: number): Promise<T | typeof TIMED_OUT> {
+  if (ms <= 0) return Promise.resolve(TIMED_OUT);
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const expiry = new Promise<typeof TIMED_OUT>((resolve) => {
+    timer = setTimeout(() => resolve(TIMED_OUT), ms);
+  });
+  return Promise.race([promise, expiry]).finally(() => clearTimeout(timer));
 }
 
 function isAbsence(error: unknown): boolean {
-  const code = errorCode(error);
+  const code = (error as { code?: unknown } | null)?.code;
   return code === "ENOENT" || code === "ENOTDIR";
 }
 
-/**
- * `<configDir>/projects`, or null when there is no one place to look.
- * `CLAUDE_CONFIG_DIR` relocates the store; a relative value resolves against the
- * CLI's own cwd, which differs per pane, so it is refused rather than resolved
- * against Daintree's.
- */
-export function resolveClaudeProjectsRoot(env: EnvLike = process.env): string | null {
-  const override = getEnvVar(env, "CLAUDE_CONFIG_DIR")?.trim();
-  if (override) return path.isAbsolute(override) ? path.join(override, "projects") : null;
-  return path.join(os.homedir(), ".claude", "projects");
+function readConfigDir(env: EnvLike | undefined): string | undefined {
+  return (env && getEnvVar(env, CONFIG_DIR_VAR)?.trim()) || undefined;
+}
+
+function projectsRootFor(configDir: string | undefined): string | null {
+  if (!configDir) return path.join(os.homedir(), ".claude", "projects");
+  // A relative value resolves against the CLI's own cwd, which differs per pane.
+  return path.isAbsolute(configDir) ? path.join(configDir, "projects") : null;
 }
 
 /**
- * Every session id with a transcript anywhere in the store, or null when the
- * store couldn't be read in full.
+ * The `projects/` directory a Claude pane launched with `spawnEnv` reads, or
+ * null when that can't be pinned to one place.
+ *
+ * A pane's shell sources the user's profile, and main copies only `PATH` out of
+ * the startup shell probe, so a `CLAUDE_CONFIG_DIR` exported from `.zshrc`
+ * reaches every pane but never this process. The probe's own observation fills
+ * that in; without one, a POSIX pane's store is unknowable. Windows panes don't
+ * source a login profile, so what they inherit is what they get. A profile that
+ * exports a different value from the one the pane inherits may or may not win,
+ * depending on how it is written, so that is unknown too.
+ */
+export function resolvePaneClaudeProjectsRoot(
+  spawnEnv?: EnvLike,
+  context: ClaudeStoreContext = {}
+): string | null {
+  const platform = context.platform ?? process.platform;
+  const shellEnv = platform === "win32" ? {} : (context.readShellEnv ?? getShellObservedEnv)();
+  if (!shellEnv) return null;
+  const inherited = readConfigDir(spawnEnv) ?? readConfigDir(context.env ?? process.env);
+  const exported = readConfigDir(shellEnv);
+  if (inherited && exported && inherited !== exported) return null;
+  return projectsRootFor(exported ?? inherited);
+}
+
+const unreachableUntil = new Map<string, number>();
+
+function isCoolingDown(projectsRoot: string): boolean {
+  const until = unreachableUntil.get(projectsRoot);
+  if (until === undefined) return false;
+  if (Date.now() < until) return true;
+  unreachableUntil.delete(projectsRoot);
+  return false;
+}
+
+function markUnreachable(projectsRoot: string): void {
+  unreachableUntil.set(projectsRoot, Date.now() + CLAUDE_STORE_UNREACHABLE_COOLDOWN_MS);
+}
+
+/**
+ * Every session id (lowercased) with a transcript anywhere in the store, or null
+ * when the store couldn't be read in full.
  *
  * The whole store, not one project directory: the slug is a guess, and an exact
  * `--resume <id>` finds a conversation in any project, so absence only means
@@ -98,7 +170,7 @@ async function scanTranscriptIds(
   try {
     projectDirs = await fs.readdir(projectsRoot);
   } catch (error) {
-    if (errorCode(error) !== "ENOENT") return null;
+    if ((error as { code?: unknown } | null)?.code !== "ENOENT") return null;
     try {
       await fs.lstat(path.dirname(projectsRoot));
       return new Set();
@@ -124,7 +196,9 @@ async function scanTranscriptIds(
         return;
       }
       for (const name of names) {
-        if (name.endsWith(TRANSCRIPT_SUFFIX)) ids.add(name.slice(0, -TRANSCRIPT_SUFFIX.length));
+        if (name.endsWith(TRANSCRIPT_SUFFIX)) {
+          ids.add(name.slice(0, -TRANSCRIPT_SUFFIX.length).toLowerCase());
+        }
       }
     }
   };
@@ -135,47 +209,56 @@ async function scanTranscriptIds(
 const inFlightScans = new Map<string, Promise<Set<string> | null>>();
 
 /**
- * Shares one scan between concurrent callers — a session restore asks for every
- * pane at once — and forgets it the moment it settles. A timed-out scan stops
- * reading further directories; `fs` calls already started can't be recalled.
+ * One scan per store at a time, shared by every caller who asks while it runs —
+ * a session restore asks for every pane at once — and forgotten the moment it
+ * settles. Each caller waits only as long as its own budget allows. The scan
+ * stops reading once the budget of the caller that started it runs out, and
+ * that store is then left alone for a while; `fs` calls already started can't
+ * be recalled.
  */
-function readTranscriptIndex(
+async function readTranscriptIndex(
   projectsRoot: string,
   fs: ClaudeStoreFs,
   timeoutMs: number
 ): Promise<Set<string> | null> {
-  const pending = inFlightScans.get(projectsRoot);
-  if (pending) return pending;
-  let cancelled = false;
-  const scan = withTimeout(
-    scanTranscriptIds(projectsRoot, fs, () => cancelled),
-    timeoutMs,
-    "Claude transcript scan timed out"
-  )
-    .catch(() => {
-      cancelled = true;
-      return null;
-    })
-    .finally(() => {
-      inFlightScans.delete(projectsRoot);
-    });
-  inFlightScans.set(projectsRoot, scan);
-  return scan;
+  if (timeoutMs <= 0) return null;
+  let scan = inFlightScans.get(projectsRoot);
+  if (!scan) {
+    let cancelled = false;
+    const started = scanTranscriptIds(projectsRoot, fs, () => cancelled).catch(() => null);
+    const shared: Promise<Set<string> | null> = within(started, timeoutMs)
+      .then((result) => {
+        if (result !== TIMED_OUT) return result;
+        cancelled = true;
+        markUnreachable(projectsRoot);
+        return null;
+      })
+      .finally(() => {
+        if (inFlightScans.get(projectsRoot) === shared) inFlightScans.delete(projectsRoot);
+      });
+    inFlightScans.set(projectsRoot, shared);
+    scan = shared;
+  }
+  const result = await within(scan, timeoutMs);
+  return result === TIMED_OUT ? null : result;
 }
 
+type DirectLookup = "found" | "absent" | "failed";
+
 /**
- * Whether `sessionId` has a transcript in the Claude store `env` points at.
- * `cwd` only buys the fast path: the derived slug is one `lstat` and hits for
- * nearly every real conversation, so resuming one never pays for the scan.
+ * Whether `sessionId` has a transcript under `projectsRoot`. `cwd` only buys the
+ * fast path: the derived slug is one `lstat` and hits for nearly every real
+ * conversation, so resuming one never pays for the scan.
  */
 export async function observeClaudeTranscript(
   sessionId: string,
   cwd: string | undefined,
-  options: ClaudeStoreOptions = {}
+  projectsRoot: string | null,
+  options: Pick<ClaudeStoreOptions, "fs" | "timeoutMs"> = {}
 ): Promise<ClaudeTranscriptObservation> {
-  if (!SESSION_ID_PATTERN.test(sessionId)) return "unknown";
-  const projectsRoot = resolveClaudeProjectsRoot(options.env);
-  if (!projectsRoot) return "unknown";
+  if (!projectsRoot || !SESSION_ID_PATTERN.test(sessionId) || isCoolingDown(projectsRoot)) {
+    return "unknown";
+  }
   const fs = options.fs ?? nodeFs;
   const deadline = Date.now() + (options.timeoutMs ?? CLAUDE_TRANSCRIPT_LOOKUP_TIMEOUT_MS);
 
@@ -185,21 +268,22 @@ export async function observeClaudeTranscript(
       deriveProjectSlug(cwd),
       `${sessionId}${TRANSCRIPT_SUFFIX}`
     );
-    try {
-      await withTimeout(
-        fs.lstat(direct),
-        deadline - Date.now(),
-        "Claude transcript lookup timed out"
-      );
-      return "present";
-    } catch (error) {
-      if (!isAbsence(error)) return "unknown";
+    const lookup = fs.lstat(direct).then(
+      (): DirectLookup => "found",
+      (error: unknown): DirectLookup => (isAbsence(error) ? "absent" : "failed")
+    );
+    const outcome = await within(lookup, deadline - Date.now());
+    if (outcome === TIMED_OUT) {
+      markUnreachable(projectsRoot);
+      return "unknown";
     }
+    if (outcome === "found") return "present";
+    if (outcome === "failed") return "unknown";
   }
 
-  const ids = await readTranscriptIndex(projectsRoot, fs, Math.max(0, deadline - Date.now()));
+  const ids = await readTranscriptIndex(projectsRoot, fs, deadline - Date.now());
   if (!ids) return "unknown";
-  return ids.has(sessionId) ? "present" : "missing";
+  return ids.has(sessionId.toLowerCase()) ? "present" : "missing";
 }
 
 /**
@@ -207,18 +291,16 @@ export async function observeClaudeTranscript(
  * conversation Claude Code never wrote (#12371), or undefined when the command
  * should run exactly as given.
  *
- * Only a proven absence changes anything. Reassigning an id that does have a
- * conversation is rejected by the CLI as already in use, so `unknown` keeps the
- * resume that would have run before this check existed.
- *
- * `env` is the spawn's own overrides; Daintree's environment fills in whatever
- * they leave out, which is where the pane inherits the rest from.
+ * Only a proven absence in the store this pane will actually read changes
+ * anything. Reassigning an id that does have a conversation is rejected by the
+ * CLI as already in use, so `unknown` keeps the resume that would have run
+ * before this check existed. `env` is the spawn's own overrides.
  */
 export async function findUntouchedClaudeSession(
   command: string,
   launchAgentId: string | undefined,
-  context: { cwd: string; agentSessionId?: string; env?: EnvLike },
-  options: Omit<ClaudeStoreOptions, "env"> = {}
+  pane: { cwd: string; agentSessionId?: string; env?: EnvLike },
+  options: ClaudeStoreOptions = {}
 ): Promise<string | undefined> {
   if (launchAgentId !== CLAUDE_AGENT_ID) return undefined;
   const relaunch = relaunchResumeAsAssignedSession(command, launchAgentId);
@@ -226,56 +308,77 @@ export async function findUntouchedClaudeSession(
   // A pane on record under a different id than the one its command resumes is
   // not a shape Daintree builds. Leave it to the CLI rather than reassign the
   // wrong conversation's id.
-  if (context.agentSessionId && context.agentSessionId !== relaunch.sessionId) return undefined;
-  const env =
-    context.env && hasEnvVar(context.env, "CLAUDE_CONFIG_DIR") ? context.env : process.env;
-  const observation = await observeClaudeTranscript(relaunch.sessionId, context.cwd, {
-    ...options,
-    env,
-  });
+  if (pane.agentSessionId && pane.agentSessionId !== relaunch.sessionId) return undefined;
+  const projectsRoot = resolvePaneClaudeProjectsRoot(pane.env, options);
+  const observation = await observeClaudeTranscript(
+    relaunch.sessionId,
+    pane.cwd,
+    projectsRoot,
+    options
+  );
   return observation === "missing" ? relaunch.sessionId : undefined;
 }
 
-type SessionRecordIdentity = Pick<AgentSessionRecord, "agentId" | "sessionId" | "bookmark">;
+type SessionRecordFacts = Pick<AgentSessionRecord, "agentId" | "sessionId" | "bookmark" | "title">;
 
-function isUnpinnedClaudeSession(record: SessionRecordIdentity): boolean {
-  return (
-    record.agentId === CLAUDE_AGENT_ID &&
-    record.bookmark === undefined &&
-    SESSION_ID_PATTERN.test(record.sessionId)
-  );
+/**
+ * A history record that could be an untouched pane: an unbookmarked Claude
+ * session still wearing Claude's pre-conversation title. A record doesn't say
+ * which store its pane read — a preset can relocate it — so the title is what
+ * keeps a real conversation, in a store this process can't see, from being
+ * judged against the wrong one.
+ */
+function couldBeUntouchedClaudeSession(record: SessionRecordFacts): boolean {
+  if (record.agentId !== CLAUDE_AGENT_ID || record.bookmark !== undefined) return false;
+  if (!SESSION_ID_PATTERN.test(record.sessionId)) return false;
+  const title = record.title?.trim();
+  return !title || UNTOUCHED_TITLE_PATTERN.test(title);
 }
 
 /**
- * True only when `record` is an unbookmarked Claude session whose transcript is
+ * True only for a record that could be an untouched pane and whose transcript is
  * proven missing — the journal's cue not to record a session nobody can resume.
  */
 export async function isClaudeSessionWithoutTranscript(
-  record: SessionRecordIdentity & Pick<AgentSessionRecord, "cwd">,
+  record: SessionRecordFacts & Pick<AgentSessionRecord, "cwd">,
   options: ClaudeStoreOptions = {}
 ): Promise<boolean> {
-  if (!isUnpinnedClaudeSession(record)) return false;
-  return (await observeClaudeTranscript(record.sessionId, record.cwd, options)) === "missing";
+  if (!couldBeUntouchedClaudeSession(record)) return false;
+  const projectsRoot = resolvePaneClaudeProjectsRoot(undefined, options);
+  const observation = await observeClaudeTranscript(
+    record.sessionId,
+    record.cwd,
+    projectsRoot,
+    options
+  );
+  return observation === "missing";
 }
 
 /**
- * Drops Claude history entries with no conversation behind them, so the resume
- * list stops offering sessions `--resume` can never open. Read-side only: the
- * journal on disk is untouched, a bookmark always stays (the user pinned it),
- * and a store that can't be read in full filters nothing.
+ * Drops untouched Claude sessions from a history list, so the resume list stops
+ * offering conversations `--resume` can never open. Read-side only: the journal
+ * on disk is untouched, bookmarks and retitled sessions always stay, and a store
+ * that can't be pinned down or read in full filters nothing.
  */
-export async function dropClaudeSessionsWithoutTranscript<T extends SessionRecordIdentity>(
+export async function dropClaudeSessionsWithoutTranscript<T extends SessionRecordFacts>(
   records: T[],
   options: ClaudeStoreOptions = {}
 ): Promise<T[]> {
-  if (!records.some(isUnpinnedClaudeSession)) return records;
-  const projectsRoot = resolveClaudeProjectsRoot(options.env);
-  if (!projectsRoot) return records;
+  if (!records.some(couldBeUntouchedClaudeSession)) return records;
+  const projectsRoot = resolvePaneClaudeProjectsRoot(undefined, options);
+  if (!projectsRoot || isCoolingDown(projectsRoot)) return records;
   const ids = await readTranscriptIndex(
     projectsRoot,
     options.fs ?? nodeFs,
     options.timeoutMs ?? CLAUDE_TRANSCRIPT_LOOKUP_TIMEOUT_MS
   );
   if (!ids) return records;
-  return records.filter((record) => !isUnpinnedClaudeSession(record) || ids.has(record.sessionId));
+  return records.filter(
+    (record) => !couldBeUntouchedClaudeSession(record) || ids.has(record.sessionId.toLowerCase())
+  );
+}
+
+export function __resetClaudeSessionStoreForTests(): void {
+  inFlightScans.clear();
+  unreachableUntil.clear();
 }

--- a/electron/services/claude/ClaudeSessionStore.ts
+++ b/electron/services/claude/ClaudeSessionStore.ts
@@ -1,0 +1,281 @@
+/**
+ * Whether a Claude Code session id has a conversation behind it, read out of the
+ * store Claude Code already keeps (#12371).
+ *
+ * Daintree assigns Claude's session id at launch (#11782), but Claude Code only
+ * writes `<configDir>/projects/<slug>/<id>.jsonl` once a message is sent. A pane
+ * nobody typed into leaves an id behind that `--resume` rejects outright ("No
+ * conversation found"), and the CLI offers no way to ask beforehand. The file is
+ * the only answer, so this reads the store — and only reads it, the same narrow
+ * side of the #4100 boundary `ClaudeSubagentReader` sits on.
+ *
+ * Every answer is one observation of one store at one moment and is never kept:
+ * the first message can create the transcript right after a `missing`.
+ */
+
+import { lstat, readdir } from "fs/promises";
+import os from "os";
+import path from "path";
+import { relaunchResumeAsAssignedSession } from "../../../shared/types/agentSettings.js";
+import type { AgentSessionRecord } from "../../../shared/types/ipc/agentSessionHistory.js";
+import { getEnvVar, hasEnvVar } from "../pty/EnvironmentFilter.js";
+import { withTimeout } from "../../utils/withTimeout.js";
+import { deriveProjectSlug } from "./ClaudeSubagentReader.js";
+
+/**
+ * `unknown` covers everything that isn't proof either way: a store that can't be
+ * located or read in full, a lookup that ran out of time, an id that can't be one
+ * of Claude's. Callers treat it as "do what you did before".
+ */
+export type ClaudeTranscriptObservation = "present" | "missing" | "unknown";
+
+/** Budget for one lookup, fallback scan included. A dead network mount must not hold up a launch. */
+export const CLAUDE_TRANSCRIPT_LOOKUP_TIMEOUT_MS = 1_500;
+
+const CLAUDE_AGENT_ID = "claude";
+const TRANSCRIPT_SUFFIX = ".jsonl";
+/** Concurrent project-directory reads during a scan. */
+const SCAN_CONCURRENCY = 8;
+/** Claude Code only accepts a UUID as a session id, so nothing else can name a transcript it wrote. */
+const SESSION_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+type EnvLike = Readonly<Record<string, string | undefined>>;
+
+/** Injection seam for tests. Both are plain `fs/promises` reads. */
+export interface ClaudeStoreFs {
+  lstat(target: string): Promise<unknown>;
+  readdir(target: string): Promise<string[]>;
+}
+
+export interface ClaudeStoreOptions {
+  env?: EnvLike;
+  timeoutMs?: number;
+  fs?: ClaudeStoreFs;
+}
+
+const nodeFs: ClaudeStoreFs = {
+  lstat: (target) => lstat(target),
+  readdir: (target) => readdir(target),
+};
+
+function errorCode(error: unknown): unknown {
+  return (error as { code?: unknown } | null)?.code;
+}
+
+function isAbsence(error: unknown): boolean {
+  const code = errorCode(error);
+  return code === "ENOENT" || code === "ENOTDIR";
+}
+
+/**
+ * `<configDir>/projects`, or null when there is no one place to look.
+ * `CLAUDE_CONFIG_DIR` relocates the store; a relative value resolves against the
+ * CLI's own cwd, which differs per pane, so it is refused rather than resolved
+ * against Daintree's.
+ */
+export function resolveClaudeProjectsRoot(env: EnvLike = process.env): string | null {
+  const override = getEnvVar(env, "CLAUDE_CONFIG_DIR")?.trim();
+  if (override) return path.isAbsolute(override) ? path.join(override, "projects") : null;
+  return path.join(os.homedir(), ".claude", "projects");
+}
+
+/**
+ * Every session id with a transcript anywhere in the store, or null when the
+ * store couldn't be read in full.
+ *
+ * The whole store, not one project directory: the slug is a guess, and an exact
+ * `--resume <id>` finds a conversation in any project, so absence only means
+ * something once every directory has been checked. A missing `projects/` is an
+ * empty store only when the config dir around it exists — Claude Code creates
+ * that on first run, and without it this is more likely the wrong place to look.
+ */
+async function scanTranscriptIds(
+  projectsRoot: string,
+  fs: ClaudeStoreFs,
+  isCancelled: () => boolean
+): Promise<Set<string> | null> {
+  let projectDirs: string[];
+  try {
+    projectDirs = await fs.readdir(projectsRoot);
+  } catch (error) {
+    if (errorCode(error) !== "ENOENT") return null;
+    try {
+      await fs.lstat(path.dirname(projectsRoot));
+      return new Set();
+    } catch {
+      return null;
+    }
+  }
+
+  const ids = new Set<string>();
+  let failed = false;
+  let next = 0;
+  const worker = async (): Promise<void> => {
+    while (!failed && !isCancelled()) {
+      const entry = projectDirs[next++];
+      if (entry === undefined) return;
+      let names: string[];
+      try {
+        names = await fs.readdir(path.join(projectsRoot, entry));
+      } catch (error) {
+        // A stray file beside the project directories, or one removed mid-scan.
+        if (isAbsence(error)) continue;
+        failed = true;
+        return;
+      }
+      for (const name of names) {
+        if (name.endsWith(TRANSCRIPT_SUFFIX)) ids.add(name.slice(0, -TRANSCRIPT_SUFFIX.length));
+      }
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(SCAN_CONCURRENCY, projectDirs.length) }, worker));
+  return failed || isCancelled() ? null : ids;
+}
+
+const inFlightScans = new Map<string, Promise<Set<string> | null>>();
+
+/**
+ * Shares one scan between concurrent callers — a session restore asks for every
+ * pane at once — and forgets it the moment it settles. A timed-out scan stops
+ * reading further directories; `fs` calls already started can't be recalled.
+ */
+function readTranscriptIndex(
+  projectsRoot: string,
+  fs: ClaudeStoreFs,
+  timeoutMs: number
+): Promise<Set<string> | null> {
+  const pending = inFlightScans.get(projectsRoot);
+  if (pending) return pending;
+  let cancelled = false;
+  const scan = withTimeout(
+    scanTranscriptIds(projectsRoot, fs, () => cancelled),
+    timeoutMs,
+    "Claude transcript scan timed out"
+  )
+    .catch(() => {
+      cancelled = true;
+      return null;
+    })
+    .finally(() => {
+      inFlightScans.delete(projectsRoot);
+    });
+  inFlightScans.set(projectsRoot, scan);
+  return scan;
+}
+
+/**
+ * Whether `sessionId` has a transcript in the Claude store `env` points at.
+ * `cwd` only buys the fast path: the derived slug is one `lstat` and hits for
+ * nearly every real conversation, so resuming one never pays for the scan.
+ */
+export async function observeClaudeTranscript(
+  sessionId: string,
+  cwd: string | undefined,
+  options: ClaudeStoreOptions = {}
+): Promise<ClaudeTranscriptObservation> {
+  if (!SESSION_ID_PATTERN.test(sessionId)) return "unknown";
+  const projectsRoot = resolveClaudeProjectsRoot(options.env);
+  if (!projectsRoot) return "unknown";
+  const fs = options.fs ?? nodeFs;
+  const deadline = Date.now() + (options.timeoutMs ?? CLAUDE_TRANSCRIPT_LOOKUP_TIMEOUT_MS);
+
+  if (cwd) {
+    const direct = path.join(
+      projectsRoot,
+      deriveProjectSlug(cwd),
+      `${sessionId}${TRANSCRIPT_SUFFIX}`
+    );
+    try {
+      await withTimeout(
+        fs.lstat(direct),
+        deadline - Date.now(),
+        "Claude transcript lookup timed out"
+      );
+      return "present";
+    } catch (error) {
+      if (!isAbsence(error)) return "unknown";
+    }
+  }
+
+  const ids = await readTranscriptIndex(projectsRoot, fs, Math.max(0, deadline - Date.now()));
+  if (!ids) return "unknown";
+  return ids.has(sessionId) ? "present" : "missing";
+}
+
+/**
+ * The session id to assign afresh when a Claude launch would resume a
+ * conversation Claude Code never wrote (#12371), or undefined when the command
+ * should run exactly as given.
+ *
+ * Only a proven absence changes anything. Reassigning an id that does have a
+ * conversation is rejected by the CLI as already in use, so `unknown` keeps the
+ * resume that would have run before this check existed.
+ *
+ * `env` is the spawn's own overrides; Daintree's environment fills in whatever
+ * they leave out, which is where the pane inherits the rest from.
+ */
+export async function findUntouchedClaudeSession(
+  command: string,
+  launchAgentId: string | undefined,
+  context: { cwd: string; agentSessionId?: string; env?: EnvLike },
+  options: Omit<ClaudeStoreOptions, "env"> = {}
+): Promise<string | undefined> {
+  if (launchAgentId !== CLAUDE_AGENT_ID) return undefined;
+  const relaunch = relaunchResumeAsAssignedSession(command, launchAgentId);
+  if (!relaunch) return undefined;
+  // A pane on record under a different id than the one its command resumes is
+  // not a shape Daintree builds. Leave it to the CLI rather than reassign the
+  // wrong conversation's id.
+  if (context.agentSessionId && context.agentSessionId !== relaunch.sessionId) return undefined;
+  const env =
+    context.env && hasEnvVar(context.env, "CLAUDE_CONFIG_DIR") ? context.env : process.env;
+  const observation = await observeClaudeTranscript(relaunch.sessionId, context.cwd, {
+    ...options,
+    env,
+  });
+  return observation === "missing" ? relaunch.sessionId : undefined;
+}
+
+type SessionRecordIdentity = Pick<AgentSessionRecord, "agentId" | "sessionId" | "bookmark">;
+
+function isUnpinnedClaudeSession(record: SessionRecordIdentity): boolean {
+  return (
+    record.agentId === CLAUDE_AGENT_ID &&
+    record.bookmark === undefined &&
+    SESSION_ID_PATTERN.test(record.sessionId)
+  );
+}
+
+/**
+ * True only when `record` is an unbookmarked Claude session whose transcript is
+ * proven missing — the journal's cue not to record a session nobody can resume.
+ */
+export async function isClaudeSessionWithoutTranscript(
+  record: SessionRecordIdentity & Pick<AgentSessionRecord, "cwd">,
+  options: ClaudeStoreOptions = {}
+): Promise<boolean> {
+  if (!isUnpinnedClaudeSession(record)) return false;
+  return (await observeClaudeTranscript(record.sessionId, record.cwd, options)) === "missing";
+}
+
+/**
+ * Drops Claude history entries with no conversation behind them, so the resume
+ * list stops offering sessions `--resume` can never open. Read-side only: the
+ * journal on disk is untouched, a bookmark always stays (the user pinned it),
+ * and a store that can't be read in full filters nothing.
+ */
+export async function dropClaudeSessionsWithoutTranscript<T extends SessionRecordIdentity>(
+  records: T[],
+  options: ClaudeStoreOptions = {}
+): Promise<T[]> {
+  if (!records.some(isUnpinnedClaudeSession)) return records;
+  const projectsRoot = resolveClaudeProjectsRoot(options.env);
+  if (!projectsRoot) return records;
+  const ids = await readTranscriptIndex(
+    projectsRoot,
+    options.fs ?? nodeFs,
+    options.timeoutMs ?? CLAUDE_TRANSCRIPT_LOOKUP_TIMEOUT_MS
+  );
+  if (!ids) return records;
+  return records.filter((record) => !isUnpinnedClaudeSession(record) || ids.has(record.sessionId));
+}

--- a/electron/services/claude/__tests__/ClaudeSessionStore.test.ts
+++ b/electron/services/claude/__tests__/ClaudeSessionStore.test.ts
@@ -3,12 +3,14 @@ import { lstat, mkdir, mkdtemp, readdir, rm, writeFile } from "fs/promises";
 import os from "os";
 import path from "path";
 import type { AgentSessionRecord } from "../../../../shared/types/ipc/agentSessionHistory.js";
+import type { ShellEnvironmentObservation } from "../../../setup/shellEnvironmentObservation.js";
 import {
   __resetClaudeSessionStoreForTests,
   dropClaudeSessionsWithoutTranscript,
   findUntouchedClaudeSession,
   isClaudeSessionWithoutTranscript,
   observeClaudeTranscript,
+  rememberClaudePaneStore,
   resolvePaneClaudeProjectsRoot,
   type ClaudeStoreFs,
   type ClaudeStoreOptions,
@@ -18,6 +20,7 @@ const SESSION = "006fdfc0-67bf-4df0-ad82-48ebfe4df184";
 const OTHER = "1ad2578c-b710-4302-90c1-b222c4c29aa2";
 const CWD = "/work/app";
 const CWD_SLUG = "-work-app";
+const SHELL = "/bin/zsh";
 
 const realFs: ClaudeStoreFs = {
   lstat: (target) => lstat(target),
@@ -26,23 +29,25 @@ const realFs: ClaudeStoreFs = {
 
 let configDir: string;
 let projectsRoot: string;
-/** A POSIX pane whose login profile points Claude at the temp store. */
-let context: ClaudeStoreOptions;
 
 beforeEach(async () => {
   __resetClaudeSessionStoreForTests();
   configDir = await mkdtemp(path.join(os.tmpdir(), "claude-session-store-"));
   projectsRoot = path.join(configDir, "projects");
-  context = {
-    platform: "linux",
-    env: {},
-    readShellEnv: () => ({ CLAUDE_CONFIG_DIR: configDir }),
-  };
 });
 
 afterEach(async () => {
   await rm(configDir, { recursive: true, force: true });
 });
+
+/** A POSIX machine whose probed login shell points Claude at `configDir`, unless told otherwise. */
+function machine(observation?: ShellEnvironmentObservation | null): ClaudeStoreOptions {
+  const observed =
+    observation === undefined
+      ? { shell: SHELL, env: { CLAUDE_CONFIG_DIR: configDir } }
+      : (observation ?? undefined);
+  return { platform: "linux", env: { SHELL }, readShellObservation: () => observed };
+}
 
 async function writeTranscript(slug: string, sessionId: string): Promise<void> {
   const dir = path.join(projectsRoot, slug);
@@ -70,66 +75,51 @@ function countingFs(
 }
 
 describe("resolvePaneClaudeProjectsRoot", () => {
-  const linux = (shell: Record<string, string> | undefined, env: Record<string, string> = {}) => ({
-    platform: "linux" as const,
-    env,
-    readShellEnv: () => shell,
+  it("follows the store the probed profile points panes at", () => {
+    expect(resolvePaneClaudeProjectsRoot({}, machine())).toBe(projectsRoot);
   });
 
-  it("follows a store the login profile exports, which main never inherits", () => {
-    expect(resolvePaneClaudeProjectsRoot(undefined, linux({ CLAUDE_CONFIG_DIR: configDir }))).toBe(
-      projectsRoot
-    );
-  });
-
-  it("uses the default store when neither the profile nor the pane relocates it", () => {
-    expect(resolvePaneClaudeProjectsRoot(undefined, linux({}))).toBe(
+  it("uses the default store when the probed profile leaves it unset", () => {
+    expect(resolvePaneClaudeProjectsRoot({}, machine({ shell: SHELL, env: {} }))).toBe(
       path.join(os.homedir(), ".claude", "projects")
     );
   });
 
-  it("follows the pane's own override when the profile sets none", () => {
-    expect(resolvePaneClaudeProjectsRoot({ CLAUDE_CONFIG_DIR: configDir }, linux({}))).toBe(
+  it("accepts a pane that names the probed shell itself", () => {
+    expect(resolvePaneClaudeProjectsRoot({ shell: SHELL }, { ...machine(), env: {} })).toBe(
       projectsRoot
     );
   });
 
-  it("agrees with a profile that exports the same store the pane inherits", () => {
-    expect(
-      resolvePaneClaudeProjectsRoot(
-        undefined,
-        linux({ CLAUDE_CONFIG_DIR: configDir }, { CLAUDE_CONFIG_DIR: configDir })
-      )
-    ).toBe(projectsRoot);
+  it("is unknown before the shell has been probed", () => {
+    expect(resolvePaneClaudeProjectsRoot({}, machine(null))).toBeNull();
   });
 
-  it("can't say which store a POSIX pane reads before its shell was observed", () => {
-    expect(resolvePaneClaudeProjectsRoot(undefined, linux(undefined))).toBeNull();
+  it("is unknown for a pane launching a different shell than the one probed", () => {
+    expect(resolvePaneClaudeProjectsRoot({ shell: "/bin/bash" }, machine())).toBeNull();
   });
 
-  it("refuses a profile and a pane that name different stores", () => {
-    expect(
-      resolvePaneClaudeProjectsRoot(
-        { CLAUDE_CONFIG_DIR: configDir },
-        linux({ CLAUDE_CONFIG_DIR: path.join(configDir, "elsewhere") })
-      )
-    ).toBeNull();
+  it("is unknown for a pane with its own CLAUDE_CONFIG_DIR, even an empty one", () => {
+    for (const value of [configDir, ""]) {
+      expect(
+        resolvePaneClaudeProjectsRoot({ env: { CLAUDE_CONFIG_DIR: value } }, machine())
+      ).toBeNull();
+    }
   });
 
-  it("refuses a relative override, which the CLI resolves against each pane's own cwd", () => {
-    expect(
-      resolvePaneClaudeProjectsRoot(undefined, linux({ CLAUDE_CONFIG_DIR: "relative/claude" }))
-    ).toBeNull();
+  it("is unknown when the profile sets an empty or relative store", () => {
+    for (const value of ["", "relative/claude"]) {
+      expect(
+        resolvePaneClaudeProjectsRoot(
+          {},
+          machine({ shell: SHELL, env: { CLAUDE_CONFIG_DIR: value } })
+        )
+      ).toBeNull();
+    }
   });
 
-  it("trusts what a Windows pane inherits, since it sources no login profile", () => {
-    expect(
-      resolvePaneClaudeProjectsRoot(undefined, {
-        platform: "win32",
-        env: { CLAUDE_CONFIG_DIR: configDir },
-        readShellEnv: () => undefined,
-      })
-    ).toBe(projectsRoot);
+  it("is unknown on Windows, whose PowerShell and cmd profiles are never probed", () => {
+    expect(resolvePaneClaudeProjectsRoot({}, { ...machine(), platform: "win32" })).toBeNull();
   });
 });
 
@@ -241,21 +231,26 @@ describe("observeClaudeTranscript", () => {
 
   it("lets a caller joining a slow scan give up at its own deadline", async () => {
     await writeTranscript(CWD_SLUG, OTHER);
+    let releaseRoot: () => void = () => {};
+    const rootListed = new Promise<void>((resolve) => {
+      releaseRoot = resolve;
+    });
     const slow: ClaudeStoreFs = {
       ...realFs,
       readdir: async (target) => {
-        if (target === projectsRoot) await new Promise((resolve) => setTimeout(resolve, 150));
+        if (target === projectsRoot) await rootListed;
         return realFs.readdir(target);
       },
     };
 
     const owner = observeClaudeTranscript(SESSION, undefined, projectsRoot, {
       fs: slow,
-      timeoutMs: 1_000,
+      timeoutMs: 30_000,
     });
     await expect(
       observeClaudeTranscript(SESSION, undefined, projectsRoot, { fs: slow, timeoutMs: 20 })
     ).resolves.toBe("unknown");
+    releaseRoot();
     // The joiner running out of time says nothing about the store itself.
     await expect(owner).resolves.toBe("missing");
   });
@@ -277,55 +272,46 @@ describe("findUntouchedClaudeSession", () => {
   it("names the id to reassign when a resume has no conversation behind it", async () => {
     await writeTranscript(CWD_SLUG, OTHER);
     await expect(
-      findUntouchedClaudeSession(
-        `claude --resume ${SESSION}`,
-        "claude",
-        { cwd: CWD, agentSessionId: SESSION },
-        context
-      )
+      findUntouchedClaudeSession(`claude --resume ${SESSION}`, "claude", {
+        cwd: CWD,
+        agentSessionId: SESSION,
+        projectsRoot,
+      })
     ).resolves.toBe(SESSION);
   });
 
   it("keeps the resume when the conversation exists", async () => {
     await writeTranscript(CWD_SLUG, SESSION);
     await expect(
-      findUntouchedClaudeSession(`claude --resume ${SESSION}`, "claude", { cwd: CWD }, context)
+      findUntouchedClaudeSession(`claude --resume ${SESSION}`, "claude", {
+        cwd: CWD,
+        projectsRoot,
+      })
     ).resolves.toBeUndefined();
   });
 
-  it("keeps the resume when it can't tell which store the pane reads", async () => {
-    await writeTranscript(CWD_SLUG, OTHER);
+  it("keeps the resume without reading anything when the pane's store isn't certain", async () => {
+    const fs = countingFs();
     await expect(
       findUntouchedClaudeSession(
         `claude --resume ${SESSION}`,
         "claude",
-        { cwd: CWD },
-        { ...context, readShellEnv: () => undefined }
+        { cwd: CWD, projectsRoot: null },
+        { fs }
       )
     ).resolves.toBeUndefined();
-  });
-
-  it("checks the store the pane's own environment points at", async () => {
-    await writeTranscript(CWD_SLUG, OTHER);
-    await expect(
-      findUntouchedClaudeSession(
-        `claude --resume ${SESSION}`,
-        "claude",
-        { cwd: CWD, env: { CLAUDE_CONFIG_DIR: configDir } },
-        { ...context, readShellEnv: () => ({}) }
-      )
-    ).resolves.toBe(SESSION);
+    expect(fs.lstatCalls).toEqual([]);
+    expect(fs.readdirCalls).toEqual([]);
   });
 
   it("leaves a pane alone when its record names a different id than its command resumes", async () => {
     await writeTranscript(CWD_SLUG, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
     await expect(
-      findUntouchedClaudeSession(
-        `claude --resume ${SESSION}`,
-        "claude",
-        { cwd: CWD, agentSessionId: OTHER },
-        context
-      )
+      findUntouchedClaudeSession(`claude --resume ${SESSION}`, "claude", {
+        cwd: CWD,
+        agentSessionId: OTHER,
+        projectsRoot,
+      })
     ).resolves.toBeUndefined();
   });
 
@@ -335,19 +321,16 @@ describe("findUntouchedClaudeSession", () => {
       findUntouchedClaudeSession(
         `claude --session-id ${SESSION}`,
         "claude",
-        { cwd: CWD },
-        {
-          ...context,
-          fs,
-        }
+        { cwd: CWD, projectsRoot },
+        { fs }
       )
     ).resolves.toBeUndefined();
     await expect(
       findUntouchedClaudeSession(
         `codex resume ${SESSION}`,
         "codex",
-        { cwd: CWD },
-        { ...context, fs }
+        { cwd: CWD, projectsRoot },
+        { fs }
       )
     ).resolves.toBeUndefined();
     expect(fs.readdirCalls).toEqual([]);
@@ -355,7 +338,6 @@ describe("findUntouchedClaudeSession", () => {
   });
 });
 
-type HistoryRecord = Pick<AgentSessionRecord, "agentId" | "sessionId" | "bookmark" | "title">;
 const BOOKMARK = { bookmarkedAt: 1 } as AgentSessionRecord["bookmark"];
 
 describe("isClaudeSessionWithoutTranscript", () => {
@@ -363,30 +345,56 @@ describe("isClaudeSessionWithoutTranscript", () => {
     await writeTranscript(CWD_SLUG, OTHER);
   });
 
-  it("flags a session still wearing Claude's pre-conversation title", async () => {
-    for (const title of ["✳ Claude Code", "Claude", null]) {
+  it("judges a closed session by the store its own terminal launched against", async () => {
+    rememberClaudePaneStore("term-1", projectsRoot);
+
+    await expect(
+      isClaudeSessionWithoutTranscript(
+        { agentId: "claude", sessionId: SESSION, cwd: CWD },
+        "term-1"
+      )
+    ).resolves.toBe(true);
+    await expect(
+      isClaudeSessionWithoutTranscript({ agentId: "claude", sessionId: OTHER, cwd: CWD }, "term-1")
+    ).resolves.toBe(false);
+  });
+
+  it("never judges a terminal whose store is unknown or was never remembered", async () => {
+    rememberClaudePaneStore("term-uncertain", null);
+    for (const terminalId of ["term-uncertain", "term-never-spawned"]) {
       await expect(
         isClaudeSessionWithoutTranscript(
-          { agentId: "claude", sessionId: SESSION, cwd: CWD, title },
-          context
+          { agentId: "claude", sessionId: SESSION, cwd: CWD },
+          terminalId
         )
-      ).resolves.toBe(true);
+      ).resolves.toBe(false);
     }
   });
 
-  it("keeps anything that shows a conversation happened or isn't this agent's to judge", async () => {
-    const records = [
-      // Retitled after its conversation, so its store may be one this process can't see.
-      { agentId: "claude", sessionId: SESSION, cwd: CWD, title: "✳ Fix the login redirect" },
-      { agentId: "claude", sessionId: OTHER, cwd: CWD, title: "✳ Claude Code" },
-      { agentId: "claude", sessionId: SESSION, cwd: CWD, title: null, bookmark: BOOKMARK },
-      { agentId: "codex", sessionId: SESSION, cwd: CWD, title: null },
-    ];
-    for (const record of records) {
-      await expect(isClaudeSessionWithoutTranscript(record, context)).resolves.toBe(false);
-    }
+  it("leaves bookmarks and other agents alone", async () => {
+    rememberClaudePaneStore("term-1", projectsRoot);
+    await expect(
+      isClaudeSessionWithoutTranscript(
+        { agentId: "claude", sessionId: SESSION, cwd: CWD, bookmark: BOOKMARK },
+        "term-1"
+      )
+    ).resolves.toBe(false);
+    await expect(
+      isClaudeSessionWithoutTranscript({ agentId: "codex", sessionId: SESSION, cwd: CWD }, "term-1")
+    ).resolves.toBe(false);
+  });
+
+  it("forgets the oldest terminals once it remembers too many", async () => {
+    rememberClaudePaneStore("term-oldest", projectsRoot);
+    for (let i = 0; i < 1_024; i++) rememberClaudePaneStore(`term-${i}`, projectsRoot);
+
+    const record = { agentId: "claude", sessionId: SESSION, cwd: CWD };
+    await expect(isClaudeSessionWithoutTranscript(record, "term-oldest")).resolves.toBe(false);
+    await expect(isClaudeSessionWithoutTranscript(record, "term-1023")).resolves.toBe(true);
   });
 });
+
+type HistoryRecord = Pick<AgentSessionRecord, "agentId" | "sessionId" | "bookmark" | "title">;
 
 describe("dropClaudeSessionsWithoutTranscript", () => {
   it("hides untouched Claude sessions with no conversation and keeps everything else", async () => {
@@ -399,28 +407,48 @@ describe("dropClaudeSessionsWithoutTranscript", () => {
       { agentId: "claude", sessionId: SESSION, title: null, bookmark: BOOKMARK },
     ];
 
-    await expect(dropClaudeSessionsWithoutTranscript(records, context)).resolves.toEqual(
+    await expect(dropClaudeSessionsWithoutTranscript(records, machine())).resolves.toEqual(
       records.slice(1)
     );
   });
 
-  it("filters nothing when it can't tell which store the sessions came from", async () => {
-    const records: HistoryRecord[] = [{ agentId: "claude", sessionId: SESSION, title: null }];
+  it("keeps whatever the caller knows may have used another store", async () => {
+    await writeTranscript(CWD_SLUG, OTHER);
+    const records: HistoryRecord[] = [
+      { agentId: "claude", sessionId: SESSION, title: "Claude" },
+      { agentId: "claude", sessionId: SESSION.replace("006f", "106f"), title: "Claude" },
+    ];
+
     await expect(
-      dropClaudeSessionsWithoutTranscript(records, { ...context, readShellEnv: () => undefined })
-    ).resolves.toBe(records);
+      dropClaudeSessionsWithoutTranscript(records, {
+        ...machine(),
+        keep: (record) => record === records[0],
+      })
+    ).resolves.toEqual([records[0]]);
   });
 
-  it("doesn't read the store for a list with nothing to check", async () => {
+  it("filters nothing when a default pane's store isn't certain", async () => {
+    const records: HistoryRecord[] = [{ agentId: "claude", sessionId: SESSION, title: null }];
+    await expect(dropClaudeSessionsWithoutTranscript(records, machine(null))).resolves.toBe(
+      records
+    );
+  });
+
+  it("doesn't read the store for a list with nothing to judge", async () => {
     const fs = countingFs();
     const records: HistoryRecord[] = [
       { agentId: "codex", sessionId: SESSION, title: null },
       { agentId: "claude", sessionId: OTHER, title: null, bookmark: BOOKMARK },
       { agentId: "claude", sessionId: OTHER, title: "✳ Fix the login redirect" },
+      { agentId: "claude", sessionId: SESSION, title: "Claude" },
     ];
-    await expect(dropClaudeSessionsWithoutTranscript(records, { ...context, fs })).resolves.toBe(
-      records
-    );
+    await expect(
+      dropClaudeSessionsWithoutTranscript(records, {
+        ...machine(),
+        fs,
+        keep: (record) => record.agentId === "claude" && record.title === "Claude",
+      })
+    ).resolves.toBe(records);
     expect(fs.readdirCalls).toEqual([]);
   });
 });

--- a/electron/services/claude/__tests__/ClaudeSessionStore.test.ts
+++ b/electron/services/claude/__tests__/ClaudeSessionStore.test.ts
@@ -6,7 +6,6 @@ import type { AgentSessionRecord } from "../../../../shared/types/ipc/agentSessi
 import type { ShellEnvironmentObservation } from "../../../setup/shellEnvironmentObservation.js";
 import {
   __resetClaudeSessionStoreForTests,
-  dropClaudeSessionsWithoutTranscript,
   findUntouchedClaudeSession,
   isClaudeSessionWithoutTranscript,
   observeClaudeTranscript,
@@ -97,6 +96,33 @@ describe("resolvePaneClaudeProjectsRoot", () => {
 
   it("is unknown for a pane launching a different shell than the one probed", () => {
     expect(resolvePaneClaudeProjectsRoot({ shell: "/bin/bash" }, machine())).toBeNull();
+  });
+
+  it("accepts bash as well as zsh, the shells a pane starts as a login shell", () => {
+    const bash = "/opt/homebrew/bin/bash";
+    expect(
+      resolvePaneClaudeProjectsRoot(
+        {},
+        { ...machine({ shell: bash, env: { CLAUDE_CONFIG_DIR: configDir } }), env: { SHELL: bash } }
+      )
+    ).toBe(projectsRoot);
+  });
+
+  it("is unknown for a shell a pane doesn't start as a login shell the way the probe does", () => {
+    expect(
+      resolvePaneClaudeProjectsRoot(
+        {},
+        { ...machine({ shell: "/bin/sh", env: {} }), env: { SHELL: "/bin/sh" } }
+      )
+    ).toBeNull();
+  });
+
+  it("is unknown for a pane that changes which startup files its shell reads", () => {
+    for (const name of ["HOME", "ZDOTDIR", "ENV", "BASH_ENV"]) {
+      expect(
+        resolvePaneClaudeProjectsRoot({ env: { [name]: "/elsewhere" } }, machine())
+      ).toBeNull();
+    }
   });
 
   it("is unknown for a pane with its own CLAUDE_CONFIG_DIR, even an empty one", () => {
@@ -391,64 +417,5 @@ describe("isClaudeSessionWithoutTranscript", () => {
     const record = { agentId: "claude", sessionId: SESSION, cwd: CWD };
     await expect(isClaudeSessionWithoutTranscript(record, "term-oldest")).resolves.toBe(false);
     await expect(isClaudeSessionWithoutTranscript(record, "term-1023")).resolves.toBe(true);
-  });
-});
-
-type HistoryRecord = Pick<AgentSessionRecord, "agentId" | "sessionId" | "bookmark" | "title">;
-
-describe("dropClaudeSessionsWithoutTranscript", () => {
-  it("hides untouched Claude sessions with no conversation and keeps everything else", async () => {
-    await writeTranscript(CWD_SLUG, OTHER);
-    const records: HistoryRecord[] = [
-      { agentId: "claude", sessionId: SESSION, title: "✳ Claude Code" },
-      { agentId: "claude", sessionId: OTHER, title: "✳ Claude Code" },
-      { agentId: "claude", sessionId: SESSION, title: "✳ Fix the login redirect" },
-      { agentId: "codex", sessionId: SESSION, title: null },
-      { agentId: "claude", sessionId: SESSION, title: null, bookmark: BOOKMARK },
-    ];
-
-    await expect(dropClaudeSessionsWithoutTranscript(records, machine())).resolves.toEqual(
-      records.slice(1)
-    );
-  });
-
-  it("keeps whatever the caller knows may have used another store", async () => {
-    await writeTranscript(CWD_SLUG, OTHER);
-    const records: HistoryRecord[] = [
-      { agentId: "claude", sessionId: SESSION, title: "Claude" },
-      { agentId: "claude", sessionId: SESSION.replace("006f", "106f"), title: "Claude" },
-    ];
-
-    await expect(
-      dropClaudeSessionsWithoutTranscript(records, {
-        ...machine(),
-        keep: (record) => record === records[0],
-      })
-    ).resolves.toEqual([records[0]]);
-  });
-
-  it("filters nothing when a default pane's store isn't certain", async () => {
-    const records: HistoryRecord[] = [{ agentId: "claude", sessionId: SESSION, title: null }];
-    await expect(dropClaudeSessionsWithoutTranscript(records, machine(null))).resolves.toBe(
-      records
-    );
-  });
-
-  it("doesn't read the store for a list with nothing to judge", async () => {
-    const fs = countingFs();
-    const records: HistoryRecord[] = [
-      { agentId: "codex", sessionId: SESSION, title: null },
-      { agentId: "claude", sessionId: OTHER, title: null, bookmark: BOOKMARK },
-      { agentId: "claude", sessionId: OTHER, title: "✳ Fix the login redirect" },
-      { agentId: "claude", sessionId: SESSION, title: "Claude" },
-    ];
-    await expect(
-      dropClaudeSessionsWithoutTranscript(records, {
-        ...machine(),
-        fs,
-        keep: (record) => record.agentId === "claude" && record.title === "Claude",
-      })
-    ).resolves.toBe(records);
-    expect(fs.readdirCalls).toEqual([]);
   });
 });

--- a/electron/services/claude/__tests__/ClaudeSessionStore.test.ts
+++ b/electron/services/claude/__tests__/ClaudeSessionStore.test.ts
@@ -1,15 +1,17 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { lstat, mkdir, mkdtemp, readdir, rm, writeFile } from "fs/promises";
 import os from "os";
 import path from "path";
 import type { AgentSessionRecord } from "../../../../shared/types/ipc/agentSessionHistory.js";
 import {
+  __resetClaudeSessionStoreForTests,
   dropClaudeSessionsWithoutTranscript,
   findUntouchedClaudeSession,
   isClaudeSessionWithoutTranscript,
   observeClaudeTranscript,
-  resolveClaudeProjectsRoot,
+  resolvePaneClaudeProjectsRoot,
   type ClaudeStoreFs,
+  type ClaudeStoreOptions,
 } from "../ClaudeSessionStore.js";
 
 const SESSION = "006fdfc0-67bf-4df0-ad82-48ebfe4df184";
@@ -23,25 +25,34 @@ const realFs: ClaudeStoreFs = {
 };
 
 let configDir: string;
-let env: Record<string, string>;
+let projectsRoot: string;
+/** A POSIX pane whose login profile points Claude at the temp store. */
+let context: ClaudeStoreOptions;
 
 beforeEach(async () => {
+  __resetClaudeSessionStoreForTests();
   configDir = await mkdtemp(path.join(os.tmpdir(), "claude-session-store-"));
-  env = { CLAUDE_CONFIG_DIR: configDir };
+  projectsRoot = path.join(configDir, "projects");
+  context = {
+    platform: "linux",
+    env: {},
+    readShellEnv: () => ({ CLAUDE_CONFIG_DIR: configDir }),
+  };
 });
 
 afterEach(async () => {
-  vi.unstubAllEnvs();
   await rm(configDir, { recursive: true, force: true });
 });
 
 async function writeTranscript(slug: string, sessionId: string): Promise<void> {
-  const dir = path.join(configDir, "projects", slug);
+  const dir = path.join(projectsRoot, slug);
   await mkdir(dir, { recursive: true });
   await writeFile(path.join(dir, `${sessionId}.jsonl`), '{"type":"user"}\n');
 }
 
-function countingFs(): ClaudeStoreFs & { readdirCalls: string[]; lstatCalls: string[] } {
+function countingFs(
+  base: ClaudeStoreFs = realFs
+): ClaudeStoreFs & { readdirCalls: string[]; lstatCalls: string[] } {
   const readdirCalls: string[] = [];
   const lstatCalls: string[] = [];
   return {
@@ -49,28 +60,76 @@ function countingFs(): ClaudeStoreFs & { readdirCalls: string[]; lstatCalls: str
     lstatCalls,
     lstat: (target) => {
       lstatCalls.push(target);
-      return realFs.lstat(target);
+      return base.lstat(target);
     },
     readdir: (target) => {
       readdirCalls.push(target);
-      return realFs.readdir(target);
+      return base.readdir(target);
     },
   };
 }
 
-describe("resolveClaudeProjectsRoot", () => {
-  it("follows CLAUDE_CONFIG_DIR to the relocated store", () => {
-    expect(resolveClaudeProjectsRoot({ CLAUDE_CONFIG_DIR: configDir })).toBe(
-      path.join(configDir, "projects")
+describe("resolvePaneClaudeProjectsRoot", () => {
+  const linux = (shell: Record<string, string> | undefined, env: Record<string, string> = {}) => ({
+    platform: "linux" as const,
+    env,
+    readShellEnv: () => shell,
+  });
+
+  it("follows a store the login profile exports, which main never inherits", () => {
+    expect(resolvePaneClaudeProjectsRoot(undefined, linux({ CLAUDE_CONFIG_DIR: configDir }))).toBe(
+      projectsRoot
     );
   });
 
-  it("falls back to the default store under the home directory", () => {
-    expect(resolveClaudeProjectsRoot({})).toBe(path.join(os.homedir(), ".claude", "projects"));
+  it("uses the default store when neither the profile nor the pane relocates it", () => {
+    expect(resolvePaneClaudeProjectsRoot(undefined, linux({}))).toBe(
+      path.join(os.homedir(), ".claude", "projects")
+    );
+  });
+
+  it("follows the pane's own override when the profile sets none", () => {
+    expect(resolvePaneClaudeProjectsRoot({ CLAUDE_CONFIG_DIR: configDir }, linux({}))).toBe(
+      projectsRoot
+    );
+  });
+
+  it("agrees with a profile that exports the same store the pane inherits", () => {
+    expect(
+      resolvePaneClaudeProjectsRoot(
+        undefined,
+        linux({ CLAUDE_CONFIG_DIR: configDir }, { CLAUDE_CONFIG_DIR: configDir })
+      )
+    ).toBe(projectsRoot);
+  });
+
+  it("can't say which store a POSIX pane reads before its shell was observed", () => {
+    expect(resolvePaneClaudeProjectsRoot(undefined, linux(undefined))).toBeNull();
+  });
+
+  it("refuses a profile and a pane that name different stores", () => {
+    expect(
+      resolvePaneClaudeProjectsRoot(
+        { CLAUDE_CONFIG_DIR: configDir },
+        linux({ CLAUDE_CONFIG_DIR: path.join(configDir, "elsewhere") })
+      )
+    ).toBeNull();
   });
 
   it("refuses a relative override, which the CLI resolves against each pane's own cwd", () => {
-    expect(resolveClaudeProjectsRoot({ CLAUDE_CONFIG_DIR: "relative/claude" })).toBeNull();
+    expect(
+      resolvePaneClaudeProjectsRoot(undefined, linux({ CLAUDE_CONFIG_DIR: "relative/claude" }))
+    ).toBeNull();
+  });
+
+  it("trusts what a Windows pane inherits, since it sources no login profile", () => {
+    expect(
+      resolvePaneClaudeProjectsRoot(undefined, {
+        platform: "win32",
+        env: { CLAUDE_CONFIG_DIR: configDir },
+        readShellEnv: () => undefined,
+      })
+    ).toBe(projectsRoot);
   });
 });
 
@@ -79,46 +138,58 @@ describe("observeClaudeTranscript", () => {
     await writeTranscript(CWD_SLUG, SESSION);
     const fs = countingFs();
 
-    await expect(observeClaudeTranscript(SESSION, CWD, { env, fs })).resolves.toBe("present");
+    await expect(observeClaudeTranscript(SESSION, CWD, projectsRoot, { fs })).resolves.toBe(
+      "present"
+    );
     // The common case costs one lstat, never the scan.
     expect(fs.readdirCalls).toEqual([]);
   });
 
   it("finds a transcript in a project directory the slug guess doesn't match", async () => {
     await writeTranscript("C--work-app", SESSION);
-    await expect(observeClaudeTranscript(SESSION, CWD, { env })).resolves.toBe("present");
+    await expect(observeClaudeTranscript(SESSION, CWD, projectsRoot)).resolves.toBe("present");
+  });
+
+  it("matches a transcript whose name differs only in case", async () => {
+    await writeTranscript(CWD_SLUG, SESSION.toUpperCase());
+    await expect(observeClaudeTranscript(SESSION, undefined, projectsRoot)).resolves.toBe(
+      "present"
+    );
   });
 
   it("reports missing when the store holds other conversations but not this one", async () => {
     await writeTranscript(CWD_SLUG, OTHER);
-    await expect(observeClaudeTranscript(SESSION, CWD, { env })).resolves.toBe("missing");
+    await expect(observeClaudeTranscript(SESSION, CWD, projectsRoot)).resolves.toBe("missing");
   });
 
   it("reports missing for a store Claude Code created but never wrote a conversation into", async () => {
-    await expect(observeClaudeTranscript(SESSION, CWD, { env })).resolves.toBe("missing");
+    await expect(observeClaudeTranscript(SESSION, CWD, projectsRoot)).resolves.toBe("missing");
   });
 
   it("reports unknown when the config dir itself doesn't exist", async () => {
-    const absent = { CLAUDE_CONFIG_DIR: path.join(configDir, "absent") };
-    await expect(observeClaudeTranscript(SESSION, CWD, { env: absent })).resolves.toBe("unknown");
+    const absent = path.join(configDir, "absent", "projects");
+    await expect(observeClaudeTranscript(SESSION, CWD, absent)).resolves.toBe("unknown");
   });
 
-  it("reports unknown for an id that can't name a Claude session, without reading anything", async () => {
+  it("reports unknown without reading anything when there is no store or no real id", async () => {
     const fs = countingFs();
-    await expect(observeClaudeTranscript("s-1", CWD, { env, fs })).resolves.toBe("unknown");
+    await expect(observeClaudeTranscript(SESSION, CWD, null, { fs })).resolves.toBe("unknown");
+    await expect(observeClaudeTranscript("s-1", CWD, projectsRoot, { fs })).resolves.toBe(
+      "unknown"
+    );
     expect(fs.readdirCalls).toEqual([]);
     expect(fs.lstatCalls).toEqual([]);
   });
 
   it("skips a stray file beside the project directories", async () => {
     await writeTranscript(CWD_SLUG, OTHER);
-    await writeFile(path.join(configDir, "projects", "notes.txt"), "not a project");
-    await expect(observeClaudeTranscript(SESSION, CWD, { env })).resolves.toBe("missing");
+    await writeFile(path.join(projectsRoot, "notes.txt"), "not a project");
+    await expect(observeClaudeTranscript(SESSION, CWD, projectsRoot)).resolves.toBe("missing");
   });
 
   it("reports unknown when a project directory can't be read, since the id could be in it", async () => {
     await writeTranscript(CWD_SLUG, OTHER);
-    await mkdir(path.join(configDir, "projects", "locked"));
+    await mkdir(path.join(projectsRoot, "locked"));
     const fs: ClaudeStoreFs = {
       ...realFs,
       readdir: async (target) => {
@@ -128,20 +199,30 @@ describe("observeClaudeTranscript", () => {
         return realFs.readdir(target);
       },
     };
-    await expect(observeClaudeTranscript(SESSION, CWD, { env, fs })).resolves.toBe("unknown");
-  });
-
-  it("reports unknown when the fast path hangs past the budget", async () => {
-    const fs: ClaudeStoreFs = { ...realFs, lstat: () => new Promise(() => {}) };
-    await expect(observeClaudeTranscript(SESSION, CWD, { env, fs, timeoutMs: 20 })).resolves.toBe(
+    await expect(observeClaudeTranscript(SESSION, CWD, projectsRoot, { fs })).resolves.toBe(
       "unknown"
     );
+  });
+
+  it("leaves a store that hung alone for a while instead of paying the budget again", async () => {
+    await writeTranscript(CWD_SLUG, OTHER);
+    const hanging: ClaudeStoreFs = { ...realFs, lstat: () => new Promise(() => {}) };
+    await expect(
+      observeClaudeTranscript(SESSION, CWD, projectsRoot, { fs: hanging, timeoutMs: 20 })
+    ).resolves.toBe("unknown");
+
+    const fs = countingFs();
+    await expect(observeClaudeTranscript(SESSION, CWD, projectsRoot, { fs })).resolves.toBe(
+      "unknown"
+    );
+    expect(fs.lstatCalls).toEqual([]);
+    expect(fs.readdirCalls).toEqual([]);
   });
 
   it("reports unknown when the scan hangs past the budget", async () => {
     const fs: ClaudeStoreFs = { ...realFs, readdir: () => new Promise(() => {}) };
     await expect(
-      observeClaudeTranscript(SESSION, undefined, { env, fs, timeoutMs: 20 })
+      observeClaudeTranscript(SESSION, undefined, projectsRoot, { fs, timeoutMs: 20 })
     ).resolves.toBe("unknown");
   });
 
@@ -150,21 +231,45 @@ describe("observeClaudeTranscript", () => {
     const fs = countingFs();
 
     const results = await Promise.all([
-      observeClaudeTranscript(SESSION, undefined, { env, fs }),
-      observeClaudeTranscript(OTHER, undefined, { env, fs }),
+      observeClaudeTranscript(SESSION, undefined, projectsRoot, { fs }),
+      observeClaudeTranscript(OTHER, undefined, projectsRoot, { fs }),
     ]);
 
     expect(results).toEqual(["missing", "present"]);
-    const projectsRoot = path.join(configDir, "projects");
     expect(fs.readdirCalls.filter((target) => target === projectsRoot)).toHaveLength(1);
+  });
+
+  it("lets a caller joining a slow scan give up at its own deadline", async () => {
+    await writeTranscript(CWD_SLUG, OTHER);
+    const slow: ClaudeStoreFs = {
+      ...realFs,
+      readdir: async (target) => {
+        if (target === projectsRoot) await new Promise((resolve) => setTimeout(resolve, 150));
+        return realFs.readdir(target);
+      },
+    };
+
+    const owner = observeClaudeTranscript(SESSION, undefined, projectsRoot, {
+      fs: slow,
+      timeoutMs: 1_000,
+    });
+    await expect(
+      observeClaudeTranscript(SESSION, undefined, projectsRoot, { fs: slow, timeoutMs: 20 })
+    ).resolves.toBe("unknown");
+    // The joiner running out of time says nothing about the store itself.
+    await expect(owner).resolves.toBe("missing");
   });
 
   it("never remembers a missing, so the first message's transcript is seen at once", async () => {
     await writeTranscript(CWD_SLUG, OTHER);
-    await expect(observeClaudeTranscript(SESSION, undefined, { env })).resolves.toBe("missing");
+    await expect(observeClaudeTranscript(SESSION, undefined, projectsRoot)).resolves.toBe(
+      "missing"
+    );
 
     await writeTranscript(CWD_SLUG, SESSION);
-    await expect(observeClaudeTranscript(SESSION, undefined, { env })).resolves.toBe("present");
+    await expect(observeClaudeTranscript(SESSION, undefined, projectsRoot)).resolves.toBe(
+      "present"
+    );
   });
 });
 
@@ -172,39 +277,55 @@ describe("findUntouchedClaudeSession", () => {
   it("names the id to reassign when a resume has no conversation behind it", async () => {
     await writeTranscript(CWD_SLUG, OTHER);
     await expect(
-      findUntouchedClaudeSession(`claude --resume ${SESSION}`, "claude", {
-        cwd: CWD,
-        agentSessionId: SESSION,
-        env,
-      })
+      findUntouchedClaudeSession(
+        `claude --resume ${SESSION}`,
+        "claude",
+        { cwd: CWD, agentSessionId: SESSION },
+        context
+      )
     ).resolves.toBe(SESSION);
   });
 
   it("keeps the resume when the conversation exists", async () => {
     await writeTranscript(CWD_SLUG, SESSION);
     await expect(
-      findUntouchedClaudeSession(`claude --resume ${SESSION}`, "claude", { cwd: CWD, env })
+      findUntouchedClaudeSession(`claude --resume ${SESSION}`, "claude", { cwd: CWD }, context)
     ).resolves.toBeUndefined();
   });
 
-  it("keeps the resume when the store can't be read", async () => {
-    const absent = { CLAUDE_CONFIG_DIR: path.join(configDir, "absent") };
+  it("keeps the resume when it can't tell which store the pane reads", async () => {
+    await writeTranscript(CWD_SLUG, OTHER);
     await expect(
-      findUntouchedClaudeSession(`claude --resume ${SESSION}`, "claude", {
-        cwd: CWD,
-        env: absent,
-      })
+      findUntouchedClaudeSession(
+        `claude --resume ${SESSION}`,
+        "claude",
+        { cwd: CWD },
+        { ...context, readShellEnv: () => undefined }
+      )
     ).resolves.toBeUndefined();
+  });
+
+  it("checks the store the pane's own environment points at", async () => {
+    await writeTranscript(CWD_SLUG, OTHER);
+    await expect(
+      findUntouchedClaudeSession(
+        `claude --resume ${SESSION}`,
+        "claude",
+        { cwd: CWD, env: { CLAUDE_CONFIG_DIR: configDir } },
+        { ...context, readShellEnv: () => ({}) }
+      )
+    ).resolves.toBe(SESSION);
   });
 
   it("leaves a pane alone when its record names a different id than its command resumes", async () => {
     await writeTranscript(CWD_SLUG, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
     await expect(
-      findUntouchedClaudeSession(`claude --resume ${SESSION}`, "claude", {
-        cwd: CWD,
-        agentSessionId: OTHER,
-        env,
-      })
+      findUntouchedClaudeSession(
+        `claude --resume ${SESSION}`,
+        "claude",
+        { cwd: CWD, agentSessionId: OTHER },
+        context
+      )
     ).resolves.toBeUndefined();
   });
 
@@ -214,87 +335,92 @@ describe("findUntouchedClaudeSession", () => {
       findUntouchedClaudeSession(
         `claude --session-id ${SESSION}`,
         "claude",
-        { cwd: CWD, env },
-        { fs }
+        { cwd: CWD },
+        {
+          ...context,
+          fs,
+        }
       )
     ).resolves.toBeUndefined();
     await expect(
-      findUntouchedClaudeSession(`codex resume ${SESSION}`, "codex", { cwd: CWD, env }, { fs })
+      findUntouchedClaudeSession(
+        `codex resume ${SESSION}`,
+        "codex",
+        { cwd: CWD },
+        { ...context, fs }
+      )
     ).resolves.toBeUndefined();
     expect(fs.readdirCalls).toEqual([]);
     expect(fs.lstatCalls).toEqual([]);
   });
-
-  it("reads the store from Daintree's environment when the spawn doesn't relocate it", async () => {
-    await writeTranscript(CWD_SLUG, OTHER);
-    vi.stubEnv("CLAUDE_CONFIG_DIR", configDir);
-    await expect(
-      findUntouchedClaudeSession(`claude --resume ${SESSION}`, "claude", {
-        cwd: CWD,
-        env: { SOME_PRESET_VAR: "1" },
-      })
-    ).resolves.toBe(SESSION);
-  });
 });
 
-type HistoryRecord = Pick<AgentSessionRecord, "agentId" | "sessionId" | "bookmark">;
+type HistoryRecord = Pick<AgentSessionRecord, "agentId" | "sessionId" | "bookmark" | "title">;
 const BOOKMARK = { bookmarkedAt: 1 } as AgentSessionRecord["bookmark"];
 
 describe("isClaudeSessionWithoutTranscript", () => {
-  it("flags only an unbookmarked Claude session with no transcript", async () => {
+  beforeEach(async () => {
     await writeTranscript(CWD_SLUG, OTHER);
-    const options = { env };
+  });
 
-    await expect(
-      isClaudeSessionWithoutTranscript({ agentId: "claude", sessionId: SESSION, cwd: CWD }, options)
-    ).resolves.toBe(true);
-    await expect(
-      isClaudeSessionWithoutTranscript({ agentId: "claude", sessionId: OTHER, cwd: CWD }, options)
-    ).resolves.toBe(false);
-    await expect(
-      isClaudeSessionWithoutTranscript(
-        { agentId: "claude", sessionId: SESSION, cwd: CWD, bookmark: BOOKMARK },
-        options
-      )
-    ).resolves.toBe(false);
-    await expect(
-      isClaudeSessionWithoutTranscript({ agentId: "codex", sessionId: SESSION, cwd: CWD }, options)
-    ).resolves.toBe(false);
+  it("flags a session still wearing Claude's pre-conversation title", async () => {
+    for (const title of ["✳ Claude Code", "Claude", null]) {
+      await expect(
+        isClaudeSessionWithoutTranscript(
+          { agentId: "claude", sessionId: SESSION, cwd: CWD, title },
+          context
+        )
+      ).resolves.toBe(true);
+    }
+  });
+
+  it("keeps anything that shows a conversation happened or isn't this agent's to judge", async () => {
+    const records = [
+      // Retitled after its conversation, so its store may be one this process can't see.
+      { agentId: "claude", sessionId: SESSION, cwd: CWD, title: "✳ Fix the login redirect" },
+      { agentId: "claude", sessionId: OTHER, cwd: CWD, title: "✳ Claude Code" },
+      { agentId: "claude", sessionId: SESSION, cwd: CWD, title: null, bookmark: BOOKMARK },
+      { agentId: "codex", sessionId: SESSION, cwd: CWD, title: null },
+    ];
+    for (const record of records) {
+      await expect(isClaudeSessionWithoutTranscript(record, context)).resolves.toBe(false);
+    }
   });
 });
 
 describe("dropClaudeSessionsWithoutTranscript", () => {
-  it("hides Claude sessions with no conversation and keeps everything else", async () => {
+  it("hides untouched Claude sessions with no conversation and keeps everything else", async () => {
     await writeTranscript(CWD_SLUG, OTHER);
     const records: HistoryRecord[] = [
-      { agentId: "claude", sessionId: SESSION },
-      { agentId: "claude", sessionId: OTHER },
-      { agentId: "codex", sessionId: SESSION },
-      { agentId: "claude", sessionId: SESSION, bookmark: BOOKMARK },
+      { agentId: "claude", sessionId: SESSION, title: "✳ Claude Code" },
+      { agentId: "claude", sessionId: OTHER, title: "✳ Claude Code" },
+      { agentId: "claude", sessionId: SESSION, title: "✳ Fix the login redirect" },
+      { agentId: "codex", sessionId: SESSION, title: null },
+      { agentId: "claude", sessionId: SESSION, title: null, bookmark: BOOKMARK },
     ];
 
-    await expect(dropClaudeSessionsWithoutTranscript(records, { env })).resolves.toEqual([
-      records[1],
-      records[2],
-      records[3],
-    ]);
-  });
-
-  it("filters nothing when the store can't be read", async () => {
-    const records: HistoryRecord[] = [{ agentId: "claude", sessionId: SESSION }];
-    const absent = { CLAUDE_CONFIG_DIR: path.join(configDir, "absent") };
-    await expect(dropClaudeSessionsWithoutTranscript(records, { env: absent })).resolves.toBe(
-      records
+    await expect(dropClaudeSessionsWithoutTranscript(records, context)).resolves.toEqual(
+      records.slice(1)
     );
   });
 
-  it("doesn't read the store for a list with no Claude sessions to check", async () => {
+  it("filters nothing when it can't tell which store the sessions came from", async () => {
+    const records: HistoryRecord[] = [{ agentId: "claude", sessionId: SESSION, title: null }];
+    await expect(
+      dropClaudeSessionsWithoutTranscript(records, { ...context, readShellEnv: () => undefined })
+    ).resolves.toBe(records);
+  });
+
+  it("doesn't read the store for a list with nothing to check", async () => {
     const fs = countingFs();
     const records: HistoryRecord[] = [
-      { agentId: "codex", sessionId: SESSION },
-      { agentId: "claude", sessionId: OTHER, bookmark: BOOKMARK },
+      { agentId: "codex", sessionId: SESSION, title: null },
+      { agentId: "claude", sessionId: OTHER, title: null, bookmark: BOOKMARK },
+      { agentId: "claude", sessionId: OTHER, title: "✳ Fix the login redirect" },
     ];
-    await expect(dropClaudeSessionsWithoutTranscript(records, { env, fs })).resolves.toBe(records);
+    await expect(dropClaudeSessionsWithoutTranscript(records, { ...context, fs })).resolves.toBe(
+      records
+    );
     expect(fs.readdirCalls).toEqual([]);
   });
 });

--- a/electron/services/claude/__tests__/ClaudeSessionStore.test.ts
+++ b/electron/services/claude/__tests__/ClaudeSessionStore.test.ts
@@ -1,0 +1,300 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { lstat, mkdir, mkdtemp, readdir, rm, writeFile } from "fs/promises";
+import os from "os";
+import path from "path";
+import type { AgentSessionRecord } from "../../../../shared/types/ipc/agentSessionHistory.js";
+import {
+  dropClaudeSessionsWithoutTranscript,
+  findUntouchedClaudeSession,
+  isClaudeSessionWithoutTranscript,
+  observeClaudeTranscript,
+  resolveClaudeProjectsRoot,
+  type ClaudeStoreFs,
+} from "../ClaudeSessionStore.js";
+
+const SESSION = "006fdfc0-67bf-4df0-ad82-48ebfe4df184";
+const OTHER = "1ad2578c-b710-4302-90c1-b222c4c29aa2";
+const CWD = "/work/app";
+const CWD_SLUG = "-work-app";
+
+const realFs: ClaudeStoreFs = {
+  lstat: (target) => lstat(target),
+  readdir: (target) => readdir(target),
+};
+
+let configDir: string;
+let env: Record<string, string>;
+
+beforeEach(async () => {
+  configDir = await mkdtemp(path.join(os.tmpdir(), "claude-session-store-"));
+  env = { CLAUDE_CONFIG_DIR: configDir };
+});
+
+afterEach(async () => {
+  vi.unstubAllEnvs();
+  await rm(configDir, { recursive: true, force: true });
+});
+
+async function writeTranscript(slug: string, sessionId: string): Promise<void> {
+  const dir = path.join(configDir, "projects", slug);
+  await mkdir(dir, { recursive: true });
+  await writeFile(path.join(dir, `${sessionId}.jsonl`), '{"type":"user"}\n');
+}
+
+function countingFs(): ClaudeStoreFs & { readdirCalls: string[]; lstatCalls: string[] } {
+  const readdirCalls: string[] = [];
+  const lstatCalls: string[] = [];
+  return {
+    readdirCalls,
+    lstatCalls,
+    lstat: (target) => {
+      lstatCalls.push(target);
+      return realFs.lstat(target);
+    },
+    readdir: (target) => {
+      readdirCalls.push(target);
+      return realFs.readdir(target);
+    },
+  };
+}
+
+describe("resolveClaudeProjectsRoot", () => {
+  it("follows CLAUDE_CONFIG_DIR to the relocated store", () => {
+    expect(resolveClaudeProjectsRoot({ CLAUDE_CONFIG_DIR: configDir })).toBe(
+      path.join(configDir, "projects")
+    );
+  });
+
+  it("falls back to the default store under the home directory", () => {
+    expect(resolveClaudeProjectsRoot({})).toBe(path.join(os.homedir(), ".claude", "projects"));
+  });
+
+  it("refuses a relative override, which the CLI resolves against each pane's own cwd", () => {
+    expect(resolveClaudeProjectsRoot({ CLAUDE_CONFIG_DIR: "relative/claude" })).toBeNull();
+  });
+});
+
+describe("observeClaudeTranscript", () => {
+  it("finds a transcript under the project directory derived from the cwd", async () => {
+    await writeTranscript(CWD_SLUG, SESSION);
+    const fs = countingFs();
+
+    await expect(observeClaudeTranscript(SESSION, CWD, { env, fs })).resolves.toBe("present");
+    // The common case costs one lstat, never the scan.
+    expect(fs.readdirCalls).toEqual([]);
+  });
+
+  it("finds a transcript in a project directory the slug guess doesn't match", async () => {
+    await writeTranscript("C--work-app", SESSION);
+    await expect(observeClaudeTranscript(SESSION, CWD, { env })).resolves.toBe("present");
+  });
+
+  it("reports missing when the store holds other conversations but not this one", async () => {
+    await writeTranscript(CWD_SLUG, OTHER);
+    await expect(observeClaudeTranscript(SESSION, CWD, { env })).resolves.toBe("missing");
+  });
+
+  it("reports missing for a store Claude Code created but never wrote a conversation into", async () => {
+    await expect(observeClaudeTranscript(SESSION, CWD, { env })).resolves.toBe("missing");
+  });
+
+  it("reports unknown when the config dir itself doesn't exist", async () => {
+    const absent = { CLAUDE_CONFIG_DIR: path.join(configDir, "absent") };
+    await expect(observeClaudeTranscript(SESSION, CWD, { env: absent })).resolves.toBe("unknown");
+  });
+
+  it("reports unknown for an id that can't name a Claude session, without reading anything", async () => {
+    const fs = countingFs();
+    await expect(observeClaudeTranscript("s-1", CWD, { env, fs })).resolves.toBe("unknown");
+    expect(fs.readdirCalls).toEqual([]);
+    expect(fs.lstatCalls).toEqual([]);
+  });
+
+  it("skips a stray file beside the project directories", async () => {
+    await writeTranscript(CWD_SLUG, OTHER);
+    await writeFile(path.join(configDir, "projects", "notes.txt"), "not a project");
+    await expect(observeClaudeTranscript(SESSION, CWD, { env })).resolves.toBe("missing");
+  });
+
+  it("reports unknown when a project directory can't be read, since the id could be in it", async () => {
+    await writeTranscript(CWD_SLUG, OTHER);
+    await mkdir(path.join(configDir, "projects", "locked"));
+    const fs: ClaudeStoreFs = {
+      ...realFs,
+      readdir: async (target) => {
+        if (path.basename(target) === "locked") {
+          throw Object.assign(new Error("permission denied"), { code: "EACCES" });
+        }
+        return realFs.readdir(target);
+      },
+    };
+    await expect(observeClaudeTranscript(SESSION, CWD, { env, fs })).resolves.toBe("unknown");
+  });
+
+  it("reports unknown when the fast path hangs past the budget", async () => {
+    const fs: ClaudeStoreFs = { ...realFs, lstat: () => new Promise(() => {}) };
+    await expect(observeClaudeTranscript(SESSION, CWD, { env, fs, timeoutMs: 20 })).resolves.toBe(
+      "unknown"
+    );
+  });
+
+  it("reports unknown when the scan hangs past the budget", async () => {
+    const fs: ClaudeStoreFs = { ...realFs, readdir: () => new Promise(() => {}) };
+    await expect(
+      observeClaudeTranscript(SESSION, undefined, { env, fs, timeoutMs: 20 })
+    ).resolves.toBe("unknown");
+  });
+
+  it("shares one scan between concurrent lookups", async () => {
+    await writeTranscript(CWD_SLUG, OTHER);
+    const fs = countingFs();
+
+    const results = await Promise.all([
+      observeClaudeTranscript(SESSION, undefined, { env, fs }),
+      observeClaudeTranscript(OTHER, undefined, { env, fs }),
+    ]);
+
+    expect(results).toEqual(["missing", "present"]);
+    const projectsRoot = path.join(configDir, "projects");
+    expect(fs.readdirCalls.filter((target) => target === projectsRoot)).toHaveLength(1);
+  });
+
+  it("never remembers a missing, so the first message's transcript is seen at once", async () => {
+    await writeTranscript(CWD_SLUG, OTHER);
+    await expect(observeClaudeTranscript(SESSION, undefined, { env })).resolves.toBe("missing");
+
+    await writeTranscript(CWD_SLUG, SESSION);
+    await expect(observeClaudeTranscript(SESSION, undefined, { env })).resolves.toBe("present");
+  });
+});
+
+describe("findUntouchedClaudeSession", () => {
+  it("names the id to reassign when a resume has no conversation behind it", async () => {
+    await writeTranscript(CWD_SLUG, OTHER);
+    await expect(
+      findUntouchedClaudeSession(`claude --resume ${SESSION}`, "claude", {
+        cwd: CWD,
+        agentSessionId: SESSION,
+        env,
+      })
+    ).resolves.toBe(SESSION);
+  });
+
+  it("keeps the resume when the conversation exists", async () => {
+    await writeTranscript(CWD_SLUG, SESSION);
+    await expect(
+      findUntouchedClaudeSession(`claude --resume ${SESSION}`, "claude", { cwd: CWD, env })
+    ).resolves.toBeUndefined();
+  });
+
+  it("keeps the resume when the store can't be read", async () => {
+    const absent = { CLAUDE_CONFIG_DIR: path.join(configDir, "absent") };
+    await expect(
+      findUntouchedClaudeSession(`claude --resume ${SESSION}`, "claude", {
+        cwd: CWD,
+        env: absent,
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it("leaves a pane alone when its record names a different id than its command resumes", async () => {
+    await writeTranscript(CWD_SLUG, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+    await expect(
+      findUntouchedClaudeSession(`claude --resume ${SESSION}`, "claude", {
+        cwd: CWD,
+        agentSessionId: OTHER,
+        env,
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it("ignores launches that resume nothing and agents that aren't Claude", async () => {
+    const fs = countingFs();
+    await expect(
+      findUntouchedClaudeSession(
+        `claude --session-id ${SESSION}`,
+        "claude",
+        { cwd: CWD, env },
+        { fs }
+      )
+    ).resolves.toBeUndefined();
+    await expect(
+      findUntouchedClaudeSession(`codex resume ${SESSION}`, "codex", { cwd: CWD, env }, { fs })
+    ).resolves.toBeUndefined();
+    expect(fs.readdirCalls).toEqual([]);
+    expect(fs.lstatCalls).toEqual([]);
+  });
+
+  it("reads the store from Daintree's environment when the spawn doesn't relocate it", async () => {
+    await writeTranscript(CWD_SLUG, OTHER);
+    vi.stubEnv("CLAUDE_CONFIG_DIR", configDir);
+    await expect(
+      findUntouchedClaudeSession(`claude --resume ${SESSION}`, "claude", {
+        cwd: CWD,
+        env: { SOME_PRESET_VAR: "1" },
+      })
+    ).resolves.toBe(SESSION);
+  });
+});
+
+type HistoryRecord = Pick<AgentSessionRecord, "agentId" | "sessionId" | "bookmark">;
+const BOOKMARK = { bookmarkedAt: 1 } as AgentSessionRecord["bookmark"];
+
+describe("isClaudeSessionWithoutTranscript", () => {
+  it("flags only an unbookmarked Claude session with no transcript", async () => {
+    await writeTranscript(CWD_SLUG, OTHER);
+    const options = { env };
+
+    await expect(
+      isClaudeSessionWithoutTranscript({ agentId: "claude", sessionId: SESSION, cwd: CWD }, options)
+    ).resolves.toBe(true);
+    await expect(
+      isClaudeSessionWithoutTranscript({ agentId: "claude", sessionId: OTHER, cwd: CWD }, options)
+    ).resolves.toBe(false);
+    await expect(
+      isClaudeSessionWithoutTranscript(
+        { agentId: "claude", sessionId: SESSION, cwd: CWD, bookmark: BOOKMARK },
+        options
+      )
+    ).resolves.toBe(false);
+    await expect(
+      isClaudeSessionWithoutTranscript({ agentId: "codex", sessionId: SESSION, cwd: CWD }, options)
+    ).resolves.toBe(false);
+  });
+});
+
+describe("dropClaudeSessionsWithoutTranscript", () => {
+  it("hides Claude sessions with no conversation and keeps everything else", async () => {
+    await writeTranscript(CWD_SLUG, OTHER);
+    const records: HistoryRecord[] = [
+      { agentId: "claude", sessionId: SESSION },
+      { agentId: "claude", sessionId: OTHER },
+      { agentId: "codex", sessionId: SESSION },
+      { agentId: "claude", sessionId: SESSION, bookmark: BOOKMARK },
+    ];
+
+    await expect(dropClaudeSessionsWithoutTranscript(records, { env })).resolves.toEqual([
+      records[1],
+      records[2],
+      records[3],
+    ]);
+  });
+
+  it("filters nothing when the store can't be read", async () => {
+    const records: HistoryRecord[] = [{ agentId: "claude", sessionId: SESSION }];
+    const absent = { CLAUDE_CONFIG_DIR: path.join(configDir, "absent") };
+    await expect(dropClaudeSessionsWithoutTranscript(records, { env: absent })).resolves.toBe(
+      records
+    );
+  });
+
+  it("doesn't read the store for a list with no Claude sessions to check", async () => {
+    const fs = countingFs();
+    const records: HistoryRecord[] = [
+      { agentId: "codex", sessionId: SESSION },
+      { agentId: "claude", sessionId: OTHER, bookmark: BOOKMARK },
+    ];
+    await expect(dropClaudeSessionsWithoutTranscript(records, { env, fs })).resolves.toBe(records);
+    expect(fs.readdirCalls).toEqual([]);
+  });
+});

--- a/electron/services/pty/__tests__/agentSessionJournal.test.ts
+++ b/electron/services/pty/__tests__/agentSessionJournal.test.ts
@@ -23,7 +23,9 @@ vi.mock("../../../utils/logger.js", () => ({
 }));
 
 const { isClaudeSessionWithoutTranscriptMock } = vi.hoisted(() => ({
-  isClaudeSessionWithoutTranscriptMock: vi.fn(async (_record: unknown) => false),
+  isClaudeSessionWithoutTranscriptMock: vi.fn(
+    async (_record: unknown, _terminalId: string) => false
+  ),
 }));
 
 // The real lookup reads the developer's own Claude store; keep every case here
@@ -33,6 +35,7 @@ vi.mock("../../claude/ClaudeSessionStore.js", () => ({
   CLAUDE_STORE_UNREACHABLE_COOLDOWN_MS: 60_000,
   resolvePaneClaudeProjectsRoot: vi.fn(() => null),
   __resetClaudeSessionStoreForTests: vi.fn(),
+  rememberClaudePaneStore: vi.fn(),
   observeClaudeTranscript: vi.fn(async () => "unknown"),
   findUntouchedClaudeSession: vi.fn(async () => undefined),
   isClaudeSessionWithoutTranscript: isClaudeSessionWithoutTranscriptMock,
@@ -288,7 +291,8 @@ describe("journalAgentSession", () => {
 
     expect(skipped).toBeNull();
     expect(isClaudeSessionWithoutTranscriptMock).toHaveBeenCalledWith(
-      expect.objectContaining({ sessionId: "sess-empty", agentId: "claude" })
+      expect.objectContaining({ sessionId: "sess-empty", agentId: "claude" }),
+      "term-1"
     );
     expect(await readSessionHistory(userDataDir)).toEqual([]);
     expect(recordedEvents).toEqual([]);

--- a/electron/services/pty/__tests__/agentSessionJournal.test.ts
+++ b/electron/services/pty/__tests__/agentSessionJournal.test.ts
@@ -39,7 +39,6 @@ vi.mock("../../claude/ClaudeSessionStore.js", () => ({
   observeClaudeTranscript: vi.fn(async () => "unknown"),
   findUntouchedClaudeSession: vi.fn(async () => undefined),
   isClaudeSessionWithoutTranscript: isClaudeSessionWithoutTranscriptMock,
-  dropClaudeSessionsWithoutTranscript: vi.fn(async (records: unknown[]) => records),
 }));
 
 import { journalAgentSession, journalAgentSessionRecord } from "../agentSessionJournal.js";

--- a/electron/services/pty/__tests__/agentSessionJournal.test.ts
+++ b/electron/services/pty/__tests__/agentSessionJournal.test.ts
@@ -22,6 +22,21 @@ vi.mock("../../../utils/logger.js", () => ({
   }),
 }));
 
+const { isClaudeSessionWithoutTranscriptMock } = vi.hoisted(() => ({
+  isClaudeSessionWithoutTranscriptMock: vi.fn(async (_record: unknown) => false),
+}));
+
+// The real lookup reads the developer's own Claude store; keep every case here
+// independent of whatever happens to be on this machine.
+vi.mock("../../claude/ClaudeSessionStore.js", () => ({
+  CLAUDE_TRANSCRIPT_LOOKUP_TIMEOUT_MS: 1_500,
+  resolveClaudeProjectsRoot: vi.fn(() => null),
+  observeClaudeTranscript: vi.fn(async () => "unknown"),
+  findUntouchedClaudeSession: vi.fn(async () => undefined),
+  isClaudeSessionWithoutTranscript: isClaudeSessionWithoutTranscriptMock,
+  dropClaudeSessionsWithoutTranscript: vi.fn(async (records: unknown[]) => records),
+}));
+
 import { journalAgentSession, journalAgentSessionRecord } from "../agentSessionJournal.js";
 import { readSessionHistory } from "../agentSessionHistory.js";
 import { getLifecycleLedger, disposeLifecycleLedger } from "../lifecycleLedger.js";
@@ -47,6 +62,8 @@ describe("journalAgentSession", () => {
     userDataDir = await fsp.mkdtemp(path.join(os.tmpdir(), "daintree-session-journal-"));
     process.env.DAINTREE_USER_DATA = userDataDir;
     disposeLifecycleLedger();
+    isClaudeSessionWithoutTranscriptMock.mockReset();
+    isClaudeSessionWithoutTranscriptMock.mockResolvedValue(false);
     recordedEvents = [];
     unsubscribe = events.on("agent-session:recorded", (payload) => {
       recordedEvents.push({ sessionId: payload.sessionId });
@@ -254,5 +271,61 @@ describe("journalAgentSession", () => {
 
     expect(dup).toBeNull();
     expect(recordedEvents).toEqual([]);
+  });
+
+  // #12371: an untouched Claude pane's assigned id has no conversation behind it.
+  it("skips a Claude session with no conversation without claiming the generation", async () => {
+    const ledger = getLifecycleLedger();
+    const generation = ledger.recordLaunch("term-1", { launchAgentId: "claude" });
+    isClaudeSessionWithoutTranscriptMock.mockResolvedValueOnce(true);
+
+    const skipped = await journalAgentSessionRecord(makeRecord("sess-empty"), {
+      terminalId: "term-1",
+      generation,
+    });
+
+    expect(skipped).toBeNull();
+    expect(isClaudeSessionWithoutTranscriptMock).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: "sess-empty", agentId: "claude" })
+    );
+    expect(await readSessionHistory(userDataDir)).toEqual([]);
+    expect(recordedEvents).toEqual([]);
+
+    // Nothing was reserved, so the same incarnation still journals once a
+    // conversation exists.
+    const written = await journalAgentSession(makeRecord("sess-empty"), {
+      terminalId: "term-1",
+      generation,
+    });
+    expect(written).toBe(true);
+    expect(recordedEvents).toEqual([{ sessionId: "sess-empty" }]);
+  });
+
+  it("never second-guesses a bookmark, even without a conversation", async () => {
+    const ledger = getLifecycleLedger();
+    const generation = ledger.recordLaunch("term-1", { launchAgentId: "claude" });
+    isClaudeSessionWithoutTranscriptMock.mockResolvedValue(true);
+
+    const record = await journalAgentSessionRecord(
+      makeRecord("sess-pin", { bookmark: { bookmarkedAt: 5, label: "Pin" } }),
+      { terminalId: "term-1", generation }
+    );
+
+    expect(record?.sessionId).toBe("sess-pin");
+    expect(isClaudeSessionWithoutTranscriptMock).not.toHaveBeenCalled();
+  });
+
+  it("journals as before when the transcript lookup fails", async () => {
+    const ledger = getLifecycleLedger();
+    const generation = ledger.recordLaunch("term-1", { launchAgentId: "claude" });
+    isClaudeSessionWithoutTranscriptMock.mockRejectedValueOnce(new Error("io"));
+
+    const written = await journalAgentSession(makeRecord("sess-1"), {
+      terminalId: "term-1",
+      generation,
+    });
+
+    expect(written).toBe(true);
+    expect(recordedEvents).toEqual([{ sessionId: "sess-1" }]);
   });
 });

--- a/electron/services/pty/__tests__/agentSessionJournal.test.ts
+++ b/electron/services/pty/__tests__/agentSessionJournal.test.ts
@@ -30,7 +30,9 @@ const { isClaudeSessionWithoutTranscriptMock } = vi.hoisted(() => ({
 // independent of whatever happens to be on this machine.
 vi.mock("../../claude/ClaudeSessionStore.js", () => ({
   CLAUDE_TRANSCRIPT_LOOKUP_TIMEOUT_MS: 1_500,
-  resolveClaudeProjectsRoot: vi.fn(() => null),
+  CLAUDE_STORE_UNREACHABLE_COOLDOWN_MS: 60_000,
+  resolvePaneClaudeProjectsRoot: vi.fn(() => null),
+  __resetClaudeSessionStoreForTests: vi.fn(),
   observeClaudeTranscript: vi.fn(async () => "unknown"),
   findUntouchedClaudeSession: vi.fn(async () => undefined),
   isClaudeSessionWithoutTranscript: isClaudeSessionWithoutTranscriptMock,
@@ -327,5 +329,43 @@ describe("journalAgentSession", () => {
 
     expect(written).toBe(true);
     expect(recordedEvents).toEqual([{ sessionId: "sess-1" }]);
+  });
+
+  it("fails open when the ledger evicts the terminal while the lookup runs", async () => {
+    const ledger = getLifecycleLedger();
+    const generation = ledger.recordLaunch("term-1", { launchAgentId: "claude" });
+    let finishLookup: (value: boolean) => void = () => {};
+    isClaudeSessionWithoutTranscriptMock.mockImplementationOnce(
+      () =>
+        new Promise<boolean>((resolve) => {
+          finishLookup = resolve;
+        })
+    );
+
+    const pending = journalAgentSessionRecord(makeRecord("sess-evicted"), {
+      terminalId: "term-1",
+      generation,
+    });
+    // The ledger tracks 256 terminals by default and pushes the oldest out.
+    for (let i = 0; i < 300; i++) ledger.recordLaunch(`other-${i}`, { launchAgentId: "claude" });
+    expect(ledger.currentGeneration("term-1")).toBeUndefined();
+    finishLookup(false);
+
+    const record = await pending;
+    expect(record?.sessionId).toBe("sess-evicted");
+    expect(recordedEvents).toEqual([{ sessionId: "sess-evicted" }]);
+  });
+
+  it("skips a Claude session with no conversation under a frozen-but-unknown generation", async () => {
+    isClaudeSessionWithoutTranscriptMock.mockResolvedValueOnce(true);
+
+    const skipped = await journalAgentSession(makeRecord("sess-empty"), {
+      terminalId: "term-evicted",
+      generation: null,
+    });
+
+    expect(skipped).toBe(false);
+    expect(await readSessionHistory(userDataDir)).toEqual([]);
+    expect(recordedEvents).toEqual([]);
   });
 });

--- a/electron/services/pty/agentSessionJournal.ts
+++ b/electron/services/pty/agentSessionJournal.ts
@@ -39,7 +39,8 @@ async function hasNoClaudeConversation(record: Omit<AgentSessionRecord, "savedAt
 /**
  * Journal one resumable agent session, exactly once per terminal generation,
  * returning the durable record (or `null` when the write was gated out as a
- * duplicate, or as a Claude session with no conversation to resume). Single funnel for every close path — the trash-expiry capture,
+ * duplicate, or as a Claude session with no conversation to resume). Single
+ * funnel for every close path — the trash-expiry capture,
  * the IPC kill / gracefulKill, app shutdown, AND the bookmark-and-close capture
  * (#11288), which passes the same shape with a `bookmark` field set. Main is the
  * journal's only writer; the lifecycle ledger provides the idempotency key
@@ -62,22 +63,25 @@ export async function journalAgentSessionRecord(
     ctx.generation === null
       ? undefined
       : (ctx.generation ?? ledger.currentGeneration(ctx.terminalId));
-  const gatedGeneration =
-    generation !== undefined && ledger.currentGeneration(ctx.terminalId) !== undefined
-      ? generation
-      : undefined;
 
   // A Claude pane nobody typed into leaves an assigned id with no conversation
   // behind it (#12371). Journaling it offers a resume that can never open and
   // spends a slot of the per-worktree cap. Checked after the generation is
-  // frozen, so the wait can't pick up a respawn's, and before the ledger
-  // reservation, so a skip claims nothing. A bookmark is the user's explicit pin
+  // frozen, so the wait can't pick up a respawn's, and before the ledger is
+  // consulted, so a skip claims nothing. A bookmark is the user's explicit pin
   // and is never second-guessed; a failed lookup journals as before.
   if (!record.bookmark && (await hasNoClaudeConversation(record))) {
     logger.debug(`Skipping journal for ${ctx.terminalId}: no Claude conversation was written`);
     return null;
   }
 
+  // Whether the ledger still knows this terminal is read only now: a bounded
+  // ledger can evict it during that wait, and an entry it no longer holds fails
+  // open exactly like one it never saw.
+  const gatedGeneration =
+    generation !== undefined && ledger.currentGeneration(ctx.terminalId) !== undefined
+      ? generation
+      : undefined;
   if (gatedGeneration !== undefined) {
     const verdict = ledger.recordJournal(ctx.terminalId, gatedGeneration, record.sessionId);
     if (!verdict.accepted) {

--- a/electron/services/pty/agentSessionJournal.ts
+++ b/electron/services/pty/agentSessionJournal.ts
@@ -1,4 +1,5 @@
 import { persistAgentSession, type AgentSessionRecord } from "./agentSessionHistory.js";
+import { isClaudeSessionWithoutTranscript } from "../claude/ClaudeSessionStore.js";
 import { getAgentSessionRetentionDays } from "./agentSessionRetention.js";
 import { getLifecycleLedger } from "./lifecycleLedger.js";
 import { events } from "../events.js";
@@ -27,10 +28,18 @@ export interface JournalCloseContext {
   generation?: number | null;
 }
 
+async function hasNoClaudeConversation(record: Omit<AgentSessionRecord, "savedAt">) {
+  try {
+    return await isClaudeSessionWithoutTranscript(record);
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Journal one resumable agent session, exactly once per terminal generation,
  * returning the durable record (or `null` when the write was gated out as a
- * duplicate). Single funnel for every close path — the trash-expiry capture,
+ * duplicate, or as a Claude session with no conversation to resume). Single funnel for every close path — the trash-expiry capture,
  * the IPC kill / gracefulKill, app shutdown, AND the bookmark-and-close capture
  * (#11288), which passes the same shape with a `bookmark` field set. Main is the
  * journal's only writer; the lifecycle ledger provides the idempotency key
@@ -57,6 +66,18 @@ export async function journalAgentSessionRecord(
     generation !== undefined && ledger.currentGeneration(ctx.terminalId) !== undefined
       ? generation
       : undefined;
+
+  // A Claude pane nobody typed into leaves an assigned id with no conversation
+  // behind it (#12371). Journaling it offers a resume that can never open and
+  // spends a slot of the per-worktree cap. Checked after the generation is
+  // frozen, so the wait can't pick up a respawn's, and before the ledger
+  // reservation, so a skip claims nothing. A bookmark is the user's explicit pin
+  // and is never second-guessed; a failed lookup journals as before.
+  if (!record.bookmark && (await hasNoClaudeConversation(record))) {
+    logger.debug(`Skipping journal for ${ctx.terminalId}: no Claude conversation was written`);
+    return null;
+  }
+
   if (gatedGeneration !== undefined) {
     const verdict = ledger.recordJournal(ctx.terminalId, gatedGeneration, record.sessionId);
     if (!verdict.accepted) {

--- a/electron/services/pty/agentSessionJournal.ts
+++ b/electron/services/pty/agentSessionJournal.ts
@@ -28,9 +28,12 @@ export interface JournalCloseContext {
   generation?: number | null;
 }
 
-async function hasNoClaudeConversation(record: Omit<AgentSessionRecord, "savedAt">) {
+async function hasNoClaudeConversation(
+  record: Omit<AgentSessionRecord, "savedAt">,
+  terminalId: string
+): Promise<boolean> {
   try {
-    return await isClaudeSessionWithoutTranscript(record);
+    return await isClaudeSessionWithoutTranscript(record, terminalId);
   } catch {
     return false;
   }
@@ -66,11 +69,12 @@ export async function journalAgentSessionRecord(
 
   // A Claude pane nobody typed into leaves an assigned id with no conversation
   // behind it (#12371). Journaling it offers a resume that can never open and
-  // spends a slot of the per-worktree cap. Checked after the generation is
+  // spends a slot of the per-worktree cap. Judged against the store the pane
+  // itself launched against, never a guess. Checked after the generation is
   // frozen, so the wait can't pick up a respawn's, and before the ledger is
   // consulted, so a skip claims nothing. A bookmark is the user's explicit pin
   // and is never second-guessed; a failed lookup journals as before.
-  if (!record.bookmark && (await hasNoClaudeConversation(record))) {
+  if (!record.bookmark && (await hasNoClaudeConversation(record, ctx.terminalId))) {
     logger.debug(`Skipping journal for ${ctx.terminalId}: no Claude conversation was written`);
     return null;
   }

--- a/electron/setup/__tests__/refreshPath.test.ts
+++ b/electron/setup/__tests__/refreshPath.test.ts
@@ -693,51 +693,75 @@ describe("refreshPath — shell probe (DAINTREE_SHELL_PROBE=1)", () => {
 });
 
 describe("refreshPath shell observation (#12371)", () => {
+  const savedShell = process.env.SHELL;
+
   beforeEach(() => {
     vi.resetModules();
     savedPath = process.env.PATH;
     vi.clearAllMocks();
     delete process.env.DAINTREE_SHELL_PROBE;
+    process.env.SHELL = "/bin/zsh";
     Object.defineProperty(process, "platform", { value: "darwin", writable: true });
   });
 
   afterEach(() => {
     process.env.PATH = savedPath;
+    if (savedShell === undefined) delete process.env.SHELL;
+    else process.env.SHELL = savedShell;
     Object.defineProperty(process, "platform", { value: originalPlatform, writable: true });
   });
 
-  it("keeps what the login shell exports for Claude's store, and nothing else", async () => {
+  it("keeps what the named login shell exports for Claude's store, and nothing else", async () => {
     shellEnvMock.mockResolvedValue({
       PATH: "/usr/bin:/bin",
       CLAUDE_CONFIG_DIR: "/custom/claude",
       UNRELATED_SECRET: "never kept",
     });
     const { refreshPath } = await import("../environment.js");
-    const { getShellObservedEnv } = await import("../shellEnvironmentObservation.js");
-    expect(getShellObservedEnv()).toBeUndefined();
+    const { getShellEnvironmentObservation } = await import("../shellEnvironmentObservation.js");
+    expect(getShellEnvironmentObservation()).toBeUndefined();
 
     await refreshPath();
 
-    expect(getShellObservedEnv()).toEqual({ CLAUDE_CONFIG_DIR: "/custom/claude" });
+    expect(shellEnvMock).toHaveBeenCalledWith("/bin/zsh");
+    expect(getShellEnvironmentObservation()).toEqual({
+      shell: "/bin/zsh",
+      env: { CLAUDE_CONFIG_DIR: "/custom/claude" },
+    });
   });
 
-  it("records an observed shell that exports no store override", async () => {
+  it("records a probed shell that leaves the store unset", async () => {
     shellEnvMock.mockResolvedValue({ PATH: "/usr/bin:/bin" });
     const { refreshPath } = await import("../environment.js");
-    const { getShellObservedEnv } = await import("../shellEnvironmentObservation.js");
+    const { getShellEnvironmentObservation } = await import("../shellEnvironmentObservation.js");
 
     await refreshPath();
 
-    expect(getShellObservedEnv()).toEqual({});
+    expect(getShellEnvironmentObservation()).toEqual({ shell: "/bin/zsh", env: {} });
   });
 
-  it("leaves the shell unobserved when shell-env fails", async () => {
-    shellEnvMock.mockRejectedValue(new Error("broken .zshrc"));
+  it("observes nothing when the named shell fails, though PATH still comes from the fallback", async () => {
+    shellEnvMock
+      .mockRejectedValueOnce(new Error("broken .zshrc"))
+      .mockResolvedValueOnce({ PATH: "/from/fallback", CLAUDE_CONFIG_DIR: "/other/claude" });
     const { refreshPath } = await import("../environment.js");
-    const { getShellObservedEnv } = await import("../shellEnvironmentObservation.js");
+    const { getShellEnvironmentObservation } = await import("../shellEnvironmentObservation.js");
 
     await refreshPath();
 
-    expect(getShellObservedEnv()).toBeUndefined();
+    expect(shellEnvMock).toHaveBeenLastCalledWith();
+    expect(process.env.PATH).toBe("/from/fallback");
+    expect(getShellEnvironmentObservation()).toBeUndefined();
+  });
+
+  it("observes nothing without a named shell to probe", async () => {
+    delete process.env.SHELL;
+    shellEnvMock.mockResolvedValue({ PATH: "/usr/bin:/bin", CLAUDE_CONFIG_DIR: "/custom/claude" });
+    const { refreshPath } = await import("../environment.js");
+    const { getShellEnvironmentObservation } = await import("../shellEnvironmentObservation.js");
+
+    await refreshPath();
+
+    expect(getShellEnvironmentObservation()).toBeUndefined();
   });
 });

--- a/electron/setup/__tests__/refreshPath.test.ts
+++ b/electron/setup/__tests__/refreshPath.test.ts
@@ -691,3 +691,53 @@ describe("refreshPath — shell probe (DAINTREE_SHELL_PROBE=1)", () => {
     }
   });
 });
+
+describe("refreshPath shell observation (#12371)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    savedPath = process.env.PATH;
+    vi.clearAllMocks();
+    delete process.env.DAINTREE_SHELL_PROBE;
+    Object.defineProperty(process, "platform", { value: "darwin", writable: true });
+  });
+
+  afterEach(() => {
+    process.env.PATH = savedPath;
+    Object.defineProperty(process, "platform", { value: originalPlatform, writable: true });
+  });
+
+  it("keeps what the login shell exports for Claude's store, and nothing else", async () => {
+    shellEnvMock.mockResolvedValue({
+      PATH: "/usr/bin:/bin",
+      CLAUDE_CONFIG_DIR: "/custom/claude",
+      UNRELATED_SECRET: "never kept",
+    });
+    const { refreshPath } = await import("../environment.js");
+    const { getShellObservedEnv } = await import("../shellEnvironmentObservation.js");
+    expect(getShellObservedEnv()).toBeUndefined();
+
+    await refreshPath();
+
+    expect(getShellObservedEnv()).toEqual({ CLAUDE_CONFIG_DIR: "/custom/claude" });
+  });
+
+  it("records an observed shell that exports no store override", async () => {
+    shellEnvMock.mockResolvedValue({ PATH: "/usr/bin:/bin" });
+    const { refreshPath } = await import("../environment.js");
+    const { getShellObservedEnv } = await import("../shellEnvironmentObservation.js");
+
+    await refreshPath();
+
+    expect(getShellObservedEnv()).toEqual({});
+  });
+
+  it("leaves the shell unobserved when shell-env fails", async () => {
+    shellEnvMock.mockRejectedValue(new Error("broken .zshrc"));
+    const { refreshPath } = await import("../environment.js");
+    const { getShellObservedEnv } = await import("../shellEnvironmentObservation.js");
+
+    await refreshPath();
+
+    expect(getShellObservedEnv()).toBeUndefined();
+  });
+});

--- a/electron/setup/environment.ts
+++ b/electron/setup/environment.ts
@@ -494,11 +494,21 @@ async function runRefreshPath(): Promise<void> {
         } else {
           try {
             const { shellEnv } = (await import("shell-env")) as {
-              shellEnv: () => Promise<Record<string, string>>;
+              shellEnv: (shell?: string) => Promise<Record<string, string>>;
             };
-            const env = await shellEnv();
+            // The shell is named first because only a named shell fails loudly.
+            // Left to choose, shell-env quietly tries other shells and then hands
+            // back this process's own environment: fine for PATH, but it says
+            // nothing about what a terminal's shell exports (#12371).
+            const probeShell = process.env.SHELL || undefined;
+            let env = probeShell ? await shellEnv(probeShell).catch(() => undefined) : undefined;
             if (timedOut) return;
-            recordShellEnvironment(env);
+            if (env && probeShell) {
+              recordShellEnvironment(probeShell, env);
+            } else {
+              env = await shellEnv();
+              if (timedOut) return;
+            }
             if (env.PATH) {
               process.env.PATH = deduplicatePath(env.PATH, false);
             }

--- a/electron/setup/environment.ts
+++ b/electron/setup/environment.ts
@@ -31,6 +31,7 @@ import {
 } from "./windowsPath.js";
 import { isLinuxWaylandHybridGpu } from "../utils/gpuDetection.js";
 import { getMaxWebGLContextCeiling } from "../utils/webglContextBudget.js";
+import { recordShellEnvironment } from "./shellEnvironmentObservation.js";
 // Deliberately the tiny pure-fs module, NOT GpuCrashMonitorService — importing
 // the service here would evaluate its logger/telemetry/store import chain at
 // module load, before this file's body re-paths userData for dev instances.
@@ -497,6 +498,7 @@ async function runRefreshPath(): Promise<void> {
             };
             const env = await shellEnv();
             if (timedOut) return;
+            recordShellEnvironment(env);
             if (env.PATH) {
               process.env.PATH = deduplicatePath(env.PATH, false);
             }

--- a/electron/setup/shellEnvironmentObservation.ts
+++ b/electron/setup/shellEnvironmentObservation.ts
@@ -3,33 +3,44 @@
  * about without inheriting them (#12371).
  *
  * The startup probe copies only `PATH` into this process, so a variable a
- * profile exports reaches every terminal Daintree opens but never main itself.
- * Code that needs to know where a CLI in one of those terminals will look asks
- * here. `undefined` means the shell hasn't been observed: the probe failed,
- * timed out, took the PATH-only route, or hasn't finished.
+ * profile exports, changes, or unsets reaches every terminal Daintree opens but
+ * never main itself. Code that needs to know what a CLI in one of those
+ * terminals will see asks here. There is an observation only when the probe ran
+ * the shell it named and that shell answered: shell-env's quiet fallbacks to
+ * other shells, and finally to this process's own environment, describe no
+ * terminal at all.
  */
 
 const OBSERVED_NAMES = ["CLAUDE_CONFIG_DIR"] as const;
 
 export type ShellObservedName = (typeof OBSERVED_NAMES)[number];
-export type ShellObservedEnv = Readonly<Partial<Record<ShellObservedName, string>>>;
 
-let observed: ShellObservedEnv | undefined;
-
-/** Keep the observed names out of a full shell environment; everything else is dropped. */
-export function recordShellEnvironment(env: Readonly<Record<string, string | undefined>>): void {
-  const next: Partial<Record<ShellObservedName, string>> = {};
-  for (const name of OBSERVED_NAMES) {
-    const value = env[name];
-    if (value !== undefined) next[name] = value;
-  }
-  observed = next;
+export interface ShellEnvironmentObservation {
+  /** The shell that was probed, exactly as it was named. */
+  readonly shell: string;
+  /** Each observed name that shell's environment defines. A missing key means unset. */
+  readonly env: Readonly<Partial<Record<ShellObservedName, string>>>;
 }
 
-export function getShellObservedEnv(): ShellObservedEnv | undefined {
-  return observed;
+let observation: ShellEnvironmentObservation | undefined;
+
+/** Keep the observed names out of a shell's full environment; everything else is dropped. */
+export function recordShellEnvironment(
+  shell: string,
+  env: Readonly<Record<string, string | undefined>>
+): void {
+  const observed: Partial<Record<ShellObservedName, string>> = {};
+  for (const name of OBSERVED_NAMES) {
+    const value = env[name];
+    if (value !== undefined) observed[name] = value;
+  }
+  observation = { shell, env: observed };
+}
+
+export function getShellEnvironmentObservation(): ShellEnvironmentObservation | undefined {
+  return observation;
 }
 
 export function __resetShellEnvironmentObservationForTests(): void {
-  observed = undefined;
+  observation = undefined;
 }

--- a/electron/setup/shellEnvironmentObservation.ts
+++ b/electron/setup/shellEnvironmentObservation.ts
@@ -1,0 +1,35 @@
+/**
+ * What the user's login shell exports, for the variables main has to reason
+ * about without inheriting them (#12371).
+ *
+ * The startup probe copies only `PATH` into this process, so a variable a
+ * profile exports reaches every terminal Daintree opens but never main itself.
+ * Code that needs to know where a CLI in one of those terminals will look asks
+ * here. `undefined` means the shell hasn't been observed: the probe failed,
+ * timed out, took the PATH-only route, or hasn't finished.
+ */
+
+const OBSERVED_NAMES = ["CLAUDE_CONFIG_DIR"] as const;
+
+export type ShellObservedName = (typeof OBSERVED_NAMES)[number];
+export type ShellObservedEnv = Readonly<Partial<Record<ShellObservedName, string>>>;
+
+let observed: ShellObservedEnv | undefined;
+
+/** Keep the observed names out of a full shell environment; everything else is dropped. */
+export function recordShellEnvironment(env: Readonly<Record<string, string | undefined>>): void {
+  const next: Partial<Record<ShellObservedName, string>> = {};
+  for (const name of OBSERVED_NAMES) {
+    const value = env[name];
+    if (value !== undefined) next[name] = value;
+  }
+  observed = next;
+}
+
+export function getShellObservedEnv(): ShellObservedEnv | undefined {
+  return observed;
+}
+
+export function __resetShellEnvironmentObservationForTests(): void {
+  observed = undefined;
+}

--- a/shared/config/agents/claude.ts
+++ b/shared/config/agents/claude.ts
@@ -155,7 +155,9 @@ export const config: AgentConfig = {
     // #11782: Claude Code accepts the session id up front, so we mint it at
     // launch instead of scraping it back out at teardown. `--resume` reuses
     // that same id on every later relaunch (only `--fork-session` mints a new
-    // one), which makes the id stable for the life of the conversation.
+    // one), which makes the id stable for the life of the conversation. Until
+    // the first message there is no conversation to resume, but the CLI accepts
+    // the same id again, which is how spawn restores an untouched pane (#12371).
     assignSessionIdArgs: (sessionId: string) => ["--session-id", sessionId],
   },
   env: {

--- a/shared/types/__tests__/agentSettings.test.ts
+++ b/shared/types/__tests__/agentSettings.test.ts
@@ -1612,6 +1612,28 @@ describe("launch-time session id assignment (#11782)", () => {
       expect(relaunchResumeAsAssignedSession("", ASSIGNING)).toBeUndefined();
     });
 
+    it("reads an escaped quote as part of a double-quoted prompt", () => {
+      const prompt = `"say \\" --resume ${sessionId} \\" once"`;
+      const command = `claude --append-system-prompt ${prompt} --resume ${sessionId}`;
+      expect(relaunchResumeAsAssignedSession(command, ASSIGNING)?.command).toBe(
+        `claude --append-system-prompt ${prompt} --session-id ${sessionId}`
+      );
+      expect(
+        stripAssignedSessionIdArgs(`claude "say \\" --session-id ${sessionId} \\" ok"`, ASSIGNING)
+      ).toBe(`claude "say \\" --session-id ${sessionId} \\" ok"`);
+    });
+
+    it("declines a command that picks its conversation more than one way", () => {
+      const other = "1ad2578c-b710-4302-90c1-b222c4c29aa2";
+      for (const command of [
+        `claude --continue --resume ${sessionId}`,
+        `claude --resume ${other} --resume ${sessionId}`,
+        `claude --session-id ${other} --resume ${sessionId}`,
+      ]) {
+        expect(relaunchResumeAsAssignedSession(command, ASSIGNING)).toBeUndefined();
+      }
+    });
+
     it("leaves agents that mint their own id alone", () => {
       const codexResume = buildResumeCommand(SCRAPING, sessionId) as string;
       expect(relaunchResumeAsAssignedSession(codexResume, SCRAPING)).toBeUndefined();

--- a/shared/types/__tests__/agentSettings.test.ts
+++ b/shared/types/__tests__/agentSettings.test.ts
@@ -1612,15 +1612,16 @@ describe("launch-time session id assignment (#11782)", () => {
       expect(relaunchResumeAsAssignedSession("", ASSIGNING)).toBeUndefined();
     });
 
-    it("reads an escaped quote as part of a double-quoted prompt", () => {
-      const prompt = `"say \\" --resume ${sessionId} \\" once"`;
-      const command = `claude --append-system-prompt ${prompt} --resume ${sessionId}`;
-      expect(relaunchResumeAsAssignedSession(command, ASSIGNING)?.command).toBe(
-        `claude --append-system-prompt ${prompt} --session-id ${sessionId}`
-      );
-      expect(
-        stripAssignedSessionIdArgs(`claude "say \\" --session-id ${sessionId} \\" ok"`, ASSIGNING)
-      ).toBe(`claude "say \\" --session-id ${sessionId} \\" ok"`);
+    it("declines a command whose quoting reads differently from shell to shell", () => {
+      // A POSIX shell ends this prompt at the last quote and PowerShell at the
+      // first; a tokenizer can only guess, so no rewrite.
+      const command = `claude --append-system-prompt "say \\" --resume ${sessionId} \\" once" --resume ${sessionId}`;
+      expect(relaunchResumeAsAssignedSession(command, ASSIGNING)).toBeUndefined();
+    });
+
+    it("strips the flag after a Windows path that ends in a backslash", () => {
+      const command = `claude --add-dir "C:\\work\\" --session-id ${sessionId}`;
+      expect(stripAssignedSessionIdArgs(command, ASSIGNING)).toBe(`claude --add-dir "C:\\work\\"`);
     });
 
     it("declines a command that picks its conversation more than one way", () => {

--- a/shared/types/__tests__/agentSettings.test.ts
+++ b/shared/types/__tests__/agentSettings.test.ts
@@ -20,6 +20,7 @@ import {
   supportsSessionIdAssignment,
   mintAssignedSessionId,
   stripAssignedSessionIdArgs,
+  relaunchResumeAsAssignedSession,
   DEFAULT_AGENT_SETTINGS,
   DEFAULT_DANGEROUS_ARGS,
 } from "../agentSettings.js";
@@ -1564,6 +1565,59 @@ describe("launch-time session id assignment (#11782)", () => {
       const assigned = generateAgentCommand("claude", {}, ASSIGNING, { sessionId });
       expect(stripAssignedSessionIdArgs(assigned, undefined)).toBe(assigned);
       expect(stripAssignedSessionIdArgs("", ASSIGNING)).toBe("");
+    });
+  });
+
+  describe("relaunching an untouched session under its own id (#12371)", () => {
+    const sessionId = "006fdfc0-67bf-4df0-ad82-48ebfe4df184";
+
+    it("turns an exact resume into an assignment of the same id", () => {
+      const resume = buildResumeCommand(ASSIGNING, sessionId, ["--verbose"]) as string;
+      expect(resume).toBe(`claude --verbose --resume ${sessionId}`);
+
+      expect(relaunchResumeAsAssignedSession(resume, ASSIGNING)).toEqual({
+        sessionId,
+        command: `claude --verbose --session-id ${sessionId}`,
+      });
+    });
+
+    it("keeps a resolved base command and the flags on both sides", () => {
+      const command = `/opt/claude/bin/claude --dangerously-skip-permissions --resume ${sessionId} --verbose`;
+      expect(relaunchResumeAsAssignedSession(command, ASSIGNING)?.command).toBe(
+        `/opt/claude/bin/claude --dangerously-skip-permissions --session-id ${sessionId} --verbose`
+      );
+    });
+
+    it("reads an id the shell escaper wrapped in quotes", () => {
+      expect(relaunchResumeAsAssignedSession(`claude --resume '${sessionId}'`, ASSIGNING)).toEqual({
+        sessionId,
+        command: `claude --session-id ${sessionId}`,
+      });
+    });
+
+    it("ignores the flag when it is only text inside a prompt", () => {
+      const command = `claude 'why does --resume ${sessionId} fail'`;
+      expect(relaunchResumeAsAssignedSession(command, ASSIGNING)).toBeUndefined();
+    });
+
+    it("refuses anything the CLI would not assign as an id", () => {
+      expect(relaunchResumeAsAssignedSession("claude --resume s-1", ASSIGNING)).toBeUndefined();
+      // A bare `--resume` opens the CLI's picker; there is no id to carry over.
+      expect(relaunchResumeAsAssignedSession("claude --resume", ASSIGNING)).toBeUndefined();
+    });
+
+    it("leaves a fresh launch alone", () => {
+      const fresh = generateAgentCommand("claude", {}, ASSIGNING, { sessionId });
+      expect(relaunchResumeAsAssignedSession(fresh, ASSIGNING)).toBeUndefined();
+      expect(relaunchResumeAsAssignedSession("", ASSIGNING)).toBeUndefined();
+    });
+
+    it("leaves agents that mint their own id alone", () => {
+      const codexResume = buildResumeCommand(SCRAPING, sessionId) as string;
+      expect(relaunchResumeAsAssignedSession(codexResume, SCRAPING)).toBeUndefined();
+      expect(
+        relaunchResumeAsAssignedSession(`claude --resume ${sessionId}`, undefined)
+      ).toBeUndefined();
     });
   });
 });

--- a/shared/types/agentSettings.ts
+++ b/shared/types/agentSettings.ts
@@ -1140,7 +1140,9 @@ export function supportsSessionIdAssignment(agentId: string | undefined): boolea
  * Always mint per launch — never reuse a persisted id here. Re-assigning an
  * existing id is rejected by the CLI ("Session ID <id> is already in use"),
  * which would take down the launch, so a duplicated pane and a restore that
- * falls through to a fresh start each need their own new id.
+ * falls through to a fresh start each need their own new id. The one exception
+ * is an id the CLI never wrote a conversation for, which it accepts again — see
+ * {@link relaunchResumeAsAssignedSession}.
  */
 export function mintAssignedSessionId(agentId: string | undefined): string | undefined {
   return supportsSessionIdAssignment(agentId) ? crypto.randomUUID() : undefined;
@@ -1253,6 +1255,77 @@ export function stripAssignedSessionIdArgs(command: string, agentId: string | un
     }
   }
   return command;
+}
+
+const ASSIGNABLE_SESSION_ID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** Drop one layer of matching quotes, the kind `escapeShellArg` wraps a word in. */
+function unquoteShellWord(word: string): string {
+  const quote = word[0];
+  if (word.length >= 2 && (quote === "'" || quote === '"') && word.endsWith(quote)) {
+    return word.slice(1, -1);
+  }
+  return word;
+}
+
+export interface AssignedSessionRelaunch {
+  /** The id the command was resuming. */
+  sessionId: string;
+  /** The same command, assigning that id to a new conversation instead. */
+  command: string;
+}
+
+/**
+ * Rewrites an exact-id resume into an assignment of that same id (#12371).
+ *
+ * An agent that takes its id at launch only writes the conversation once the
+ * user sends something, so a pane nobody typed into leaves an id `--resume`
+ * can't find. The CLI still accepts that id for a NEW conversation — the "already
+ * in use" rejection {@link mintAssignedSessionId} warns about only applies once a
+ * conversation exists — so the pane can come back as a working fresh session
+ * under the id the rest of the app already has on record. Proving no
+ * conversation exists is the caller's job; this only reshapes the command.
+ *
+ * Matches the agent's own resume args on shell words, like
+ * {@link stripAssignedSessionIdArgs}, so a prompt that merely mentions the flag
+ * is left alone. Only a UUID qualifies, since the CLI assigns nothing else.
+ *
+ * Returns `undefined` when the agent can't assign ids or the command resumes no
+ * such id.
+ */
+export function relaunchResumeAsAssignedSession(
+  command: string,
+  agentId: string | undefined
+): AssignedSessionRelaunch | undefined {
+  if (!command || !agentId || !supportsSessionIdAssignment(agentId)) return undefined;
+  const resume = getEffectiveAgentConfig(agentId)?.resume;
+  if (resume?.kind !== "session-id") return undefined;
+  const shape = resume.args(SESSION_ID_SLOT);
+  const slotOffset = shape.findIndex((token) => token.includes(SESSION_ID_SLOT));
+  if (slotOffset === -1) return undefined;
+  const [prefix = "", suffix = ""] = (shape[slotOffset] ?? "").split(SESSION_ID_SLOT);
+
+  const words = splitShellWords(command);
+  for (let i = 0; i + shape.length <= words.length; i++) {
+    if (!shape.every((token, offset) => shapeWordMatches(token, words[i + offset] ?? ""))) {
+      continue;
+    }
+    const slotWord = words[i + slotOffset] ?? "";
+    const sessionId = unquoteShellWord(
+      slotWord.slice(prefix.length, slotWord.length - suffix.length)
+    );
+    if (!ASSIGNABLE_SESSION_ID_PATTERN.test(sessionId)) return undefined;
+    const assigning = buildAssignedSessionIdArgs(agentId, sessionId);
+    if (!assigning?.length) return undefined;
+    words.splice(
+      i,
+      shape.length,
+      ...assigning.map((arg) => (arg.startsWith("-") ? arg : escapeShellArgOptional(arg)))
+    );
+    return { sessionId, command: words.join(" ") };
+  }
+  return undefined;
 }
 
 export interface BuildLaunchCommandFromFlagsOptions {

--- a/shared/types/agentSettings.ts
+++ b/shared/types/agentSettings.ts
@@ -1163,7 +1163,7 @@ const SESSION_ID_SLOT = " daintree-session-id-slot ";
  * `'\''` for every apostrophe: read without them, that sequence leaves the
  * quote state inverted and splits an ordinary prompt like `don't` mid-word.
  */
-function splitShellWords(command: string): string[] {
+function scanShellWords(command: string): { words: string[]; unterminated: boolean } {
   const words: string[] = [];
   let current = "";
   let started = false;
@@ -1173,16 +1173,7 @@ function splitShellWords(command: string): string[] {
   for (const char of command) {
     if (quote) {
       current += char;
-      // Inside double quotes a backslash still escapes the next character, so
-      // `\"` belongs to the word instead of ending it; POSIX shells and Windows
-      // argv parsing agree on that. Single quotes take everything literally.
-      if (escaped) {
-        escaped = false;
-      } else if (quote === '"' && char === "\\") {
-        escaped = true;
-      } else if (char === quote) {
-        quote = null;
-      }
+      if (char === quote) quote = null;
       continue;
     }
     if (escaped) {
@@ -1215,7 +1206,11 @@ function splitShellWords(command: string): string[] {
     started = true;
   }
   if (started) words.push(current);
-  return words;
+  return { words, unterminated: quote !== null };
+}
+
+function splitShellWords(command: string): string[] {
+  return scanShellWords(command).words;
 }
 
 /** Does one command word fill this slot of the agent's assigning-arg shape? */
@@ -1315,7 +1310,11 @@ export function relaunchResumeAsAssignedSession(
   if (slotOffset === -1) return undefined;
   const [prefix = "", suffix = ""] = (shape[slotOffset] ?? "").split(SESSION_ID_SLOT);
 
-  const words = splitShellWords(command);
+  const { words, unterminated } = scanShellWords(command);
+  // A quote left open reads differently in a POSIX shell, where a backslash can
+  // escape it, than in PowerShell, where it can't. There is no telling which
+  // words are real arguments then, so nothing is rewritten.
+  if (unterminated) return undefined;
   const matchesAt = (tokens: readonly string[], at: number): boolean =>
     tokens.length > 0 &&
     tokens.every((token, offset) => shapeWordMatches(token, words[at + offset] ?? ""));

--- a/shared/types/agentSettings.ts
+++ b/shared/types/agentSettings.ts
@@ -1173,7 +1173,16 @@ function splitShellWords(command: string): string[] {
   for (const char of command) {
     if (quote) {
       current += char;
-      if (char === quote) quote = null;
+      // Inside double quotes a backslash still escapes the next character, so
+      // `\"` belongs to the word instead of ending it; POSIX shells and Windows
+      // argv parsing agree on that. Single quotes take everything literally.
+      if (escaped) {
+        escaped = false;
+      } else if (quote === '"' && char === "\\") {
+        escaped = true;
+      } else if (char === quote) {
+        quote = null;
+      }
       continue;
     }
     if (escaped) {
@@ -1307,25 +1316,35 @@ export function relaunchResumeAsAssignedSession(
   const [prefix = "", suffix = ""] = (shape[slotOffset] ?? "").split(SESSION_ID_SLOT);
 
   const words = splitShellWords(command);
-  for (let i = 0; i + shape.length <= words.length; i++) {
-    if (!shape.every((token, offset) => shapeWordMatches(token, words[i + offset] ?? ""))) {
-      continue;
-    }
-    const slotWord = words[i + slotOffset] ?? "";
-    const sessionId = unquoteShellWord(
-      slotWord.slice(prefix.length, slotWord.length - suffix.length)
-    );
-    if (!ASSIGNABLE_SESSION_ID_PATTERN.test(sessionId)) return undefined;
-    const assigning = buildAssignedSessionIdArgs(agentId, sessionId);
-    if (!assigning?.length) return undefined;
-    words.splice(
-      i,
-      shape.length,
-      ...assigning.map((arg) => (arg.startsWith("-") ? arg : escapeShellArgOptional(arg)))
-    );
-    return { sessionId, command: words.join(" ") };
+  const matchesAt = (tokens: readonly string[], at: number): boolean =>
+    tokens.length > 0 &&
+    tokens.every((token, offset) => shapeWordMatches(token, words[at + offset] ?? ""));
+
+  // One unambiguous selector or nothing. A second resume, an id already being
+  // assigned, or a resume-latest flag each mean the CLI picks the conversation
+  // some other way, and swapping one flag would leave it contradicting the rest.
+  const resumeAt = words.flatMap((_, at) => (matchesAt(shape, at) ? [at] : []));
+  const [at] = resumeAt;
+  if (at === undefined || resumeAt.length > 1) return undefined;
+  const assignShape = resume.assignSessionIdArgs?.(SESSION_ID_SLOT) ?? [];
+  const latestShape = resume.resumeLatestArgs ?? [];
+  if (words.some((_, i) => matchesAt(assignShape, i) || matchesAt(latestShape, i))) {
+    return undefined;
   }
-  return undefined;
+
+  const slotWord = words[at + slotOffset] ?? "";
+  const sessionId = unquoteShellWord(
+    slotWord.slice(prefix.length, slotWord.length - suffix.length)
+  );
+  if (!ASSIGNABLE_SESSION_ID_PATTERN.test(sessionId)) return undefined;
+  const assigning = buildAssignedSessionIdArgs(agentId, sessionId);
+  if (!assigning?.length) return undefined;
+  words.splice(
+    at,
+    shape.length,
+    ...assigning.map((arg) => (arg.startsWith("-") ? arg : escapeShellArgOptional(arg)))
+  );
+  return { sessionId, command: words.join(" ") };
 }
 
 export interface BuildLaunchCommandFromFlagsOptions {


### PR DESCRIPTION
Resolves #12371

An untouched Claude pane was restored with `claude --resume <id>` for an id Claude Code never wrote a transcript for, so it exited with "No conversation found". Every restore path (app relaunch, restart, sleep/wake, eviction, the resume list) goes through the main-process spawn handler, so the fix lives there.

## What changed

- **Spawn repairs the launch.** For a Claude launch whose command resumes a UUID, main reads Claude's store read-only. If the transcript is proven missing from the store that pane will read, `--resume <id>` becomes `--session-id <id>`. The id stays the same, which the CLI accepts for an id that never had a conversation.
- **Only a certain store counts.** The startup shell probe now names `$SHELL` and records what it exports for `CLAUDE_CONFIG_DIR`. A pane's store is known only for a zsh or bash pane launching that same shell with no override of `CLAUDE_CONFIG_DIR`, `HOME`, `ZDOTDIR`, `ENV` or `BASH_ENV`. Anything else, including Windows, is unknown and keeps today's resume.
- **The journal stops recording empty sessions.** Each Claude terminal's store is remembered at spawn, and a close whose transcript is proven missing there is not journaled. Bookmarks are never skipped.
- **The lookup is bounded.** One `lstat` for the usual case, then a whole-store scan shared across concurrent callers, a 1.5 s budget per caller, a 60 s cooldown for a store that timed out, and case-insensitive ids.
- **Ambiguous commands are left alone.** The rewrite declines unterminated quotes, a second resume, an existing `--session-id`, and `--continue`.

## Limitations

- Existing empty entries in the session history list are not hidden retroactively. A record doesn't carry the environment its pane launched with, and inferring it from titles or current settings could hide a real conversation. They stop accumulating, age out with retention, and opening one now starts a fresh session when the store is certain.
- No repair on Windows, for sh, fish or nu panes, for panes with a store or startup override, or when the startup shell probe fails. Those keep the current behaviour.
- A pty-host crash replay of a repaired pane comes back as a fresh launch without an id, the same as any fresh launch today.

## Verification

- `npx vitest run` on the 12 changed and covering suites: 621 tests pass.
- Widened run over 42 suites that load the changed modules (spawn, shutdown, project sleep/close, ProjectViewManager, refreshPath, CLI availability): 1986 tests pass.
- Assignment-stripping consumers (agent registry, serializer, pane duplication, restart, PtyClient): 15 suites, 630 tests pass.
- `npx eslint` and `npx prettier --check` on the 12 changed files: clean.
- Full `npm test` and `npm run check` run in CI.