### PR TITLE
fix(toolbar): overflow budget, focus on eviction, grouping, high contrast

### DIFF
--- a/e2e/screenshots/toolbar-strip-review.spec.ts
+++ b/e2e/screenshots/toolbar-strip-review.spec.ts
@@ -178,7 +178,11 @@ async function dumpStripState(page: Page, slug: string): Promise<void> {
       const trigger = root.querySelector<HTMLElement>(
         `[data-toolbar-overflow-trigger][data-toolbar-overflow-side="${side}"]`
       );
-      const row = trigger?.parentElement?.previousElementSibling as HTMLElement | null;
+      // The measured row sits directly before its side's trigger.
+      const row = trigger?.previousElementSibling as HTMLElement | null;
+      if (row && !row.classList.contains("toolbar-measured-row")) {
+        throw new Error(`expected the measured row before the ${side} trigger`);
+      }
       const rowRect = row ? rect(row) : null;
       const items = row
         ? Array.from(row.querySelectorAll<HTMLElement>("[data-toolbar-button-id]")).map((el) => {
@@ -264,7 +268,8 @@ async function snapStrip(page: Page, slug: string, padBottom = 14): Promise<void
 const ONLY = (process.env.DAINTREE_SHOT_ONLY ?? "").split(",").filter(Boolean);
 const stepFailures: string[] = [];
 async function step(page: Page | null, name: string, fn: () => Promise<void>): Promise<void> {
-  if (ONLY.length > 0 && !ONLY.includes(name)) return;
+  // `-seed` steps are prerequisites the caller has already decided to run.
+  if (ONLY.length > 0 && !ONLY.includes(name) && !name.endsWith("-seed")) return;
   try {
     await fn();
   } catch (error) {
@@ -427,12 +432,17 @@ async function expectNoOverflow(page: Page): Promise<void> {
 }
 
 /** `navigator.platform` drives the mac/windows/linux branches; CDP can lie about it. */
+let originalUserAgent: string | null = null;
 async function overridePlatform(
   page: Page,
   platform: "Win32" | "Linux x86_64" | "MacIntel"
 ): Promise<void> {
   const cdp = await page.context().newCDPSession(page);
-  const base = await page.evaluate(() => navigator.userAgent);
+  // From the ORIGINAL user agent every time: after the Windows override the
+  // live one no longer says Macintosh, and a replace on it left Linux
+  // looking like Windows.
+  originalUserAgent ??= await page.evaluate(() => navigator.userAgent);
+  const base = originalUserAgent;
   const userAgent =
     platform === "Win32"
       ? base.replace(/\(Macintosh;[^)]*\)/, "(Windows NT 10.0; Win64; x64)")
@@ -441,6 +451,20 @@ async function overridePlatform(
         : base;
   await cdp.send("Emulation.setUserAgentOverride", { userAgent, platform });
   await reloadAndWait(page);
+  // The app's platform branches read these two; assert we landed in the
+  // one this capture is named for.
+  const seen = await page.evaluate(() => ({
+    platform: navigator.platform,
+    linux: navigator.userAgent.includes("Linux"),
+  }));
+  const ok =
+    platform === "Linux x86_64"
+      ? seen.linux
+      : platform === "Win32"
+        ? seen.platform.toUpperCase().includes("WIN") && !seen.linux
+        : seen.platform.toUpperCase().includes("MAC");
+  if (!ok)
+    throw new Error(`platform override to ${platform} did not take: ${JSON.stringify(seen)}`);
 }
 
 test("toolbar strip review — every state of the strip", async () => {
@@ -550,6 +574,11 @@ test("toolbar strip review — every state of the strip", async () => {
     // 3. Wide, all signals: agent waiting, three errors, two unread, forge pill.
     await step(page, "signals", async () => {
       await expectNoOverflow(page);
+      // The defining state, asserted here too: a filtered run that skipped
+      // `agent-signal` must not write this file without the waiting pip.
+      await expect(
+        page.locator(`${BUTTON("claude")} .toolbar-pip[data-visible="true"]`).first()
+      ).toHaveClass(/waiting/, { timeout: 5000 });
       await snapStrip(page, "03-signals-wide");
     });
 
@@ -655,12 +684,12 @@ test("toolbar strip review — every state of the strip", async () => {
           return "right-overflow-trigger";
         return el.getAttribute("aria-label") ?? el.tagName;
       });
-      // Capture first: a shot of where focus actually went is the evidence,
-      // whichever way the assertion falls.
-      await snapStrip(page, "11-eviction-focus-redirect");
       if (landed !== "right-overflow-trigger") {
+        // Still worth a look, but never under the name a good run would use.
+        await snapStrip(page, "11-eviction-focus-redirect-failed");
         throw new Error(`after eviction focus landed on "${landed}", not the right … trigger`);
       }
+      await snapStrip(page, "11-eviction-focus-redirect");
     });
 
     // 12. Long names at a squeezed width: a long project name and a long
@@ -754,10 +783,30 @@ test("toolbar strip review — every state of the strip", async () => {
     // 15-16. The re-shuffled composition. A reload drops the in-memory
     // signals, so the errors and unread are re-seeded; the agent panel is left
     // to session restore, and the capture is honest either way.
+    // The reshuffled composition is a prerequisite of both alt steps, not a
+    // capture, so it runs whenever either is selected — a filtered run must
+    // never write an alt-named PNG of the rich composition.
+    const altSelected =
+      ONLY.length === 0 ||
+      ONLY.includes("composition-alt") ||
+      ONLY.includes("composition-alt-overflow");
+    if (altSelected) {
+      await step(page, "composition-alt-seed", async () => {
+        await seedComposition(page, ALT_LEFT, ALT_RIGHT);
+        await seedSignals(page);
+        await expect(page.locator(BUTTON("settings")).first()).toBeVisible({ timeout: 10_000 });
+      });
+    }
+    const expectAltComposition = async () => {
+      // settings persisted on the left is the composition's signature.
+      const settingsOnLeft = await page
+        .locator(`[aria-label="Navigation and agents"] ${BUTTON("settings")}`)
+        .count();
+      if (settingsOnLeft === 0) throw new Error("the reshuffled composition is not in place");
+    };
+
     await step(page, "composition-alt", async () => {
-      await seedComposition(page, ALT_LEFT, ALT_RIGHT);
-      await seedSignals(page);
-      await expect(page.locator(BUTTON("settings")).first()).toBeVisible({ timeout: 10_000 });
+      await expectAltComposition();
       // No fit assertion: with an agent and four panel buttons moved right,
       // this composition earns two dividers and may overflow even at 1680px.
       // Whether it does is part of what the capture is for.
@@ -765,6 +814,7 @@ test("toolbar strip review — every state of the strip", async () => {
     });
 
     await step(page, "composition-alt-overflow", async () => {
+      await expectAltComposition();
       await page.setViewportSize({ width: 900, height: 1050 });
       await settle(page, 800);
       await expectOverflow(page, "right");
@@ -778,15 +828,19 @@ test("toolbar strip review — every state of the strip", async () => {
     await step(page, "platform-windows", async () => {
       await overridePlatform(page, "Win32");
       await seedSignals(page);
-      await expect(page.locator('[aria-label="Application menu"], [data-app-menu-button]').first())
-        .toBeVisible({ timeout: 8000 })
-        .catch(() => {});
+      await expect(page.locator('[aria-label="Application menu"]').first()).toBeVisible({
+        timeout: 8000,
+      });
       await snapStrip(page, "17-platform-windows");
     });
 
     await step(page, "platform-linux", async () => {
       await overridePlatform(page, "Linux x86_64");
       await seedSignals(page);
+      await expect(page.locator('[aria-label="Application menu"]').first()).toBeVisible({
+        timeout: 8000,
+      });
+      await expect(page.locator(".window-resize-strip")).toHaveCount(0);
       await snapStrip(page, "18-platform-linux");
     });
 

--- a/e2e/screenshots/toolbar-strip-review.spec.ts
+++ b/e2e/screenshots/toolbar-strip-review.spec.ts
@@ -1,0 +1,811 @@
+/**
+ * Toolbar strip visual-review harness.
+ *
+ * Drives the main toolbar — `src/components/Layout/Toolbar.tsx`, the 48px strip
+ * on screen in every window all day — through the states that carry design
+ * weight and writes a full-width PNG of the strip for each. The five dropdowns
+ * it hosts have their own harnesses; this one is about the strip as a composed
+ * whole: grouping, dividers, the overflow engine and its severity badge, the
+ * project pill's degradation, the platform spacers, and where keyboard focus
+ * goes when the button it was on is evicted.
+ *
+ * There is no canonical composition — every button is user-hideable and
+ * user-movable — so two compositions are captured: a rich default-shaped one
+ * with live signals, and a deliberately re-shuffled one that puts utilities on
+ * the left and panels on the right, so the grouping and divider rules can be
+ * judged on both sides.
+ *
+ * Signals are pushed through the seams the app already uses, never faked in
+ * CSS: a fake `claude` on PATH drives the real agent-state FSM to `waiting`,
+ * the E2E error bridge feeds the problems count, the notification backdoor
+ * seeds unread history, and a github.com remote resolves the forge pill.
+ *
+ * Opt-in only: skips itself unless DAINTREE_SHOT_THEME is set, so neither the
+ * marketing screenshots workflow nor a bare `--project=screenshots` runs it.
+ *
+ *   DAINTREE_SHOT_THEME=daintree DAINTREE_SHOT_DIR=/abs/out \
+ *     npx playwright test --project=screenshots toolbar-strip-review
+ *
+ * Env knobs:
+ *   DAINTREE_SHOT_THEME  required — theme id to render (e.g. daintree, bondi)
+ *   DAINTREE_SHOT_DIR    required — absolute output dir. Deliberately no default:
+ *                        the spec is committed, and an in-repo fallback would
+ *                        outlive the run and put PNGs into someone's tree.
+ *   DAINTREE_SHOT_TAG    optional suffix to keep before/after rounds side by side
+ *   DAINTREE_SHOT_ONLY   comma-separated step filter (see STEPS below)
+ *   DAINTREE_SCREENSHOT_SCALE  device scale factor (default 2)
+ *
+ * Output: <dir>/<theme>/<NN-slug>[-tag].png
+ */
+
+import { expect, test, type Page } from "@playwright/test";
+import { execSync } from "child_process";
+import { mkdirSync, mkdtempSync, existsSync, readdirSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+import { launchApp, closeApp, type AppContext } from "../helpers/launch";
+import { openAndOnboardProject } from "../helpers/project";
+import { dismissBlockingPalette } from "../helpers/overlays";
+import { setAppTheme } from "../helpers/theme";
+import { createFixtureRepo } from "../helpers/fixtures";
+import { installFakeAgent, fakeAgentEnv, ptyWrite, FAKE_AGENT_IDLE } from "../helpers/fakeAgent";
+import { FAKE_AGENT_READY } from "../helpers/fakeAgent";
+import { getTerminalText, waitForTerminalText, writeTerminalInput } from "../helpers/terminal";
+import { getGridPanelIds } from "../helpers/panels";
+import { seedNotificationHistory } from "../helpers/notifications";
+import { SEL } from "../helpers/selectors";
+import { T_LONG } from "../helpers/timeouts";
+
+const THEME = process.env.DAINTREE_SHOT_THEME ?? "";
+const TAG = process.env.DAINTREE_SHOT_TAG ? `-${process.env.DAINTREE_SHOT_TAG}` : "";
+const SCALE = process.env.DAINTREE_SCREENSHOT_SCALE ?? "2";
+const SHOT_DIR = process.env.DAINTREE_SHOT_DIR ?? "";
+const OUTPUT_DIR = path.join(SHOT_DIR || "unset", THEME || "unset");
+
+const STRIP = '[role="toolbar"][aria-label="Main toolbar"]';
+const OVERFLOW_TRIGGER = (side: "left" | "right") =>
+  `[data-toolbar-overflow-trigger][data-toolbar-overflow-side="${side}"][data-visible="true"]`;
+const BUTTON = (id: string) => `[data-toolbar-button-id="${id}"] button`;
+
+const WIDE = { width: 1680, height: 1050 };
+const PROJECT_NAME = "Helios Dashboard";
+const LONG_PROJECT_NAME = "Helios Dashboard Platform Services";
+const LONG_BRANCH = "feature/oauth-device-flow-with-refresh-token-rotation";
+
+/**
+ * Every shot this harness owes, in capture order. Kept as data rather than
+ * spelled only inside the steps so the run can count what actually landed on
+ * disk against what was promised — an exit code alone has never been evidence
+ * that a capture harness produced anything.
+ */
+const STEPS = [
+  { name: "no-workspace", slug: "01-no-workspace" },
+  { name: "rest", slug: "02-rest-default" },
+  { name: "signals", slug: "03-signals-wide" },
+  { name: "hover", slug: "04-hover" },
+  { name: "focus", slug: "05-focus-visible" },
+  { name: "armed", slug: "06-armed-launcher" },
+  { name: "overflow-mild", slug: "07-overflow-mild" },
+  { name: "overflow-severe", slug: "08-overflow-severe" },
+  { name: "overflow-extreme", slug: "09-overflow-extreme" },
+  { name: "overflow-menu", slug: "10-overflow-menu-open" },
+  { name: "eviction", slug: "11-eviction-focus-redirect" },
+  { name: "long-names", slug: "12-long-names" },
+  { name: "forced-colors", slug: "13-forced-colors" },
+  { name: "contrast-more", slug: "14-contrast-more" },
+  { name: "composition-alt", slug: "15-composition-alt" },
+  { name: "composition-alt-overflow", slug: "16-composition-alt-overflow" },
+  { name: "platform-windows", slug: "17-platform-windows" },
+  { name: "platform-linux", slug: "18-platform-linux" },
+  { name: "fullscreen", slug: "19-fullscreen-mac" },
+] as const;
+
+// Freeze animations and hide carets so captures are deterministic. Badges and
+// the overflow trigger animate in; a mid-transition frame reads as a design
+// flaw that isn't there.
+const POLISH_CSS = `
+  ::-webkit-scrollbar { display: none !important; width: 0 !important; height: 0 !important; }
+  *, *::before, *::after {
+    animation-duration: 0s !important;
+    animation-delay: 0s !important;
+    transition-duration: 0s !important;
+    transition-delay: 0s !important;
+    caret-color: transparent !important;
+  }
+`;
+
+// The rich composition: launcher, a pinned agent, every panel button on the
+// left; the full default utility set on the right. Enough buttons that
+// overflow has real work to do at 1180px and every group boundary draws.
+const RICH_LEFT = ["launcher", "claude", "terminal", "browser", "file-browser", "dev-server"];
+const RICH_RIGHT = [
+  "voice-recording",
+  "forge-stats",
+  "plugin-tray",
+  "notification-center",
+  "copy-tree",
+  "resume-sessions",
+  "command-palette",
+  "settings",
+  "problems",
+];
+
+// The re-shuffled composition: utilities interleaved on the left, panels and
+// the agent on the right. The persisted order is deliberately NOT grouped —
+// the toolbar is supposed to regroup it at render, and the capture shows
+// whether it does so on both sides.
+const ALT_LEFT = ["settings", "launcher", "problems", "terminal", "notification-center"];
+const ALT_RIGHT = [
+  "file-browser",
+  "voice-recording",
+  "claude",
+  "forge-stats",
+  "browser",
+  "copy-tree",
+  "command-palette",
+  "resume-sessions",
+  "dev-server",
+  "plugin-tray",
+];
+
+function git(cmd: string, cwd: string): void {
+  execSync(`git ${cmd}`, { cwd, stdio: "ignore" });
+}
+
+async function settle(page: Page, ms = 400): Promise<void> {
+  await page.evaluate(
+    () => new Promise<void>((r) => requestAnimationFrame(() => requestAnimationFrame(() => r())))
+  );
+  await page.waitForTimeout(ms);
+}
+
+/**
+ * A JSON sidecar beside every PNG: which buttons each side shows and hides,
+ * whether each `…` trigger is up, the measured row's box against the boxes of
+ * the buttons it holds, and the device pixel ratio the PNG was rendered at.
+ * Pixels cannot tell an evicted button from one the row's overflow-hidden has
+ * simply clipped; the rects can.
+ */
+async function dumpStripState(page: Page, slug: string): Promise<void> {
+  const state = await page.evaluate((strip) => {
+    const root = document.querySelector<HTMLElement>(strip);
+    if (!root) return null;
+    const rect = (el: Element) => {
+      const r = el.getBoundingClientRect();
+      return { x: Math.round(r.x), w: Math.round(r.width), h: Math.round(r.height) };
+    };
+    const sides = ["left", "right"].map((side) => {
+      const trigger = root.querySelector<HTMLElement>(
+        `[data-toolbar-overflow-trigger][data-toolbar-overflow-side="${side}"]`
+      );
+      const row = trigger?.parentElement?.previousElementSibling as HTMLElement | null;
+      const rowRect = row ? rect(row) : null;
+      const items = row
+        ? Array.from(row.querySelectorAll<HTMLElement>("[data-toolbar-button-id]")).map((el) => {
+            const r = rect(el);
+            const hidden = el.getAttribute("aria-hidden") === "true";
+            const clipped =
+              !hidden &&
+              rowRect !== null &&
+              (r.x < rowRect.x - 1 || r.x + r.w > rowRect.x + rowRect.w + 1);
+            return { id: el.getAttribute("data-toolbar-button-id"), hidden, clipped, ...r };
+          })
+        : [];
+      const dividers = row
+        ? Array.from(row.querySelectorAll<HTMLElement>(".toolbar-divider")).map((el) => ({
+            ...rect(el),
+            painted: getComputedStyle(el).display !== "none" && rect(el).h > 0,
+          }))
+        : [];
+      return {
+        side,
+        dividers,
+        triggerVisible: trigger?.getAttribute("data-visible") === "true",
+        triggerSeverity: trigger?.querySelector("[data-severity]")?.getAttribute("data-severity"),
+        row: rowRect,
+        items,
+      };
+    });
+    const pill = root.querySelector('[data-testid="project-switcher-trigger"]');
+    return {
+      devicePixelRatio: window.devicePixelRatio,
+      viewport: window.innerWidth,
+      strip: rect(root),
+      pill: pill ? { ...rect(pill), text: pill.textContent } : null,
+      activeElement:
+        document.activeElement === document.body
+          ? "body"
+          : (document.activeElement?.getAttribute("aria-label") ??
+            document.activeElement?.tagName ??
+            null),
+      sides,
+    };
+  }, STRIP);
+  writeFileSync(path.join(OUTPUT_DIR, `${slug}${TAG}.json`), JSON.stringify(state, null, 2));
+}
+
+/**
+ * Full-width crop of the strip plus a little of what sits under it, so the
+ * bottom border and the surface tint read against their real neighbour. A pad
+ * of 0 at the top: the strip is the window's top edge.
+ *
+ * Throws when the file did not land. A harness that writes a success artifact
+ * it has not verified is worse than one that fails.
+ */
+async function snapStrip(page: Page, slug: string, padBottom = 14): Promise<void> {
+  await settle(page);
+  const box = await page.locator(STRIP).first().boundingBox();
+  if (!box) throw new Error(`no bounding box for ${STRIP}`);
+  const viewport = page.viewportSize() ?? WIDE;
+  const file = path.join(OUTPUT_DIR, `${slug}${TAG}.png`);
+  await dumpStripState(page, slug);
+  await page.screenshot({
+    path: file,
+    type: "png",
+    scale: "device",
+    animations: "disabled",
+    caret: "hide",
+    clip: {
+      x: 0,
+      y: 0,
+      width: viewport.width,
+      height: Math.min(box.y + box.height + padBottom, viewport.height),
+    },
+  });
+  if (!existsSync(file)) throw new Error(`screenshot did not land at ${file}`);
+}
+
+/**
+ * Run a capture step. A failure never stops the remaining shots — one missing
+ * state should not cost the whole sweep — but it IS recorded, and the test
+ * fails at the end. Every step leaves the viewport wide and the media
+ * emulation cleared, so a step that dies mid-flight cannot poison the next.
+ */
+const ONLY = (process.env.DAINTREE_SHOT_ONLY ?? "").split(",").filter(Boolean);
+const stepFailures: string[] = [];
+async function step(page: Page | null, name: string, fn: () => Promise<void>): Promise<void> {
+  if (ONLY.length > 0 && !ONLY.includes(name)) return;
+  try {
+    await fn();
+  } catch (error) {
+    const detail = String(error).split("\n")[0];
+    console.warn(`[toolbar-shots] step "${name}" FAILED:`, detail);
+    stepFailures.push(`${name}: ${detail}`);
+  }
+  if (page) {
+    await page.keyboard.press("Escape").catch(() => {});
+    // A keyboard-closed dropdown hands focus back to its trigger with a
+    // focus-visible ring, which would then sit in every later capture.
+    await page
+      .evaluate(() => (document.activeElement as HTMLElement | null)?.blur())
+      .catch(() => {});
+    await page.emulateMedia({ forcedColors: "none", contrast: "no-preference" }).catch(() => {});
+    await page.setViewportSize(WIDE).catch(() => {});
+    await settle(page, 300).catch(() => {});
+  }
+}
+
+/** Reload and wait for the toolbar to be back, mirroring `setAppTheme`'s waits. */
+async function reloadAndWait(page: Page): Promise<void> {
+  await page.reload({ waitUntil: "domcontentloaded" });
+  await page.locator(SEL.toolbar.toggleSidebar).waitFor({ state: "visible", timeout: T_LONG });
+  await page
+    .locator(SEL.toolbar.projectSwitcherTrigger)
+    .waitFor({ state: "visible", timeout: T_LONG });
+  await page.addStyleTag({ content: POLISH_CSS }).catch(() => {});
+  await dismissBlockingPalette(page);
+  await settle(page, 800);
+}
+
+/**
+ * Seeds the persisted toolbar layout and developer-tools preference, then
+ * reloads so the stores rehydrate from it. Both stores merge a partial blob
+ * over their defaults, so only the keys under review need writing.
+ */
+async function seedComposition(page: Page, left: string[], right: string[]): Promise<void> {
+  await page.evaluate(
+    ({ left, right }) => {
+      localStorage.setItem(
+        "daintree-toolbar-preferences",
+        JSON.stringify({
+          state: { layout: { leftButtons: left, rightButtons: right, pinnedButtons: {} } },
+          version: 14,
+        })
+      );
+      localStorage.setItem(
+        "daintree-preferences",
+        JSON.stringify({ state: { showDeveloperTools: true }, version: 20 })
+      );
+    },
+    { left, right }
+  );
+  await reloadAndWait(page);
+}
+
+/** Error count → the problems badge; unread history → the notification dot. */
+async function seedSignals(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const w = window as unknown as { __DAINTREE_E2E_ADD_ERROR__?: (m: string) => void };
+    if (!w.__DAINTREE_E2E_ADD_ERROR__) throw new Error("E2E error bridge not attached");
+    w.__DAINTREE_E2E_ADD_ERROR__("Dev server exited with code 1");
+    w.__DAINTREE_E2E_ADD_ERROR__("Failed to read .env: EACCES");
+    w.__DAINTREE_E2E_ADD_ERROR__("Recipe 'Review' references a missing preset");
+  });
+  const now = Date.now();
+  await seedNotificationHistory(page, [
+    {
+      id: "toolbar-shot-1",
+      type: "info",
+      title: "PR #12384 merged",
+      message: "Menu rows no longer ring on hover",
+      timestamp: now - 90_000,
+    },
+    {
+      id: "toolbar-shot-2",
+      type: "warning",
+      title: "Watcher degraded",
+      message: "Falling back to polling for feature/oauth-device-flow",
+      timestamp: now - 30_000,
+    },
+  ]);
+  await settle(page, 500);
+  await expect(
+    page.locator(`${BUTTON("problems")} .toolbar-problems-badge[data-visible="true"]`),
+    "problems badge did not light — refusing to capture a signals state without it"
+  ).toBeAttached({ timeout: 5000 });
+}
+
+/**
+ * Launches the pinned fake `claude` from its toolbar button and drives it to
+ * `waiting` — the loudest state the agent pip can show. Returns the panel id.
+ */
+async function launchWaitingAgent(page: Page): Promise<string> {
+  const before = new Set(await getGridPanelIds(page));
+  await page.locator(BUTTON("claude")).first().click();
+  let panelId: string | null = null;
+  for (let i = 0; i < 60 && !panelId; i++) {
+    const ids = await getGridPanelIds(page).catch(() => [] as string[]);
+    panelId = ids.find((id) => !before.has(id)) ?? null;
+    if (!panelId) await page.waitForTimeout(250);
+  }
+  if (!panelId) throw new Error("agent panel never appeared after clicking the claude button");
+  const panel = page.locator(`[data-panel-id="${panelId}"]`);
+  const deadline = Date.now() + 20_000;
+  while (Date.now() < deadline) {
+    const text = (await getTerminalText(panel).catch(() => "")).toLowerCase();
+    if (text.includes(FAKE_AGENT_READY.toLowerCase())) break;
+    if (text.includes("enter to confirm") || text.includes("trust this folder")) {
+      await writeTerminalInput(page, panel, "\r").catch(() => {});
+      break;
+    }
+    await page.waitForTimeout(250);
+  }
+  await waitForTerminalText(panel, FAKE_AGENT_READY, T_LONG);
+  await expect
+    .poll(() => panel.getAttribute("data-agent-state"), { timeout: T_LONG })
+    .toBe("working");
+  const wrote = await ptyWrite(page, panelId, `${FAKE_AGENT_IDLE}\r`);
+  if (!wrote) throw new Error("terminal.write unavailable — cannot drive the agent to waiting");
+  // The idle debounce that settles `working` into `waiting` runs longer than
+  // T_LONG on a loaded machine; the theme tour gives it 2x and still warns.
+  await expect
+    .poll(() => panel.getAttribute("data-agent-state"), {
+      timeout: T_LONG * 3,
+      intervals: [500, 1000],
+    })
+    .toBe("waiting");
+  // The toolbar reads dominant state per worktree, so the pip lags the panel
+  // by a store tick.
+  // The pip's colour follows the waiting state one store tick behind the
+  // panel; a capture taken on the working colour would mislabel the state.
+  await expect
+    .poll(
+      () =>
+        page
+          .locator(`${BUTTON("claude")} .toolbar-pip[data-visible="true"]`)
+          .first()
+          .getAttribute("class"),
+      { timeout: 10_000, message: "agent pip never took the waiting colour" }
+    )
+    .toContain("waiting");
+  return panelId;
+}
+
+async function expectOverflow(page: Page, side: "left" | "right"): Promise<void> {
+  await expect(
+    page.locator(OVERFLOW_TRIGGER(side)),
+    `${side} overflow trigger is not visible — the width did not evict anything`
+  ).toBeVisible({ timeout: 5000 });
+}
+
+async function expectNoOverflow(page: Page): Promise<void> {
+  await expect(page.locator(OVERFLOW_TRIGGER("left"))).toHaveCount(0);
+  await expect(page.locator(OVERFLOW_TRIGGER("right"))).toHaveCount(0);
+}
+
+/** `navigator.platform` drives the mac/windows/linux branches; CDP can lie about it. */
+async function overridePlatform(
+  page: Page,
+  platform: "Win32" | "Linux x86_64" | "MacIntel"
+): Promise<void> {
+  const cdp = await page.context().newCDPSession(page);
+  const base = await page.evaluate(() => navigator.userAgent);
+  const userAgent =
+    platform === "Win32"
+      ? base.replace(/\(Macintosh;[^)]*\)/, "(Windows NT 10.0; Win64; x64)")
+      : platform === "Linux x86_64"
+        ? base.replace(/\(Macintosh;[^)]*\)/, "(X11; Linux x86_64)")
+        : base;
+  await cdp.send("Emulation.setUserAgentOverride", { userAgent, platform });
+  await reloadAndWait(page);
+}
+
+test("toolbar strip review — every state of the strip", async () => {
+  test.info().annotations.push({
+    type: "conditional-skip",
+    description: "DAINTREE_SHOT_THEME is required for the toolbar-strip-review capture",
+  });
+  test.skip(!THEME, "Set DAINTREE_SHOT_THEME to run the toolbar-strip-review capture");
+  if (!SHOT_DIR || !path.isAbsolute(SHOT_DIR)) {
+    throw new Error("DAINTREE_SHOT_DIR must be an absolute directory outside the repo");
+  }
+  test.setTimeout(900_000);
+
+  mkdirSync(OUTPUT_DIR, { recursive: true });
+  const repo = createFixtureRepo({
+    name: "helios",
+    withMultipleFiles: true,
+    withFeatureBranch: true,
+    withGitHubRemote: true,
+  });
+  // A second worktree on a long branch, so the chip's middle-truncation and
+  // the pill's own truncation both have something to bite on.
+  const wtRoot = path.join(path.dirname(repo.dir), path.basename(repo.dir) + "-worktrees");
+  mkdirSync(wtRoot, { recursive: true });
+  git(`branch ${LONG_BRANCH}`, repo.dir);
+  git(
+    `worktree add ${JSON.stringify(path.join(wtRoot, LONG_BRANCH.replace(/[/]/g, "-")))} ${LONG_BRANCH}`,
+    repo.dir
+  );
+  const fakeBinDir = installFakeAgent(repo.dir);
+
+  // Prefix deliberately avoids "daintree-e2e" — launchApp's pre-launch hygiene
+  // pkills that pattern, and parallel theme captures would SIGKILL each other.
+  const userDataDir = mkdtempSync(path.join(tmpdir(), "daintree-toolbarshot-"));
+  let ctx: AppContext | undefined;
+  try {
+    ctx = await launchApp({
+      userDataDir,
+      screenshotScale: SCALE,
+      windowSize: WIDE,
+      env: fakeAgentEnv(fakeBinDir),
+      extraArgs: ["--disable-gpu", "--in-process-gpu", "--disable-breakpad", "--noerrdialogs"],
+    });
+
+    // 1. No workspace. The welcome window's toolbar: disabled sidebar toggle,
+    // a pill with nothing to name, the forge-stats measurement ghost. Captured
+    // before any project is opened, because that is the only time it exists.
+    // `setAppTheme` waits for the command input, which the welcome screen does
+    // not have, so the theme is applied by hand here.
+    await step(null, "no-workspace", async () => {
+      const win = ctx!.window;
+      await win.evaluate(async (id) => {
+        await window.electron.appTheme.setColorScheme(id);
+      }, THEME);
+      await win.reload({ waitUntil: "domcontentloaded" });
+      await win.locator(SEL.toolbar.toggleSidebar).waitFor({ state: "visible", timeout: T_LONG });
+      await expect
+        .poll(() => win.locator("html").getAttribute("data-theme"), { timeout: 10_000 })
+        .toBe(THEME);
+      await win.setViewportSize(WIDE);
+      await win.addStyleTag({ content: POLISH_CSS }).catch(() => {});
+      await dismissBlockingPalette(win);
+      await settle(win, 1200);
+      await expect(
+        win.locator(`${SEL.toolbar.toggleSidebar}[aria-disabled="true"]`)
+      ).toBeAttached();
+      await snapStrip(win, "01-no-workspace");
+    });
+
+    const page = await openAndOnboardProject(ctx.app, ctx.window, repo.dir, "helios");
+    await page.evaluate(async (name) => {
+      const cur = await window.electron.project.getCurrent();
+      if (cur?.id) await window.electron.project.update(cur.id, { emoji: "☀️", name });
+    }, PROJECT_NAME);
+    await setAppTheme(page, THEME);
+    await page.setViewportSize(WIDE);
+    await page.addStyleTag({ content: POLISH_CSS }).catch(() => {});
+    await dismissBlockingPalette(page);
+    await page
+      .locator(SEL.worktree.mainCard)
+      .waitFor({ state: "visible", timeout: T_LONG })
+      .catch(() => {});
+    await settle(page, 2000);
+    await dismissBlockingPalette(page);
+
+    // 2. Rest, default composition, nothing lit. The strip most users see most
+    // of the time.
+    await step(page, "rest", async () => {
+      await expectNoOverflow(page);
+      await snapStrip(page, "02-rest-default");
+    });
+
+    // The rich composition with every signal live, for everything that follows.
+    await page.evaluate(() => window.electron.agentSettings.set("claude", { pinned: true }));
+    await seedComposition(page, RICH_LEFT, RICH_RIGHT);
+    await expect(page.locator(BUTTON("claude")).first()).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator(BUTTON("problems")).first()).toBeVisible({ timeout: 10_000 });
+    await seedSignals(page);
+    // Not a shot of its own, but a `step` so a fake agent that never settles
+    // fails the run at the end instead of aborting every capture after it.
+    await step(page, "agent-signal", async () => {
+      await launchWaitingAgent(page);
+    });
+    await page.mouse.move(WIDE.width / 2, WIDE.height - 20);
+    await settle(page, 600);
+
+    // 3. Wide, all signals: agent waiting, three errors, two unread, forge pill.
+    await step(page, "signals", async () => {
+      await expectNoOverflow(page);
+      await snapStrip(page, "03-signals-wide");
+    });
+
+    // 4. Hover on an icon button, so the hover tier can be judged against the
+    // armed tier two shots down.
+    await step(page, "hover", async () => {
+      const box = await page.locator(BUTTON("settings")).first().boundingBox();
+      if (!box) throw new Error("no bounding box for the settings button");
+      await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+      await settle(page, 500);
+      await snapStrip(page, "04-hover");
+      await page.mouse.move(WIDE.width / 2, WIDE.height - 20);
+    });
+
+    // 5. Keyboard focus, delivered by the keyboard so Chromium paints
+    // :focus-visible. Two arrows in from the sidebar toggle lands on a
+    // measured-row button.
+    await step(page, "focus", async () => {
+      await page.locator(SEL.toolbar.toggleSidebar).focus();
+      await page.keyboard.press("ArrowRight");
+      await page.keyboard.press("ArrowRight");
+      await settle(page, 300);
+      const focused = await page.evaluate(() =>
+        document.activeElement
+          ?.closest("[data-toolbar-button-id]")
+          ?.getAttribute("data-toolbar-button-id")
+      );
+      if (!focused) throw new Error("arrow keys did not move focus onto a toolbar button");
+      await snapStrip(page, "05-focus-visible");
+      await page.keyboard.press("Escape");
+      await page.locator("body").click({ position: { x: WIDE.width / 2, y: WIDE.height - 20 } });
+    });
+
+    // 6. An armed trigger: the launcher open. The dropdown itself is out of
+    // scope; the crop keeps just enough of it to show the anchor relationship.
+    await step(page, "armed", async () => {
+      await page.locator(BUTTON("launcher")).first().click();
+      await page
+        .locator('[role="dialog"][aria-label="Launch"]')
+        .waitFor({ state: "visible", timeout: 8000 });
+      await settle(page, 500);
+      await snapStrip(page, "06-armed-launcher", 40);
+    });
+
+    // 7-9. Overflow at three widths. Mild evicts the right-side priority-5
+    // buttons; severe takes both sides and drops the branch chip; extreme
+    // leaves the pill squeezed between two `…` triggers.
+    await step(page, "overflow-mild", async () => {
+      await page.setViewportSize({ width: 1180, height: 1050 });
+      await settle(page, 800);
+      await expectOverflow(page, "right");
+      await snapStrip(page, "07-overflow-mild");
+    });
+
+    await step(page, "overflow-severe", async () => {
+      await page.setViewportSize({ width: 820, height: 1050 });
+      await settle(page, 800);
+      await expectOverflow(page, "right");
+      await expectOverflow(page, "left");
+      await snapStrip(page, "08-overflow-severe");
+    });
+
+    await step(page, "overflow-extreme", async () => {
+      await page.setViewportSize({ width: 560, height: 1050 });
+      await settle(page, 800);
+      await expectOverflow(page, "right");
+      await snapStrip(page, "09-overflow-extreme");
+    });
+
+    // 10. The right `…` menu open at the severe width, so the trigger's armed
+    // state and its badge can be read against the open menu's top edge.
+    await step(page, "overflow-menu", async () => {
+      await page.setViewportSize({ width: 820, height: 1050 });
+      await settle(page, 800);
+      await expectOverflow(page, "right");
+      await page.locator(OVERFLOW_TRIGGER("right")).click();
+      await page.locator('[role="menu"]').first().waitFor({ state: "visible", timeout: 5000 });
+      await settle(page, 400);
+      await snapStrip(page, "10-overflow-menu-open", 220);
+    });
+
+    // 11. Eviction focus redirect. Focus a right-side button by keyboard at
+    // full width, shrink until it is evicted, and capture where focus went.
+    // The assertion is the point: a capture of focus on <body> would be a
+    // capture of the defect, and it would be labelled as the fix.
+    await step(page, "eviction", async () => {
+      await page.locator(BUTTON("settings")).first().focus();
+      await page.keyboard.press("ArrowLeft");
+      await page.keyboard.press("ArrowRight");
+      const start = await page.evaluate(() =>
+        document.activeElement
+          ?.closest("[data-toolbar-button-id]")
+          ?.getAttribute("data-toolbar-button-id")
+      );
+      if (start !== "settings") throw new Error(`focus started on ${start}, not settings`);
+      await page.setViewportSize({ width: 820, height: 1050 });
+      await settle(page, 800);
+      await expectOverflow(page, "right");
+      const landed = await page.evaluate(() => {
+        const el = document.activeElement;
+        if (!el || el === document.body) return "body";
+        if (el.matches('[data-toolbar-overflow-trigger][data-toolbar-overflow-side="right"]'))
+          return "right-overflow-trigger";
+        return el.getAttribute("aria-label") ?? el.tagName;
+      });
+      // Capture first: a shot of where focus actually went is the evidence,
+      // whichever way the assertion falls.
+      await snapStrip(page, "11-eviction-focus-redirect");
+      if (landed !== "right-overflow-trigger") {
+        throw new Error(`after eviction focus landed on "${landed}", not the right … trigger`);
+      }
+    });
+
+    // 12. Long names at a squeezed width: a long project name and a long
+    // branch, so the pill's truncation order and the chip's middle-cut show.
+    await step(page, "long-names", async () => {
+      const rename = (name: string) =>
+        page.evaluate(async (n) => {
+          const cur = await window.electron.project.getCurrent();
+          if (cur?.id) await window.electron.project.update(cur.id, { name: n });
+        }, name);
+      await rename(LONG_PROJECT_NAME);
+      try {
+        // Through the action layer, the way the switch-benchmark fixture does
+        // it: a click on the sidebar card selects the row without always
+        // switching the active worktree the pill reads.
+        await page.locator(SEL.worktree.card(LONG_BRANCH)).first().waitFor({
+          state: "visible",
+          timeout: T_LONG,
+        });
+        const selected = await page.evaluate(async (branch) => {
+          const w = window as unknown as {
+            __DAINTREE_E2E_WORKTREES__?: () => Array<{ id: string; branch: string }>;
+            __daintreeDispatchAction?: (
+              id: string,
+              payload: unknown,
+              opts: { source: string }
+            ) => Promise<{ ok: boolean; error?: { message: string } }>;
+          };
+          const target = w.__DAINTREE_E2E_WORKTREES__?.().find((t) => t.branch === branch);
+          if (!target || !w.__daintreeDispatchAction) return "no bridge";
+          const result = await w.__daintreeDispatchAction(
+            "worktree.select",
+            { worktreeId: target.id },
+            { source: "test" }
+          );
+          return result.ok ? "ok" : (result.error?.message ?? "failed");
+        }, LONG_BRANCH);
+        if (selected !== "ok") throw new Error(`worktree.select: ${selected}`);
+        // `middleTruncate` spells its ellipsis as three dots.
+        let last = "";
+        for (let i = 0; i < 40; i++) {
+          const pill = await page.locator(SEL.toolbar.projectSwitcherTrigger).textContent();
+          if (pill?.includes("...")) break;
+          const cards = await page
+            .locator("[data-worktree-branch]")
+            .evaluateAll((els) => els.map((el) => el.getAttribute("data-worktree-branch")));
+          last = `pill="${pill}" cards=${JSON.stringify(cards)}`;
+          await page.waitForTimeout(250);
+          if (i === 39) throw new Error(`pill never showed the truncated long branch: ${last}`);
+        }
+        await page.setViewportSize({ width: 1180, height: 1050 });
+        await settle(page, 800);
+        await snapStrip(page, "12-long-names");
+      } finally {
+        await page
+          .locator(SEL.worktree.mainCard)
+          .first()
+          .click()
+          .catch(() => {});
+        await rename(PROJECT_NAME);
+      }
+    });
+
+    // 13-14. The two accessibility media modes, with every signal live.
+    // forced-colors strips box-shadow (every ring) and repaints backgrounds;
+    // contrast-more swaps in the high-contrast block. A pip that only exists
+    // as a coloured fill disappears in both.
+    await step(page, "forced-colors", async () => {
+      await page.emulateMedia({ forcedColors: "active" });
+      await settle(page, 500);
+      await snapStrip(page, "13-forced-colors");
+    });
+
+    await step(page, "contrast-more", async () => {
+      await page.emulateMedia({ contrast: "more" });
+      await settle(page, 500);
+      await snapStrip(page, "14-contrast-more");
+    });
+
+    // 15-16. The re-shuffled composition. A reload drops the in-memory
+    // signals, so the errors and unread are re-seeded; the agent panel is left
+    // to session restore, and the capture is honest either way.
+    await step(page, "composition-alt", async () => {
+      await seedComposition(page, ALT_LEFT, ALT_RIGHT);
+      await seedSignals(page);
+      await expect(page.locator(BUTTON("settings")).first()).toBeVisible({ timeout: 10_000 });
+      await expectNoOverflow(page);
+      await snapStrip(page, "15-composition-alt");
+    });
+
+    await step(page, "composition-alt-overflow", async () => {
+      await page.setViewportSize({ width: 900, height: 1050 });
+      await settle(page, 800);
+      await expectOverflow(page, "right");
+      await snapStrip(page, "16-composition-alt-overflow");
+    });
+
+    // 17-18. Platform variants. `isMac`/`isWindows`/`isLinux` read
+    // navigator.platform and userAgent, which CDP can override for the page;
+    // the native window chrome stays macOS, so only the strip's own spacers
+    // and app-menu button are under review here.
+    await step(page, "platform-windows", async () => {
+      await overridePlatform(page, "Win32");
+      await seedSignals(page);
+      await expect(page.locator('[aria-label="Application menu"], [data-app-menu-button]').first())
+        .toBeVisible({ timeout: 8000 })
+        .catch(() => {});
+      await snapStrip(page, "17-platform-windows");
+    });
+
+    await step(page, "platform-linux", async () => {
+      await overridePlatform(page, "Linux x86_64");
+      await seedSignals(page);
+      await snapStrip(page, "18-platform-linux");
+    });
+
+    await overridePlatform(page, "MacIntel").catch(() => {});
+
+    // 19. macOS fullscreen: the traffic-light spacer collapses to w-0. Last,
+    // because entering fullscreen resizes the window under everything else.
+    await step(page, "fullscreen", async () => {
+      await seedSignals(page);
+      await ctx!.app.evaluate(({ BrowserWindow }) => {
+        BrowserWindow.getAllWindows()[0]?.setFullScreen(true);
+      });
+      await expect(page.locator('[data-fullscreen="true"]').first()).toBeAttached({
+        timeout: 8000,
+      });
+      await settle(page, 1500);
+      await snapStrip(page, "19-fullscreen-mac");
+      await ctx!.app.evaluate(({ BrowserWindow }) => {
+        BrowserWindow.getAllWindows()[0]?.setFullScreen(false);
+      });
+      await settle(page, 1500);
+    });
+
+    // Count what landed against what was promised. The exit code says only
+    // that no step threw; this says the sweep actually produced its artifacts.
+    const expected = STEPS.filter((s) => ONLY.length === 0 || ONLY.includes(s.name)).map(
+      (s) => `${s.slug}${TAG}.png`
+    );
+    const present = new Set(readdirSync(OUTPUT_DIR));
+    const missing = expected.filter((f) => !present.has(f));
+
+    expect(stepFailures, `toolbar capture steps failed in "${THEME}"`).toEqual([]);
+    expect(missing, `toolbar captures missing in "${THEME}"`).toEqual([]);
+  } finally {
+    if (ctx) await closeApp(ctx.app);
+    repo.cleanup();
+  }
+});

--- a/e2e/screenshots/toolbar-strip-review.spec.ts
+++ b/e2e/screenshots/toolbar-strip-review.spec.ts
@@ -281,6 +281,9 @@ async function step(page: Page | null, name: string, fn: () => Promise<void>): P
       .catch(() => {});
     await page.emulateMedia({ forcedColors: "none", contrast: "no-preference" }).catch(() => {});
     await page.setViewportSize(WIDE).catch(() => {});
+    // A step that clicked a button leaves the pointer on it, and the next
+    // capture would show that button hovered.
+    await page.mouse.move(WIDE.width / 2, WIDE.height - 20).catch(() => {});
     await settle(page, 300).catch(() => {});
   }
 }
@@ -713,9 +716,20 @@ test("toolbar strip review — every state of the strip", async () => {
         await snapStrip(page, "12-long-names");
       } finally {
         await page
-          .locator(SEL.worktree.mainCard)
-          .first()
-          .click()
+          .evaluate(async () => {
+            const w = window as unknown as {
+              __DAINTREE_E2E_WORKTREES__?: () => Array<{ id: string; branch: string }>;
+              __daintreeDispatchAction?: (id: string, payload: unknown, o: unknown) => unknown;
+            };
+            const main = w.__DAINTREE_E2E_WORKTREES__?.().find((t) => t.branch === "main");
+            if (main) {
+              await w.__daintreeDispatchAction?.(
+                "worktree.select",
+                { worktreeId: main.id },
+                { source: "test" }
+              );
+            }
+          })
           .catch(() => {});
         await rename(PROJECT_NAME);
       }
@@ -744,7 +758,9 @@ test("toolbar strip review — every state of the strip", async () => {
       await seedComposition(page, ALT_LEFT, ALT_RIGHT);
       await seedSignals(page);
       await expect(page.locator(BUTTON("settings")).first()).toBeVisible({ timeout: 10_000 });
-      await expectNoOverflow(page);
+      // No fit assertion: with an agent and four panel buttons moved right,
+      // this composition earns two dividers and may overflow even at 1680px.
+      // Whether it does is part of what the capture is for.
       await snapStrip(page, "15-composition-alt");
     });
 

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -1102,7 +1102,14 @@ export function Toolbar({
     [getToolbarItems, syncToolbarTabStops]
   );
 
-  const toolbarDividerClass = "toolbar-divider w-px h-5 mx-1";
+  // `shrink-0`: a 1px flex item is the first thing a squeezed row gives up,
+  // and a group boundary that silently goes to zero width is worse than one
+  // that costs the row a pixel.
+  const toolbarDividerClass = "toolbar-divider w-px h-5 mx-1 shrink-0";
+  // The two fixed dividers sit in the outer groups, whose `gap-1.5` already
+  // supplies the 6px the measured rows' own `gap-0.5` + `mx-1` add up to;
+  // an `mx-1` on top gave the launcher 10px on one side and 6px on the other.
+  const toolbarFixedDividerClass = "toolbar-divider w-px h-5 shrink-0";
 
   const { buttonIds: pluginButtonIds, configs: pluginConfigs } = usePluginToolbarButtons();
 
@@ -2301,7 +2308,7 @@ export function Toolbar({
             aria-label="Main toolbar"
             onKeyDown={handleToolbarKeyDown}
             onFocusCapture={handleToolbarFocusCapture}
-            className="@container/toolbar relative z-[60] grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] gap-x-2 h-12 items-center px-4 pt-1 shrink-0 app-drag-region surface-toolbar border-b border-divider"
+            className="@container/toolbar relative z-[60] grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] gap-x-3 h-12 items-center px-4 shrink-0 app-drag-region surface-toolbar border-b border-divider"
           >
             {!isLinux() && <div className="window-resize-strip" />}
 
@@ -2336,7 +2343,7 @@ export function Toolbar({
               )}
               <div className="app-no-drag">{buttonRegistry["sidebar-toggle"]!.render()}</div>
 
-              <div className={toolbarDividerClass} />
+              <div className={toolbarFixedDividerClass} />
 
               <div
                 ref={leftGroupRef}
@@ -2549,7 +2556,7 @@ export function Toolbar({
                 </div>
               )}
 
-              <div className={toolbarDividerClass} />
+              <div className={toolbarFixedDividerClass} />
 
               <div className="app-no-drag flex items-center gap-0.5">
                 {buttonRegistry["assistant-toggle"]!.render()}

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -146,7 +146,11 @@ import { HostMemoryPauseIndicator } from "./HostMemoryPauseIndicator";
 import { useHostMemoryPauseStore } from "@/store/hostMemoryPauseStore";
 import { ToolbarPortalButton } from "./ToolbarPortalButton";
 import { ToolbarAssistantButton } from "./ToolbarAssistantButton";
-import { useOverflowBadgeSeverity, type OverflowBadgeSeverity } from "./useOverflowBadgeSeverity";
+import {
+  useOverflowAgentObservations,
+  useOverflowBadgeSeverity,
+  type OverflowBadgeSeverity,
+} from "./useOverflowBadgeSeverity";
 import { CopyTreeMenuContent } from "@/components/CopyTree/CopyTreeRecentsPanel";
 import { useCopyTreeCompletionNotice } from "@/hooks/useCopyTreeCompletionNotice";
 import { useCopyTreeRunStore } from "@/store/copyTreeRunStore";
@@ -211,6 +215,9 @@ interface OverflowMenuProps {
   severity: OverflowBadgeSeverity;
   errorCount: number;
   notificationUnreadCount: number;
+  // Per-session agent states behind the badge, already worded — derived by
+  // the same rule as `severity`, so the name never says less than the dot.
+  agentObservations: readonly string[];
   agentDominantStates: Map<string, AgentState | null>;
   hasActiveWorktree: boolean;
   forgeStatsRef: React.RefObject<ForgeStatsHandle | null>;
@@ -252,6 +259,7 @@ function OverflowMenu({
   severity,
   errorCount,
   notificationUnreadCount,
+  agentObservations,
   agentDominantStates,
   hasActiveWorktree,
   forgeStatsRef,
@@ -316,16 +324,7 @@ function OverflowMenu({
   if (overflowIds.includes("notification-center") && notificationUnreadCount > 0) {
     observations.push(`${notificationUnreadCount} unread`);
   }
-  const agentsByState = new Map<AgentState, number>();
-  for (const id of overflowIds) {
-    if (!isBuiltInAgentId(id)) continue;
-    const state = agentDominantStates.get(id);
-    if (!state || !agentStateDotColor(state)) continue;
-    agentsByState.set(state, (agentsByState.get(state) ?? 0) + 1);
-  }
-  for (const [state, count] of agentsByState) {
-    observations.push(`${count} ${count === 1 ? "agent" : "agents"} ${state}`);
-  }
+  observations.push(...agentObservations);
   const tooltipText = `More — ${n} hidden${observations.length > 0 ? ` · ${observations.join(" · ")}` : ""}`;
   const ariaLabel = `More toolbar items — ${n} hidden${observations.length > 0 ? `, ${observations.join(", ")}` : ""}`;
 
@@ -1852,6 +1851,8 @@ export function Toolbar({
 
   const leftOverflowSeverity = useOverflowBadgeSeverity(visibleLeftOverflow, errorCount);
   const rightOverflowSeverity = useOverflowBadgeSeverity(visibleRightOverflow, errorCount);
+  const leftAgentObservations = useOverflowAgentObservations(visibleLeftOverflow);
+  const rightAgentObservations = useOverflowAgentObservations(visibleRightOverflow);
 
   const leftVisibleSet = useMemo(() => new Set<AnyToolbarButtonId>(leftVisible), [leftVisible]);
   const rightVisibleSet = useMemo(() => new Set<AnyToolbarButtonId>(rightVisible), [rightVisible]);
@@ -2121,7 +2122,8 @@ export function Toolbar({
   const renderOverflowMenu = (
     overflowIds: AnyToolbarButtonId[],
     side: "left" | "right",
-    severity: OverflowBadgeSeverity
+    severity: OverflowBadgeSeverity,
+    agentObservations: readonly string[]
   ) => (
     <OverflowMenu
       overflowIds={overflowIds}
@@ -2129,6 +2131,7 @@ export function Toolbar({
       severity={severity}
       errorCount={errorCount}
       notificationUnreadCount={notificationUnreadCount}
+      agentObservations={agentObservations}
       agentDominantStates={agentDominantStates}
       hasActiveWorktree={!!activeWorktree}
       forgeStatsRef={forgeStatsRef}
@@ -2356,7 +2359,12 @@ export function Toolbar({
               >
                 {renderGroupedButtons(effectiveLeftButtons, leftVisibleSet)}
               </div>
-              {renderOverflowMenu(visibleLeftOverflow, "left", leftOverflowSeverity)}
+              {renderOverflowMenu(
+                visibleLeftOverflow,
+                "left",
+                leftOverflowSeverity,
+                leftAgentObservations
+              )}
             </div>
 
             {/* CENTER GROUP - Grid-centered, shrinks gracefully on narrow windows */}
@@ -2546,7 +2554,12 @@ export function Toolbar({
               >
                 {renderGroupedButtons(effectiveRightButtons, rightVisibleSet)}
               </div>
-              {renderOverflowMenu(visibleRightOverflow, "right", rightOverflowSeverity)}
+              {renderOverflowMenu(
+                visibleRightOverflow,
+                "right",
+                rightOverflowSeverity,
+                rightAgentObservations
+              )}
 
               {/* Fixed chrome outside the measured button row: it exists only
                   while a terminal host has output paused for memory (#12375),

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -185,10 +185,12 @@ function ForgeStatsPlaceholder() {
   );
 }
 
+// The same box as the `size="icon"` button it stands in for, so the overflow
+// budget and the row height it reserves are the button's, not 4px more.
 function DevServerPlaceholder() {
   return (
     <div
-      className={cn(toolbarIconButtonClass, "h-9 w-9 opacity-0 pointer-events-none")}
+      className={cn(toolbarIconButtonClass, "h-8 w-8 opacity-0 pointer-events-none")}
       aria-hidden="true"
     />
   );
@@ -299,20 +301,33 @@ function OverflowMenu({
   // flag mutating a ref passed in as a prop.
   const overflowMenuPointerCloseRef = useRef(false);
 
-  // Keep the accessible name stable and terse: a comma-enumerated list
-  // re-announces the full set on every focus pass and goes stale as
-  // resize-driven overflow changes. Surface only the purpose plus a
-  // count, escalating the noun to "problem(s)" when severity is
-  // actionable (critical/warning) so screen-reader users still learn
-  // there's something to act on without the list churn.
+  // Keep the accessible name stable and terse: a comma-enumerated list of
+  // the hidden buttons re-announces the full set on every focus pass and goes
+  // stale as resize-driven overflow changes. The count is always a count of
+  // hidden items — it was once re-nouned to "problems" whenever the badge lit,
+  // which read five hidden commands as five problems. What the badge is
+  // actually reporting rides behind the count instead, as the observations
+  // themselves: the error count, the unread count, the agent states seen.
   const n = overflowIds.length;
-  const hasProblem = severity === "critical" || severity === "warning";
-  const tooltipText = hasProblem
-    ? `More — ${n} ${n === 1 ? "problem" : "problems"}`
-    : `More — ${n} ${n === 1 ? "item" : "items"}`;
-  const ariaLabel = hasProblem
-    ? `More toolbar items — ${n} ${n === 1 ? "problem" : "problems"} hidden`
-    : `More toolbar items — ${n} hidden`;
+  const observations: string[] = [];
+  if (overflowIds.includes("problems") && errorCount > 0) {
+    observations.push(`${errorCount} ${errorCount === 1 ? "error" : "errors"}`);
+  }
+  if (overflowIds.includes("notification-center") && notificationUnreadCount > 0) {
+    observations.push(`${notificationUnreadCount} unread`);
+  }
+  const agentsByState = new Map<AgentState, number>();
+  for (const id of overflowIds) {
+    if (!isBuiltInAgentId(id)) continue;
+    const state = agentDominantStates.get(id);
+    if (!state || !agentStateDotColor(state)) continue;
+    agentsByState.set(state, (agentsByState.get(state) ?? 0) + 1);
+  }
+  for (const [state, count] of agentsByState) {
+    observations.push(`${count} ${count === 1 ? "agent" : "agents"} ${state}`);
+  }
+  const tooltipText = `More — ${n} hidden${observations.length > 0 ? ` · ${observations.join(" · ")}` : ""}`;
+  const ariaLabel = `More toolbar items — ${n} hidden${observations.length > 0 ? `, ${observations.join(", ")}` : ""}`;
 
   const countSuffix = (id: AnyToolbarButtonId) => {
     if (id === "problems" && errorCount > 0) return ` (${errorCount})`;
@@ -1010,7 +1025,13 @@ export function Toolbar({
       // redirect below is skipped — but the ref must still be cleared so
       // a later unrelated re-render doesn't trigger a phantom redirect.
       prevFocusedToolbarItemRef.current = null;
-      if (document.activeElement === document.body) {
+      // Two shapes of "focus is about to be nowhere". The evicted button has
+      // just gone `visibility: hidden`, but the browser only drops focus from
+      // it at its next rendering update — after this layout effect — so at
+      // this point it is still `activeElement` and the redirect has to fire
+      // now, or focus lands on <body> with nothing left to catch it. The
+      // body case covers an eviction whose fixup already ran (an unmount).
+      if (document.activeElement === document.body || document.activeElement === prevFocused) {
         // Redirect to the overflow trigger on the SAME side as the
         // evicted item; falling back to the other side's trigger would
         // pull focus across the toolbar to the wrong group.
@@ -1744,7 +1765,11 @@ export function Toolbar({
     // replaced. Buttons the user already dragged into a side list keep that
     // position and are filtered on promotion below like any other id.
     const extra = pluginButtonIds.filter((id) => !positioned.has(id) && pinnedButtons[id] === true);
-    return [...base, ...extra];
+    // Grouped like the left (#11681): the default right set is all utilities,
+    // so this changes nothing until a user moves a panel or agent across the
+    // centre — at which point the divider rules have to mean the same thing
+    // on both sides.
+    return orderToolbarButtonsByGroup([...base, ...extra], resolveToolbarGroup);
   }, [
     toolbarLayout.rightButtons,
     toolbarLayout.leftButtons,
@@ -1753,6 +1778,7 @@ export function Toolbar({
     unpositionedLauncherItemPins,
     pluginButtonIds,
     pinnedButtons,
+    resolveToolbarGroup,
   ]);
 
   const effectiveRightButtons = useMemo(
@@ -1789,7 +1815,8 @@ export function Toolbar({
     rightGroupRef,
     availableLeftIds,
     availableRightIds,
-    pinnedIds
+    pinnedIds,
+    resolveToolbarGroup
   );
 
   // Voice recording reserves layout via an always-available slot but should
@@ -1858,28 +1885,7 @@ export function Toolbar({
     }
   }, [leftOverflow, rightOverflow]);
 
-  const renderButtons = (buttonIds: AnyToolbarButtonId[], visibleSet: Set<AnyToolbarButtonId>) => {
-    return buttonIds
-      .filter((id) => buttonRegistry[id]?.isAvailable)
-      .map((id) => (
-        <div
-          key={id}
-          data-toolbar-button-id={id}
-          className={cn(
-            "app-no-drag",
-            !visibleSet.has(id) && "invisible absolute pointer-events-none"
-          )}
-          aria-hidden={visibleSet.has(id) ? undefined : true}
-          data-toolbar-placeholder={
-            !currentProject && PROJECT_SCOPED_TOOLBAR_IDS.has(id) ? "true" : undefined
-          }
-        >
-          {buttonRegistry[id]!.render()}
-        </div>
-      ));
-  };
-
-  const renderLeftButtons = (
+  const renderGroupedButtons = (
     buttonIds: AnyToolbarButtonId[],
     visibleSet: Set<AnyToolbarButtonId>
   ) => {
@@ -2231,7 +2237,7 @@ export function Toolbar({
       <TooltipTrigger asChild>
         <button
           data-toolbar-item=""
-          className="toolbar-project-pill app-no-drag pointer-events-auto flex h-9 min-w-0 max-w-full items-center justify-center gap-2 overflow-hidden border px-3 outline-hidden focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-accent-primary focus-visible:outline-offset-2"
+          className="toolbar-project-pill app-no-drag pointer-events-auto flex h-9 min-w-0 max-w-full items-center justify-center gap-2 overflow-hidden border px-3 focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-accent-primary focus-visible:outline-offset-2"
           data-testid="project-switcher-trigger"
           aria-label={workspaceIdentity.ariaLabel}
           role={workspaceIdentity.kind !== "none" ? "combobox" : undefined}
@@ -2295,7 +2301,7 @@ export function Toolbar({
             aria-label="Main toolbar"
             onKeyDown={handleToolbarKeyDown}
             onFocusCapture={handleToolbarFocusCapture}
-            className="@container/toolbar relative z-[60] grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] h-12 items-center px-4 pt-1 shrink-0 app-drag-region surface-toolbar border-b border-divider"
+            className="@container/toolbar relative z-[60] grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] gap-x-2 h-12 items-center px-4 pt-1 shrink-0 app-drag-region surface-toolbar border-b border-divider"
           >
             {!isLinux() && <div className="window-resize-strip" />}
 
@@ -2310,7 +2316,11 @@ export function Toolbar({
                   data-fullscreen={isFullscreen ? "true" : undefined}
                   className={cn(
                     "shrink-0 transition-[width] duration-200 data-[fullscreen=true]:duration-120",
-                    isFullscreen ? "w-0" : "w-16"
+                    // A zero-width flex item still owns a gap on each side;
+                    // the negative margin folds the group's gap back in so
+                    // fullscreen's first button lands at the same inset a
+                    // spacer-less platform gives it.
+                    isFullscreen ? "w-0 -mr-1.5" : "w-16"
                   )}
                 />
               )}
@@ -2330,9 +2340,9 @@ export function Toolbar({
 
               <div
                 ref={leftGroupRef}
-                className="flex flex-1 min-w-0 items-center gap-0.5 overflow-hidden"
+                className="toolbar-measured-row flex flex-1 min-w-0 items-center gap-0.5"
               >
-                {renderLeftButtons(effectiveLeftButtons, leftVisibleSet)}
+                {renderGroupedButtons(effectiveLeftButtons, leftVisibleSet)}
               </div>
               <div className="app-no-drag">
                 {renderOverflowMenu(visibleLeftOverflow, "left", leftOverflowSeverity)}
@@ -2522,9 +2532,9 @@ export function Toolbar({
             >
               <div
                 ref={rightGroupRef}
-                className="flex flex-1 min-w-0 items-center gap-0.5 overflow-hidden justify-end"
+                className="toolbar-measured-row flex flex-1 min-w-0 items-center gap-0.5 justify-end"
               >
-                {renderButtons(effectiveRightButtons, rightVisibleSet)}
+                {renderGroupedButtons(effectiveRightButtons, rightVisibleSet)}
               </div>
               <div className="app-no-drag">
                 {renderOverflowMenu(visibleRightOverflow, "right", rightOverflowSeverity)}
@@ -2552,7 +2562,7 @@ export function Toolbar({
                   data-fullscreen={isFullscreen ? "true" : undefined}
                   className={cn(
                     "shrink-0 transition-[width] duration-200 data-[fullscreen=true]:duration-120",
-                    isFullscreen && "w-0"
+                    isFullscreen && "w-0 -ml-1.5"
                   )}
                   style={isFullscreen ? undefined : { width: `${WINDOWS_CAPTION_WIDTH_PX}px` }}
                 />

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -350,7 +350,12 @@ function OverflowMenu({
               data-visible={isEmpty ? "false" : "true"}
               aria-hidden={isEmpty || undefined}
               tabIndex={isEmpty ? -1 : undefined}
-              className={toolbarIconButtonClass}
+              // The no-drag rectangle lives on the button itself, not on a
+              // wrapper: an empty trigger is display:none, and a wrapper
+              // around it would stay a zero-width flex item that still owns a
+              // gap — which is what gave the fixed divider 12px of clearance
+              // on one side while there was nothing to overflow.
+              className={cn(toolbarIconButtonClass, "app-no-drag")}
               aria-label={ariaLabel}
             >
               <Ellipsis />
@@ -2351,9 +2356,7 @@ export function Toolbar({
               >
                 {renderGroupedButtons(effectiveLeftButtons, leftVisibleSet)}
               </div>
-              <div className="app-no-drag">
-                {renderOverflowMenu(visibleLeftOverflow, "left", leftOverflowSeverity)}
-              </div>
+              {renderOverflowMenu(visibleLeftOverflow, "left", leftOverflowSeverity)}
             </div>
 
             {/* CENTER GROUP - Grid-centered, shrinks gracefully on narrow windows */}
@@ -2543,9 +2546,7 @@ export function Toolbar({
               >
                 {renderGroupedButtons(effectiveRightButtons, rightVisibleSet)}
               </div>
-              <div className="app-no-drag">
-                {renderOverflowMenu(visibleRightOverflow, "right", rightOverflowSeverity)}
-              </div>
+              {renderOverflowMenu(visibleRightOverflow, "right", rightOverflowSeverity)}
 
               {/* Fixed chrome outside the measured button row: it exists only
                   while a terminal host has output paused for memory (#12375),

--- a/src/components/Layout/__tests__/Toolbar.layout.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.layout.test.ts
@@ -113,12 +113,24 @@ describe("Toolbar layout — issue #2584 project switcher collision", () => {
       );
     });
 
-    it("has renderLeftButtons helper that inserts group dividers", () => {
-      expect(source).toContain("renderLeftButtons");
+    it("has one grouped renderer that inserts group dividers", () => {
+      expect(source).toContain("renderGroupedButtons");
+      // The old right-side renderer drew no dividers and read the persisted
+      // order; both sides go through the grouped one now.
+      expect(source).not.toMatch(/const renderButtons\s*=/);
     });
 
-    it("uses renderLeftButtons for the left button group", () => {
-      expect(source).toContain("renderLeftButtons(effectiveLeftButtons");
+    it("renders both sides through the grouped renderer", () => {
+      expect(source).toContain("renderGroupedButtons(effectiveLeftButtons");
+      expect(source).toContain("renderGroupedButtons(effectiveRightButtons");
+    });
+
+    it("orders the right buttons by declared group too, so a moved button keeps the divider rules", () => {
+      const rightMemo = source.match(
+        /const positionedRightButtons = useMemo\(\(\) => \{[\s\S]*?\n {2}\}, \[/
+      );
+      expect(rightMemo).not.toBeNull();
+      expect(rightMemo![0]).toContain("orderToolbarButtonsByGroup(");
     });
 
     it("divider element has aria-hidden for accessibility", () => {
@@ -290,7 +302,8 @@ describe("Toolbar layout — issue #2584 project switcher collision", () => {
     });
 
     it("collapses the spacer to zero width when entering fullscreen", () => {
-      expect(source).toMatch(/isFullscreen\s*&&\s*"w-0"/);
+      // Extra classes may ride along (the gap fold); the width must go to 0.
+      expect(source).toMatch(/isFullscreen\s*&&\s*"w-0(\s[^"]*)?"/);
     });
 
     it("places the spacer inside the right toolbar group, after the portal toggle", () => {

--- a/src/components/Layout/__tests__/Toolbar.responsive.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.responsive.test.ts
@@ -197,9 +197,11 @@ describe("Toolbar responsive design — issue #4133", () => {
       expect(text).toMatch(
         /overflowIds\.includes\("notification-center"\) && notificationUnreadCount > 0/
       );
-      expect(text).toMatch(/agentDominantStates\.get\(id\)/);
-      // Observed state names, never a verdict: the text says what was seen.
-      expect(text).toMatch(/\$\{state\}/);
+      // Agent observations come from the same per-session derivation as the
+      // badge severity, never from the per-agent dominant state — a working
+      // session must not silence a waiting sibling in the name.
+      expect(text).toMatch(/observations\.push\(\.\.\.agentObservations\)/);
+      expect(text).not.toMatch(/agentDominantStates\.get\(id\)/);
       expect(text).not.toMatch(/needs attention|requires attention/);
       // The observations are joined into the tooltip and the aria-label.
       expect(text).toMatch(/tooltipText = `More — \$\{n\} hidden\$\{observations\.length > 0 \?/);

--- a/src/components/Layout/__tests__/Toolbar.responsive.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.responsive.test.ts
@@ -170,32 +170,50 @@ describe("Toolbar responsive design — issue #4133", () => {
       expect(source).toMatch(/data-severity=\{severity\}/);
     });
 
-    it("builds a terse count-only tooltip — no enumerated list (issue #8159)", () => {
+    it("builds a terse count-bearing tooltip — no enumerated list (issue #8159)", () => {
       // The enumerated list re-announced the full set on every focus pass
       // and went stale on resize; it must be gone entirely.
       expect(source).not.toContain("itemLabels");
       expect(source).not.toMatch(/\$\{overflowIds\.length\} more — /);
-      // Tooltip is "More — {n} item(s)" / "More — {n} problem(s)".
-      expect(source).toContain('`More — ${n} ${n === 1 ? "item" : "items"}`');
-      expect(source).toContain('`More — ${n} ${n === 1 ? "problem" : "problems"}`');
+      expect(source).toContain("`More — ${n} hidden");
     });
 
-    it("escalates tooltip/aria noun to 'problem' for actionable severity (issue #8159)", () => {
-      expect(source).toContain(
-        'const hasProblem = severity === "critical" || severity === "warning";'
+    it("never re-nouns the hidden count as 'problems' — the count is always of hidden items", () => {
+      // Severity used to swap the noun, so five hidden commands announced as
+      // five problems. The count is a count; the signal rides behind it.
+      expect(source).not.toMatch(/n === 1 \? "problem" : "problems"/);
+      expect(source).not.toContain("hasProblem");
+      expect(source).toContain("`More toolbar items — ${n} hidden");
+    });
+
+    it("appends what the badge reports, as observations, to both the tooltip and the name", () => {
+      const block = source.match(
+        /const observations: string\[\] = \[\];[\s\S]*?const ariaLabel = [^;]*;/
+      );
+      expect(block).not.toBeNull();
+      const text = block![0];
+      // Each signal the badge severity is derived from has a textual counterpart.
+      expect(text).toMatch(/overflowIds\.includes\("problems"\) && errorCount > 0/);
+      expect(text).toMatch(
+        /overflowIds\.includes\("notification-center"\) && notificationUnreadCount > 0/
+      );
+      expect(text).toMatch(/agentDominantStates\.get\(id\)/);
+      // Observed state names, never a verdict: the text says what was seen.
+      expect(text).toMatch(/\$\{state\}/);
+      expect(text).not.toMatch(/needs attention|requires attention/);
+      // The observations are joined into the tooltip and the aria-label.
+      expect(text).toMatch(/tooltipText = `More — \$\{n\} hidden\$\{observations\.length > 0 \?/);
+      expect(text).toMatch(
+        /ariaLabel = `More toolbar items — \$\{n\} hidden\$\{observations\.length > 0 \?/
       );
     });
 
-    it("uses a stable, count-bearing aria-label instead of the enumerated list (issue #8159)", () => {
-      // voice-recording special-casing is gone — the tooltip/aria-label no
-      // longer enumerate, so the count/list alignment hack is unnecessary.
+    it("keeps the count shape the overflow E2E parses (— N hidden)", () => {
+      // e2e/full/panels/core-toolbar-overflow.spec.ts reads the number out
+      // of the name with /—\s*(\d+)\s+(?:problems?\s+)?hidden/.
+      expect(source).toContain("`More toolbar items — ${n} hidden");
       expect(source).not.toContain('id === "voice-recording"');
       expect(source).not.toContain('"Voice recording"');
-      // aria-label is purpose-naming + count; severity escalates the noun.
-      expect(source).toContain("`More toolbar items — ${n} hidden`");
-      expect(source).toContain(
-        '`More toolbar items — ${n} ${n === 1 ? "problem" : "problems"} hidden`'
-      );
     });
 
     it("pins voice-recording out of overflow while actively recording — issue #8158", () => {
@@ -207,7 +225,7 @@ describe("Toolbar responsive design — issue #4133", () => {
       expect(source).toContain("VOICE_RECORDING_PINNED");
       // Pin applies to whichever side the button lives on — passed as a
       // single pinnedIds set into useToolbarOverflow, not a right-only param.
-      expect(source).toMatch(/useToolbarOverflow\(\s*[\s\S]*?pinnedIds\s*\)/);
+      expect(source).toMatch(/useToolbarOverflow\(\s*[\s\S]*?pinnedIds\s*[,)]/);
       expect(source).not.toContain('id === "voice-recording"');
       expect(source).not.toContain("OVERFLOW_DROPDOWN_SKIP");
     });

--- a/src/components/Layout/__tests__/Toolbar.strip.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.strip.test.ts
@@ -110,7 +110,7 @@ describe("Toolbar strip — composition invariants", () => {
     it("the grid keeps a gutter between the side groups and the pill", () => {
       const root = source.match(/role="toolbar"[\s\S]*?className="([^"]+)"/);
       expect(root).not.toBeNull();
-      expect(root![1]).toMatch(/\bgap-x-\d/);
+      expect(root![1]).toMatch(/\bgap-x-[1-9]\d*\b/);
     });
 
     it("the strip's content is centred in its height — no top padding pushing it low", () => {

--- a/src/components/Layout/__tests__/Toolbar.strip.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.strip.test.ts
@@ -81,7 +81,15 @@ describe("Toolbar strip — composition invariants", () => {
         /@media \(forced-colors: active\) \{[\s\S]*?\.toolbar-badge,[\s\S]*?\n\}/
       );
       expect(block).not.toBeNull();
-      expect(block![0]).toMatch(/\.toolbar-badge,[\s\S]*?outline:\s*1px solid Canvas/);
+      expect(block![0]).toMatch(/\.toolbar-badge,[\s\S]*?outline:\s*\d+(\.\d+)?px solid Canvas/);
+    });
+
+    it("group dividers survive forced colours — their background is otherwise reset to Canvas", () => {
+      const block = css.match(
+        /@media \(forced-colors: active\) \{[\s\S]*?\.toolbar-divider\s*\{([^}]*)\}/
+      );
+      expect(block).not.toBeNull();
+      expect(block![1]).toMatch(/background-color:\s*CanvasText/);
     });
   });
 
@@ -103,6 +111,34 @@ describe("Toolbar strip — composition invariants", () => {
       const root = source.match(/role="toolbar"[\s\S]*?className="([^"]+)"/);
       expect(root).not.toBeNull();
       expect(root![1]).toMatch(/\bgap-x-\d/);
+    });
+
+    it("the strip's content is centred in its height — no top padding pushing it low", () => {
+      const root = source.match(/role="toolbar"[\s\S]*?className="([^"]+)"/);
+      expect(root).not.toBeNull();
+      expect(root![1]).toMatch(/\bh-12\b/);
+      expect(root![1]).toMatch(/\bitems-center\b/);
+      expect(root![1]).not.toMatch(/\bp[tby]-\d/);
+    });
+
+    it("dividers never shrink to nothing under width pressure", () => {
+      const classes = source.match(/const toolbar(?:Fixed)?DividerClass = "([^"]+)"/g) ?? [];
+      expect(classes.length).toBeGreaterThanOrEqual(2);
+      for (const c of classes) expect(c).toContain("shrink-0");
+    });
+
+    it("every divider gets the same clearance as its neighbours' gap", () => {
+      // Inside a measured row: gap-0.5 + mx-1 on each side. In the outer
+      // groups: gap-1.5 alone. Both come to the same 6px, so the fixed
+      // dividers carry no margin of their own.
+      const fixed = source.match(/const toolbarFixedDividerClass = "([^"]+)"/);
+      expect(fixed).not.toBeNull();
+      expect(fixed![1]).not.toMatch(/\bm[xlr]-\d/);
+      const inner = source.match(/const toolbarDividerClass = "([^"]+)"/);
+      expect(inner).not.toBeNull();
+      expect(inner![1]).toMatch(/\bmx-1\b/);
+      // And the two outer-group dividers use the fixed class.
+      expect(source.match(/className=\{toolbarFixedDividerClass\}/g)).toHaveLength(2);
     });
 
     it("a collapsed platform spacer folds its flex gap away too", () => {

--- a/src/components/Layout/__tests__/Toolbar.strip.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.strip.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import fs from "fs/promises";
+import path from "path";
+
+const TOOLBAR_PATH = path.resolve(__dirname, "../Toolbar.tsx");
+const TOOLBAR_CSS_PATH = path.resolve(__dirname, "../../../styles/components/toolbar.css");
+const BUTTON_PATH = path.resolve(__dirname, "../../ui/button.tsx");
+
+// The strip as a composed whole. Static-source assertions, like the rest of
+// the Toolbar.* suite — Toolbar.tsx has too many IPC dependencies to render in
+// jsdom — each pinning the rule a rendered-pixel review exposed, not the value
+// that happened to satisfy it.
+describe("Toolbar strip — composition invariants", () => {
+  let source: string;
+  let css: string;
+  let button: string;
+
+  beforeEach(async () => {
+    [source, css, button] = await Promise.all([
+      fs.readFile(TOOLBAR_PATH, "utf-8"),
+      fs.readFile(TOOLBAR_CSS_PATH, "utf-8"),
+      fs.readFile(BUTTON_PATH, "utf-8"),
+    ]);
+  });
+
+  describe("eviction keeps keyboard focus somewhere real", () => {
+    it("redirects while the evicted button is still activeElement, not only once focus has hit body", () => {
+      // The browser only drops focus from a newly hidden button at its next
+      // rendering update — after the layout effect that notices the eviction.
+      // A body-only gate therefore never fired, and focus was lost.
+      const effect = source.match(/useLayoutEffect\(\(\) => \{[\s\S]*?\n {2}\}\);/);
+      expect(effect).not.toBeNull();
+      expect(effect![0]).toMatch(
+        /document\.activeElement === document\.body \|\| document\.activeElement === prevFocused/
+      );
+    });
+  });
+
+  describe("the measured rows clip without cropping the focus ring", () => {
+    it("both rows use the shared clip class, never a bare overflow-hidden", () => {
+      const rows = source.match(/ref=\{(left|right)GroupRef\}\s*className="([^"]+)"/g) ?? [];
+      expect(rows).toHaveLength(2);
+      for (const row of rows) {
+        expect(row).toContain("toolbar-measured-row");
+        expect(row).not.toContain("overflow-hidden");
+      }
+    });
+
+    it("the clip margin covers the focus ring's full extent (offset plus width)", () => {
+      const rule = css.match(/\.toolbar-measured-row\s*\{([^}]*)\}/);
+      expect(rule).not.toBeNull();
+      const body = rule![1]!;
+      expect(body).toMatch(/overflow:\s*clip/);
+      const margin = Number(/overflow-clip-margin:\s*(\d+)px/.exec(body)?.[1]);
+      // The ring the rows must not cut: outline width + outline-offset from
+      // the toolbar button focus rule.
+      const ring = css.match(
+        /\.toolbar-icon-button:focus-visible,[\s\S]*?\{[^}]*outline:\s*(\d+)px[^}]*outline-offset:\s*(\d+)px/
+      );
+      expect(ring).not.toBeNull();
+      const extent = Number(ring![1]) + Number(ring![2]);
+      expect(margin).toBeGreaterThanOrEqual(extent);
+    });
+  });
+
+  describe("forced colours", () => {
+    it("the project pill carries no at-rest outline suppressor — forced-colors paints its transparent outline as a second ring", () => {
+      const pill = source.match(/data-testid="project-switcher-trigger"[\s\S]{0,400}/)?.[0] ?? "";
+      const trigger = source.match(
+        /<button\s+data-toolbar-item=""\s+className="([^"]+)"[\s\S]{0,200}data-testid="project-switcher-trigger"/
+      );
+      expect(trigger).not.toBeNull();
+      const className = trigger![1]!;
+      expect(className).not.toMatch(/(^|\s)outline-hidden(\s|$)/);
+      expect(className).toMatch(/focus-visible:outline-/);
+      expect(pill).toBeTruthy();
+    });
+
+    it("every toolbar badge gets a Canvas outline in place of its stripped ring, so a dot cannot fuse with its glyph", () => {
+      const block = css.match(
+        /@media \(forced-colors: active\) \{[\s\S]*?\.toolbar-badge,[\s\S]*?\n\}/
+      );
+      expect(block).not.toBeNull();
+      expect(block![0]).toMatch(/\.toolbar-badge,[\s\S]*?outline:\s*1px solid Canvas/);
+    });
+  });
+
+  describe("geometry", () => {
+    it("measurement ghosts are the size of the button they stand in for", () => {
+      const icon = button.match(/icon:\s*"([^"]+)"/);
+      expect(icon).not.toBeNull();
+      const size = icon![1]!.match(/\b(h-\d+)\b[^"]*\b(w-\d+)\b/);
+      expect(size).not.toBeNull();
+      const ghost = source.match(
+        /function DevServerPlaceholder\(\)[\s\S]*?className=\{cn\(toolbarIconButtonClass, "([^"]+)"\)\}/
+      );
+      expect(ghost).not.toBeNull();
+      expect(ghost![1]).toContain(size![1]!);
+      expect(ghost![1]).toContain(size![2]!);
+    });
+
+    it("the grid keeps a gutter between the side groups and the pill", () => {
+      const root = source.match(/role="toolbar"[\s\S]*?className="([^"]+)"/);
+      expect(root).not.toBeNull();
+      expect(root![1]).toMatch(/\bgap-x-\d/);
+    });
+
+    it("a collapsed platform spacer folds its flex gap away too", () => {
+      // Both spacers: a w-0 item still owns a gap on each side of it.
+      const collapsed =
+        source.match(/isFullscreen \? "w-0[^"]*"|isFullscreen && "w-0[^"]*"/g) ?? [];
+      expect(collapsed).toHaveLength(2);
+      for (const c of collapsed) expect(c).toMatch(/-m[lr]-/);
+    });
+  });
+
+  describe("both sides share one rulebook", () => {
+    it("the right side is grouped and divided exactly like the left", () => {
+      expect(source).toContain("renderGroupedButtons(effectiveLeftButtons");
+      expect(source).toContain("renderGroupedButtons(effectiveRightButtons");
+      const left =
+        source.match(/const positionedLeftButtons = useMemo\([\s\S]*?\n {2}\}, \[/)?.[0] ?? "";
+      const right =
+        source.match(/const positionedRightButtons = useMemo\([\s\S]*?\n {2}\}, \[/)?.[0] ?? "";
+      expect(left).toContain("orderToolbarButtonsByGroup(");
+      expect(right).toContain("orderToolbarButtonsByGroup(");
+    });
+
+    it("the overflow engine is told what a group boundary costs", () => {
+      expect(source).toMatch(/useToolbarOverflow\([\s\S]*?pinnedIds,\s*resolveToolbarGroup\s*\)/);
+    });
+  });
+});

--- a/src/components/Layout/__tests__/Toolbar.strip.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.strip.test.ts
@@ -141,6 +141,15 @@ describe("Toolbar strip — composition invariants", () => {
       expect(source.match(/className=\{toolbarFixedDividerClass\}/g)).toHaveLength(2);
     });
 
+    it("an empty overflow trigger leaves no wrapper behind to own a gap", () => {
+      // The trigger is display:none when nothing is hidden; a wrapper around
+      // it would still be a zero-width flex item costing gap-1.5.
+      expect(source).not.toMatch(/<div className="app-no-drag">\s*\{renderOverflowMenu\(/);
+      expect(source).toMatch(
+        /data-toolbar-overflow-trigger=""[\s\S]{0,600}?className=\{cn\(toolbarIconButtonClass, "app-no-drag"\)\}/
+      );
+    });
+
     it("a collapsed platform spacer folds its flex gap away too", () => {
       // Both spacers: a w-0 item still owns a gap on each side of it.
       const collapsed =

--- a/src/components/Layout/__tests__/useOverflowBadgeSeverity.test.ts
+++ b/src/components/Layout/__tests__/useOverflowBadgeSeverity.test.ts
@@ -68,7 +68,10 @@ vi.mock("@/utils/terminalType", () => ({
   getRuntimeOrBootAgentId: (panel: { agentId?: string }) => panel?.agentId,
 }));
 
-import { useOverflowBadgeSeverity } from "../useOverflowBadgeSeverity";
+import {
+  useOverflowAgentObservations,
+  useOverflowBadgeSeverity,
+} from "../useOverflowBadgeSeverity";
 
 function makePanel(overrides: {
   id: string;
@@ -294,5 +297,45 @@ describe("useOverflowBadgeSeverity", () => {
     );
     expect(left.current).toBe("warning");
     expect(right.current).toBe("info");
+  });
+});
+
+describe("useOverflowAgentObservations — per session, like the badge", () => {
+  beforeEach(() => {
+    mockPanelsById = {};
+    mockPanelIds = [];
+    mockActiveWorktreeId = "wt";
+  });
+
+  it("reports the waiting session even when a sibling of the same agent is working", () => {
+    mockPanelsById = {
+      a: makePanel({ id: "a", agentId: "claude", agentState: "working", worktreeId: "wt" }),
+      b: makePanel({ id: "b", agentId: "claude", agentState: "waiting", worktreeId: "wt" }),
+    };
+    mockPanelIds = ["a", "b"];
+    const { result } = renderHook(() => useOverflowAgentObservations(["claude"]));
+    expect(result.current).toEqual(["1 agent waiting"]);
+    // And it agrees with the badge.
+    const severity = renderHook(() => useOverflowBadgeSeverity(["claude"], 0));
+    expect(severity.result.current).toBe("warning");
+  });
+
+  it("counts sessions, not agent types", () => {
+    mockPanelsById = {
+      a: makePanel({ id: "a", agentId: "claude", agentState: "waiting", worktreeId: "wt" }),
+      b: makePanel({ id: "b", agentId: "claude", agentState: "waiting", worktreeId: "wt" }),
+    };
+    mockPanelIds = ["a", "b"];
+    const { result } = renderHook(() => useOverflowAgentObservations(["claude"]));
+    expect(result.current).toEqual(["2 agents waiting"]);
+  });
+
+  it("says nothing for an agent that is not overflowed", () => {
+    mockPanelsById = {
+      a: makePanel({ id: "a", agentId: "claude", agentState: "waiting", worktreeId: "wt" }),
+    };
+    mockPanelIds = ["a"];
+    const { result } = renderHook(() => useOverflowAgentObservations(["settings"]));
+    expect(result.current).toEqual([]);
   });
 });

--- a/src/components/Layout/useOverflowBadgeSeverity.ts
+++ b/src/components/Layout/useOverflowBadgeSeverity.ts
@@ -7,17 +7,77 @@ import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
 import { useAgentDiscoveryOnboarding } from "@/hooks/app/useAgentDiscoveryOnboarding";
 import { agentStateDotColor } from "@/components/Worktree/AgentStatusIndicator";
 import { getRuntimeOrBootAgentId } from "@/utils/terminalType";
-import {
-  LAUNCHABLE_AGENT_IDS,
-  isBuiltInAgentId,
-  type BuiltInAgentId,
-} from "@shared/config/agentIds";
-import type { AgentState } from "@shared/types";
+import { LAUNCHABLE_AGENT_IDS, isBuiltInAgentId } from "@shared/config/agentIds";
+import type { AgentState, PanelInstance } from "@shared/types";
 import { isAgentLaunchable } from "../../../shared/utils/agentAvailability";
 import { isPtyPanel } from "@shared/types/panel";
 import type { AnyToolbarButtonId } from "@/../../shared/types/toolbar";
 
 export type OverflowBadgeSeverity = "critical" | "warning" | "info" | null;
+
+/**
+ * Sessions of overflowed agents whose state carries a dot, counted per state.
+ * Per PANEL, never per agent type: a `working` session must not hide a
+ * sibling `waiting` one — that is exactly what the badge exists to surface,
+ * and the trigger's accessible name has to agree with the badge.
+ */
+export function countOverflowAgentStates(
+  panelsById: Record<string, PanelInstance>,
+  panelIds: readonly string[],
+  activeWorktreeId: string | null,
+  overflowIds: readonly AnyToolbarButtonId[]
+): Map<AgentState, number> {
+  const counts = new Map<AgentState, number>();
+  const overflowedAgentSet = new Set<string>();
+  for (const id of overflowIds) {
+    if (isBuiltInAgentId(id)) overflowedAgentSet.add(id);
+  }
+  if (overflowedAgentSet.size === 0) return counts;
+  for (const pid of panelIds) {
+    const p = panelsById[pid];
+    if (
+      !p ||
+      !isPtyPanel(p) ||
+      p.location === "trash" ||
+      p.location === "background" ||
+      p.location === "overlay"
+    )
+      continue;
+    const agentId = getRuntimeOrBootAgentId(p);
+    if (!agentId || !overflowedAgentSet.has(agentId)) continue;
+    if (activeWorktreeId && p.worktreeId !== activeWorktreeId) continue;
+    if (!ACTIVE_AGENT_STATES.has(p.agentState)) continue;
+    if (!p.agentState || !agentStateDotColor(p.agentState)) continue;
+    counts.set(p.agentState, (counts.get(p.agentState) ?? 0) + 1);
+  }
+  return counts;
+}
+
+/** `["1 agent waiting", "2 agents directing"]` — the words behind the badge. */
+export function formatAgentObservations(counts: ReadonlyMap<AgentState, number>): string[] {
+  const out: string[] = [];
+  for (const [state, count] of counts) {
+    out.push(`${count} ${count === 1 ? "agent" : "agents"} ${state}`);
+  }
+  return out;
+}
+
+/**
+ * The agent half of the overflow trigger's observations, from the same
+ * sessions `useOverflowBadgeSeverity` derives its warning from.
+ */
+export function useOverflowAgentObservations(overflowIds: readonly AnyToolbarButtonId[]): string[] {
+  const panelsById = usePanelStore(useShallow((s) => s.panelsById));
+  const panelIds = usePanelStore(useShallow((s) => s.panelIds));
+  const activeWorktreeId = useWorktreeSelectionStore((s) => s.activeWorktreeId);
+  return useMemo(
+    () =>
+      formatAgentObservations(
+        countOverflowAgentStates(panelsById, panelIds, activeWorktreeId, overflowIds)
+      ),
+    [panelsById, panelIds, activeWorktreeId, overflowIds]
+  );
+}
 
 const ACTIVE_AGENT_STATES: ReadonlySet<AgentState | undefined> = new Set<AgentState | undefined>([
   "idle",
@@ -64,36 +124,12 @@ export function useOverflowBadgeSeverity(
       critical = true;
     }
 
-    const overflowedAgentIds: BuiltInAgentId[] = [];
-    for (const id of overflowIds) {
-      if (isBuiltInAgentId(id)) overflowedAgentIds.push(id);
-    }
-    if (overflowedAgentIds.length > 0) {
-      const overflowedAgentSet = new Set<string>(overflowedAgentIds);
-      // Check each panel independently rather than folding to a dominant
-      // state — `getDominantAgentState` would let a `working` panel
-      // suppress a sibling `waiting`/`directing` panel for the same
-      // agent, which is exactly the silenced-state the overflow dot is
-      // meant to surface.
-      for (const pid of panelIds) {
-        const p = panelsById[pid];
-        if (
-          !p ||
-          !isPtyPanel(p) ||
-          p.location === "trash" ||
-          p.location === "background" ||
-          p.location === "overlay"
-        )
-          continue;
-        const agentId = getRuntimeOrBootAgentId(p);
-        if (!agentId || !overflowedAgentSet.has(agentId)) continue;
-        if (activeWorktreeId && p.worktreeId !== activeWorktreeId) continue;
-        if (!ACTIVE_AGENT_STATES.has(p.agentState)) continue;
-        if (p.agentState && agentStateDotColor(p.agentState)) {
-          warning = true;
-          break;
-        }
-      }
+    // Each panel independently rather than folded to a dominant state —
+    // `getDominantAgentState` would let a `working` panel suppress a sibling
+    // `waiting`/`directing` panel for the same agent, which is exactly the
+    // silenced state the overflow dot is meant to surface.
+    if (countOverflowAgentStates(panelsById, panelIds, activeWorktreeId, overflowIds).size > 0) {
+      warning = true;
     }
 
     if (overflowIds.includes("notification-center") && notificationUnreadCount > 0) {

--- a/src/hooks/__tests__/useToolbarOverflow.test.ts
+++ b/src/hooks/__tests__/useToolbarOverflow.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect } from "vitest";
 import { computeOverflow, computeGuardedOverflow } from "../useToolbarOverflow";
 import type { OverflowResult } from "../useToolbarOverflow";
-import type { ToolbarButtonId, ToolbarButtonPriority } from "@shared/types/toolbar";
+import type {
+  AnyToolbarButtonId,
+  ToolbarButtonId,
+  ToolbarButtonPriority,
+} from "@shared/types/toolbar";
 import { TOOLBAR_BUTTON_PRIORITIES } from "@shared/types/toolbar";
 
 function makeWidths(ids: ToolbarButtonId[], width = 36): Map<string, number> {
@@ -444,5 +448,92 @@ describe("computeGuardedOverflow", () => {
       previous
     );
     expect(release).not.toBe(previous);
+  });
+});
+
+describe("computeOverflow — layout chrome (gaps and dividers)", () => {
+  // Widths chosen so the buttons alone fit but the row they actually form
+  // does not: this is the shape that clipped the last button silently.
+  const ids: ToolbarButtonId[] = ["launcher", "claude", "terminal", "browser"];
+  const groupOf = (id: AnyToolbarButtonId) =>
+    id === "launcher" ? "launcher" : id === "claude" ? "agents" : "panels";
+
+  function realFootprint(
+    visible: AnyToolbarButtonId[],
+    widths: Map<string, number>,
+    layout: { gap: number; dividerWidth: number }
+  ): number {
+    let total = 0;
+    for (let i = 0; i < visible.length; i++) {
+      total += widths.get(visible[i]!)!;
+      if (i === 0) continue;
+      total += layout.gap;
+      if (groupOf(visible[i - 1]!) !== groupOf(visible[i]!))
+        total += layout.dividerWidth + layout.gap;
+    }
+    return total;
+  }
+
+  it("evicts when the items fit but the items plus their gaps and dividers do not", () => {
+    const widths = makeWidths(ids, 30); // 120 of buttons
+    const layout = { gap: 2, dividerWidth: 9, resolveGroup: groupOf };
+    // 120 + 3 gaps (6) + 2 boundaries (2 × 11) = 148
+    const withoutChrome = computeOverflow(140, widths, ids, TOOLBAR_BUTTON_PRIORITIES);
+    const withChrome = computeOverflow(
+      140,
+      widths,
+      ids,
+      TOOLBAR_BUTTON_PRIORITIES,
+      undefined,
+      layout
+    );
+    expect(withoutChrome.overflowIds).toEqual([]);
+    expect(withChrome.overflowIds.length).toBeGreaterThan(0);
+  });
+
+  it("never leaves a visible set whose real footprint exceeds the container", () => {
+    const widths = makeWidths(ids, 30);
+    const layout = { gap: 2, dividerWidth: 9, resolveGroup: groupOf };
+    for (let container = 20; container <= 160; container += 1) {
+      const { visibleIds } = computeOverflow(
+        container,
+        widths,
+        ids,
+        TOOLBAR_BUTTON_PRIORITIES,
+        undefined,
+        layout
+      );
+      if (visibleIds.length === 0) continue;
+      expect(realFootprint(visibleIds, widths, layout)).toBeLessThanOrEqual(container);
+    }
+  });
+
+  it("credits a divider back when evicting the last button of its group", () => {
+    // launcher | claude | terminal browser — evicting `terminal` alone frees
+    // nothing but its width; evicting both panels also frees their divider.
+    const widths = makeWidths(ids, 30);
+    const layout = { gap: 2, dividerWidth: 9, resolveGroup: groupOf };
+    // launcher + claude = 30 + 2 + 11 + 30 = 73 fits in 80 only because the
+    // panels' boundary divider went with them.
+    const { visibleIds, overflowIds } = computeOverflow(
+      80,
+      widths,
+      ids,
+      TOOLBAR_BUTTON_PRIORITIES,
+      undefined,
+      layout
+    );
+    expect(visibleIds).toEqual(["launcher", "claude"]);
+    expect(overflowIds).toEqual(["terminal", "browser"]);
+  });
+
+  it("is unchanged by a zero layout", () => {
+    const widths = makeWidths(ids, 36);
+    const plain = computeOverflow(100, widths, ids, TOOLBAR_BUTTON_PRIORITIES);
+    const zero = computeOverflow(100, widths, ids, TOOLBAR_BUTTON_PRIORITIES, undefined, {
+      gap: 0,
+      dividerWidth: 0,
+    });
+    expect(zero).toEqual(plain);
   });
 });

--- a/src/hooks/__tests__/useToolbarOverflow.test.ts
+++ b/src/hooks/__tests__/useToolbarOverflow.test.ts
@@ -104,9 +104,7 @@ describe("computeOverflow", () => {
     // broken. This asserts the resulting order, not the constant itself.
     const ordered: ToolbarButtonId[] = ["terminal", "browser", "file-browser", "dev-server"];
     const widths = makeWidths(ordered, 40);
-    // Total 160 in a 130 container. The removal loop stops only once the running
-    // width is *strictly* under target, so the container needs real slack past
-    // the three survivors (120) — at exactly 120 it evicts a second button.
+    // Total 160 in a 130 container: the three survivors (120) fit with slack.
     const result = computeOverflow(130, widths, ordered, TOOLBAR_BUTTON_PRIORITIES);
     expect(result.overflowIds).toEqual(["dev-server"]);
     expect(result.visibleIds).toContain("file-browser");
@@ -611,5 +609,122 @@ describe("dividerFootprint", () => {
 
   it("is null for a divider squeezed to nothing — margins alone are not a divider", () => {
     expect(dividerFootprint({ width: 0, marginLeft: 4, marginRight: 4 })).toBeNull();
+  });
+});
+
+describe("computeOverflow — post-eviction boundary", () => {
+  const ordered: ToolbarButtonId[] = ["terminal", "browser", "file-browser", "dev-server"];
+  const widths = makeWidths(ordered, 40);
+
+  it("keeps a set that fits exactly after eviction", () => {
+    expect(computeOverflow(120, widths, ordered, TOOLBAR_BUTTON_PRIORITIES).visibleIds).toEqual([
+      "terminal",
+      "browser",
+      "file-browser",
+    ]);
+  });
+
+  it("evicts one more the pixel below", () => {
+    expect(computeOverflow(119, widths, ordered, TOOLBAR_BUTTON_PRIORITIES).visibleIds).toEqual([
+      "terminal",
+      "browser",
+    ]);
+  });
+});
+
+describe("computeOverflow — backfill across a group boundary", () => {
+  // terminal (panels) | forge-stats (utilities) notification-center (utilities)
+  const ordered: ToolbarButtonId[] = ["terminal", "forge-stats", "notification-center"];
+  const widths = new Map<string, number>([
+    ["terminal", 32],
+    ["forge-stats", 130],
+    ["notification-center", 32],
+  ]);
+  const layout = {
+    gap: 2,
+    dividerWidth: 9,
+    resolveGroup: (id: AnyToolbarButtonId) => (id === "terminal" ? "panels" : "utilities"),
+  };
+  // After the pill is evicted, terminal + notification-center still straddle
+  // the boundary: 32 + 2 + (9 + 2) + 32 = 77.
+  it("keeps the boundary divider in the backfilled footprint", () => {
+    expect(
+      computeOverflow(77, widths, ordered, TOOLBAR_BUTTON_PRIORITIES, undefined, layout).visibleIds
+    ).toEqual(["terminal", "notification-center"]);
+    expect(
+      computeOverflow(76, widths, ordered, TOOLBAR_BUTTON_PRIORITIES, undefined, layout).visibleIds
+    ).toEqual(["terminal"]);
+  });
+});
+
+describe("computeGuardedOverflow — restoring a wide item after a backfill", () => {
+  // forge-stats (130, priority 1) plus three 32px utilities, gap 2.
+  const ids: ToolbarButtonId[] = ["forge-stats", "notification-center", "settings", "problems"];
+  const widths = new Map<string, number>([
+    ["forge-stats", 130],
+    ["notification-center", 32],
+    ["settings", 32],
+    ["problems", 32],
+  ]);
+  const layout = { gap: 2, dividerWidth: 0 };
+
+  it("does not wait for the whole row to fit before restoring the pill", () => {
+    // 138: the pill alone fits. The trigger appears and shrinks the row to
+    // 100 (shrinking → fresh): the pill goes, three utilities backfill.
+    const at138 = computeGuardedOverflow(
+      138,
+      widths,
+      ids,
+      TOOLBAR_BUTTON_PRIORITIES,
+      0,
+      null,
+      undefined,
+      layout
+    );
+    expect(at138.visibleIds).toEqual(["forge-stats"]);
+    const at100 = computeGuardedOverflow(
+      100,
+      widths,
+      ids,
+      TOOLBAR_BUTTON_PRIORITIES,
+      138,
+      at138,
+      undefined,
+      layout
+    );
+    expect(at100.visibleIds).toEqual(["notification-center", "settings", "problems"]);
+    // Growing to 150: fresh restores the pill (130) by evicting the 100px of
+    // utilities — 30px of real growth, well past the 16px buffer. The old gate
+    // wanted 100 + 130 + 2 + 16 = 248.
+    const at150 = computeGuardedOverflow(
+      150,
+      widths,
+      ids,
+      TOOLBAR_BUTTON_PRIORITIES,
+      100,
+      at100,
+      undefined,
+      layout
+    );
+    expect(at150.visibleIds).toEqual(["forge-stats"]);
+  });
+
+  it("still holds the previous result inside the buffer", () => {
+    const held = {
+      visibleIds: ["notification-center", "settings", "problems"],
+      overflowIds: ["forge-stats"],
+    } as OverflowResult;
+    // 140: growth needed is 30 → threshold 100 + 30 + 16 = 146 > 140.
+    const at140 = computeGuardedOverflow(
+      140,
+      widths,
+      ids,
+      TOOLBAR_BUTTON_PRIORITIES,
+      100,
+      held,
+      undefined,
+      layout
+    );
+    expect(at140).toBe(held);
   });
 });

--- a/src/hooks/__tests__/useToolbarOverflow.test.ts
+++ b/src/hooks/__tests__/useToolbarOverflow.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { computeOverflow, computeGuardedOverflow } from "../useToolbarOverflow";
+import { computeOverflow, computeGuardedOverflow, dividerFootprint } from "../useToolbarOverflow";
 import type { OverflowResult } from "../useToolbarOverflow";
 import type {
   AnyToolbarButtonId,
@@ -535,5 +535,81 @@ describe("computeOverflow — layout chrome (gaps and dividers)", () => {
       dividerWidth: 0,
     });
     expect(zero).toEqual(plain);
+  });
+});
+
+describe("computeOverflow — backfill after an oversized eviction", () => {
+  // forge-stats is priority 1 and four buttons wide; the utilities are 5.
+  const ids: ToolbarButtonId[] = ["forge-stats", "notification-center", "settings", "problems"];
+
+  it("refills the room a wide eviction leaves with narrower lower-priority buttons", () => {
+    const widths = new Map<string, number>([
+      ["forge-stats", 130],
+      ["notification-center", 32],
+      ["settings", 32],
+      ["problems", 32],
+    ]);
+    // 226 in 100: the utilities go first (226→194→162→130), then the pill
+    // (130 > 100) — leaving 100px with nothing in it. Three 32s fit in 96.
+    const { visibleIds, overflowIds } = computeOverflow(
+      100,
+      widths,
+      ids,
+      TOOLBAR_BUTTON_PRIORITIES
+    );
+    expect(overflowIds).toEqual(["forge-stats"]);
+    expect(visibleIds).toEqual(["notification-center", "settings", "problems"]);
+  });
+
+  it("backfills in row order within a tier and skips what still does not fit", () => {
+    const widths = new Map<string, number>([
+      ["forge-stats", 130],
+      ["notification-center", 32],
+      ["settings", 60],
+      ["problems", 32],
+    ]);
+    // 70px: notification-center (32) fits; settings (60) would not alongside
+    // it and is skipped rather than ending the pass; problems (32) then fits.
+    const { visibleIds } = computeOverflow(70, widths, ids, TOOLBAR_BUTTON_PRIORITIES, undefined, {
+      gap: 2,
+      dividerWidth: 0,
+    });
+    expect(visibleIds).toEqual(["notification-center", "problems"]);
+  });
+
+  it("never backfills past the container, gaps and dividers included", () => {
+    const widths = new Map<string, number>([
+      ["forge-stats", 130],
+      ["notification-center", 32],
+      ["settings", 32],
+      ["problems", 32],
+    ]);
+    const layout = { gap: 2, dividerWidth: 9 };
+    for (let container = 30; container <= 240; container += 1) {
+      const { visibleIds } = computeOverflow(
+        container,
+        widths,
+        ids,
+        TOOLBAR_BUTTON_PRIORITIES,
+        undefined,
+        layout
+      );
+      let total = 0;
+      visibleIds.forEach((id, i) => {
+        total += widths.get(id)!;
+        if (i > 0) total += layout.gap;
+      });
+      expect(total).toBeLessThanOrEqual(container);
+    }
+  });
+});
+
+describe("dividerFootprint", () => {
+  it("is the box plus its margins", () => {
+    expect(dividerFootprint({ width: 1, marginLeft: 4, marginRight: 4 })).toBe(9);
+  });
+
+  it("is null for a divider squeezed to nothing — margins alone are not a divider", () => {
+    expect(dividerFootprint({ width: 0, marginLeft: 4, marginRight: 4 })).toBeNull();
   });
 });

--- a/src/hooks/useToolbarOverflow.ts
+++ b/src/hooks/useToolbarOverflow.ts
@@ -2,17 +2,55 @@ import { useState, useRef, useLayoutEffect, useCallback } from "react";
 import type { ToolbarButtonPriority, AnyToolbarButtonId } from "@shared/types/toolbar";
 import { TOOLBAR_BUTTON_PRIORITIES } from "@shared/types/toolbar";
 
-const OVERFLOW_TRIGGER_WIDTH = 0;
 // Restore is intentionally harder than remove: once an item is hidden, the
 // container must grow past its width plus this buffer before we surface it
 // again. Asymmetry kills the boundary flip-flop that symmetric thresholds
 // produce when clientWidth jitters by 1px at fractional zoom.
 const RESTORE_HYSTERESIS_BUFFER = 16;
 const DEFAULT_ITEM_WIDTH = 36;
+// `toolbar-divider w-px h-5 mx-1` until a real one has been measured.
+const DEFAULT_DIVIDER_WIDTH = 9;
 
 export interface OverflowResult {
   visibleIds: AnyToolbarButtonId[];
   overflowIds: AnyToolbarButtonId[];
+}
+
+/**
+ * What the row spends between items, on top of the items themselves. The
+ * buttons are laid out with a flex gap, and a divider — itself a flex child,
+ * so it costs a second gap — sits at every group boundary of the VISIBLE
+ * sequence. Budgeting the item widths alone under-counts the row by the sum
+ * of these, and at small deficits that under-count is the whole deficit: the
+ * engine decides everything fits, the row's overflow-hidden clips the last
+ * button, and no `…` trigger appears to say where it went.
+ */
+export interface OverflowLayout {
+  gap: number;
+  dividerWidth: number;
+  resolveGroup?: (id: AnyToolbarButtonId) => string;
+}
+
+const NO_LAYOUT: OverflowLayout = { gap: 0, dividerWidth: 0 };
+
+function footprint(
+  visible: readonly AnyToolbarButtonId[],
+  itemWidths: Map<string, number>,
+  layout: OverflowLayout
+): number {
+  let total = 0;
+  for (let i = 0; i < visible.length; i++) {
+    total += itemWidths.get(visible[i]!) ?? DEFAULT_ITEM_WIDTH;
+    if (i === 0) continue;
+    total += layout.gap;
+    if (
+      layout.resolveGroup &&
+      layout.resolveGroup(visible[i - 1]!) !== layout.resolveGroup(visible[i]!)
+    ) {
+      total += layout.dividerWidth + layout.gap;
+    }
+  }
+  return total;
 }
 
 /**
@@ -33,31 +71,19 @@ export function computeOverflow(
   itemWidths: Map<string, number>,
   orderedIds: AnyToolbarButtonId[],
   priorities: Record<string, ToolbarButtonPriority>,
-  pinnedIds?: ReadonlySet<AnyToolbarButtonId>
+  pinnedIds?: ReadonlySet<AnyToolbarButtonId>,
+  layout: OverflowLayout = NO_LAYOUT
 ): OverflowResult {
   if (orderedIds.length === 0) {
     return { visibleIds: [], overflowIds: [] };
   }
 
   const hasPinned = pinnedIds !== undefined && pinnedIds.size > 0;
+  // Pinned items are never removed, but they still take real DOM space: the
+  // footprint below counts them, so removable items absorb all the pressure.
   const removableIds = hasPinned ? orderedIds.filter((id) => !pinnedIds.has(id)) : orderedIds;
-  // Pinned items still take real DOM space, so they reduce the room available
-  // for removable items. Only count widths for IDs actually present in this
-  // side's order — pinned IDs that don't apply here contribute nothing.
-  const pinnedWidth = hasPinned
-    ? orderedIds.reduce(
-        (sum, id) => (pinnedIds.has(id) ? sum + (itemWidths.get(id) ?? DEFAULT_ITEM_WIDTH) : sum),
-        0
-      )
-    : 0;
-  const availableWidth = containerWidth - pinnedWidth;
 
-  const removableWidth = removableIds.reduce(
-    (sum, id) => sum + (itemWidths.get(id) ?? DEFAULT_ITEM_WIDTH),
-    0
-  );
-
-  if (removableWidth <= availableWidth) {
+  if (footprint(orderedIds, itemWidths, layout) <= containerWidth) {
     return { visibleIds: [...orderedIds], overflowIds: [] };
   }
 
@@ -72,17 +98,21 @@ export function computeOverflow(
       return b.index - a.index;
     });
 
+  // The `…` trigger costs nothing here: it is the row's sibling, not its
+  // child, so its appearance shrinks the row, the ResizeObserver reports the
+  // new width, and the next pass budgets against it — hysteresis keeps that
+  // second pass from oscillating.
   const overflowSet = new Set<AnyToolbarButtonId>();
-  let currentWidth = removableWidth;
-  const targetWidth = availableWidth - OVERFLOW_TRIGGER_WIDTH;
+  let visibleIds = [...orderedIds];
 
   for (const item of sortedForRemoval) {
-    if (currentWidth < targetWidth) break;
+    // Re-measured after every eviction rather than decremented: removing a
+    // button can also remove a divider, when it was the last of its group.
+    if (footprint(visibleIds, itemWidths, layout) <= containerWidth) break;
     overflowSet.add(item.id);
-    currentWidth -= itemWidths.get(item.id) ?? DEFAULT_ITEM_WIDTH;
+    visibleIds = visibleIds.filter((id) => id !== item.id);
   }
 
-  const visibleIds = orderedIds.filter((id) => !overflowSet.has(id));
   const overflowIds = orderedIds.filter((id) => overflowSet.has(id));
 
   return { visibleIds, overflowIds };
@@ -110,9 +140,17 @@ export function computeGuardedOverflow(
   priorities: Record<string, ToolbarButtonPriority>,
   previousWidth: number,
   previousResult: OverflowResult | null,
-  pinnedIds?: ReadonlySet<AnyToolbarButtonId>
+  pinnedIds?: ReadonlySet<AnyToolbarButtonId>,
+  layout: OverflowLayout = NO_LAYOUT
 ): OverflowResult {
-  const fresh = computeOverflow(containerWidth, itemWidths, orderedIds, priorities, pinnedIds);
+  const fresh = computeOverflow(
+    containerWidth,
+    itemWidths,
+    orderedIds,
+    priorities,
+    pinnedIds,
+    layout
+  );
 
   if (previousResult === null || previousResult.overflowIds.length === 0) {
     return fresh;
@@ -140,7 +178,9 @@ export function computeGuardedOverflow(
     return w < min ? w : min;
   }, Number.POSITIVE_INFINITY);
 
-  const restoreThreshold = previousWidth + smallestOverflowedItemWidth + RESTORE_HYSTERESIS_BUFFER;
+  // Restoring an item also restores the gap in front of it.
+  const restoreThreshold =
+    previousWidth + smallestOverflowedItemWidth + layout.gap + RESTORE_HYSTERESIS_BUFFER;
 
   if (containerWidth >= restoreThreshold) {
     return fresh;
@@ -158,7 +198,8 @@ export function useToolbarOverflow(
   rightContainerRef: React.RefObject<HTMLDivElement | null>,
   leftIds: AnyToolbarButtonId[],
   rightIds: AnyToolbarButtonId[],
-  pinnedIds?: ReadonlySet<AnyToolbarButtonId>
+  pinnedIds?: ReadonlySet<AnyToolbarButtonId>,
+  resolveGroup?: (id: AnyToolbarButtonId) => string
 ): {
   leftVisible: AnyToolbarButtonId[];
   leftOverflow: AnyToolbarButtonId[];
@@ -191,6 +232,28 @@ export function useToolbarOverflow(
   const leftPendingWidthRef = useRef<number>(0);
   const rightPendingWidthRef = useRef<number>(0);
 
+  // Read once a divider exists and kept: a row with no visible group boundary
+  // right now still needs to know what one would cost when eviction changes
+  // the visible sequence.
+  const dividerWidthRef = useRef<number>(DEFAULT_DIVIDER_WIDTH);
+
+  const measureLayout = useCallback(
+    (container: HTMLElement): OverflowLayout => {
+      const gap = parseFloat(getComputedStyle(container).columnGap) || 0;
+      const divider = container.querySelector<HTMLElement>(".toolbar-divider");
+      if (divider) {
+        const style = getComputedStyle(divider);
+        const width =
+          divider.getBoundingClientRect().width +
+          (parseFloat(style.marginLeft) || 0) +
+          (parseFloat(style.marginRight) || 0);
+        if (width > 0) dividerWidthRef.current = width;
+      }
+      return { gap, dividerWidth: dividerWidthRef.current, resolveGroup };
+    },
+    [resolveGroup]
+  );
+
   const measureItems = useCallback((container: HTMLElement, widthsCache: Map<string, number>) => {
     const elements = container.querySelectorAll<HTMLElement>("[data-toolbar-button-id]");
     for (const el of elements) {
@@ -221,7 +284,8 @@ export function useToolbarOverflow(
         TOOLBAR_BUTTON_PRIORITIES,
         leftPrevWidthRef.current,
         leftPrevResultRef.current,
-        pinnedIds
+        pinnedIds,
+        measureLayout(leftContainer)
       );
       // Ref writes inside the updater are safe under concurrent rendering:
       // `containerWidth` and `result` are captured in the enclosing closure,
@@ -251,7 +315,8 @@ export function useToolbarOverflow(
         TOOLBAR_BUTTON_PRIORITIES,
         rightPrevWidthRef.current,
         rightPrevResultRef.current,
-        pinnedIds
+        pinnedIds,
+        measureLayout(rightContainer)
       );
       setRightResult((prev) => {
         if (
@@ -265,7 +330,15 @@ export function useToolbarOverflow(
         return result;
       });
     }
-  }, [leftContainerRef, rightContainerRef, leftIds, rightIds, pinnedIds, measureItems]);
+  }, [
+    leftContainerRef,
+    rightContainerRef,
+    leftIds,
+    rightIds,
+    pinnedIds,
+    measureItems,
+    measureLayout,
+  ]);
 
   useLayoutEffect(() => {
     const leftContainer = leftContainerRef.current;

--- a/src/hooks/useToolbarOverflow.ts
+++ b/src/hooks/useToolbarOverflow.ts
@@ -33,6 +33,20 @@ export interface OverflowLayout {
 
 const NO_LAYOUT: OverflowLayout = { gap: 0, dividerWidth: 0 };
 
+/**
+ * What a divider costs the row, from its measured box. `null` for a divider
+ * that has been squeezed to nothing — its margins alone would otherwise pass
+ * a positive-width check and teach the budget a divider is 8px wide.
+ */
+export function dividerFootprint(box: {
+  width: number;
+  marginLeft: number;
+  marginRight: number;
+}): number | null {
+  if (!(box.width > 0)) return null;
+  return box.width + box.marginLeft + box.marginRight;
+}
+
 function footprint(
   visible: readonly AnyToolbarButtonId[],
   itemWidths: Map<string, number>,
@@ -111,6 +125,22 @@ export function computeOverflow(
     if (footprint(visibleIds, itemWidths, layout) <= containerWidth) break;
     overflowSet.add(item.id);
     visibleIds = visibleIds.filter((id) => id !== item.id);
+  }
+
+  // Backfill. Evicting a wide item — the forge pill is four buttons across —
+  // can leave room that several narrower, lower-priority buttons would fill,
+  // and without this pass that room sat empty while those commands hid
+  // behind the trigger. Candidates are tried highest priority first, earlier
+  // in the row first within a tier, each against the full ordered footprint;
+  // one that still does not fit is skipped, not a stopping point.
+  for (let i = sortedForRemoval.length - 1; i >= 0; i--) {
+    const item = sortedForRemoval[i]!;
+    if (!overflowSet.has(item.id)) continue;
+    const candidate = orderedIds.filter((id) => !overflowSet.has(id) || id === item.id);
+    if (footprint(candidate, itemWidths, layout) <= containerWidth) {
+      overflowSet.delete(item.id);
+      visibleIds = candidate;
+    }
   }
 
   const overflowIds = orderedIds.filter((id) => overflowSet.has(id));
@@ -243,11 +273,12 @@ export function useToolbarOverflow(
       const divider = container.querySelector<HTMLElement>(".toolbar-divider");
       if (divider) {
         const style = getComputedStyle(divider);
-        const width =
-          divider.getBoundingClientRect().width +
-          (parseFloat(style.marginLeft) || 0) +
-          (parseFloat(style.marginRight) || 0);
-        if (width > 0) dividerWidthRef.current = width;
+        const width = dividerFootprint({
+          width: divider.getBoundingClientRect().width,
+          marginLeft: parseFloat(style.marginLeft) || 0,
+          marginRight: parseFloat(style.marginRight) || 0,
+        });
+        if (width !== null) dividerWidthRef.current = width;
       }
       return { gap, dividerWidth: dividerWidthRef.current, resolveGroup };
     },

--- a/src/hooks/useToolbarOverflow.ts
+++ b/src/hooks/useToolbarOverflow.ts
@@ -209,8 +209,21 @@ export function computeGuardedOverflow(
   }, Number.POSITIVE_INFINITY);
 
   // Restoring an item also restores the gap in front of it.
+  // What accepting the fresh result actually costs in width. After a backfill
+  // the only item still hidden can be the widest one — the forge pill — and
+  // restoring it evicts the narrower buttons that took its place, so the row
+  // needs far less than "the smallest hidden width" more room. Gate on
+  // whichever is smaller: the classic one-item restore, or the real footprint
+  // growth from the held result to the fresh one.
+  const footprintGrowth = Math.max(
+    0,
+    footprint(fresh.visibleIds, itemWidths, layout) -
+      footprint(previousResult.visibleIds, itemWidths, layout)
+  );
   const restoreThreshold =
-    previousWidth + smallestOverflowedItemWidth + layout.gap + RESTORE_HYSTERESIS_BUFFER;
+    previousWidth +
+    Math.min(smallestOverflowedItemWidth + layout.gap, footprintGrowth) +
+    RESTORE_HYSTERESIS_BUFFER;
 
   if (containerWidth >= restoreThreshold) {
     return fresh;

--- a/src/hooks/useToolbarOverflow.ts
+++ b/src/hooks/useToolbarOverflow.ts
@@ -74,11 +74,10 @@ function footprint(
  * Items are removed lowest-priority-first (highest number). Within the same
  * priority, items later in the array are removed first.
  *
- * `pinnedIds` are immune to overflow — they always land in `visibleIds` and
- * their widths are excluded from the budget calculation, so non-pinned items
- * absorb all width pressure. Used for hardware-privacy indicators (e.g. an
- * active mic recording) where presence must remain stable regardless of
- * container width.
+ * `pinnedIds` are immune to removal — they always land in `visibleIds` — but
+ * their widths still count against the budget, so non-pinned items absorb all
+ * width pressure. Used for hardware-privacy indicators (e.g. an active mic
+ * recording) where presence must remain stable regardless of container width.
  */
 export function computeOverflow(
   containerWidth: number,

--- a/src/styles/components/toolbar.css
+++ b/src/styles/components/toolbar.css
@@ -174,6 +174,20 @@
   background: var(--toolbar-divider, var(--theme-border-divider));
 }
 
+/* The two measured button rows. They have to clip: the overflow engine
+ * decides in a rAF after the ResizeObserver fires, and for that one frame a
+ * row that no longer fits would otherwise push into the project pill. But a
+ * bare clip also cuts the keyboard focus ring — the 2px outline sits 2px
+ * outside a button that already fills the row's height, so the ring rendered
+ * as two brackets with its top and bottom missing. The clip margin gives it
+ * exactly that 4px back on every edge, including the row's outer ends where
+ * the first and last button's ring would otherwise lose a side. `clip`
+ * rather than `hidden` so the row never becomes a scroll container. */
+.toolbar-measured-row {
+  overflow: clip;
+  overflow-clip-margin: 4px;
+}
+
 /* Split-button seam: persistent 1px hairline at rest so the chevron half
  * reads as a separate control. The color chain mirrors .toolbar-divider so
  * per-theme --toolbar-divider overrides apply identically. Suppressed when
@@ -609,17 +623,26 @@
 /* ── Forced colors / Windows High Contrast ──
  * Every pip — including the GitHub activity corner chips — paints state via
  * background-color, which the UA forces to Canvas (invisible). Repaint with
- * CanvasText so the dot stays visible. The overflow severity ring (box-shadow)
- * is stripped, but it only carved a background-colored moat to separate the pip
- * from overlapping chrome; against the high-contrast Canvas/CanvasText palette
- * the filled pip already separates cleanly, so no replacement is needed. The
- * per-severity shape tiers (border-radius — not a color property) survive and
- * remain the non-color WCAG 1.4.1 cue. */
+ * CanvasText so the dot stays visible. The rings (box-shadow) are stripped,
+ * and they carved the moat that keeps a dot apart from the glyph under it —
+ * without one, the dots that sit at the button corner land on the glyph's
+ * own CanvasText stroke and fuse with it (the problems dot became a filled
+ * quadrant of its circle). Re-declared as a Canvas outline, per the
+ * design-system rule for badge cut-outs. The corner chips are clipPath
+ * triangles, which an outline cannot follow, so they stay as they are. The
+ * per-severity shape tiers (border-radius — not a color property) survive
+ * and remain the non-color WCAG 1.4.1 cue. */
 @media (forced-colors: active) {
   .toolbar-badge,
   .toolbar-badge-chip,
   .toolbar-overflow-badge,
   .toolbar-problems-badge {
     background-color: CanvasText;
+  }
+
+  .toolbar-badge,
+  .toolbar-overflow-badge,
+  .toolbar-problems-badge {
+    outline: 1px solid Canvas;
   }
 }

--- a/src/styles/components/toolbar.css
+++ b/src/styles/components/toolbar.css
@@ -643,6 +643,14 @@
   .toolbar-badge,
   .toolbar-overflow-badge,
   .toolbar-problems-badge {
-    outline: 1px solid Canvas;
+    outline: 2px solid Canvas;
+  }
+
+  /* The divider paints with background-color, which forced-colors resets to
+   * Canvas — every group boundary vanished and the icon runs read as one
+   * segmented control. CanvasText, like the badges above: a separator is
+   * structure, not disabled text, so not GrayText. */
+  .toolbar-divider {
+    background-color: CanvasText;
   }
 }


### PR DESCRIPTION
## Summary

A pass over the main toolbar strip as a composed whole. The responsive overflow logic wasn't counting the row's width properly: it ignored the gaps between buttons and the group dividers, so at some window widths the last button was cut off with no overflow menu. The budget now uses the real footprint, and a backfill step re-adds narrower buttons after a wide one (the forge pill) is evicted. Keyboard focus was dropped to the page body when a focused button moved into the overflow menu, and the focus ring was clipped by the row container. Both are fixed, along with the right side of the toolbar now following the same grouping and divider rules as the left, and a handful of Windows high contrast issues.

This also lands a Playwright screenshot harness, `e2e/screenshots/toolbar-strip-review.spec.ts`, that captures 19 toolbar states with a JSON sidecar of the DOM geometry beside each PNG. It's opt-in (`DAINTREE_SHOT_THEME`) like the other review specs.

## Changes

- `useToolbarOverflow.ts`: `computeOverflow` takes an `OverflowLayout` (gap, divider width, group resolver) and budgets the visible sequence's real footprint, re-measured after each eviction. A backfill pass re-admits evicted buttons in priority order where the full footprint fits. The restore gate keys off real footprint growth, so a backfilled row doesn't hold the forge pill hidden until the whole row fits.
- `Toolbar.tsx`: the eviction focus redirect fires while the evicted button is still `activeElement` (Chromium only drops it at the next rendering update, after the layout effect). The right side goes through `orderToolbarButtonsByGroup` and one `renderGroupedButtons` with dividers from the visible subsequence. The overflow trigger's name counts hidden items and appends what its badge saw: errors, unread, and agent states counted per session, the same way the badge severity is derived.
- `toolbar.css`: the measured rows use `overflow: clip` with a 4px `overflow-clip-margin` so the focus ring stays whole; badges get a Canvas outline moat and dividers paint `CanvasText` under forced colours. The project pill drops the at-rest `outline-hidden` that forced colours was painting as a second ring.
- Geometry: `pt-1` removed so controls centre in the 48px strip (and on the macOS traffic lights), a `gap-x-3` gutter between the side groups and the pill, fixed dividers without their extra `mx-1`, collapsed platform spacers fold their flex gap, the dev-server ghost is sized to the button, and an empty overflow trigger no longer leaves a wrapper owning a gap.
- Tests: `Toolbar.strip.test.ts` pins the rules above (clip margin at least the ring extent, ghost equals the icon size, both sides grouped, no bare outline suppressor on the pill), plus engine tests for the footprint budget, backfill across a group boundary, and the restore sequence.

Two follow-ups are out of scope here: `ToolbarSettingsTab.tsx` still projects only the left column through grouping, so a right-column drag across groups renders elsewhere in the strip, and the voice-recording placeholder in `VoiceRecordingToolbarButton.tsx` is 36px against 32px buttons, which is why the right row is 4px taller than the left.

## Testing

`npm test`: 2646 test files pass. The three that fail (`PluginDevArtifactWatcher`, `ProjectPluginWatcher`, `scenarioLiveness`) fail identically on an untouched `develop` checkout on this machine (fs watcher timeouts), so they're pre-existing. `npm run check` passes typecheck, all 12 guard checks, the lint ratchet and format; `check:sample-views` regenerates a sample plugin artifact differently from the committed one at baseline too, so that file was left alone. Every new test was mutation-checked by reintroducing its bug. The harness ran against the built app across all 15 themes for the rest, signals and overflow states, and the full 19 states on daintree.

A Codex review of the branch found the restore gate issue after backfill and the per-session agent observation mismatch, both fixed here, plus three harness bugs (sidecar navigation, the Linux user agent override, filtered runs skipping prerequisites) that are also fixed.