### PR TITLE
fix(plugins): keep plugin rows one height when their switch flips

### DIFF
--- a/scripts/baselines/eslint-warnings-baseline.json
+++ b/scripts/baselines/eslint-warnings-baseline.json
@@ -1,13 +1,13 @@
 {
-  "count": 3015,
+  "count": 3013,
   "byRule": {
     "@typescript-eslint/no-explicit-any": 51,
     "@typescript-eslint/no-floating-promises": 80,
     "@typescript-eslint/no-unsafe-type-assertion": 477,
     "component-contract/no-arbitrary-text-size": 6,
-    "component-contract/no-legacy-daintree-utilities": 876,
+    "component-contract/no-legacy-daintree-utilities": 875,
     "component-contract/no-raw-radius": 495,
-    "component-contract/no-text-color-slash-alpha": 516,
+    "component-contract/no-text-color-slash-alpha": 515,
     "component-contract/no-unpaired-outline-suppression": 35,
     "no-restricted-imports": 5,
     "no-restricted-syntax": 367,
@@ -16,5 +16,5 @@
     "react-compiler/react-compiler": 16,
     "react-hooks/exhaustive-deps": 34
   },
-  "updatedAt": "2026-09-11T10:09:43.509Z"
+  "updatedAt": "2026-09-11T15:03:58.974Z"
 }

