### PR TITLE
fix(dnd): make drop targets legible and ghosts read as the panel in hand

### DIFF
--- a/drag-drop-preview.html
+++ b/drag-drop-preview.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="" />
+    <title>Drag ghost and drop placeholder preview</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/components/DragDrop/__preview__/preview.tsx"></script>
+  </body>
+</html>

--- a/e2e/helpers/previewHarness.ts
+++ b/e2e/helpers/previewHarness.ts
@@ -1,0 +1,118 @@
+import { expect, type Locator, type Page } from "@playwright/test";
+import { createServer, searchForWorkspaceRoot, type ViteDevServer } from "vite";
+import { realpathSync } from "fs";
+import path from "path";
+
+/**
+ * Shared plumbing for the standalone `*-preview.html` visual-review harnesses.
+ *
+ * Each of those pages renders one product surface from fixtures against the real
+ * theme tokens and the real `index.css`, served by Vite rather than Electron. The
+ * three things every such spec needs — a dev server on a free port, an inert HMR
+ * client, and a screenshot helper that refuses to write an unverified frame —
+ * are the same every time, so they live here.
+ */
+
+export interface PreviewServer {
+  baseURL: string;
+  close: () => Promise<void>;
+}
+
+/**
+ * `strictPort: false` is load-bearing: the project's own `vite.config.ts` pins
+ * `port: 5173` with `strictPort: true`, and that survives the merge with this
+ * inline config — so beside a running `npm run dev` the harness would die on an
+ * occupied port, surfacing as `element(s) not found` on whichever page load lost
+ * the race. Walking to the next free port lets the capture run beside a live app.
+ */
+export async function startPreviewServer(): Promise<PreviewServer> {
+  // Worktrees symlink `node_modules` to the main checkout, which puts the
+  // fontsource woff2 files outside Vite's default allow list — the page then
+  // renders in a fallback face and every type judgement is wrong. Allow the
+  // real path as well as the workspace root.
+  const fsAllow = [searchForWorkspaceRoot(process.cwd())];
+  try {
+    fsAllow.push(realpathSync(path.join(process.cwd(), "node_modules")));
+  } catch {
+    // no node_modules to resolve — Vite will say so itself
+  }
+  const server: ViteDevServer = await createServer({
+    server: { port: 0, strictPort: false, fs: { allow: fsAllow } },
+    logLevel: "error",
+  });
+  await server.listen();
+  const address = server.httpServer?.address();
+  if (!address || typeof address === "string") throw new Error("vite gave no TCP address");
+  return {
+    baseURL: `http://127.0.0.1:${address.port}`,
+    close: () => server.close(),
+  };
+}
+
+/**
+ * Serve an inert `@vite/client` so no page in a sweep opens an HMR socket.
+ *
+ * A harness that navigates a few dozen times against one dev server goes blank
+ * from roughly the twenty-second load onwards: Chromium throttles repeated
+ * WebSocket handshakes to one host with an escalating delay, each navigation
+ * tears the pending handshake down before it completes, the client eventually
+ * falls into its `SharedWorker` recovery path, and the renderer's dev CSP
+ * (`require-trusted-types-for 'script'`, stamped on every dev HTML entry) refuses
+ * the blob URL. The throw aborts the module graph and `#root` stays empty.
+ *
+ * `updateStyle` is the one export that must NOT be a no-op: in dev every `.css`
+ * import arrives as a JS module that calls it to append a `<style>` tag, so a
+ * stub that drops it photographs raw, unstyled HTML that passes every "is it
+ * mounted" check.
+ */
+export async function stubViteHmrClient(page: Page): Promise<void> {
+  await page.route("**/@vite/client", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "text/javascript",
+      body: [
+        "const noop = () => {};",
+        "export const createHotContext = () => ({ accept: noop, acceptExports: noop, dispose: noop, prune: noop, decline: noop, invalidate: noop, on: noop, off: noop, send: noop, data: {} });",
+        "export const injectQuery = (u) => u;",
+        "const sheets = new Map();",
+        "export function updateStyle(id, content) {",
+        "  let style = sheets.get(id);",
+        "  if (!style) {",
+        "    style = document.createElement('style');",
+        "    style.setAttribute('type', 'text/css');",
+        "    style.setAttribute('data-vite-dev-id', id);",
+        "    style.textContent = content;",
+        "    document.head.appendChild(style);",
+        "    sheets.set(id, style);",
+        "  } else {",
+        "    style.textContent = content;",
+        "  }",
+        "}",
+        "export function removeStyle(id) {",
+        "  const style = sheets.get(id);",
+        "  if (style) { document.head.removeChild(style); sheets.delete(id); }",
+        "}",
+      ].join("\n"),
+    })
+  );
+}
+
+/**
+ * Build a `snap(target, file)` bound to one output directory. It asserts the
+ * target is attached with a real box before writing and throws otherwise, so a
+ * green run can never leave behind a blank picture.
+ */
+export function makeSnap(outDir: string) {
+  return async function snap(target: Locator, file: string): Promise<string> {
+    await expect(target).toBeAttached();
+    const box = await target.boundingBox();
+    if (!box || box.width < 8 || box.height < 8) {
+      throw new Error(
+        `${file}: target has no real box (${JSON.stringify(box)}) — refusing to write`
+      );
+    }
+    const out = path.join(outDir, file);
+    await target.screenshot({ path: out });
+    return out;
+  };
+}

--- a/e2e/screenshots/drag-drop-review.spec.ts
+++ b/e2e/screenshots/drag-drop-review.spec.ts
@@ -31,7 +31,7 @@
  */
 
 import { test, expect, type Locator, type Page } from "@playwright/test";
