### PR TITLE
fix(worktree): drop phantom issue when linked PR claims its number

### DIFF
--- a/electron/workspace-host/SnapshotBuilder.ts
+++ b/electron/workspace-host/SnapshotBuilder.ts
@@ -11,6 +11,7 @@ import type { CIStatusState } from "../../shared/types/forge.js";
 import type { WorktreeSnapshot } from "../../shared/types/workspace-host.js";
 import type { WorktreeChanges, RepoState } from "../../shared/types/git.js";
 import type { PluginWorktreeLinked } from "../../shared/types/plugin.js";
+import { issueNumberBelongsToLinkedPr } from "../../shared/utils/worktreeIssueProjection.js";
 
 export interface SnapshotBuilderHost {
   readonly id: string;
@@ -113,6 +114,11 @@ export class SnapshotBuilder {
         linkedPr.ciStatus.state === "pending")
         ? linkedPr.ciStatus.state
         : undefined;
+    const detectedIssueNumber = linkedIssue?.ref.number ?? this.host.issueNumber;
+    // Dropped from the projection only: the monitor keeps the parsed number so
+    // `onIssueNotFound` still matches its lookup, and a genuine PR clear brings
+    // the #8851 offline fallback back (#12381).
+    const issueIsLinkedPr = issueNumberBelongsToLinkedPr(detectedIssueNumber, this.host.linked);
 
     const snapshot: WorktreeSnapshot = {
       id: this.host.id,
@@ -130,7 +136,7 @@ export class SnapshotBuilder {
       createdAt: this.host.createdAt,
       aiNote: this.host.aiNote,
       aiNoteTimestamp: this.host.aiNoteTimestamp,
-      issueNumber: linkedIssue?.ref.number ?? this.host.issueNumber,
+      issueNumber: issueIsLinkedPr ? undefined : detectedIssueNumber,
       prNumber: linkedPr?.ref.number ?? this.host.prNumber,
       prUrl: linkedPr?.url ?? this.host.prUrl,
       prState: linkedPr
@@ -140,11 +146,15 @@ export class SnapshotBuilder {
           : this.host.prState,
       prCiStatus: linkedPr ? linkedPrCiStatus : this.host.prCiStatus,
       prTitle: linkedPr ? linkedPr.title : this.host.prTitle,
-      issueTitle: linkedIssue ? linkedIssue.title : this.host.issueTitle,
-      branchDerivedTitle: this.host.branchDerivedTitle,
+      issueTitle: issueIsLinkedPr
+        ? undefined
+        : linkedIssue
+          ? linkedIssue.title
+          : this.host.issueTitle,
+      branchDerivedTitle: issueIsLinkedPr ? undefined : this.host.branchDerivedTitle,
       sourcePrNumber: this.host.sourcePrNumber,
       prLastUpdatedAt: this.host.prLastUpdatedAt,
-      issueLastUpdatedAt: this.host.issueLastUpdatedAt,
+      issueLastUpdatedAt: issueIsLinkedPr ? undefined : this.host.issueLastUpdatedAt,
       worktreeChanges: this.host.worktreeChanges,
       worktreeId: this.host.id,
       timestamp: Date.now(),

--- a/electron/workspace-host/SnapshotBuilder.ts
+++ b/electron/workspace-host/SnapshotBuilder.ts
@@ -151,10 +151,10 @@ export class SnapshotBuilder {
         : linkedIssue
           ? linkedIssue.title
           : this.host.issueTitle,
-      branchDerivedTitle: issueIsLinkedPr ? undefined : this.host.branchDerivedTitle,
+      branchDerivedTitle: this.host.branchDerivedTitle,
       sourcePrNumber: this.host.sourcePrNumber,
       prLastUpdatedAt: this.host.prLastUpdatedAt,
-      issueLastUpdatedAt: issueIsLinkedPr ? undefined : this.host.issueLastUpdatedAt,
+      issueLastUpdatedAt: this.host.issueLastUpdatedAt,
       worktreeChanges: this.host.worktreeChanges,
       worktreeId: this.host.id,
       timestamp: Date.now(),

--- a/electron/workspace-host/__tests__/SnapshotBuilder.test.ts
+++ b/electron/workspace-host/__tests__/SnapshotBuilder.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { SnapshotBuilder, type SnapshotBuilderHost } from "../SnapshotBuilder.js";
+import type { PluginWorktreeLinked } from "../../../shared/types/plugin.js";
+import { BUILTIN_GITHUB_PROVIDER_ID } from "../../../shared/utils/forgeProviderIds.js";
 
 function makeHost(overrides: Partial<SnapshotBuilderHost> = {}): SnapshotBuilderHost {
   return {
@@ -260,5 +262,93 @@ describe("SnapshotBuilder", () => {
     expect(
       new SnapshotBuilder(makeHost({ isExternal: undefined })).build().isExternal
     ).toBeUndefined();
+  });
+
+  describe("an issue number the linked PR already carries (#12381)", () => {
+    function githubPr(number: number): PluginWorktreeLinked {
+      return {
+        providerId: BUILTIN_GITHUB_PROVIDER_ID,
+        pr: {
+          ref: {
+            providerId: BUILTIN_GITHUB_PROVIDER_ID,
+            owner: "daintreehq",
+            repo: "daintree",
+            number,
+            rawData: null,
+          },
+          title: "Native Daintree assistant",
+          url: `https://github.com/daintreehq/daintree/pull/${number}`,
+          state: "open",
+        },
+      };
+    }
+
+    it("drops the phantom issue and keeps the PR", () => {
+      const snapshot = new SnapshotBuilder(
+        makeHost({
+          issueNumber: 12189,
+          issueTitle: "Stale title",
+          branchDerivedTitle: "Native daintree assistant",
+          issueLastUpdatedAt: 1_700_000_000_000,
+          linked: githubPr(12189),
+        })
+      ).build();
+
+      expect(snapshot.issueNumber).toBeUndefined();
+      expect(snapshot.issueTitle).toBeUndefined();
+      expect(snapshot.branchDerivedTitle).toBeUndefined();
+      expect(snapshot.issueLastUpdatedAt).toBeUndefined();
+      expect(snapshot.prNumber).toBe(12189);
+      expect(snapshot.prTitle).toBe("Native Daintree assistant");
+      expect(snapshot.linked?.pr?.ref.number).toBe(12189);
+    });
+
+    it("keeps a parsed issue with a different number beside the PR (#8851)", () => {
+      const snapshot = new SnapshotBuilder(
+        makeHost({
+          issueNumber: 8851,
+          branchDerivedTitle: "Sidebar shows branch",
+          linked: githubPr(12189),
+        })
+      ).build();
+
+      expect(snapshot.issueNumber).toBe(8851);
+      expect(snapshot.branchDerivedTitle).toBe("Sidebar shows branch");
+      expect(snapshot.prNumber).toBe(12189);
+    });
+
+    it("keeps an equal-numbered issue on a forge that numbers merge requests separately", () => {
+      const snapshot = new SnapshotBuilder(
+        makeHost({
+          issueNumber: 12,
+          linked: {
+            providerId: "acme.gitlab",
+            pr: {
+              ref: {
+                providerId: "acme.gitlab",
+                owner: "acme",
+                repo: "demo",
+                number: 12,
+                rawData: null,
+              },
+              url: "https://gitlab.acme.test/acme/demo/-/merge_requests/12",
+              state: "open",
+            },
+          },
+        })
+      ).build();
+
+      expect(snapshot.issueNumber).toBe(12);
+      expect(snapshot.prNumber).toBe(12);
+    });
+
+    it("keeps the issue when only legacy flat PR fields carry the number", () => {
+      const snapshot = new SnapshotBuilder(
+        makeHost({ issueNumber: 12189, prNumber: 12189 })
+      ).build();
+
+      expect(snapshot.issueNumber).toBe(12189);
+      expect(snapshot.prNumber).toBe(12189);
+    });
   });
 });

--- a/electron/workspace-host/__tests__/SnapshotBuilder.test.ts
+++ b/electron/workspace-host/__tests__/SnapshotBuilder.test.ts
@@ -283,24 +283,24 @@ describe("SnapshotBuilder", () => {
       };
     }
 
-    it("drops the phantom issue and keeps the PR", () => {
+    it("drops the phantom issue and its title but keeps the PR", () => {
       const snapshot = new SnapshotBuilder(
         makeHost({
           issueNumber: 12189,
           issueTitle: "Stale title",
           branchDerivedTitle: "Native daintree assistant",
-          issueLastUpdatedAt: 1_700_000_000_000,
           linked: githubPr(12189),
         })
       ).build();
 
       expect(snapshot.issueNumber).toBeUndefined();
       expect(snapshot.issueTitle).toBeUndefined();
-      expect(snapshot.branchDerivedTitle).toBeUndefined();
-      expect(snapshot.issueLastUpdatedAt).toBeUndefined();
       expect(snapshot.prNumber).toBe(12189);
       expect(snapshot.prTitle).toBe("Native Daintree assistant");
       expect(snapshot.linked?.pr?.ref.number).toBe(12189);
+      // Every issue surface already gates on the number; the branch still
+      // names the work for labels that fall back to it.
+      expect(snapshot.branchDerivedTitle).toBe("Native daintree assistant");
     });
 
     it("keeps a parsed issue with a different number beside the PR (#8851)", () => {

--- a/electron/workspace-host/__tests__/WorktreeMonitor.snapshotState.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeMonitor.snapshotState.test.ts
@@ -501,9 +501,10 @@ describe("WorktreeMonitor", () => {
       },
     };
 
-    it("drops the phantom issue whether the not-found or the PR lands first", () => {
-      // onIssueNotFound clears the title; onPRDetected links the PR. Their
-      // lookups settle in either order.
+    // onIssueNotFound clears the title and onPRDetected links the PR. Their
+    // lookups settle in either order, so the projection must hold after each
+    // step of both sequences, not just once both have landed.
+    it("keeps the phantom issue out of the snapshot whichever state change lands first", () => {
       const notFoundFirst = new WorktreeMonitor(
         TEST_WORKTREE,
         TEST_CONFIG,
@@ -511,17 +512,24 @@ describe("WorktreeMonitor", () => {
         "main"
       );
       notFoundFirst.setIssueNumber(12189);
+      notFoundFirst.setIssueTitle("Stale title");
+      expect(notFoundFirst.getSnapshot().issueNumber).toBe(12189);
       notFoundFirst.setIssueTitle(undefined);
       notFoundFirst.setLinked(githubPr);
+      expect(notFoundFirst.getSnapshot().issueNumber).toBeUndefined();
 
       const prFirst = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, makeCallbacks(), "main");
       prFirst.setIssueNumber(12189);
+      prFirst.setIssueTitle("Stale title");
       prFirst.setLinked(githubPr);
+      expect(prFirst.getSnapshot().issueNumber).toBeUndefined();
+      expect(prFirst.getSnapshot().issueTitle).toBeUndefined();
       prFirst.setIssueTitle(undefined);
 
       for (const monitor of [notFoundFirst, prFirst]) {
         const snapshot = monitor.getSnapshot();
         expect(snapshot.issueNumber).toBeUndefined();
+        expect(snapshot.issueTitle).toBeUndefined();
         expect(snapshot.prNumber).toBe(12189);
         // The raw parsed number stays so onIssueNotFound still matches its lookup.
         expect(monitor.issueNumber).toBe(12189);

--- a/electron/workspace-host/__tests__/WorktreeMonitor.snapshotState.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeMonitor.snapshotState.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { Worktree } from "../../../shared/types/worktree.js";
+import type { PluginWorktreeLinked } from "../../../shared/types/plugin.js";
+import { BUILTIN_GITHUB_PROVIDER_ID } from "../../../shared/utils/forgeProviderIds.js";
 import { WorktreeRemovedError } from "../../utils/errorTypes.js";
 
 const mockGetWorktreeChangesWithStats = vi.fn();
@@ -481,6 +483,61 @@ describe("WorktreeMonitor", () => {
     monitor.clearPRInfo();
 
     expect(monitor.getSnapshot().prCiStatus).toBeUndefined();
+  });
+
+  describe("issue number carried by the linked PR (#12381)", () => {
+    const githubPr: PluginWorktreeLinked = {
+      providerId: BUILTIN_GITHUB_PROVIDER_ID,
+      pr: {
+        ref: {
+          providerId: BUILTIN_GITHUB_PROVIDER_ID,
+          owner: "daintreehq",
+          repo: "daintree",
+          number: 12189,
+          rawData: null,
+        },
+        url: "https://github.com/daintreehq/daintree/pull/12189",
+        state: "open",
+      },
+    };
+
+    it("drops the phantom issue whether the not-found or the PR lands first", () => {
+      // onIssueNotFound clears the title; onPRDetected links the PR. Their
+      // lookups settle in either order.
+      const notFoundFirst = new WorktreeMonitor(
+        TEST_WORKTREE,
+        TEST_CONFIG,
+        makeCallbacks(),
+        "main"
+      );
+      notFoundFirst.setIssueNumber(12189);
+      notFoundFirst.setIssueTitle(undefined);
+      notFoundFirst.setLinked(githubPr);
+
+      const prFirst = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, makeCallbacks(), "main");
+      prFirst.setIssueNumber(12189);
+      prFirst.setLinked(githubPr);
+      prFirst.setIssueTitle(undefined);
+
+      for (const monitor of [notFoundFirst, prFirst]) {
+        const snapshot = monitor.getSnapshot();
+        expect(snapshot.issueNumber).toBeUndefined();
+        expect(snapshot.prNumber).toBe(12189);
+        // The raw parsed number stays so onIssueNotFound still matches its lookup.
+        expect(monitor.issueNumber).toBe(12189);
+      }
+    });
+
+    it("brings the parsed number back once the PR link is genuinely cleared", () => {
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, makeCallbacks(), "main");
+      monitor.setIssueNumber(12189);
+      monitor.setLinked(githubPr);
+      expect(monitor.getSnapshot().issueNumber).toBeUndefined();
+
+      monitor.clearPRInfo();
+      monitor.clearLinked();
+      expect(monitor.getSnapshot().issueNumber).toBe(12189);
+    });
   });
 
   describe("branchDerivedTitle in snapshot (#8851)", () => {

--- a/shared/utils/__tests__/worktreeIssueProjection.test.ts
+++ b/shared/utils/__tests__/worktreeIssueProjection.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import type { PluginWorktreeLinked } from "../../types/plugin.js";
+import { BUILTIN_GITHUB_PROVIDER_ID, BUILTIN_GITLAB_PROVIDER_ID } from "../forgeProviderIds.js";
+import { issueNumberBelongsToLinkedPr } from "../worktreeIssueProjection.js";
+
+function linkedPr(providerId: string, number: number): PluginWorktreeLinked {
+  return {
+    providerId,
+    pr: {
+      ref: { providerId, owner: "daintreehq", repo: "daintree", number, rawData: null },
+      url: `https://example.test/pull/${number}`,
+      state: "open",
+    },
+  };
+}
+
+describe("issueNumberBelongsToLinkedPr", () => {
+  it("claims the number when a linked GitHub PR carries it (#12381)", () => {
+    expect(issueNumberBelongsToLinkedPr(12189, linkedPr(BUILTIN_GITHUB_PROVIDER_ID, 12189))).toBe(
+      true
+    );
+  });
+
+  it("recognises the legacy bare github provider id", () => {
+    expect(issueNumberBelongsToLinkedPr(12189, linkedPr("github", 12189))).toBe(true);
+  });
+
+  it("leaves a different number alone", () => {
+    expect(issueNumberBelongsToLinkedPr(8851, linkedPr(BUILTIN_GITHUB_PROVIDER_ID, 12189))).toBe(
+      false
+    );
+  });
+
+  it("leaves the number alone without a linked PR", () => {
+    expect(issueNumberBelongsToLinkedPr(12189, undefined)).toBe(false);
+    expect(issueNumberBelongsToLinkedPr(12189, null)).toBe(false);
+    expect(issueNumberBelongsToLinkedPr(12189, { providerId: BUILTIN_GITHUB_PROVIDER_ID })).toBe(
+      false
+    );
+  });
+
+  it("never claims an absent issue number", () => {
+    expect(
+      issueNumberBelongsToLinkedPr(undefined, linkedPr(BUILTIN_GITHUB_PROVIDER_ID, 12189))
+    ).toBe(false);
+  });
+
+  it("defers to a linked issue even when the numbers match", () => {
+    const linked: PluginWorktreeLinked = {
+      ...linkedPr(BUILTIN_GITHUB_PROVIDER_ID, 12189),
+      issue: {
+        ref: {
+          providerId: BUILTIN_GITHUB_PROVIDER_ID,
+          owner: "daintreehq",
+          repo: "daintree",
+          number: 12189,
+          rawData: null,
+        },
+        title: "Tracked elsewhere",
+      },
+    };
+    expect(issueNumberBelongsToLinkedPr(12189, linked)).toBe(false);
+  });
+
+  it("keeps equal numbers apart on forges that number issues and merge requests separately", () => {
+    expect(issueNumberBelongsToLinkedPr(12, linkedPr(BUILTIN_GITLAB_PROVIDER_ID, 12))).toBe(false);
+    expect(issueNumberBelongsToLinkedPr(12, linkedPr("acme.gitlab", 12))).toBe(false);
+  });
+});

--- a/shared/utils/worktreeIssueProjection.ts
+++ b/shared/utils/worktreeIssueProjection.ts
@@ -1,0 +1,19 @@
+import type { PluginWorktreeLinked } from "../types/plugin.js";
+import { BUILTIN_GITHUB_PROVIDER_ID, normalizeProviderId } from "./forgeProviderIds.js";
+
+/**
+ * Whether a worktree's detected issue number is really its linked PR's number
+ * (#12381). GitHub gives issues and pull requests one number space per
+ * repository, so a linked GitHub PR carrying the number proves no issue by that
+ * number exists — a folder named `issue-12189` named the PR. Other forges number
+ * the two separately (GitLab `#12` vs `!12`), and a linked issue is an explicit
+ * association rather than a parse, so neither ever counts as a collision.
+ */
+export function issueNumberBelongsToLinkedPr(
+  issueNumber: number | undefined,
+  linked: PluginWorktreeLinked | null | undefined
+): boolean {
+  if (issueNumber === undefined || !linked?.pr || linked.issue) return false;
+  if (linked.pr.ref.number !== issueNumber) return false;
+  return normalizeProviderId(linked.providerId) === BUILTIN_GITHUB_PROVIDER_ID;
+}

--- a/src/contexts/__tests__/WorktreeStoreContext.prDetected.test.tsx
+++ b/src/contexts/__tests__/WorktreeStoreContext.prDetected.test.tsx
@@ -310,6 +310,7 @@ describe("WorktreeStoreProvider pr-detected handler", () => {
       prNumber: 12189,
       prUrl,
       prState: "open",
+      prTitle: "Native Daintree assistant",
       issueNumber: 12189,
       branchName: branch,
       providerId: BUILTIN_GITHUB_PROVIDER_ID,
@@ -323,12 +324,16 @@ describe("WorktreeStoreProvider pr-detected handler", () => {
           .getState()
           .applyUpdate(makeWorktree("wt-1", { branch, prNumber: 12189, prUrl, linked }), nextV());
       });
+      expect(store.getState().worktrees.get("wt-1")?.prTitle).toBeUndefined();
 
       act(() => {
         emit("pr-detected", prDetected);
       });
 
       const wt = store.getState().worktrees.get("wt-1");
+      // The overlay landed…
+      expect(wt?.prTitle).toBe("Native Daintree assistant");
+      // …without bringing the phantom issue back.
       expect(wt?.issueNumber).toBeUndefined();
       expect(wt?.prNumber).toBe(12189);
     });
@@ -340,6 +345,7 @@ describe("WorktreeStoreProvider pr-detected handler", () => {
           makeWorktree("wt-1", {
             branch,
             issueNumber: 12189,
+            issueTitle: "Stale title",
             prNumber: undefined,
             prUrl: undefined,
             prState: undefined,
@@ -354,7 +360,10 @@ describe("WorktreeStoreProvider pr-detected handler", () => {
         emit("pr-detected", prDetected);
       });
 
-      expect(store.getState().worktrees.get("wt-1")?.issueNumber).toBeUndefined();
+      const wt = store.getState().worktrees.get("wt-1");
+      expect(wt?.prNumber).toBe(12189);
+      expect(wt?.issueNumber).toBeUndefined();
+      expect(wt?.issueTitle).toBeUndefined();
     });
   });
 

--- a/src/contexts/__tests__/WorktreeStoreContext.prDetected.test.tsx
+++ b/src/contexts/__tests__/WorktreeStoreContext.prDetected.test.tsx
@@ -15,6 +15,8 @@ import { wakeActiveWorktreeTerminals } from "@/store/wakeActiveWorktreeTerminals
 import type { CIStatusState, PR } from "@shared/types/forge";
 import type { WorktreeSnapshot, WorktreeEventVersion } from "@shared/types";
 import type { Project } from "@shared/types/project";
+import type { PluginWorktreeLinked } from "@shared/types/plugin";
+import { BUILTIN_GITHUB_PROVIDER_ID } from "@shared/utils/forgeProviderIds";
 
 vi.mock("@/store/wakeActiveWorktreeTerminals", () => ({
   restoreTerminalFocusOnReveal: () => false,
@@ -282,6 +284,78 @@ describe("WorktreeStoreProvider pr-detected handler", () => {
     });
 
     expect(store.getState().worktrees.get("wt-1")?.prCiStatus).toBe("success");
+  });
+
+  describe("an issue number the linked GitHub PR carries (#12381)", () => {
+    const branch = "feature/native-daintree-assistant";
+    const prUrl = "https://github.com/daintreehq/daintree/pull/12189";
+    const linked: PluginWorktreeLinked = {
+      providerId: BUILTIN_GITHUB_PROVIDER_ID,
+      pr: {
+        ref: {
+          providerId: BUILTIN_GITHUB_PROVIDER_ID,
+          owner: "daintreehq",
+          repo: "daintree",
+          number: 12189,
+          rawData: null,
+        },
+        url: prUrl,
+        state: "open",
+      },
+    };
+    // The PR service stamps its raw candidate issue number on every detection.
+    const prDetected = {
+      type: "pr-detected",
+      worktreeId: "wt-1",
+      prNumber: 12189,
+      prUrl,
+      prState: "open",
+      issueNumber: 12189,
+      branchName: branch,
+      providerId: BUILTIN_GITHUB_PROVIDER_ID,
+      linked,
+    };
+
+    it("does not restore it over the host's corrected snapshot", async () => {
+      const store = await renderProvider();
+      act(() => {
+        store
+          .getState()
+          .applyUpdate(makeWorktree("wt-1", { branch, prNumber: 12189, prUrl, linked }), nextV());
+      });
+
+      act(() => {
+        emit("pr-detected", prDetected);
+      });
+
+      const wt = store.getState().worktrees.get("wt-1");
+      expect(wt?.issueNumber).toBeUndefined();
+      expect(wt?.prNumber).toBe(12189);
+    });
+
+    it("drops it when the PR lands before any corrected snapshot", async () => {
+      const store = await renderProvider();
+      act(() => {
+        store.getState().applyUpdate(
+          makeWorktree("wt-1", {
+            branch,
+            issueNumber: 12189,
+            prNumber: undefined,
+            prUrl: undefined,
+            prState: undefined,
+            prCiStatus: undefined,
+          }),
+          nextV()
+        );
+      });
+      expect(store.getState().worktrees.get("wt-1")?.issueNumber).toBe(12189);
+
+      act(() => {
+        emit("pr-detected", prDetected);
+      });
+
+      expect(store.getState().worktrees.get("wt-1")?.issueNumber).toBeUndefined();
+    });
   });
 
   it("does nothing when the worktree is not in the store", async () => {

--- a/src/store/__tests__/createWorktreeStore.associations.test.ts
+++ b/src/store/__tests__/createWorktreeStore.associations.test.ts
@@ -348,16 +348,14 @@ describe("createWorktreeStore — issue number carried by the linked PR (#12381)
       );
     expect(store.getState().worktrees.get("wt-1")?.issueTitle).toBe("Stale title");
 
-    store
-      .getState()
-      .applyUpdate(
-        makeSnapshot("wt-1", {
-          issueNumber: 12189,
-          issueTitle: undefined,
-          linked: githubPr(12189),
-        }),
-        nextV()
-      );
+    store.getState().applyUpdate(
+      makeSnapshot("wt-1", {
+        issueNumber: 12189,
+        issueTitle: undefined,
+        linked: githubPr(12189),
+      }),
+      nextV()
+    );
 
     const wt = store.getState().worktrees.get("wt-1");
     expect(wt?.issueNumber).toBeUndefined();

--- a/src/store/__tests__/createWorktreeStore.associations.test.ts
+++ b/src/store/__tests__/createWorktreeStore.associations.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { createWorktreeStore } from "@/store/createWorktreeStore";
 import type { WorktreeSnapshot, WorktreeEventVersion } from "@shared/types";
 import type { PluginWorktreeLinked } from "@shared/types/plugin";
+import { BUILTIN_GITHUB_PROVIDER_ID } from "@shared/utils/forgeProviderIds";
 
 // Host-minted versions are now `(epoch, seq)` tuples (#8403). Tests mint a
 // monotonic seq under a fixed epoch; each fresh store starts at epoch "" so
@@ -279,5 +280,97 @@ describe("createWorktreeStore — linked PR preservation (#8870)", () => {
     store.getState().applyUpdate(makeSnapshot("wt-1", { branch: "feature/x" }), nextV());
 
     expect(store.getState().worktrees.get("wt-1")?.linked).toBeNull();
+  });
+});
+
+describe("createWorktreeStore — issue number carried by the linked PR (#12381)", () => {
+  function githubPr(number: number): PluginWorktreeLinked {
+    return {
+      providerId: BUILTIN_GITHUB_PROVIDER_ID,
+      pr: {
+        ref: {
+          providerId: BUILTIN_GITHUB_PROVIDER_ID,
+          owner: "daintreehq",
+          repo: "daintree",
+          number,
+          rawData: null,
+        },
+        url: `https://github.com/daintreehq/daintree/pull/${number}`,
+        state: "open",
+      },
+    };
+  }
+
+  it("drops a parsed issue number the linked GitHub PR carries", () => {
+    const store = createWorktreeStore();
+    store.getState().applySnapshot(
+      [
+        makeSnapshot("wt-1", {
+          issueNumber: 12189,
+          branchDerivedTitle: "Native assistant",
+          issueLastUpdatedAt: 1_700_000_000_000,
+          linked: githubPr(12189),
+        }),
+      ],
+      nextV()
+    );
+
+    const wt = store.getState().worktrees.get("wt-1");
+    expect(wt?.issueNumber).toBeUndefined();
+    expect(wt?.branchDerivedTitle).toBeUndefined();
+    expect(wt?.issueLastUpdatedAt).toBeUndefined();
+    expect(wt?.linked?.pr?.ref.number).toBe(12189);
+  });
+
+  it("drops it when an update omits linked and the stored row carries the PR", () => {
+    const store = createWorktreeStore();
+    store.getState().applySnapshot([makeSnapshot("wt-1", { linked: githubPr(12189) })], nextV());
+
+    store.getState().applyUpdate(makeSnapshot("wt-1", { issueNumber: 12189 }), nextV());
+
+    expect(store.getState().worktrees.get("wt-1")?.issueNumber).toBeUndefined();
+  });
+
+  it("lets a manual association with the PR's number win (MANUAL_OVER_AUTO)", () => {
+    const store = createWorktreeStore();
+    store
+      .getState()
+      .applySnapshot(
+        [makeSnapshot("wt-1", { issueNumber: 12189, linked: githubPr(12189) })],
+        nextV(),
+        { "wt-1": { issueNumber: 12189, issueTitle: "Chosen by hand" } }
+      );
+
+    const wt = store.getState().worktrees.get("wt-1");
+    expect(wt?.issueNumber).toBe(12189);
+    expect(wt?.issueTitle).toBe("Chosen by hand");
+  });
+
+  it("keeps equal numbers on a forge that numbers merge requests separately", () => {
+    const store = createWorktreeStore();
+    store.getState().applySnapshot(
+      [
+        makeSnapshot("wt-1", {
+          issueNumber: 12,
+          linked: {
+            providerId: "acme.gitlab",
+            pr: {
+              ref: {
+                providerId: "acme.gitlab",
+                owner: "acme",
+                repo: "demo",
+                number: 12,
+                rawData: null,
+              },
+              url: "https://gitlab.acme.test/acme/demo/-/merge_requests/12",
+              state: "open",
+            },
+          },
+        }),
+      ],
+      nextV()
+    );
+
+    expect(store.getState().worktrees.get("wt-1")?.issueNumber).toBe(12);
   });
 });

--- a/src/store/__tests__/createWorktreeStore.associations.test.ts
+++ b/src/store/__tests__/createWorktreeStore.associations.test.ts
@@ -301,14 +301,14 @@ describe("createWorktreeStore — issue number carried by the linked PR (#12381)
     };
   }
 
-  it("drops a parsed issue number the linked GitHub PR carries", () => {
+  it("drops a parsed issue number and its title when the linked GitHub PR carries it", () => {
     const store = createWorktreeStore();
     store.getState().applySnapshot(
       [
         makeSnapshot("wt-1", {
           issueNumber: 12189,
+          issueTitle: "Stale title",
           branchDerivedTitle: "Native assistant",
-          issueLastUpdatedAt: 1_700_000_000_000,
           linked: githubPr(12189),
         }),
       ],
@@ -317,8 +317,8 @@ describe("createWorktreeStore — issue number carried by the linked PR (#12381)
 
     const wt = store.getState().worktrees.get("wt-1");
     expect(wt?.issueNumber).toBeUndefined();
-    expect(wt?.branchDerivedTitle).toBeUndefined();
-    expect(wt?.issueLastUpdatedAt).toBeUndefined();
+    expect(wt?.issueTitle).toBeUndefined();
+    expect(wt?.branchDerivedTitle).toBe("Native assistant");
     expect(wt?.linked?.pr?.ref.number).toBe(12189);
   });
 
@@ -326,9 +326,43 @@ describe("createWorktreeStore — issue number carried by the linked PR (#12381)
     const store = createWorktreeStore();
     store.getState().applySnapshot([makeSnapshot("wt-1", { linked: githubPr(12189) })], nextV());
 
-    store.getState().applyUpdate(makeSnapshot("wt-1", { issueNumber: 12189 }), nextV());
+    store
+      .getState()
+      .applyUpdate(
+        makeSnapshot("wt-1", { branch: "feature/native-daintree-assistant", issueNumber: 12189 }),
+        nextV()
+      );
 
-    expect(store.getState().worktrees.get("wt-1")?.issueNumber).toBeUndefined();
+    const wt = store.getState().worktrees.get("wt-1");
+    expect(wt?.branch).toBe("feature/native-daintree-assistant");
+    expect(wt?.issueNumber).toBeUndefined();
+  });
+
+  it("clears a title the unchanged-number flicker rule would otherwise restore", () => {
+    const store = createWorktreeStore();
+    store
+      .getState()
+      .applySnapshot(
+        [makeSnapshot("wt-1", { issueNumber: 12189, issueTitle: "Stale title" })],
+        nextV()
+      );
+    expect(store.getState().worktrees.get("wt-1")?.issueTitle).toBe("Stale title");
+
+    store
+      .getState()
+      .applyUpdate(
+        makeSnapshot("wt-1", {
+          issueNumber: 12189,
+          issueTitle: undefined,
+          linked: githubPr(12189),
+        }),
+        nextV()
+      );
+
+    const wt = store.getState().worktrees.get("wt-1");
+    expect(wt?.issueNumber).toBeUndefined();
+    expect(wt?.issueTitle).toBeUndefined();
+    expect(wt?.linked?.pr?.ref.number).toBe(12189);
   });
 
   it("lets a manual association with the PR's number win (MANUAL_OVER_AUTO)", () => {

--- a/src/store/createWorktreeStore.ts
+++ b/src/store/createWorktreeStore.ts
@@ -12,6 +12,7 @@ import {
 import { logDebug } from "@/utils/logger";
 import { notify } from "@/lib/notify";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
+import { issueNumberBelongsToLinkedPr } from "@shared/utils/worktreeIssueProjection";
 
 /**
  * How long a `worktree-removed` tombstone suppresses a late `worktree-update`
@@ -2076,6 +2077,8 @@ function mergeIssueState(
 ): WorktreeSnapshot {
   let issueNumber = incoming.issueNumber;
   let issueTitle = incoming.issueTitle;
+  let branchDerivedTitle = incoming.branchDerivedTitle;
+  let issueLastUpdatedAt = incoming.issueLastUpdatedAt;
 
   if (
     existing &&
@@ -2087,12 +2090,6 @@ function mergeIssueState(
     issueTitle = existing.issueTitle;
   }
 
-  // MANUAL_OVER_AUTO: explicit user association wins over auto-detection.
-  if (manual) {
-    issueNumber = manual.issueNumber;
-    issueTitle = manual.issueTitle;
-  }
-
   // `linked: undefined` from the host means "PR service hasn't run yet" —
   // preserve whatever the renderer already has (e.g. `linked.pr` from a
   // prior session's `pr-detected` event). `linked: null` is an explicit
@@ -2102,14 +2099,33 @@ function mergeIssueState(
       ? existing.linked
       : incoming.linked;
 
+  // The host already drops an issue number its linked GitHub PR carries, but
+  // the `pr-detected` overlay re-adds the raw candidate number the event was
+  // sent with. Applied before the manual override so an explicit association
+  // still wins (#12381).
+  if (issueNumberBelongsToLinkedPr(issueNumber, linked)) {
+    issueNumber = undefined;
+    issueTitle = undefined;
+    branchDerivedTitle = undefined;
+    issueLastUpdatedAt = undefined;
+  }
+
+  // MANUAL_OVER_AUTO: explicit user association wins over auto-detection.
+  if (manual) {
+    issueNumber = manual.issueNumber;
+    issueTitle = manual.issueTitle;
+  }
+
   if (
     issueNumber === incoming.issueNumber &&
     issueTitle === incoming.issueTitle &&
+    branchDerivedTitle === incoming.branchDerivedTitle &&
+    issueLastUpdatedAt === incoming.issueLastUpdatedAt &&
     linked === incoming.linked
   ) {
     return incoming;
   }
-  return { ...incoming, issueNumber, issueTitle, linked };
+  return { ...incoming, issueNumber, issueTitle, branchDerivedTitle, issueLastUpdatedAt, linked };
 }
 
 function snapshotsEqual(a: WorktreeSnapshot, b: WorktreeSnapshot): boolean {

--- a/src/store/createWorktreeStore.ts
+++ b/src/store/createWorktreeStore.ts
@@ -2077,8 +2077,6 @@ function mergeIssueState(
 ): WorktreeSnapshot {
   let issueNumber = incoming.issueNumber;
   let issueTitle = incoming.issueTitle;
-  let branchDerivedTitle = incoming.branchDerivedTitle;
-  let issueLastUpdatedAt = incoming.issueLastUpdatedAt;
 
   if (
     existing &&
@@ -2106,8 +2104,6 @@ function mergeIssueState(
   if (issueNumberBelongsToLinkedPr(issueNumber, linked)) {
     issueNumber = undefined;
     issueTitle = undefined;
-    branchDerivedTitle = undefined;
-    issueLastUpdatedAt = undefined;
   }
 
   // MANUAL_OVER_AUTO: explicit user association wins over auto-detection.
@@ -2119,13 +2115,11 @@ function mergeIssueState(
   if (
     issueNumber === incoming.issueNumber &&
     issueTitle === incoming.issueTitle &&
-    branchDerivedTitle === incoming.branchDerivedTitle &&
-    issueLastUpdatedAt === incoming.issueLastUpdatedAt &&
     linked === incoming.linked
   ) {
     return incoming;
   }
-  return { ...incoming, issueNumber, issueTitle, branchDerivedTitle, issueLastUpdatedAt, linked };
+  return { ...incoming, issueNumber, issueTitle, linked };
 }
 
 function snapshotsEqual(a: WorktreeSnapshot, b: WorktreeSnapshot): boolean {


### PR DESCRIPTION
## Summary
- A worktree folder named `issue-12189` with a branch that carries no number gets issue `12189` parsed from the folder name, but `12189` is actually a pull request opened from that branch. GitHub shares one number space between issues and pull requests, so an issue can never carry a PR's number.
- The forge correctly reports the issue as not found, but the handler from #8851 keeps the parsed number on purpose (a not-found result could mean the issue is private, deleted, or in another org), so the card ends up rendering issue `#12189` stacked on top of PR `#12189`.
- Fixes this by dropping the issue number specifically when a linked GitHub PR carries the same number, without touching the #8851 fallback for every other not-found case.

Resolves #12381

## Changes
- New shared helper `issueNumberBelongsToLinkedPr` in `shared/utils/worktreeIssueProjection.ts`. Returns true only when a linked GitHub pull request (checked via `normalizeProviderId(linked.providerId) === BUILTIN_GITHUB_PROVIDER_ID`) carries the same number and there's no linked issue.
- Applied at the two projection boundaries: `SnapshotBuilder.build()` in the workspace host, and `mergeIssueState` in the renderer store. Only `issueNumber` and `issueTitle` get dropped; `branchDerivedTitle` stays, since every issue surface already gates display on the number being present.
- The renderer needs the same fix because `PullRequestService` stamps every `pr-detected` event with the raw candidate issue number, and the overlay logic does `event.issueNumber ?? existing.issueNumber`, which would restore the phantom number over an already-corrected snapshot. `mergeIssueState` applies the rule before the manual-association override, so an explicit user association still wins.
- What stays the same: the monitor keeps the raw parsed number so `onIssueNotFound` can still correlate lookups; the fix is order-independent since `sys:pr:detected` and `sys:issue:not-found` can settle in either order and both funnel through the same projection; other forges keep separate numbering (GitLab issue `#12` vs merge request `!12`) and are untouched; flat PR state with no linked provider is untouched; a genuine PR clear still restores the original #8851 fallback.

## Testing
- Unit tests for the new helper.
- `SnapshotBuilder` tests for the collision case, the non-collision #8851 case, a GitLab equal-numbers case, and a flat-only PR case.
- `WorktreeMonitor` snapshot tests after each step of both event orders, plus a PR-clear restore case.
- Store tests for hydration, an omitted-linked update, an unchanged-number title restore-then-suppress case, manual-over-auto precedence, and GitLab.
- `WorktreeStoreContext` test for the `pr-detected` overlay landing over an already-corrected snapshot, and for PR-before-snapshot ordering.
- Ran targeted vitest across 27 related files, 549 tests, all passing. eslint clean on the changed files, no new warnings. prettier clean. Full suite, typecheck, and build run in CI.
- Two known, pre-existing gaps flagged as out of scope: `GitStatusPass`'s poll-detected branch switch calls `clearPRInfo` without `clearLinked`, so linked PR state can briefly outlive a branch switch until topology reconciliation catches up; `closingIssueRef` discards owner/repo on cross-repo closing references.