--- a/src/components/Plugin/PluginManagerView.tsx
+++ b/src/components/Plugin/PluginManagerView.tsx
@@ -8,7 +8,6 @@ import {
   AlertTriangle,
   ArrowUpCircle,
   ChevronLeft,
-  CircleSlash,
   RefreshCw,
   RotateCw,
   X,
@@ -84,9 +83,11 @@ function rowStatusFor(plugin: LoadedPluginInfo): RowStatus | null {
   if (plugin.pendingRestart === true) {
     return { label: "Restart required", icon: RotateCw, tone: "text-status-warning" };
   }
-  if (plugin.disabled === true) {
-    return { label: "Disabled", icon: CircleSlash, tone: "text-text-secondary" };
-  }
+  // No chip for a plain "disabled". The switch beside the row already states it,
+  // textually and through `aria-checked`, and a chip that appeared on toggle
+  // grew the row by a line for every built-in — the one layout shift a control
+  // acting on its own row must never cause. Status here is reserved for states
+  // the switch CANNOT express.
   return null;
 }
 
@@ -134,11 +135,16 @@ interface PluginRowProps {
  * metadata, actions, and settings live there now, so the row stays scannable
  * and never shifts layout.
  *
- * A disabled plugin stays in its category section, dimmed in place with a
- * "Disabled" badge — the dominant pattern (VS Code, JetBrains, browsers) and
- * the one that preserves spatial memory; relocation to a quarantine section
- * was the old #9554 behavior. Provenance only earns a badge when it differs
- * from the catalog's default (non-builtin sources: file / URL / catalog).
+ * A disabled plugin stays in its category section, dimmed in place with its
+ * switch off — the dominant pattern (VS Code, JetBrains, browsers) and the one
+ * that preserves spatial memory; relocation to a quarantine section was the
+ * old #9554 behavior. Provenance only earns a badge when it differs from the
+ * catalog's default (non-builtin sources: file / URL / catalog).
+ *
+ * The badge line is ALWAYS rendered, at a fixed minimum height, even when it is
+ * empty. Rows used to gain or lose that line as their state changed, so a
+ * built-in's row grew by a line the moment its own switch was flipped and shrank
+ * again on the way back. Every row is the same height in every state now.
  *
  * The row is an `<li>` in a plain list, NOT an option in a composite listbox.
  * The selection target is a `<button aria-current>` covering the info area and
@@ -237,31 +243,32 @@ function PluginRow({
               {blurb}
             </span>
           )}
-          {(status || update || !plugin.isBuiltin || plugin.devMode) && (
-            <span className="mt-1 flex items-center gap-1.5 min-w-0">
-              {status && (
-                <span
-                  className={cn(
-                    "inline-flex items-center gap-0.5 text-3xs font-medium uppercase tracking-wide shrink-0",
-                    status.tone
-                  )}
-                >
-                  <status.icon className="w-3 h-3" aria-hidden="true" />
-                  {status.label}
-                </span>
-              )}
-              {update && (
-                <span className="inline-flex items-center gap-0.5 min-w-0 text-3xs font-medium uppercase tracking-wide text-status-warning">
-                  <ArrowUpCircle className="w-3 h-3 shrink-0" aria-hidden="true" />
-                  <span className="truncate">{update.version}</span>
-                </span>
-              )}
-              {plugin.devMode && <span className={ROW_BADGE_CLASS}>Dev</span>}
-              {!plugin.isBuiltin && (
-                <span className={cn(ROW_BADGE_CLASS, "truncate")}>{sourceLabel}</span>
-              )}
-            </span>
-          )}
+          <span
+            data-testid="plugin-row-badges"
+            className="mt-1 flex items-center gap-1.5 min-w-0 min-h-[1.125rem]"
+          >
+            {status && (
+              <span
+                className={cn(
+                  "inline-flex items-center gap-0.5 text-3xs font-medium uppercase tracking-wide shrink-0",
+                  status.tone
+                )}
+              >
+                <status.icon className="w-3 h-3" aria-hidden="true" />
+                {status.label}
+              </span>
+            )}
+            {update && (
+              <span className="inline-flex items-center gap-0.5 min-w-0 text-3xs font-medium uppercase tracking-wide text-status-warning">
+                <ArrowUpCircle className="w-3 h-3 shrink-0" aria-hidden="true" />
+                <span className="truncate">{update.version}</span>
+              </span>
+            )}
+            {plugin.devMode && <span className={ROW_BADGE_CLASS}>Dev</span>}
+            {!plugin.isBuiltin && (
+              <span className={cn(ROW_BADGE_CLASS, "truncate")}>{sourceLabel}</span>
+            )}
+          </span>
         </span>
       </button>
 

--- a/src/components/Plugin/__tests__/PluginManagerView.test.tsx
+++ b/src/components/Plugin/__tests__/PluginManagerView.test.tsx
@@ -1344,11 +1344,13 @@ describe("PluginManagerView", () => {
       ]);
       renderDialog();
       await screen.findAllByText("Core GitHub");
-      // No quarantine section — disabled plugins dim in place (#9554 successor).
+      // No quarantine section — disabled plugins dim in place (#9554 successor),
+      // and the switch carries the state: a "Disabled" chip that appeared on
+      // toggle changed the row's height, so there isn't one.
       expect(pluginInSection("Forge providers", "Core GitHub")).toBeTruthy();
       expect(sectionExists("Disabled")).toBe(false);
-      const listbox = pluginList();
-      expect(within(listbox).getByText("Disabled")).toBeTruthy();
+      const toggle = screen.getByRole("switch", { name: "Enable Core GitHub" });
+      expect(toggle.getAttribute("aria-checked")).toBe("false");
     });
 
     it("renders category sections in registry order for a mixed list", async () => {
@@ -1785,6 +1787,31 @@ describe("PluginManagerView design invariants", () => {
     expect(row.getAttribute("data-selected")).toBe("true");
     expect(row.getAttribute("aria-current")).toBeNull();
     expect(PALETTE_ROW_CLASS).not.toMatch(/aria-\[current/);
+  });
+
+  it("renders the badge line in every state, so a toggle can never change a row's height", async () => {
+    // The rule is structural: the line is present whether or not it has
+    // anything to show. Before this, a built-in with nothing to badge had no
+    // line at all, so flipping its own switch grew the row and flipping it back
+    // shrank it, a layout shift caused by a control acting on its own row.
+    (window.electron.plugin.list as ReturnType<typeof vi.fn>).mockResolvedValue([
+      makePlugin({ isBuiltin: true, source: "builtin", disabled: false }),
+      makePlugin({
+        manifest: { ...makePlugin().manifest, name: "acme.off", displayName: "Off Plugin" },
+        isBuiltin: true,
+        source: "builtin",
+        disabled: true,
+      } as Parameters<typeof makePlugin>[0]),
+    ]);
+    renderDialog();
+    await screen.findAllByText("Acme Demo");
+
+    for (const name of ["Acme Demo", "Off Plugin"]) {
+      const badges = within(rowFor(name)).getByTestId("plugin-row-badges");
+      expect(badges).toBeTruthy();
+      // And the plain disabled state adds no chip to it.
+      expect(/disabled/i.test(badges.textContent ?? "")).toBe(false);
+    }
   });
 
   it("keeps the enable switch out of any composite widget that may not own it", async () => {


### PR DESCRIPTION
## Summary

Follow-up to #12377. Toggling a plugin off added a `DISABLED` chip to its row, and for a built-in with nothing else to badge that meant a whole new line, so the row grew under the switch you had just clicked and shrank again when you turned it back on. A control acting on its own row shouldn't move it.

## Changes

- No `Disabled` chip in the row. The off switch right beside it already says so, and says it to assistive tech through `aria-checked`. Status on the row is reserved for the states the switch can't express: failed, blocked, restart required.
- The badge line always renders at a fixed minimum height, empty or not, so provenance and fault badges can't change a row's height either. Every row is the same height in every state now.
- The detail pane keeps its `Disabled` badge and the `@disabled` filter chip is unchanged.

## Testing

- `npm test` passes apart from `PluginDevArtifactWatcher`, `ProjectPluginWatcher` and `scenarioLiveness`, the same three that fail on `develop` with no changes.
- `npm run typecheck` clean; lint ratchet down by two (the chip's icon import went with it), baseline regenerated.
- New invariant test asserts the badge line exists for enabled and disabled rows alike. Checked by reintroducing the old conditional and confirming it fails.
- Verified in the screenshot harness: the disabled row now matches its neighbours' height, and the built-in rows reserve the line.