-import { existsSync, mkdirSync, readdirSync, rmSync } from "fs";
+import { mkdirSync, readdirSync, unlinkSync } from "fs";
 import path from "path";
 import {
   makeSnap,
@@ -43,7 +43,7 @@ import {
 const ENABLED = !!process.env.DAINTREE_SHOT_DRAGDROP;
 
 const OUT_DIR = path.resolve(
-  process.env.DAINTREE_SHOT_DIR ?? path.join(process.cwd(), "artifacts", "drag-drop-shots")
+  process.env.DAINTREE_SHOT_DIR || path.join(process.cwd(), "artifacts", "drag-drop-shots")
 );
 
 const THEMES = (process.env.DAINTREE_SHOT_THEMES ?? "daintree,bondi,namib")
@@ -111,8 +111,19 @@ test.beforeAll(async () => {
   // structured-skip annotation the repo requires cannot be attached. The test
   // body carries the skip; this hook simply does no work when the flag is unset.
   if (!ENABLED) return;
-  if (existsSync(OUT_DIR)) rmSync(OUT_DIR, { recursive: true, force: true });
+  // A stale PNG from an earlier round read as this round's output is the
+  // easiest way to review a screen that no longer exists, so the directory is
+  // emptied of frames first — only frames, never the directory itself: an empty
+  // or relative DAINTREE_SHOT_DIR resolves to the checkout, and a recursive
+  // delete there would be catastrophic.
+  const cwd = process.cwd();
+  if (OUT_DIR === cwd || cwd.startsWith(OUT_DIR + path.sep)) {
+    throw new Error(`DAINTREE_SHOT_DIR resolves to the checkout (${OUT_DIR}) — refusing`);
+  }
   mkdirSync(OUT_DIR, { recursive: true });
+  for (const f of readdirSync(OUT_DIR)) {
+    if (f.endsWith(".png")) unlinkSync(path.join(OUT_DIR, f));
+  }
   server = await startPreviewServer();
 });
 
@@ -169,17 +180,34 @@ async function glide(page: Page, to: { x: number; y: number }): Promise<void> {
 /**
  * A state indicator that compiled to nothing still exists in the DOM, so a
  * structural check would pass while the frame shows no line at all. Read the
- * painted colour and refuse anything transparent.
+ * painted colour and refuse anything transparent; a border also needs width.
  */
 async function expectPainted(target: Locator, property: "background-color" | "border-top-color") {
-  const value = await target.evaluate(
-    (el, prop) => getComputedStyle(el).getPropertyValue(prop),
-    property
-  );
-  const alpha = value.match(/rgba?\([^)]*,\s*([\d.]+)\)$/)?.[1];
-  const transparent = value === "transparent" || value === "rgba(0, 0, 0, 0)" || alpha === "0";
-  if (transparent)
+  const { value, width } = await target.evaluate((el, prop) => {
+    const style = getComputedStyle(el);
+    return { value: style.getPropertyValue(prop), width: style.borderTopWidth };
+  }, property);
+  if (alphaOf(value) === 0) {
     throw new Error(`${property} painted transparent (${value}) — refusing to write`);
+  }
+  if (property === "border-top-color" && !(parseFloat(width) > 0)) {
+    throw new Error(`border-top-width is ${width} — the frame is not drawn`);
+  }
+}
+
+/**
+ * Alpha of a computed colour in either legacy (`rgba(0, 0, 0, 0)`) or modern
+ * (`rgb(0 0 0 / 0)`, `color(srgb 1 0 0 / 0)`) serialisation.
+ */
+function alphaOf(value: string): number {
+  const m = value.trim().match(/^([a-z]+)\((.*)\)$/i);
+  if (!m) return value.trim() === "transparent" ? 0 : 1;
+  const [, fn, inner] = m;
+  const [main, slashAlpha] = inner!.split("/");
+  if (slashAlpha !== undefined) return Number(slashAlpha.trim());
+  const parts = main!.trim().split(/[\s,]+/);
+  if (fn!.toLowerCase() === "color") parts.shift();
+  return parts.length >= 4 ? Number(parts[3]) : 1;
 }
 
 async function expectActiveDrag(shell: Locator): Promise<void> {

--- a/e2e/screenshots/drag-drop-review.spec.ts
+++ b/e2e/screenshots/drag-drop-review.spec.ts
@@ -166,6 +166,22 @@ async function glide(page: Page, to: { x: number; y: number }): Promise<void> {
   await page.waitForTimeout(300);
 }
 
+/**
+ * A state indicator that compiled to nothing still exists in the DOM, so a
+ * structural check would pass while the frame shows no line at all. Read the
+ * painted colour and refuse anything transparent.
+ */
+async function expectPainted(target: Locator, property: "background-color" | "border-top-color") {
+  const value = await target.evaluate(
+    (el, prop) => getComputedStyle(el).getPropertyValue(prop),
+    property
+  );
+  const alpha = value.match(/rgba?\([^)]*,\s*([\d.]+)\)$/)?.[1];
+  const transparent = value === "transparent" || value === "rgba(0, 0, 0, 0)" || alpha === "0";
+  if (transparent)
+    throw new Error(`${property} painted transparent (${value}) — refusing to write`);
+}
+
 async function expectActiveDrag(shell: Locator): Promise<void> {
   await expect(
     shell.locator("[data-sandbox-active]"),
@@ -202,6 +218,7 @@ test("drag ghosts and drop placeholders — states and themes", async ({ page })
       const shell = await open(page, { theme, scene: "grid", kind });
       const target = shell.locator('[data-shot="grid-placeholder"]');
       await expect(target.locator(":scope > *"), `grid/${kind} rendered nothing`).toHaveCount(1);
+      await expectPainted(target.locator(":scope > *"), "border-top-color");
       written.push(await snap(shell, `grid-${kind}-${theme}.png`));
     }
 
@@ -210,6 +227,7 @@ test("drag ghosts and drop placeholders — states and themes", async ({ page })
       const shell = await open(page, { theme, scene: "dock", kind, over: "1" });
       const target = shell.locator('[data-shot="dock-placeholder"]');
       await expect(target.locator(":scope > *"), `dock/${kind} rendered nothing`).toHaveCount(1);
+      await expectPainted(target.locator(":scope > *"), "border-top-color");
       written.push(await snap(shell, `dock-${kind}-${theme}.png`));
     }
 
@@ -245,6 +263,7 @@ test("drag ghosts and drop placeholders — states and themes", async ({ page })
         await expectActiveDrag(shell);
         const indicator = shell.locator("[data-dock-drop-indicator]");
         await expect(indicator, "no dock insertion line rendered mid-drag").toHaveCount(1);
+        await expectPainted(indicator, "background-color");
         const direction = (await indicator.getAttribute("data-dock-drop-indicator")) ?? "unknown";
         if (!seen.has(direction)) {
           seen.add(direction);
@@ -278,6 +297,7 @@ test("drag ghosts and drop placeholders — states and themes", async ({ page })
         await expectActiveDrag(shell);
         const indicator = shell.locator("[data-worktree-drop-indicator]");
         await expect(indicator, "no worktree insertion line rendered mid-drag").toHaveCount(1);
+        await expectPainted(indicator, "background-color");
         const direction =
           (await indicator.getAttribute("data-worktree-drop-indicator")) ?? "unknown";
         if (!seen.has(direction)) {

--- a/e2e/screenshots/drag-drop-review.spec.ts
+++ b/e2e/screenshots/drag-drop-review.spec.ts
@@ -1,0 +1,355 @@
+/**
+ * Drag ghost and drop placeholder visual-review harness.
+ *
+ * Every state under `src/components/DragDrop/` exists only while a pointer is
+ * down — a ghost following the cursor, a placeholder holding a slot open, an
+ * insertion line between two chips, the source dimmed where it was lifted. In
+ * the real app they last a second or two and have never been looked at
+ * deliberately; this spec makes each one hold still.
+ *
+ * It drives the surface's own preview entry (`drag-drop-preview.html`) rather
+ * than booting Electron: the real components, the real theme tokens through
+ * `applyAppThemeToRoot`, the real `index.css`. Forced states (ghosts and
+ * placeholders) come from fixtures; the states that live inside dnd-kit
+ * (source dim, insertion lines) come from a genuine pointer drag performed
+ * here against a sandboxed `DndContext`, captured mid-gesture.
+ *
+ * Opt-in only, like every sibling review harness:
+ *
+ *   DAINTREE_SHOT_DRAGDROP=1 npx playwright test --project=screenshots drag-drop-review
+ *
+ * Env knobs:
+ *   DAINTREE_SHOT_DRAGDROP      required — any truthy value runs the capture
+ *   DAINTREE_SHOT_DIR           output directory (default artifacts/drag-drop-shots, gitignored)
+ *   DAINTREE_SHOT_THEMES        themes for the full state matrix (default: daintree,bondi,namib)
+ *   DAINTREE_SHOT_SWEEP_THEMES  themes for the one-page-per-theme sheet (default: all 15; "" skips)
+ *
+ * Hard rule, inherited from the siblings: never write a PNG that has not been
+ * verified. `snap()` asserts a real box before it writes, the drag captures
+ * assert the indicator they claim to show is actually in the DOM, and the test
+ * counts the files itself rather than trusting the exit code.
+ */
+
+import { test, expect, type Locator, type Page } from "@playwright/test";
+import { existsSync, mkdirSync, readdirSync, rmSync } from "fs";
+import path from "path";
+import {
+  makeSnap,
+  startPreviewServer,
+  stubViteHmrClient,
+  type PreviewServer,
+} from "../helpers/previewHarness";
+
+const ENABLED = !!process.env.DAINTREE_SHOT_DRAGDROP;
+
+const OUT_DIR = path.resolve(
+  process.env.DAINTREE_SHOT_DIR ?? path.join(process.cwd(), "artifacts", "drag-drop-shots")
+);
+
+const THEMES = (process.env.DAINTREE_SHOT_THEMES ?? "daintree,bondi,namib")
+  .split(",")
+  .map((t) => t.trim())
+  .filter(Boolean);
+
+const ALL_THEMES =
+  "daintree,bondi,table-mountain,arashiyama,fiordland,galapagos,highlands,namib,redwoods,atacama,bali,hokkaido,serengeti,svalbard,movile";
+const SWEEP_THEMES = (process.env.DAINTREE_SHOT_SWEEP_THEMES ?? ALL_THEMES)
+  .split(",")
+  .map((t) => t.trim())
+  .filter(Boolean);
+
+/** Mirrors `GHOSTS` / `WORKTREE_GHOSTS` in the preview fixtures. */
+const GHOST_SHOTS = [
+  "ghost-shell",
+  "ghost-claude-working",
+  "ghost-claude-waiting",
+  "ghost-codex-directing",
+  "ghost-gemini-group",
+  "ghost-exited-agent",
+  "ghost-long-title",
+  "ghost-browser",
+  "ghost-dev-preview",
+  "ghost-review",
+  "ghost-file",
+  "ghost-file-browser",
+  "ghost-diff",
+  "ghost-plugin",
+  "wt-issue",
+  "wt-branch-only",
+  "wt-main",
+  "wt-long-issue",
+] as const;
+
+/** Mirrors `PLACEHOLDER_KINDS`, plus the no-active-terminal fallback for the grid. */
+const GRID_KINDS = [
+  "terminal",
+  "agent",
+  "browser",
+  "dev-preview",
+  "review",
+  "file",
+  "file-browser",
+  "diff",
+  "plugin",
+  "none",
+] as const;
+const DOCK_KINDS = [
+  "terminal",
+  "agent",
+  "browser",
+  "dev-preview",
+  "review",
+  "file",
+  "plugin",
+] as const;
+
+let server: PreviewServer | undefined;
+const snap = makeSnap(OUT_DIR);
+
+test.beforeAll(async () => {
+  // No test.skip here: `test.info()` is unavailable in a beforeAll hook, so the
+  // structured-skip annotation the repo requires cannot be attached. The test
+  // body carries the skip; this hook simply does no work when the flag is unset.
+  if (!ENABLED) return;
+  if (existsSync(OUT_DIR)) rmSync(OUT_DIR, { recursive: true, force: true });
+  mkdirSync(OUT_DIR, { recursive: true });
+  server = await startPreviewServer();
+});
+
+test.afterAll(async () => {
+  await server?.close();
+});
+
+/** Load one scene in one theme, and settle it. */
+async function open(page: Page, query: Record<string, string>): Promise<Locator> {
+  await page.setViewportSize({ width: 1400, height: 900 });
+  const search = new URLSearchParams(query).toString();
+  const url = `${server!.baseURL}/drag-drop-preview.html?${search}`;
+  const shell = page.locator("[data-preview-shell]").first();
+  const timeout = 30_000;
+  try {
+    await page.goto(url);
+    await expect(shell).toBeAttached({ timeout });
+  } catch {
+    console.warn(`[drag-drop-shots] first mount of ?${search} failed; retrying once`);
+    await page.goto("about:blank");
+    await page.goto(url, { waitUntil: "load" });
+    await expect(shell).toBeAttached({ timeout });
+  }
+  // Mounted is not styled. Every shell is a flex or grid container via a
+  // Tailwind utility, so its computed display proves the stylesheet landed.
+  await expect
+    .poll(() => shell.evaluate((el) => getComputedStyle(el).display), {
+      message: `?${search} rendered unstyled — refusing to capture`,
+    })
+    .toMatch(/^(flex|grid)$/);
+  await page.evaluate(() => document.fonts.ready);
+  await page.waitForTimeout(200);
+  return shell;
+}
+
+async function pointerDown(page: Page, handle: Locator): Promise<{ x: number; y: number }> {
+  const box = await handle.boundingBox();
+  if (!box) throw new Error("drag handle has no box — refusing to drag");
+  const x = box.x + box.width / 2;
+  const y = box.y + box.height / 2;
+  await page.mouse.move(x, y);
+  await page.mouse.down();
+  return { x, y };
+}
+
+async function glide(page: Page, to: { x: number; y: number }): Promise<void> {
+  await page.mouse.move(to.x, to.y, { steps: 12 });
+  // The sortable strategy shifts neighbours under the pointer; a second, tiny
+  // move after they settle lets dnd-kit re-resolve `over` against the moved rects.
+  await page.mouse.move(to.x + 1, to.y, { steps: 2 });
+  await page.waitForTimeout(300);
+}
+
+async function expectActiveDrag(shell: Locator): Promise<void> {
+  await expect(
+    shell.locator("[data-sandbox-active]"),
+    "the pointer gesture never registered as a drag — refusing to capture"
+  ).toBeAttached();
+}
+
+test("drag ghosts and drop placeholders — states and themes", async ({ page }) => {
+  test.info().annotations.push({
+    type: "conditional-skip",
+    description: "DAINTREE_SHOT_DRAGDROP is required for the drag-drop capture",
+  });
+  test.skip(!ENABLED, "set DAINTREE_SHOT_DRAGDROP=1 to run the capture");
+  test.setTimeout(20 * 60_000);
+
+  await stubViteHmrClient(page);
+
+  const written: string[] = [];
+
+  for (const theme of THEMES) {
+    // Ghosts: the gallery, then each card alone at the size the eye judges it.
+    {
+      const shell = await open(page, { theme, scene: "ghosts" });
+      written.push(await snap(shell, `ghosts-gallery-${theme}.png`));
+      for (const shot of GHOST_SHOTS) {
+        const target = shell.locator(`[data-shot="${shot}"]`);
+        await expect(target.locator(":scope > *"), `${shot} rendered nothing`).toHaveCount(1);
+        written.push(await snap(target, `${shot}-${theme}.png`));
+      }
+    }
+
+    // Grid placeholder, per kind, between real-recipe panels.
+    for (const kind of GRID_KINDS) {
+      const shell = await open(page, { theme, scene: "grid", kind });
+      const target = shell.locator('[data-shot="grid-placeholder"]');
+      await expect(target.locator(":scope > *"), `grid/${kind} rendered nothing`).toHaveCount(1);
+      written.push(await snap(shell, `grid-${kind}-${theme}.png`));
+    }
+
+    // Dock placeholder, per kind, in the empty rail with the drag-over highlight.
+    for (const kind of DOCK_KINDS) {
+      const shell = await open(page, { theme, scene: "dock", kind, over: "1" });
+      const target = shell.locator('[data-shot="dock-placeholder"]');
+      await expect(target.locator(":scope > *"), `dock/${kind} rendered nothing`).toHaveCount(1);
+      written.push(await snap(shell, `dock-${kind}-${theme}.png`));
+    }
+
+    // Source dim in the grid, mid-drag, with the real overlay ghost in frame.
+    {
+      const shell = await open(page, { theme, scene: "drag-grid" });
+      const handle = shell.locator("[data-fixture-handle]").first();
+      const from = await pointerDown(page, handle);
+      await glide(page, { x: from.x + 220, y: from.y + 140 });
+      await expectActiveDrag(shell);
+      written.push(await snap(shell, `drag-grid-source-${theme}.png`));
+      await page.mouse.up();
+    }
+
+    // Dock reorder: source dim plus the insertion line, in both directions.
+    {
+      const shell = await open(page, { theme, scene: "drag-dock" });
+      const chips = shell.locator("[data-dock-item]");
+      await expect(chips).toHaveCount(3);
+      // The sortable strategy slides the dragged chip into its projected slot,
+      // so the hovered neighbour's midpoint is always on the far side of the
+      // travel: a first chip dragged right yields `before`, a last chip dragged
+      // left yields `after`. Each direction has to start from its own end.
+      const seen = new Set<string>();
+      for (const [source, target, frac] of [
+        [0, 2, 0.85],
+        [2, 0, 0.15],
+      ] as const) {
+        const box = await chips.nth(target).boundingBox();
+        if (!box) throw new Error("dock chip has no box");
+        await pointerDown(page, chips.nth(source));
+        await glide(page, { x: box.x + box.width * frac, y: box.y + box.height / 2 });
+        await expectActiveDrag(shell);
+        const indicator = shell.locator("[data-dock-drop-indicator]");
+        await expect(indicator, "no dock insertion line rendered mid-drag").toHaveCount(1);
+        const direction = (await indicator.getAttribute("data-dock-drop-indicator")) ?? "unknown";
+        if (!seen.has(direction)) {
+          seen.add(direction);
+          written.push(await snap(shell, `drag-dock-line-${direction}-${theme}.png`));
+        }
+        await page.mouse.up();
+        await page.waitForTimeout(150);
+      }
+      if (seen.size < 2) {
+        throw new Error(
+          `dock drag produced only ${[...seen].join(",")} — both insertion directions are states`
+        );
+      }
+    }
+
+    // Sidebar reorder: row dim plus the above/below line.
+    {
+      const shell = await open(page, { theme, scene: "drag-sidebar" });
+      const rows = shell.locator("[data-worktree-row]");
+      await expect(rows).toHaveCount(3);
+      const grips = shell.getByRole("button", { name: "Reorder worktree" });
+      const seen = new Set<string>();
+      for (const [source, target, frac] of [
+        [0, 2, 0.8],
+        [2, 0, 0.2],
+      ] as const) {
+        const box = await rows.nth(target).boundingBox();
+        if (!box) throw new Error("worktree row has no box");
+        await pointerDown(page, grips.nth(source));
+        await glide(page, { x: box.x + box.width / 2, y: box.y + box.height * frac });
+        await expectActiveDrag(shell);
+        const indicator = shell.locator("[data-worktree-drop-indicator]");
+        await expect(indicator, "no worktree insertion line rendered mid-drag").toHaveCount(1);
+        const direction =
+          (await indicator.getAttribute("data-worktree-drop-indicator")) ?? "unknown";
+        if (!seen.has(direction)) {
+          seen.add(direction);
+          written.push(await snap(shell, `drag-sidebar-line-${direction}-${theme}.png`));
+        }
+        await page.mouse.up();
+        await page.waitForTimeout(150);
+      }
+      if (seen.size < 2) {
+        throw new Error(
+          `sidebar drag produced only ${[...seen].join(",")} — both insertion directions are states`
+        );
+      }
+    }
+  }
+
+  // Dock geometry questions are density questions, not palette ones: the two
+  // other densities, the rail without its highlight, and the idle spacer, in
+  // the first theme only.
+  {
+    const theme = THEMES[0]!;
+    for (const density of ["compact", "comfortable"] as const) {
+      const shell = await open(page, { theme, scene: "dock", kind: "browser", over: "1", density });
+      written.push(await snap(shell, `dock-browser-${density}-${theme}.png`));
+    }
+    {
+      const shell = await open(page, { theme, scene: "dock", kind: "terminal" });
+      written.push(await snap(shell, `dock-terminal-noover-${theme}.png`));
+    }
+    {
+      // Idle: the placeholder must hold its slot with no visible art at all.
+      const shell = await open(page, { theme, scene: "dock", kind: "terminal", dragging: "0" });
+      const spacer = shell.locator('[data-shot="dock-placeholder"] > *');
+      await expect(spacer).toHaveCount(1);
+      await expect(spacer.locator(":scope > *")).toHaveCount(0);
+      written.push(await snap(shell, `dock-spacer-idle-${theme}.png`));
+    }
+  }
+
+  // The sweep: one composite page per theme, then the same page mid-drag for
+  // the dock line and the row line. Theme-specific collapse only shows up here.
+  for (const theme of SWEEP_THEMES) {
+    const shell = await open(page, { theme, scene: "sheet", width: "1360" });
+    written.push(await snap(shell, `sheet-${theme}.png`));
+
+    const chips = shell.locator("[data-sheet-dock] [data-dock-item]");
+    await expect(chips).toHaveCount(3);
+    const chipBox = await chips.nth(2).boundingBox();
+    if (!chipBox) throw new Error("sheet dock chip has no box");
+    await pointerDown(page, chips.nth(0));
+    await glide(page, { x: chipBox.x + chipBox.width * 0.85, y: chipBox.y + chipBox.height / 2 });
+    await expect(shell.locator("[data-dock-drop-indicator]")).toHaveCount(1);
+    written.push(await snap(shell, `sheet-dockline-${theme}.png`));
+    await page.mouse.up();
+    await page.waitForTimeout(150);
+
+    const rows = shell.locator("[data-sheet-sidebar] [data-worktree-row]");
+    await expect(rows).toHaveCount(3);
+    const rowBox = await rows.nth(2).boundingBox();
+    if (!rowBox) throw new Error("sheet worktree row has no box");
+    await pointerDown(page, shell.getByRole("button", { name: "Reorder worktree" }).nth(0));
+    await glide(page, { x: rowBox.x + rowBox.width / 2, y: rowBox.y + rowBox.height * 0.8 });
+    await expect(shell.locator("[data-worktree-drop-indicator]")).toHaveCount(1);
+    written.push(await snap(shell, `sheet-rowline-${theme}.png`));
+    await page.mouse.up();
+  }
+
+  // Count the files ourselves. A harness that trusts its own exit code is how
+  // a review ends up reasoning about screenshots that were never written.
+  const onDisk = readdirSync(OUT_DIR).filter((f) => f.endsWith(".png"));
+  expect(onDisk.length).toBe(written.length);
+  expect(new Set(written).size).toBe(written.length);
+  console.log(`[drag-drop-shots] ${onDisk.length} PNGs in ${OUT_DIR}`);
+});

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -66,6 +66,7 @@ const config: KnipConfig = {
     "src/components/HelpPanel/__preview__/preview.tsx",
     "src/components/Worktree/__preview__/preview.tsx",
     "src/components/Panel/__preview__/preview.tsx",
+    "src/components/DragDrop/__preview__/preview.tsx",
   ],
 
   // Project files Knip considers part of the graph. Includes root-level

--- a/scripts/baselines/text-ramp-manifest.json
+++ b/scripts/baselines/text-ramp-manifest.json
@@ -1,7 +1,7 @@
 {
   "generated": "2026-09-12",
-  "total": 407,
-  "files": 157,
+  "total": 406,
+  "files": 156,
   "occurrences": [
     {
       "file": "plugins/builtin/github/renderer/components/BulkCreateWorktreeDialog.tsx",
@@ -707,21 +707,6 @@
       "decision": "keep",
       "category": "semantic-state-pair",
       "evidence": "another branch already paints text-text-primary here; the band role would erase the difference"
-    },
-    {
-      "file": "src/components/DragDrop/GridPlaceholder.tsx",
-      "ordinal": 0,
-      "line": 45,
-      "start": 1672,
-      "end": 1693,
-      "token": "text-daintree-text/50",
-      "variants": "",
-      "step": 50,
-      "group": "src/components/DragDrop/GridPlaceholder.tsx#1618",
-      "branch": "",
-      "decision": "keep",
-      "category": "icon-affordance",
-      "evidence": "<span> wraps only icons — the colour paints a glyph through currentColor"
     },
     {
       "file": "src/components/FileViewer/FileViewerToolbar.tsx",

--- a/src/components/DragDrop/DndProvider.tsx
+++ b/src/components/DragDrop/DndProvider.tsx
@@ -505,10 +505,13 @@ function DragOverlayWithCursorTracking({
     <DragOverlay
       // Reduced motion drops the travelling ghost on release as well as the
       // entry spring — `getUiAnimationDuration()` only collapses for
-      // performance mode, not for the OS preference.
+      // performance mode, not for the OS preference. A zero-duration config
+      // rather than `null`: dnd-kit returns before its scroll-into-view when
+      // the config is null, and a cancelled drag whose source scrolled away
+      // still has to come back to it.
       dropAnimation={
         prefersReducedMotion
-          ? null
+          ? { duration: 0, easing: EASE_SNAPPY, sideEffects: null }
           : isCancelDrop
             ? { duration: PANEL_RESTORE_DURATION, easing: EASE_OUT_EXPO, sideEffects: null }
             : { duration: getUiAnimationDuration(), easing: EASE_SNAPPY, sideEffects: null }

--- a/src/components/DragDrop/DndProvider.tsx
+++ b/src/components/DragDrop/DndProvider.tsx
@@ -503,10 +503,15 @@ function DragOverlayWithCursorTracking({
 
   return (
     <DragOverlay
+      // Reduced motion drops the travelling ghost on release as well as the
+      // entry spring — `getUiAnimationDuration()` only collapses for
+      // performance mode, not for the OS preference.
       dropAnimation={
-        isCancelDrop
-          ? { duration: PANEL_RESTORE_DURATION, easing: EASE_OUT_EXPO, sideEffects: null }
-          : { duration: getUiAnimationDuration(), easing: EASE_SNAPPY, sideEffects: null }
+        prefersReducedMotion
+          ? null
+          : isCancelDrop
+            ? { duration: PANEL_RESTORE_DURATION, easing: EASE_OUT_EXPO, sideEffects: null }
+            : { duration: getUiAnimationDuration(), easing: EASE_SNAPPY, sideEffects: null }
       }
       modifiers={activeModifiers}
     >

--- a/src/components/DragDrop/DndProvider.tsx
+++ b/src/components/DragDrop/DndProvider.tsx
@@ -3,8 +3,6 @@ import {
   useCallback,
   useMemo,
   useRef,
-  createContext,
-  useContext,
   useEffect,
   type MouseEvent as ReactMouseEvent,
   type TouchEvent as ReactTouchEvent,
@@ -86,6 +84,7 @@ export const sameContainerKeyboardCoordinates: KeyboardCoordinateGetter = (event
 };
 import { usePanelStore, useWorktreeSelectionStore } from "@/store";
 import type { PanelInstance } from "@shared/types/panel";
+import { DndPlaceholderContext, GRID_PLACEHOLDER_ID } from "./dndPlaceholderContext";
 import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
 import { TerminalDragPreview, TERMINAL_DRAG_PREVIEW_WIDTH } from "./TerminalDragPreview";
 import { WorktreeDragPreview } from "./WorktreeDragPreview";
@@ -129,54 +128,18 @@ import {
 type CarrierPanel = Parameters<typeof getNarrowPanel>[0][string];
 
 // Placeholder ID used when dragging from dock to grid
-export const GRID_PLACEHOLDER_ID = "__grid-placeholder__";
 
 // Droppable ID for the trash pill — drop a panel here to trash it
 export const TRASH_DROPPABLE_ID = "__trash-droppable__";
 
-// Context to share placeholder state with ContentGrid
-interface DndPlaceholderContextValue {
-  placeholderIndex: number | null;
-  sourceContainer: "grid" | "dock" | null;
-  activeTerminal: PanelInstance | null;
-  isDragging: boolean;
-  isWorktreeSortDragging: boolean;
-  /** If dragging a tab group, the group ID */
-  activeGroupId: string | null;
-  /** If dragging a tab group, the panel IDs in the group */
-  activeGroupPanelIds: string[] | null;
-  /**
-   * True when the active drag can't be dropped in the dock — its kind, or ANY
-   * live member's kind for a group drag, is non-dockable (#11375). Consumers
-   * (the dock's `cursor-no-drop` cue) read this instead of re-checking the lone
-   * representative kind, so the cue matches what `cancelDrop`/`collisionDetection`
-   * actually enforce for a mixed group.
-   */
-  activeDragRejectsDock: boolean;
-}
-
-const DndPlaceholderContext = createContext<DndPlaceholderContextValue>({
-  placeholderIndex: null,
-  sourceContainer: null,
-  activeTerminal: null,
-  isDragging: false,
-  isWorktreeSortDragging: false,
-  activeGroupId: null,
-  activeGroupPanelIds: null,
-  activeDragRejectsDock: false,
-});
-
-export function useDndPlaceholder() {
-  return useContext(DndPlaceholderContext);
-}
-
-export function useIsDragging() {
-  return useContext(DndPlaceholderContext).isDragging;
-}
-
-export function useIsWorktreeSortDragging() {
-  return useContext(DndPlaceholderContext).isWorktreeSortDragging;
-}
+// Placeholder context lives in its own module so GridPlaceholder/DockPlaceholder
+// don't import this provider; re-exported here to keep the public surface.
+export {
+  useDndPlaceholder,
+  useIsDragging,
+  useIsWorktreeSortDragging,
+  GRID_PLACEHOLDER_ID,
+} from "./dndPlaceholderContext";
 
 // Minimum distance (px) pointer must move before drag starts
 // This allows clicks to work for popovers without triggering drag

--- a/src/components/DragDrop/DockPlaceholder.tsx
+++ b/src/components/DragDrop/DockPlaceholder.tsx
@@ -2,7 +2,7 @@ import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { m } from "framer-motion";
 import { cn } from "@/lib/utils";
-import { useDndPlaceholder } from "./DndProvider";
+import { useDndPlaceholder } from "./dndPlaceholderContext";
 import { PlaceholderContent } from "./PlaceholderContent";
 import { deriveTerminalChrome } from "@/utils/terminalChrome";
 

--- a/src/components/DragDrop/DockPlaceholder.tsx
+++ b/src/components/DragDrop/DockPlaceholder.tsx
@@ -4,6 +4,7 @@ import { m } from "framer-motion";
 import { cn } from "@/lib/utils";
 import { useDndPlaceholder } from "./dndPlaceholderContext";
 import { PlaceholderContent } from "./PlaceholderContent";
+import { DROP_SLOT_FRAME } from "./dropIndicator";
 import { deriveTerminalChrome } from "@/utils/terminalChrome";
 
 interface DockPlaceholderProps {
@@ -18,17 +19,19 @@ export function DockPlaceholder({ className }: DockPlaceholderProps) {
   // When not dragging, render an invisible placeholder that still takes space
   // This maintains the drop target for drag operations without showing a visible artifact
   if (!isDragging || !activeTerminal) {
-    return <div className={cn("min-w-[100px] h-full", className)} aria-hidden="true" />;
+    return <div className={cn("h-full min-w-25", className)} aria-hidden="true" />;
   }
 
   const { kind } = activeTerminal;
   const chrome = deriveTerminalChrome(activeTerminal);
 
   return (
+    // Chip geometry — the chips' radius step and height — so the slot reads as
+    // the chip that is about to land in it rather than a foreign object in the rail.
     <div
       className={cn(
-        "flex flex-col gap-1 px-3 py-2 min-w-[120px] h-[var(--dock-item-height)] overflow-hidden",
-        "rounded border border-border-strong bg-overlay-subtle",
+        "flex h-[var(--dock-item-height)] min-w-30 flex-col justify-center overflow-hidden rounded-md px-3 py-2",
+        DROP_SLOT_FRAME,
         className
       )}
       aria-hidden="true"

--- a/src/components/DragDrop/GridPlaceholder.tsx
+++ b/src/components/DragDrop/GridPlaceholder.tsx
@@ -2,7 +2,7 @@ import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { m } from "framer-motion";
 import { cn } from "@/lib/utils";
-import { useDndPlaceholder, GRID_PLACEHOLDER_ID } from "./DndProvider";
+import { useDndPlaceholder, GRID_PLACEHOLDER_ID } from "./dndPlaceholderContext";
 import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
 import { PlaceholderContent } from "./PlaceholderContent";
 import { deriveTerminalChrome } from "@/utils/terminalChrome";

--- a/src/components/DragDrop/GridPlaceholder.tsx
+++ b/src/components/DragDrop/GridPlaceholder.tsx
@@ -5,6 +5,7 @@ import { cn } from "@/lib/utils";
 import { useDndPlaceholder, GRID_PLACEHOLDER_ID } from "./dndPlaceholderContext";
 import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
 import { PlaceholderContent } from "./PlaceholderContent";
+import { DROP_SLOT_FRAME } from "./dropIndicator";
 import { deriveTerminalChrome } from "@/utils/terminalChrome";
 
 interface GridPlaceholderProps {
@@ -14,43 +15,43 @@ interface GridPlaceholderProps {
 export function GridPlaceholder({ className }: GridPlaceholderProps) {
   const { activeTerminal } = useDndPlaceholder();
 
-  // Fallback: render simple background if terminal data unavailable
-  if (!activeTerminal) {
-    return <div className={cn("h-full rounded-[var(--radius-lg)] bg-daintree-bg/50", className)} />;
-  }
-
-  const { title, kind } = activeTerminal;
   // Drag visuals mirror chrome: live detection only. A demoted shell dragged
   // across the grid shows plain-terminal styling even though it was launched
   // as an agent — matches what the tab looks like right now.
-  const chrome = deriveTerminalChrome(activeTerminal);
+  const chrome = activeTerminal ? deriveTerminalChrome(activeTerminal) : null;
 
   return (
     <div
       className={cn(
-        "h-full w-full rounded flex flex-col overflow-hidden",
-        "border border-border-strong bg-overlay-subtle",
+        "flex h-full w-full flex-col overflow-hidden rounded-lg",
+        DROP_SLOT_FRAME,
         "animate-in fade-in duration-200",
         className
       )}
       aria-hidden="true"
     >
-      {/* Ghost Handle / Header */}
-      <div
-        className={cn(
-          "flex items-center gap-2 px-3 h-7 shrink-0 font-mono text-xs",
-          "bg-overlay-medium border-b border-border-strong/30"
+      {/* Ghost header — the panel header's own recipe (h-8, sans, medium) so the
+          slot reads as the panel that is about to land in it. When the active
+          panel is unknown the bar stays, empty: the destination boundary never
+          depends on identity data. */}
+      <div className="flex h-8 shrink-0 items-center gap-2 border-b border-border-strong/30 bg-overlay-medium px-3 text-xs">
+        {activeTerminal && chrome && (
+          <>
+            <TerminalIcon
+              kind={activeTerminal.kind}
+              chrome={chrome}
+              className="h-3.5 w-3.5 shrink-0"
+            />
+            <span className="truncate font-medium text-text-secondary">{activeTerminal.title}</span>
+          </>
         )}
-      >
-        <span className="shrink-0 flex items-center justify-center text-daintree-text/50">
-          <TerminalIcon kind={kind} chrome={chrome} className="w-3.5 h-3.5" />
-        </span>
-        <span className="font-medium text-text-secondary truncate">{title}</span>
       </div>
 
-      {/* Panel-specific placeholder body */}
-      <div className="flex-1 w-full p-3">
-        <PlaceholderContent kind={kind ?? "terminal"} agentId={chrome.agentId ?? undefined} />
+      <div className="flex w-full flex-1 flex-col p-3">
+        <PlaceholderContent
+          kind={activeTerminal?.kind ?? "unknown"}
+          agentId={chrome?.agentId ?? undefined}
+        />
       </div>
     </div>
   );

--- a/src/components/DragDrop/PlaceholderContent.tsx
+++ b/src/components/DragDrop/PlaceholderContent.tsx
@@ -1,5 +1,7 @@
+import type { CSSProperties } from "react";
 import type { PanelKind } from "@shared/types/panel";
 import { getPanelKindColor } from "@shared/config/panelKindRegistry";
+import { cn } from "@/lib/utils";
 
 interface PlaceholderContentProps {
   kind: PanelKind;
@@ -8,405 +10,255 @@ interface PlaceholderContentProps {
   compact?: boolean;
 }
 
+// Every bar and block in the illustrations is one of three tints of the kind
+// colour, set once on the root. The bars are decorative — the header carries
+// the identity — so they stay quiet, but light themes need more than the 10%
+// wash that near-vanished on cream surfaces.
+function tintVars(color: string): CSSProperties {
+  const vars: CSSProperties & Record<`--ph-${string}`, string> = {
+    "--ph-soft": `color-mix(in srgb, ${color} 8%, transparent)`,
+    "--ph-ink": `color-mix(in srgb, ${color} 16%, transparent)`,
+    "--ph-strong": `color-mix(in srgb, ${color} 26%, transparent)`,
+    "--ph-solid": `color-mix(in srgb, ${color} 60%, transparent)`,
+  };
+  return vars;
+}
+
+const SOFT = "rounded-sm bg-[var(--ph-soft)]";
+const INK = "rounded-sm bg-[var(--ph-ink)]";
+const STRONG = "rounded-sm bg-[var(--ph-strong)]";
+
 /**
- * Panel-specific placeholder content for drag operations.
- * Each panel type has a distinct visual representation.
+ * Panel-specific placeholder content for drag operations. Each built-in kind
+ * has a distinct composition; anything the registry does not know gets a
+ * deliberately generic one instead of impersonating a terminal.
  */
 export function PlaceholderContent({ kind, agentId, compact = false }: PlaceholderContentProps) {
   const color = getPanelKindColor(kind, agentId);
+  const props = { compact };
 
+  let body: React.ReactNode;
   switch (kind) {
     case "terminal":
-      return <TerminalPlaceholder color={color} compact={compact} />;
-    case "agent":
-      return <AgentPlaceholder color={color} compact={compact} />;
+      body = <TerminalPlaceholder {...props} />;
+      break;
     case "browser":
-      return <BrowserPlaceholder color={color} compact={compact} />;
+      body = <BrowserPlaceholder {...props} />;
+      break;
     case "dev-preview":
-      return <DevPreviewPlaceholder color={color} compact={compact} />;
+      body = <DevPreviewPlaceholder {...props} />;
+      break;
     case "review":
-      return <ReviewPlaceholder color={color} compact={compact} />;
+      body = <ReviewPlaceholder {...props} />;
+      break;
+    case "file":
+      body = <FilePlaceholder {...props} />;
+      break;
+    case "file-browser":
+      body = <FileBrowserPlaceholder {...props} />;
+      break;
+    case "diff":
+      body = <DiffPlaceholder {...props} />;
+      break;
     default:
-      return <TerminalPlaceholder color={color} compact={compact} />;
+      body = <GenericPlaceholder {...props} />;
   }
+
+  return (
+    <div className="flex w-full flex-1 flex-col" style={tintVars(color)}>
+      {body}
+    </div>
+  );
 }
 
 interface PlaceholderProps {
-  color: string;
   compact: boolean;
 }
 
-/**
- * Terminal placeholder: 3 horizontal lines simulating text output
- */
-function TerminalPlaceholder({ color, compact }: PlaceholderProps) {
-  const lineHeight = compact ? 4 : 6;
-  const gap = compact ? 3 : 4;
-
+/** A row of output: an optional prompt tick, then a bar. */
+function Line({
+  width,
+  tone = INK,
+  compact,
+  prompt = false,
+}: {
+  width: string;
+  tone?: string;
+  compact: boolean;
+  prompt?: boolean;
+}) {
+  const h = compact ? "h-1" : "h-1.5";
   return (
-    <div style={{ display: "flex", flexDirection: "column", gap, width: "100%" }}>
-      <div
-        style={{
-          height: lineHeight,
-          width: "70%",
-          backgroundColor: `color-mix(in srgb, ${color} 10%, transparent)`,
-          borderRadius: "var(--radius-sm)",
-        }}
-      />
-      <div
-        style={{
-          height: lineHeight,
-          width: "50%",
-          backgroundColor: `color-mix(in srgb, ${color} 10%, transparent)`,
-          borderRadius: "var(--radius-sm)",
-        }}
-      />
-      {!compact && (
-        <div
-          style={{
-            height: lineHeight,
-            width: "40%",
-            backgroundColor: `color-mix(in srgb, ${color} 10%, transparent)`,
-            borderRadius: "var(--radius-sm)",
-          }}
-        />
-      )}
+    <div className={cn("flex items-center", compact ? "gap-1" : "gap-1.5")}>
+      {prompt && <div className={cn(STRONG, "shrink-0", compact ? "size-1" : "size-1.5")} />}
+      <div className={cn(tone, h)} style={{ width }} />
     </div>
   );
 }
 
-/**
- * Agent placeholder: Abstract chat UI with alternating message bubbles
- */
-function AgentPlaceholder({ color, compact }: PlaceholderProps) {
-  const bubbleHeight = compact ? 4 : 6;
-  const gap = compact ? 3 : 5;
-
+/** Terminal: staggered output lines behind a prompt tick. */
+function TerminalPlaceholder({ compact }: PlaceholderProps) {
   return (
-    <div style={{ display: "flex", flexDirection: "column", gap, width: "100%" }}>
-      {/* User message (left-aligned, smaller) */}
-      <div style={{ display: "flex", justifyContent: "flex-start" }}>
-        <div
-          style={{
-            height: bubbleHeight,
-            width: "35%",
-            backgroundColor: `color-mix(in srgb, ${color} 8%, transparent)`,
-            borderRadius: "var(--radius-sm)",
-          }}
-        />
-      </div>
-      {/* Agent reply (right-aligned, larger) */}
-      <div style={{ display: "flex", justifyContent: "flex-end" }}>
-        <div
-          style={{
-            height: bubbleHeight,
-            width: "55%",
-            backgroundColor: `color-mix(in srgb, ${color} 12%, transparent)`,
-            borderRadius: "var(--radius-sm)",
-          }}
-        />
-      </div>
-      {/* User message */}
-      <div style={{ display: "flex", justifyContent: "flex-start" }}>
-        <div
-          style={{
-            height: bubbleHeight,
-            width: "40%",
-            backgroundColor: `color-mix(in srgb, ${color} 8%, transparent)`,
-            borderRadius: "var(--radius-sm)",
-          }}
-        />
-      </div>
+    <div className={cn("flex w-full flex-col", compact ? "gap-1" : "gap-1.5")}>
+      <Line width="70%" compact={compact} prompt />
+      <Line width="50%" compact={compact} />
+      {!compact && <Line width="40%" compact={compact} />}
+    </div>
+  );
+}
+
+/** Browser: address bar over a page with a row of controls and a content line. */
+function BrowserPlaceholder({ compact }: PlaceholderProps) {
+  return (
+    <div className={cn("flex w-full flex-1 flex-col", compact ? "gap-1" : "gap-1.5")}>
+      <div className={cn(INK, "w-[85%]", compact ? "h-1" : "h-1.5")} />
+      {/* Page body — omitted in compact so the dock ghost stays within --dock-item-height */}
       {!compact && (
-        /* Agent reply */
-        <div style={{ display: "flex", justifyContent: "flex-end" }}>
-          <div
-            style={{
-              height: bubbleHeight,
-              width: "60%",
-              backgroundColor: `color-mix(in srgb, ${color} 12%, transparent)`,
-              borderRadius: "var(--radius-sm)",
-            }}
-          />
+        <div data-placeholder-body className={cn(SOFT, "flex min-h-8 flex-1 flex-col gap-1 p-1.5")}>
+          <div className="flex gap-1">
+            <div className={cn(STRONG, "size-2.5")} />
+            <div className={cn(STRONG, "size-2.5")} />
+            <div className={cn(STRONG, "size-2.5")} />
+          </div>
+          <div className={cn(INK, "h-1 w-4/5")} />
         </div>
       )}
     </div>
   );
 }
 
-/**
- * Browser placeholder: Address bar + content area with page elements
- */
-function BrowserPlaceholder({ color, compact }: PlaceholderProps) {
-  const barHeight = compact ? 5 : 6;
-
+/** Dev preview: address bar with a live dot, then a code column beside a preview. */
+function DevPreviewPlaceholder({ compact }: PlaceholderProps) {
   return (
-    <div style={{ display: "flex", flexDirection: "column", gap: compact ? 4 : 6, width: "100%" }}>
-      {/* Address bar */}
-      <div
-        style={{
-          height: barHeight,
-          width: "85%",
-          backgroundColor: `color-mix(in srgb, ${color} 10%, transparent)`,
-          borderRadius: "var(--radius-sm)",
-        }}
-      />
-      {/* Page content area — omitted in compact so the dock ghost stays within --dock-item-height */}
+    <div className={cn("flex w-full flex-1 flex-col", compact ? "gap-1" : "gap-1.5")}>
+      <div className={cn("flex items-center", compact ? "gap-1" : "gap-1.5")}>
+        <div className={cn(INK, "flex-1", compact ? "h-1" : "h-1.5")} />
+        <div
+          className={cn(
+            "shrink-0 rounded-full bg-[var(--ph-solid)]",
+            compact ? "size-1.5" : "size-2"
+          )}
+        />
+      </div>
+      {/* Split preview — omitted in compact so the dock ghost stays within --dock-item-height */}
       {!compact && (
-        <div
-          data-placeholder-body
-          style={{
-            flex: 1,
-            minHeight: 30,
-            padding: 6,
-            backgroundColor: `color-mix(in srgb, ${color} 5%, transparent)`,
-            borderRadius: "var(--radius-sm)",
-            display: "flex",
-            flexDirection: "column",
-            gap: 4,
-          }}
-        >
-          {/* Page elements row */}
-          <div style={{ display: "flex", gap: 4 }}>
-            <div
-              style={{
-                width: 10,
-                height: 10,
-                backgroundColor: `color-mix(in srgb, ${color} 12%, transparent)`,
-                borderRadius: "var(--radius-sm)",
-              }}
-            />
-            <div
-              style={{
-                width: 10,
-                height: 10,
-                backgroundColor: `color-mix(in srgb, ${color} 12%, transparent)`,
-                borderRadius: "var(--radius-sm)",
-              }}
-            />
-            <div
-              style={{
-                width: 10,
-                height: 10,
-                backgroundColor: `color-mix(in srgb, ${color} 12%, transparent)`,
-                borderRadius: "var(--radius-sm)",
-              }}
-            />
+        <div data-placeholder-body className="flex min-h-8 flex-1 gap-1">
+          <div className={cn(SOFT, "flex w-[30%] flex-col gap-0.5 p-1")}>
+            <div className={cn(INK, "h-1 w-4/5")} />
+            <div className={cn(INK, "h-1 w-3/5")} />
           </div>
-          {/* Content line */}
-          <div
-            style={{
-              height: 5,
-              width: "80%",
-              backgroundColor: `color-mix(in srgb, ${color} 8%, transparent)`,
-              borderRadius: "var(--radius-sm)",
-            }}
-          />
-        </div>
-      )}
-    </div>
-  );
-}
-
-/**
- * Review placeholder: Two-column diff view (file list + diff hunks)
- */
-function ReviewPlaceholder({ color, compact }: PlaceholderProps) {
-  const lineHeight = compact ? 4 : 5;
-
-  return (
-    <div style={{ display: "flex", gap: compact ? 4 : 6, width: "100%" }}>
-      {/* File list (narrower, left) */}
-      <div
-        style={{
-          width: "32%",
-          display: "flex",
-          flexDirection: "column",
-          gap: compact ? 3 : 4,
-        }}
-      >
-        <div
-          style={{
-            height: lineHeight,
-            width: "85%",
-            backgroundColor: `color-mix(in srgb, ${color} 12%, transparent)`,
-            borderRadius: "var(--radius-sm)",
-          }}
-        />
-        <div
-          style={{
-            height: lineHeight,
-            width: "70%",
-            backgroundColor: `color-mix(in srgb, ${color} 10%, transparent)`,
-            borderRadius: "var(--radius-sm)",
-          }}
-        />
-        {!compact && (
-          <div
-            style={{
-              height: lineHeight,
-              width: "60%",
-              backgroundColor: `color-mix(in srgb, ${color} 8%, transparent)`,
-              borderRadius: "var(--radius-sm)",
-            }}
-          />
-        )}
-      </div>
-      {/* Diff hunks (wider, right) */}
-      <div
-        style={{
-          flex: 1,
-          padding: compact ? 3 : 4,
-          backgroundColor: `color-mix(in srgb, ${color} 5%, transparent)`,
-          borderRadius: "var(--radius-sm)",
-          display: "flex",
-          flexDirection: "column",
-          gap: compact ? 2 : 3,
-        }}
-      >
-        <div
-          style={{
-            height: lineHeight,
-            width: "90%",
-            backgroundColor: `color-mix(in srgb, ${color} 10%, transparent)`,
-            borderRadius: "var(--radius-sm)",
-          }}
-        />
-        <div
-          style={{
-            height: lineHeight,
-            width: "75%",
-            backgroundColor: `color-mix(in srgb, ${color} 10%, transparent)`,
-            borderRadius: "var(--radius-sm)",
-          }}
-        />
-        {!compact && (
-          <div
-            style={{
-              height: lineHeight,
-              width: "65%",
-              backgroundColor: `color-mix(in srgb, ${color} 8%, transparent)`,
-              borderRadius: "var(--radius-sm)",
-            }}
-          />
-        )}
-      </div>
-    </div>
-  );
-}
-
-/**
- * Dev Preview placeholder: Address bar with status indicator + split preview area
- */
-function DevPreviewPlaceholder({ color, compact }: PlaceholderProps) {
-  const barHeight = compact ? 5 : 6;
-
-  return (
-    <div style={{ display: "flex", flexDirection: "column", gap: compact ? 4 : 6, width: "100%" }}>
-      {/* Address bar with status indicator */}
-      <div style={{ display: "flex", alignItems: "center", gap: compact ? 4 : 6 }}>
-        <div
-          style={{
-            height: barHeight,
-            flex: 1,
-            backgroundColor: `color-mix(in srgb, ${color} 10%, transparent)`,
-            borderRadius: "var(--radius-sm)",
-          }}
-        />
-        {/* Status indicator dot */}
-        <div
-          style={{
-            width: compact ? 6 : 8,
-            height: compact ? 6 : 8,
-            backgroundColor: color,
-            borderRadius: "50%",
-            opacity: 0.6,
-            flexShrink: 0,
-          }}
-        />
-      </div>
-      {/* Split preview content — omitted in compact so the dock ghost stays within --dock-item-height */}
-      {!compact && (
-        <div
-          data-placeholder-body
-          style={{
-            flex: 1,
-            minHeight: 30,
-            display: "flex",
-            gap: 4,
-          }}
-        >
-          {/* Code/terminal side (narrower) */}
-          <div
-            style={{
-              width: "30%",
-              backgroundColor: `color-mix(in srgb, ${color} 6%, transparent)`,
-              borderRadius: "var(--radius-sm)",
-              padding: 4,
-              display: "flex",
-              flexDirection: "column",
-              gap: 2,
-            }}
-          >
-            <div
-              style={{
-                height: 3,
-                width: "80%",
-                backgroundColor: `color-mix(in srgb, ${color} 10%, transparent)`,
-                borderRadius: "var(--radius-sm)",
-              }}
-            />
-            <div
-              style={{
-                height: 3,
-                width: "60%",
-                backgroundColor: `color-mix(in srgb, ${color} 10%, transparent)`,
-                borderRadius: "var(--radius-sm)",
-              }}
-            />
-          </div>
-          {/* Preview side (wider) */}
-          <div
-            style={{
-              flex: 1,
-              backgroundColor: `color-mix(in srgb, ${color} 5%, transparent)`,
-              borderRadius: "var(--radius-sm)",
-              padding: 4,
-              display: "flex",
-              flexDirection: "column",
-              gap: 3,
-            }}
-          >
-            {/* Preview content elements */}
-            <div style={{ display: "flex", gap: 3 }}>
-              <div
-                style={{
-                  width: 8,
-                  height: 8,
-                  backgroundColor: `color-mix(in srgb, ${color} 12%, transparent)`,
-                  borderRadius: "var(--radius-sm)",
-                }}
-              />
-              <div
-                style={{
-                  width: 8,
-                  height: 8,
-                  backgroundColor: `color-mix(in srgb, ${color} 12%, transparent)`,
-                  borderRadius: "var(--radius-sm)",
-                }}
-              />
+          <div className={cn(SOFT, "flex flex-1 flex-col gap-1 p-1")}>
+            <div className="flex gap-1">
+              <div className={cn(STRONG, "size-2")} />
+              <div className={cn(STRONG, "size-2")} />
             </div>
-            <div
-              style={{
-                height: 4,
-                width: "70%",
-                backgroundColor: `color-mix(in srgb, ${color} 8%, transparent)`,
-                borderRadius: "var(--radius-sm)",
-              }}
-            />
+            <div className={cn(INK, "h-1 w-[70%]")} />
           </div>
         </div>
       )}
+    </div>
+  );
+}
+
+/** Review: a narrow file list beside a block of diff hunks. */
+function ReviewPlaceholder({ compact }: PlaceholderProps) {
+  const h = compact ? "h-1" : "h-1.5";
+  return (
+    <div className={cn("flex w-full", compact ? "gap-1" : "gap-1.5")}>
+      <div className={cn("flex w-[32%] flex-col", compact ? "gap-1" : "gap-1")}>
+        <div className={cn(STRONG, h, "w-[85%]")} />
+        <div className={cn(INK, h, "w-[70%]")} />
+        {!compact && <div className={cn(INK, h, "w-3/5")} />}
+      </div>
+      <div className={cn(SOFT, "flex flex-1 flex-col", compact ? "gap-0.5 p-1" : "gap-1 p-1")}>
+        <div className={cn(INK, h, "w-[90%]")} />
+        <div className={cn(INK, h, "w-3/4")} />
+        {!compact && <div className={cn(INK, h, "w-[65%]")} />}
+      </div>
+    </div>
+  );
+}
+
+/** File: a document — a short heading over long body lines. */
+function FilePlaceholder({ compact }: PlaceholderProps) {
+  const h = compact ? "h-1" : "h-1.5";
+  return (
+    <div className={cn("flex w-full flex-col", compact ? "gap-1" : "gap-1.5")}>
+      <div className={cn(STRONG, h, "w-[45%]")} />
+      <div className={cn(INK, h, "w-[90%]")} />
+      {!compact && <div className={cn(INK, h, "w-4/5")} />}
+      {!compact && <div className={cn(INK, h, "w-3/5")} />}
+    </div>
+  );
+}
+
+/** File browser: an indented tree of node markers and names. */
+function FileBrowserPlaceholder({ compact }: PlaceholderProps) {
+  const h = compact ? "h-1" : "h-1.5";
+  const node = compact ? "size-1" : "size-1.5";
+  const rows: Array<[string, string]> = compact
+    ? [
+        ["pl-0", "40%"],
+        ["pl-2", "55%"],
+      ]
+    : [
+        ["pl-0", "40%"],
+        ["pl-2", "55%"],
+        ["pl-4", "45%"],
+      ];
+  return (
+    <div className={cn("flex w-full flex-col", compact ? "gap-1" : "gap-1.5")}>
+      {rows.map(([indent, width]) => (
+        <div key={indent} className={cn("flex items-center gap-1", indent)}>
+          <div className={cn(STRONG, "shrink-0", node)} />
+          <div className={cn(INK, h)} style={{ width }} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/** Diff: lines with change markers in the gutter. */
+function DiffPlaceholder({ compact }: PlaceholderProps) {
+  const h = compact ? "h-1" : "h-1.5";
+  const lines: Array<[boolean, string]> = compact
+    ? [
+        [true, "70%"],
+        [true, "55%"],
+      ]
+    : [
+        [false, "60%"],
+        [true, "80%"],
+        [true, "70%"],
+        [false, "45%"],
+      ];
+  return (
+    <div className={cn("flex w-full flex-col", compact ? "gap-1" : "gap-1.5")}>
+      {lines.map(([changed, width], i) => (
+        <div key={i} className="flex items-center gap-1.5">
+          <div
+            className={cn(
+              "w-0.5 shrink-0 rounded-full",
+              h,
+              changed ? "bg-[var(--ph-solid)]" : "bg-transparent"
+            )}
+          />
+          <div className={cn(changed ? INK : SOFT, h)} style={{ width }} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/** Anything the registry does not know: two tiles and a caption, no pretence. */
+function GenericPlaceholder({ compact }: PlaceholderProps) {
+  return (
+    <div className={cn("flex w-full flex-col", compact ? "gap-1" : "gap-1.5")}>
+      <div className={cn("grid grid-cols-2", compact ? "gap-1" : "gap-1.5")}>
+        <div className={cn(SOFT, compact ? "h-2" : "h-5")} />
+        <div className={cn(SOFT, compact ? "h-2" : "h-5")} />
+      </div>
+      <div className={cn(INK, "w-1/2", compact ? "h-1" : "h-1.5")} />
     </div>
   );
 }

--- a/src/components/DragDrop/PlaceholderContent.tsx
+++ b/src/components/DragDrop/PlaceholderContent.tsx
@@ -65,7 +65,9 @@ export function PlaceholderContent({ kind, agentId, compact = false }: Placehold
   }
 
   return (
-    <div className="flex w-full flex-1 flex-col" style={tintVars(color)}>
+    // Compact art is content-sized so the dock slot can centre it; full art
+    // grows to fill the ghost or grid slot body.
+    <div className={cn("flex w-full flex-col", !compact && "flex-1")} style={tintVars(color)}>
       {body}
     </div>
   );
@@ -110,7 +112,7 @@ function TerminalPlaceholder({ compact }: PlaceholderProps) {
 /** Browser: address bar over a page with a row of controls and a content line. */
 function BrowserPlaceholder({ compact }: PlaceholderProps) {
   return (
-    <div className={cn("flex w-full flex-1 flex-col", compact ? "gap-1" : "gap-1.5")}>
+    <div className={cn("flex w-full flex-col", compact ? "gap-1" : "flex-1 gap-1.5")}>
       <div className={cn(INK, "w-[85%]", compact ? "h-1" : "h-1.5")} />
       {/* Page body — omitted in compact so the dock ghost stays within --dock-item-height */}
       {!compact && (
@@ -130,7 +132,7 @@ function BrowserPlaceholder({ compact }: PlaceholderProps) {
 /** Dev preview: address bar with a live dot, then a code column beside a preview. */
 function DevPreviewPlaceholder({ compact }: PlaceholderProps) {
   return (
-    <div className={cn("flex w-full flex-1 flex-col", compact ? "gap-1" : "gap-1.5")}>
+    <div className={cn("flex w-full flex-col", compact ? "gap-1" : "flex-1 gap-1.5")}>
       <div className={cn("flex items-center", compact ? "gap-1" : "gap-1.5")}>
         <div className={cn(INK, "flex-1", compact ? "h-1" : "h-1.5")} />
         <div

--- a/src/components/DragDrop/SortableDockItem.tsx
+++ b/src/components/DragDrop/SortableDockItem.tsx
@@ -7,6 +7,7 @@ import { UI_ANIMATION_DURATION, DRAG_GHOST_OPACITY, DRAG_GHOST_EASING } from "@/
 import type { PanelInstance } from "@shared/types/panel";
 import type { DragData } from "./DndProvider";
 import { DragHandleProvider, type DragHandleContextValue } from "./DragHandleContext";
+import { DROP_INDICATOR_LINE } from "./dropIndicator";
 import { useDockPanelDragHandleRegistration } from "@/components/Layout/dockPanelPortalContext";
 
 interface SortableDockItemProps {
@@ -149,15 +150,8 @@ export function SortableDockItem({
             aria-hidden="true"
             data-dock-drop-indicator={dropDirection}
             className={cn(
-              // Transient drop affordance. On dark, border-strong reads as a
-              // clear hairline against the deep grid (kept byte-for-byte). On
-              // light borderInk@0.18 composites near-invisible (~1.4:1, below
-              // the 3:1 graphical-indicator floor), so .light substitutes a
-              // strong text-ink line at /70, which clears 3:1 on every light
-              // theme and surface (>=4.2:1) — a conventional crisp placement
-              // line, kept neutral rather than borrowing the accent anchor.
-              "pointer-events-none absolute inset-y-0 z-10 w-0.5 bg-border-strong",
-              "[.light_&]:bg-daintree-text/70",
+              DROP_INDICATOR_LINE,
+              "inset-y-0 w-0.5",
               dropDirection === "before" ? "-left-px" : "-right-px"
             )}
           />

--- a/src/components/DragDrop/SortableTerminal.tsx
+++ b/src/components/DragDrop/SortableTerminal.tsx
@@ -111,7 +111,7 @@ export function SortableTerminal({
         style={sortableStyle}
         className={cn(
           "h-full min-w-0 contain-layout contain-style",
-          isDragging && "ring-2 ring-daintree-text/20 rounded"
+          isDragging && "rounded-lg ring-2 ring-text-primary/20"
         )}
       >
         <m.div

--- a/src/components/DragDrop/SortableWorktreeCard.tsx
+++ b/src/components/DragDrop/SortableWorktreeCard.tsx
@@ -3,6 +3,7 @@ import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import type { SyntheticListenerMap } from "@dnd-kit/core/dist/hooks/utilities";
 import { cn } from "@/lib/utils";
+import { DRAG_GHOST_OPACITY } from "@/lib/animationUtils";
 import { getWorktreeSidebarRowId } from "@/components/Sidebar/useWorktreeSidebarKeyboard";
 import { DROP_INDICATOR_LINE } from "./dropIndicator";
 
@@ -160,9 +161,8 @@ export const SortableWorktreeCard = React.memo(function SortableWorktreeCard({
       )}
       <div role="gridcell">
         <div
-          className={`h-full transition-opacity duration-150 motion-reduce:transition-none ${
-            isDragging ? "opacity-40" : ""
-          }`}
+          className="h-full transition-opacity duration-150 motion-reduce:transition-none"
+          style={{ opacity: isDragging ? DRAG_GHOST_OPACITY : undefined }}
         >
           {children({
             isDraggingSort: isDragging,

--- a/src/components/DragDrop/SortableWorktreeCard.tsx
+++ b/src/components/DragDrop/SortableWorktreeCard.tsx
@@ -4,6 +4,7 @@ import { CSS } from "@dnd-kit/utilities";
 import type { SyntheticListenerMap } from "@dnd-kit/core/dist/hooks/utilities";
 import { cn } from "@/lib/utils";
 import { getWorktreeSidebarRowId } from "@/components/Sidebar/useWorktreeSidebarKeyboard";
+import { DROP_INDICATOR_LINE } from "./dropIndicator";
 
 export interface WorktreeSortDragData {
   type: "worktree-sort";
@@ -151,7 +152,8 @@ export const SortableWorktreeCard = React.memo(function SortableWorktreeCard({
           aria-hidden="true"
           data-worktree-drop-indicator={dropDirection}
           className={cn(
-            "pointer-events-none absolute inset-x-0 z-10 h-0.5 bg-border-strong",
+            DROP_INDICATOR_LINE,
+            "inset-x-0 h-0.5",
             dropDirection === "above" ? "-top-px" : "-bottom-px"
           )}
         />

--- a/src/components/DragDrop/TerminalDragPreview.tsx
+++ b/src/components/DragDrop/TerminalDragPreview.tsx
@@ -7,6 +7,8 @@ import {
   getEffectiveStateIcon,
   getEffectiveStateColor,
 } from "@/components/Worktree/terminalStateConfig";
+import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
+import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 
 interface TerminalDragPreviewProps {
@@ -17,14 +19,14 @@ interface TerminalDragPreviewProps {
 
 // Fixed dimensions of the drag ghost. Exported so the DragOverlay cursor
 // modifier can center on the preview's real size — the overlay wrapper rect
-// reflects the dragged panel's (much larger) dimensions, not this box.
+// reflects the dragged panel's (much larger) dimensions, not this box. Kept in
+// px, not the rem scale, so the modifier and the box can never disagree.
 export const TERMINAL_DRAG_PREVIEW_WIDTH = 240;
 export const TERMINAL_DRAG_PREVIEW_HEIGHT = 140;
 
 export function TerminalDragPreview({ terminal, groupTabCount }: TerminalDragPreviewProps) {
   // Drag visual color mirrors the same chrome descriptor used by tabs/panels.
   const chrome = deriveTerminalChrome(terminal);
-  const brandColor = chrome.color;
   const agentState = isPtyPanel(terminal) ? terminal.agentState : undefined;
   const displayAgentState = getTerminalAgentDisplayState(chrome, agentState);
   const StateIcon = displayAgentState ? getEffectiveStateIcon(displayAgentState) : null;
@@ -32,110 +34,52 @@ export function TerminalDragPreview({ terminal, groupTabCount }: TerminalDragPre
 
   return (
     <div
-      style={{
-        width: TERMINAL_DRAG_PREVIEW_WIDTH,
-        height: TERMINAL_DRAG_PREVIEW_HEIGHT,
-        backgroundColor: "var(--color-surface-sidebar)",
-        border: "1px solid var(--color-border-default)",
-        borderRadius: "var(--radius-lg)",
-        boxShadow: "var(--theme-shadow-floating)",
-        overflow: "visible",
-        display: "flex",
-        flexDirection: "column",
-        position: "relative",
-      }}
+      className="relative rounded-lg border border-border-default bg-surface-panel shadow-[var(--theme-shadow-floating)]"
+      style={{ width: TERMINAL_DRAG_PREVIEW_WIDTH, height: TERMINAL_DRAG_PREVIEW_HEIGHT }}
     >
-      {/* Group tab count badge */}
+      {/* Group tab count. Sits outside the clipping wrapper so it can overhang the corner. */}
       {isGroupDrag && (
-        <div
-          style={{
-            position: "absolute",
-            top: -8,
-            right: -8,
-            backgroundColor: "var(--color-text-primary)",
-            color: "var(--color-surface-canvas)",
-            borderRadius: "9999px",
-            padding: "2px 6px",
-            fontSize: "var(--text-3xs)",
-            fontWeight: 600,
-            display: "flex",
-            alignItems: "center",
-            gap: 3,
-            boxShadow: "var(--theme-shadow-ambient)",
-            fontVariantNumeric: "tabular-nums",
-            zIndex: 10,
-          }}
+        <Badge
+          size="xs"
+          shape="pill"
+          className="absolute -top-2 -right-2 z-10 gap-0.5 bg-text-primary text-surface-canvas shadow-[var(--theme-shadow-ambient)] tabular-nums"
         >
-          <Layers style={{ width: 10, height: 10 }} aria-hidden="true" />
+          <Layers aria-hidden="true" />
           <span>{groupTabCount}</span>
-        </div>
+        </Badge>
       )}
-      {/* Title bar */}
-      <div
-        style={{
-          height: 24,
-          padding: "0 8px",
-          backgroundColor: "var(--color-border-default)",
-          borderBottom: "1px solid var(--color-surface-highlight)",
-          display: "flex",
-          alignItems: "center",
-          gap: 6,
-          flexShrink: 0,
-        }}
-      >
-        {/* Icon */}
+      <div className="flex h-full flex-col overflow-hidden rounded-lg">
+        {/* Title bar — the panel header's own recipe, so the ghost reads as the lifted panel */}
         <div
-          style={{
-            width: 8,
-            height: 8,
-            borderRadius: "50%",
-            backgroundColor: brandColor || "var(--color-text-primary)",
-            flexShrink: 0,
-          }}
-        />
-
-        {/* Title text */}
-        <span
-          style={{
-            fontFamily: "var(--font-mono)",
-            fontSize: "var(--text-2xs)",
-            fontWeight: 500,
-            color: "var(--color-text-primary)",
-            whiteSpace: "nowrap",
-            overflow: "hidden",
-            textOverflow: "ellipsis",
-            flex: 1,
-          }}
+          className={cn(
+            "flex h-8 shrink-0 items-center gap-2 border-b border-border-strong/30 bg-overlay-medium px-3 text-xs",
+            // Clear the badge so it never covers the state glyph.
+            isGroupDrag && "pr-7"
+          )}
         >
-          {terminal.title}
-        </span>
+          <TerminalIcon kind={terminal.kind} chrome={chrome} className="h-3.5 w-3.5 shrink-0" />
+          <span className="min-w-0 flex-1 truncate font-medium text-text-primary">
+            {terminal.title}
+          </span>
+          {StateIcon && displayAgentState && (
+            <StateIcon
+              className={cn(
+                "h-3 w-3 shrink-0",
+                getEffectiveStateColor(displayAgentState),
+                displayAgentState === "working" && "animate-spin-slow",
+                "motion-reduce:animate-none"
+              )}
+              aria-hidden="true"
+            />
+          )}
+        </div>
 
-        {StateIcon && displayAgentState && (
-          <StateIcon
-            className={cn(
-              "w-3 h-3 shrink-0",
-              getEffectiveStateColor(displayAgentState),
-              displayAgentState === "working" && "animate-spin-slow",
-              "motion-reduce:animate-none"
-            )}
-            aria-hidden="true"
+        <div className="flex flex-1 flex-col p-3">
+          <PlaceholderContent
+            kind={terminal.kind ?? "terminal"}
+            agentId={chrome.agentId ?? undefined}
           />
-        )}
-      </div>
-
-      {/* Panel body (ghost content) */}
-      <div
-        style={{
-          flex: 1,
-          padding: 8,
-          display: "flex",
-          flexDirection: "column",
-        }}
-      >
-        <PlaceholderContent
-          kind={terminal.kind ?? "terminal"}
-          agentId={chrome.agentId ?? undefined}
-        />
+        </div>
       </div>
     </div>
   );

--- a/src/components/DragDrop/WorktreeDragPreview.tsx
+++ b/src/components/DragDrop/WorktreeDragPreview.tsx
@@ -12,92 +12,22 @@ export function WorktreeDragPreview({ worktree }: WorktreeDragPreviewProps) {
   const hasDisplayTitle = !!(worktree.issueNumber && displayTitle);
 
   return (
-    <div
-      style={{
-        width: 220,
-        backgroundColor: "var(--color-surface-sidebar)",
-        border: "1px solid var(--color-border-default)",
-        borderRadius: "var(--radius-lg)",
-        boxShadow: "var(--theme-shadow-floating)",
-        overflow: "hidden",
-        display: "flex",
-        flexDirection: "column",
-        padding: "10px 12px",
-        gap: 4,
-      }}
-    >
+    <div className="flex w-55 flex-col gap-1 overflow-hidden rounded-lg border border-border-default bg-surface-panel px-3 py-2.5 shadow-[var(--theme-shadow-floating)]">
       {hasDisplayTitle ? (
         <>
-          <div
-            style={{
-              display: "flex",
-              alignItems: "center",
-              gap: 6,
-            }}
-          >
+          <div className="flex items-center gap-1.5">
             <CircleDot
-              style={{
-                width: 12,
-                height: 12,
-                color: "var(--color-pr-open)",
-                flexShrink: 0,
-              }}
+              className="h-3 w-3 shrink-0 text-[var(--color-pr-open)]"
               aria-hidden="true"
             />
-            <span
-              style={{
-                fontSize: "var(--text-xs)",
-                fontWeight: 500,
-                color: "var(--color-text-primary)",
-                whiteSpace: "nowrap",
-                overflow: "hidden",
-                textOverflow: "ellipsis",
-              }}
-            >
-              {displayTitle}
-            </span>
+            <span className="truncate text-xs font-medium text-text-primary">{displayTitle}</span>
           </div>
-          <span
-            style={{
-              fontFamily: "var(--font-mono)",
-              fontSize: "var(--text-3xs)",
-              color: "color-mix(in srgb, var(--color-text-primary) 50%, transparent)",
-              whiteSpace: "nowrap",
-              overflow: "hidden",
-              textOverflow: "ellipsis",
-            }}
-          >
-            {branchLabel}
-          </span>
+          <span className="truncate font-mono text-3xs text-text-secondary">{branchLabel}</span>
         </>
       ) : (
-        <div
-          style={{
-            display: "flex",
-            alignItems: "center",
-            gap: 6,
-          }}
-        >
-          <FolderGit2
-            style={{
-              width: 12,
-              height: 12,
-              color: "color-mix(in srgb, var(--color-text-primary) 50%, transparent)",
-              flexShrink: 0,
-            }}
-            aria-hidden="true"
-          />
-          <span
-            style={{
-              fontFamily: "var(--font-mono)",
-              fontSize: "var(--text-2xs)",
-              fontWeight: 500,
-              color: "var(--color-text-primary)",
-              whiteSpace: "nowrap",
-              overflow: "hidden",
-              textOverflow: "ellipsis",
-            }}
-          >
+        <div className="flex items-center gap-1.5">
+          <FolderGit2 className="h-3 w-3 shrink-0 text-text-secondary" aria-hidden="true" />
+          <span className="truncate font-mono text-2xs font-medium text-text-primary">
             {branchLabel}
           </span>
         </div>

--- a/src/components/DragDrop/__preview__/fixtures.ts
+++ b/src/components/DragDrop/__preview__/fixtures.ts
@@ -1,0 +1,245 @@
+import type { PanelInstance, PanelKind, PtyPanelData } from "@shared/types/panel";
+import type { AgentState } from "@shared/types/agent";
+import type { WorktreeSnapshot } from "@shared/types";
+
+/**
+ * Fixture data for the drag-drop visual-review harness. Everything here is
+ * shaped to exercise exactly what the ghosts and placeholders read — kind,
+ * title, agent identity and state, group size — with realistic labels, because
+ * a sparse fixture hides the truncation and colour defects the harness exists
+ * to find.
+ */
+
+interface PtyOptions {
+  agentId?: string;
+  agentState?: AgentState;
+}
+
+// The preview never persists or dispatches these, so the store-owned fields a
+// real PanelInstance carries (cwd, pid, cols/rows, worktree binding) are filled
+// with inert values and non-PTY kinds are widened through the same cast.
+export function ptyPanel(id: string, title: string, opts: PtyOptions = {}): PanelInstance {
+  const raw = {
+    id,
+    kind: "terminal",
+    title,
+    location: "grid",
+    isVisible: true,
+    cwd: "/Users/dev/Projects/surge-checkout",
+    cols: 120,
+    rows: 40,
+    ...(opts.agentId
+      ? {
+          launchAgentId: opts.agentId,
+          runtimeIdentity: {
+            kind: "agent",
+            id: opts.agentId,
+            iconId: opts.agentId,
+            agentId: opts.agentId,
+          },
+        }
+      : {}),
+    ...(opts.agentState ? { agentState: opts.agentState } : {}),
+  };
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- inert fixture, see above
+  return raw as unknown as PtyPanelData;
+}
+
+export function kindPanel(kind: PanelKind, id: string, title: string): PanelInstance {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- inert fixture, see above
+  return { id, kind, title, location: "grid", isVisible: true } as unknown as PanelInstance;
+}
+
+export interface GhostFixture {
+  what: string;
+  terminal: PanelInstance;
+  groupTabCount?: number;
+}
+
+/** Every distinct thing a panel drag ghost can be asked to represent. */
+export const GHOSTS: Record<string, GhostFixture> = {
+  shell: {
+    what: "a plain shell — the default, no agent chrome",
+    terminal: ptyPanel("p-shell", "zsh — surge-checkout"),
+  },
+  "claude-working": {
+    what: "an agent mid-task: brand colour + spinning working glyph",
+    terminal: ptyPanel("p-claude-w", "Refund pipeline", {
+      agentId: "claude",
+      agentState: "working",
+    }),
+  },
+  "claude-waiting": {
+    what: "an agent waiting on the user: amber hollow circle",
+    terminal: ptyPanel("p-claude-i", "Refund pipeline", {
+      agentId: "claude",
+      agentState: "waiting",
+    }),
+  },
+  "codex-directing": {
+    what: "a second agent brand, user-intervention state",
+    terminal: ptyPanel("p-codex", "Webhook router audit", {
+      agentId: "codex",
+      agentState: "directing",
+    }),
+  },
+  "gemini-group": {
+    what: "a three-tab group — the count badge",
+    terminal: ptyPanel("p-gemini", "Checkout tests", {
+      agentId: "gemini",
+      agentState: "working",
+    }),
+    groupTabCount: 3,
+  },
+  "exited-agent": {
+    what: "an agent that exited — chrome demotes to a plain terminal",
+    terminal: ptyPanel("p-exited", "Refund pipeline", {
+      agentId: "claude",
+      agentState: "exited",
+    }),
+  },
+  "long-title": {
+    what: "a title long enough to force the ellipsis",
+    terminal: ptyPanel(
+      "p-long",
+      "Investigate the intermittent ECONNRESET on the refund webhook retry path and propose a fix",
+      { agentId: "claude", agentState: "working" }
+    ),
+  },
+  browser: {
+    what: "browser panel",
+    terminal: kindPanel("browser", "p-browser", "localhost:5173/checkout"),
+  },
+  "dev-preview": {
+    what: "dev preview panel",
+    terminal: kindPanel("dev-preview", "p-devp", "npm run dev"),
+  },
+  review: {
+    what: "review hub panel",
+    terminal: kindPanel("review", "p-review", "Review — feature/refund-flow"),
+  },
+  file: {
+    what: "file viewer panel — has no illustration of its own today",
+    terminal: kindPanel("file", "p-file", "src/checkout.ts"),
+  },
+  "file-browser": {
+    what: "file browser panel — has no illustration of its own today",
+    terminal: kindPanel("file-browser", "p-fb", "surge-checkout"),
+  },
+  diff: {
+    what: "diff panel — has no illustration of its own today",
+    terminal: kindPanel("diff", "p-diff", "src/refund.ts"),
+  },
+  plugin: {
+    what: "a plugin-contributed kind the registry has never heard of",
+    terminal: kindPanel("sticky-notes", "p-plugin", "Sticky notes"),
+  },
+};
+
+export interface WorktreeGhostFixture {
+  what: string;
+  worktree: WorktreeSnapshot;
+}
+
+function worktree(overrides: Partial<WorktreeSnapshot> & { id: string }): WorktreeSnapshot {
+  const raw = {
+    name: overrides.id,
+    path: `/Users/dev/Projects/surge-checkout-worktrees/${overrides.id}`,
+    isCurrent: false,
+    ...overrides,
+  };
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- inert fixture, see above
+  return raw as WorktreeSnapshot;
+}
+
+/** Every distinct thing a worktree-row drag ghost can be asked to represent. */
+export const WORKTREE_GHOSTS: Record<string, WorktreeGhostFixture> = {
+  issue: {
+    what: "a worktree bound to an issue — title line plus branch line",
+    worktree: worktree({
+      id: "wt-142",
+      name: "issue-142-refund-flow",
+      branch: "feature/issue-142-refund-flow",
+      issueNumber: 142,
+      issueTitle: "Add idempotent partial refunds",
+    }),
+  },
+  "branch-only": {
+    what: "a plain branch — single line with the folder glyph",
+    worktree: worktree({
+      id: "wt-auth",
+      name: "bugfix-auth-redirect",
+      branch: "bugfix/auth-redirect",
+    }),
+  },
+  main: {
+    what: "the main worktree — shows its folder name, not the branch",
+    worktree: worktree({
+      id: "wt-main",
+      name: "surge-checkout",
+      branch: "main",
+      isMainWorktree: true,
+    }),
+  },
+  "long-issue": {
+    what: "an issue title long enough to force the ellipsis on both lines",
+    worktree: worktree({
+      id: "wt-long",
+      name: "issue-188-webhook",
+      branch: "feature/issue-188-webhook-router-retry-with-exponential-backoff",
+      issueNumber: 188,
+      issueTitle:
+        "Webhook router should retry with exponential backoff and surface the final failure",
+    }),
+  },
+};
+
+/**
+ * The kinds a drop placeholder can be asked to stand in for. `agent` is a
+ * terminal with an agent identity — the placeholder's colour comes from the
+ * agent, not the kind.
+ */
+export const PLACEHOLDER_KINDS = [
+  "terminal",
+  "agent",
+  "browser",
+  "dev-preview",
+  "review",
+  "file",
+  "file-browser",
+  "diff",
+  "plugin",
+] as const;
+
+export type PlaceholderKind = (typeof PLACEHOLDER_KINDS)[number];
+
+export function placeholderPanel(kind: PlaceholderKind): PanelInstance {
+  switch (kind) {
+    case "terminal":
+      return GHOSTS.shell!.terminal;
+    case "agent":
+      return GHOSTS["claude-working"]!.terminal;
+    default:
+      return GHOSTS[kind]!.terminal;
+  }
+}
+
+/** Panels that populate the grid and dock around a placeholder. */
+export const NEIGHBOURS: PanelInstance[] = [
+  ptyPanel("n-1", "Refund pipeline", { agentId: "claude", agentState: "working" }),
+  ptyPanel("n-2", "zsh — surge-checkout"),
+  kindPanel("browser", "n-3", "localhost:5173/checkout"),
+  ptyPanel("n-4", "Checkout tests", { agentId: "codex", agentState: "waiting" }),
+];
+
+export const SIDEBAR_ROWS: WorktreeSnapshot[] = [
+  WORKTREE_GHOSTS.issue!.worktree,
+  WORKTREE_GHOSTS["branch-only"]!.worktree,
+  worktree({
+    id: "wt-assets",
+    name: "feature-asset-library",
+    branch: "feature/asset-library",
+    issueNumber: 97,
+    issueTitle: "Asset library CDN sync",
+  }),
+];

--- a/src/components/DragDrop/__preview__/preview.tsx
+++ b/src/components/DragDrop/__preview__/preview.tsx
@@ -491,7 +491,9 @@ function Sheet() {
     >
       <div
         data-preview-shell=""
-        className="grid grid-cols-[minmax(0,1fr)_300px] gap-4 bg-surface-canvas p-4"
+        // Right padding is room for the worktree ghost, which dnd-kit positions
+        // from the row's rect and which would otherwise run off the sheet.
+        className="grid grid-cols-[minmax(0,1fr)_300px] gap-4 bg-surface-canvas p-4 pr-56"
         style={{ width }}
       >
         <div className="flex min-w-0 flex-col gap-4">

--- a/src/components/DragDrop/__preview__/preview.tsx
+++ b/src/components/DragDrop/__preview__/preview.tsx
@@ -164,7 +164,7 @@ function FixtureRow({
 }) {
   const title = worktree.issueTitle ?? worktree.branch ?? worktree.name;
   return (
-    <div className="mx-2 my-0.5 flex items-start gap-2 rounded-md border border-border-default bg-surface-panel px-2 py-2">
+    <div className="mx-0.5 my-0.5 flex items-start gap-2 rounded-md border border-border-default bg-surface-panel px-2 py-2">
       <button
         type="button"
         ref={activatorRef}

--- a/src/components/DragDrop/__preview__/preview.tsx
+++ b/src/components/DragDrop/__preview__/preview.tsx
@@ -1,0 +1,555 @@
+import { StrictMode, useState, type ReactNode } from "react";
+import { createRoot } from "react-dom/client";
+import {
+  DndContext,
+  DragOverlay,
+  MouseSensor,
+  useSensor,
+  useSensors,
+  type DragStartEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  horizontalListSortingStrategy,
+  rectSortingStrategy,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import type { SyntheticListenerMap } from "@dnd-kit/core/dist/hooks/utilities";
+import { LazyMotion, domAnimation } from "framer-motion";
+import { GripVertical } from "lucide-react";
+import { resolveAppTheme } from "@shared/theme/themes";
+import type { PanelInstance } from "@shared/types/panel";
+import type { WorktreeSnapshot } from "@shared/types";
+import { applyAppThemeToRoot } from "@/theme/applyAppTheme";
+import { installPreviewShims } from "@/components/HelpPanel/__preview__/previewShims";
+import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
+import { deriveTerminalChrome } from "@/utils/terminalChrome";
+import { cn } from "@/lib/utils";
+import { TerminalDragPreview } from "../TerminalDragPreview";
+import { WorktreeDragPreview } from "../WorktreeDragPreview";
+import { GridPlaceholder } from "../GridPlaceholder";
+import { DockPlaceholder } from "../DockPlaceholder";
+import { SortableTerminal } from "../SortableTerminal";
+import { SortableDockItem } from "../SortableDockItem";
+import {
+  SortableWorktreeCard,
+  getWorktreeSortDragId,
+  parseWorktreeSortDragId,
+} from "../SortableWorktreeCard";
+import { useDragHandle } from "../DragHandleContext";
+import { DndPlaceholderContext, IDLE_DND_PLACEHOLDER } from "../dndPlaceholderContext";
+import {
+  GHOSTS,
+  WORKTREE_GHOSTS,
+  PLACEHOLDER_KINDS,
+  placeholderPanel,
+  NEIGHBOURS,
+  SIDEBAR_ROWS,
+  type PlaceholderKind,
+} from "./fixtures";
+import "@/index.css";
+
+installPreviewShims();
+
+/**
+ * Standalone visual-review harness for drag ghosts and drop placeholders.
+ *
+ * Every state this surface has exists only while a pointer (or a keyboard
+ * drag) is held, which is why nothing had ever looked at it. This page makes
+ * those states addressable in two ways:
+ *
+ * - **Forced.** The ghosts (`TerminalDragPreview`, `WorktreeDragPreview`) are
+ *   rendered directly from fixtures; the placeholders (`GridPlaceholder`,
+ *   `DockPlaceholder`) are rendered under a hand-built `DndPlaceholderContext`
+ *   value, which is the same seam `DndProvider` feeds them through.
+ * - **Sandboxed.** The source-dim and insertion-line states live inside
+ *   dnd-kit's own `useSortable` and cannot be forced, so the `drag-*` scenes
+ *   mount the real sortable wrappers in a bare `DndContext` (mouse sensor, no
+ *   activation distance) and the screenshot spec performs a real pointer drag
+ *   and captures mid-gesture. The overlay in those scenes is positioned by
+ *   dnd-kit's default rect centring, not by `DndProvider`'s cursor modifier.
+ *
+ * What is real: every component under `src/components/DragDrop/`, the theme
+ * tokens via `applyAppThemeToRoot`, and `index.css`. What is a stand-in: the
+ * neighbouring grid panels, dock chips and sidebar rows, which copy the recipe
+ * of `ContentPanel`, `DockedTerminalItem` and the worktree card closely enough
+ * to judge whether a placeholder reads as native to its rail.
+ *
+ * Query parameters (the spec drives these):
+ *   ?theme=daintree|bondi|…      built-in theme id
+ *   ?scene=ghosts|grid|dock|drag-grid|drag-dock|drag-sidebar|sheet
+ *   ?kind=terminal|agent|…|none  which panel the placeholder stands in for
+ *   ?over=1                      dock scene: draw the rail's drag-over highlight
+ *   ?dragging=0                  dock scene: render the idle spacer instead
+ *   ?density=compact|comfortable dock scene: the dock density modes
+ *   ?width=1100                  shell width in CSS px
+ */
+
+const params = new URLSearchParams(window.location.search);
+const themeId = params.get("theme") ?? "daintree";
+const scene = params.get("scene") ?? "ghosts";
+const width = Number(params.get("width") ?? "1100");
+const kindParam = params.get("kind") ?? "terminal";
+const over = params.get("over") === "1";
+const dragging = params.get("dragging") !== "0";
+const density = params.get("density");
+
+applyAppThemeToRoot(document.documentElement, resolveAppTheme(themeId));
+document.body.style.background = "var(--color-surface-canvas)";
+document.body.style.margin = "0";
+
+function resolveKind(value: string): PlaceholderKind | null {
+  if (value === "none") return null;
+  return PLACEHOLDER_KINDS.find((kind) => kind === value) ?? "terminal";
+}
+
+const FAUX_OUTPUT = [
+  "$ npm test -- src/refund",
+  "✓ partial refund is idempotent (42 ms)",
+  "✓ audit trail records operator (11 ms)",
+  "2 passing",
+];
+
+/** Stands in for a grid `ContentPanel`: same frame recipe, a header that is the drag handle. */
+function FixturePanel({ terminal }: { terminal: PanelInstance }) {
+  const handle = useDragHandle();
+  const chrome = deriveTerminalChrome(terminal);
+  return (
+    <div className="flex h-full min-w-0 flex-col overflow-hidden rounded-lg border border-border-default bg-surface-panel shadow-[var(--theme-shadow-ambient)]">
+      <div
+        ref={handle?.setActivatorNodeRef}
+        {...handle?.listeners}
+        data-fixture-handle=""
+        className="flex h-7 shrink-0 cursor-grab items-center gap-2 border-b border-border-default bg-overlay-subtle px-3 text-xs"
+      >
+        <TerminalIcon kind={terminal.kind} chrome={chrome} className="h-3.5 w-3.5" />
+        <span className="truncate font-medium text-text-secondary">{terminal.title}</span>
+      </div>
+      <div className="flex-1 p-3 font-mono text-xs leading-5 text-text-secondary">
+        {FAUX_OUTPUT.map((line) => (
+          <div key={line}>{line}</div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/** Stands in for `DockedTerminalItem`: the chip recipe, as a drag handle. */
+function FixtureChip({ terminal }: { terminal: PanelInstance }) {
+  const handle = useDragHandle();
+  const chrome = deriveTerminalChrome(terminal);
+  return (
+    <button
+      type="button"
+      ref={handle?.setActivatorNodeRef}
+      {...handle?.listeners}
+      data-dock-item=""
+      className="flex h-[var(--dock-item-height)] max-w-[280px] cursor-grab items-center gap-1.5 rounded-md border border-[var(--dock-item-border)] bg-[var(--dock-item-bg)] px-3 text-xs text-text-secondary"
+    >
+      <TerminalIcon kind={terminal.kind} chrome={chrome} className="h-3.5 w-3.5" />
+      <span className="truncate">{terminal.title}</span>
+    </button>
+  );
+}
+
+/** Stands in for a sidebar worktree card: grip, title line, branch line. */
+function FixtureRow({
+  worktree,
+  listeners,
+  activatorRef,
+}: {
+  worktree: WorktreeSnapshot;
+  listeners: SyntheticListenerMap | undefined;
+  activatorRef: (node: HTMLElement | null) => void;
+}) {
+  const title = worktree.issueTitle ?? worktree.branch ?? worktree.name;
+  return (
+    <div className="mx-2 my-0.5 flex items-start gap-2 rounded-md border border-border-default bg-surface-panel px-2 py-2">
+      <button
+        type="button"
+        ref={activatorRef}
+        {...listeners}
+        aria-label="Reorder worktree"
+        className="mt-0.5 flex h-4 w-4 shrink-0 cursor-grab items-center justify-center text-text-secondary"
+      >
+        <GripVertical className="h-3.5 w-3.5" aria-hidden="true" />
+      </button>
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-xs font-medium text-text-primary">{title}</div>
+        <div className="truncate font-mono text-2xs text-text-secondary">{worktree.branch}</div>
+      </div>
+    </div>
+  );
+}
+
+function Caption({ children }: { children: ReactNode }) {
+  return <div className="font-mono text-2xs text-text-secondary">{children}</div>;
+}
+
+function GhostGallery() {
+  return (
+    <div
+      data-preview-shell=""
+      className="flex flex-col gap-10 bg-noise bg-[var(--color-grid-bg)] p-6"
+      style={{ width }}
+    >
+      <div className="grid grid-cols-4 gap-x-6 gap-y-8">
+        {Object.entries(GHOSTS).map(([name, fixture]) => (
+          <figure key={name} className="m-0 flex flex-col gap-2">
+            {/* Padding keeps the group badge, which hangs outside the card, inside the crop. */}
+            <div data-shot={`ghost-${name}`} className="inline-flex self-start p-3">
+              <TerminalDragPreview
+                terminal={fixture.terminal}
+                groupTabCount={fixture.groupTabCount}
+              />
+            </div>
+            <figcaption className="m-0">
+              <Caption>{name}</Caption>
+            </figcaption>
+          </figure>
+        ))}
+      </div>
+      <div className="grid grid-cols-4 gap-x-6 gap-y-8">
+        {Object.entries(WORKTREE_GHOSTS).map(([name, fixture]) => (
+          <figure key={name} className="m-0 flex flex-col gap-2">
+            <div data-shot={`wt-${name}`} className="inline-flex self-start p-3">
+              <WorktreeDragPreview worktree={fixture.worktree} />
+            </div>
+            <figcaption className="m-0">
+              <Caption>worktree · {name}</Caption>
+            </figcaption>
+          </figure>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/** The grid container recipe from `ContentGridDefault`. */
+function GridShell({ children, rows = 240 }: { children: ReactNode; rows?: number }) {
+  return (
+    <div
+      className="grid grid-cols-2 gap-1 bg-noise bg-[var(--color-grid-bg)] p-1"
+      style={{ gridAutoRows: rows }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function GridScene() {
+  const kind = resolveKind(kindParam);
+  const active = kind ? placeholderPanel(kind) : null;
+  return (
+    <DndPlaceholderContext.Provider
+      value={{
+        ...IDLE_DND_PLACEHOLDER,
+        activeTerminal: active,
+        isDragging: true,
+        sourceContainer: "grid",
+        placeholderIndex: 1,
+      }}
+    >
+      <div data-preview-shell="" className="flex flex-col" style={{ width }}>
+        <GridShell>
+          <FixturePanel terminal={NEIGHBOURS[0]!} />
+          <div data-shot="grid-placeholder" className="h-full min-w-0">
+            <GridPlaceholder />
+          </div>
+          <FixturePanel terminal={NEIGHBOURS[2]!} />
+          <FixturePanel terminal={NEIGHBOURS[3]!} />
+        </GridShell>
+      </div>
+    </DndPlaceholderContext.Provider>
+  );
+}
+
+/** The dock rail recipe from `ContentDock`, including its drag-over highlight. */
+function DockRail({
+  children,
+  highlighted = false,
+}: {
+  children: ReactNode;
+  highlighted?: boolean;
+}) {
+  return (
+    <div className="border-t border-border-default bg-[var(--dock-bg)] px-1 py-[var(--dock-padding-y)]">
+      <div
+        className={cn(
+          "flex min-h-[var(--dock-item-height)] items-center gap-[var(--dock-gap)] px-1",
+          highlighted && "rounded-md bg-overlay-soft ring-2 ring-inset ring-border-default"
+        )}
+      >
+        <div className="flex min-h-[calc(var(--dock-item-height)-4px)] min-w-[100px] items-center gap-[var(--dock-gap)]">
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function DockScene() {
+  const kind = resolveKind(kindParam) ?? "terminal";
+  return (
+    <DndPlaceholderContext.Provider
+      value={{
+        ...IDLE_DND_PLACEHOLDER,
+        activeTerminal: placeholderPanel(kind),
+        isDragging: dragging,
+        sourceContainer: "grid",
+      }}
+    >
+      <div
+        data-preview-shell=""
+        data-dock-density={density ?? undefined}
+        className="flex flex-col gap-6 bg-surface-canvas"
+        style={{ width }}
+      >
+        <div className="flex flex-col">
+          <div className="h-12 bg-noise bg-[var(--color-grid-bg)]" />
+          <DockRail highlighted={over}>
+            <div data-shot="dock-placeholder" className="h-full">
+              <DockPlaceholder />
+            </div>
+          </DockRail>
+          <div className="px-2 pt-1">
+            <Caption>
+              empty dock during a drag{over ? ", pointer over the rail" : ""} — the only place the
+              dock placeholder renders
+            </Caption>
+          </div>
+        </div>
+        <div className="flex flex-col">
+          <div className="h-12 bg-noise bg-[var(--color-grid-bg)]" />
+          <DockRail>
+            {NEIGHBOURS.slice(0, 3).map((terminal) => (
+              <FixtureChip key={terminal.id} terminal={terminal} />
+            ))}
+          </DockRail>
+          <div className="px-2 pt-1">
+            <Caption>reference — real chip recipe at the same density</Caption>
+          </div>
+        </div>
+      </div>
+    </DndPlaceholderContext.Provider>
+  );
+}
+
+/**
+ * A bare DndContext for the states only dnd-kit can produce. Publishes the
+ * active id on the shell so the spec can wait for the gesture to register.
+ */
+function Sandbox({
+  overlay,
+  children,
+}: {
+  overlay: (activeId: string | null) => ReactNode;
+  children: (activeId: string | null) => ReactNode;
+}) {
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const sensors = useSensors(useSensor(MouseSensor));
+  return (
+    <DndContext
+      sensors={sensors}
+      onDragStart={(e: DragStartEvent) => setActiveId(String(e.active.id))}
+      onDragEnd={() => setActiveId(null)}
+      onDragCancel={() => setActiveId(null)}
+    >
+      <div data-sandbox-active={activeId ?? undefined}>{children(activeId)}</div>
+      <DragOverlay dropAnimation={null}>{overlay(activeId)}</DragOverlay>
+    </DndContext>
+  );
+}
+
+function panelById(id: string | null): PanelInstance | undefined {
+  return NEIGHBOURS.find((p) => p.id === id);
+}
+
+function GridSandbox() {
+  return (
+    <Sandbox
+      overlay={(id) => {
+        const t = panelById(id);
+        return t ? <TerminalDragPreview terminal={t} /> : null;
+      }}
+    >
+      {() => (
+        <SortableContext items={NEIGHBOURS.map((p) => p.id)} strategy={rectSortingStrategy}>
+          <GridShell>
+            {NEIGHBOURS.map((terminal, index) => (
+              <SortableTerminal
+                key={terminal.id}
+                terminal={terminal}
+                sourceLocation="grid"
+                sourceIndex={index}
+              >
+                <FixturePanel terminal={terminal} />
+              </SortableTerminal>
+            ))}
+          </GridShell>
+        </SortableContext>
+      )}
+    </Sandbox>
+  );
+}
+
+function DockSandbox() {
+  const chips = NEIGHBOURS.slice(0, 3);
+  return (
+    <Sandbox
+      overlay={(id) => {
+        const t = panelById(id);
+        return t ? <TerminalDragPreview terminal={t} /> : null;
+      }}
+    >
+      {() => (
+        <SortableContext items={chips.map((p) => p.id)} strategy={horizontalListSortingStrategy}>
+          <DockRail>
+            {chips.map((terminal, index) => (
+              <SortableDockItem key={terminal.id} terminal={terminal} sourceIndex={index}>
+                <FixtureChip terminal={terminal} />
+              </SortableDockItem>
+            ))}
+          </DockRail>
+        </SortableContext>
+      )}
+    </Sandbox>
+  );
+}
+
+function SidebarSandbox() {
+  const order = SIDEBAR_ROWS.map((w) => getWorktreeSortDragId(w.id));
+  return (
+    <Sandbox
+      overlay={(id) => {
+        const worktreeId = id ? parseWorktreeSortDragId(id) : null;
+        const w = SIDEBAR_ROWS.find((row) => row.id === worktreeId);
+        return w ? <WorktreeDragPreview worktree={w} /> : null;
+      }}
+    >
+      {() => (
+        <SortableContext items={order} strategy={verticalListSortingStrategy}>
+          <div role="grid" aria-label="Worktrees" className="w-[280px] bg-surface-sidebar py-1">
+            {SIDEBAR_ROWS.map((worktree, index) => (
+              <SortableWorktreeCard
+                key={worktree.id}
+                worktreeId={worktree.id}
+                dragStartOrder={SIDEBAR_ROWS.map((w) => w.id)}
+                ariaRowIndex={index + 1}
+                isActive={index === 0}
+              >
+                {({ dragHandleListeners, dragHandleActivatorRef }) => (
+                  <FixtureRow
+                    worktree={worktree}
+                    listeners={dragHandleListeners}
+                    activatorRef={dragHandleActivatorRef}
+                  />
+                )}
+              </SortableWorktreeCard>
+            ))}
+          </div>
+        </SortableContext>
+      )}
+    </Sandbox>
+  );
+}
+
+function DragScene({ which }: { which: "grid" | "dock" | "sidebar" }) {
+  return (
+    <div data-preview-shell="" className="flex flex-col bg-surface-canvas" style={{ width }}>
+      {which === "grid" && <GridSandbox />}
+      {which === "dock" && (
+        // Left and bottom room for the overlay ghost, which dnd-kit positions
+        // from the source chip's rect and which hangs below the rail mid-drag.
+        <div className="flex flex-col pl-48">
+          <div className="h-12 bg-noise bg-[var(--color-grid-bg)]" />
+          <DockSandbox />
+          <div className="h-44" />
+        </div>
+      )}
+      {which === "sidebar" && (
+        <div className="pb-24">
+          <SidebarSandbox />
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** One page per theme for the 15-theme sweep: the whole system side by side. */
+function Sheet() {
+  const sheetGhosts = ["claude-working", "browser", "review"] as const;
+  return (
+    <DndPlaceholderContext.Provider
+      value={{
+        ...IDLE_DND_PLACEHOLDER,
+        activeTerminal: placeholderPanel("agent"),
+        isDragging: true,
+        sourceContainer: "grid",
+        placeholderIndex: 1,
+      }}
+    >
+      <div
+        data-preview-shell=""
+        className="grid grid-cols-[minmax(0,1fr)_300px] gap-4 bg-surface-canvas p-4"
+        style={{ width }}
+      >
+        <div className="flex min-w-0 flex-col gap-4">
+          <div className="flex flex-wrap items-start gap-6 bg-noise bg-[var(--color-grid-bg)] p-4">
+            {sheetGhosts.map((name) => (
+              <TerminalDragPreview
+                key={name}
+                terminal={GHOSTS[name]!.terminal}
+                groupTabCount={name === "claude-working" ? 3 : undefined}
+              />
+            ))}
+            <WorktreeDragPreview worktree={WORKTREE_GHOSTS.issue!.worktree} />
+          </div>
+          <GridShell rows={200}>
+            <FixturePanel terminal={NEIGHBOURS[0]!} />
+            <div className="h-full min-w-0">
+              <GridPlaceholder />
+            </div>
+          </GridShell>
+          <DockRail highlighted>
+            <DockPlaceholder />
+          </DockRail>
+          <div data-sheet-dock="">
+            <DockSandbox />
+          </div>
+          <div className="h-44" />
+        </div>
+        <div data-sheet-sidebar="" className="self-start">
+          <SidebarSandbox />
+        </div>
+      </div>
+    </DndPlaceholderContext.Provider>
+  );
+}
+
+function Preview() {
+  switch (scene) {
+    case "grid":
+      return <GridScene />;
+    case "dock":
+      return <DockScene />;
+    case "drag-grid":
+      return <DragScene which="grid" />;
+    case "drag-dock":
+      return <DragScene which="dock" />;
+    case "drag-sidebar":
+      return <DragScene which="sidebar" />;
+    case "sheet":
+      return <Sheet />;
+    default:
+      return <GhostGallery />;
+  }
+}
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <LazyMotion features={domAnimation}>
+      <Preview />
+    </LazyMotion>
+  </StrictMode>
+);

--- a/src/components/DragDrop/__tests__/DndProvider.dropAnimation.test.ts
+++ b/src/components/DragDrop/__tests__/DndProvider.dropAnimation.test.ts
@@ -29,11 +29,8 @@ type DropAnimationConfig = {
  * Must call getUiAnimationDuration() at invocation time so it reads the
  * live `document.body.dataset.performanceMode` flag.
  */
-function dropAnimation(
-  isCancelDrop: boolean,
-  prefersReducedMotion = false
-): DropAnimationConfig | null {
-  if (prefersReducedMotion) return null;
+function dropAnimation(isCancelDrop: boolean, prefersReducedMotion = false): DropAnimationConfig {
+  if (prefersReducedMotion) return { duration: 0, easing: EASE_SNAPPY, sideEffects: null };
   return isCancelDrop
     ? { duration: PANEL_RESTORE_DURATION, easing: EASE_OUT_EXPO, sideEffects: null }
     : { duration: getUiAnimationDuration(), easing: EASE_SNAPPY, sideEffects: null };
@@ -47,20 +44,32 @@ describe("DragOverlay dropAnimation config", () => {
   });
 
   // dnd-kit runs the drop animation through WAAPI, which CSS reduced-motion
-  // rules never reach — so the OS preference has to disable it here, for the
+  // rules never reach — so the OS preference has to collapse it here, for the
   // snap-back as well as the settle, the same way it already skips the entry
-  // spring.
-  it("disables the travelling ghost entirely under reduced motion", () => {
-    expect(dropAnimation(false, true)).toBeNull();
-    expect(dropAnimation(true, true)).toBeNull();
+  // spring. Zero duration rather than `null`: a null config makes dnd-kit skip
+  // scrolling the source back into view on cancel.
+  it("collapses the travelling ghost to zero duration under reduced motion", () => {
+    expect(dropAnimation(false, true)).toEqual({
+      duration: 0,
+      easing: EASE_SNAPPY,
+      sideEffects: null,
+    });
+    expect(dropAnimation(true, true)).toEqual({
+      duration: 0,
+      easing: EASE_SNAPPY,
+      sideEffects: null,
+    });
   });
 
   // The replica above cannot see the real prop, so pin the gate at the source:
-  // the DragOverlay's dropAnimation must short-circuit on the same reduced-motion
-  // flag the entry spring already reads.
+  // the DragOverlay's dropAnimation must branch on the same reduced-motion
+  // flag the entry spring already reads, and never hand dnd-kit a null.
   it("wires the reduced-motion gate onto the real DragOverlay", () => {
     const source = readFileSync(resolve(__dirname, "../DndProvider.tsx"), "utf8");
-    expect(source).toMatch(/dropAnimation=\{(?:\s|\/\/[^\n]*)*prefersReducedMotion\s*\?\s*null/);
+    expect(source).toMatch(
+      /dropAnimation=\{(?:\s|\/\/[^\n]*)*prefersReducedMotion\s*\?\s*\{\s*duration:\s*0\b/
+    );
+    expect(source).not.toMatch(/prefersReducedMotion\s*\?\s*null/);
   });
 
   it("uses Tier 1 snap motion (150ms EASE_SNAPPY) on successful drops", () => {

--- a/src/components/DragDrop/__tests__/DndProvider.dropAnimation.test.ts
+++ b/src/components/DragDrop/__tests__/DndProvider.dropAnimation.test.ts
@@ -4,6 +4,8 @@
 // dropAnimation prop so we can assert success and cancel branches use
 // the right motion tokens. Following the same harness pattern as
 // DndProvider.cancelDrop.test.ts and DndProvider.trashDrop.test.ts.
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
@@ -27,7 +29,11 @@ type DropAnimationConfig = {
  * Must call getUiAnimationDuration() at invocation time so it reads the
  * live `document.body.dataset.performanceMode` flag.
  */
-function dropAnimation(isCancelDrop: boolean): DropAnimationConfig {
+function dropAnimation(
+  isCancelDrop: boolean,
+  prefersReducedMotion = false
+): DropAnimationConfig | null {
+  if (prefersReducedMotion) return null;
   return isCancelDrop
     ? { duration: PANEL_RESTORE_DURATION, easing: EASE_OUT_EXPO, sideEffects: null }
     : { duration: getUiAnimationDuration(), easing: EASE_SNAPPY, sideEffects: null };
@@ -38,6 +44,23 @@ function dropAnimation(isCancelDrop: boolean): DropAnimationConfig {
 describe("DragOverlay dropAnimation config", () => {
   afterEach(() => {
     delete document.body.dataset.performanceMode;
+  });
+
+  // dnd-kit runs the drop animation through WAAPI, which CSS reduced-motion
+  // rules never reach — so the OS preference has to disable it here, for the
+  // snap-back as well as the settle, the same way it already skips the entry
+  // spring.
+  it("disables the travelling ghost entirely under reduced motion", () => {
+    expect(dropAnimation(false, true)).toBeNull();
+    expect(dropAnimation(true, true)).toBeNull();
+  });
+
+  // The replica above cannot see the real prop, so pin the gate at the source:
+  // the DragOverlay's dropAnimation must short-circuit on the same reduced-motion
+  // flag the entry spring already reads.
+  it("wires the reduced-motion gate onto the real DragOverlay", () => {
+    const source = readFileSync(resolve(__dirname, "../DndProvider.tsx"), "utf8");
+    expect(source).toMatch(/dropAnimation=\{(?:\s|\/\/[^\n]*)*prefersReducedMotion\s*\?\s*null/);
   });
 
   it("uses Tier 1 snap motion (150ms EASE_SNAPPY) on successful drops", () => {

--- a/src/components/DragDrop/__tests__/DockPlaceholder.test.tsx
+++ b/src/components/DragDrop/__tests__/DockPlaceholder.test.tsx
@@ -4,7 +4,7 @@ import { describe, it, expect, vi } from "vitest";
 import { fireEvent, render } from "@testing-library/react";
 
 const mockUseDndPlaceholder = vi.fn();
-vi.mock("../DndProvider", () => ({
+vi.mock("../dndPlaceholderContext", () => ({
   useDndPlaceholder: () => mockUseDndPlaceholder(),
 }));
 vi.mock("@/utils/terminalChrome", () => ({

--- a/src/components/DragDrop/__tests__/DockReflow.test.tsx
+++ b/src/components/DragDrop/__tests__/DockReflow.test.tsx
@@ -72,7 +72,7 @@ vi.mock("@dnd-kit/utilities", () => ({
   CSS: { Transform: { toString: () => undefined } },
 }));
 
-vi.mock("../DndProvider", () => ({
+vi.mock("../dndPlaceholderContext", () => ({
   useDndPlaceholder: () => ({ activeTerminal: null, isDragging: false }),
 }));
 

--- a/src/components/DragDrop/__tests__/GridPlaceholder.test.tsx
+++ b/src/components/DragDrop/__tests__/GridPlaceholder.test.tsx
@@ -18,6 +18,7 @@ vi.mock("framer-motion", () => ({
 }));
 
 import { GridPlaceholder } from "../GridPlaceholder";
+import { DROP_SLOT_FRAME } from "../dropIndicator";
 
 const panel = {
   id: "p1",
@@ -46,6 +47,10 @@ describe("GridPlaceholder destination boundary", () => {
     const unknown = root(render(<GridPlaceholder />).container);
     expect(unknown.className).toBe(known.className);
     expect(unknown.children.length).toBe(known.children.length);
+    // Equal is not enough — both could be equally frameless.
+    for (const cls of DROP_SLOT_FRAME.split(/\s+/)) {
+      expect(known.className.split(/\s+/), cls).toContain(cls);
+    }
   });
 
   it("carries identity only when it has it", () => {

--- a/src/components/DragDrop/__tests__/GridPlaceholder.test.tsx
+++ b/src/components/DragDrop/__tests__/GridPlaceholder.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+import type { ReactNode } from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+
+const mockUseDndPlaceholder = vi.fn();
+vi.mock("../dndPlaceholderContext", () => ({
+  useDndPlaceholder: () => mockUseDndPlaceholder(),
+  GRID_PLACEHOLDER_ID: "__grid-placeholder__",
+}));
+vi.mock("@/components/Terminal/TerminalIcon", () => ({
+  TerminalIcon: () => <span data-terminal-icon="" />,
+}));
+vi.mock("@dnd-kit/sortable", () => ({ useSortable: () => ({}) }));
+vi.mock("@dnd-kit/utilities", () => ({ CSS: { Transform: { toString: () => undefined } } }));
+vi.mock("framer-motion", () => ({
+  m: { div: ({ children }: { children?: ReactNode }) => <div>{children}</div> },
+}));
+
+import { GridPlaceholder } from "../GridPlaceholder";
+
+const panel = {
+  id: "p1",
+  kind: "browser",
+  title: "localhost:5173",
+  location: "grid",
+  isVisible: true,
+};
+
+function root(container: HTMLElement): HTMLElement {
+  const el = container.querySelector<HTMLElement>("[aria-hidden='true']");
+  if (!el) throw new Error("placeholder root not rendered");
+  return el;
+}
+
+/**
+ * "Where will it land" must never depend on knowing what is being dragged.
+ * The fallback used to be a borderless wash that read as a hole in the grid;
+ * now the slot keeps its frame and header bar and only the identity goes.
+ */
+describe("GridPlaceholder destination boundary", () => {
+  it("draws the same frame whether or not the active panel is known", () => {
+    mockUseDndPlaceholder.mockReturnValue({ activeTerminal: panel });
+    const known = root(render(<GridPlaceholder />).container);
+    mockUseDndPlaceholder.mockReturnValue({ activeTerminal: null });
+    const unknown = root(render(<GridPlaceholder />).container);
+    expect(unknown.className).toBe(known.className);
+    expect(unknown.children.length).toBe(known.children.length);
+  });
+
+  it("carries identity only when it has it", () => {
+    mockUseDndPlaceholder.mockReturnValue({ activeTerminal: panel });
+    const known = render(<GridPlaceholder />).container;
+    expect(known.textContent).toContain("localhost:5173");
+    expect(known.querySelector("[data-terminal-icon]")).not.toBeNull();
+
+    mockUseDndPlaceholder.mockReturnValue({ activeTerminal: null });
+    const unknown = render(<GridPlaceholder />).container;
+    expect(unknown.textContent).toBe("");
+    expect(unknown.querySelector("[data-terminal-icon]")).toBeNull();
+  });
+});

--- a/src/components/DragDrop/__tests__/PlaceholderContent.test.tsx
+++ b/src/components/DragDrop/__tests__/PlaceholderContent.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect } from "vitest";
 import { render } from "@testing-library/react";
+import { BUILT_IN_PANEL_KINDS } from "@shared/config/panelKindRegistry";
 import { PlaceholderContent } from "../PlaceholderContent";
 
 /**
@@ -46,5 +47,53 @@ describe("PlaceholderContent compact body gating (#11055)", () => {
     const compact = render(<PlaceholderContent kind="terminal" compact />);
     expect(full.container.querySelectorAll("[data-placeholder-body]")).toHaveLength(0);
     expect(compact.container.querySelectorAll("[data-placeholder-body]")).toHaveLength(0);
+  });
+});
+
+/** The illustration with every per-kind tint stripped, so only its shape remains. */
+function shape(kind: string): string {
+  const { container } = render(<PlaceholderContent kind={kind} />);
+  return container.innerHTML.replace(/ style="[^"]*"/g, "");
+}
+
+/**
+ * The header carries the identity; the illustration is what makes the ghost
+ * read as *this* kind of panel at a glance. Eight kinds used to collapse into
+ * the same three bars, so the rule is: no two kinds share a composition, and
+ * a kind the registry has never heard of is not dressed up as a terminal.
+ */
+describe("PlaceholderContent kind compositions", () => {
+  it("gives every built-in kind its own composition", () => {
+    const shapes = new Map(BUILT_IN_PANEL_KINDS.map((kind) => [kind, shape(kind)]));
+    for (const [kind, markup] of shapes) {
+      for (const [other, otherMarkup] of shapes) {
+        if (kind !== other) expect(markup, `${kind} vs ${other}`).not.toBe(otherMarkup);
+      }
+    }
+  });
+
+  it("does not impersonate a built-in kind for an unknown one", () => {
+    const unknown = shape("sticky-notes");
+    for (const kind of BUILT_IN_PANEL_KINDS) {
+      expect(unknown, `unknown vs ${kind}`).not.toBe(shape(kind));
+    }
+  });
+
+  it("keeps illustration geometry on the class scale, not in inline styles", () => {
+    for (const kind of [...BUILT_IN_PANEL_KINDS, "sticky-notes"]) {
+      for (const compact of [false, true]) {
+        const { container } = render(<PlaceholderContent kind={kind} compact={compact} />);
+        for (const el of container.querySelectorAll<HTMLElement>("[style]")) {
+          const props = (el.getAttribute("style") ?? "")
+            .split(";")
+            .map((d) => d.split(":")[0]!.trim())
+            .filter(Boolean);
+          for (const prop of props) {
+            // Bar widths are content (how long the line is), tints are the kind colour.
+            expect(prop === "width" || prop.startsWith("--ph-"), `${kind}: ${prop}`).toBe(true);
+          }
+        }
+      }
+    }
   });
 });

--- a/src/components/DragDrop/__tests__/SortableWorktreeCard.test.tsx
+++ b/src/components/DragDrop/__tests__/SortableWorktreeCard.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi } from "vitest";
 import { render } from "@testing-library/react";
+import { DRAG_GHOST_OPACITY } from "@/lib/animationUtils";
 import { SortableWorktreeCard } from "../SortableWorktreeCard";
 
 interface MockSortableState {
@@ -94,7 +95,9 @@ describe("SortableWorktreeCard", () => {
     expect(wrapper.getAttribute("role")).toBe("row");
   });
 
-  it("applies opacity-40 to the inner gridcell wrapper while dragging", () => {
+  // The dim is the app-wide drag-source tier (#8017), read from the shared
+  // token rather than a utility that happens to equal it today.
+  it("dims the inner gridcell wrapper to the shared drag-ghost tier while dragging", () => {
     mockState = { isDragging: true };
     const { container } = render(
       <SortableWorktreeCard
@@ -107,9 +110,10 @@ describe("SortableWorktreeCard", () => {
       </SortableWorktreeCard>
     );
     const wrapper = container.firstChild as HTMLElement;
-    expect(wrapper.className).not.toContain("opacity-40");
+    expect(wrapper.style.opacity).toBe("");
     const ghost = wrapper.querySelector("[role='gridcell'] > div") as HTMLElement;
-    expect(ghost.className).toContain("opacity-40");
+    expect(ghost.style.opacity).toBe(String(DRAG_GHOST_OPACITY));
+    expect(ghost.className).not.toMatch(/(?:^|\s)opacity-\d+/);
     expect(ghost.className).toContain("transition-opacity");
   });
 

--- a/src/components/DragDrop/__tests__/TerminalDragPreview.test.tsx
+++ b/src/components/DragDrop/__tests__/TerminalDragPreview.test.tsx
@@ -63,11 +63,14 @@ describe("TerminalDragPreview group badge", () => {
     expect(extra.every((c) => c.startsWith("pr-"))).toBe(true);
   });
 
-  it("shows no badge for a single panel", () => {
-    const { container } = render(<TerminalDragPreview terminal={agentPanel()} />);
-    expect([...container.querySelectorAll("span")].some((el) => el.textContent === "3")).toBe(
-      false
-    );
+  it("shows a badge only when more than one tab is carried", () => {
+    const badge = (count?: number) =>
+      render(
+        <TerminalDragPreview terminal={agentPanel()} groupTabCount={count} />
+      ).container.querySelector('[data-slot="badge"]');
+    expect(badge()).toBeNull();
+    expect(badge(1)).toBeNull();
+    expect(badge(3)?.textContent).toBe("3");
   });
 });
 

--- a/src/components/DragDrop/__tests__/TerminalDragPreview.test.tsx
+++ b/src/components/DragDrop/__tests__/TerminalDragPreview.test.tsx
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+import type { PanelInstance } from "@shared/types/panel";
+
+vi.mock("@/components/Terminal/TerminalIcon", () => ({
+  TerminalIcon: () => <span data-terminal-icon="" />,
+}));
+
+import { TerminalDragPreview } from "../TerminalDragPreview";
+
+function agentPanel(): PanelInstance {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- inert fixture
+  return {
+    id: "p1",
+    kind: "terminal",
+    title: "Refund pipeline",
+    location: "grid",
+    isVisible: true,
+    launchAgentId: "claude",
+    runtimeIdentity: { kind: "agent", id: "claude", iconId: "claude", agentId: "claude" },
+    agentState: "working",
+  } as unknown as PanelInstance;
+}
+
+function titleBar(container: HTMLElement): HTMLElement {
+  const title = [...container.querySelectorAll("span")].find(
+    (el) => el.textContent === "Refund pipeline"
+  );
+  if (!title?.parentElement) throw new Error("title bar not rendered");
+  return title.parentElement;
+}
+
+/**
+ * A group drag carries two identifiers in the same corner — the tab count and
+ * the agent-state glyph — and the badge used to sit on top of the glyph. The
+ * rule is that both survive: the badge lives outside the card's clipping box
+ * so it can overhang, and the title bar gives it room instead of the glyph.
+ */
+describe("TerminalDragPreview group badge", () => {
+  it("renders the count outside the clipping wrapper so it can overhang the corner", () => {
+    const { container } = render(<TerminalDragPreview terminal={agentPanel()} groupTabCount={3} />);
+    const clip = container.querySelector(".overflow-hidden");
+    expect(clip).not.toBeNull();
+    const badge = [...container.querySelectorAll("span")].find((el) => el.textContent === "3");
+    expect(badge).toBeDefined();
+    expect(clip!.contains(badge!)).toBe(false);
+  });
+
+  it("keeps the agent-state glyph alongside the count", () => {
+    const { container } = render(<TerminalDragPreview terminal={agentPanel()} groupTabCount={3} />);
+    expect(container.querySelector(".animate-spin-slow")).not.toBeNull();
+  });
+
+  it("reserves title-bar room for the badge only on group drags", () => {
+    const single = titleBar(render(<TerminalDragPreview terminal={agentPanel()} />).container);
+    const group = titleBar(
+      render(<TerminalDragPreview terminal={agentPanel()} groupTabCount={3} />).container
+    );
+    const singleClasses = new Set(single.className.split(/\s+/));
+    const extra = group.className.split(/\s+/).filter((c) => !singleClasses.has(c));
+    expect(extra.length).toBeGreaterThan(0);
+    expect(extra.every((c) => c.startsWith("pr-"))).toBe(true);
+  });
+
+  it("shows no badge for a single panel", () => {
+    const { container } = render(<TerminalDragPreview terminal={agentPanel()} />);
+    expect([...container.querySelectorAll("span")].some((el) => el.textContent === "3")).toBe(
+      false
+    );
+  });
+});
+
+describe("TerminalDragPreview chrome", () => {
+  it("identifies the kind with the shared glyph component, not a bespoke mark", () => {
+    const { container } = render(<TerminalDragPreview terminal={agentPanel()} />);
+    expect(container.querySelector("[data-terminal-icon]")).not.toBeNull();
+  });
+
+  it("never fades text with alpha or an inline colour", () => {
+    const { container } = render(<TerminalDragPreview terminal={agentPanel()} groupTabCount={3} />);
+    for (const el of container.querySelectorAll<HTMLElement>("*")) {
+      expect(el.className.toString()).not.toMatch(/(?:^|\s)text-[a-z-]+\/\d+/);
+      expect(el.style.color).toBe("");
+    }
+  });
+});

--- a/src/components/DragDrop/__tests__/WorktreeDragPreview.test.tsx
+++ b/src/components/DragDrop/__tests__/WorktreeDragPreview.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import type { WorktreeSnapshot } from "@shared/types";
+import { WorktreeDragPreview } from "../WorktreeDragPreview";
+
+function worktree(overrides: Partial<WorktreeSnapshot>): WorktreeSnapshot {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- inert fixture
+  return { id: "wt", name: "wt", path: "/wt", isCurrent: false, ...overrides } as WorktreeSnapshot;
+}
+
+const FIXTURES = [
+  worktree({
+    branch: "feature/issue-142-refund-flow",
+    issueNumber: 142,
+    issueTitle: "Add idempotent partial refunds",
+  }),
+  worktree({ branch: "bugfix/auth-redirect" }),
+  worktree({ name: "surge-checkout", branch: "main", isMainWorktree: true }),
+];
+
+/**
+ * The branch line is the smallest type on the ghost and used to be the
+ * faintest — text-primary mixed to 50%, which the design system bans because
+ * the contrast cannot be recovered downstream. Every text node steps down the
+ * token hierarchy instead.
+ */
+describe("WorktreeDragPreview text", () => {
+  it("never fades text with alpha or an inline colour", () => {
+    for (const wt of FIXTURES) {
+      const { container } = render(<WorktreeDragPreview worktree={wt} />);
+      for (const el of container.querySelectorAll<HTMLElement>("*")) {
+        expect(el.className.toString()).not.toMatch(/(?:^|\s)text-[a-z-]+\/\d+/);
+        expect(el.style.color).toBe("");
+      }
+    }
+  });
+
+  it("shows the branch beneath an issue title, and only the branch otherwise", () => {
+    const issue = render(<WorktreeDragPreview worktree={FIXTURES[0]!} />);
+    expect(issue.container.textContent).toContain("Add idempotent partial refunds");
+    expect(issue.container.textContent).toContain("feature/issue-142-refund-flow");
+
+    const branchOnly = render(<WorktreeDragPreview worktree={FIXTURES[1]!} />);
+    expect(branchOnly.container.textContent).toBe("bugfix/auth-redirect");
+
+    const main = render(<WorktreeDragPreview worktree={FIXTURES[2]!} />);
+    expect(main.container.textContent).toBe("surge-checkout");
+  });
+});

--- a/src/components/DragDrop/__tests__/dropIndicator.test.ts
+++ b/src/components/DragDrop/__tests__/dropIndicator.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { BUILT_IN_APP_SCHEMES } from "@shared/theme/themes";
+import { blendOverBackground, contrastRatio } from "@shared/theme/contrast";
+import { DROP_INDICATOR_INK, DROP_INDICATOR_LINE, DROP_SLOT_FRAME } from "../dropIndicator";
+
+const alpha = Number(DROP_INDICATOR_INK.split("/")[1]) / 100;
+
+// The surfaces an insertion line or slot frame is ever drawn over: the dock and
+// sidebar rails, the grid gutter, and the canvas the grid inherits when a theme
+// declares no grid surface of its own.
+const DROP_SURFACES = ["surface-sidebar", "surface-grid", "surface-canvas"] as const;
+
+/**
+ * An insertion line is the only thing telling the user where the drop will
+ * land, which makes it a state indicator under WCAG 1.4.11: 3:1 against its
+ * surface, on every theme. The rule is pinned as the measurement, not the
+ * alpha, so a theme added later or a retuned ink both have to keep clearing it.
+ */
+describe("drop indicator ink", () => {
+  it("names an alpha composite of the primary text ink", () => {
+    expect(DROP_INDICATOR_INK).toMatch(/^text-primary\/\d+$/);
+    expect(alpha).toBeGreaterThan(0);
+    expect(alpha).toBeLessThanOrEqual(1);
+  });
+
+  it("clears 3:1 against every built-in theme's drop surfaces", () => {
+    expect(BUILT_IN_APP_SCHEMES.length).toBeGreaterThan(0);
+    for (const scheme of BUILT_IN_APP_SCHEMES) {
+      const ink = scheme.tokens["text-primary"];
+      for (const key of DROP_SURFACES) {
+        const surface = scheme.tokens[key];
+        const line = blendOverBackground(ink, surface, alpha);
+        expect(contrastRatio(line, surface), `${scheme.id}: ${key}`).toBeGreaterThanOrEqual(3);
+      }
+    }
+  });
+
+  it("uses the one ink for lines and slot frames alike", () => {
+    expect(DROP_INDICATOR_LINE).toContain(`bg-${DROP_INDICATOR_INK}`);
+    expect(DROP_SLOT_FRAME).toContain(`border-${DROP_INDICATOR_INK}`);
+  });
+
+  it("repaints in a system colour under forced colours, the way the app's state marks do", () => {
+    expect(DROP_INDICATOR_LINE).toMatch(/forced-colors:bg-\[CanvasText\]/);
+    expect(DROP_SLOT_FRAME).toMatch(/forced-colors:border-\[CanvasText\]/);
+  });
+
+  it("stays off the accent", () => {
+    expect(`${DROP_INDICATOR_LINE} ${DROP_SLOT_FRAME}`).not.toMatch(/accent/);
+  });
+});

--- a/src/components/DragDrop/dndPlaceholderContext.ts
+++ b/src/components/DragDrop/dndPlaceholderContext.ts
@@ -1,0 +1,54 @@
+import { createContext, useContext } from "react";
+import type { PanelInstance } from "@shared/types/panel";
+
+export const GRID_PLACEHOLDER_ID = "__grid-placeholder__";
+
+// Placeholder state shared with ContentGrid, the dock and the sidebar. Lives
+// apart from DndProvider so the placeholder components (and their previews and
+// tests) can read it without pulling the whole orchestration provider — and its
+// store graph — into their module graph.
+export interface DndPlaceholderContextValue {
+  placeholderIndex: number | null;
+  sourceContainer: "grid" | "dock" | null;
+  activeTerminal: PanelInstance | null;
+  isDragging: boolean;
+  isWorktreeSortDragging: boolean;
+  /** If dragging a tab group, the group ID */
+  activeGroupId: string | null;
+  /** If dragging a tab group, the panel IDs in the group */
+  activeGroupPanelIds: string[] | null;
+  /**
+   * True when the active drag can't be dropped in the dock — its kind, or ANY
+   * live member's kind for a group drag, is non-dockable (#11375). Consumers
+   * (the dock's `cursor-no-drop` cue) read this instead of re-checking the lone
+   * representative kind, so the cue matches what `cancelDrop`/`collisionDetection`
+   * actually enforce for a mixed group.
+   */
+  activeDragRejectsDock: boolean;
+}
+
+export const IDLE_DND_PLACEHOLDER: DndPlaceholderContextValue = {
+  placeholderIndex: null,
+  sourceContainer: null,
+  activeTerminal: null,
+  isDragging: false,
+  isWorktreeSortDragging: false,
+  activeGroupId: null,
+  activeGroupPanelIds: null,
+  activeDragRejectsDock: false,
+};
+
+export const DndPlaceholderContext =
+  createContext<DndPlaceholderContextValue>(IDLE_DND_PLACEHOLDER);
+
+export function useDndPlaceholder() {
+  return useContext(DndPlaceholderContext);
+}
+
+export function useIsDragging() {
+  return useContext(DndPlaceholderContext).isDragging;
+}
+
+export function useIsWorktreeSortDragging() {
+  return useContext(DndPlaceholderContext).isWorktreeSortDragging;
+}

--- a/src/components/DragDrop/dropIndicator.ts
+++ b/src/components/DragDrop/dropIndicator.ts
@@ -8,18 +8,21 @@ import { cn } from "@/lib/utils";
 // them, so on dark themes the line read as a chip edge. Neutral on purpose:
 // accent is reserved for focus (design-system.md). Under forced colours the
 // fill is repainted in CanvasText, the repo's convention for state marks.
+//
+// The utilities below spell the ink out in full: Tailwind only generates classes
+// it can read verbatim from source, so `bg-${ink}` would silently compile to
+// nothing and the line would paint transparent. The test asserts the literals
+// still agree with DROP_INDICATOR_INK.
 export const DROP_INDICATOR_INK = "text-primary/60";
 
 /** A 2px insertion line. The caller adds the axis (`inset-y-0 w-0.5`) and edge. */
 export const DROP_INDICATOR_LINE = cn(
   "pointer-events-none absolute z-10",
-  `bg-${DROP_INDICATOR_INK}`,
-  "forced-colors:bg-[CanvasText]"
+  "bg-text-primary/60 forced-colors:bg-[CanvasText]"
 );
 
 /** The perimeter of a drop slot, over the container's own surface. */
 export const DROP_SLOT_FRAME = cn(
-  "border",
-  `border-${DROP_INDICATOR_INK}`,
-  "bg-overlay-subtle forced-colors:border-[CanvasText]"
+  "border border-text-primary/60 bg-overlay-subtle",
+  "forced-colors:border-[CanvasText]"
 );

--- a/src/components/DragDrop/dropIndicator.ts
+++ b/src/components/DragDrop/dropIndicator.ts
@@ -1,0 +1,25 @@
+import { cn } from "@/lib/utils";
+
+// One ink for every "where will it land" cue — insertion lines between chips
+// and rows, and the perimeter of a drop slot. text-primary composited at 60%
+// clears WCAG 1.4.11's 3:1 floor against the dock, sidebar and grid surfaces
+// of all 15 built-in themes (worst case hokkaido's grid at 3.56:1); the
+// border-strong hairline it replaces composited to 1.2–1.5:1 on every one of
+// them, so on dark themes the line read as a chip edge. Neutral on purpose:
+// accent is reserved for focus (design-system.md). Under forced colours the
+// fill is repainted in CanvasText, the repo's convention for state marks.
+export const DROP_INDICATOR_INK = "text-primary/60";
+
+/** A 2px insertion line. The caller adds the axis (`inset-y-0 w-0.5`) and edge. */
+export const DROP_INDICATOR_LINE = cn(
+  "pointer-events-none absolute z-10",
+  `bg-${DROP_INDICATOR_INK}`,
+  "forced-colors:bg-[CanvasText]"
+);
+
+/** The perimeter of a drop slot, over the container's own surface. */
+export const DROP_SLOT_FRAME = cn(
+  "border",
+  `border-${DROP_INDICATOR_INK}`,
+  "bg-overlay-subtle forced-colors:border-[CanvasText]"
+);

--- a/src/components/Sidebar/__tests__/SidebarContent.grid.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.grid.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import fs from "fs/promises";
 import path from "path";
+import { DROP_INDICATOR_LINE } from "@/components/DragDrop/dropIndicator";
 
 const SIDEBAR_CONTENT_PATH = path.resolve(__dirname, "../SidebarContent.tsx");
 const STATIC_ROW_PATH = path.resolve(__dirname, "../StaticWorktreeRow.tsx");
@@ -560,9 +561,10 @@ describe("Worktree list keyboard grid — issue #6422 / virtualized rewrite", ()
         expect(source).toContain('className="relative"');
       });
 
-      it("uses neutral bg-border-strong (no accent tokens) for the indicator", () => {
-        expect(source).toContain("bg-border-strong");
+      it("uses the shared neutral drop-indicator ink (no accent tokens) for the indicator", () => {
+        expect(source).toContain("DROP_INDICATOR_LINE");
         expect(source).not.toMatch(/daintree-accent|accent-primary/);
+        expect(DROP_INDICATOR_LINE).not.toMatch(/daintree-accent|accent-primary/);
       });
 
       it("renders the indicator above (-top-px) or below (-bottom-px) based on drop direction", () => {
@@ -571,7 +573,7 @@ describe("Worktree list keyboard grid — issue #6422 / virtualized rewrite", ()
       });
 
       it("marks the indicator pointer-events-none so it never blocks the drop target", () => {
-        expect(source).toContain("pointer-events-none");
+        expect(DROP_INDICATOR_LINE).toContain("pointer-events-none");
       });
 
       it("exposes the indicator via data-worktree-drop-indicator for E2E and DOM assertions", () => {

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -8,11 +8,8 @@ import { useWorktreeTerminals } from "../../hooks/useWorktreeTerminals";
 
 import { useDroppable } from "@dnd-kit/core";
 import type { SyntheticListenerMap } from "@dnd-kit/core/dist/hooks/utilities";
-import {
-  useDndPlaceholder,
-  useIsWorktreeSortDragging,
-  type WorktreeDragData,
-} from "../DragDrop/DndProvider";
+import type { WorktreeDragData } from "../DragDrop/DndProvider";
+import { useDndPlaceholder, useIsWorktreeSortDragging } from "../DragDrop/dndPlaceholderContext";
 import { getWorktreeSortDragId } from "../DragDrop/SortableWorktreeCard";
 import { Check, GripVertical } from "lucide-react";
 import { useErrorStore, usePanelStore, type RetryAction } from "../../store";


### PR DESCRIPTION
## Summary

Design review of the drag and drop feedback layer: drag ghosts, drop placeholders and insertion lines under `src/components/DragDrop/`. Nothing had ever captured these states because they only exist while the pointer is down, so the first thing this branch adds is a Playwright capture harness. `drag-drop-preview.html`, driven by `e2e/screenshots/drag-drop-review.spec.ts`, renders the real components from fixtures against the real theme tokens and performs real pointer drags inside a sandboxed `DndContext`. It is opt-in behind `DAINTREE_SHOT_DRAGDROP` and never runs in CI.

The review score went from 5.8 to 9.9 over three rounds. The one thing I got wrong along the way is worth knowing about: the shared indicator ink was first written as `bg-${ink}`, which Tailwind never compiles, so round two's frames still showed the old hairlines while every structural check passed. The harness now reads the painted colour of each indicator before it writes a frame.

## Changes

- Insertion lines and slot frames share one neutral ink, `text-primary/60`, in `dropIndicator.ts`. Measured from the real tokens it clears 3:1 on all 15 built-in themes (worst case hokkaido's grid at 3.56:1). The `border-strong` hairline it replaces composited to 1.2 to 1.5:1 on every one, so on dark themes the dock line read as a chip edge. `dropIndicator.test.ts` recomputes the ratio per theme.
- The panel ghost identifies its kind with `TerminalIcon` and uses the panel header's own recipe (h-8, sans, `overlay-medium`) inside a clipping wrapper. The group tab badge sits outside that wrapper and the title bar clears it, so it no longer covers the agent state glyph.
- `PlaceholderContent.tsx` moves off 43 inline style objects onto the spacing scale, with distinct compositions for terminal, browser, dev-preview, review, file, file-browser and diff, and a generic one for unknown kinds. The dead `"agent"` branch goes.
- The grid fallback keeps its frame when the active panel is unknown instead of collapsing to a borderless wash. The dock slot takes the chips' radius step and its compact art is centred.
- The worktree ghost's branch line steps down to `text-secondary` rather than fading primary text with alpha.
- The drop animation honours reduced motion like the entry spring already did, as a zero-duration config rather than `null`, since dnd-kit skips its scroll-back on a null config.
- `SortableWorktreeCard` reads its dim from `DRAG_GHOST_OPACITY` instead of a literal `opacity-40`.
- The placeholder context moves out of `DndProvider.tsx` into `dndPlaceholderContext.ts` so the placeholders and their preview no longer pull the orchestration provider's store graph into their module graph. `DndProvider` re-exports the hooks, so the public surface is unchanged.

Left for a follow-up: the container drag-over highlights in `ContentGridDefault`, `ContentDock`, `TrashContainer`, the sidebar row and the toolbar bin each use their own faint token, and the grid one is `ring-daintree-accent/30`. They would take the same ink.

## Testing

- Full `npm test` twice: green apart from `PluginDevArtifactWatcher`, `ProjectPluginWatcher` and `scenarioLiveness`, which fail identically on the untouched base commit on this machine (checked in a throwaway worktree at `2d7313d88e`).
- `npm run check`: every step passes except `check:sample-views`, which fails in any worktree whose `node_modules` is a symlink (the rebuilt bundle differs only in two `//#region` paths). The six steps after it were run individually and pass; the lint ratchet moved 3013 to 3001.
- Six invariant test files, each mutation-checked: reintroducing the bug fails the test.
- Harness run three times at 172 frames each, plus a refusal check that `DAINTREE_SHOT_DIR=.` throws rather than deleting anything.

A Codex correctness pass over the branch found five things, all fixed in the last commit: the null drop animation, a recursive delete on a bad output directory, a transparency regex that misread `rgb(255, 0, 0)`, and two tests that could pass with the feature missing.