### PR TITLE
fix(ui): make the global recovery banners read as one family

### DIFF
--- a/e2e/full/resilience/watchdog-disabled-restart.spec.ts
+++ b/e2e/full/resilience/watchdog-disabled-restart.spec.ts
@@ -9,7 +9,7 @@ import { T_LONG, T_SHORT } from "../../helpers/timeouts";
 // cycle. The real path requires three genuine watchdog-host crashes inside the
 // rapid-crash window; the fault-mode hook `__daintreeSimulateWatchdogDisabled`
 // fires the same `notifyDisabled()` → `watchdog:disabled` broadcast instead.
-// The banner (`WatchdogDisabledBanner`, role="alert") then drives the real
+// The banner (`WatchdogDisabledBanner`, role="status") then drives the real
 // `watchdog.restart` action, which broadcasts `watchdog:active` and resets the
 // once-per-cycle `disabledNotified` guard so a second cap-hit can re-fire.
 
@@ -66,8 +66,14 @@ test.describe.serial("Resilience: watchdog disabled banner + restart", () => {
     const banner = ctx.window.locator(SEL.recovery.watchdogDisabledBanner);
     await expect(banner).toBeVisible({ timeout: T_LONG });
 
-    // Title-Message-Action: a single contextual button, no "Dismiss".
-    await expect(banner.locator("button")).toHaveCount(1, { timeout: T_SHORT });
+    // One contextual action plus the session dismiss, nothing else.
+    await expect(banner.locator(SEL.recovery.watchdogRestartButton)).toHaveCount(1, {
+      timeout: T_SHORT,
+    });
+    await expect(banner.locator('button[aria-label="Dismiss watchdog warning"]')).toHaveCount(1, {
+      timeout: T_SHORT,
+    });
+    await expect(banner.locator("button")).toHaveCount(2, { timeout: T_SHORT });
     await expect(ctx.window.locator(SEL.recovery.watchdogRestartButton)).toBeVisible({
       timeout: T_SHORT,
     });

--- a/e2e/helpers/selectors.ts
+++ b/e2e/helpers/selectors.ts
@@ -573,7 +573,7 @@ export const SEL = {
     item: (id: string) => `[data-checklist-item="${id}"]`,
   },
   recovery: {
-    watchdogDisabledBanner: '[role="alert"]:has-text("Crash watchdog disabled")',
+    watchdogDisabledBanner: '[role="status"]:has-text("Crash watchdog disabled")',
     watchdogRestartButton: 'button:has-text("Restart watchdog")',
   },
 } as const;

--- a/e2e/screenshots/recovery-banners-review.spec.ts
+++ b/e2e/screenshots/recovery-banners-review.spec.ts
@@ -269,11 +269,12 @@ test("global banner family — every slot, every state, every theme", async ({ c
   // outside the band, and it carries its own hand-rolled controls.
   written.push(
     await withPage(context, "safe-mode details", async (page) => {
-      const shell = await openFixture(page, "safe-mode", theme, DEFAULT_WIDTH, 0);
+      await openFixture(page, "safe-mode", theme, DEFAULT_WIDTH, 0);
       await page.getByRole("button", { name: "Show details" }).click();
       await expect(page.getByText(/quarantined/)).toBeVisible();
       await page.waitForTimeout(250);
-      return snap(shell, `safe-mode-${theme}-details.png`);
+      // The popover hangs below the shell, so the shell's own box would clip it.
+      return snap(page.locator("body"), `safe-mode-${theme}-details.png`);
     })
   );
 

--- a/e2e/screenshots/recovery-banners-review.spec.ts
+++ b/e2e/screenshots/recovery-banners-review.spec.ts
@@ -90,7 +90,7 @@ const ATTACH_TIMEOUT_MS = 30_000;
 let server: ViteDevServer | undefined;
 let baseURL = "";
 
-test.beforeAll(async ({ browser }) => {
+test.beforeAll(async () => {
   // No test.skip here: `test.info()` is unavailable in a beforeAll hook, so the
   // structured-skip annotation the repo requires cannot be attached. The test
   // body carries the skip; this hook simply does no work when the flag is unset.
@@ -106,15 +106,19 @@ test.beforeAll(async ({ browser }) => {
   const address = server.httpServer?.address();
   if (!address || typeof address === "string") throw new Error("vite gave no TCP address");
   baseURL = `http://127.0.0.1:${address.port}`;
-
-  // Vite discovers dependencies as it transforms, and a discovery mid-run
-  // re-bundles and force-reloads every open page — which under Playwright is a
-  // blank document at the exact moment the shell is asserted. Transform the
-  // entry graph up front, then hold a throwaway page open until the optimizer
-  // has stopped reloading it, so every capture that follows loads a settled
-  // server.
   await server.warmupRequest("/src/components/Recovery/__preview__/preview.tsx");
-  const page = await browser.newPage();
+});
+
+/**
+ * Vite discovers dependencies as it transforms, and a discovery mid-run
+ * re-bundles and force-reloads every open page — which under Playwright is a
+ * blank document at the exact moment the shell is asserted. Hold a throwaway
+ * page open until the optimizer has stopped reloading it, so every capture
+ * that follows loads a settled server. Runs inside the test, after the skip,
+ * so an opted-out run never opens a browser.
+ */
+async function settleDevServer(context: BrowserContext) {
+  const page = await context.newPage();
   let navigations = 0;
   page.on("framenavigated", () => navigations++);
   await page.goto(`${baseURL}/recovery-banners-preview.html?fixture=sheet`);
@@ -125,7 +129,7 @@ test.beforeAll(async ({ browser }) => {
     if (navigations === before && shellCount === 1) break;
   }
   await page.close();
-});
+}
 
 test.afterAll(async () => {
   await server?.close();
@@ -243,6 +247,7 @@ test("global banner family — every slot, every state, every theme", async ({ c
   });
   test.skip(!ENABLED, "set DAINTREE_SHOT_BANNERS=1 to run the capture");
 
+  await settleDevServer(context);
   const written: string[] = [];
 
   for (const theme of THEMES) {

--- a/e2e/screenshots/recovery-banners-review.spec.ts
+++ b/e2e/screenshots/recovery-banners-review.spec.ts
@@ -1,0 +1,313 @@
+/**
+ * Global banner family visual-review harness.
+ *
+ * Ten banners contend for the one slot above the toolbar, so the real app can
+ * never show two of them side by side — and a family nobody has seen together
+ * is a family nobody has noticed disagreeing. This drives the Recovery
+ * preview entry (`recovery-banners-preview.html`): the real banner components
+ * against their real stores, the real theme tokens and `index.css`, in the
+ * title-bar band they actually occupy.
+ *
+ * Opt-in only, like every sibling review harness:
+ *
+ *   DAINTREE_SHOT_BANNERS=1 npx playwright test --project=screenshots recovery-banners-review
+ *
+ * Env knobs:
+ *   DAINTREE_SHOT_BANNERS  required — any truthy value runs the capture
+ *   DAINTREE_SHOT_DIR      output directory (default artifacts/recovery-banner-shots)
+ *   DAINTREE_SHOT_THEMES   comma-separated theme sweep (default: daintree,bondi,namib)
+ *
+ * Output, per theme:
+ *   sheet-<theme>.png              all ten slots stacked, one canonical state each
+ *   <fixture>-<theme>.png          each state, rendered through GlobalBannerCoordinator
+ * Plus, in the first theme only:
+ *   sheet-<theme>-windows.png      the sheet with the Windows caption inset
+ *   safe-mode-<theme>-details.png  the details popover open
+ *   <fixture>-<theme>-narrow.png   width-pressure cases
+ *
+ * Hard rule, inherited from the siblings: never write a PNG that has not been
+ * verified. `snap()` asserts the target is attached with a real box before it
+ * writes, and the test counts the files itself rather than trusting the exit code.
+ */
+
+import { test, expect, type BrowserContext, type Locator, type Page } from "@playwright/test";
+import { existsSync, mkdirSync, readdirSync, rmSync } from "fs";
+import path from "path";
+import { createServer, type ViteDevServer } from "vite";
+
+const ENABLED = !!process.env.DAINTREE_SHOT_BANNERS;
+
+const DEFAULT_WIDTH = 1100;
+const NARROW_WIDTH = 640;
+
+const OUT_DIR = path.resolve(
+  process.env.DAINTREE_SHOT_DIR ?? path.join(process.cwd(), "artifacts", "recovery-banner-shots")
+);
+
+const THEMES = (process.env.DAINTREE_SHOT_THEMES ?? "daintree,bondi,namib")
+  .split(",")
+  .map((t) => t.trim())
+  .filter(Boolean);
+
+/** Mirrors `BANNER_FIXTURES`; the settle covers the Doherty-gated variants. */
+const FIXTURES = [
+  { name: "host-crash", settleMs: 0 },
+  { name: "host-crash-diagnostics-failed", settleMs: 0 },
+  { name: "host-crash-recovering", settleMs: 600 },
+  { name: "watchdog-disabled", settleMs: 0 },
+  { name: "host-memory-stall", settleMs: 0 },
+  { name: "safe-mode", settleMs: 0 },
+  { name: "restore-confirmation", settleMs: 0 },
+  { name: "restore-confirmation-suspects", settleMs: 0 },
+  { name: "missing-prerequisite", settleMs: 0 },
+  { name: "missing-prerequisite-outdated", settleMs: 0 },
+  { name: "missing-prerequisite-installing", settleMs: 0 },
+  { name: "missing-prerequisite-failed", settleMs: 0 },
+  { name: "forge-token", settleMs: 0 },
+  { name: "forge-token-single", settleMs: 0 },
+  { name: "plugin-document", settleMs: 0 },
+  { name: "cloud-sync", settleMs: 0 },
+  { name: "rosetta", settleMs: 0 },
+] as const;
+
+const SHEET_ROWS = 10;
+
+/** Width pressure is where a long title and a wide action collide. */
+const NARROW_FIXTURES = [
+  "host-crash",
+  "restore-confirmation-suspects",
+  "missing-prerequisite-installing",
+  "forge-token",
+  "rosetta",
+] as const;
+
+/**
+ * The dev server compiles each page on first request, and under load that can
+ * outrun Playwright's 5s default — a timeout there is not a finding.
+ */
+const ATTACH_TIMEOUT_MS = 30_000;
+
+let server: ViteDevServer | undefined;
+let baseURL = "";
+
+test.beforeAll(async ({ browser }) => {
+  // No test.skip here: `test.info()` is unavailable in a beforeAll hook, so the
+  // structured-skip annotation the repo requires cannot be attached. The test
+  // body carries the skip; this hook simply does no work when the flag is unset.
+  if (!ENABLED) return;
+  if (existsSync(OUT_DIR)) rmSync(OUT_DIR, { recursive: true, force: true });
+  mkdirSync(OUT_DIR, { recursive: true });
+
+  // `strictPort: false` matters: the project's own vite config sets
+  // `strictPort: true`, and that wins over an inline `port: 0` — so with the app
+  // running this harness would die on "Port 5173 is already in use".
+  server = await createServer({ server: { port: 0, strictPort: false }, logLevel: "warn" });
+  await server.listen();
+  const address = server.httpServer?.address();
+  if (!address || typeof address === "string") throw new Error("vite gave no TCP address");
+  baseURL = `http://127.0.0.1:${address.port}`;
+
+  // Vite discovers dependencies as it transforms, and a discovery mid-run
+  // re-bundles and force-reloads every open page — which under Playwright is a
+  // blank document at the exact moment the shell is asserted. Transform the
+  // entry graph up front, then hold a throwaway page open until the optimizer
+  // has stopped reloading it, so every capture that follows loads a settled
+  // server.
+  await server.warmupRequest("/src/components/Recovery/__preview__/preview.tsx");
+  const page = await browser.newPage();
+  let navigations = 0;
+  page.on("framenavigated", () => navigations++);
+  await page.goto(`${baseURL}/recovery-banners-preview.html?fixture=sheet`);
+  for (let attempt = 0; attempt < 6; attempt++) {
+    const before = navigations;
+    await page.waitForTimeout(2_500);
+    const shellCount = await page.locator("[data-preview-shell]").count();
+    if (navigations === before && shellCount === 1) break;
+  }
+  await page.close();
+});
+
+test.afterAll(async () => {
+  await server?.close();
+});
+
+/** Write one PNG, having proved there is something to write. */
+async function snap(target: Locator, file: string): Promise<string> {
+  await expect(target).toBeAttached();
+  const box = await target.boundingBox();
+  if (!box || box.width < 8 || box.height < 8) {
+    throw new Error(`${file}: target has no real box (${JSON.stringify(box)}) — refusing to write`);
+  }
+  const out = path.join(OUT_DIR, file);
+  await target.screenshot({ path: out });
+  return out;
+}
+
+/**
+ * Every capture gets its own page, and a renderer that dies gets one more go.
+ *
+ * A page that throws renders nothing, and a renderer the OS kills under load
+ * renders nothing either — both look like "no shell" from outside, and both
+ * are the worst way for a visual-review tool to fail: silently. So the page
+ * reports its own uncaught errors and console errors into any failure, a crash
+ * is named as a crash, and one crash is retried before it fails the run, since
+ * a crash under load is noise and two in a row are not.
+ */
+async function withPage<T>(
+  context: BrowserContext,
+  what: string,
+  body: (page: Page) => Promise<T>,
+  init?: (page: Page) => Promise<void>
+): Promise<T> {
+  for (let attempt = 1; ; attempt++) {
+    const page = await context.newPage();
+    let crashed = false;
+    const errors: string[] = [];
+    const consoleErrors: string[] = [];
+    page.on("crash", () => {
+      crashed = true;
+    });
+    page.on("pageerror", (error) => errors.push(error.message));
+    page.on("console", (message) => {
+      if (message.type() === "error") consoleErrors.push(message.text().slice(0, 300));
+    });
+    try {
+      await init?.(page);
+      const result = await body(page);
+      if (errors.length > 0) throw new Error(`${what}: page threw: ${errors.join(" | ")}`);
+      return result;
+    } catch (error) {
+      if (crashed && attempt === 1) {
+        console.warn(`[recovery-banner-shots] renderer crashed on ${what}; retrying once`);
+        continue;
+      }
+      if (crashed) throw new Error(`${what}: renderer crashed twice`, { cause: error });
+      const html = await page.content().catch(() => "<unavailable>");
+      throw new Error(
+        `${what}: ${String(error)}\n  url: ${page.url()}\n  console: ${consoleErrors.join(" | ") || "(none)"}\n  html: ${html.slice(0, 400)}`,
+        { cause: error }
+      );
+    } finally {
+      await page.close().catch(() => undefined);
+    }
+  }
+}
+
+async function settle(page: Page, extraMs: number) {
+  await page.evaluate(() => document.fonts.ready);
+  // The banner's entrance is a 250ms opacity-and-slide; wait it out so no
+  // capture lands mid-transition.
+  await page.waitForTimeout(350 + extraMs);
+}
+
+/** Load one state in one theme at one width, through the coordinator, and settle it. */
+async function openFixture(
+  page: Page,
+  fixture: string,
+  theme: string,
+  width: number,
+  settleMs: number
+): Promise<Locator> {
+  await page.setViewportSize({ width, height: 400 });
+  await page.goto(
+    `${baseURL}/recovery-banners-preview.html?theme=${theme}&fixture=${fixture}&width=${width}`
+  );
+  const shell = page.locator("[data-preview-shell]").first();
+  await expect(shell).toBeAttached({ timeout: ATTACH_TIMEOUT_MS });
+  await settle(page, settleMs);
+  const banner = page.locator("[data-banner-slot] [role]").first();
+  // An empty slot means the coordinator resolved to nothing, or the banner
+  // returned null — a picture of the toolbar strip dressed up as a passing run.
+  await expect(banner, `fixture "${fixture}" rendered no banner`).toBeAttached();
+  return shell;
+}
+
+async function openSheet(page: Page, theme: string, width: number): Promise<Locator> {
+  await page.setViewportSize({ width, height: 2400 });
+  await page.goto(
+    `${baseURL}/recovery-banners-preview.html?theme=${theme}&fixture=sheet&width=${width}`
+  );
+  const shell = page.locator("[data-preview-shell]").first();
+  await expect(shell).toBeAttached({ timeout: ATTACH_TIMEOUT_MS });
+  await settle(page, 0);
+  // Every row must hold a banner — a sheet with a silent gap is the exact
+  // failure this harness exists to make visible.
+  await expect(page.locator("[data-banner-slot] [role]")).toHaveCount(SHEET_ROWS);
+  return shell;
+}
+
+test("global banner family — every slot, every state, every theme", async ({ context }) => {
+  test.info().annotations.push({
+    type: "conditional-skip",
+    description: "DAINTREE_SHOT_BANNERS is required for the banner capture",
+  });
+  test.skip(!ENABLED, "set DAINTREE_SHOT_BANNERS=1 to run the capture");
+
+  const written: string[] = [];
+
+  for (const theme of THEMES) {
+    written.push(
+      await withPage(context, `sheet ${theme}`, async (page) =>
+        snap(await openSheet(page, theme, DEFAULT_WIDTH), `sheet-${theme}.png`)
+      )
+    );
+    for (const { name, settleMs } of FIXTURES) {
+      written.push(
+        await withPage(context, `${name} ${theme}`, async (page) =>
+          snap(
+            await openFixture(page, name, theme, DEFAULT_WIDTH, settleMs),
+            `${name}-${theme}.png`
+          )
+        )
+      );
+    }
+  }
+
+  const theme = THEMES[0]!;
+
+  // The safe-mode details popover is the one piece of banner UI that lives
+  // outside the band, and it carries its own hand-rolled controls.
+  written.push(
+    await withPage(context, "safe-mode details", async (page) => {
+      const shell = await openFixture(page, "safe-mode", theme, DEFAULT_WIDTH, 0);
+      await page.getByRole("button", { name: "Show details" }).click();
+      await expect(page.getByText(/quarantined/)).toBeVisible();
+      await page.waitForTimeout(250);
+      return snap(shell, `safe-mode-${theme}-details.png`);
+    })
+  );
+
+  for (const name of NARROW_FIXTURES) {
+    const fixture = FIXTURES.find((f) => f.name === name)!;
+    written.push(
+      await withPage(context, `${name} narrow`, async (page) =>
+        snap(
+          await openFixture(page, name, theme, NARROW_WIDTH, fixture.settleMs),
+          `${name}-${theme}-narrow.png`
+        )
+      )
+    );
+  }
+
+  // The Windows caption strip reserves the right edge instead of the left, so
+  // the dismiss button and actions sit against it there.
+  written.push(
+    await withPage(
+      context,
+      "sheet windows",
+      async (page) =>
+        snap(await openSheet(page, theme, DEFAULT_WIDTH), `sheet-${theme}-windows.png`),
+      (page) =>
+        page.addInitScript(() => {
+          Object.defineProperty(navigator, "platform", { get: () => "Win32" });
+        })
+    )
+  );
+
+  // Count the files ourselves. A harness that trusts its own exit code is how a
+  // review ends up reasoning about screenshots that were never written.
+  const onDisk = readdirSync(OUT_DIR).filter((f) => f.endsWith(".png"));
+  expect(onDisk.length).toBe(written.length);
+  expect(onDisk.length).toBeGreaterThanOrEqual(THEMES.length * (FIXTURES.length + 1));
+  console.log(`[recovery-banner-shots] ${onDisk.length} PNGs in ${OUT_DIR}`);
+});

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -68,6 +68,7 @@ const config: KnipConfig = {
     "src/components/Worktree/__preview__/preview.tsx",
     "src/components/Panel/__preview__/preview.tsx",
     "src/components/DragDrop/__preview__/preview.tsx",
+    "src/components/Recovery/__preview__/preview.tsx",
   ],
 
   // Project files Knip considers part of the graph. Includes root-level

--- a/recovery-banners-preview.html
+++ b/recovery-banners-preview.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="" />
+    <title>Recovery banners preview</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/components/Recovery/__preview__/preview.tsx"></script>
+  </body>
+</html>

--- a/scripts/baselines/text-ramp-manifest.json
+++ b/scripts/baselines/text-ramp-manifest.json
@@ -1,7 +1,7 @@
 {
   "generated": "2026-09-12",
-  "total": 391,
-  "files": 149,
+  "total": 389,
+  "files": 148,
   "occurrences": [
     {
       "file": "plugins/builtin/github/renderer/components/BulkCreateWorktreeDialog.tsx",
@@ -4907,36 +4907,6 @@
       "decision": "keep",
       "category": "icon-affordance",
       "evidence": "<button> wraps only icons — the colour paints a glyph through currentColor"
-    },
-    {
-      "file": "src/components/Terminal/InlineStatusBanner.tsx",
-      "ordinal": 0,
-      "line": 270,
-      "start": 9877,
-      "end": 9898,
-      "token": "text-daintree-text/60",
-      "variants": "",
-      "step": 60,
-      "group": "src/components/Terminal/InlineStatusBanner.tsx#9834",
-      "branch": "9675T",
-      "decision": "keep",
-      "category": "icon-affordance",
-      "evidence": "<button> wraps only icons — the colour paints a glyph through currentColor"
-    },
-    {
-      "file": "src/components/Terminal/InlineStatusBanner.tsx",
-      "ordinal": 1,
-      "line": 318,
-      "start": 12172,
-      "end": 12193,
-      "token": "text-daintree-text/60",
-      "variants": "",
-      "step": 60,
-      "group": "src/components/Terminal/InlineStatusBanner.tsx#12048",
-      "branch": "",
-      "decision": "keep",
-      "category": "decorative-glyph",
-      "evidence": "aria-hidden with no text content — decorative"
     },
     {
       "file": "src/components/Terminal/LauncherQuickActions.tsx",

--- a/src/components/Plugin/PluginDocumentWarning.tsx
+++ b/src/components/Plugin/PluginDocumentWarning.tsx
@@ -10,6 +10,7 @@ import { pluginManifestIdFromInstanceKey } from "@shared/types/plugin";
 import { useProjectStore } from "@/store/projectStore";
 import { notify } from "@/lib/notify";
 import { useNotificationHistoryStore } from "@/store/slices/notificationHistorySlice";
+import { useGlobalBannerDismissalStore } from "@/store/globalBannerDismissalStore";
 
 function affectedPlugins(diagnostics: readonly PluginDocumentDiagnostic[]): string {
   return [
@@ -30,12 +31,16 @@ export function PluginDocumentWarning() {
     pluginDocumentRuntime.subscribe,
     pluginDocumentRuntime.getSnapshot
   );
+  const dismiss = useGlobalBannerDismissalStore((s) => s.dismiss);
   if (diagnostics.length === 0) return null;
   return (
     <InlineStatusBanner
       severity="warning"
       role="status"
       title="Plugins need a window reload"
+      // A reload is the user's to schedule; the inbox entry keeps it findable.
+      onClose={() => dismiss("plugin-document")}
+      closeAriaLabel="Dismiss plugin reload warning"
       description="Plugin registrations can't be replaced until this project window reloads. Save edits before continuing."
       contextLine={affectedPlugins(diagnostics)}
       action={{ id: "reload-project-window", label: "Reload window", onClick: requestReload }}

--- a/src/components/Plugin/PluginDocumentWarning.tsx
+++ b/src/components/Plugin/PluginDocumentWarning.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useRef, useSyncExternalStore } from "react";
-import { TriangleAlert } from "lucide-react";
 import { InlineStatusBanner } from "@/components/Terminal/InlineStatusBanner";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import {
@@ -34,8 +33,8 @@ export function PluginDocumentWarning() {
   if (diagnostics.length === 0) return null;
   return (
     <InlineStatusBanner
-      icon={TriangleAlert}
       severity="warning"
+      role="status"
       title="Plugins need a window reload"
       description="Plugin registrations can't be replaced until this project window reloads. Save edits before continuing."
       contextLine={affectedPlugins(diagnostics)}

--- a/src/components/Recovery/CloudSyncBanner.tsx
+++ b/src/components/Recovery/CloudSyncBanner.tsx
@@ -1,4 +1,3 @@
-import { AlertTriangle } from "lucide-react";
 import { InlineStatusBanner } from "@/components/Terminal/InlineStatusBanner";
 import { useCloudSyncBannerStore } from "@/store/cloudSyncBannerStore";
 import { useProjectStore } from "@/store/projectStore";
@@ -52,16 +51,20 @@ export function CloudSyncBanner() {
 
   return (
     <InlineStatusBanner
-      icon={AlertTriangle}
       title={copy.title}
       description={copy.description}
       severity="warning"
       role="status"
+      // × hides the warning for this session; the inbox entry the hook raised
+      // keeps it findable. Silencing it for good is a preference change, so it
+      // stays a labelled action rather than hiding behind the ×.
+      onClose={() => setBanner({ service: null, projectId: null })}
+      closeAriaLabel="Dismiss cloud folder warning"
       actions={[
         {
           id: "dismiss",
           label: "Don't warn for this project",
-          variant: "primary",
+          variant: "dismiss",
           onClick: handleDismiss,
         },
       ]}

--- a/src/components/Recovery/ForgeTokenBanner.tsx
+++ b/src/components/Recovery/ForgeTokenBanner.tsx
@@ -1,8 +1,29 @@
 import { useEffect } from "react";
 import { actionService } from "@/services/ActionService";
 import { InlineStatusBanner, type BannerAction } from "@/components/Terminal/InlineStatusBanner";
-import { useForgeProviderHealthStore } from "@/store/forgeProviderHealthStore";
+import {
+  useForgeProviderHealthStore,
+  type ForgeProviderHealth,
+} from "@/store/forgeProviderHealthStore";
 import { usePluginRuntimeStore } from "@/store/pluginRuntimeStore";
+
+/**
+ * The provider this banner would show, or `undefined`. Shared with the
+ * coordinator so the slot is claimed by exactly the condition that renders:
+ * a dismissed or disabled-plugin provider must not hold an empty band and
+ * suppress the banners beneath it.
+ */
+export function selectActiveForgeTokenProvider(
+  providers: Record<string, ForgeProviderHealth>,
+  disabledPluginIds: ReadonlySet<string>
+): [providerId: string, health: ForgeProviderHealth] | undefined {
+  return Object.entries(providers).find(
+    ([, health]) =>
+      health.tokenUnhealthy &&
+      !health.tokenBannerDismissed &&
+      (health.pluginId === null || !disabledPluginIds.has(health.pluginId))
+  );
+}
 
 export function ForgeTokenBanner() {
   const providers = useForgeProviderHealthStore((s) => s.providers);
@@ -14,12 +35,7 @@ export function ForgeTokenBanner() {
   const init = usePluginRuntimeStore((s) => s.init);
   useEffect(() => init(), [init]);
 
-  const active = Object.entries(providers).find(
-    ([, health]) =>
-      health.tokenUnhealthy &&
-      !health.tokenBannerDismissed &&
-      (health.pluginId === null || !disabledPluginIds.has(health.pluginId))
-  );
+  const active = selectActiveForgeTokenProvider(providers, disabledPluginIds);
   if (!active) return null;
 
   const [providerId, health] = active;

--- a/src/components/Recovery/ForgeTokenBanner.tsx
+++ b/src/components/Recovery/ForgeTokenBanner.tsx
@@ -1,5 +1,4 @@
 import { useEffect } from "react";
-import { AlertTriangle } from "lucide-react";
 import { actionService } from "@/services/ActionService";
 import { InlineStatusBanner, type BannerAction } from "@/components/Terminal/InlineStatusBanner";
 import { useForgeProviderHealthStore } from "@/store/forgeProviderHealthStore";
@@ -59,7 +58,6 @@ export function ForgeTokenBanner() {
 
   return (
     <InlineStatusBanner
-      icon={AlertTriangle}
       title={`${name} token expired`}
       description="Reconnect to restore issue, PR, and repository data."
       severity="warning"

--- a/src/components/Recovery/HostCrashBanner.tsx
+++ b/src/components/Recovery/HostCrashBanner.tsx
@@ -39,7 +39,7 @@ export function HostCrashBanner() {
         title={HOST_CRASH_RECOVERING_COPY.title}
         description={HOST_CRASH_RECOVERING_COPY.description}
         severity="warning"
-        role="alert"
+        role="status"
         animated={false}
         actions={[]}
       />

--- a/src/components/Recovery/HostCrashBanner.tsx
+++ b/src/components/Recovery/HostCrashBanner.tsx
@@ -1,6 +1,7 @@
 import { useState, type CSSProperties } from "react";
-import { AlertTriangle, Download, Loader2 } from "lucide-react";
+import { Download, Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
 import { usePanelStore } from "@/store/panelStore";
 import { useDiagnosticsReviewStore } from "@/store/diagnosticsReviewStore";
 import { actionService } from "@/services/ActionService";
@@ -76,29 +77,22 @@ export function HostCrashBanner() {
 
   // `trailingSlot` is the documented escape hatch for surfacing a secondary
   // affordance on an error banner without breaking the single-action rule
-  // (see InlineStatusBanner.tsx). Keeping "Restart service" as the primary
-  // `action` preserves the dangerFilled emphasis.
+  // (see InlineStatusBanner.tsx). "Restart service" stays the one `action`.
   const sendDiagnosticsButton = (
-    <button
-      type="button"
+    <Button
+      variant="ghost"
+      size="sm"
       onClick={handleSendDiagnostics}
       disabled={isCollectingDiagnostics}
       aria-label="Send diagnostics"
-      className={cn(
-        "flex items-center gap-1.5 px-2 py-1 text-xs font-medium rounded transition-colors",
-        "text-text-secondary hover:text-text-primary hover:bg-daintree-border/50",
-        "outline-hidden focus-visible:outline-solid focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-primary",
-        isCollectingDiagnostics && "cursor-not-allowed opacity-60 hover:bg-transparent"
-      )}
     >
-      <Download className="w-3 h-3" aria-hidden="true" />
+      <Download aria-hidden="true" />
       {isCollectingDiagnostics ? "Collecting…" : "Send diagnostics"}
-    </button>
+    </Button>
   );
 
   return (
     <InlineStatusBanner
-      icon={AlertTriangle}
       title={title}
       description={description}
       severity="error"
@@ -108,8 +102,7 @@ export function HostCrashBanner() {
       descriptionExtras={
         diagnosticsError ? (
           <p
-            className="text-xs mt-1.5 break-words"
-            style={{ color: "color-mix(in oklab, var(--color-status-error) 80%, transparent)" }}
+            className="text-xs mt-1 break-words text-text-primary"
             data-testid="host-crash-banner-diagnostics-error"
           >
             Diagnostics collection failed: {diagnosticsError}
@@ -119,7 +112,7 @@ export function HostCrashBanner() {
       action={{
         id: "restart",
         label: isRestarting ? "Restarting…" : "Restart service",
-        variant: "dangerFilled",
+        variant: "primary",
         onClick: handleRestart,
         disabled: isRestarting,
       }}

--- a/src/components/Recovery/HostMemoryStallBanner.tsx
+++ b/src/components/Recovery/HostMemoryStallBanner.tsx
@@ -1,4 +1,3 @@
-import { MemoryStick } from "@/components/icons";
 import { InlineStatusBanner } from "@/components/Terminal/InlineStatusBanner";
 import { HOST_MEMORY_PAUSE_COPY } from "@/lib/hostMemoryPauseCopy";
 import { actionService } from "@/services/ActionService";
@@ -20,12 +19,10 @@ export function HostMemoryStallBanner() {
 
   return (
     <InlineStatusBanner
-      icon={MemoryStick}
       title={title}
       description={description}
       severity="warning"
       role="status"
-      animated={false}
       actions={[
         {
           id: "why-slow",

--- a/src/components/Recovery/MissingPrerequisiteBanner.tsx
+++ b/src/components/Recovery/MissingPrerequisiteBanner.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { AlertTriangle } from "lucide-react";
+import { Button } from "@/components/ui/button";
 import type { AgentInstallBlock } from "@shared/config/agentRegistry";
 import type { PrerequisiteCheckResult } from "@shared/types";
 import { InlineStatusBanner } from "@/components/Terminal/InlineStatusBanner";
@@ -62,15 +62,31 @@ function pickGuidance(result: PrerequisiteCheckResult): Guidance | null {
   };
 }
 
+/** What actually stops working without each fatal tool; the spec carries no such field. */
+const CONSEQUENCE: Record<string, string> = {
+  git: "git operations",
+  node: "agent launches",
+};
+
 function describe(missing: PrerequisiteCheckResult[]): string {
   const names = missing.map((m) => m.label).join(", ");
   const isOne = missing.length === 1;
   const subject = isOne ? "it's" : "they're";
   const outdated = missing.every((m) => m.available);
+  const versions = missing
+    .filter((m) => m.available && m.minVersion)
+    .map((m) => `${m.label} ${m.version ?? "?"} is installed and ${m.minVersion} is needed`);
   const problem = outdated
-    ? `${names} ${isOne ? "is" : "are"} below the version Daintree needs`
+    ? versions.length > 0
+      ? versions.join("; ")
+      : `${names} ${isOne ? "is" : "are"} below the version Daintree needs`
     : `${names} ${isOne ? "is" : "are"} not installed or not on PATH`;
-  return `${problem}, so git operations and agent launches will fail until ${subject} sorted.`;
+  const consequences = [...new Set(missing.map((m) => CONSEQUENCE[m.tool] ?? "some features"))];
+  const consequence =
+    consequences.length === 1
+      ? consequences[0]
+      : `${consequences.slice(0, -1).join(", ")} and ${consequences[consequences.length - 1]}`;
+  return `${problem}, so ${consequence} will fail until ${subject} sorted.`;
 }
 
 function title(missing: PrerequisiteCheckResult[]): string {
@@ -276,7 +292,8 @@ export function MissingPrerequisiteBanner() {
   const description = handedOff
     ? "Finish the macOS installer, then re-check"
     : failed
-      ? install.error
+      ? // The tool's own "Error:" prefix says nothing the red band doesn't.
+        install.error?.replace(/^error:\s*/i, "")
       : describe(missing);
 
   const contextLine = isRunning
@@ -333,16 +350,25 @@ export function MissingPrerequisiteBanner() {
     // The job carries the tool id; the banner speaks the display name.
     const failedLabel =
       missing.find((m) => m.tool === install.tool)?.label ?? guidance?.result.label ?? "the tool";
+    // The failure answers the user's own click, so they are already looking:
+    // a polite announcement is enough. Retry is the one action; the guide is
+    // the way out when retrying the same command cannot help.
     return (
       <InlineStatusBanner
-        icon={AlertTriangle}
         title={`Couldn't install ${failedLabel}`}
         description={description}
         contextLine={command}
         severity="error"
-        role="alert"
+        role="status"
         onClose={dismiss}
         closeAriaLabel="Dismiss missing tool warning"
+        trailingSlot={
+          guidance?.result.installUrl ? (
+            <Button variant="ghost" size="sm" onClick={openInstallUrl}>
+              View install guide
+            </Button>
+          ) : undefined
+        }
         action={{
           id: "retry",
           label: "Retry",
@@ -355,7 +381,6 @@ export function MissingPrerequisiteBanner() {
 
   return (
     <InlineStatusBanner
-      icon={AlertTriangle}
       title={title(missing)}
       description={description}
       contextLine={contextLine}

--- a/src/components/Recovery/MissingPrerequisiteBanner.tsx
+++ b/src/components/Recovery/MissingPrerequisiteBanner.tsx
@@ -68,19 +68,18 @@ const CONSEQUENCE: Record<string, string> = {
   node: "agent launches",
 };
 
+/** One tool's own condition — a missing Git and an outdated Node are not the same sentence. */
+function condition(m: PrerequisiteCheckResult): string {
+  if (!m.available) return `${m.label} is not installed or not on PATH`;
+  if (m.minVersion)
+    return `${m.label} ${m.version ?? "?"} is installed and ${m.minVersion} is needed`;
+  return `${m.label} is below the version Daintree needs`;
+}
+
 function describe(missing: PrerequisiteCheckResult[]): string {
-  const names = missing.map((m) => m.label).join(", ");
   const isOne = missing.length === 1;
   const subject = isOne ? "it's" : "they're";
-  const outdated = missing.every((m) => m.available);
-  const versions = missing
-    .filter((m) => m.available && m.minVersion)
-    .map((m) => `${m.label} ${m.version ?? "?"} is installed and ${m.minVersion} is needed`);
-  const problem = outdated
-    ? versions.length > 0
-      ? versions.join("; ")
-      : `${names} ${isOne ? "is" : "are"} below the version Daintree needs`
-    : `${names} ${isOne ? "is" : "are"} not installed or not on PATH`;
+  const problem = missing.map(condition).join("; ");
   const consequences = [...new Set(missing.map((m) => CONSEQUENCE[m.tool] ?? "some features"))];
   const consequence =
     consequences.length === 1
@@ -91,7 +90,12 @@ function describe(missing: PrerequisiteCheckResult[]): string {
 
 function title(missing: PrerequisiteCheckResult[]): string {
   const only = missing.length === 1 ? missing[0] : undefined;
-  if (!only) return "Required tools are missing";
+  if (!only) {
+    // Two or more tools, each in its own state — the description says which.
+    return missing.every((m) => !m.available)
+      ? "Required tools are missing"
+      : "Required tools need attention";
+  }
   return only.available ? `${only.label} is out of date` : `${only.label} is missing`;
 }
 
@@ -386,6 +390,10 @@ export function MissingPrerequisiteBanner() {
       contextLine={contextLine}
       severity="warning"
       role="status"
+      // While the package manager streams, the context line changes on every
+      // chunk and a status region would read each one aloud. The button is
+      // busy and the finish is a toast; nothing here needs announcing.
+      ariaLive={isRunning ? "off" : undefined}
       onClose={dismiss}
       closeAriaLabel="Dismiss missing tool warning"
       actions={[action]}

--- a/src/components/Recovery/RestoreConfirmationBanner.tsx
+++ b/src/components/Recovery/RestoreConfirmationBanner.tsx
@@ -1,7 +1,6 @@
-import { AlertTriangle } from "lucide-react";
 import { useRestoreConfirmationStore } from "@/store/restoreConfirmationStore";
 import { InlineStatusBanner } from "@/components/Terminal/InlineStatusBanner";
-import { getRestoreConfirmationTitle } from "./recoveryCopy";
+import { RESTORE_CONFIRMATION_TITLE, getRestoreConfirmationDescription } from "./recoveryCopy";
 
 const AUTO_DISMISS_MS = 10_000;
 
@@ -12,16 +11,20 @@ export function RestoreConfirmationBanner() {
 
   if (!visible) return null;
 
+  // A clean recovery is news, not a problem: it says so in the info tier and
+  // leaves on its own. Once panels are implicated it is a warning that stands
+  // until the user has read it.
+  const description = getRestoreConfirmationDescription(suspectCount);
   return (
     <InlineStatusBanner
-      icon={AlertTriangle}
-      title={getRestoreConfirmationTitle(suspectCount)}
-      severity="warning"
+      title={RESTORE_CONFIRMATION_TITLE}
+      description={description}
+      severity={description ? "warning" : "info"}
       role="status"
       actions={[]}
       onClose={dismiss}
       closeAriaLabel="Dismiss recovery confirmation"
-      autoDismissAfter={suspectCount > 0 ? undefined : AUTO_DISMISS_MS}
+      autoDismissAfter={description ? undefined : AUTO_DISMISS_MS}
     />
   );
 }

--- a/src/components/Recovery/RosettaBanner.tsx
+++ b/src/components/Recovery/RosettaBanner.tsx
@@ -1,4 +1,3 @@
-import { AlertTriangle } from "lucide-react";
 import { actionService } from "@/services/ActionService";
 import { InlineStatusBanner } from "@/components/Terminal/InlineStatusBanner";
 import { useRosettaBannerStore } from "@/store/rosettaBannerStore";
@@ -14,8 +13,8 @@ export function RosettaBanner() {
 
   if (!visible) return null;
 
-  const handleDismiss = async () => {
-    // Hide immediately — the dismissal is permanent (the binary's architecture
+  const handleDismissForever = async () => {
+    // Hide immediately — this dismissal is permanent (the binary's architecture
     // never changes via auto-update), and a persistence failure shouldn't
     // resurrect the banner mid-session; it just returns on the next launch.
     setVisible(false);
@@ -39,12 +38,13 @@ export function RosettaBanner() {
 
   return (
     <InlineStatusBanner
-      icon={AlertTriangle}
       title="Running under Rosetta"
       description="This is the Intel build running translated on Apple Silicon, which degrades performance. Install the Apple Silicon build for native speed."
       severity="warning"
       role="status"
-      onClose={() => void handleDismiss()}
+      // × only hides it until the next launch. Never showing it again is a
+      // choice the user has to make in words, so it gets a labelled action.
+      onClose={() => setVisible(false)}
       closeAriaLabel="Dismiss Rosetta warning"
       actions={[
         {
@@ -52,6 +52,12 @@ export function RosettaBanner() {
           label: "Download Apple Silicon build",
           variant: "primary",
           onClick: handleDownload,
+        },
+        {
+          id: "dismiss-forever",
+          label: "Don't show again",
+          variant: "dismiss",
+          onClick: () => void handleDismissForever(),
         },
       ]}
     />

--- a/src/components/Recovery/SafeModeBanner.tsx
+++ b/src/components/Recovery/SafeModeBanner.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
-import { AlertTriangle } from "lucide-react";
 import { useSafeModeStore } from "@/store/safeModeStore";
+import { Button } from "@/components/ui/button";
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
 import { InlineStatusBanner } from "@/components/Terminal/InlineStatusBanner";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
@@ -46,8 +46,10 @@ function QuarantinedPanelRow({ panel }: QuarantinedPanelRowProps) {
   const displayTitle = panel.title.trim().length > 0 ? panel.title : "Untitled panel";
   // Prefer worktree context when present; cwd is verbose and often a long
   // absolute path that wraps the popover badly. Either way it's a single
-  // secondary line so the panel is identifiable across collisions.
-  const subtitle = panel.worktreeId ?? panel.cwd ?? null;
+  // secondary line so the panel is identifiable across collisions — unless
+  // the title already says it, in which case a second copy is noise.
+  const context = panel.worktreeId ?? panel.cwd ?? null;
+  const subtitle = context && !displayTitle.includes(context) ? context : null;
 
   return (
     <li className="flex items-start justify-between gap-3 py-1.5">
@@ -62,13 +64,9 @@ function QuarantinedPanelRow({ panel }: QuarantinedPanelRowProps) {
         )}
       </div>
       {state === "idle" && (
-        <button
-          type="button"
-          onClick={handleRestore}
-          className="shrink-0 rounded border border-[var(--color-status-warning)]/30 px-2 py-0.5 text-3xs transition-colors hover:bg-[var(--color-status-warning)]/10"
-        >
-          Restore panel
-        </button>
+        <Button variant="outline" size="xs" onClick={handleRestore} className="shrink-0">
+          Restore on next launch
+        </Button>
       )}
       {state === "clearing" && (
         <span className="shrink-0 text-3xs text-text-secondary">Clearing…</span>
@@ -77,13 +75,9 @@ function QuarantinedPanelRow({ panel }: QuarantinedPanelRowProps) {
         <span className="shrink-0 text-3xs text-text-secondary">Restoring on next launch</span>
       )}
       {state === "failed" && (
-        <button
-          type="button"
-          onClick={handleRestore}
-          className="shrink-0 rounded border border-[var(--color-status-warning)]/30 px-2 py-0.5 text-3xs transition-colors hover:bg-[var(--color-status-warning)]/10"
-        >
+        <Button variant="outline" size="xs" onClick={handleRestore} className="shrink-0">
           Retry
-        </button>
+        </Button>
       )}
     </li>
   );
@@ -140,16 +134,15 @@ export function SafeModeBanner() {
 
   const detailsPopover = hasDetails ? (
     <Popover>
-      <PopoverTrigger
-        type="button"
-        className="text-xs px-2 py-1 rounded border border-[var(--color-status-warning)]/30 hover:bg-[var(--color-status-warning)]/10 transition-colors shrink-0"
-      >
-        Show details
+      <PopoverTrigger asChild>
+        <Button variant="ghost" size="sm" className="shrink-0">
+          Show details
+        </Button>
       </PopoverTrigger>
       <PopoverContent
         align="end"
         sideOffset={8}
-        className="p-3 text-xs max-w-xs space-y-2 text-text-primary"
+        className="p-3 text-xs max-w-sm space-y-2 text-text-primary"
       >
         {crashMetaText && <p className="font-medium">{crashMetaText}</p>}
         {hasQuarantineList ? (
@@ -183,7 +176,6 @@ export function SafeModeBanner() {
   return (
     <>
       <InlineStatusBanner
-        icon={AlertTriangle}
         title={SAFE_MODE_BANNER_COPY.title}
         severity="warning"
         role="status"

--- a/src/components/Recovery/WatchdogDisabledBanner.tsx
+++ b/src/components/Recovery/WatchdogDisabledBanner.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { usePanelStore } from "@/store/panelStore";
+import { useGlobalBannerDismissalStore } from "@/store/globalBannerDismissalStore";
 import { actionService } from "@/services/ActionService";
 import { InlineStatusBanner } from "@/components/Terminal/InlineStatusBanner";
 import { logError } from "@/utils/logger";
@@ -8,6 +9,7 @@ export function WatchdogDisabledBanner() {
   const watchdogStatus = usePanelStore((s) => s.watchdogStatus);
   const info = usePanelStore((s) => s.watchdogDisabledInfo);
   const [isRestarting, setIsRestarting] = useState(false);
+  const dismiss = useGlobalBannerDismissalStore((s) => s.dismiss);
 
   if (watchdogStatus !== "disabled") return null;
 
@@ -35,6 +37,10 @@ export function WatchdogDisabledBanner() {
       description={description}
       severity="warning"
       role="status"
+      // The protection layer being down is worth knowing, not worth blocking
+      // the band on: × hides it for the session and the next disable re-shows it.
+      onClose={() => dismiss("watchdog-disabled")}
+      closeAriaLabel="Dismiss watchdog warning"
       actions={[
         {
           id: "restart",

--- a/src/components/Recovery/WatchdogDisabledBanner.tsx
+++ b/src/components/Recovery/WatchdogDisabledBanner.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import { AlertTriangle } from "lucide-react";
 import { usePanelStore } from "@/store/panelStore";
 import { actionService } from "@/services/ActionService";
 import { InlineStatusBanner } from "@/components/Terminal/InlineStatusBanner";
@@ -32,12 +31,10 @@ export function WatchdogDisabledBanner() {
 
   return (
     <InlineStatusBanner
-      icon={AlertTriangle}
       title="Crash watchdog disabled"
       description={description}
       severity="warning"
-      role="alert"
-      animated={false}
+      role="status"
       actions={[
         {
           id: "restart",

--- a/src/components/Recovery/__preview__/bannerFixtures.ts
+++ b/src/components/Recovery/__preview__/bannerFixtures.ts
@@ -1,0 +1,270 @@
+import { usePanelStore } from "@/store/panelStore";
+import { useSafeModeStore } from "@/store/safeModeStore";
+import { useRestoreConfirmationStore } from "@/store/restoreConfirmationStore";
+import { useForgeProviderHealthStore } from "@/store/forgeProviderHealthStore";
+import { useCloudSyncBannerStore } from "@/store/cloudSyncBannerStore";
+import { useRosettaBannerStore } from "@/store/rosettaBannerStore";
+import { useHostMemoryPauseStore } from "@/store/hostMemoryPauseStore";
+import { useMissingPrerequisiteStore } from "@/store/missingPrerequisiteStore";
+import { useDiagnosticsReviewStore } from "@/store/diagnosticsReviewStore";
+import { pluginDocumentRuntime } from "@/services/plugin/pluginDocumentRuntime";
+import type { GlobalBannerSlot } from "../useGlobalBannerPriority";
+import type { PrerequisiteCheckResult } from "@shared/types";
+
+/**
+ * Seeds for the visual-review harness — every state of every global banner,
+ * pushed through the stores the banners actually read. No prop-level mocks:
+ * the banner components are the real ones, and so is what they subscribe to.
+ *
+ * `slot` names which coordinator slot the seed claims, so the single-banner
+ * page can render through `GlobalBannerCoordinator` and prove the priority
+ * hook resolves to it; the comparison sheet seeds everything at once and
+ * mounts each banner directly, since only one can ever hold the slot.
+ */
+export interface BannerFixture {
+  slot: Exclude<GlobalBannerSlot, null>;
+  /** What this state is here to prove. */
+  what: string;
+  seed: () => void;
+  /** Extra settle time after seeding — the Doherty-gated variants need it. */
+  settleMs?: number;
+}
+
+const GIT_MISSING: PrerequisiteCheckResult = {
+  tool: "git",
+  label: "Git",
+  available: false,
+  unavailableReason: "not-found",
+  version: null,
+  severity: "fatal",
+  meetsMinVersion: false,
+  installUrl: "https://git-scm.com/downloads",
+  installBlocks: {
+    macos: [{ label: "Homebrew", commands: ["brew install git"] }],
+    linux: [{ label: "apt", commands: ["sudo apt install git"] }],
+    windows: [{ label: "winget", commands: ["winget install Git.Git"] }],
+  },
+};
+
+const NODE_OUTDATED: PrerequisiteCheckResult = {
+  tool: "node",
+  label: "Node.js",
+  available: true,
+  version: "18.20.4",
+  severity: "fatal",
+  meetsMinVersion: false,
+  minVersion: "22.0.0",
+  installUrl: "https://nodejs.org/en/download",
+};
+
+function seedForgeToken(withReauth: boolean) {
+  const store = useForgeProviderHealthStore.getState();
+  store.setProviderMeta("github", { providerName: "GitHub", pluginId: null });
+  store.setTokenUnhealthy("github", true, {
+    status: "unhealthy",
+    tokenVersion: 1,
+    checkedAt: Date.now(),
+    reauthUrl: withReauth ? "https://github.com/settings/tokens" : undefined,
+  });
+}
+
+/** A plugin package that fails to import is the smallest real diagnostic the runtime emits. */
+function seedPluginDocument() {
+  pluginDocumentRuntime.registerView("acme.markdown", "plugin://acme-markdown/view.js");
+  void pluginDocumentRuntime
+    .load("plugin://acme-markdown/view.js", {
+      name: "@acme/markdown-editor",
+      version: "1.4.0",
+      buildId: "a".repeat(64),
+      entryUrl: "/document.js",
+    })
+    .catch(() => undefined);
+}
+
+export const BANNER_FIXTURES = {
+  "host-crash": {
+    slot: "host-crash",
+    what: "backend gone after three restarts — the one blocking error in the family",
+    seed: () => {
+      usePanelStore.setState({ backendStatus: "disconnected", lastCrashType: "OUT_OF_MEMORY" });
+    },
+  },
+  "host-crash-diagnostics-failed": {
+    slot: "host-crash",
+    what: "the secondary affordance failed and has to say so inside the banner",
+    seed: () => {
+      usePanelStore.setState({ backendStatus: "disconnected", lastCrashType: "UNKNOWN_CRASH" });
+      useDiagnosticsReviewStore.setState({
+        downloadError: "Log directory is not readable (EACCES)",
+      });
+    },
+  },
+  "host-crash-recovering": {
+    slot: "host-crash",
+    what: "auto-restart in flight — shown only past the 400ms Doherty gate",
+    seed: () => {
+      usePanelStore.setState({ backendStatus: "recovering", lastCrashType: "UNKNOWN_CRASH" });
+    },
+    settleMs: 600,
+  },
+  "watchdog-disabled": {
+    slot: "watchdog-disabled",
+    what: "the deadlock detector gave up; the backend itself is fine",
+    seed: () => {
+      usePanelStore.setState({
+        watchdogStatus: "disabled",
+        watchdogDisabledInfo: { attemptCount: 3, lastExitCode: 1, timestamp: Date.now() },
+      });
+    },
+  },
+  "host-memory-stall": {
+    slot: "host-memory-stall",
+    what: "a memory pause that is not recovering — not dismissible, self-clearing",
+    seed: () => {
+      useHostMemoryPauseStore.setState({
+        snapshot: { active: true, paused: true, stalled: true },
+        visible: true,
+      });
+    },
+  },
+  "safe-mode": {
+    slot: "safe-mode",
+    what: "panels withheld after a crash loop; details live behind a popover",
+    seed: () => {
+      useSafeModeStore.getState().setSafeMode(true, {
+        crashCount: 3,
+        skippedPanelCount: 4,
+        lastCrashAt: Date.now() - 4 * 60_000,
+        quarantinedPanels: [
+          {
+            id: "p1",
+            kind: "terminal",
+            title: "claude — feature/issue-12100-diff-pane",
+            worktreeId: "feature/issue-12100-diff-pane",
+          },
+          { id: "p2", kind: "browser", title: "", cwd: "/Users/dev/Projects/daintree" },
+        ],
+      });
+    },
+  },
+  "restore-confirmation": {
+    slot: "restore-confirmation",
+    what: "the reassurance — nothing is wrong, the session came back",
+    seed: () => {
+      useRestoreConfirmationStore.getState().showRestoreConfirmation({
+        suspectCount: 0,
+        crashCount: 1,
+      });
+    },
+  },
+  "restore-confirmation-suspects": {
+    slot: "restore-confirmation",
+    what: "the reassurance with a caveat: some panels may be implicated",
+    seed: () => {
+      useRestoreConfirmationStore.getState().showRestoreConfirmation({
+        suspectCount: 3,
+        crashCount: 2,
+      });
+    },
+  },
+  "missing-prerequisite": {
+    slot: "missing-prerequisite",
+    what: "git absent, install command on offer",
+    seed: () => {
+      useMissingPrerequisiteStore.getState().setMissing([GIT_MISSING]);
+    },
+  },
+  "missing-prerequisite-outdated": {
+    slot: "missing-prerequisite",
+    what: "the tool exists but is too old — a different sentence, same banner",
+    seed: () => {
+      useMissingPrerequisiteStore.getState().setMissing([NODE_OUTDATED]);
+    },
+  },
+  "missing-prerequisite-installing": {
+    slot: "missing-prerequisite",
+    what: "install running; the context line carries the package manager's output",
+    seed: () => {
+      useMissingPrerequisiteStore.getState().setMissing([GIT_MISSING]);
+      useMissingPrerequisiteStore.getState().setInstall({
+        jobId: "job-1",
+        tool: "git",
+        status: "running",
+        statusLine: "==> Downloading https://ghcr.io/v2/homebrew/core/git/manifests/2.47.1",
+        error: null,
+      });
+    },
+  },
+  "missing-prerequisite-failed": {
+    slot: "missing-prerequisite",
+    what: "install failed — the only other error-severity member of the family",
+    seed: () => {
+      useMissingPrerequisiteStore.getState().setMissing([GIT_MISSING]);
+      useMissingPrerequisiteStore.getState().setInstall({
+        jobId: "job-1",
+        tool: "git",
+        status: "error",
+        statusLine: "",
+        error: "Error: Homebrew requires macOS 13 or newer",
+      });
+    },
+  },
+  "forge-token": {
+    slot: "forge-token",
+    what: "expired credentials with a reauthorization link — the two-action case",
+    seed: () => seedForgeToken(true),
+  },
+  "forge-token-single": {
+    slot: "forge-token",
+    what: "expired credentials, no reauth URL — one action",
+    seed: () => seedForgeToken(false),
+  },
+  "plugin-document": {
+    slot: "plugin-document",
+    what: "plugin registrations stuck until the window reloads",
+    seed: seedPluginDocument,
+  },
+  "cloud-sync": {
+    slot: "cloud-sync",
+    what: "an environmental warning whose only action is to silence itself",
+    seed: () => {
+      useCloudSyncBannerStore.getState().setBanner({ service: "iCloud Drive", projectId: "p1" });
+    },
+  },
+  rosetta: {
+    slot: "rosetta",
+    what: "the lowest-priority, most static warning in the family",
+    seed: () => {
+      useRosettaBannerStore.getState().setVisible(true);
+    },
+  },
+} as const satisfies Record<string, BannerFixture>;
+
+export type BannerFixtureName = keyof typeof BANNER_FIXTURES;
+
+/** The ten slots, in coordinator priority order, one canonical fixture each. */
+export const SHEET_ROWS: readonly BannerFixtureName[] = [
+  "host-crash",
+  "watchdog-disabled",
+  "host-memory-stall",
+  "safe-mode",
+  "restore-confirmation",
+  "missing-prerequisite",
+  "forge-token",
+  "plugin-document",
+  "cloud-sync",
+  "rosetta",
+];
+
+function isBannerFixtureName(name: string): name is BannerFixtureName {
+  return Object.hasOwn(BANNER_FIXTURES, name);
+}
+
+export function requireBannerFixture(name: string): BannerFixture & { name: BannerFixtureName } {
+  if (!isBannerFixtureName(name)) {
+    throw new Error(
+      `Unknown banner fixture "${name}". Known: ${Object.keys(BANNER_FIXTURES).join(", ")}`
+    );
+  }
+  return { name, ...BANNER_FIXTURES[name] };
+}

--- a/src/components/Recovery/__preview__/preview.tsx
+++ b/src/components/Recovery/__preview__/preview.tsx
@@ -1,0 +1,193 @@
+import { StrictMode, type ReactNode } from "react";
+import { createRoot } from "react-dom/client";
+import { resolveAppTheme } from "@shared/theme/themes";
+import { applyAppThemeToRoot } from "@/theme/applyAppTheme";
+import { installPreviewShims } from "@/components/HelpPanel/__preview__/previewShims";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { WindowControlsInsetProvider } from "@/components/ui/WindowControlsInset";
+import { isMac, isWindows } from "@/lib/platform";
+import { GlobalBannerCoordinator } from "../GlobalBannerCoordinator";
+import { HostCrashBanner } from "../HostCrashBanner";
+import { WatchdogDisabledBanner } from "../WatchdogDisabledBanner";
+import { HostMemoryStallBanner } from "../HostMemoryStallBanner";
+import { SafeModeBanner } from "../SafeModeBanner";
+import { RestoreConfirmationBanner } from "../RestoreConfirmationBanner";
+import { MissingPrerequisiteBanner } from "../MissingPrerequisiteBanner";
+import { ForgeTokenBanner } from "../ForgeTokenBanner";
+import { CloudSyncBanner } from "../CloudSyncBanner";
+import { RosettaBanner } from "../RosettaBanner";
+import { PluginDocumentWarning } from "@/components/Plugin/PluginDocumentWarning";
+import type { GlobalBannerSlot } from "../useGlobalBannerPriority";
+import { BANNER_FIXTURES, SHEET_ROWS, requireBannerFixture } from "./bannerFixtures";
+import "@/index.css";
+
+installPreviewShims();
+
+/**
+ * Standalone visual-review harness for the global banner family.
+ *
+ * Only one of these banners ever holds the top-of-window slot, so in the real
+ * app no two of them can be seen together — which is how ten banners came to
+ * disagree with each other without anyone noticing. This page renders them
+ * against the real stores, the real theme tokens and the real `index.css`,
+ * in the band they actually occupy: pinned above the toolbar, sharing the row
+ * with the OS window controls.
+ *
+ * Query parameters:
+ *   ?theme=daintree|bondi|…   built-in theme id
+ *   ?fixture=host-crash       one state, rendered through GlobalBannerCoordinator
+ *   ?fixture=sheet            every slot at once, one canonical state each
+ *   ?width=1100               window width in CSS px
+ *
+ * The traffic lights and the toolbar strip are harness decoration, drawn so a
+ * reviewer can judge the banner's relationship to the chrome it shares the
+ * band with. They are not the app's.
+ */
+
+const params = new URLSearchParams(window.location.search);
+const themeId = params.get("theme") ?? "daintree";
+const width = Number(params.get("width") ?? "1100");
+const fixtureName = params.get("fixture") ?? "sheet";
+
+applyAppThemeToRoot(document.documentElement, resolveAppTheme(themeId));
+document.body.style.background = "var(--color-surface-canvas)";
+document.body.style.margin = "0";
+// `index.css` pins the document to the window, as the app needs. The sheet is
+// taller than any viewport, and an element screenshot of a clipped document is
+// a picture of the fold with the rows below it silently missing.
+for (const el of [document.documentElement, document.body]) {
+  el.style.height = "auto";
+  el.style.minHeight = "100vh";
+  el.style.overflow = "visible";
+}
+
+/** macOS traffic lights sit in the 80px the inset reserves; Windows caption buttons in the 138px on the right. */
+function WindowControlsDecoration() {
+  if (isMac()) {
+    return (
+      <div
+        data-harness-decoration
+        aria-hidden="true"
+        className="pointer-events-none absolute left-[13px] top-[18px] z-10 flex gap-2"
+      >
+        <span className="h-3 w-3 rounded-full bg-[#ff5f57]" />
+        <span className="h-3 w-3 rounded-full bg-[#febc2e]" />
+        <span className="h-3 w-3 rounded-full bg-[#28c840]" />
+      </div>
+    );
+  }
+  if (isWindows()) {
+    return (
+      <div
+        data-harness-decoration
+        aria-hidden="true"
+        className="pointer-events-none absolute right-0 top-0 z-10 flex h-12 w-[138px] items-center justify-around text-text-secondary"
+      >
+        <span>—</span>
+        <span>▢</span>
+        <span>✕</span>
+      </div>
+    );
+  }
+  return null;
+}
+
+/** A stand-in for the toolbar row beneath, so the banner's bottom edge has something to meet. */
+function ToolbarStrip() {
+  return (
+    <div
+      data-harness-decoration
+      aria-hidden="true"
+      className="flex h-12 shrink-0 items-center gap-2 border-b border-divider px-4 pt-1 surface-toolbar"
+    >
+      <div className="h-6 w-24 rounded-[var(--radius-md)] bg-overlay-subtle" />
+      <div className="h-6 w-6 rounded-[var(--radius-md)] bg-overlay-subtle" />
+      <div className="h-6 w-6 rounded-[var(--radius-md)] bg-overlay-subtle" />
+      <div className="ml-auto h-6 w-32 rounded-[var(--radius-md)] bg-overlay-subtle" />
+    </div>
+  );
+}
+
+function BannerHost({ children, label }: { children: ReactNode; label?: string }) {
+  return (
+    <div data-banner-host className="relative">
+      {label && (
+        <div
+          data-harness-decoration
+          className="px-3 pb-1 pt-3 font-mono text-2xs uppercase tracking-wide text-text-muted"
+        >
+          {label}
+        </div>
+      )}
+      <div className="relative">
+        <WindowControlsDecoration />
+        <div data-banner-slot>{children}</div>
+      </div>
+      <ToolbarStrip />
+    </div>
+  );
+}
+
+function bannerForSlot(slot: Exclude<GlobalBannerSlot, null>) {
+  switch (slot) {
+    case "host-crash":
+      return <HostCrashBanner />;
+    case "watchdog-disabled":
+      return <WatchdogDisabledBanner />;
+    case "host-memory-stall":
+      return <HostMemoryStallBanner />;
+    case "safe-mode":
+      return <SafeModeBanner />;
+    case "restore-confirmation":
+      return <RestoreConfirmationBanner />;
+    case "missing-prerequisite":
+      return <MissingPrerequisiteBanner />;
+    case "forge-token":
+      return <ForgeTokenBanner />;
+    case "plugin-document":
+      return <PluginDocumentWarning />;
+    case "cloud-sync":
+      return <CloudSyncBanner />;
+    case "rosetta":
+      return <RosettaBanner />;
+  }
+}
+
+function Sheet() {
+  return (
+    <div data-preview-shell className="flex flex-col gap-4 pb-6" style={{ width: `${width}px` }}>
+      {SHEET_ROWS.map((name) => (
+        <BannerHost key={name} label={`${name} — ${BANNER_FIXTURES[name].what}`}>
+          <WindowControlsInsetProvider onSeverityChange={() => undefined}>
+            {bannerForSlot(BANNER_FIXTURES[name].slot)}
+          </WindowControlsInsetProvider>
+        </BannerHost>
+      ))}
+    </div>
+  );
+}
+
+function Single() {
+  return (
+    <div data-preview-shell className="flex flex-col" style={{ width: `${width}px` }}>
+      <BannerHost>
+        <GlobalBannerCoordinator />
+      </BannerHost>
+      <div className="h-24" />
+    </div>
+  );
+}
+
+// Seed before mounting: a store write during render is a cross-component
+// update React rightly complains about, and the banners read on first render.
+if (fixtureName === "sheet") {
+  for (const name of SHEET_ROWS) BANNER_FIXTURES[name].seed();
+} else {
+  requireBannerFixture(fixtureName).seed();
+}
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <TooltipProvider>{fixtureName === "sheet" ? <Sheet /> : <Single />}</TooltipProvider>
+  </StrictMode>
+);

--- a/src/components/Recovery/__preview__/preview.tsx
+++ b/src/components/Recovery/__preview__/preview.tsx
@@ -68,11 +68,14 @@ function WindowControlsDecoration() {
       <div
         data-harness-decoration
         aria-hidden="true"
-        className="pointer-events-none absolute left-[13px] top-[18px] z-10 flex gap-2"
+        className="pointer-events-none absolute z-10 flex gap-2"
+        // Inline, not utilities: Tailwind scans this directory, and preview-only
+        // arbitrary values would otherwise land in the app's stylesheet.
+        style={{ left: 13, top: 18 }}
       >
-        <span className="h-3 w-3 rounded-full bg-[#ff5f57]" />
-        <span className="h-3 w-3 rounded-full bg-[#febc2e]" />
-        <span className="h-3 w-3 rounded-full bg-[#28c840]" />
+        {["#ff5f57", "#febc2e", "#28c840"].map((color) => (
+          <span key={color} className="h-3 w-3 rounded-full" style={{ backgroundColor: color }} />
+        ))}
       </div>
     );
   }
@@ -81,7 +84,8 @@ function WindowControlsDecoration() {
       <div
         data-harness-decoration
         aria-hidden="true"
-        className="pointer-events-none absolute right-0 top-0 z-10 flex h-12 w-[138px] items-center justify-around text-text-secondary"
+        className="pointer-events-none absolute right-0 top-0 z-10 flex h-12 items-center justify-around text-text-secondary"
+        style={{ width: 138 }}
       >
         <span>—</span>
         <span>▢</span>

--- a/src/components/Recovery/__tests__/GlobalBannerCoordinator.test.tsx
+++ b/src/components/Recovery/__tests__/GlobalBannerCoordinator.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from "vitest";
-import { render, screen, cleanup, act } from "@testing-library/react";
+import { render, screen, cleanup, act, fireEvent } from "@testing-library/react";
 
 vi.mock("@/services/ActionService", () => ({
   actionService: {
@@ -27,6 +27,7 @@ import { useHostMemoryPauseStore } from "@/store/hostMemoryPauseStore";
 import { HOST_MEMORY_PAUSE_COPY } from "@/lib/hostMemoryPauseCopy";
 import { getCloudSyncWarningCopy } from "@/utils/cloudSyncWarningCopy";
 import { useMissingPrerequisiteStore } from "@/store/missingPrerequisiteStore";
+import { useGlobalBannerDismissalStore } from "@/store/globalBannerDismissalStore";
 import type { PrerequisiteCheckResult } from "@shared/types";
 
 function missingGit(overrides: Partial<PrerequisiteCheckResult> = {}): PrerequisiteCheckResult {
@@ -109,6 +110,7 @@ function resetStores() {
   useForgeProviderHealthStore.setState({ providers: {} });
   useCloudSyncBannerStore.setState({ service: null, projectId: null });
   useRosettaBannerStore.setState({ visible: false });
+  useGlobalBannerDismissalStore.setState({ dismissed: new Set() });
   useMissingPrerequisiteStore.setState({
     missing: [],
     dismissed: false,
@@ -368,6 +370,45 @@ describe("GlobalBannerCoordinator", () => {
     render(<GlobalBannerCoordinator />);
 
     expect(screen.getByText("GitHub token expired")).toBeTruthy();
+  });
+
+  it("releases the slot to the next banner once the forge warning is dismissed", () => {
+    // The slot is claimed by the same predicate that renders: a dismissed
+    // token must not hold an empty band over cloud-sync.
+    setForgeTokenUnhealthy(true);
+    useCloudSyncBannerStore.setState({ service: "Dropbox", projectId: "p1" });
+
+    render(<GlobalBannerCoordinator />);
+    expect(screen.getByText("GitHub token expired")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss GitHub token warning" }));
+
+    expect(screen.queryByText("GitHub token expired")).toBeNull();
+    expect(screen.getByText("Project in a cloud folder")).toBeTruthy();
+  });
+
+  it("lets a dismissed watchdog warning yield the slot, and shows it again on the next disable", () => {
+    usePanelStore.setState({
+      watchdogStatus: "disabled",
+      watchdogDisabledInfo: { attemptCount: 3, lastExitCode: null, timestamp: 0 },
+    });
+    useCloudSyncBannerStore.setState({ service: "Dropbox", projectId: "p1" });
+
+    render(<GlobalBannerCoordinator />);
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss watchdog warning" }));
+    expect(screen.queryByText("Crash watchdog disabled")).toBeNull();
+    expect(screen.getByText("Project in a cloud folder")).toBeTruthy();
+
+    act(() => {
+      usePanelStore.setState({ watchdogStatus: "active", watchdogDisabledInfo: null });
+    });
+    act(() => {
+      usePanelStore.setState({
+        watchdogStatus: "disabled",
+        watchdogDisabledInfo: { attemptCount: 1, lastExitCode: null, timestamp: 1 },
+      });
+    });
+    expect(screen.getByText("Crash watchdog disabled")).toBeTruthy();
   });
 
   it("renders the cloud sync banner when only a synced folder is detected", () => {

--- a/src/components/Recovery/__tests__/GlobalBannerCoordinator.test.tsx
+++ b/src/components/Recovery/__tests__/GlobalBannerCoordinator.test.tsx
@@ -197,7 +197,7 @@ describe("GlobalBannerCoordinator", () => {
 
     render(<GlobalBannerCoordinator />);
 
-    expect(screen.getByText("Session recovered after unexpected exit.")).toBeTruthy();
+    expect(screen.getByText("Session recovered after unexpected exit")).toBeTruthy();
   });
 
   it("treats a dismissed safe mode as inactive and promotes restore", () => {
@@ -206,7 +206,7 @@ describe("GlobalBannerCoordinator", () => {
 
     render(<GlobalBannerCoordinator />);
 
-    expect(screen.getByText("Session recovered after unexpected exit.")).toBeTruthy();
+    expect(screen.getByText("Session recovered after unexpected exit")).toBeTruthy();
     expect(screen.queryByText("Safe mode — panels weren't restored")).toBeNull();
   });
 
@@ -254,7 +254,7 @@ describe("GlobalBannerCoordinator", () => {
   it("switches from restore to safe mode reactively via store subscription", async () => {
     useRestoreConfirmationStore.setState({ visible: true, suspectCount: 0, crashCount: 1 });
     render(<GlobalBannerCoordinator />);
-    expect(screen.getByText("Session recovered after unexpected exit.")).toBeTruthy();
+    expect(screen.getByText("Session recovered after unexpected exit")).toBeTruthy();
 
     act(() => {
       useSafeModeStore.setState({ safeMode: true, dismissed: false });
@@ -306,7 +306,7 @@ describe("GlobalBannerCoordinator", () => {
     act(() => {
       useSafeModeStore.setState({ dismissed: true });
     });
-    expect(screen.getByText("Session recovered after unexpected exit.")).toBeTruthy();
+    expect(screen.getByText("Session recovered after unexpected exit")).toBeTruthy();
 
     act(() => {
       vi.advanceTimersByTime(10_000);
@@ -395,7 +395,7 @@ describe("GlobalBannerCoordinator", () => {
 
     render(<GlobalBannerCoordinator />);
 
-    expect(screen.getByText("Session recovered after unexpected exit.")).toBeTruthy();
+    expect(screen.getByText("Session recovered after unexpected exit")).toBeTruthy();
     expect(screen.queryByText("GitHub token expired")).toBeNull();
     expect(screen.queryByText(cloudSyncTitle)).toBeNull();
   });

--- a/src/components/Recovery/__tests__/HostCrashBanner.test.tsx
+++ b/src/components/Recovery/__tests__/HostCrashBanner.test.tsx
@@ -57,6 +57,18 @@ describe("HostCrashBanner", () => {
     expect(container.firstChild).toBeNull();
   });
 
+  it("announces an automatic restart politely; only the exhausted crash is an alert", () => {
+    vi.useFakeTimers();
+    usePanelStore.setState({ backendStatus: "recovering" });
+    render(<HostCrashBanner />);
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+    expect(screen.getByRole("status")).toBeTruthy();
+    expect(screen.queryByRole("alert")).toBeNull();
+    vi.useRealTimers();
+  });
+
   it("renders recovering banner after Doherty threshold", () => {
     vi.useFakeTimers();
     usePanelStore.setState({ backendStatus: "recovering" });

--- a/src/components/Recovery/__tests__/MissingPrerequisiteBanner.test.tsx
+++ b/src/components/Recovery/__tests__/MissingPrerequisiteBanner.test.tsx
@@ -321,7 +321,8 @@ describe("MissingPrerequisiteBanner", () => {
         await Promise.resolve();
       });
 
-      expect(await screen.findByText("Error: no such formula")).toBeTruthy();
+      // The tool's "Error:" prefix is stripped — the red band already says it.
+      expect(await screen.findByText("no such formula")).toBeTruthy();
       expect(await screen.findByRole("button", { name: "Retry" })).toBeTruthy();
     });
 

--- a/src/components/Recovery/__tests__/MissingPrerequisiteBanner.test.tsx
+++ b/src/components/Recovery/__tests__/MissingPrerequisiteBanner.test.tsx
@@ -232,6 +232,23 @@ describe("MissingPrerequisiteBanner", () => {
   });
 
   describe("install flow", () => {
+    it("stops announcing while the package manager streams its output", () => {
+      useMissingPrerequisiteStore.setState({
+        missing: [missingGit()],
+        install: {
+          jobId: "live",
+          tool: "git",
+          status: "running",
+          statusLine: "==> Downloading",
+          error: null,
+        },
+      });
+      render(<MissingPrerequisiteBanner />);
+      // role=status is implicitly polite and atomic; every stdout chunk would
+      // re-read the whole banner. The busy button and the finishing toast carry it.
+      expect(screen.getByRole("status").getAttribute("aria-live")).toBe("off");
+    });
+
     it("streams the latest output line as the status", async () => {
       installAgentMock.mockReturnValue(new Promise(() => {}));
       useMissingPrerequisiteStore.setState({ missing: [missingGit()] });

--- a/src/components/Recovery/__tests__/RestoreConfirmationBanner.test.tsx
+++ b/src/components/Recovery/__tests__/RestoreConfirmationBanner.test.tsx
@@ -38,28 +38,33 @@ describe("RestoreConfirmationBanner", () => {
   it("renders info copy for non-suspect restore", () => {
     useRestoreConfirmationStore.setState({ visible: true, suspectCount: 0, crashCount: 1 });
     render(<RestoreConfirmationBanner />);
-    expect(screen.getByText("Session recovered after unexpected exit.")).toBeTruthy();
+    expect(screen.getByText("Session recovered after unexpected exit")).toBeTruthy();
     expect(screen.queryByText(/may be affected/)).toBeNull();
   });
 
   it("renders warning copy with suspect count (singular)", () => {
     useRestoreConfirmationStore.setState({ visible: true, suspectCount: 1, crashCount: 1 });
     render(<RestoreConfirmationBanner />);
-    expect(
-      screen.getByText(
-        "Session recovered after unexpected exit — 1 panel created near the crash may be affected."
-      )
-    ).toBeTruthy();
+    expect(screen.getByText("Session recovered after unexpected exit")).toBeTruthy();
+    expect(screen.getByText("1 panel created near the crash may be affected.")).toBeTruthy();
   });
 
   it("renders warning copy with suspect count (plural)", () => {
     useRestoreConfirmationStore.setState({ visible: true, suspectCount: 3, crashCount: 1 });
     render(<RestoreConfirmationBanner />);
-    expect(
-      screen.getByText(
-        "Session recovered after unexpected exit — 3 panels created near the crash may be affected."
-      )
-    ).toBeTruthy();
+    expect(screen.getByText("Session recovered after unexpected exit")).toBeTruthy();
+    expect(screen.getByText("3 panels created near the crash may be affected.")).toBeTruthy();
+  });
+
+  it("is informational when nothing is implicated and a warning once panels are", () => {
+    useRestoreConfirmationStore.setState({ visible: true, suspectCount: 0, crashCount: 1 });
+    const clean = render(<RestoreConfirmationBanner />);
+    expect(screen.getByRole("status").style.backgroundColor).toContain("--color-status-info");
+    clean.unmount();
+
+    useRestoreConfirmationStore.setState({ visible: true, suspectCount: 2, crashCount: 1 });
+    render(<RestoreConfirmationBanner />);
+    expect(screen.getByRole("status").style.backgroundColor).toContain("--color-status-warning");
   });
 
   it("auto-dismisses non-suspect banner after 10 seconds", () => {

--- a/src/components/Recovery/__tests__/RosettaBanner.test.tsx
+++ b/src/components/Recovery/__tests__/RosettaBanner.test.tsx
@@ -82,11 +82,24 @@ describe("RosettaBanner", () => {
     );
   });
 
-  it("hides the banner and persists the dismissal on close", async () => {
+  it("× hides the banner for this session without persisting anything", async () => {
     useRosettaBannerStore.setState({ visible: true });
     render(<RosettaBanner />);
 
     fireEvent.click(screen.getByRole("button", { name: "Dismiss Rosetta warning" }));
+
+    expect(useRosettaBannerStore.getState().visible).toBe(false);
+    expect(screen.queryByRole("status")).toBeNull();
+    await Promise.resolve();
+    expect(dismissRosettaWarningMock).not.toHaveBeenCalled();
+    expect(notifyMock).not.toHaveBeenCalled();
+  });
+
+  it("'Don't show again' hides the banner and persists the dismissal", async () => {
+    useRosettaBannerStore.setState({ visible: true });
+    render(<RosettaBanner />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Don't show again" }));
 
     expect(useRosettaBannerStore.getState().visible).toBe(false);
     expect(screen.queryByRole("status")).toBeNull();
@@ -101,7 +114,7 @@ describe("RosettaBanner", () => {
     useRosettaBannerStore.setState({ visible: true });
     render(<RosettaBanner />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Dismiss Rosetta warning" }));
+    fireEvent.click(screen.getByRole("button", { name: "Don't show again" }));
 
     await waitFor(() => {
       expect(notifyMock).toHaveBeenCalledWith(

--- a/src/components/Recovery/__tests__/SafeModeBanner.test.tsx
+++ b/src/components/Recovery/__tests__/SafeModeBanner.test.tsx
@@ -247,7 +247,7 @@ describe("SafeModeBanner", () => {
     expect(screen.getByText("Another")).toBeTruthy();
     expect(screen.getByText("/repo/foo")).toBeTruthy();
     expect(screen.getByText("wt-issue-1")).toBeTruthy();
-    expect(screen.getAllByRole("button", { name: /Restore panel/ })).toHaveLength(2);
+    expect(screen.getAllByRole("button", { name: /Restore on next launch/ })).toHaveLength(2);
   });
 
   it("falls back to count-only copy when ledger has no quarantined entries", () => {
@@ -259,10 +259,10 @@ describe("SafeModeBanner", () => {
     render(<SafeModeBanner />);
     fireEvent.click(screen.getByRole("button", { name: /Show details/i }));
     expect(screen.getByText(/4 panels were skipped/)).toBeTruthy();
-    expect(screen.queryByRole("button", { name: /Restore panel/ })).toBeNull();
+    expect(screen.queryByRole("button", { name: /Restore on next launch/ })).toBeNull();
   });
 
-  it("clicking Restore panel calls clearQuarantinedPanel and shows the restoring hint", async () => {
+  it("clicking Restore on next launch calls clearQuarantinedPanel and shows the restoring hint", async () => {
     useSafeModeStore.setState({
       safeMode: true,
       crashCount: 2,
@@ -271,7 +271,7 @@ describe("SafeModeBanner", () => {
     });
     render(<SafeModeBanner />);
     fireEvent.click(screen.getByRole("button", { name: /Show details/i }));
-    fireEvent.click(screen.getByRole("button", { name: /Restore panel/ }));
+    fireEvent.click(screen.getByRole("button", { name: /Restore on next launch/ }));
     await waitFor(() => {
       expect(clearQuarantinedPanel).toHaveBeenCalledWith("p1");
     });
@@ -291,7 +291,7 @@ describe("SafeModeBanner", () => {
     });
     render(<SafeModeBanner />);
     fireEvent.click(screen.getByRole("button", { name: /Show details/i }));
-    fireEvent.click(screen.getByRole("button", { name: /Restore panel/ }));
+    fireEvent.click(screen.getByRole("button", { name: /Restore on next launch/ }));
     await waitFor(() => {
       expect(screen.getByRole("button", { name: /Retry/ })).toBeTruthy();
     });

--- a/src/components/Recovery/__tests__/WatchdogDisabledBanner.test.tsx
+++ b/src/components/Recovery/__tests__/WatchdogDisabledBanner.test.tsx
@@ -130,14 +130,15 @@ describe("WatchdogDisabledBanner", () => {
     expect(container.firstChild).toBeNull();
   });
 
-  it("uses role=alert without redundant aria-live", () => {
+  it("announces politely: a downed monitor is a standing condition, not an emergency", () => {
     usePanelStore.setState({
       watchdogStatus: "disabled",
       watchdogDisabledInfo: { attemptCount: 3, lastExitCode: null, timestamp: 0 },
     });
     render(<WatchdogDisabledBanner />);
-    const alert = screen.getByRole("alert");
-    expect(alert.hasAttribute("aria-live")).toBe(false);
+    const status = screen.getByRole("status");
+    expect(status.hasAttribute("aria-live")).toBe(false);
+    expect(screen.queryByRole("alert")).toBeNull();
   });
 
   it("does not render a dismiss button", () => {

--- a/src/components/Recovery/__tests__/WatchdogDisabledBanner.test.tsx
+++ b/src/components/Recovery/__tests__/WatchdogDisabledBanner.test.tsx
@@ -17,6 +17,7 @@ vi.mock("@/utils/logger", () => ({
 
 import { WatchdogDisabledBanner } from "../WatchdogDisabledBanner";
 import { usePanelStore } from "@/store/panelStore";
+import { useGlobalBannerDismissalStore } from "@/store/globalBannerDismissalStore";
 import { actionService } from "@/services/ActionService";
 
 const mockedDispatch = vi.mocked(actionService.dispatch);
@@ -141,12 +142,15 @@ describe("WatchdogDisabledBanner", () => {
     expect(screen.queryByRole("alert")).toBeNull();
   });
 
-  it("does not render a dismiss button", () => {
+  it("× records a session dismissal for the coordinator rather than touching the watchdog", () => {
     usePanelStore.setState({
       watchdogStatus: "disabled",
       watchdogDisabledInfo: { attemptCount: 3, lastExitCode: null, timestamp: 0 },
     });
+    useGlobalBannerDismissalStore.getState().reset("watchdog-disabled");
     render(<WatchdogDisabledBanner />);
-    expect(screen.queryByRole("button", { name: /dismiss/i })).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss watchdog warning" }));
+    expect(useGlobalBannerDismissalStore.getState().dismissed.has("watchdog-disabled")).toBe(true);
+    expect(usePanelStore.getState().watchdogStatus).toBe("disabled");
   });
 });

--- a/src/components/Recovery/__tests__/recoveryCopy.test.ts
+++ b/src/components/Recovery/__tests__/recoveryCopy.test.ts
@@ -5,7 +5,8 @@ import {
   HOST_CRASH_RECOVERING_COPY,
   SAFE_MODE_BANNER_COPY,
   getHostCrashBannerCopy,
-  getRestoreConfirmationTitle,
+  RESTORE_CONFIRMATION_TITLE,
+  getRestoreConfirmationDescription,
 } from "../recoveryCopy";
 
 describe("HOST_CRASH_BANNER_COPY", () => {
@@ -69,20 +70,24 @@ describe("SAFE_MODE_BANNER_COPY", () => {
   });
 });
 
-describe("getRestoreConfirmationTitle", () => {
-  it("returns the static title when there are no suspect panels", () => {
-    expect(getRestoreConfirmationTitle(0)).toBe("Session recovered after unexpected exit.");
+describe("restore confirmation copy", () => {
+  it("keeps the title a noun phrase with no trailing period", () => {
+    expect(RESTORE_CONFIRMATION_TITLE.endsWith(".")).toBe(false);
+  });
+
+  it("has no description when there are no suspect panels", () => {
+    expect(getRestoreConfirmationDescription(0)).toBeUndefined();
   });
 
   it("pluralises panel/panels by suspectCount", () => {
-    expect(getRestoreConfirmationTitle(1)).toBe(
-      "Session recovered after unexpected exit — 1 panel created near the crash may be affected."
+    expect(getRestoreConfirmationDescription(1)).toBe(
+      "1 panel created near the crash may be affected."
     );
-    expect(getRestoreConfirmationTitle(2)).toBe(
-      "Session recovered after unexpected exit — 2 panels created near the crash may be affected."
+    expect(getRestoreConfirmationDescription(2)).toBe(
+      "2 panels created near the crash may be affected."
     );
-    expect(getRestoreConfirmationTitle(3)).toBe(
-      "Session recovered after unexpected exit — 3 panels created near the crash may be affected."
+    expect(getRestoreConfirmationDescription(3)).toBe(
+      "3 panels created near the crash may be affected."
     );
   });
 });

--- a/src/components/Recovery/recoveryCopy.ts
+++ b/src/components/Recovery/recoveryCopy.ts
@@ -47,11 +47,16 @@ export const SAFE_MODE_BANNER_COPY = {
   title: "Safe mode — panels weren't restored",
 } as const;
 
-export function getRestoreConfirmationTitle(suspectCount: number): string {
-  if (suspectCount > 0) {
-    return `Session recovered after unexpected exit — ${suspectCount} ${suspectCount === 1 ? "panel" : "panels"} created near the crash may be affected.`;
-  }
-  return "Session recovered after unexpected exit.";
+export const RESTORE_CONFIRMATION_TITLE = "Session recovered after unexpected exit";
+
+/**
+ * The caveat under the title, or `undefined` when there is none — a clean
+ * recovery is a one-line reassurance, and the description is what turns it
+ * into a warning.
+ */
+export function getRestoreConfirmationDescription(suspectCount: number): string | undefined {
+  if (suspectCount <= 0) return undefined;
+  return `${suspectCount} ${suspectCount === 1 ? "panel" : "panels"} created near the crash may be affected.`;
 }
 
 export function getSuspectPanelBannerTitle(count: number, deselected: boolean): string {

--- a/src/components/Recovery/useGlobalBannerPriority.ts
+++ b/src/components/Recovery/useGlobalBannerPriority.ts
@@ -5,8 +5,11 @@ import { useForgeProviderHealthStore } from "@/store/forgeProviderHealthStore";
 import { useCloudSyncBannerStore } from "@/store/cloudSyncBannerStore";
 import { useRosettaBannerStore } from "@/store/rosettaBannerStore";
 import { useHostMemoryPauseStore } from "@/store/hostMemoryPauseStore";
-import { useSyncExternalStore } from "react";
+import { useEffect, useSyncExternalStore } from "react";
 import { pluginDocumentRuntime } from "@/services/plugin/pluginDocumentRuntime";
+import { usePluginRuntimeStore } from "@/store/pluginRuntimeStore";
+import { useGlobalBannerDismissalStore } from "@/store/globalBannerDismissalStore";
+import { selectActiveForgeTokenProvider } from "./ForgeTokenBanner";
 import {
   useMissingPrerequisiteStore,
   selectMissingPrerequisiteVisible,
@@ -73,9 +76,16 @@ export function useGlobalBannerPriority(): GlobalBannerSlot {
   const safeMode = useSafeModeStore((s) => s.safeMode);
   const safeModeDismissed = useSafeModeStore((s) => s.dismissed);
   const restoreVisible = useRestoreConfirmationStore((s) => s.visible);
-  const tokenUnhealthy = useForgeProviderHealthStore((s) =>
-    Object.values(s.providers).some((p) => p.tokenUnhealthy)
-  );
+  // A banner that would render nothing must not claim the slot, or the band
+  // sits empty while every lower banner stays suppressed. Forge's eligibility
+  // is the banner's own predicate; watchdog and plugin-document honour a
+  // session dismissal that clears with the condition.
+  const forgeProviders = useForgeProviderHealthStore((s) => s.providers);
+  const disabledPluginIds = usePluginRuntimeStore((s) => s.disabledPluginIds);
+  const tokenUnhealthy =
+    selectActiveForgeTokenProvider(forgeProviders, disabledPluginIds) !== undefined;
+  const dismissed = useGlobalBannerDismissalStore((s) => s.dismissed);
+  const resetDismissal = useGlobalBannerDismissalStore((s) => s.reset);
   const cloudSyncService = useCloudSyncBannerStore((s) => s.service);
   const rosettaVisible = useRosettaBannerStore((s) => s.visible);
   const prerequisiteVisible = useMissingPrerequisiteStore(selectMissingPrerequisiteVisible);
@@ -84,14 +94,21 @@ export function useGlobalBannerPriority(): GlobalBannerSlot {
     pluginDocumentRuntime.getSnapshot
   );
 
+  const watchdogDisabled = watchdogStatus === "disabled";
+  const pluginsNeedReload = documentDiagnostics.length > 0;
+  useEffect(() => {
+    if (!watchdogDisabled) resetDismissal("watchdog-disabled");
+    if (!pluginsNeedReload) resetDismissal("plugin-document");
+  }, [watchdogDisabled, pluginsNeedReload, resetDismissal]);
+
   if (backendStatus !== "connected") return "host-crash";
-  if (watchdogStatus === "disabled") return "watchdog-disabled";
+  if (watchdogDisabled && !dismissed.has("watchdog-disabled")) return "watchdog-disabled";
   if (hostMemoryStalled) return "host-memory-stall";
   if (safeMode && !safeModeDismissed) return "safe-mode";
   if (restoreVisible) return "restore-confirmation";
   if (prerequisiteVisible) return "missing-prerequisite";
   if (tokenUnhealthy) return "forge-token";
-  if (documentDiagnostics.length > 0) return "plugin-document";
+  if (pluginsNeedReload && !dismissed.has("plugin-document")) return "plugin-document";
   if (cloudSyncService !== null) return "cloud-sync";
   if (rosettaVisible) return "rosetta";
   return null;

--- a/src/components/Sidebar/__tests__/WorktreeLoadErrorBanner.test.tsx
+++ b/src/components/Sidebar/__tests__/WorktreeLoadErrorBanner.test.tsx
@@ -82,12 +82,14 @@ describe("WorktreeLoadErrorBanner (#8400)", () => {
     expect(onRetry).toHaveBeenCalledTimes(1);
     expect(dispatchMock).not.toHaveBeenCalled();
 
+    // While the retry is in flight the control is busy (aria, not native
+    // disabled, so focus stays on it); settling clears that.
+    expect(button.getAttribute("aria-busy")).toBe("true");
     resolveRetry();
     await waitFor(() =>
       expect(
-        (screen.getByRole("button", { name: "Retry loading worktrees" }) as HTMLButtonElement)
-          .disabled
-      ).toBe(false)
+        screen.getByRole("button", { name: "Retry loading worktrees" }).getAttribute("aria-busy")
+      ).toBeNull()
     );
   });
 });

--- a/src/components/Terminal/InlineStatusBanner.tsx
+++ b/src/components/Terminal/InlineStatusBanner.tsx
@@ -51,11 +51,11 @@ interface BaseInlineStatusBannerProps {
   /** Accessible label for the dismiss button. Defaults to "Dismiss". */
   closeAriaLabel?: string;
   /**
-   * Non-button control rendered alongside the actions (e.g. a Popover
-   * trigger). Rendered first in the controls row, before the action buttons
-   * and the dismiss button. This is the escape hatch for surfacing secondary
-   * affordances on an error banner without breaking the single-action rule.
-   * Render it with `Button` so it shares the row's geometry.
+   * Secondary control rendered after the action buttons and before the
+   * dismiss (e.g. a Popover trigger, a ghost link). This is the escape hatch
+   * for surfacing a secondary affordance on an error banner without breaking
+   * the single-action rule. Render it with `Button` so it shares the row's
+   * geometry; the primary action always leads the row.
    */
   trailingSlot?: React.ReactNode;
   /**
@@ -268,26 +268,45 @@ export function InlineStatusBanner({
 
   const rootRef = useRef<HTMLDivElement>(null);
 
+  // Whether focus is inside the banner, tracked so an unmount that takes the
+  // focused control with it — ×, an action that hides the banner, the
+  // auto-dismiss timer — can hand focus to the app shell instead of leaving
+  // it on <body>. Chromium fires no blur when a focused element is removed,
+  // so a blur with no target is checked a tick later: still mounted means the
+  // user clicked away; gone means the banner left with the focus.
+  const focusWithinRef = useRef(false);
+  const handleFocusCapture = () => {
+    focusWithinRef.current = true;
+  };
+  const handleBlurCapture = (e: React.FocusEvent) => {
+    const root = rootRef.current;
+    if (e.relatedTarget instanceof Node && root?.contains(e.relatedTarget)) return;
+    if (e.relatedTarget) {
+      focusWithinRef.current = false;
+      return;
+    }
+    queueMicrotask(() => {
+      if (root?.isConnected) focusWithinRef.current = false;
+    });
+  };
+  useEffect(
+    () => () => {
+      if (!focusWithinRef.current) return;
+      requestAnimationFrame(() => {
+        if (document.activeElement && document.activeElement !== document.body) return;
+        restoreFocusTo();
+      });
+    },
+    []
+  );
+
   const actionList: BannerAction[] = actions ?? (action ? [action] : []);
 
   const hasDescription = description || contextLine || descriptionExtras;
 
   const handleClose = (e: React.MouseEvent) => {
     e.stopPropagation();
-    // A keyboard dismissal unmounts the control that holds focus, which would
-    // drop focus on <body> and strand the user at the top of the document.
-    // The unmount lands after this handler returns, so check on the next
-    // frame: if the banner is gone and focus went with it, hand it to the app
-    // shell's first tabbable. A pointer dismissal moved focus with the click.
-    const root = rootRef.current;
-    const hadFocus = !!root && root.contains(document.activeElement);
     onClose?.();
-    if (!hadFocus) return;
-    requestAnimationFrame(() => {
-      if (root?.isConnected) return;
-      if (document.activeElement && document.activeElement !== document.body) return;
-      restoreFocusTo();
-    });
   };
 
   const closeButton = onClose ? (
@@ -334,6 +353,8 @@ export function InlineStatusBanner({
         ...windowControlsInset,
       }}
       role={role}
+      onFocusCapture={handleFocusCapture}
+      onBlurCapture={handleBlurCapture}
       aria-live={ariaLive}
       aria-atomic={ariaLive && ariaLive !== "off" ? "true" : undefined}
     >
@@ -385,7 +406,6 @@ export function InlineStatusBanner({
             isTitleBarSurface && "app-no-drag"
           )}
         >
-          {trailingSlot}
           {actionList.map((action) => {
             const variant = BUTTON_VARIANT[action.variant ?? "primary"];
             const buttonEl = (
@@ -415,8 +435,10 @@ export function InlineStatusBanner({
               <React.Fragment key={action.id}>{buttonEl}</React.Fragment>
             );
           })}
-          {/* Dismiss sits after the actions, at the row's end, in both layouts —
-              never between two controls, where it reads as a third action. */}
+          {trailingSlot}
+          {/* Dismiss sits after every other control, at the row's end, in both
+              layouts — never between two controls, where it reads as a third
+              action. */}
           {!hasDescription && closeButton}
         </div>
       )}

--- a/src/components/Terminal/InlineStatusBanner.tsx
+++ b/src/components/Terminal/InlineStatusBanner.tsx
@@ -4,7 +4,7 @@ import { cn } from "@/lib/utils";
 import { Button, type ButtonProps } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useWindowControlsInset, useTitleBarSurface } from "@/components/ui/WindowControlsInset";
-import { restoreFocusTo } from "@/lib/accessibility";
+import { getVisibleTabbableElements, restoreFocusTo } from "@/lib/accessibility";
 import { isLinux } from "@/lib/platform";
 import { BANNER_TINT_ALPHA, type BannerSeverity } from "@shared/config/windowChrome";
 
@@ -268,33 +268,49 @@ export function InlineStatusBanner({
 
   const rootRef = useRef<HTMLDivElement>(null);
 
-  // Whether focus is inside the banner, tracked so an unmount that takes the
-  // focused control with it — ×, an action that hides the banner, the
-  // auto-dismiss timer — can hand focus to the app shell instead of leaving
-  // it on <body>. Chromium fires no blur when a focused element is removed,
-  // so a blur with no target is checked a tick later: still mounted means the
-  // user clicked away; gone means the banner left with the focus.
+  // Whether focus is inside the banner's own DOM, tracked so an unmount that
+  // takes the focused control with it — ×, an action that hides the banner,
+  // the auto-dismiss timer — can hand focus somewhere sensible instead of
+  // leaving it on <body>. React focus events also arrive from portalled
+  // children (a Popover opened from trailingSlot), so only DOM containment
+  // counts. Chromium fires no blur when a focused element is removed, so a
+  // blur with no target is checked a tick later: focus back inside means a
+  // move within the banner, still mounted means the user clicked away, gone
+  // means the banner left with the focus.
   const focusWithinRef = useRef(false);
-  const handleFocusCapture = () => {
+  // Where focus should land if the banner disappears: the enclosing dialog,
+  // else the banner's own container (the pane, the sidebar), never the window
+  // chrome behind an open dialog. Captured on focus, since the ref is gone by
+  // the time the unmount cleanup runs.
+  const focusHomeRef = useRef<HTMLElement | null>(null);
+  const handleFocusCapture = (e: React.FocusEvent) => {
+    const root = rootRef.current;
+    if (!root || !(e.target instanceof Node) || !root.contains(e.target)) return;
     focusWithinRef.current = true;
+    focusHomeRef.current =
+      root.closest<HTMLElement>("[role='dialog'], [role='alertdialog']") ?? root.parentElement;
   };
   const handleBlurCapture = (e: React.FocusEvent) => {
     const root = rootRef.current;
-    if (e.relatedTarget instanceof Node && root?.contains(e.relatedTarget)) return;
+    if (!root || !(e.target instanceof Node) || !root.contains(e.target)) return;
+    if (e.relatedTarget instanceof Node && root.contains(e.relatedTarget)) return;
     if (e.relatedTarget) {
       focusWithinRef.current = false;
       return;
     }
     queueMicrotask(() => {
-      if (root?.isConnected) focusWithinRef.current = false;
+      if (!root.isConnected) return;
+      focusWithinRef.current = root.contains(document.activeElement);
     });
   };
   useEffect(
     () => () => {
       if (!focusWithinRef.current) return;
+      const home = focusHomeRef.current;
       requestAnimationFrame(() => {
         if (document.activeElement && document.activeElement !== document.body) return;
-        restoreFocusTo();
+        const nearest = home?.isConnected ? getVisibleTabbableElements(home)[0] : undefined;
+        restoreFocusTo(nearest);
       });
     },
     []
@@ -302,12 +318,15 @@ export function InlineStatusBanner({
   // A re-render can also replace the focused control without unmounting the
   // banner — Retry becoming Install once a re-check succeeds — which drops
   // focus on <body> just as an unmount would. Keep it on the banner's next
-  // control instead.
+  // action, and only fall back to the dismiss when there is none.
   useEffect(() => {
     const root = rootRef.current;
     if (!focusWithinRef.current || !root?.isConnected) return;
     if (document.activeElement && document.activeElement !== document.body) return;
-    root.querySelector<HTMLElement>("button:not([disabled]), [href], [tabindex]")?.focus();
+    const controls = root.querySelector<HTMLElement>("[data-banner-controls]");
+    const next =
+      (controls && getVisibleTabbableElements(controls)[0]) ?? getVisibleTabbableElements(root)[0];
+    next?.focus();
   });
 
   const actionList: BannerAction[] = actions ?? (action ? [action] : []);
@@ -408,6 +427,7 @@ export function InlineStatusBanner({
 
       {showControlsRow && (
         <div
+          data-banner-controls
           className={cn(
             "flex items-center shrink-0",
             hasDescription ? "gap-2 ml-6" : "gap-1",
@@ -415,6 +435,10 @@ export function InlineStatusBanner({
             // row, including nested popover triggers.
             isTitleBarSurface && "app-no-drag"
           )}
+          // A busy or disabled Button opts out of hit-testing, so a click on it
+          // lands on this row instead — and would otherwise bubble on to the
+          // pane and activate it. The controls never mean "select the pane".
+          onClick={(e) => e.stopPropagation()}
         >
           {actionList.map((action) => {
             const variant = BUTTON_VARIANT[action.variant ?? "primary"];

--- a/src/components/Terminal/InlineStatusBanner.tsx
+++ b/src/components/Terminal/InlineStatusBanner.tsx
@@ -1,9 +1,10 @@
 import React, { useState, useEffect, useRef, type CSSProperties } from "react";
-import { X } from "lucide-react";
+import { AlertTriangle, CheckCircle2, Info, X, XCircle } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { Spinner } from "@/components/ui/Spinner";
+import { Button, type ButtonProps } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useWindowControlsInset, useTitleBarSurface } from "@/components/ui/WindowControlsInset";
+import { restoreFocusTo } from "@/lib/accessibility";
 import { isLinux } from "@/lib/platform";
 import { BANNER_TINT_ALPHA, type BannerSeverity } from "@shared/config/windowChrome";
 
@@ -30,8 +31,16 @@ export interface BannerAction {
  */
 export type InlineStatusBannerSeverity = BannerSeverity;
 
+type BannerIcon = React.ComponentType<{ className?: string; style?: CSSProperties }>;
+
 interface BaseInlineStatusBannerProps {
-  icon: React.ComponentType<{ className?: string; style?: CSSProperties }>;
+  /**
+   * The glyph is the severity's non-colour channel, so it defaults per
+   * severity to the same vocabulary the notification inbox uses. Pass one only
+   * when the glyph is the message itself — a spinner for "restarting", a file
+   * for "files changed" — never to restate the severity.
+   */
+  icon?: BannerIcon;
   title: React.ReactNode;
   description?: React.ReactNode;
   contextLine?: string;
@@ -43,10 +52,10 @@ interface BaseInlineStatusBannerProps {
   closeAriaLabel?: string;
   /**
    * Non-button control rendered alongside the actions (e.g. a Popover
-   * trigger). Rendered first in the controls row, before the dismiss
-   * button and the primary action buttons. This is the escape hatch for
-   * surfacing secondary affordances on an error banner without breaking
-   * the single-action rule.
+   * trigger). Rendered first in the controls row, before the action buttons
+   * and the dismiss button. This is the escape hatch for surfacing secondary
+   * affordances on an error banner without breaking the single-action rule.
+   * Render it with `Button` so it shares the row's geometry.
    */
   trailingSlot?: React.ReactNode;
   /**
@@ -129,40 +138,38 @@ const SEVERITY_VAR: Record<Exclude<InlineStatusBannerSeverity, "neutral">, strin
   success: "--color-status-success",
 };
 
-function getButtonClasses(variant: ButtonVariant): string {
-  switch (variant) {
-    case "primary":
-      return "bg-border-default text-text-primary hover:bg-daintree-border/80";
-    case "accent":
-      return "bg-status-info/10 text-status-info hover:bg-status-info/20";
-    case "dismiss":
-      return "text-text-secondary hover:text-text-primary hover:bg-daintree-border/50";
-    case "danger":
-    case "dangerFilled":
-      return "rounded transition-colors";
-  }
-}
+/**
+ * One glyph per severity, matching `NotificationCenterEntry` so a banner and
+ * the inbox row it may also produce read as the same event. Shape, not hue,
+ * is what tells a red banner from an amber one under forced colours.
+ */
+export const SEVERITY_ICON: Record<InlineStatusBannerSeverity, BannerIcon> = {
+  error: XCircle,
+  warning: AlertTriangle,
+  info: Info,
+  success: CheckCircle2,
+  neutral: Info,
+};
 
-function getButtonStyle(variant: ButtonVariant, colorVar: string): React.CSSProperties | undefined {
-  if (variant === "danger") {
-    return {
-      color: `color-mix(in oklab, var(${colorVar}) 70%, transparent)`,
-      ["--hover-color" as string]: `var(${colorVar})`,
-      ["--hover-bg" as string]: `color-mix(in oklab, var(${colorVar}) 10%, transparent)`,
-    };
-  }
-  if (variant === "dangerFilled") {
-    return {
-      backgroundColor: `color-mix(in oklab, var(${colorVar}) 10%, transparent)`,
-      color: `var(${colorVar})`,
-      ["--hover-bg" as string]: `color-mix(in oklab, var(${colorVar}) 20%, transparent)`,
-    };
-  }
-  return undefined;
-}
+/**
+ * Banner actions are ordinary `Button`s so the family shares one geometry
+ * with every other control in the app. The names here are the banner's own
+ * vocabulary — what the action *means* on a banner — mapped onto the
+ * primitive's variants; severity is carried by the band, so even the
+ * "primary" treatment is neutral.
+ */
+const BUTTON_VARIANT: Record<ButtonVariant, NonNullable<ButtonProps["variant"]>> = {
+  primary: "outline",
+  accent: "ghost-info",
+  dismiss: "ghost",
+  danger: "ghost-danger",
+  // Every caller uses this for the *fix* on an error banner — Retry, Reload,
+  // Restart — which is the primary action, not a destructive one.
+  dangerFilled: "outline",
+};
 
 export function InlineStatusBanner({
-  icon: IconComponent,
+  icon,
   title,
   description,
   contextLine,
@@ -179,6 +186,15 @@ export function InlineStatusBanner({
   descriptionExtras,
   autoDismissAfter,
 }: InlineStatusBannerProps) {
+  // Non-null only in the global banner host, where this banner owns the
+  // window's title-bar band: it has to supply the drag region and top-edge
+  // resize strip the toolbar normally provides (both get pushed below the
+  // caption buttons while a banner is up), and report its severity so the
+  // native caption strip can be tinted to match. Inline banners get none of
+  // this — a banner inside a terminal must never drag the window.
+  const reportSeverity = useTitleBarSurface();
+  const isTitleBarSurface = reportSeverity !== null;
+
   const prefersReducedMotion =
     typeof window !== "undefined" &&
     // `matchMedia` is guarded separately from `window`: the SSR check above only
@@ -192,26 +208,22 @@ export function InlineStatusBanner({
       (typeof document !== "undefined" &&
         (document.body.getAttribute("data-reduce-animations") === "true" ||
           document.body.getAttribute("data-performance-mode") === "true")));
-  const shouldAnimate = animated && !prefersReducedMotion;
+  // The title-bar surface never slides in: main tints the native caption strip
+  // the instant the severity is reported, and a banner easing in under an
+  // already-tinted strip reads as two surfaces disagreeing. Inline banners
+  // keep their entrance.
+  const shouldAnimate = animated && !prefersReducedMotion && !isTitleBarSurface;
 
   const [isVisible, setIsVisible] = useState(!shouldAnimate);
   const rafRef = useRef<number | null>(null);
   const isNeutral = severity === "neutral";
   const colorVar = isNeutral ? undefined : SEVERITY_VAR[severity];
+  const IconComponent = icon ?? SEVERITY_ICON[severity];
 
   // When hosted at the top of the window (global banner host), reserve space so
   // the title/icon and action buttons never sit under the OS window controls.
   // Empty for the common inline usage — see WindowControlsInset.
   const windowControlsInset = useWindowControlsInset();
-
-  // Non-null only in the global banner host, where this banner owns the
-  // window's title-bar band: it has to supply the drag region and top-edge
-  // resize strip the toolbar normally provides (both get pushed below the
-  // caption buttons while a banner is up), and report its severity so the
-  // native caption strip can be tinted to match. Inline banners get none of
-  // this — a banner inside a terminal must never drag the window.
-  const reportSeverity = useTitleBarSurface();
-  const isTitleBarSurface = reportSeverity !== null;
 
   useEffect(() => {
     if (!reportSeverity) return;
@@ -254,31 +266,47 @@ export function InlineStatusBanner({
     };
   }, [shouldAnimate]);
 
+  const rootRef = useRef<HTMLDivElement>(null);
+
   const actionList: BannerAction[] = actions ?? (action ? [action] : []);
 
   const hasDescription = description || contextLine || descriptionExtras;
 
+  const handleClose = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    // A keyboard dismissal unmounts the control that holds focus, which would
+    // drop focus on <body> and strand the user at the top of the document.
+    // The unmount lands after this handler returns, so check on the next
+    // frame: if the banner is gone and focus went with it, hand it to the app
+    // shell's first tabbable. A pointer dismissal moved focus with the click.
+    const root = rootRef.current;
+    const hadFocus = !!root && root.contains(document.activeElement);
+    onClose?.();
+    if (!hadFocus) return;
+    requestAnimationFrame(() => {
+      if (root?.isConnected) return;
+      if (document.activeElement && document.activeElement !== document.body) return;
+      restoreFocusTo();
+    });
+  };
+
   const closeButton = onClose ? (
-    <button
-      type="button"
-      onClick={(e) => {
-        e.stopPropagation();
-        onClose();
-      }}
+    <Button
+      variant="ghost"
+      size="icon-sm"
+      onClick={handleClose}
       aria-label={closeAriaLabel}
-      className={cn(
-        "p-1 rounded text-daintree-text/60 hover:text-text-primary hover:bg-daintree-border/50 transition-colors outline-hidden focus-visible:outline-solid focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-primary shrink-0",
-        isTitleBarSurface && "app-no-drag"
-      )}
+      className={cn("shrink-0", isTitleBarSurface && "app-no-drag")}
     >
-      <X className="h-3.5 w-3.5" aria-hidden="true" />
-    </button>
+      <X aria-hidden="true" />
+    </Button>
   ) : null;
 
   const showControlsRow = !!trailingSlot || (!hasDescription && !!onClose) || actionList.length > 0;
 
   return (
     <div
+      ref={rootRef}
       className={cn(
         hasDescription
           ? "flex flex-col gap-2 px-3 py-2 shrink-0"
@@ -310,50 +338,27 @@ export function InlineStatusBanner({
       aria-atomic={ariaLive && ariaLive !== "off" ? "true" : undefined}
     >
       {isTitleBarSurface && !isLinux() && <div className="window-resize-strip" />}
-      <div className={cn("flex", hasDescription ? "items-start" : "items-center", "gap-2 min-w-0")}>
+      {/* The band's tint and this glyph carry the severity; the text does not.
+          Severity-coloured type failed 4.5:1 on most themes, and a title that
+          is only legible on some of them is not a title. */}
+      <div className="flex items-start gap-2 min-w-0">
         <IconComponent
-          className={cn(
-            "w-4 h-4 shrink-0",
-            hasDescription && "mt-0.5",
-            isNeutral && "text-daintree-text/60"
-          )}
+          className={cn("w-4 h-4 shrink-0 mt-0.5", isNeutral && "text-text-secondary")}
           style={isNeutral ? undefined : { color: `var(${colorVar})` }}
           aria-hidden="true"
         />
         {hasDescription ? (
           <div className="flex-1 min-w-0">
             <div className="flex justify-between items-start gap-2">
-              <span
-                className={cn("text-sm font-medium", isNeutral && "text-text-primary")}
-                style={isNeutral ? undefined : { color: `var(${colorVar})` }}
-              >
-                {title}
-              </span>
-              {closeButton}
+              <span className="text-sm font-medium text-text-primary">{title}</span>
+              {closeButton && <div className="-mt-1 -mr-1">{closeButton}</div>}
             </div>
             {description && (
-              <p
-                className={cn("text-xs mt-0.5 break-words", isNeutral && "text-text-secondary")}
-                style={
-                  isNeutral
-                    ? undefined
-                    : { color: `color-mix(in oklab, var(${colorVar}) 80%, transparent)` }
-                }
-              >
-                {description}
-              </p>
+              <p className="text-xs mt-0.5 break-words text-text-secondary">{description}</p>
             )}
             {contextLine && (
               <p
-                className={cn(
-                  "text-xs font-mono mt-1 truncate",
-                  isNeutral && "text-text-secondary"
-                )}
-                style={
-                  isNeutral
-                    ? undefined
-                    : { color: `color-mix(in oklab, var(${colorVar}) 60%, transparent)` }
-                }
+                className="text-xs font-mono mt-1 truncate text-text-secondary"
                 title={contextLine}
               >
                 {contextLine}
@@ -366,12 +371,7 @@ export function InlineStatusBanner({
             )}
           </div>
         ) : (
-          <span
-            className={cn("text-sm", isNeutral && "text-text-primary")}
-            style={isNeutral ? undefined : { color: `var(${colorVar})` }}
-          >
-            {title}
-          </span>
+          <span className="text-sm font-medium text-text-primary">{title}</span>
         )}
       </div>
 
@@ -386,45 +386,24 @@ export function InlineStatusBanner({
           )}
         >
           {trailingSlot}
-          {!hasDescription && closeButton}
           {actionList.map((action) => {
-            const variant = action.variant ?? "primary";
-            const variantClasses = getButtonClasses(variant);
-            const variantStyle = colorVar ? getButtonStyle(variant, colorVar) : undefined;
-            const isDisabled = action.disabled || action.loading;
-            const iconClasses = action.iconOnly ? "w-3.5 h-3.5" : "w-3 h-3";
-            const spinnerSize = action.iconOnly ? "sm" : "xs";
+            const variant = BUTTON_VARIANT[action.variant ?? "primary"];
             const buttonEl = (
-              <button
+              <Button
                 key={action.id}
-                type="button"
-                disabled={isDisabled}
-                aria-busy={action.loading || undefined}
+                variant={variant}
+                size={action.iconOnly ? "icon-sm" : "sm"}
+                disabled={action.disabled}
+                loading={action.loading}
                 onClick={(e) => {
                   e.stopPropagation();
-                  if (isDisabled) return;
                   action.onClick();
                 }}
-                className={cn(
-                  action.iconOnly
-                    ? "p-1"
-                    : "flex items-center gap-1.5 px-2 py-1 text-xs font-medium",
-                  "transition-colors outline-hidden focus-visible:outline-solid focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-primary",
-                  variantClasses,
-                  (variant === "danger" || variant === "dangerFilled") &&
-                    "hover:[color:var(--hover-color)] hover:[background:var(--hover-bg)]",
-                  isDisabled && "cursor-not-allowed opacity-60 hover:bg-transparent"
-                )}
-                style={variantStyle}
                 aria-label={action.ariaLabel}
               >
-                {action.loading ? (
-                  <Spinner size={spinnerSize} />
-                ) : (
-                  action.icon && <action.icon className={iconClasses} aria-hidden="true" />
-                )}
+                {action.icon && <action.icon aria-hidden="true" />}
                 {!action.iconOnly && action.label}
-              </button>
+              </Button>
             );
 
             return action.title ? (
@@ -436,6 +415,9 @@ export function InlineStatusBanner({
               <React.Fragment key={action.id}>{buttonEl}</React.Fragment>
             );
           })}
+          {/* Dismiss sits after the actions, at the row's end, in both layouts —
+              never between two controls, where it reads as a third action. */}
+          {!hasDescription && closeButton}
         </div>
       )}
     </div>

--- a/src/components/Terminal/InlineStatusBanner.tsx
+++ b/src/components/Terminal/InlineStatusBanner.tsx
@@ -299,6 +299,16 @@ export function InlineStatusBanner({
     },
     []
   );
+  // A re-render can also replace the focused control without unmounting the
+  // banner — Retry becoming Install once a re-check succeeds — which drops
+  // focus on <body> just as an unmount would. Keep it on the banner's next
+  // control instead.
+  useEffect(() => {
+    const root = rootRef.current;
+    if (!focusWithinRef.current || !root?.isConnected) return;
+    if (document.activeElement && document.activeElement !== document.body) return;
+    root.querySelector<HTMLElement>("button:not([disabled]), [href], [tabindex]")?.focus();
+  });
 
   const actionList: BannerAction[] = actions ?? (action ? [action] : []);
 

--- a/src/components/Terminal/__tests__/AgentCompletionBanner.test.tsx
+++ b/src/components/Terminal/__tests__/AgentCompletionBanner.test.tsx
@@ -163,7 +163,6 @@ describe("AgentCompletionBanner", () => {
     const buttons = container.querySelectorAll("button");
     buttons.forEach((b) => {
       const cls = b.getAttribute("class")!;
-      expect(cls).toContain("transition-colors");
       expect(cls).not.toMatch(/\btransition-all\b/);
     });
   });

--- a/src/components/Terminal/__tests__/InlineStatusBanner.test.tsx
+++ b/src/components/Terminal/__tests__/InlineStatusBanner.test.tsx
@@ -829,6 +829,30 @@ describe("InlineStatusBanner focus handoff on any removal", () => {
     }
   });
 
+  it("keeps focus on the banner when the focused action is replaced in place", () => {
+    function Host() {
+      const [phase, setPhase] = useState<"retry" | "install">("retry");
+      return (
+        <InlineStatusBanner
+          title="t"
+          severity="warning"
+          animated={false}
+          actions={
+            phase === "retry"
+              ? [{ id: "retry", label: "Retry", onClick: () => setPhase("install") }]
+              : [{ id: "install", label: "Install Git", onClick: () => {} }]
+          }
+        />
+      );
+    }
+    render(<Host />);
+    const retry = screen.getByRole("button", { name: "Retry" });
+    retry.focus();
+    fireEvent.click(retry);
+    const install = screen.getByRole("button", { name: "Install Git" });
+    expect(document.activeElement).toBe(install);
+  });
+
   it("leaves focus alone when the banner unmounts without holding it", () => {
     vi.useFakeTimers();
     const raf = vi

--- a/src/components/Terminal/__tests__/InlineStatusBanner.test.tsx
+++ b/src/components/Terminal/__tests__/InlineStatusBanner.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import { AlertTriangle, CheckCircle2, FileEdit, Info, XCircle } from "lucide-react";
@@ -661,8 +662,8 @@ describe("InlineStatusBanner family invariants", () => {
       // rule is that no text node carries an inline status colour.
       expect(title.getAttribute("style")).toBeNull();
       expect(description.getAttribute("style")).toBeNull();
-      expect(title.className).toMatch(/\btext-text-primary\b/);
-      expect(description.className).toMatch(/\btext-text-secondary\b/);
+      expect(title.className).not.toMatch(/status-/);
+      expect(description.className).not.toMatch(/status-/);
       const icon = container.querySelector("svg");
       expect(icon?.getAttribute("style")).toContain("--color-status-");
       unmount();
@@ -851,6 +852,151 @@ describe("InlineStatusBanner focus handoff on any removal", () => {
     fireEvent.click(retry);
     const install = screen.getByRole("button", { name: "Install Git" });
     expect(document.activeElement).toBe(install);
+  });
+
+  it("prefers the next action over the title-row dismiss when the focused action is replaced", () => {
+    function Host() {
+      const [phase, setPhase] = useState<"retry" | "install">("retry");
+      return (
+        <InlineStatusBanner
+          title="t"
+          description="d"
+          severity="warning"
+          animated={false}
+          onClose={() => {}}
+          actions={
+            phase === "retry"
+              ? [{ id: "retry", label: "Retry", onClick: () => setPhase("install") }]
+              : [{ id: "install", label: "Install Git", onClick: () => {} }]
+          }
+        />
+      );
+    }
+    render(<Host />);
+    const retry = screen.getByRole("button", { name: "Retry" });
+    retry.focus();
+    fireEvent.click(retry);
+    expect(document.activeElement).toBe(screen.getByRole("button", { name: "Install Git" }));
+  });
+
+  it("stays inside an open dialog when a banner in it is dismissed", () => {
+    vi.useFakeTimers();
+    const raf = vi
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation((cb: FrameRequestCallback) => {
+        setTimeout(() => cb(0), 0);
+        return 1;
+      });
+    try {
+      const root = document.createElement("div");
+      root.id = "root";
+      document.body.appendChild(root);
+      const chrome = document.createElement("button");
+      chrome.textContent = "Toolbar";
+      root.appendChild(chrome);
+      function Host() {
+        const [open, setOpen] = useState(true);
+        return (
+          <div role="dialog">
+            <button type="button">Dialog primary</button>
+            {open && (
+              <InlineStatusBanner
+                title="t"
+                severity="error"
+                animated={false}
+                onClose={() => setOpen(false)}
+              />
+            )}
+          </div>
+        );
+      }
+      const view = render(<Host />, { container: root.appendChild(document.createElement("div")) });
+      const dismiss = screen.getByRole("button", { name: "Dismiss" });
+      dismiss.focus();
+      fireEvent.click(dismiss);
+      act(() => {
+        vi.runAllTimers();
+      });
+      expect(document.activeElement).toBe(screen.getByRole("button", { name: "Dialog primary" }));
+      view.unmount();
+      root.remove();
+    } finally {
+      raf.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not arm the handoff from focus inside portalled popover content", () => {
+    vi.useFakeTimers();
+    const raf = vi
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation((cb: FrameRequestCallback) => {
+        setTimeout(() => cb(0), 0);
+        return 1;
+      });
+    try {
+      const root = document.createElement("div");
+      root.id = "root";
+      document.body.appendChild(root);
+      const chrome = document.createElement("button");
+      chrome.textContent = "Toolbar";
+      root.appendChild(chrome);
+      const portalHost = document.createElement("div");
+      document.body.appendChild(portalHost);
+      function Host() {
+        const [open, setOpen] = useState(true);
+        return (
+          <>
+            <button type="button" onClick={() => setOpen(false)}>
+              Outside
+            </button>
+            {open && (
+              <InlineStatusBanner
+                title="t"
+                severity="warning"
+                animated={false}
+                trailingSlot={createPortal(<input aria-label="Portalled field" />, portalHost)}
+              />
+            )}
+          </>
+        );
+      }
+      const view = render(<Host />, { container: root.appendChild(document.createElement("div")) });
+      // React bubbles focus from the portal through the banner; the DOM does not.
+      const field = screen.getByLabelText("Portalled field");
+      field.focus();
+      field.blur();
+      fireEvent.click(screen.getByRole("button", { name: "Outside" }));
+      act(() => {
+        vi.runAllTimers();
+      });
+      // Focus was never in the banner's own DOM, so nothing is handed anywhere.
+      expect(document.activeElement).toBe(document.body);
+      view.unmount();
+      root.remove();
+      portalHost.remove();
+    } finally {
+      raf.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps a click on a busy control from reaching the surface behind the banner", () => {
+    const onPaneClick = vi.fn();
+    render(
+      <div onClick={onPaneClick}>
+        <InlineStatusBanner
+          title="t"
+          severity="warning"
+          animated={false}
+          actions={[{ id: "retry", label: "Retry", loading: true, onClick: () => {} }]}
+        />
+      </div>
+    );
+    const row = screen.getByRole("button", { name: "Retry" }).parentElement!;
+    // A busy Button opts out of hit-testing, so the pointer lands on the row.
+    fireEvent.click(row);
+    expect(onPaneClick).not.toHaveBeenCalled();
   });
 
   it("leaves focus alone when the banner unmounts without holding it", () => {

--- a/src/components/Terminal/__tests__/InlineStatusBanner.test.tsx
+++ b/src/components/Terminal/__tests__/InlineStatusBanner.test.tsx
@@ -456,12 +456,11 @@ describe("InlineStatusBanner", () => {
       );
       const title = screen.getByText("25 panels open");
       const dismiss = screen.getByRole("button", { name: "Dismiss" });
-      // Dismiss shares a parent with the title text (the flex justify-between wrapper)
-      const titleParent = title.closest('[class*="flex"]');
-      const dismissParent = dismiss.closest('[class*="flex"]');
-      expect(titleParent).toBe(dismissParent);
-      // The parent is the justify-between wrapper, not the controls row
-      expect(titleParent?.className).toContain("justify-between");
+      // Dismiss lives inside the title's row (the justify-between wrapper),
+      // not in the controls row beneath the description.
+      const titleRow = title.parentElement;
+      expect(titleRow?.className).toContain("justify-between");
+      expect(titleRow?.contains(dismiss)).toBe(true);
     });
 
     it("fires onClose when the title-row dismiss is clicked", () => {
@@ -641,6 +640,150 @@ describe("InlineStatusBanner", () => {
  * None of that may leak into the far more common inline usage — a banner
  * inside a terminal must never become a window drag handle.
  */
+describe("InlineStatusBanner family invariants", () => {
+  const STATUS_SEVERITIES: InlineStatusBannerSeverity[] = ["error", "warning", "info", "success"];
+
+  it("keeps severity off the text: title and description use neutral tokens, only the icon is coloured", () => {
+    for (const severity of STATUS_SEVERITIES) {
+      const { container, unmount } = render(
+        <InlineStatusBanner
+          title={`${severity} title`}
+          description="Body copy"
+          severity={severity}
+          animated={false}
+          onClose={() => {}}
+          autoDismissAfter={1000}
+        />
+      );
+      const title = screen.getByText(`${severity} title`);
+      const description = screen.getByText("Body copy");
+      // Severity-coloured type failed the contrast floor on most themes; the
+      // rule is that no text node carries an inline status colour.
+      expect(title.getAttribute("style")).toBeNull();
+      expect(description.getAttribute("style")).toBeNull();
+      expect(title.className).toMatch(/\btext-text-primary\b/);
+      expect(description.className).toMatch(/\btext-text-secondary\b/);
+      const icon = container.querySelector("svg");
+      expect(icon?.getAttribute("style")).toContain("--color-status-");
+      unmount();
+    }
+  });
+
+  it("gives each status severity its own default glyph, so shape tells them apart without hue", () => {
+    const glyphs = STATUS_SEVERITIES.map((severity) => {
+      const { container, unmount } = render(
+        <InlineStatusBanner
+          title="t"
+          severity={severity}
+          animated={false}
+          onClose={() => {}}
+          autoDismissAfter={1000}
+        />
+      );
+      const html = container.querySelector("svg")!.innerHTML;
+      unmount();
+      return html;
+    });
+    expect(new Set(glyphs).size).toBe(glyphs.length);
+  });
+
+  it("lets a caller's icon win only when one is passed", () => {
+    const { container } = render(
+      <InlineStatusBanner icon={FileEdit} title="t" severity="warning" animated={false} />
+    );
+    const explicit = container.querySelector("svg")!.innerHTML;
+    const { container: defaulted } = render(
+      <InlineStatusBanner title="t2" severity="warning" animated={false} />
+    );
+    expect(explicit).not.toBe(defaulted.querySelector("svg")!.innerHTML);
+  });
+
+  it("renders every action and the dismiss through the shared Button primitive", () => {
+    render(
+      <InlineStatusBanner
+        title="t"
+        severity="warning"
+        animated={false}
+        onClose={() => {}}
+        actions={[
+          { id: "a", label: "Primary", onClick: () => {} },
+          { id: "b", label: "Secondary", variant: "dismiss", onClick: () => {} },
+        ]}
+      />
+    );
+    for (const button of screen.getAllByRole("button")) {
+      // One geometry for the family: the primitive stamps its variant.
+      expect(button.getAttribute("data-variant")).toBeTruthy();
+      expect(button.className).not.toMatch(/(^|\s)rounded(\s|$)/);
+    }
+  });
+
+  it("places the dismiss after the actions in the single-line layout, never between controls", () => {
+    render(
+      <InlineStatusBanner
+        title="t"
+        severity="warning"
+        animated={false}
+        onClose={() => {}}
+        trailingSlot={<button type="button">Details</button>}
+        actions={[{ id: "a", label: "Fix it", onClick: () => {} }]}
+      />
+    );
+    const buttons = screen
+      .getAllByRole("button")
+      .map((b) => b.getAttribute("aria-label") ?? b.textContent);
+    expect(buttons.at(-1)).toBe("Dismiss");
+    expect(buttons.indexOf("Details")).toBeLessThan(buttons.indexOf("Fix it"));
+  });
+
+  it("hands focus back to the app shell when a focused dismiss unmounts the banner", () => {
+    vi.useFakeTimers();
+    // The handoff runs on the next frame, after React has committed the
+    // unmount — a frame that fires inside the click would still see the banner.
+    const raf = vi
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation((cb: FrameRequestCallback) => {
+        setTimeout(() => cb(0), 0);
+        return 1;
+      });
+    try {
+      const root = document.createElement("div");
+      root.id = "root";
+      document.body.appendChild(root);
+      const landing = document.createElement("button");
+      landing.textContent = "Toolbar";
+      root.appendChild(landing);
+
+      function Host() {
+        const [open, setOpen] = useState(true);
+        return open ? (
+          <InlineStatusBanner
+            title="t"
+            severity="warning"
+            animated={false}
+            onClose={() => setOpen(false)}
+          />
+        ) : null;
+      }
+      const view = render(<Host />, { container: root.appendChild(document.createElement("div")) });
+      const dismiss = screen.getByRole("button", { name: "Dismiss" });
+      dismiss.focus();
+      expect(document.activeElement).toBe(dismiss);
+      fireEvent.click(dismiss);
+      expect(screen.queryByRole("button", { name: "Dismiss" })).toBeNull();
+      act(() => {
+        vi.runAllTimers();
+      });
+      expect(document.activeElement).toBe(landing);
+      view.unmount();
+      root.remove();
+    } finally {
+      raf.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+});
+
 describe("InlineStatusBanner as the window title-bar surface", () => {
   // Success is excluded on purpose: it is required to dismiss itself, so it
   // cannot be the window's standing title-bar surface. Narrowing here keeps the
@@ -687,6 +830,12 @@ describe("InlineStatusBanner as the window title-bar surface", () => {
       }
     }
   }
+
+  it("never slides in: the native caption tint switches instantly, so the band must too", () => {
+    renderGlobal({ animated: true });
+    expect(root().className).not.toMatch(/\btransition-\[/);
+    expect(root().className).not.toContain("opacity-0");
+  });
 
   it("becomes draggable and fills the caption band's height", () => {
     renderGlobal();

--- a/src/components/Terminal/__tests__/InlineStatusBanner.test.tsx
+++ b/src/components/Terminal/__tests__/InlineStatusBanner.test.tsx
@@ -732,8 +732,8 @@ describe("InlineStatusBanner family invariants", () => {
     const buttons = screen
       .getAllByRole("button")
       .map((b) => b.getAttribute("aria-label") ?? b.textContent);
-    expect(buttons.at(-1)).toBe("Dismiss");
-    expect(buttons.indexOf("Details")).toBeLessThan(buttons.indexOf("Fix it"));
+    // Primary leads the row, the secondary affordance follows, dismiss ends it.
+    expect(buttons).toEqual(["Fix it", "Details", "Dismiss"]);
   });
 
   it("hands focus back to the app shell when a focused dismiss unmounts the banner", () => {
@@ -777,6 +777,88 @@ describe("InlineStatusBanner family invariants", () => {
       expect(document.activeElement).toBe(landing);
       view.unmount();
       root.remove();
+    } finally {
+      raf.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("InlineStatusBanner focus handoff on any removal", () => {
+  it("hands focus back when an action, not the ×, unmounts the banner", () => {
+    vi.useFakeTimers();
+    const raf = vi
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation((cb: FrameRequestCallback) => {
+        setTimeout(() => cb(0), 0);
+        return 1;
+      });
+    try {
+      const root = document.createElement("div");
+      root.id = "root";
+      document.body.appendChild(root);
+      const landing = document.createElement("button");
+      landing.textContent = "Toolbar";
+      root.appendChild(landing);
+
+      function Host() {
+        const [open, setOpen] = useState(true);
+        return open ? (
+          <InlineStatusBanner
+            title="t"
+            severity="warning"
+            animated={false}
+            actions={[{ id: "hide", label: "Don't show again", onClick: () => setOpen(false) }]}
+          />
+        ) : null;
+      }
+      const view = render(<Host />, { container: root.appendChild(document.createElement("div")) });
+      const hide = screen.getByRole("button", { name: "Don't show again" });
+      hide.focus();
+      fireEvent.click(hide);
+      expect(screen.queryByRole("button", { name: "Don't show again" })).toBeNull();
+      act(() => {
+        vi.runAllTimers();
+      });
+      expect(document.activeElement).toBe(landing);
+      view.unmount();
+      root.remove();
+    } finally {
+      raf.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it("leaves focus alone when the banner unmounts without holding it", () => {
+    vi.useFakeTimers();
+    const raf = vi
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation((cb: FrameRequestCallback) => {
+        setTimeout(() => cb(0), 0);
+        return 1;
+      });
+    try {
+      const elsewhere = document.createElement("input");
+      document.body.appendChild(elsewhere);
+      function Host() {
+        const [open, setOpen] = useState(true);
+        return (
+          <>
+            <button type="button" onClick={() => setOpen(false)}>
+              Outside
+            </button>
+            {open && <InlineStatusBanner title="t" severity="warning" animated={false} />}
+          </>
+        );
+      }
+      render(<Host />);
+      elsewhere.focus();
+      fireEvent.click(screen.getByRole("button", { name: "Outside" }));
+      act(() => {
+        vi.runAllTimers();
+      });
+      expect(document.activeElement).toBe(elsewhere);
+      elsewhere.remove();
     } finally {
       raf.mockRestore();
       vi.useRealTimers();

--- a/src/components/Terminal/__tests__/ReconnectErrorBanner.test.tsx
+++ b/src/components/Terminal/__tests__/ReconnectErrorBanner.test.tsx
@@ -91,7 +91,8 @@ describe("ReconnectErrorBanner", () => {
   it("disables retry and sets aria-busy when isRestarting is true", () => {
     renderBanner("error", { isRestarting: true });
     const button = screen.getByRole("button", { name: /retry reconnecting/i });
-    expect(button.hasAttribute("disabled")).toBe(true);
+    // Loading keeps focus on the control (no native disabled) and blocks activation.
+    expect(button.getAttribute("aria-disabled")).toBe("true");
     expect(button.getAttribute("aria-busy")).toBe("true");
   });
 

--- a/src/components/Terminal/__tests__/ScrollbackRestoreErrorBanner.test.tsx
+++ b/src/components/Terminal/__tests__/ScrollbackRestoreErrorBanner.test.tsx
@@ -107,7 +107,8 @@ describe("ScrollbackRestoreErrorBanner", () => {
   it("disables reset and shows aria-busy when isRestarting is true", () => {
     renderBanner("error", { isRestarting: true });
     const button = screen.getByRole("button", { name: /reset terminal/i });
-    expect(button.hasAttribute("disabled")).toBe(true);
+    // Loading keeps focus on the control (no native disabled) and blocks activation.
+    expect(button.getAttribute("aria-disabled")).toBe("true");
     expect(button.getAttribute("aria-busy")).toBe("true");
   });
 });

--- a/src/components/Terminal/__tests__/SpawnErrorBanner.test.tsx
+++ b/src/components/Terminal/__tests__/SpawnErrorBanner.test.tsx
@@ -221,7 +221,8 @@ describe("SpawnErrorBanner", () => {
   it("disables retry and shows aria-busy when isRestarting is true", () => {
     renderBanner("ENOENT", { isRestarting: true });
     const retry = screen.getByRole("button", { name: /retry starting terminal/i });
-    expect(retry.hasAttribute("disabled")).toBe(true);
+    // Loading keeps focus on the control (no native disabled) and blocks activation.
+    expect(retry.getAttribute("aria-disabled")).toBe("true");
     expect(retry.getAttribute("aria-busy")).toBe("true");
   });
 

--- a/src/components/Terminal/__tests__/TerminalAttachErrorBanner.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalAttachErrorBanner.test.tsx
@@ -93,7 +93,8 @@ describe("TerminalAttachErrorBanner", () => {
     const { onRetry } = renderBanner({ isRetrying: true });
 
     const button = screen.getByRole("button", { name: "Retry terminal display" });
-    expect(button.hasAttribute("disabled")).toBe(true);
+    // Loading keeps focus on the control (no native disabled) and blocks activation.
+    expect(button.getAttribute("aria-disabled")).toBe("true");
 
     fireEvent.click(button);
     expect(onRetry).not.toHaveBeenCalled();

--- a/src/components/Terminal/__tests__/TerminalErrorBanner.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalErrorBanner.test.tsx
@@ -155,7 +155,8 @@ describe("TerminalErrorBanner", () => {
       { isRestarting: true }
     );
     const retry = screen.getByRole("button", { name: /retry restart/i });
-    expect(retry.hasAttribute("disabled")).toBe(true);
+    // Loading keeps focus on the control (no native disabled) and blocks activation.
+    expect(retry.getAttribute("aria-disabled")).toBe("true");
     expect(retry.getAttribute("aria-busy")).toBe("true");
   });
 });

--- a/src/components/ui/WindowControlsInset.tsx
+++ b/src/components/ui/WindowControlsInset.tsx
@@ -69,7 +69,10 @@ export function WindowControlsInsetProvider({
   const inset = useMemo<CSSProperties>(() => {
     if (isFullscreen) return EMPTY;
     if (isMac()) return { paddingLeft: "5rem" };
-    if (isWindows()) return { paddingRight: `${WINDOWS_CAPTION_WIDTH_PX}px` };
+    // A gutter past the caption strip: the surface's own dismiss is an × too,
+    // and flush against the minimize backplate it reads as one more caption
+    // glyph rather than the banner's control.
+    if (isWindows()) return { paddingRight: `${WINDOWS_CAPTION_WIDTH_PX + 12}px` };
     return EMPTY;
   }, [isFullscreen]);
 

--- a/src/components/ui/__tests__/WindowControlsInset.test.tsx
+++ b/src/components/ui/__tests__/WindowControlsInset.test.tsx
@@ -48,7 +48,10 @@ describe("WindowControlsInsetProvider", () => {
     );
     // Constant, not env(titlebar-area-width): WCO variables never resolve in
     // the child WebContentsView the app renders in (electron/electron#34947).
-    expect(screen.getByTestId("probe").style.paddingRight).toBe(`${WINDOWS_CAPTION_WIDTH_PX}px`);
+    // At least the caption strip, so no control can sit under it; anything
+    // beyond that is the gutter that keeps the surface's own × off the strip.
+    const paddingRight = Number.parseInt(screen.getByTestId("probe").style.paddingRight, 10);
+    expect(paddingRight).toBeGreaterThanOrEqual(WINDOWS_CAPTION_WIDTH_PX);
     expect(screen.getByTestId("probe").style.paddingLeft).toBe("");
   });
 

--- a/src/store/globalBannerDismissalStore.ts
+++ b/src/store/globalBannerDismissalStore.ts
@@ -1,0 +1,28 @@
+import { create } from "zustand";
+
+/**
+ * Session dismissals for global banners whose condition has no dismissal of
+ * its own. The coordinator reads this so a dismissed banner gives up the slot
+ * instead of rendering nothing while still holding it; the entry is cleared
+ * when the condition clears, so the next occurrence shows again.
+ */
+export type DismissibleGlobalBannerSlot = "watchdog-disabled" | "plugin-document";
+
+interface GlobalBannerDismissalState {
+  dismissed: ReadonlySet<DismissibleGlobalBannerSlot>;
+  dismiss: (slot: DismissibleGlobalBannerSlot) => void;
+  reset: (slot: DismissibleGlobalBannerSlot) => void;
+}
+
+export const useGlobalBannerDismissalStore = create<GlobalBannerDismissalState>((set) => ({
+  dismissed: new Set(),
+  dismiss: (slot) =>
+    set((s) => (s.dismissed.has(slot) ? s : { dismissed: new Set(s.dismissed).add(slot) })),
+  reset: (slot) =>
+    set((s) => {
+      if (!s.dismissed.has(slot)) return s;
+      const next = new Set(s.dismissed);
+      next.delete(slot);
+      return { dismissed: next };
+    }),
+}));


### PR DESCRIPTION
## Summary

There are ten global recovery banners (host crash, watchdog disabled, memory stall, safe mode, restore confirmation, missing prerequisite, forge token, plugin document, cloud sync, Rosetta). Only one ever shows at a time, so nobody had seen them together. A new screenshot harness renders all ten on a single sheet, and the differences were glaring: nine used the same warning triangle, three different button shapes, the dismiss control in three different places, and severity-coloured text that failed the 4.5:1 contrast floor on most of the 15 themes.

The fix is almost all in the shared `InlineStatusBanner` shell, so every consumer inherits it. On the way I found a coordinator bug: a dismissed forge-token banner still claimed the slot and suppressed the banners below it.

## Changes

- `InlineStatusBanner`: title and description on neutral text tokens, severity carried by the icon, tint and border; a default icon per severity (`XCircle`, `AlertTriangle`, `Info`, `CheckCircle2`); every action and the dismiss rendered through `Button`; dismiss always last; no entrance animation in the title bar; focus handed to the enclosing dialog or container when a dismissal or an action removes the focused control
- `useGlobalBannerPriority`: claims the forge slot with the banner's own predicate; honours session dismissals from the new `globalBannerDismissalStore` and clears them when the condition clears
- Banners: redundant icons dropped; restore confirmation is `info` when clean and `warning` once panels are implicated; Rosetta's × is session-only with a labelled "Don't show again"; cloud sync gains a session ×; watchdog and plugin-document gain a session ×; prerequisite copy names each tool's own condition and versions; `role=status` on standing conditions, `alert` only for the exhausted host crash
- `WindowControlsInset`: a 12px gutter past the Windows caption strip so the banner's × does not sit against the native close
- Harness: `recovery-banners-review.spec.ts` plus `src/components/Recovery/__preview__/`, opt-in via `DAINTREE_SHOT_BANNERS=1`, no Electron and no build
- Text-ramp manifest regenerated after the shell left the `text-daintree-text/60` ramp

There are 44 other `InlineStatusBanner` callers that still pass an icon the shell now defaults. Leaving those for a follow-up.

## Testing

Full `vitest` run: 59,256 passed. Three suites fail on `develop` too on this machine (`PluginDevArtifactWatcher`, `ProjectPluginWatcher`, `scenarioLiveness`), and `portalCloseEscalation` timed out once under load and passes on re-run. `typecheck`, the lint ratchet (down 15 warnings) and every `npm run check` step pass, except `check:sample-views`, which fails on a generated sample artifact this branch never touched. Fifteen new invariant tests, each mutation-checked. The watchdog E2E spec and selector were updated for `role=status` and the session dismiss, but the E2E bucket was not run locally.

A Codex review of the shell rewrite and the coordinator turned up four focus-handling gaps (dialog containment, portalled popover content arming the handoff, replacement focus landing on the title-row dismiss, busy buttons letting clicks reach the pane), all fixed in the last commit.