### PR TITLE
fix(ui): stop menu rows ringing on mouse hover

### DIFF
--- a/.claude/rules/overlay-focus.md
+++ b/.claude/rules/overlay-focus.md
@@ -27,6 +27,12 @@ The plain interactive entries in that selector are load-bearing, not padding: a 
 
 The flags live on the overlay **root** and reset on every open. The content wrapper outlives each close, so a close that skips `onCloseAutoFocus` would otherwise strand them onto the next opening.
 
+## The hover half
+
+Radix also focuses a **row** on mouse hover, and Chromium rings that script focus or not depending on whether the user last typed or last clicked something focusable — nothing about opening a menu updates the heuristic (#12383). `menuRowPointerMove` in `src/components/ui/menu-row-hover-focus.ts` is wired into all nine row wrappers (`DropdownMenu`, `ContextMenu` and `Select` items, sub-triggers, checkbox and radio rows), so again **no per-site wiring**.
+
+It decorates the row's own `focus` for the length of the pointer event rather than focusing the row itself. That is not fussiness: Radix deliberately skips its focus when the pointer is crossing a sibling into an open submenu's grace area, and pre-empting it there closes the submenu. Re-focusing afterwards is inert — Blink bails out early once the element is already `activeElement`, which is also what keeps a keyboard ring alive when the mouse drifts over the focused row.
+
 ## The tooltip half
 
 Element-scoped, in `src/lib/tooltipFocusSuppression.ts`: the close arms a one-shot **capture** `focusin` listener, marks whichever element focus lands on, and `Tooltip` refuses a focus-driven open for its own trigger while that mark stands. A genuine `pointerenter` clears it. React listens on the root container, below `document`, so the capture listener always wins the race.
@@ -51,4 +57,4 @@ A `PopoverAnchor` without a `Trigger` has no focus target, so the shared policy 
 
 `AppDialog`'s `stopPropagation` kills Radix 1.1.15+ deferred dismissal — see `docs/themes/interaction-state-recipes.md`.
 
-Canonical: `src/components/ui/overlay-focus-restore.ts`, `src/components/ui/tooltip.tsx`.
+Canonical: `src/components/ui/overlay-focus-restore.ts`, `src/components/ui/menu-row-hover-focus.ts`, `src/components/ui/tooltip.tsx`.

--- a/src/components/ui/__tests__/menu-row-hover-focus.test.tsx
+++ b/src/components/ui/__tests__/menu-row-hover-focus.test.tsx
@@ -1,0 +1,309 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import * as ContextMenuPrimitive from "@radix-ui/react-context-menu";
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
+import * as SelectPrimitive from "@radix-ui/react-select";
+import {
+  ContextMenuCheckboxItem,
+  ContextMenuItem,
+  ContextMenuRadioItem,
+  ContextMenuSubTrigger,
+} from "../context-menu";
+import {
+  DropdownMenuCheckboxItem,
+  DropdownMenuItem,
+  DropdownMenuRadioItem,
+  DropdownMenuSubTrigger,
+} from "../dropdown-menu";
+import { SelectItem } from "../select";
+import { menuRowPointerMove } from "../menu-row-hover-focus";
+import { primeRadix } from "../radix-loader";
+
+// jsdom has no `:focus-visible` heuristic and drops `focusVisible` from
+// `FocusOptions`, so the ring itself is not observable here. What is observable
+// — and what the fix turns on — is the options Radix's own hover focus lands
+// with, so every assertion is about the recorded focus call.
+type RecordedFocus = { row: HTMLElement; options?: FocusOptions };
+let recorded: RecordedFocus[];
+let originalFocus: typeof HTMLElement.prototype.focus;
+
+beforeAll(async () => {
+  await primeRadix();
+  originalFocus = HTMLElement.prototype.focus;
+});
+
+beforeEach(() => {
+  recorded = [];
+  vi.spyOn(HTMLElement.prototype, "focus").mockImplementation(function (
+    this: HTMLElement,
+    options?: FocusOptions
+  ) {
+    recorded.push({ row: this, options });
+    originalFocus.call(this, options);
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  cleanup();
+});
+
+function focusesOf(row: HTMLElement): RecordedFocus[] {
+  return recorded.filter((call) => call.row === row);
+}
+
+function hover(row: HTMLElement, init: PointerEventInit = {}) {
+  fireEvent.pointerMove(row, { pointerType: "mouse", clientX: 10, clientY: 10, ...init });
+}
+
+function renderDropdown(children: React.ReactNode) {
+  render(
+    <DropdownMenuPrimitive.Root open>
+      <DropdownMenuPrimitive.Trigger>trigger</DropdownMenuPrimitive.Trigger>
+      <DropdownMenuPrimitive.Portal>
+        <DropdownMenuPrimitive.Content forceMount>{children}</DropdownMenuPrimitive.Content>
+      </DropdownMenuPrimitive.Portal>
+    </DropdownMenuPrimitive.Root>
+  );
+}
+
+function renderContextMenu(children: React.ReactNode) {
+  const { container } = render(
+    <ContextMenuPrimitive.Root>
+      <ContextMenuPrimitive.Trigger data-testid="trigger">trigger</ContextMenuPrimitive.Trigger>
+      <ContextMenuPrimitive.Portal>
+        <ContextMenuPrimitive.Content forceMount>{children}</ContextMenuPrimitive.Content>
+      </ContextMenuPrimitive.Portal>
+    </ContextMenuPrimitive.Root>
+  );
+  // Radix's context-menu root has no `open` prop; the gesture is what mounts
+  // the content into the portal.
+  fireEvent.contextMenu(container.querySelector("[data-testid='trigger']") as HTMLElement);
+}
+
+function row(selector: string): HTMLElement {
+  const found = document.querySelector(selector);
+  if (!found) throw new Error(`No row matched ${selector}`);
+  return found as HTMLElement;
+}
+
+describe("menu row hover focus — issue #12383", () => {
+  it("lands Radix's hover focus with focusVisible: false", () => {
+    renderDropdown(<DropdownMenuItem>Copy full context</DropdownMenuItem>);
+    const item = row("[role='menuitem']");
+
+    hover(item);
+
+    const calls = focusesOf(item);
+    expect(calls.length).toBeGreaterThan(0);
+    expect(calls[0]?.options).toEqual({ preventScroll: true, focusVisible: false });
+    expect(document.activeElement).toBe(item);
+    // The hover highlight is what should paint instead, and Radix drives it
+    // from the same focus — suppressing the ring must not cost the background.
+    expect(item.hasAttribute("data-highlighted")).toBe(true);
+  });
+
+  it("runs a caller's onPointerMove first and still suppresses the ring", () => {
+    const order: string[] = [];
+    renderDropdown(
+      <DropdownMenuItem onPointerMove={() => order.push("caller")}>Preview</DropdownMenuItem>
+    );
+    const item = row("[role='menuitem']");
+    recorded = [];
+
+    hover(item);
+
+    expect(order).toEqual(["caller"]);
+    expect(focusesOf(item)[0]?.options).toEqual({ preventScroll: true, focusVisible: false });
+  });
+
+  it("leaves focus alone when the caller cancels the event", () => {
+    renderDropdown(
+      <DropdownMenuItem onPointerMove={(event) => event.preventDefault()}>Preview</DropdownMenuItem>
+    );
+    const item = row("[role='menuitem']");
+    recorded = [];
+
+    hover(item);
+
+    expect(focusesOf(item)).toHaveLength(0);
+  });
+
+  it("ignores non-mouse pointers, matching Radix's own gate", () => {
+    renderDropdown(<DropdownMenuItem>Tap target</DropdownMenuItem>);
+    const item = row("[role='menuitem']");
+    recorded = [];
+
+    hover(item, { pointerType: "touch" });
+
+    expect(focusesOf(item)).toHaveLength(0);
+  });
+
+  it("never focuses a disabled row", () => {
+    renderDropdown(<DropdownMenuItem disabled>Unavailable</DropdownMenuItem>);
+    const item = row("[role='menuitem']");
+    recorded = [];
+
+    hover(item);
+
+    expect(focusesOf(item)).toHaveLength(0);
+    expect(item.hasAttribute("data-highlighted")).toBe(false);
+  });
+
+  it("stops decorating the row once the pointer event has been dispatched", async () => {
+    renderDropdown(<DropdownMenuItem>Copy full context</DropdownMenuItem>);
+    const item = row("[role='menuitem']");
+    hover(item);
+
+    await Promise.resolve();
+    expect(Object.hasOwn(item, "focus")).toBe(false);
+
+    recorded = [];
+    item.focus({ preventScroll: true });
+    expect(focusesOf(item)[0]?.options).toEqual({ preventScroll: true });
+  });
+
+  it("leaves keyboard focus untouched so arrow keys still ring", () => {
+    renderDropdown(
+      <>
+        <DropdownMenuItem>First</DropdownMenuItem>
+        <DropdownMenuItem>Second</DropdownMenuItem>
+      </>
+    );
+    const content = row("[role='menu']");
+    const first = row("[role='menuitem']");
+    recorded = [];
+
+    fireEvent.keyDown(content, { key: "ArrowDown" });
+
+    const calls = focusesOf(first);
+    expect(calls.length).toBeGreaterThan(0);
+    for (const call of calls) {
+      expect(call.options?.focusVisible).not.toBe(false);
+    }
+  });
+});
+
+describe("menu row hover focus — every row primitive", () => {
+  it("covers the dropdown sub-trigger", () => {
+    renderDropdown(
+      <DropdownMenuPrimitive.Sub>
+        <DropdownMenuSubTrigger>More</DropdownMenuSubTrigger>
+      </DropdownMenuPrimitive.Sub>
+    );
+    const trigger = row("[role='menuitem']");
+    recorded = [];
+
+    hover(trigger);
+
+    expect(focusesOf(trigger)[0]?.options).toEqual({ preventScroll: true, focusVisible: false });
+  });
+
+  it("covers the dropdown checkbox and radio rows", () => {
+    renderDropdown(
+      <>
+        <DropdownMenuCheckboxItem checked>Wrap lines</DropdownMenuCheckboxItem>
+        <DropdownMenuPrimitive.RadioGroup value="a">
+          <DropdownMenuRadioItem value="a">A</DropdownMenuRadioItem>
+        </DropdownMenuPrimitive.RadioGroup>
+      </>
+    );
+    const checkbox = row("[role='menuitemcheckbox']");
+    const radio = row("[role='menuitemradio']");
+    recorded = [];
+
+    hover(checkbox);
+    hover(radio);
+
+    expect(focusesOf(checkbox)[0]?.options).toEqual({ preventScroll: true, focusVisible: false });
+    expect(focusesOf(radio)[0]?.options).toEqual({ preventScroll: true, focusVisible: false });
+  });
+
+  it("covers the context-menu item, sub-trigger, checkbox and radio rows", () => {
+    renderContextMenu(
+      <>
+        <ContextMenuItem>Reveal</ContextMenuItem>
+        <ContextMenuPrimitive.Sub>
+          <ContextMenuSubTrigger>More</ContextMenuSubTrigger>
+        </ContextMenuPrimitive.Sub>
+        <ContextMenuCheckboxItem checked>Wrap lines</ContextMenuCheckboxItem>
+        <ContextMenuPrimitive.RadioGroup value="a">
+          <ContextMenuRadioItem value="a">A</ContextMenuRadioItem>
+        </ContextMenuPrimitive.RadioGroup>
+      </>
+    );
+    const rows = Array.from(
+      document.querySelectorAll(
+        "[role='menuitem'],[role='menuitemcheckbox'],[role='menuitemradio']"
+      )
+    ) as HTMLElement[];
+    expect(rows).toHaveLength(4);
+
+    for (const target of rows) {
+      recorded = [];
+      hover(target);
+      expect(focusesOf(target)[0]?.options).toEqual({ preventScroll: true, focusVisible: false });
+    }
+  });
+
+  it("covers the select option row", () => {
+    render(
+      <SelectPrimitive.Root open value="a">
+        <SelectPrimitive.Trigger>trigger</SelectPrimitive.Trigger>
+        <SelectPrimitive.Portal>
+          <SelectPrimitive.Content position="popper">
+            <SelectPrimitive.Viewport>
+              <SelectItem value="a">Option A</SelectItem>
+            </SelectPrimitive.Viewport>
+          </SelectPrimitive.Content>
+        </SelectPrimitive.Portal>
+      </SelectPrimitive.Root>
+    );
+    const option = row("[role='option']");
+    recorded = [];
+
+    hover(option);
+
+    expect(focusesOf(option)[0]?.options).toEqual({ preventScroll: true, focusVisible: false });
+  });
+});
+
+describe("menuRowPointerMove", () => {
+  function pointerEvent(target: HTMLElement, pointerType = "mouse") {
+    let prevented = false;
+    return {
+      currentTarget: target,
+      pointerType,
+      get defaultPrevented() {
+        return prevented;
+      },
+      preventDefault() {
+        prevented = true;
+      },
+    } as unknown as React.PointerEvent<HTMLElement>;
+  }
+
+  it("injects focusVisible: false into whatever options the caller of focus passes", () => {
+    const el = document.createElement("div");
+    document.body.appendChild(el);
+
+    menuRowPointerMove(pointerEvent(el), undefined);
+    el.focus();
+
+    expect(focusesOf(el)[0]?.options).toEqual({ focusVisible: false });
+    el.remove();
+  });
+
+  it("does not double-decorate a row hovered twice in one task", () => {
+    const el = document.createElement("div");
+    document.body.appendChild(el);
+
+    menuRowPointerMove(pointerEvent(el), undefined);
+    const decorated = Object.getOwnPropertyDescriptor(el, "focus")?.value;
+    menuRowPointerMove(pointerEvent(el), undefined);
+
+    expect(Object.getOwnPropertyDescriptor(el, "focus")?.value).toBe(decorated);
+    el.remove();
+  });
+});

--- a/src/components/ui/__tests__/menu-row-hover-focus.test.tsx
+++ b/src/components/ui/__tests__/menu-row-hover-focus.test.tsx
@@ -253,6 +253,10 @@ describe("menu row hover focus — issue #12383", () => {
     const second = rowAt(1);
 
     hover(first);
+    // Asserted, not assumed: without it, plain Radix navigation satisfies
+    // everything below and the test stops noticing an unwired primitive.
+    expect(focusesOf(first)).toEqual([{ row: first, options: SUPPRESSED }]);
+
     await Promise.resolve();
     await pressKey(first, "ArrowDown");
     expect(document.activeElement).toBe(second);
@@ -302,9 +306,10 @@ describe("menu row hover focus — every row primitive", () => {
         </DropdownMenuPrimitive.RadioGroup>
       </>
     );
-    const targets = rows();
-    expect(targets).toHaveLength(4);
-    for (const target of targets) expectSuppressedHover(target, seen);
+    expect(rows()).toHaveLength(4);
+    // Re-queried per iteration: hovering a row re-renders it, and a snapshot
+    // taken up front would be asserting against nodes from before that.
+    for (let index = 0; index < 4; index += 1) expectSuppressedHover(rowAt(index), seen);
   });
 
   it("covers the context-menu item, sub-trigger, checkbox and radio rows", () => {
@@ -326,9 +331,10 @@ describe("menu row hover focus — every row primitive", () => {
         </ContextMenuPrimitive.RadioGroup>
       </>
     );
-    const targets = rows();
-    expect(targets).toHaveLength(4);
-    for (const target of targets) expectSuppressedHover(target, seen);
+    expect(rows()).toHaveLength(4);
+    // Re-queried per iteration: hovering a row re-renders it, and a snapshot
+    // taken up front would be asserting against nodes from before that.
+    for (let index = 0; index < 4; index += 1) expectSuppressedHover(rowAt(index), seen);
   });
 
   it("covers the select option row", () => {
@@ -370,9 +376,33 @@ describe("menu row hover focus — the decoration itself", () => {
     expect(asked).toEqual({ preventScroll: false, focusVisible: true });
   });
 
-  it("leaves a row that already owns a focus implementation alone", () => {
-    renderDropdown(<DropdownMenuItem>Copy full context</DropdownMenuItem>);
+  it("decorates the row the pointer is over, not the child it entered through", () => {
+    renderDropdown(
+      <DropdownMenuItem>
+        <span data-testid="label">Copy full context</span>
+      </DropdownMenuItem>
+    );
     const item = rowAt(0);
+    const label = must(document.querySelector<HTMLElement>("[data-testid='label']"), "label");
+    recorded = [];
+
+    hover(label);
+
+    // Rows carry icons and text spans, so `event.target` is routinely a child.
+    // The row is the thing Radix focuses, so the row is what must be decorated.
+    expect(focusesOf(item)).toEqual([{ row: item, options: SUPPRESSED }]);
+    expect(Object.hasOwn(label, "focus")).toBe(false);
+  });
+
+  it("leaves a row that already owns a focus implementation alone", async () => {
+    renderDropdown(
+      <>
+        <DropdownMenuItem>Overridden</DropdownMenuItem>
+        <DropdownMenuItem>Control</DropdownMenuItem>
+      </>
+    );
+    const item = rowAt(0);
+    const control = rowAt(1);
     const own = vi.fn();
     Object.defineProperty(item, "focus", { configurable: true, value: own });
     recorded = [];
@@ -380,12 +410,20 @@ describe("menu row hover focus — the decoration itself", () => {
     hover(item);
 
     // An instance override — a per-element spy, say — keeps its own behaviour
-    // rather than being silently swapped out and then deleted.
+    // rather than being silently swapped out.
     expect(own).toHaveBeenCalledWith({ preventScroll: true });
     expect(focusesOf(item)).toHaveLength(0);
+
+    // And it must survive the teardown too: a decoration that was never
+    // installed must not take someone else's property with it.
+    await Promise.resolve();
+    expect(Object.getOwnPropertyDescriptor(item, "focus")?.value).toBe(own);
+
+    hover(control);
+    expect(focusesOf(control)).toEqual([{ row: control, options: SUPPRESSED }]);
   });
 
-  it("keeps one decoration across repeated hovers in the same task", async () => {
+  it("decorates once per task and can decorate again on a later event", async () => {
     renderDropdown(<DropdownMenuItem>Copy full context</DropdownMenuItem>);
     const item = rowAt(0);
 
@@ -395,7 +433,6 @@ describe("menu row hover focus — the decoration itself", () => {
     hover(item);
     expect(Object.getOwnPropertyDescriptor(item, "focus")?.value).toBe(decorated);
 
-    // One teardown for one decoration, and a later event can decorate again.
     await Promise.resolve();
     expect(Object.hasOwn(item, "focus")).toBe(false);
     hover(item);

--- a/src/components/ui/__tests__/menu-row-hover-focus.test.tsx
+++ b/src/components/ui/__tests__/menu-row-hover-focus.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { act, cleanup, fireEvent, render } from "@testing-library/react";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import * as ContextMenuPrimitive from "@radix-ui/react-context-menu";
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
@@ -17,15 +17,20 @@ import {
   DropdownMenuSubTrigger,
 } from "../dropdown-menu";
 import { SelectItem } from "../select";
-import { menuRowPointerMove } from "../menu-row-hover-focus";
 import { primeRadix } from "../radix-loader";
 
 // jsdom has no `:focus-visible` heuristic and drops `focusVisible` from
-// `FocusOptions`, so the ring itself is not observable here. What is observable
-// — and what the fix turns on — is the options Radix's own hover focus lands
-// with, so every assertion is about the recorded focus call.
+// `FocusOptions`, so the painted ring is not observable here. What is
+// observable — and what the fix turns on — is which focus calls happen at all,
+// in what order, and with which options. The spy lives on the prototype
+// deliberately: a row-level spy would install an own `focus` property and trip
+// the helper's own-property opt-out.
 type RecordedFocus = { row: HTMLElement; options?: FocusOptions };
 let recorded: RecordedFocus[];
+// Ordering evidence for the one row a test is watching, so "the caller ran
+// first" is a claim about the timeline rather than about a lone marker.
+let timeline: string[];
+let watched: HTMLElement | null;
 let originalFocus: typeof HTMLElement.prototype.focus;
 
 beforeAll(async () => {
@@ -35,11 +40,16 @@ beforeAll(async () => {
 
 beforeEach(() => {
   recorded = [];
+  timeline = [];
+  watched = null;
   vi.spyOn(HTMLElement.prototype, "focus").mockImplementation(function (
     this: HTMLElement,
     options?: FocusOptions
   ) {
-    recorded.push({ row: this, options });
+    // Copied on entry: an implementation that focused first and only then
+    // added `focusVisible` to the same object would otherwise read as a pass.
+    recorded.push({ row: this, options: options ? { ...options } : undefined });
+    if (this === watched) timeline.push("focus");
     originalFocus.call(this, options);
   });
 });
@@ -49,12 +59,28 @@ afterEach(() => {
   cleanup();
 });
 
+const SUPPRESSED: FocusOptions = { preventScroll: true, focusVisible: false };
+
+function must<T>(value: T | null | undefined, what: string): T {
+  if (value == null) throw new Error(`Missing ${what}`);
+  return value;
+}
+
 function focusesOf(row: HTMLElement): RecordedFocus[] {
   return recorded.filter((call) => call.row === row);
 }
 
 function hover(row: HTMLElement, init: PointerEventInit = {}) {
   fireEvent.pointerMove(row, { pointerType: "mouse", clientX: 10, clientY: 10, ...init });
+}
+
+// Radix's roving focus defers its move to a macrotask, so a keypress is only
+// settled once that has run.
+async function pressKey(target: HTMLElement, key: string) {
+  await act(async () => {
+    fireEvent.keyDown(target, { key });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
 }
 
 function renderDropdown(children: React.ReactNode) {
@@ -79,104 +105,164 @@ function renderContextMenu(children: React.ReactNode) {
   );
   // Radix's context-menu root has no `open` prop; the gesture is what mounts
   // the content into the portal.
-  fireEvent.contextMenu(container.querySelector("[data-testid='trigger']") as HTMLElement);
+  fireEvent.contextMenu(
+    must(container.querySelector<HTMLElement>("[data-testid='trigger']"), "trigger")
+  );
 }
 
-function row(selector: string): HTMLElement {
-  const found = document.querySelector(selector);
-  if (!found) throw new Error(`No row matched ${selector}`);
-  return found as HTMLElement;
+function rows(): HTMLElement[] {
+  return Array.from(
+    document.querySelectorAll<HTMLElement>(
+      "[role='menuitem'],[role='menuitemcheckbox'],[role='menuitemradio']"
+    )
+  );
+}
+
+function rowAt(index: number): HTMLElement {
+  return must(rows()[index], `row ${index}`);
+}
+
+function optionRow(): HTMLElement {
+  return must(document.querySelector<HTMLElement>("[role='option']"), "select option");
 }
 
 describe("menu row hover focus — issue #12383", () => {
-  it("lands Radix's hover focus with focusVisible: false", () => {
+  it("lands Radix's hover focus with focusVisible: false, exactly once", () => {
     renderDropdown(<DropdownMenuItem>Copy full context</DropdownMenuItem>);
-    const item = row("[role='menuitem']");
+    const item = rowAt(0);
+    recorded = [];
 
     hover(item);
 
-    const calls = focusesOf(item);
-    expect(calls.length).toBeGreaterThan(0);
-    expect(calls[0]?.options).toEqual({ preventScroll: true, focusVisible: false });
+    // Exactly one focus call for this row: Radix's. A fix that focused the row
+    // itself before Radix would produce two, and one that focused it INSTEAD of
+    // Radix would leave Radix's grace-area veto without a say.
+    expect(focusesOf(item)).toEqual([{ row: item, options: SUPPRESSED }]);
     expect(document.activeElement).toBe(item);
     // The hover highlight is what should paint instead, and Radix drives it
     // from the same focus — suppressing the ring must not cost the background.
     expect(item.hasAttribute("data-highlighted")).toBe(true);
   });
 
-  it("runs a caller's onPointerMove first and still suppresses the ring", () => {
-    const order: string[] = [];
+  it("runs a caller's onPointerMove before the focus it suppresses", () => {
     renderDropdown(
-      <DropdownMenuItem onPointerMove={() => order.push("caller")}>Preview</DropdownMenuItem>
+      <DropdownMenuItem onPointerMove={() => timeline.push("caller")}>Preview</DropdownMenuItem>
     );
-    const item = row("[role='menuitem']");
+    const item = rowAt(0);
+    watched = item;
     recorded = [];
+    timeline = [];
 
     hover(item);
 
-    expect(order).toEqual(["caller"]);
-    expect(focusesOf(item)[0]?.options).toEqual({ preventScroll: true, focusVisible: false });
+    expect(timeline).toEqual(["caller", "focus"]);
+    expect(focusesOf(item)).toEqual([{ row: item, options: SUPPRESSED }]);
   });
 
   it("leaves focus alone when the caller cancels the event", () => {
     renderDropdown(
-      <DropdownMenuItem onPointerMove={(event) => event.preventDefault()}>Preview</DropdownMenuItem>
+      <>
+        <DropdownMenuItem onPointerMove={(event) => event.preventDefault()}>
+          Cancelled
+        </DropdownMenuItem>
+        <DropdownMenuItem>Control</DropdownMenuItem>
+      </>
     );
-    const item = row("[role='menuitem']");
+    const cancelled = rowAt(0);
+    const control = rowAt(1);
     recorded = [];
 
-    hover(item);
+    hover(cancelled);
 
-    expect(focusesOf(item)).toHaveLength(0);
+    expect(focusesOf(cancelled)).toHaveLength(0);
+    expect(Object.hasOwn(cancelled, "focus")).toBe(false);
+    // Control: the same fixture must still suppress an ordinary hover, so a
+    // silently unwired primitive cannot pass this test.
+    hover(control);
+    expect(focusesOf(control)).toEqual([{ row: control, options: SUPPRESSED }]);
   });
 
-  it("ignores non-mouse pointers, matching Radix's own gate", () => {
-    renderDropdown(<DropdownMenuItem>Tap target</DropdownMenuItem>);
-    const item = row("[role='menuitem']");
+  it.each(["touch", "pen"])("ignores %s pointers, matching Radix's own gate", (pointerType) => {
+    const seen: string[] = [];
+    renderDropdown(
+      <>
+        <DropdownMenuItem onPointerMove={() => seen.push("caller")}>Tap target</DropdownMenuItem>
+        <DropdownMenuItem>Control</DropdownMenuItem>
+      </>
+    );
+    const target = rowAt(0);
+    const control = rowAt(1);
     recorded = [];
 
-    hover(item, { pointerType: "touch" });
+    hover(target, { pointerType });
 
-    expect(focusesOf(item)).toHaveLength(0);
+    expect(seen).toEqual(["caller"]);
+    expect(focusesOf(target)).toHaveLength(0);
+    expect(Object.hasOwn(target, "focus")).toBe(false);
+    hover(control);
+    expect(focusesOf(control)).toEqual([{ row: control, options: SUPPRESSED }]);
   });
 
   it("never focuses a disabled row", () => {
-    renderDropdown(<DropdownMenuItem disabled>Unavailable</DropdownMenuItem>);
-    const item = row("[role='menuitem']");
+    renderDropdown(
+      <>
+        <DropdownMenuItem disabled>Unavailable</DropdownMenuItem>
+        <DropdownMenuItem>Control</DropdownMenuItem>
+      </>
+    );
+    const disabled = rowAt(0);
+    const control = rowAt(1);
     recorded = [];
 
-    hover(item);
+    hover(disabled);
 
-    expect(focusesOf(item)).toHaveLength(0);
-    expect(item.hasAttribute("data-highlighted")).toBe(false);
+    // The helper never focuses anything itself — Radix decides, and it routes a
+    // disabled row to `onItemLeave` instead. Anything that pre-empted Radix
+    // would light this row up.
+    expect(focusesOf(disabled)).toHaveLength(0);
+    expect(disabled.hasAttribute("data-highlighted")).toBe(false);
+    hover(control);
+    expect(focusesOf(control)).toEqual([{ row: control, options: SUPPRESSED }]);
   });
 
   it("stops decorating the row once the pointer event has been dispatched", async () => {
     renderDropdown(<DropdownMenuItem>Copy full context</DropdownMenuItem>);
-    const item = row("[role='menuitem']");
+    const item = rowAt(0);
+    recorded = [];
+
     hover(item);
+    expect(focusesOf(item)).toEqual([{ row: item, options: SUPPRESSED }]);
+    expect(Object.hasOwn(item, "focus")).toBe(true);
 
     await Promise.resolve();
     expect(Object.hasOwn(item, "focus")).toBe(false);
 
     recorded = [];
     item.focus({ preventScroll: true });
-    expect(focusesOf(item)[0]?.options).toEqual({ preventScroll: true });
+    expect(focusesOf(item)).toEqual([{ row: item, options: { preventScroll: true } }]);
   });
 
-  it("leaves keyboard focus untouched so arrow keys still ring", () => {
+  it("leaves keyboard focus untouched, including back onto a row it suppressed", async () => {
     renderDropdown(
       <>
         <DropdownMenuItem>First</DropdownMenuItem>
         <DropdownMenuItem>Second</DropdownMenuItem>
       </>
     );
-    const content = row("[role='menu']");
-    const first = row("[role='menuitem']");
+    const first = rowAt(0);
+    const second = rowAt(1);
+
+    hover(first);
+    await Promise.resolve();
+    await pressKey(first, "ArrowDown");
+    expect(document.activeElement).toBe(second);
+
     recorded = [];
+    await pressKey(second, "ArrowUp");
 
-    fireEvent.keyDown(content, { key: "ArrowDown" });
-
+    // Coming back by keyboard is a real focus transition, and it must be free
+    // to ring: the decoration is gone and nothing forces `focusVisible`.
+    expect(document.activeElement).toBe(first);
     const calls = focusesOf(first);
     expect(calls.length).toBeGreaterThan(0);
     for (const call of calls) {
@@ -186,124 +272,133 @@ describe("menu row hover focus — issue #12383", () => {
 });
 
 describe("menu row hover focus — every row primitive", () => {
-  it("covers the dropdown sub-trigger", () => {
-    renderDropdown(
-      <DropdownMenuPrimitive.Sub>
-        <DropdownMenuSubTrigger>More</DropdownMenuSubTrigger>
-      </DropdownMenuPrimitive.Sub>
-    );
-    const trigger = row("[role='menuitem']");
+  // Every wrapper gets the caller-handler half of the contract too: dropping
+  // `onPointerMove` on the floor, or letting the spread clobber the helper, is
+  // the failure mode that `FleetArmingRibbon`'s preview handlers would hit.
+  function expectSuppressedHover(target: HTMLElement, seen: string[]) {
     recorded = [];
+    seen.length = 0;
+    hover(target);
+    expect(seen).toEqual(["caller"]);
+    expect(focusesOf(target)).toEqual([{ row: target, options: SUPPRESSED }]);
+  }
 
-    hover(trigger);
-
-    expect(focusesOf(trigger)[0]?.options).toEqual({ preventScroll: true, focusVisible: false });
-  });
-
-  it("covers the dropdown checkbox and radio rows", () => {
+  it("covers the dropdown item, sub-trigger, checkbox and radio rows", () => {
+    const seen: string[] = [];
+    const spy = () => seen.push("caller");
     renderDropdown(
       <>
-        <DropdownMenuCheckboxItem checked>Wrap lines</DropdownMenuCheckboxItem>
+        <DropdownMenuItem onPointerMove={spy}>Reveal</DropdownMenuItem>
+        <DropdownMenuPrimitive.Sub>
+          <DropdownMenuSubTrigger onPointerMove={spy}>More</DropdownMenuSubTrigger>
+        </DropdownMenuPrimitive.Sub>
+        <DropdownMenuCheckboxItem checked onPointerMove={spy}>
+          Wrap lines
+        </DropdownMenuCheckboxItem>
         <DropdownMenuPrimitive.RadioGroup value="a">
-          <DropdownMenuRadioItem value="a">A</DropdownMenuRadioItem>
+          <DropdownMenuRadioItem value="a" onPointerMove={spy}>
+            A
+          </DropdownMenuRadioItem>
         </DropdownMenuPrimitive.RadioGroup>
       </>
     );
-    const checkbox = row("[role='menuitemcheckbox']");
-    const radio = row("[role='menuitemradio']");
-    recorded = [];
-
-    hover(checkbox);
-    hover(radio);
-
-    expect(focusesOf(checkbox)[0]?.options).toEqual({ preventScroll: true, focusVisible: false });
-    expect(focusesOf(radio)[0]?.options).toEqual({ preventScroll: true, focusVisible: false });
+    const targets = rows();
+    expect(targets).toHaveLength(4);
+    for (const target of targets) expectSuppressedHover(target, seen);
   });
 
   it("covers the context-menu item, sub-trigger, checkbox and radio rows", () => {
+    const seen: string[] = [];
+    const spy = () => seen.push("caller");
     renderContextMenu(
       <>
-        <ContextMenuItem>Reveal</ContextMenuItem>
+        <ContextMenuItem onPointerMove={spy}>Reveal</ContextMenuItem>
         <ContextMenuPrimitive.Sub>
-          <ContextMenuSubTrigger>More</ContextMenuSubTrigger>
+          <ContextMenuSubTrigger onPointerMove={spy}>More</ContextMenuSubTrigger>
         </ContextMenuPrimitive.Sub>
-        <ContextMenuCheckboxItem checked>Wrap lines</ContextMenuCheckboxItem>
+        <ContextMenuCheckboxItem checked onPointerMove={spy}>
+          Wrap lines
+        </ContextMenuCheckboxItem>
         <ContextMenuPrimitive.RadioGroup value="a">
-          <ContextMenuRadioItem value="a">A</ContextMenuRadioItem>
+          <ContextMenuRadioItem value="a" onPointerMove={spy}>
+            A
+          </ContextMenuRadioItem>
         </ContextMenuPrimitive.RadioGroup>
       </>
     );
-    const rows = Array.from(
-      document.querySelectorAll(
-        "[role='menuitem'],[role='menuitemcheckbox'],[role='menuitemradio']"
-      )
-    ) as HTMLElement[];
-    expect(rows).toHaveLength(4);
-
-    for (const target of rows) {
-      recorded = [];
-      hover(target);
-      expect(focusesOf(target)[0]?.options).toEqual({ preventScroll: true, focusVisible: false });
-    }
+    const targets = rows();
+    expect(targets).toHaveLength(4);
+    for (const target of targets) expectSuppressedHover(target, seen);
   });
 
   it("covers the select option row", () => {
+    const seen: string[] = [];
     render(
       <SelectPrimitive.Root open value="a">
         <SelectPrimitive.Trigger>trigger</SelectPrimitive.Trigger>
         <SelectPrimitive.Portal>
           <SelectPrimitive.Content position="popper">
             <SelectPrimitive.Viewport>
-              <SelectItem value="a">Option A</SelectItem>
+              <SelectItem value="a" onPointerMove={() => seen.push("caller")}>
+                Option A
+              </SelectItem>
             </SelectPrimitive.Viewport>
           </SelectPrimitive.Content>
         </SelectPrimitive.Portal>
       </SelectPrimitive.Root>
     );
-    const option = row("[role='option']");
-    recorded = [];
 
-    hover(option);
-
-    expect(focusesOf(option)[0]?.options).toEqual({ preventScroll: true, focusVisible: false });
+    expectSuppressedHover(optionRow(), seen);
   });
 });
 
-describe("menuRowPointerMove", () => {
-  function pointerEvent(target: HTMLElement, pointerType = "mouse") {
-    let prevented = false;
-    return {
-      currentTarget: target,
-      pointerType,
-      get defaultPrevented() {
-        return prevented;
-      },
-      preventDefault() {
-        prevented = true;
-      },
-    } as unknown as React.PointerEvent<HTMLElement>;
-  }
+describe("menu row hover focus — the decoration itself", () => {
+  it("overrides focusVisible without disturbing the caller's other options", () => {
+    renderDropdown(<DropdownMenuItem>Copy full context</DropdownMenuItem>);
+    const item = rowAt(0);
+    hover(item);
+    recorded = [];
 
-  it("injects focusVisible: false into whatever options the caller of focus passes", () => {
-    const el = document.createElement("div");
-    document.body.appendChild(el);
+    const asked = Object.freeze({ preventScroll: false, focusVisible: true });
+    item.focus(asked);
 
-    menuRowPointerMove(pointerEvent(el), undefined);
-    el.focus();
-
-    expect(focusesOf(el)[0]?.options).toEqual({ focusVisible: false });
-    el.remove();
+    // `preventScroll` is the caller's to decide; only visibility is ours. A
+    // reversed spread would hand back `focusVisible: true` here.
+    expect(focusesOf(item)).toEqual([
+      { row: item, options: { preventScroll: false, focusVisible: false } },
+    ]);
+    expect(asked).toEqual({ preventScroll: false, focusVisible: true });
   });
 
-  it("does not double-decorate a row hovered twice in one task", () => {
-    const el = document.createElement("div");
-    document.body.appendChild(el);
+  it("leaves a row that already owns a focus implementation alone", () => {
+    renderDropdown(<DropdownMenuItem>Copy full context</DropdownMenuItem>);
+    const item = rowAt(0);
+    const own = vi.fn();
+    Object.defineProperty(item, "focus", { configurable: true, value: own });
+    recorded = [];
 
-    menuRowPointerMove(pointerEvent(el), undefined);
-    const decorated = Object.getOwnPropertyDescriptor(el, "focus")?.value;
-    menuRowPointerMove(pointerEvent(el), undefined);
+    hover(item);
 
-    expect(Object.getOwnPropertyDescriptor(el, "focus")?.value).toBe(decorated);
-    el.remove();
+    // An instance override — a per-element spy, say — keeps its own behaviour
+    // rather than being silently swapped out and then deleted.
+    expect(own).toHaveBeenCalledWith({ preventScroll: true });
+    expect(focusesOf(item)).toHaveLength(0);
+  });
+
+  it("keeps one decoration across repeated hovers in the same task", async () => {
+    renderDropdown(<DropdownMenuItem>Copy full context</DropdownMenuItem>);
+    const item = rowAt(0);
+
+    hover(item);
+    const decorated = Object.getOwnPropertyDescriptor(item, "focus")?.value;
+    expect(decorated).toBeTypeOf("function");
+    hover(item);
+    expect(Object.getOwnPropertyDescriptor(item, "focus")?.value).toBe(decorated);
+
+    // One teardown for one decoration, and a later event can decorate again.
+    await Promise.resolve();
+    expect(Object.hasOwn(item, "focus")).toBe(false);
+    hover(item);
+    expect(Object.hasOwn(item, "focus")).toBe(true);
   });
 });

--- a/src/components/ui/context-menu.tsx
+++ b/src/components/ui/context-menu.tsx
@@ -8,6 +8,7 @@ import { useScrollShadowOverlays } from "@/components/ui/ScrollShadow";
 import { primeOnEvent, useRadixPrimitives } from "./radix-loader";
 import { useIsDockPopoverChild } from "./DockPopoverChildContext";
 import { MenuActionSourceContext, useMenuActionSource } from "./menu-source";
+import { menuRowPointerMove } from "./menu-row-hover-focus";
 import {
   OverlayFocusRestoreContext,
   useOverlayFocusRestore,
@@ -184,7 +185,7 @@ type ContextMenuSubTriggerProps = React.ComponentPropsWithoutRef<
 const ContextMenuSubTrigger = React.forwardRef<
   React.ElementRef<typeof ContextMenuPrimitiveType.SubTrigger>,
   ContextMenuSubTriggerProps
->(({ className, inset, children, ...props }, ref) => {
+>(({ className, inset, children, onPointerMove, ...props }, ref) => {
   const radix = useRadixPrimitives();
   if (!radix) return null;
   const SubTrigger = radix.ContextMenuPrimitive.SubTrigger;
@@ -197,6 +198,7 @@ const ContextMenuSubTrigger = React.forwardRef<
         className
       )}
       {...props}
+      onPointerMove={(event) => menuRowPointerMove(event, onPointerMove)}
     >
       {children}
       <ChevronRight className="ml-auto h-3.5 w-3.5" aria-hidden="true" />
@@ -352,7 +354,7 @@ type ContextMenuItemProps = React.ComponentPropsWithoutRef<typeof ContextMenuPri
 const ContextMenuItem = React.forwardRef<
   React.ElementRef<typeof ContextMenuPrimitiveType.Item>,
   ContextMenuItemProps
->(({ className, inset, destructive, ...props }, ref) => {
+>(({ className, inset, destructive, onPointerMove, ...props }, ref) => {
   const radix = useRadixPrimitives();
   if (!radix) return null;
   const Item = radix.ContextMenuPrimitive.Item;
@@ -367,6 +369,7 @@ const ContextMenuItem = React.forwardRef<
         className
       )}
       {...props}
+      onPointerMove={(event) => menuRowPointerMove(event, onPointerMove)}
     />
   );
 });
@@ -486,7 +489,7 @@ type ContextMenuCheckboxItemProps = React.ComponentPropsWithoutRef<
 const ContextMenuCheckboxItem = React.forwardRef<
   React.ElementRef<typeof ContextMenuPrimitiveType.CheckboxItem>,
   ContextMenuCheckboxItemProps
->(({ className, children, checked, ...props }, ref) => {
+>(({ className, children, checked, onPointerMove, ...props }, ref) => {
   const radix = useRadixPrimitives();
   if (!radix) return null;
   const CheckboxItem = radix.ContextMenuPrimitive.CheckboxItem;
@@ -500,6 +503,7 @@ const ContextMenuCheckboxItem = React.forwardRef<
       )}
       checked={checked}
       {...props}
+      onPointerMove={(event) => menuRowPointerMove(event, onPointerMove)}
     >
       <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
         <ItemIndicator>
@@ -531,7 +535,7 @@ type ContextMenuRadioItemProps = React.ComponentPropsWithoutRef<
 const ContextMenuRadioItem = React.forwardRef<
   React.ElementRef<typeof ContextMenuPrimitiveType.RadioItem>,
   ContextMenuRadioItemProps
->(({ className, children, ...props }, ref) => {
+>(({ className, children, onPointerMove, ...props }, ref) => {
   const radix = useRadixPrimitives();
   if (!radix) return null;
   const RadioItem = radix.ContextMenuPrimitive.RadioItem;
@@ -544,6 +548,7 @@ const ContextMenuRadioItem = React.forwardRef<
         className
       )}
       {...props}
+      onPointerMove={(event) => menuRowPointerMove(event, onPointerMove)}
     >
       <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
         <ItemIndicator>

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -9,6 +9,7 @@ import { useScrollShadowOverlays } from "@/components/ui/ScrollShadow";
 import { primeOnEvent, useRadixPrimitives } from "./radix-loader";
 import { useIsDockPopoverChild } from "./DockPopoverChildContext";
 import { MenuActionSourceContext, useMenuActionSource } from "./menu-source";
+import { menuRowPointerMove } from "./menu-row-hover-focus";
 import {
   OverlayFocusRestoreContext,
   useOverlayFocusRestore,
@@ -236,7 +237,7 @@ type DropdownMenuSubTriggerProps = React.ComponentPropsWithoutRef<
 const DropdownMenuSubTrigger = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitiveType.SubTrigger>,
   DropdownMenuSubTriggerProps
->(({ className, inset, children, ...props }, ref) => {
+>(({ className, inset, children, onPointerMove, ...props }, ref) => {
   const radix = useRadixPrimitives();
   if (!radix) return null;
   const SubTrigger = radix.DropdownMenuPrimitive.SubTrigger;
@@ -249,6 +250,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
         className
       )}
       {...props}
+      onPointerMove={(event) => menuRowPointerMove(event, onPointerMove)}
     >
       {children}
       <ChevronRight className="ml-auto h-3.5 w-3.5" aria-hidden="true" />
@@ -417,7 +419,7 @@ type DropdownMenuItemProps = React.ComponentPropsWithoutRef<
 const DropdownMenuItem = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitiveType.Item>,
   DropdownMenuItemProps
->(({ className, inset, destructive, ...props }, ref) => {
+>(({ className, inset, destructive, onPointerMove, ...props }, ref) => {
   const radix = useRadixPrimitives();
   if (!radix) return null;
   const Item = radix.DropdownMenuPrimitive.Item;
@@ -432,6 +434,7 @@ const DropdownMenuItem = React.forwardRef<
         className
       )}
       {...props}
+      onPointerMove={(event) => menuRowPointerMove(event, onPointerMove)}
     />
   );
 });
@@ -563,7 +566,7 @@ type DropdownMenuRadioItemProps = React.ComponentPropsWithoutRef<
 const DropdownMenuRadioItem = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitiveType.RadioItem>,
   DropdownMenuRadioItemProps
->(({ className, children, ...props }, ref) => {
+>(({ className, children, onPointerMove, ...props }, ref) => {
   const radix = useRadixPrimitives();
   if (!radix) return null;
   const RadioItem = radix.DropdownMenuPrimitive.RadioItem;
@@ -576,6 +579,7 @@ const DropdownMenuRadioItem = React.forwardRef<
         className
       )}
       {...props}
+      onPointerMove={(event) => menuRowPointerMove(event, onPointerMove)}
     >
       <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
         <ItemIndicator>
@@ -595,7 +599,7 @@ type DropdownMenuCheckboxItemProps = React.ComponentPropsWithoutRef<
 const DropdownMenuCheckboxItem = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitiveType.CheckboxItem>,
   DropdownMenuCheckboxItemProps
->(({ className, children, checked, ...props }, ref) => {
+>(({ className, children, checked, onPointerMove, ...props }, ref) => {
   const radix = useRadixPrimitives();
   if (!radix) return null;
   const CheckboxItem = radix.DropdownMenuPrimitive.CheckboxItem;
@@ -609,6 +613,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
       )}
       checked={checked}
       {...props}
+      onPointerMove={(event) => menuRowPointerMove(event, onPointerMove)}
     >
       <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
         <ItemIndicator>

--- a/src/components/ui/menu-row-hover-focus.ts
+++ b/src/components/ui/menu-row-hover-focus.ts
@@ -26,6 +26,12 @@ import type * as React from "react";
  * So the row's own `focus` is decorated for the length of the pointer event
  * instead. Radix keeps every decision about whether to focus at all; only the
  * options it asks with change.
+ *
+ * Known edge: because the state is decided per focus transition, a keystroke
+ * that lands on the row already under the pointer — Home on the first row, an
+ * unlooped Arrow at either end — leaves it ringless until focus actually moves.
+ * Restoring the ring there needs document-wide modality tracking, which is a
+ * much bigger mechanism than one dead keypress is worth.
  */
 export function menuRowPointerMove<T extends HTMLElement>(
   event: React.PointerEvent<T>,

--- a/src/components/ui/menu-row-hover-focus.ts
+++ b/src/components/ui/menu-row-hover-focus.ts
@@ -1,0 +1,56 @@
+import type * as React from "react";
+
+/**
+ * Hover-time focus policy shared by every menu row primitive (`DropdownMenu`,
+ * `ContextMenu`, `Select`), the open-menu counterpart to the close-time policy
+ * in `overlay-focus-restore.ts`.
+ *
+ * Radix moves DOM focus to a row on mouse hover — `item.focus({ preventScroll:
+ * true })` from its own `onPointerMove`. That is script focus, so Chromium
+ * decides `:focus-visible` from a per-document heuristic that nothing about
+ * opening a menu updates: `last_focus_type_` only tracks user-driven focus and
+ * `had_keyboard_event_` flips true on any plain keypress. So the keyboard ring
+ * paints on hover or not depending on whether the user last typed or last
+ * clicked something focusable, and each project view carries its own copy of
+ * that state (#12383).
+ *
+ * `focusVisible: false` settles it, but the call belongs to Radix and only a
+ * real focus transition re-runs the decision — re-focusing an already focused
+ * element bails out early, so there is nothing to correct after the fact.
+ * Focusing the row ourselves first is worse than it looks: Radix deliberately
+ * does NOT focus a row the pointer is only crossing on its way into an open
+ * submenu (`onItemEnter` preventDefaults inside the grace area), and taking
+ * that focus closes the submenu the user was reaching for. Disabled rows and
+ * non-mouse pointers are skipped by Radix for their own reasons.
+ *
+ * So the row's own `focus` is decorated for the length of the pointer event
+ * instead. Radix keeps every decision about whether to focus at all; only the
+ * options it asks with change.
+ */
+export function menuRowPointerMove<T extends HTMLElement>(
+  event: React.PointerEvent<T>,
+  onPointerMove?: React.PointerEventHandler<T>
+): void {
+  onPointerMove?.(event);
+
+  // Radix gates its own hover focus the same two ways: a cancelled event skips
+  // its composed handler entirely, and `whenMouse` ignores touch and pen.
+  if (event.defaultPrevented || event.pointerType !== "mouse") return;
+
+  const row: HTMLElement = event.currentTarget;
+  if (Object.hasOwn(row, "focus")) return;
+
+  Object.defineProperty(row, "focus", {
+    configurable: true,
+    value(this: HTMLElement, options?: FocusOptions) {
+      // Resolved at call time so a prototype spy still observes the call.
+      HTMLElement.prototype.focus.call(this, { ...options, focusVisible: false });
+    },
+  });
+
+  // The dispatch Radix focuses in is synchronous, so the first microtask after
+  // it is the earliest moment the decoration is no longer needed.
+  queueMicrotask(() => {
+    Reflect.deleteProperty(row, "focus");
+  });
+}

--- a/src/components/ui/menu-row-hover-focus.ts
+++ b/src/components/ui/menu-row-hover-focus.ts
@@ -27,11 +27,15 @@ import type * as React from "react";
  * instead. Radix keeps every decision about whether to focus at all; only the
  * options it asks with change.
  *
- * Known edge: because the state is decided per focus transition, a keystroke
- * that lands on the row already under the pointer — Home on the first row, an
- * unlooped Arrow at either end — leaves it ringless until focus actually moves.
- * Restoring the ring there needs document-wide modality tracking, which is a
- * much bigger mechanism than one dead keypress is worth.
+ * Known edge: an explicit `focusVisible: false` is a decision, not a heuristic
+ * reading, and it sticks to the element until focus actually moves. So a
+ * keystroke that resolves to the row already under the pointer — Home on the
+ * first row, an unlooped Arrow at either end, a typeahead match on the current
+ * row — leaves that row ringless, and in a single-item menu there is nowhere
+ * else for focus to go. The fill alone is weak as a keyboard indicator (see
+ * the note on the item styles), so this wants a menu-scoped keyboard indicator
+ * rather than a wider suppression; it is not worth document-wide modality
+ * tracking.
  */
 export function menuRowPointerMove<T extends HTMLElement>(
   event: React.PointerEvent<T>,

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -5,6 +5,7 @@ import { cn } from "@/lib/utils";
 import { OVERLAY_MOTION_CLASS } from "./overlayMotion";
 import { composeHandlers, primeOnEvent, useRadixPrimitives } from "./radix-loader";
 import { useIsDockPopoverChild } from "./DockPopoverChildContext";
+import { menuRowPointerMove } from "./menu-row-hover-focus";
 import { armTooltipFocusSuppression } from "@/lib/tooltipFocusSuppression";
 
 const SelectIntentContext = React.createContext<((next: boolean) => void) | null>(null);
@@ -303,7 +304,7 @@ interface SelectItemProps extends React.ComponentPropsWithoutRef<typeof SelectPr
 const SelectItem = React.forwardRef<
   React.ElementRef<typeof SelectPrimitiveType.Item>,
   SelectItemProps
->(({ className, children, description, ...props }, ref) => {
+>(({ className, children, description, onPointerMove, ...props }, ref) => {
   const radix = useRadixPrimitives();
   if (!radix) return null;
   const Item = radix.SelectPrimitive.Item;
@@ -319,6 +320,7 @@ const SelectItem = React.forwardRef<
         className
       )}
       {...props}
+      onPointerMove={(event) => menuRowPointerMove(event, onPointerMove)}
     >
       <span className="absolute left-2 top-1.5 flex h-3.5 w-3.5 items-center justify-center">
         <ItemIndicator>


### PR DESCRIPTION
## Summary

- Radix focuses a menu row on hover with `item.focus({ preventScroll: true })`. That's script focus, so Chromium falls back to its per-document heuristic to decide `:focus-visible`, and nothing about opening a menu updates that heuristic. So whether a hovered row paints the ring depends on what the user did before opening the menu: a plain keypress arms it, a mouse click on something focusable disarms it, a cold start leaves it armed.
- The fix is a new shared module, `src/components/ui/menu-row-hover-focus.ts`, exporting `menuRowPointerMove`, wired into all nine row wrappers across `context-menu.tsx`, `dropdown-menu.tsx`, and `select.tsx`. It runs the caller's own `onPointerMove` first, bails on a cancelled event or a non-mouse pointer, then decorates the row's own `focus` for the length of that pointer event so it forwards to the prototype with `focusVisible: false` merged in, removing the decoration in a `queueMicrotask`.
- It does not focus the row itself. Pre-empting Radix's focus was the obvious approach and it's wrong: Radix deliberately declines to focus a row the pointer is only crossing on its way into an open submenu (`onItemEnter` calls `preventDefault()` inside the grace area), and taking that focus fires the submenu's `onFocusOutside` and closes the submenu the user is reaching for. It also bypasses Radix's disabled routing and its `whenMouse` gate. Decorating the focus call instead leaves every decision with Radix and only changes the options it's called with. Refocusing after the fact isn't an option either: Blink bails out early once the element is already `activeElement`, the same rule that keeps an existing keyboard ring alive when the mouse drifts over the focused row.

Resolves #12383

## Changes

- `src/components/ui/menu-row-hover-focus.ts` (new): the shared decoration logic, exported as `menuRowPointerMove`.
- `src/components/ui/context-menu.tsx`, `src/components/ui/dropdown-menu.tsx`, `src/components/ui/select.tsx`: wire the nine row types (`ContextMenuItem`, `ContextMenuSubTrigger`, `ContextMenuCheckboxItem`, `ContextMenuRadioItem`, their four dropdown-menu equivalents, and `SelectItem`) into it.
- `.claude/rules/overlay-focus.md`: documents the new hover half alongside the existing close-time policy.
- Known edge, documented in the module: an explicit `focusVisible: false` sticks to the element until focus actually moves, so a keystroke that resolves to the row already under the pointer (Home on the first row, an unlooped arrow key at either end) leaves that row ringless. That wants a menu-scoped keyboard indicator rather than a wider suppression, and isn't worth document-wide modality tracking.

## Testing

New suite `src/components/ui/__tests__/menu-row-hover-focus.test.tsx`, 15 tests. jsdom has no `:focus-visible` heuristic and drops `focusVisible` from `FocusOptions`, so the suite asserts the mechanism instead: the exact per-row focus-call list and its options, caller-handler ordering and cancellation, disabled and touch/pen rows getting no focus at all, the decoration's install and microtask teardown, an existing own `focus` being left alone, a pointer entering through a child span decorating the row rather than the child, and keyboard navigation staying free to ring. Every negative case carries a positive control row so an unwired primitive can't pass.

Locally: 312 tests across 21 affected files pass, `npm run typecheck` exits 0, `npm run lint:ratchet` exits 0 with no baseline widened, prettier and eslint clean on the changed files.

Reviewed across three passes by Codex, for correctness, tests, and a confirmation pass. Every finding was either applied or explicitly noted.
